### PR TITLE
fix(typeform): pass typeform client id to the frontend

### DIFF
--- a/apps/typeform/frontend/src/Auth/TypeformOAuth.tsx
+++ b/apps/typeform/frontend/src/Auth/TypeformOAuth.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { AppExtensionSDK } from 'contentful-ui-extensions-sdk';
 import { Button } from '@contentful/forma-36-react-components';
-import { BASE_URL } from '../constants';
+import { BASE_URL, CLIENT_ID } from '../constants';
 
 interface Props {
   sdk?: AppExtensionSDK;
@@ -32,7 +32,7 @@ export function TypeformOAuth({
 
   const executeOauth = () => {
     const url = `${BASE_URL}/oauth/authorize?&client_id=${
-      process.env.CLIENT_ID
+      CLIENT_ID
     }&redirect_uri=${encodeURIComponent(
       `${window.location.origin}/callback`
     )}&scope=forms:read+workspaces:read`;

--- a/apps/typeform/frontend/src/constants.ts
+++ b/apps/typeform/frontend/src/constants.ts
@@ -1,2 +1,11 @@
-export const SDK_WINDOW_HEIGHT = 450;
-export const BASE_URL = 'https://api.typeform.com';
+
+const SDK_WINDOW_HEIGHT = 450;
+const BASE_URL = 'https://api.typeform.com';
+const CLIENT_ID = 'HC3UDnoiaP1UCMqJ7kCAyTFdHrDt8nLtXx4BKRJxom2M'
+
+export {
+  SDK_WINDOW_HEIGHT,
+  BASE_URL,
+  CLIENT_ID,
+}
+


### PR DESCRIPTION
## Target

Since the typeform `client id` is publicly anyway in the URL it can be passed as a constant to the OAuth flow. 