### PR TITLE
GA: Add "Last 24 hours"; Improve config validation

### DIFF
--- a/apps/google-analytics/src/Analytics.tsx
+++ b/apps/google-analytics/src/Analytics.tsx
@@ -7,12 +7,12 @@ import { formatLargeNumbers, DAY_IN_MS, getDateRangeInterval, getErrorNotificati
 import { RangeOption, AnalyticsProps, AnalyticsState, ChartData, GapiError } from './typings';
 
 const RANGE_OPTIONS: RangeOption[] = [
+  { label: 'Last 24 hours', startDaysAgo: 1, endDaysAgo: 0 },
   { label: 'Last 7 days', startDaysAgo: 7, endDaysAgo: 0 },
-  { label: 'Last 28 days', startDaysAgo: 28, endDaysAgo: 0 },
-  { label: 'Last 60 days', startDaysAgo: 60, endDaysAgo: 0 }
+  { label: 'Last 28 days', startDaysAgo: 28, endDaysAgo: 0 }
 ];
 
-const INITIAL_RANGE_INDEX = 0;
+const INITIAL_RANGE_INDEX = 1;
 
 function getRangeDates(rangeOptionIndex: number) {
   const range = RANGE_OPTIONS[rangeOptionIndex];

--- a/apps/google-analytics/src/Analytics.tsx
+++ b/apps/google-analytics/src/Analytics.tsx
@@ -59,7 +59,7 @@ export default class Analytics extends React.Component<AnalyticsProps, Analytics
       this.props.setHelpText(errorNotification)
     }
     else {
-      this.props.sdk.notifier.error(error.message)
+      this.props.sdk.notifier.error(`Google Analytics: ${error.message}`)
     }
 
     this.props.gapi.analytics.auth.signOut()

--- a/apps/google-analytics/src/AppConfig.tsx
+++ b/apps/google-analytics/src/AppConfig.tsx
@@ -291,7 +291,6 @@ export default class AppConfig extends React.Component<AppConfigParams, AppConfi
                   name={'contentType-' + index}
                   id={'contentType-' + index}
                   value={key}
-                  hasError={!key}
                   onChange={(event: React.ChangeEvent<HTMLSelectElement>) =>
                     this.handleContentTypeChange(key, event.target.value)
                   }>

--- a/apps/google-analytics/src/AppConfig.tsx
+++ b/apps/google-analytics/src/AppConfig.tsx
@@ -38,7 +38,39 @@ export default class AppConfig extends React.Component<AppConfigParams, AppConfi
       getAndUpdateSavedParams(sdk)
     ]);
 
+    const allContentTypes = sortBy(spaceContentTypes, 'name').reduce(
+      (acc: AllContentTypes, contentType) => {
+        const fields = sortBy(
+          // use only short text fields of content type
+          contentType.fields.filter(f => f.type === 'Symbol'),
+          // sort by field name
+          'name'
+        )
+
+        if (fields.length) {
+          acc[contentType.sys.id] = {
+            ...contentType,
+            fields
+          };
+        }
+
+        return acc;
+      },
+      {}
+    );
     const { contentTypes } = savedParams;
+
+    for (const [type, { slugField }] of Object.entries(contentTypes)) {
+      if (
+        // if the saved content type is no longer in the list of all available types
+        !(type in allContentTypes) ||
+        // or the saved slugField is no longer available
+        !allContentTypes[type].fields.some(f => f.id === slugField)
+      ) {
+        // remove the content type from the list
+        delete contentTypes[type]
+      }
+    }
 
     // add an incomplete contentType entry if there are none saved
     if (!Object.keys(contentTypes).length) {
@@ -48,27 +80,7 @@ export default class AppConfig extends React.Component<AppConfigParams, AppConfi
     // eslint-disable-next-line react/no-did-mount-set-state
     this.setState(
       {
-        // sort contentTypes by display name
-        allContentTypes: sortBy(spaceContentTypes, 'name').reduce(
-          (acc: AllContentTypes, contentType) => {
-            const fields = sortBy(
-              // use only short text fields of content type
-              contentType.fields.filter(f => f.type === 'Symbol'),
-                // sort by field name
-                'name'
-            )
-
-            if (fields.length) {
-              acc[contentType.sys.id] = {
-                ...contentType,
-                fields
-              };
-            }
-
-            return acc;
-          },
-          {}
-        ),
+        allContentTypes,
         contentTypes,
         clientId: savedParams.clientId || '',
         viewId: savedParams.viewId || ''

--- a/apps/google-analytics/src/utils.ts
+++ b/apps/google-analytics/src/utils.ts
@@ -6,7 +6,7 @@ export function formatDate(date: Date) {
   return date.toISOString().slice(0, 10);
 }
 
-export async function getAndUpdateSavedParams(sdk: AppExtensionSDK) {
+export async function getAndUpdateSavedParams(sdk: AppExtensionSDK): Promise<SavedParams> {
   const { space, ids } = sdk;
   const [savedParams, eisResponse] = await Promise.all([
     sdk.app.getParameters() as Promise<SavedParams>,

--- a/apps/google-analytics/src/utils.ts
+++ b/apps/google-analytics/src/utils.ts
@@ -67,7 +67,7 @@ export const DAY_IN_MS = 1000 * 60 * 60 * 24;
 const daysBreakpoints = [
   { lowerLimit: 29, interval: 'nthWeek' },
   { lowerLimit: 5, interval: 'date' },
-  { lowerLimit: -Infinity, interval: 'nthhour' }
+  { lowerLimit: -Infinity, interval: 'dateHour' }
 ];
 
 export function getDateRangeInterval(start: Date, end: Date) {


### PR DESCRIPTION
The content type dropdown in the app config no longer gets a red border when a value isn't selected.

The slug field will be red when a content type is selected and a slug wasn't detected automatically - no `/^slug/i` field and multiple short text fields to chose from). The form will fail to save if there are no content types selected or a content type is selected without a slug field selected.

If a selected slugField is deleted from a content type or the content type itself is deleted, it will be removed from the content type list in the app's config page the next time it's opened.