### PR TITLE
exporting targetState field utils for external use

### DIFF
--- a/lib/shared-dam-app/src/index.tsx
+++ b/lib/shared-dam-app/src/index.tsx
@@ -19,6 +19,8 @@ import AppConfig from './AppConfig/AppConfig';
 
 import { Integration } from './interfaces';
 
+export * from './AppConfig/fields';
+
 export function setup(integration: Integration) {
   init(sdk => {
     const root = document.getElementById('root');


### PR DESCRIPTION
This change helps improve the reusability of the utils we have from the shared-dam-app libs. For example, Mux (#80) would like to use the utilities without the UI. 