### PR TITLE
Build improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,9 @@ jobs:
       - checkout
       - run:
           name: Install dependencies
-          command: npm i
+          command: |
+            npm i
+            npm run bootstrap:ci
       - run:
           name: Lint
           command: npm run lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,9 @@ jobs:
           name: Lint
           command: npm run lint
       - run:
+          name: Build
+          command: npm run build
+      - run:
           name: Test
           command: npm run test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,18 +23,21 @@ jobs:
       - run:
           name: Configure deployment
           command: |
-            static_bucket='cf-apps-static-test'
-            test "$CIRCLE_BRANCH" == 'master' && static_bucket='cf-apps-static'
-            echo "export STATIC_BUCKET=\"$static_bucket\"" >> $BASH_ENV
-            static_jira_bucket='cf-apps-jira-test'
-            test "$CIRCLE_BRANCH" == 'master' && static_jira_bucket='cf-apps-jira'
-            echo "export STATIC_JIRA_BUCKET=\"$static_jira_bucket\"" >> $BASH_ENV
+            static_s3_base="s3://cf-apps-static/apps-test-$CIRCLE_SHA1"
+            test "$CIRCLE_BRANCH" == 'master' && static_s3_base='s3://cf-apps-static/apps'
+            echo "export STATIC_S3_BASE=\"$static_s3_base\"" >> $BASH_ENV
+
+            static_jira_s3_base="s3://cf-apps-static/apps-test-$CIRCLE_SHA1/jira"
+            test "$CIRCLE_BRANCH" == 'master' && static_jira_s3_base='s3://cf-apps-jira'
+            echo "export STATIC_JIRA_S3_BASE=\"$static_jira_s3_base\"" >> $BASH_ENV
+
             stage='test'
             test "$CIRCLE_BRANCH" == 'master' && stage='prd'
             echo "export STAGE=\"$stage\"" >> $BASH_ENV
+
             source "$BASH_ENV"
-            echo "Static deployment bucket: $STATIC_BUCKET"
-            echo "Static Jira deployment bucket: $STATIC_JIRA_BUCKET"
+            echo "Static deployment S3 base: $STATIC_S3_BASE"
+            echo "Static Jira deployment S3 base: $STATIC_JIRA_S3_BASE"
             echo "API Gateway stage: $STAGE"
       - run:
           name: Install pip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,24 +21,11 @@ jobs:
           name: Test
           command: npm run test
       - run:
-          name: Configure deployment
+          name: Exit successfully if not in master
           command: |
-            static_s3_base="s3://cf-apps-static/apps-test-$CIRCLE_SHA1"
-            test "$CIRCLE_BRANCH" == 'master' && static_s3_base='s3://cf-apps-static/apps'
-            echo "export STATIC_S3_BASE=\"$static_s3_base\"" >> $BASH_ENV
-
-            static_jira_s3_base="s3://cf-apps-static/apps-test-$CIRCLE_SHA1/jira"
-            test "$CIRCLE_BRANCH" == 'master' && static_jira_s3_base='s3://cf-apps-jira'
-            echo "export STATIC_JIRA_S3_BASE=\"$static_jira_s3_base\"" >> $BASH_ENV
-
-            stage='test'
-            test "$CIRCLE_BRANCH" == 'master' && stage='prd'
-            echo "export STAGE=\"$stage\"" >> $BASH_ENV
-
-            source "$BASH_ENV"
-            echo "Static deployment S3 base: $STATIC_S3_BASE"
-            echo "Static Jira deployment S3 base: $STATIC_JIRA_S3_BASE"
-            echo "API Gateway stage: $STAGE"
+            if [ "$CIRCLE_BRANCH" != "master" ]; then
+                circleci-agent step halt
+            fi
       - run:
           name: Install pip
           command: sudo apt-get install python-pip python-dev
@@ -46,8 +33,17 @@ jobs:
           name: Install awscli
           command: sudo pip install awscli
       - run:
-          name: Deploy apps
-          command: npm run deploy
+          name: Deploy apps to test
+          command: |
+            STATIC_S3_BASE="s3://cf-apps-static-dev/apps-test-$CIRCLE_SHA1" \
+                STATIC_JIRA_S3_BASE="s3://cf-apps-static-dev/apps-test-$CIRCLE_SHA1/jira" \
+                STAGE='test' npm run deploy
+      - run:
+          name: Deploy apps to prod
+          command: |
+            STATIC_S3_BASE="s3://cf-apps-static/apps" \
+                STATIC_JIRA_S3_BASE="s3://cf-apps-jira" \
+                STAGE='prd' npm run deploy
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,7 @@
 version: 2
-# Required secret environment variables
-# AWS_ACCESS_KEY_ID
-# AWS_SECRET_ACCESS_KEY
 
 jobs:
-  test:
+  all:
     docker:
       - image: circleci/node:10-stretch
     steps:
@@ -29,20 +26,16 @@ jobs:
             static_bucket='cf-apps-static-test'
             test "$CIRCLE_BRANCH" == 'master' && static_bucket='cf-apps-static'
             echo "export STATIC_BUCKET=\"$static_bucket\"" >> $BASH_ENV
+            static_jira_bucket='cf-apps-jira-test'
+            test "$CIRCLE_BRANCH" == 'master' && static_jira_bucket='cf-apps-jira'
+            echo "export STATIC_JIRA_BUCKET=\"$static_jira_bucket\"" >> $BASH_ENV
             stage='test'
             test "$CIRCLE_BRANCH" == 'master' && stage='prd'
             echo "export STAGE=\"$stage\"" >> $BASH_ENV
             source "$BASH_ENV"
             echo "Static deployment bucket: $STATIC_BUCKET"
