### PR TITLE
fix: stop cloudinary covering up dialog header and close button

### DIFF
--- a/apps/cloudinary/src/index.html
+++ b/apps/cloudinary/src/index.html
@@ -16,6 +16,7 @@
       }
 
       iframe {
+        max-height: 825px;
         height: 100vh;
         position: relative;
       }


### PR DESCRIPTION
add fixed height to Cloudinary iframe, this fixes a rendering bug where Cloudinary would
cover up the modal header when you opened the comments pane in the edit widget

This isn't a great fix really, as to be honest I'm not sure why the rendering issue is happening. Cloudinary are looking into this on their end as well, and should hopefully be able to shed more light. 