### PR TITLE
Mux asset error handling

### DIFF
--- a/apps/mux/src/config.tsx
+++ b/apps/mux/src/config.tsx
@@ -147,7 +147,14 @@ class Config extends React.Component<ConfigProps, IState> {
               configure for Mux Video. For those configured fields you'll get a
               video uploader in the Contentful UI. Your videos will be
               transcoded, stored and delivered by{' '}
-              <TextLink href="https://mux.com" rel="noopener noreferrer" target="_blank">Mux</TextLink>.
+              <TextLink
+                href="https://mux.com"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                Mux
+              </TextLink>
+              .
             </Paragraph>
           </Typography>
           <hr className="config-splitter" />
@@ -156,7 +163,11 @@ class Config extends React.Component<ConfigProps, IState> {
               <Heading>API credentials</Heading>
               <Paragraph>
                 These can be obtained by clicking 'Generate new token' in the{' '}
-                <TextLink href="https://dashboard.mux.com/settings/access-tokens" rel="noopener noreferrer" target="_blank">
+                <TextLink
+                  href="https://dashboard.mux.com/settings/access-tokens"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
                   settings on your dashboard
                 </TextLink>
                 . Note that you must be an admin in your Mux account.
@@ -257,9 +268,12 @@ class Config extends React.Component<ConfigProps, IState> {
 
   async onConfigure() {
     const { parameters } = this.state;
-    const isParamValid = (value?: string) => (value || '').trim().length > 0
+    const isParamValid = (value?: string) => (value || '').trim().length > 0;
 
-    if (!isParamValid(parameters.muxAccessTokenId) || !isParamValid(parameters.muxAccessTokenSecret)) {
+    if (
+      !isParamValid(parameters.muxAccessTokenId) ||
+      !isParamValid(parameters.muxAccessTokenSecret)
+    ) {
       this.props.sdk.notifier.error(
         'Please enter a valid access token and secret.'
       );

--- a/apps/mux/src/index.tsx
+++ b/apps/mux/src/index.tsx
@@ -178,6 +178,7 @@ export class App extends React.Component<AppProps, AppState> {
       playbackId: undefined,
       ready: undefined,
       ratio: undefined,
+      error: undefined,
     });
     this.setState({ error: false, errorShowResetAction: false });
   };

--- a/apps/mux/test/index.test.tsx
+++ b/apps/mux/test/index.test.tsx
@@ -65,6 +65,23 @@ test('displays a player when the asset is ready', () => {
   expect(wrapper.find('Player')).toHaveLength(1);
 });
 
+test('displays an error if the asset is errored', () => {
+  const mockedSdk = {
+    ...SDK_MOCK,
+    field: {
+      ...SDK_MOCK.field,
+      getValue: () => ({
+        error: 'Input file does not contain a duration'
+      }),
+    },
+  };
+
+  const wrapper = mount(<App sdk={mockedSdk as any} />);
+  const note = wrapper.find('Note');
+  expect(note.prop('noteType')).toBe('negative');
+  expect(note.text()).toContain('Input file does not contain a duration');
+});
+
 test('displays a loading state between the asset getting created and waiting for it to be ready', () => {
   const mockedSdk = {
     ...SDK_MOCK,


### PR DESCRIPTION
This handles assets that are in the errored state. This state most commonly happens when someone uploads a file that is not a video file.

![asset-error-handling-contentful](https://user-images.githubusercontent.com/764988/83558780-6568c180-a4c8-11ea-8265-023a8038271a.gif)