+            echo "Static Jira deployment bucket: $STATIC_JIRA_BUCKET"
             echo "API Gateway stage: $STAGE"
-
-  deploy:
-    docker:
-      - image: circleci/node:10-stretch
-        environment:
-          STATIC_APPS_BUCKET: s3://cf-apps-static
-    steps:
-      - checkout
       - run:
           name: Install pip
           command: sudo apt-get install python-pip python-dev
@@ -50,22 +43,11 @@ jobs:
           name: Install awscli
           command: sudo pip install awscli
       - run:
-          name: Install dependencies
-          command: |
-            npm i
-      - run:
-          name: 'Deploy apps'
-          command: npm run deploy -- --concurrency=1
+          name: Deploy apps
+          command: npm run deploy
 
 workflows:
   version: 2
   test-deploy:
     jobs:
-      - test
-      - deploy:
-          filters:
-            branches:
-              only:
-                - master
-          requires:
-            - test
+      - all

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,18 @@ jobs:
       - run:
           name: Test
           command: npm run test
+      - run:
+          name: Configure deployment
+          command: |
+            static_bucket='cf-apps-static-test'
+            test "$CIRCLE_BRANCH" == 'master' && static_bucket='cf-apps-static'
+            echo "export STATIC_BUCKET=\"$static_bucket\"" >> $BASH_ENV
+            stage='test'
+            test "$CIRCLE_BRANCH" == 'master' && stage='prd'
+            echo "export STAGE=\"$stage\"" >> $BASH_ENV
+            source "$BASH_ENV"
+            echo "Static deployment bucket: $STATIC_BUCKET"
+            echo "API Gateway stage: $STAGE"
 
   deploy:
     docker:

--- a/apps/ai-image-tagging/frontend/package.json
+++ b/apps/ai-image-tagging/frontend/package.json
@@ -22,7 +22,7 @@
     "build": "contentful-extension-scripts build --no-inline",
     "lint": "eslint ./ --ext .js,.jsx,.ts,.tsx",
     "test": "contentful-extension-scripts test --env=jsdom --watch",
