### PR TITLE
Making shared-dam utils export in different location.

### DIFF
--- a/lib/shared-dam-app/src/index.tsx
+++ b/lib/shared-dam-app/src/index.tsx
@@ -19,8 +19,6 @@ import AppConfig from './AppConfig/AppConfig';
 
 import { Integration } from './interfaces';
 
-export * from './AppConfig/fields';
-
 export function setup(integration: Integration) {
   init(sdk => {
     const root = document.getElementById('root');

--- a/lib/shared-dam-app/src/utils.ts
+++ b/lib/shared-dam-app/src/utils.ts
@@ -1,0 +1,2 @@
+export * from './AppConfig/fields';
+


### PR DESCRIPTION
What this fix is doing:

When importing `contentful-ui-extensions-sdk`, the `init` function is exported but before export, `createInitializer ` is called. This means that if you import the SDK multiple times in a project, it will initialize multiple times which can lead to duplication of calls.

https://github.com/contentful/ui-extensions-sdk/blob/master/lib/index.ts#L7

The Mux app has exposed this bug by trying to import components of the shared-dam-app lib through the index export file. Because of this, the SDK is also invoked.

This fix simply allows for importing the utility methods without invoking the SDK again.