-    "test:ci": "contentful-extension-scripts test --env=jsdom --coverage"
+    "test:ci": "contentful-extension-scripts test --env=jsdom"
   },
   "dependencies": {
     "@contentful/forma-36-fcss": "^0.0.20",

--- a/apps/ai-image-tagging/lambda/package.json
+++ b/apps/ai-image-tagging/lambda/package.json
@@ -9,7 +9,7 @@
     "test": "jest",
     "test:ci": "jest",
     "serve": "node serve.js",
-    "deploy": "sls deploy --stage prd"
+    "deploy": "sls deploy --stage $STAGE"
   },
   "devDependencies": {
     "eslint": "6.8.0",

--- a/apps/ai-image-tagging/lambda/package.json
+++ b/apps/ai-image-tagging/lambda/package.json
@@ -9,8 +9,7 @@
     "test": "jest",
     "test:ci": "jest",
     "serve": "node serve.js",
-    "build-frontend": "cd ../frontend && npm run build",
-    "deploy": "npm run build-frontend && sls deploy --stage prd"
+    "deploy": "sls deploy --stage prd"
   },
   "devDependencies": {
     "eslint": "6.8.0",

--- a/apps/bynder/package.json
+++ b/apps/bynder/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "start": "contentful-extension-scripts start --serve-only",
     "build": "contentful-extension-scripts build --no-inline",
-    "deploy": "npm run build && aws s3 sync ./build ${STATIC_APPS_BUCKET}/apps/bynder --acl public-read"
+    "deploy": "aws s3 sync ./build ${STATIC_APPS_BUCKET}/apps/bynder --acl public-read"
   },
   "browserslist": [
     "last 5 Chrome version",

--- a/apps/bynder/package.json
+++ b/apps/bynder/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "start": "contentful-extension-scripts start --serve-only",
     "build": "contentful-extension-scripts build --no-inline",
-    "deploy": "aws s3 sync ./build s3://${STATIC_BUCKET}/apps/bynder --acl public-read"
+    "deploy": "aws s3 sync ./build ${STATIC_S3_BASE}/bynder --acl public-read"
   },
   "browserslist": [
     "last 5 Chrome version",

--- a/apps/bynder/package.json
+++ b/apps/bynder/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "start": "contentful-extension-scripts start --serve-only",
     "build": "contentful-extension-scripts build --no-inline",
-    "deploy": "aws s3 sync ./build ${STATIC_APPS_BUCKET}/apps/bynder --acl public-read"
+    "deploy": "aws s3 sync ./build s3://${STATIC_BUCKET}/apps/bynder --acl public-read"
   },
   "browserslist": [
     "last 5 Chrome version",

--- a/apps/cloudinary/package.json
+++ b/apps/cloudinary/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "start": "contentful-extension-scripts start --serve-only",
     "build": "contentful-extension-scripts build --no-inline",
-    "deploy": "aws s3 sync ./build s3://${STATIC_BUCKET}/apps/cloudinary --acl public-read"
+    "deploy": "aws s3 sync ./build ${STATIC_S3_BASE}/cloudinary --acl public-read"
   },
   "browserslist": [
     "last 5 Chrome version",

--- a/apps/cloudinary/package.json
+++ b/apps/cloudinary/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "start": "contentful-extension-scripts start --serve-only",
     "build": "contentful-extension-scripts build --no-inline",
-    "deploy": "npm run build && aws s3 sync ./build ${STATIC_APPS_BUCKET}/apps/cloudinary --acl public-read"
+    "deploy": "aws s3 sync ./build ${STATIC_APPS_BUCKET}/apps/cloudinary --acl public-read"
   },
   "browserslist": [
     "last 5 Chrome version",

--- a/apps/cloudinary/package.json
+++ b/apps/cloudinary/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "start": "contentful-extension-scripts start --serve-only",
     "build": "contentful-extension-scripts build --no-inline",
-    "deploy": "aws s3 sync ./build ${STATIC_APPS_BUCKET}/apps/cloudinary --acl public-read"
+    "deploy": "aws s3 sync ./build s3://${STATIC_BUCKET}/apps/cloudinary --acl public-read"
   },
   "browserslist": [
     "last 5 Chrome version",

--- a/apps/commercelayer/package.json
+++ b/apps/commercelayer/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "start": "contentful-extension-scripts start --serve-only",
     "build": "contentful-extension-scripts build --no-inline",
-    "deploy": "aws s3 sync ./build s3://${STATIC_BUCKET}/apps/commercelayer --acl public-read"
+    "deploy": "aws s3 sync ./build ${STATIC_S3_BASE}/commercelayer --acl public-read"
   },
   "browserslist": [
     "last 5 Chrome version",

--- a/apps/commercelayer/package.json
+++ b/apps/commercelayer/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "start": "contentful-extension-scripts start --serve-only",
     "build": "contentful-extension-scripts build --no-inline",
-    "deploy": "aws s3 sync ./build ${STATIC_APPS_BUCKET}/apps/commercelayer --acl public-read"
+    "deploy": "aws s3 sync ./build s3://${STATIC_BUCKET}/apps/commercelayer --acl public-read"
   },
   "browserslist": [
     "last 5 Chrome version",

--- a/apps/commercelayer/package.json
+++ b/apps/commercelayer/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "start": "contentful-extension-scripts start --serve-only",
     "build": "contentful-extension-scripts build --no-inline",
-    "deploy": "npm run build && aws s3 sync ./build ${STATIC_APPS_BUCKET}/apps/commercelayer --acl public-read"
+    "deploy": "aws s3 sync ./build ${STATIC_APPS_BUCKET}/apps/commercelayer --acl public-read"
   },
   "browserslist": [
     "last 5 Chrome version",

--- a/apps/commercetools/package.json
+++ b/apps/commercetools/package.json
@@ -47,7 +47,7 @@
   "scripts": {
     "start": "contentful-extension-scripts start --serve-only",
     "build": "contentful-extension-scripts build --no-inline",
-    "deploy": "npm run build && aws s3 sync ./build ${STATIC_APPS_BUCKET}/apps/commercetools --acl public-read",
+    "deploy": "aws s3 sync ./build ${STATIC_APPS_BUCKET}/apps/commercetools --acl public-read",
     "test": "contentful-extension-scripts test --env=jsdom --watch",
     "test:ci": "contentful-extension-scripts test --env=jsdom --coverage",
     "lint": "eslint ./ --ext .js,.jsx,.ts,.tsx && tsc -p ./ --noEmit"

--- a/apps/commercetools/package.json
+++ b/apps/commercetools/package.json
@@ -47,7 +47,7 @@
   "scripts": {
     "start": "contentful-extension-scripts start --serve-only",
     "build": "contentful-extension-scripts build --no-inline",
-    "deploy": "aws s3 sync ./build ${STATIC_APPS_BUCKET}/apps/commercetools --acl public-read",
+    "deploy": "aws s3 sync ./build s3://${STATIC_BUCKET}/apps/commercetools --acl public-read",
     "test": "contentful-extension-scripts test --env=jsdom --watch",
     "test:ci": "contentful-extension-scripts test --env=jsdom",
     "lint": "eslint ./ --ext .js,.jsx,.ts,.tsx && tsc -p ./ --noEmit"

--- a/apps/commercetools/package.json
+++ b/apps/commercetools/package.json
@@ -47,7 +47,7 @@
   "scripts": {
     "start": "contentful-extension-scripts start --serve-only",
     "build": "contentful-extension-scripts build --no-inline",
-    "deploy": "aws s3 sync ./build s3://${STATIC_BUCKET}/apps/commercetools --acl public-read",
+    "deploy": "aws s3 sync ./build ${STATIC_S3_BASE}/commercetools --acl public-read",
     "test": "contentful-extension-scripts test --env=jsdom --watch",
     "test:ci": "contentful-extension-scripts test --env=jsdom",
     "lint": "eslint ./ --ext .js,.jsx,.ts,.tsx && tsc -p ./ --noEmit"

--- a/apps/commercetools/package.json
+++ b/apps/commercetools/package.json
@@ -49,7 +49,7 @@
     "build": "contentful-extension-scripts build --no-inline",
     "deploy": "aws s3 sync ./build ${STATIC_APPS_BUCKET}/apps/commercetools --acl public-read",
     "test": "contentful-extension-scripts test --env=jsdom --watch",
-    "test:ci": "contentful-extension-scripts test --env=jsdom --coverage",
+    "test:ci": "contentful-extension-scripts test --env=jsdom",
     "lint": "eslint ./ --ext .js,.jsx,.ts,.tsx && tsc -p ./ --noEmit"
   },
   "browserslist": [

--- a/apps/dropbox/package.json
+++ b/apps/dropbox/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "start": "contentful-extension-scripts start --serve-only",
     "build": "contentful-extension-scripts build --no-inline",
-    "deploy": "npm run build && aws s3 sync ./build ${STATIC_APPS_BUCKET}/apps/dropbox --acl public-read"
+    "deploy": "aws s3 sync ./build ${STATIC_APPS_BUCKET}/apps/dropbox --acl public-read"
   },
   "browserslist": [
     "last 5 Chrome version",

--- a/apps/dropbox/package.json
+++ b/apps/dropbox/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "start": "contentful-extension-scripts start --serve-only",
     "build": "contentful-extension-scripts build --no-inline",
-    "deploy": "aws s3 sync ./build s3://${STATIC_BUCKET}/apps/dropbox --acl public-read"
+    "deploy": "aws s3 sync ./build ${STATIC_S3_BASE}/dropbox --acl public-read"
   },
   "browserslist": [
     "last 5 Chrome version",

--- a/apps/dropbox/package.json
+++ b/apps/dropbox/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "start": "contentful-extension-scripts start --serve-only",
     "build": "contentful-extension-scripts build --no-inline",
-    "deploy": "aws s3 sync ./build ${STATIC_APPS_BUCKET}/apps/dropbox --acl public-read"
+    "deploy": "aws s3 sync ./build s3://${STATIC_BUCKET}/apps/dropbox --acl public-read"
   },
   "browserslist": [
     "last 5 Chrome version",

--- a/apps/frontify/package.json
+++ b/apps/frontify/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "start": "contentful-extension-scripts start --serve-only",
     "build": "contentful-extension-scripts build --no-inline",
-    "deploy": "npm run build && aws s3 sync ./build ${STATIC_APPS_BUCKET}/apps/frontify --acl public-read"
+    "deploy": "aws s3 sync ./build ${STATIC_APPS_BUCKET}/apps/frontify --acl public-read"
   },
   "browserslist": [
     "last 5 Chrome version",

--- a/apps/frontify/package.json
+++ b/apps/frontify/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "start": "contentful-extension-scripts start --serve-only",
     "build": "contentful-extension-scripts build --no-inline",
-    "deploy": "aws s3 sync ./build ${STATIC_APPS_BUCKET}/apps/frontify --acl public-read"
+    "deploy": "aws s3 sync ./build s3://${STATIC_BUCKET}/apps/frontify --acl public-read"
   },
   "browserslist": [
     "last 5 Chrome version",

--- a/apps/frontify/package.json
+++ b/apps/frontify/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "start": "contentful-extension-scripts start --serve-only",
     "build": "contentful-extension-scripts build --no-inline",
-    "deploy": "aws s3 sync ./build s3://${STATIC_BUCKET}/apps/frontify --acl public-read"
+    "deploy": "aws s3 sync ./build ${STATIC_S3_BASE}/frontify --acl public-read"
   },
   "browserslist": [
     "last 5 Chrome version",

--- a/apps/gatsby/package.json
+++ b/apps/gatsby/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "start": "contentful-extension-scripts start --serve-only",
     "build": "contentful-extension-scripts build --no-inline",
-    "deploy": "aws s3 sync ./build s3://${STATIC_BUCKET}/apps/gatsby --acl public-read",
+    "deploy": "aws s3 sync ./build ${STATIC_S3_BASE}/gatsby --acl public-read",
     "test": "TZ=UTC contentful-extension-scripts test --env=jsdom --watch",
     "test:ci": "TZ=UTC contentful-extension-scripts test --env=jsdom"
   },

--- a/apps/gatsby/package.json
+++ b/apps/gatsby/package.json
@@ -28,7 +28,7 @@
     "build": "contentful-extension-scripts build --no-inline",
     "deploy": "aws s3 sync ./build ${STATIC_APPS_BUCKET}/apps/gatsby --acl public-read",
     "test": "TZ=UTC contentful-extension-scripts test --env=jsdom --watch",
-    "test:ci": "TZ=UTC contentful-extension-scripts test --env=jsdom --coverage"
+    "test:ci": "TZ=UTC contentful-extension-scripts test --env=jsdom"
   },
   "browserslist": [
     "last 5 Chrome version",

--- a/apps/gatsby/package.json
+++ b/apps/gatsby/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "start": "contentful-extension-scripts start --serve-only",
     "build": "contentful-extension-scripts build --no-inline",
-    "deploy": "aws s3 sync ./build ${STATIC_APPS_BUCKET}/apps/gatsby --acl public-read",
+    "deploy": "aws s3 sync ./build s3://${STATIC_BUCKET}/apps/gatsby --acl public-read",
     "test": "TZ=UTC contentful-extension-scripts test --env=jsdom --watch",
     "test:ci": "TZ=UTC contentful-extension-scripts test --env=jsdom"
   },

--- a/apps/gatsby/package.json
+++ b/apps/gatsby/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "start": "contentful-extension-scripts start --serve-only",
     "build": "contentful-extension-scripts build --no-inline",
-    "deploy": "npm run build && aws s3 sync ./build ${STATIC_APPS_BUCKET}/apps/gatsby --acl public-read",
+    "deploy": "aws s3 sync ./build ${STATIC_APPS_BUCKET}/apps/gatsby --acl public-read",
     "test": "TZ=UTC contentful-extension-scripts test --env=jsdom --watch",
     "test:ci": "TZ=UTC contentful-extension-scripts test --env=jsdom --coverage"
   },

--- a/apps/google-analytics/package.json
+++ b/apps/google-analytics/package.json
@@ -26,7 +26,7 @@
     "start": "contentful-extension-scripts start --serve-only",
     "build": "contentful-extension-scripts build --no-inline",
     "lint:fixme": "eslint ./ --ext .js,.jsx,.ts,.tsx && tsc -p ./ --noEmit",
-    "deploy": "aws s3 sync ./build ${STATIC_APPS_BUCKET}/apps/google-analytics --acl public-read"
+    "deploy": "aws s3 sync ./build s3://${STATIC_BUCKET}/apps/google-analytics --acl public-read"
   },
   "dependencies": {
     "@contentful/forma-36-fcss": "^0.0.20",

--- a/apps/google-analytics/package.json
+++ b/apps/google-analytics/package.json
@@ -26,7 +26,7 @@
     "start": "contentful-extension-scripts start --serve-only",
     "build": "contentful-extension-scripts build --no-inline",
     "lint:fixme": "eslint ./ --ext .js,.jsx,.ts,.tsx && tsc -p ./ --noEmit",
-    "deploy": "aws s3 sync ./build s3://${STATIC_BUCKET}/apps/google-analytics --acl public-read"
+    "deploy": "aws s3 sync ./build ${STATIC_S3_BASE}/google-analytics --acl public-read"
   },
   "dependencies": {
     "@contentful/forma-36-fcss": "^0.0.20",

--- a/apps/google-analytics/package.json
+++ b/apps/google-analytics/package.json
@@ -26,7 +26,7 @@
     "start": "contentful-extension-scripts start --serve-only",
     "build": "contentful-extension-scripts build --no-inline",
     "lint:fixme": "eslint ./ --ext .js,.jsx,.ts,.tsx && tsc -p ./ --noEmit",
-    "deploy": "npm run build && aws s3 sync ./build ${STATIC_APPS_BUCKET}/apps/google-analytics --acl public-read"
+    "deploy": "aws s3 sync ./build ${STATIC_APPS_BUCKET}/apps/google-analytics --acl public-read"
   },
   "dependencies": {
     "@contentful/forma-36-fcss": "^0.0.20",

--- a/apps/image-focal-point/package.json
+++ b/apps/image-focal-point/package.json
@@ -19,7 +19,7 @@
     "start": "contentful-extension-scripts start --serve-only",
     "build": "contentful-extension-scripts build --no-inline",
     "lint": "eslint ./ --ext .js,.jsx,.ts,.tsx",
-    "deploy": "aws s3 sync ./build s3://${STATIC_BUCKET}/apps/focal-point --acl public-read",
+    "deploy": "aws s3 sync ./build ${STATIC_S3_BASE}/focal-point --acl public-read",
     "test": "contentful-extension-scripts test --env=jsdom --watch",
     "test:ci": "contentful-extension-scripts test --env=jsdom"
   },

--- a/apps/image-focal-point/package.json
+++ b/apps/image-focal-point/package.json
@@ -19,7 +19,7 @@
     "start": "contentful-extension-scripts start --serve-only",
     "build": "contentful-extension-scripts build --no-inline",
     "lint": "eslint ./ --ext .js,.jsx,.ts,.tsx",
-    "deploy": "aws s3 sync ./build ${STATIC_APPS_BUCKET}/apps/focal-point --acl public-read",
+    "deploy": "aws s3 sync ./build s3://${STATIC_BUCKET}/apps/focal-point --acl public-read",
     "test": "contentful-extension-scripts test --env=jsdom --watch",
     "test:ci": "contentful-extension-scripts test --env=jsdom"
   },

--- a/apps/image-focal-point/package.json
+++ b/apps/image-focal-point/package.json
@@ -21,7 +21,7 @@
     "lint": "eslint ./ --ext .js,.jsx,.ts,.tsx",
     "deploy": "aws s3 sync ./build ${STATIC_APPS_BUCKET}/apps/focal-point --acl public-read",
     "test": "contentful-extension-scripts test --env=jsdom --watch",
-    "test:ci": "contentful-extension-scripts test --env=jsdom --coverage"
+    "test:ci": "contentful-extension-scripts test --env=jsdom"
   },
   "dependencies": {
     "@contentful/forma-36-fcss": "0.0.31",

--- a/apps/image-focal-point/package.json
+++ b/apps/image-focal-point/package.json
@@ -19,7 +19,7 @@
     "start": "contentful-extension-scripts start --serve-only",
     "build": "contentful-extension-scripts build --no-inline",
     "lint": "eslint ./ --ext .js,.jsx,.ts,.tsx",
-    "deploy": "npm run build && aws s3 sync ./build ${STATIC_APPS_BUCKET}/apps/focal-point --acl public-read",
+    "deploy": "aws s3 sync ./build ${STATIC_APPS_BUCKET}/apps/focal-point --acl public-read",
     "test": "contentful-extension-scripts test --env=jsdom --watch",
     "test:ci": "contentful-extension-scripts test --env=jsdom --coverage"
   },

--- a/apps/jira/functions/package.json
+++ b/apps/jira/functions/package.json
@@ -10,7 +10,7 @@
     "prettify": "prettier --config ./.prettierrc --write '{bin/*,lib/**/*.ts,typings/**.*.ts,test/**/*.ts,*.json,*.ts}'",
     "test": "ts-mocha '**/*.spec.ts'",
     "test:ci": "npm run test",
-    "deploy": "sls deploy --stage prd"
+    "deploy": "sls deploy --stage $STAGE"
   },
   "dependencies": {
     "aws-sdk": "^2.581.0",

--- a/apps/jira/functions/package.json
+++ b/apps/jira/functions/package.json
@@ -10,7 +10,7 @@
     "prettify": "prettier --config ./.prettierrc --write '{bin/*,lib/**/*.ts,typings/**.*.ts,test/**/*.ts,*.json,*.ts}'",
     "test": "ts-mocha '**/*.spec.ts'",
     "test:ci": "npm run test",
-    "deploy": "npm run build && sls deploy --stage prd"
+    "deploy": "sls deploy --stage prd"
   },
   "dependencies": {
     "aws-sdk": "^2.581.0",

--- a/apps/jira/jira-app/package.json
+++ b/apps/jira/jira-app/package.json
@@ -29,7 +29,7 @@
     "start": "contentful-extension-scripts start --serve-only",
     "build": "contentful-extension-scripts build --no-inline",
     "lint": "eslint ./ --ext .js,.jsx,.ts,.tsx && tsc -p ./ --noEmit",
-    "deploy": "aws s3 sync ./build s3://${STATIC_JIRA_BUCKET} --acl public-read",
+    "deploy": "aws s3 sync ./build ${STATIC_JIRA_S3_BASE} --acl public-read",
     "test": "contentful-extension-scripts test --env=jsdom",
     "test:ci": "contentful-extension-scripts test --env=jsdom",
     "test:dev": "contentful-extension-scripts test --env=jsdom --watch",

--- a/apps/jira/jira-app/package.json
+++ b/apps/jira/jira-app/package.json
@@ -29,7 +29,7 @@
     "start": "contentful-extension-scripts start --serve-only",
     "build": "contentful-extension-scripts build --no-inline",
     "lint": "eslint ./ --ext .js,.jsx,.ts,.tsx && tsc -p ./ --noEmit",
-    "deploy": "npm run build && aws s3 sync ./build s3://cf-apps-jira --acl public-read",
+    "deploy": "aws s3 sync ./build s3://cf-apps-jira --acl public-read",
     "test": "contentful-extension-scripts test --env=jsdom",
     "test:ci": "contentful-extension-scripts test --env=jsdom --coverage",
     "test:dev": "contentful-extension-scripts test --env=jsdom --watch",

--- a/apps/jira/jira-app/package.json
+++ b/apps/jira/jira-app/package.json
@@ -29,7 +29,7 @@
     "start": "contentful-extension-scripts start --serve-only",
     "build": "contentful-extension-scripts build --no-inline",
     "lint": "eslint ./ --ext .js,.jsx,.ts,.tsx && tsc -p ./ --noEmit",
-    "deploy": "aws s3 sync ./build s3://cf-apps-jira --acl public-read",
+    "deploy": "aws s3 sync ./build s3://${STATIC_JIRA_BUCKET} --acl public-read",
     "test": "contentful-extension-scripts test --env=jsdom",
     "test:ci": "contentful-extension-scripts test --env=jsdom",
     "test:dev": "contentful-extension-scripts test --env=jsdom --watch",

--- a/apps/jira/jira-app/package.json
+++ b/apps/jira/jira-app/package.json
@@ -31,7 +31,7 @@
     "lint": "eslint ./ --ext .js,.jsx,.ts,.tsx && tsc -p ./ --noEmit",
     "deploy": "aws s3 sync ./build s3://cf-apps-jira --acl public-read",
     "test": "contentful-extension-scripts test --env=jsdom",
-    "test:ci": "contentful-extension-scripts test --env=jsdom --coverage",
+    "test:ci": "contentful-extension-scripts test --env=jsdom",
     "test:dev": "contentful-extension-scripts test --env=jsdom --watch",
     "pretty": "prettier --config ./.prettierrc --write '{**/*.tsx,**/*.ts}'"
   },

--- a/apps/netlify/package.json
+++ b/apps/netlify/package.json
@@ -32,7 +32,7 @@
   "scripts": {
     "start": "contentful-extension-scripts start --serve-only",
     "build": "contentful-extension-scripts build --no-inline",
-    "deploy": "aws s3 sync ./build ${STATIC_APPS_BUCKET}/apps/netlify --acl public-read",
+    "deploy": "aws s3 sync ./build s3://${STATIC_BUCKET}/apps/netlify --acl public-read",
     "test": "TZ=UTC contentful-extension-scripts test --env=jsdom --watch",
     "test:ci": "TZ=UTC contentful-extension-scripts test --env=jsdom"
   },

--- a/apps/netlify/package.json
+++ b/apps/netlify/package.json
@@ -34,7 +34,7 @@
     "build": "contentful-extension-scripts build --no-inline",
     "deploy": "aws s3 sync ./build ${STATIC_APPS_BUCKET}/apps/netlify --acl public-read",
     "test": "TZ=UTC contentful-extension-scripts test --env=jsdom --watch",
-    "test:ci": "TZ=UTC contentful-extension-scripts test --env=jsdom --coverage"
+    "test:ci": "TZ=UTC contentful-extension-scripts test --env=jsdom"
   },
   "browserslist": [
     "last 5 Chrome version",

--- a/apps/netlify/package.json
+++ b/apps/netlify/package.json
@@ -32,7 +32,7 @@
   "scripts": {
     "start": "contentful-extension-scripts start --serve-only",
     "build": "contentful-extension-scripts build --no-inline",
-    "deploy": "aws s3 sync ./build s3://${STATIC_BUCKET}/apps/netlify --acl public-read",
+    "deploy": "aws s3 sync ./build ${STATIC_S3_BASE}/netlify --acl public-read",
     "test": "TZ=UTC contentful-extension-scripts test --env=jsdom --watch",
     "test:ci": "TZ=UTC contentful-extension-scripts test --env=jsdom"
   },

--- a/apps/netlify/package.json
+++ b/apps/netlify/package.json
@@ -32,7 +32,7 @@
   "scripts": {
     "start": "contentful-extension-scripts start --serve-only",
     "build": "contentful-extension-scripts build --no-inline",
-    "deploy": "npm run build && aws s3 sync ./build ${STATIC_APPS_BUCKET}/apps/netlify --acl public-read",
+    "deploy": "aws s3 sync ./build ${STATIC_APPS_BUCKET}/apps/netlify --acl public-read",
     "test": "TZ=UTC contentful-extension-scripts test --env=jsdom --watch",
     "test:ci": "TZ=UTC contentful-extension-scripts test --env=jsdom --coverage"
   },

--- a/apps/optimizely/package.json
+++ b/apps/optimizely/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "start": "contentful-extension-scripts start --serve-only",
     "build": "contentful-extension-scripts build --no-inline",
-    "deploy": "aws s3 sync ./build ${STATIC_APPS_BUCKET}/apps/optimizely --acl public-read",
+    "deploy": "aws s3 sync ./build s3://${STATIC_BUCKET}/apps/optimizely --acl public-read",
     "test": "TZ=UTC contentful-extension-scripts test --watch",
     "test:ci": "TZ=UTC contentful-extension-scripts test --env=jsdom"
   },

--- a/apps/optimizely/package.json
+++ b/apps/optimizely/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "start": "contentful-extension-scripts start --serve-only",
     "build": "contentful-extension-scripts build --no-inline",
-    "deploy": "npm run build && aws s3 sync ./build ${STATIC_APPS_BUCKET}/apps/optimizely --acl public-read",
+    "deploy": "aws s3 sync ./build ${STATIC_APPS_BUCKET}/apps/optimizely --acl public-read",
     "test": "TZ=UTC contentful-extension-scripts test --watch",
     "test:ci": "TZ=UTC contentful-extension-scripts test --env=jsdom --coverage"
   },

--- a/apps/optimizely/package.json
+++ b/apps/optimizely/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "start": "contentful-extension-scripts start --serve-only",
     "build": "contentful-extension-scripts build --no-inline",
-    "deploy": "aws s3 sync ./build s3://${STATIC_BUCKET}/apps/optimizely --acl public-read",
+    "deploy": "aws s3 sync ./build ${STATIC_S3_BASE}/optimizely --acl public-read",
     "test": "TZ=UTC contentful-extension-scripts test --watch",
     "test:ci": "TZ=UTC contentful-extension-scripts test --env=jsdom"
   },

--- a/apps/optimizely/package.json
+++ b/apps/optimizely/package.json
@@ -33,7 +33,7 @@
     "build": "contentful-extension-scripts build --no-inline",
     "deploy": "aws s3 sync ./build ${STATIC_APPS_BUCKET}/apps/optimizely --acl public-read",
     "test": "TZ=UTC contentful-extension-scripts test --watch",
-    "test:ci": "TZ=UTC contentful-extension-scripts test --env=jsdom --coverage"
+    "test:ci": "TZ=UTC contentful-extension-scripts test --env=jsdom"
   },
   "browserslist": [
     "last 5 Chrome version",

--- a/apps/shopify/package.json
+++ b/apps/shopify/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "start": "contentful-extension-scripts start --serve-only",
     "build": "contentful-extension-scripts build --no-inline",
-    "deploy": "aws s3 sync ./build ${STATIC_APPS_BUCKET}/apps/shopify --acl public-read"
+    "deploy": "aws s3 sync ./build s3://${STATIC_BUCKET}/apps/shopify --acl public-read"
   },
   "browserslist": [
     "last 5 Chrome version",

--- a/apps/shopify/package.json
+++ b/apps/shopify/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "start": "contentful-extension-scripts start --serve-only",
     "build": "contentful-extension-scripts build --no-inline",
-    "deploy": "aws s3 sync ./build s3://${STATIC_BUCKET}/apps/shopify --acl public-read"
+    "deploy": "aws s3 sync ./build ${STATIC_S3_BASE}/shopify --acl public-read"
   },
   "browserslist": [
     "last 5 Chrome version",

--- a/apps/shopify/package.json
+++ b/apps/shopify/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "start": "contentful-extension-scripts start --serve-only",
     "build": "contentful-extension-scripts build --no-inline",
-    "deploy": "npm run build && aws s3 sync ./build ${STATIC_APPS_BUCKET}/apps/shopify --acl public-read"
+    "deploy": "aws s3 sync ./build ${STATIC_APPS_BUCKET}/apps/shopify --acl public-read"
   },
   "browserslist": [
     "last 5 Chrome version",

--- a/apps/smartling/frontend/package.json
+++ b/apps/smartling/frontend/package.json
@@ -31,7 +31,7 @@
     "build": "contentful-extension-scripts build --no-inline",
     "lint": "eslint ./ --ext .js,.jsx,.ts,.tsx && tsc -p ./ --noEmit",
     "test": "TZ=UTC contentful-extension-scripts test --env=jsdom",
-    "test:ci": "contentful-extension-scripts test --env=jsdom --coverage",
+    "test:ci": "contentful-extension-scripts test --env=jsdom",
     "test:dev": "TZ=UTC contentful-extension-scripts test --env=jsdom --watch",
     "pretty": "prettier --config ./.prettierrc --write '{**/*.tsx,**/*.ts}'"
   },

--- a/apps/smartling/lambda/package.json
+++ b/apps/smartling/lambda/package.json
@@ -9,7 +9,7 @@
     "pretty": "prettier --config ./.prettierrc --write '{src/*.ts,src/*.spec.ts}'",
     "test": "jest --watch",
     "test:ci": "jest",
-    "deploy": "sls deploy --stage prd"
+    "deploy": "sls deploy --stage $STAGE"
   },
   "dependencies": {
     "@types/express": "^4.17.2",

--- a/apps/smartling/lambda/package.json
+++ b/apps/smartling/lambda/package.json
@@ -4,17 +4,12 @@
   "private": true,
   "scripts": {
     "start": "LOCAL_DEV=true ts-node src/index.ts",
-    "clean": "rimraf built",
-    "build-lambda": "npm run clean && tsc",
-    "build-frontend": "cd ../frontend && npm run build",
-    "build": "npm run clean && npm run build-lambda && npm run build-frontend",
+    "build": "rimraf built && tsc",
     "lint": "tslint --project ./tsconfig.json",
-    "lint-fix": "tslint --project ./tsconfig.json --fix",
     "pretty": "prettier --config ./.prettierrc --write '{src/*.ts,src/*.spec.ts}'",
-    "test": "LOCAL_DEV=true jest **/*.spec.ts",
-    "test:ci": "npm run build-frontend && npm run test",
-    "test-dev": "LOCAL_DEV=true jest **/*.spec.ts --watch",
-    "deploy": "npm run build && sls deploy --stage prd"
+    "test": "jest --watch",
+    "test:ci": "jest",
+    "deploy": "sls deploy --stage prd"
   },
   "dependencies": {
     "@types/express": "^4.17.2",

--- a/lib/shared-dam-app/package.json
+++ b/lib/shared-dam-app/package.json
@@ -40,7 +40,7 @@
   "scripts": {
     "tsc": "tsc -p ./ --noEmit",
     "test": "contentful-extension-scripts test --env=jsdom --watch",
-    "test:ci": "contentful-extension-scripts test --env=jsdom --coverage"
+    "test:ci": "contentful-extension-scripts test --env=jsdom"
   },
   "browserslist": [
     "last 5 Chrome version",

--- a/lib/shared-sku-app/package.json
+++ b/lib/shared-sku-app/package.json
@@ -40,7 +40,7 @@
   "scripts": {
     "tsc": "tsc -p ./ --noEmit",
     "test": "contentful-extension-scripts test --env=jsdom --watch",
-    "test:ci": "contentful-extension-scripts test --env=jsdom --coverage"
+    "test:ci": "contentful-extension-scripts test --env=jsdom"
   },
   "browserslist": [
     "last 5 Chrome version",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "bootstrap": "lerna bootstrap --no-ci",
     "bootstrap:ci": "lerna bootstrap --ci --concurrency=2",
     "lint": "lerna run lint --concurrency=2",
-    "build": "lerna run build --concurrency=2",
+    "build": "lerna run build --concurrency=1",
     "test": "lerna run test:ci --concurrency=2",
     "deploy": "lerna run deploy --concurrency=2"
   },

--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
   "private": true,
   "scripts": {
     "bootstrap": "lerna bootstrap --no-ci",
-    "bootstrap:ci": "lerna bootstrap --ci",
-    "lint": "lerna run lint --concurrency=1",
-    "build": "lerna run build --concurrency=1",
-    "test": "lerna run test:ci --concurrency=1",
-    "deploy": "lerna run deploy --concurrency=1"
+    "bootstrap:ci": "lerna bootstrap --ci --concurrency=2",
+    "lint": "lerna run lint --concurrency=2",
+    "build": "lerna run build --concurrency=2",
+    "test": "lerna run test:ci --concurrency=2",
+    "deploy": "lerna run deploy --concurrency=2"
   },
   "dependencies": {
     "lerna": "^3.20.2"

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "apps",
   "private": true,
   "scripts": {
-    "bootstrap": "lerna bootstrap --no-ci --concurrency=1",
-    "postinstall": "npm run bootstrap",
+    "bootstrap": "lerna bootstrap --no-ci",
+    "bootstrap:ci": "lerna bootstrap --ci",
     "lint": "lerna run lint --concurrency=1",
     "build": "lerna run build --concurrency=1",
     "test": "lerna run test:ci --concurrency=1",

--- a/package.json
+++ b/package.json
@@ -1,14 +1,15 @@
 {
   "name": "apps",
+  "private": true,
   "scripts": {
-    "lint": "lerna run lint --concurrency=1",
-    "test": "lerna run test:ci --concurrency=1",
     "bootstrap": "lerna bootstrap --no-ci --concurrency=1",
-    "deploy": "lerna run deploy",
-    "postinstall": "npm run bootstrap"
+    "postinstall": "npm run bootstrap",
+    "lint": "lerna run lint --concurrency=1",
+    "build": "lerna run build --concurrency=1",
+    "test": "lerna run test:ci --concurrency=1",
+    "deploy": "lerna run deploy --concurrency=1"
   },
   "dependencies": {
     "lerna": "^3.20.2"
-  },
-  "private": true
+  }
 }


### PR DESCRIPTION
This PR:

- [x] Cuts build 2-3 times thanks to use of concurrency=2 (matching number of vCPUs) for all tasks but bundling (experienced hanging processes), use of `npm ci`, skipping code coverage instrumentation, not reinstalling dependencies in deployment step
- [x] Separates building artifacts from testing/deploying them
- [x] Stops to default deployment stage to production (to avoid deployment to production from local environments)
- [x] Always deploys all apps to verify that the process wasn't broken in a feature branch

Note that the test deployment from all branches ends up in the same location (same bucket, same stage). It's not intended to be used for sharing because builds will eventually override each other. The sole purpose of deployment is to test if it wasn't broken.

<img width="713" alt="Screen Shot 2020-02-14 at 15 01 03" src="https://user-images.githubusercontent.com/1936596/74537769-08f28e00-4f3b-11ea-8032-8e757c4a38e2.png">
