### PR TITLE
feat: improve empty states of assignments [EXT-1960]

### DIFF
--- a/apps/commercetools/src/AppConfig/FieldTypeInstructions.tsx
+++ b/apps/commercetools/src/AppConfig/FieldTypeInstructions.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
-import { Heading, Paragraph } from '@contentful/forma-36-react-components';
+import { Heading, Paragraph, TextLink } from '@contentful/forma-36-react-components';
 
 interface Props {
   contentTypesFound: boolean;
+  space: string;
+  environment: string;
 }
 
-export const FieldTypeInstructions = ({ contentTypesFound }: Props) => (
+export const FieldTypeInstructions = ({ contentTypesFound, space, environment }: Props) => (
   <>
     <Heading>Assign to fields</Heading>
     {contentTypesFound ? (
@@ -20,7 +22,18 @@ export const FieldTypeInstructions = ({ contentTypesFound }: Props) => (
         </Paragraph>
         <Paragraph>
           There are <strong>no content types with Short text</strong> fields in this environment.
-          You can add one here later.
+          You can add one in your{' '}
+          <TextLink
+            linkType="primary"
+            target="_blank"
+            href={
+              environment === 'master'
+                ? `https://app.contentful.com/spaces/${space}/content_types`
+                : `https://app.contentful.com/spaces/${space}/environments/${environment}/content_types`
+            }>
+            content model
+          </TextLink>{' '}
+          and assign it to the app from this screen.
         </Paragraph>
       </>
     )}

--- a/apps/commercetools/src/AppConfig/index.tsx
+++ b/apps/commercetools/src/AppConfig/index.tsx
@@ -1,22 +1,18 @@
-import * as React from "react";
+import * as React from 'react';
 
-import get from "lodash/get";
-import { AppExtensionSDK } from "contentful-ui-extensions-sdk";
+import get from 'lodash/get';
+import { AppExtensionSDK } from 'contentful-ui-extensions-sdk';
 import {
   Heading,
   Paragraph,
   Typography,
   TextField,
   Form
-} from "@contentful/forma-36-react-components";
+} from '@contentful/forma-36-react-components';
 
-import FieldSelector from "./FieldSelector";
+import FieldSelector from './FieldSelector';
 
-import {
-  parameterDefinitions,
-  toInputParameters,
-  toAppParameters
-} from "./parameters";
+import { parameterDefinitions, toInputParameters, toAppParameters } from './parameters';
 import {
   getCompatibleFields,
   editorInterfacesToSelectedFields,
@@ -25,14 +21,14 @@ import {
   ContentType,
   CompatibleFields,
   FieldsConfig
-} from "./fields";
-import { validateParameters } from "./parameters";
+} from './fields';
+import { validateParameters } from './parameters';
 
-import { styles } from "./styles";
+import { styles } from './styles';
 
-import { Hash } from "../interfaces";
-import logo from "../logo.svg";
-import { FieldTypeInstructions } from "./FieldTypeInstructions";
+import { Hash } from '../interfaces';
+import logo from '../logo.svg';
+import { FieldTypeInstructions } from './FieldTypeInstructions';
 
 interface Props {
   sdk: AppExtensionSDK;
@@ -64,7 +60,7 @@ export default class AppConfig extends React.Component<Props, State> {
       app.getParameters()
     ]);
 
-    const fieldsConfig = get(parameters, ["fieldsConfig"], {});
+    const fieldsConfig = get(parameters, ['fieldsConfig'], {});
 
     const contentTypes = (contentTypesResponse as Hash).items as ContentType[];
     const editorInterfaces = (eisResponse as Hash).items as EditorInterface[];
@@ -80,11 +76,7 @@ export default class AppConfig extends React.Component<Props, State> {
       {
         contentTypes: filteredContentTypes,
         compatibleFields,
-        selectedFields: editorInterfacesToSelectedFields(
-          editorInterfaces,
-          fieldsConfig,
-          ids.app
-        ),
+        selectedFields: editorInterfacesToSelectedFields(editorInterfaces, fieldsConfig, ids.app),
         parameters: toInputParameters(parameterDefinitions, parameters)
       },
       () => app.setReady()
@@ -124,12 +116,11 @@ export default class AppConfig extends React.Component<Props, State> {
   };
 
   render() {
+    const { contentTypes, compatibleFields, selectedFields, parameters } = this.state;
+    const { sdk } = this.props;
     const {
-      contentTypes,
-      compatibleFields,
-      selectedFields,
-      parameters
-    } = this.state;
+      ids: { space, environment }
+    } = sdk;
 
     return (
       <div className={styles.background}>
@@ -137,9 +128,8 @@ export default class AppConfig extends React.Component<Props, State> {
           <Typography>
             <Heading>About commercetools</Heading>
             <Paragraph>
-              The commercetools app allows editors to select products from their
-              commercetools account and reference them inside of Contentful
-              entries.
+              The commercetools app allows editors to select products from their commercetools
+              account and reference them inside of Contentful entries.
             </Paragraph>
 
             <hr className={styles.splitter} />
@@ -156,7 +146,7 @@ export default class AppConfig extends React.Component<Props, State> {
                     name={key}
                     labelText={def.name}
                     textInputProps={{
-                      width: "large",
+                      width: 'large',
                       maxLength: 255
                     }}
                     helpText={def.description}
@@ -170,6 +160,8 @@ export default class AppConfig extends React.Component<Props, State> {
             <hr className={styles.splitter} />
 
             <FieldTypeInstructions
+              space={space}
+              environment={environment}
               contentTypesFound={contentTypes.length > 0}
             />
             <FieldSelector

--- a/apps/gatsby/src/AppConfig/AppConfig.js
+++ b/apps/gatsby/src/AppConfig/AppConfig.js
@@ -1,24 +1,25 @@
-import get from 'lodash.get';
-import React from 'react';
-import PropTypes from 'prop-types';
+import get from "lodash.get";
+import React from "react";
+import PropTypes from "prop-types";
 import {
   Heading,
   Typography,
   Paragraph,
   TextField,
   TextLink,
-} from '@contentful/forma-36-react-components';
-import GatsbyIcon from '../GatsbyIcon';
-import ContentTypesPanel from './ContentTypesPanel';
-import styles from '../styles';
+} from "@contentful/forma-36-react-components";
+import GatsbyIcon from "../GatsbyIcon";
+import ContentTypesPanel from "./ContentTypesPanel";
+import styles from "../styles";
 
 function editorInterfacesToEnabledContentTypes(eis, appId) {
-  const findAppWidget = item => item.widgetNamespace === 'app' && item.widgetId === appId;
+  const findAppWidget = (item) =>
+    item.widgetNamespace === "app" && item.widgetId === appId;
 
   return eis
-    .filter(ei => !!get(ei, ['sidebar'], []).find(findAppWidget))
-    .map(ei => get(ei, ['sys', 'contentType', 'sys', 'id']))
-    .filter(ctId => typeof ctId === 'string' && ctId.length > 0);
+    .filter((ei) => !!get(ei, ["sidebar"], []).find(findAppWidget))
+    .map((ei) => get(ei, ["sys", "contentType", "sys", "id"]))
+    .filter((ctId) => typeof ctId === "string" && ctId.length > 0);
 }
 
 function enabledContentTypesToTargetState(contentTypes, enabledContentTypes) {
@@ -26,25 +27,27 @@ function enabledContentTypesToTargetState(contentTypes, enabledContentTypes) {
     EditorInterface: contentTypes.reduce((acc, ct) => {
       return {
         ...acc,
-        [ct.sys.id]: enabledContentTypes.includes(ct.sys.id) ? { sidebar: { position: 3 } } : {}
+        [ct.sys.id]: enabledContentTypes.includes(ct.sys.id)
+          ? { sidebar: { position: 3 } }
+          : {},
       };
-    }, {})
+    }, {}),
   };
 }
 
 export class AppConfig extends React.Component {
   static propTypes = {
-    sdk: PropTypes.object.isRequired
+    sdk: PropTypes.object.isRequired,
   };
 
   state = {
     contentTypes: null,
     enabledContentTypes: {},
-    previewUrl: '',
-    webhookUrl: '',
-    authToken: '',
+    previewUrl: "",
+    webhookUrl: "",
+    authToken: "",
     validPreview: true,
-    validWebhook: true
+    validWebhook: true,
   };
 
   async componentDidMount() {
@@ -53,7 +56,7 @@ export class AppConfig extends React.Component {
     const [installationParams, eisRes, contentTypesRes] = await Promise.all([
       app.getParameters(),
       space.getEditorInterfaces(),
-      space.getContentTypes()
+      space.getContentTypes(),
     ]);
 
     const params = installationParams || {};
@@ -62,10 +65,13 @@ export class AppConfig extends React.Component {
     this.setState(
       {
         contentTypes: contentTypesRes.items,
-        enabledContentTypes: editorInterfacesToEnabledContentTypes(eisRes.items, ids.app),
-        previewUrl: params.previewUrl || '',
-        webhookUrl: params.webhookUrl || '',
-        authToken: params.authToken || ''
+        enabledContentTypes: editorInterfacesToEnabledContentTypes(
+          eisRes.items,
+          ids.app
+        ),
+        previewUrl: params.previewUrl || "",
+        webhookUrl: params.webhookUrl || "",
+        authToken: params.authToken || "",
       },
       () => app.setReady()
     );
@@ -74,7 +80,13 @@ export class AppConfig extends React.Component {
   }
 
   configureApp = async () => {
-    const { contentTypes, enabledContentTypes, previewUrl, webhookUrl, authToken } = this.state;
+    const {
+      contentTypes,
+      enabledContentTypes,
+      previewUrl,
+      webhookUrl,
+      authToken,
+    } = this.state;
 
     this.setState({ validPreview: true, validWebhook: true });
 
@@ -85,19 +97,19 @@ export class AppConfig extends React.Component {
       valid = false;
     }
 
-    if (!previewUrl.startsWith('http')) {
+    if (!previewUrl.startsWith("http")) {
       this.setState({ validPreview: false });
       valid = false;
     }
 
     // the webhookUrl is optional but if it is passed, check that it is valid
-    if (webhookUrl && !webhookUrl.startsWith('http')) {
+    if (webhookUrl && !webhookUrl.startsWith("http")) {
       this.setState({ validWebhook: false });
       valid = false;
     }
 
     if (!valid) {
-      this.props.sdk.notifier.error('Please review the errors in the form.');
+      this.props.sdk.notifier.error("Please review the errors in the form.");
       return false;
     }
 
@@ -105,53 +117,63 @@ export class AppConfig extends React.Component {
       parameters: {
         previewUrl,
         webhookUrl,
-        authToken
+        authToken,
       },
-      targetState: enabledContentTypesToTargetState(contentTypes, enabledContentTypes)
+      targetState: enabledContentTypesToTargetState(
+        contentTypes,
+        enabledContentTypes
+      ),
     };
   };
 
-  updatePreviewUrl = e => {
+  updatePreviewUrl = (e) => {
     this.setState({ previewUrl: e.target.value, validPreview: true });
   };
 
-  updateWebhookUrl = e => {
+  updateWebhookUrl = (e) => {
     this.setState({ webhookUrl: e.target.value, validWebhook: true });
   };
 
-  updateAuthToken = e => {
+  updateAuthToken = (e) => {
     this.setState({ authToken: e.target.value });
   };
 
   validatePreviewUrl = () => {
-    if (!this.state.previewUrl.startsWith('http')) {
+    if (!this.state.previewUrl.startsWith("http")) {
       this.setState({ validPreview: false });
     }
   };
 
   validateWebhookUrl = () => {
-    if (this.state.webhookUrl && !this.state.webhookUrl.startsWith('http')) {
+    if (this.state.webhookUrl && !this.state.webhookUrl.startsWith("http")) {
       this.setState({ validWebhook: false });
     }
   };
 
   toggleContentType = (enabledContentTypes, ctId) => {
     if (enabledContentTypes.includes(ctId)) {
-      return enabledContentTypes.filter(cur => cur !== ctId);
+      return enabledContentTypes.filter((cur) => cur !== ctId);
     } else {
       return enabledContentTypes.concat([ctId]);
     }
   };
 
-  onContentTypeToggle = ctId => {
-    this.setState(prevState => ({
+  onContentTypeToggle = (ctId) => {
+    this.setState((prevState) => ({
       ...prevState,
-      enabledContentTypes: this.toggleContentType(prevState.enabledContentTypes, ctId)
+      enabledContentTypes: this.toggleContentType(
+        prevState.enabledContentTypes,
+        ctId
+      ),
     }));
   };
 
   render() {
     const { contentTypes, enabledContentTypes } = this.state;
+    const { sdk } = this.props;
+    const {
+      ids: { space, environment },
+    } = sdk;
 
     return (
       <>
@@ -161,16 +183,19 @@ export class AppConfig extends React.Component {
             <Typography>
               <Heading>About Gatsby Cloud</Heading>
               <Paragraph>
-                This app connects to Gatsby Cloud which lets you see updates to your Gatsby site as
-                soon as you change content in Contentful. This makes it easy for content creators to
-                see changes they make to the website before going live.
+                This app connects to Gatsby Cloud which lets you see updates to
+                your Gatsby site as soon as you change content in Contentful.
+                This makes it easy for content creators to see changes they make
+                to the website before going live.
               </Paragraph>
             </Typography>
           </div>
           <hr className={styles.splitter} />
           <Typography>
             <Heading>Account Details</Heading>
-            <Paragraph>Gatsby Cloud needs a Site URL in order to preview projects.</Paragraph>
+            <Paragraph>
+              Gatsby Cloud needs a Site URL in order to preview projects.
+            </Paragraph>
             <TextField
               name="previewUrl"
               id="previewUrl"
@@ -182,11 +207,12 @@ export class AppConfig extends React.Component {
               className={styles.input}
               helpText={
                 <span>
-                  To get your Site URL, see your{' '}
+                  To get your Site URL, see your{" "}
                   <TextLink
                     href="https://www.gatsbyjs.com/dashboard/sites"
                     target="_blank"
-                    rel="noopener noreferrer">
+                    rel="noopener noreferrer"
+                  >
                     Gatsby dashboard
                   </TextLink>
                   .
@@ -194,11 +220,11 @@ export class AppConfig extends React.Component {
               }
               validationMessage={
                 !this.state.validPreview
-                  ? 'Please provide a valid URL (It should start with http)'
-                  : ''
+                  ? "Please provide a valid URL (It should start with http)"
+                  : ""
               }
               textInputProps={{
-                type: 'text'
+                type: "text",
               }}
             />
             <TextField
@@ -212,11 +238,11 @@ export class AppConfig extends React.Component {
               helpText="Optional Webhook URL. If provided, your site will be automatically rebuilt as you change content."
               validationMessage={
                 !this.state.validWebhook
-                  ? 'Please provide a valid URL (It should start with http)'
-                  : ''
+                  ? "Please provide a valid URL (It should start with http)"
+                  : ""
               }
               textInputProps={{
-                type: 'text'
+                type: "text",
               }}
             />
             <TextField
@@ -228,12 +254,18 @@ export class AppConfig extends React.Component {
               className={styles.input}
               helpText="Optional Authentication token for private Gatsby Cloud sites."
               textInputProps={{
-                type: 'password'
+                type: "password",
               }}
             />
           </Typography>
           <hr className={styles.splitter} />
-          <ContentTypesPanel contentTypes={contentTypes} enabledContentTypes={enabledContentTypes} onContentTypeToggle={this.onContentTypeToggle} />
+          <ContentTypesPanel
+            space={space}
+            environment={environment}
+            contentTypes={contentTypes}
+            enabledContentTypes={enabledContentTypes}
+            onContentTypeToggle={this.onContentTypeToggle}
+          />
         </div>
         <div className={styles.icon}>
           <GatsbyIcon />

--- a/apps/gatsby/src/AppConfig/ContentTypesPanel.js
+++ b/apps/gatsby/src/AppConfig/ContentTypesPanel.js
@@ -20,8 +20,7 @@ const ContentTypesSkeleton = () => (
 
 const NoContentTypes = ({ space, environment }) => (
   <Note noteType="warning">
-    There are no content types available in this environment. You can add one in
-    your{" "}
+    There are no content types available in this environment. You can add one{" "}
     <TextLink
       target="_blank"
       href={
@@ -31,7 +30,7 @@ const NoContentTypes = ({ space, environment }) => (
       }
       rel="noopener noreferrer"
     >
-      content model
+      content type
     </TextLink>{" "}
     and assign it to the app from this screen.
   </Note>

--- a/apps/gatsby/src/AppConfig/ContentTypesPanel.js
+++ b/apps/gatsby/src/AppConfig/ContentTypesPanel.js
@@ -7,32 +7,49 @@ import {
   SkeletonBodyText,
   SkeletonContainer,
   TextLink,
-  Typography
-} from '@contentful/forma-36-react-components';
-import styles from '../styles';
-import React from 'react';
+  Typography,
+} from "@contentful/forma-36-react-components";
+import styles from "../styles";
+import React from "react";
 
 const ContentTypesSkeleton = () => (
   <SkeletonContainer width="100%">
-    <SkeletonBodyText numberOfLines={3}/>
+    <SkeletonBodyText numberOfLines={3} />
   </SkeletonContainer>
 );
 
-const NoContentTypes = () => (
+const NoContentTypes = ({ space, environment }) => (
   <Note noteType="warning">
-    There are no content types available in this environment. <TextLink
-    href="https://www.contentful.com/faq/basics/#how-do-i-add-a-new-content-type" target="_blank"
-    rel="noopener noreferrer">How do I add a new content type?</TextLink>
+    There are no content types available in this environment. You can add one in
+    your{" "}
+    <TextLink
+      target="_blank"
+      href={
+        environment === "master"
+          ? `https://app.contentful.com/spaces/${space}/content_types`
+          : `https://app.contentful.com/spaces/${space}/environments/${environment}/content_types`
+      }
+      rel="noopener noreferrer"
+    >
+      content model
+    </TextLink>{" "}
+    and assign it to the app from this screen.
   </Note>
 );
 
-export const ContentTypesList = ({ contentTypes, enabledContentTypes, onContentTypeToggle }) => {
+export const ContentTypesList = ({
+  contentTypes,
+  enabledContentTypes,
+  onContentTypeToggle,
+  space,
+  environment,
+}) => {
   if (!contentTypes) {
-    return <ContentTypesSkeleton/>;
+    return <ContentTypesSkeleton />;
   }
 
   if (0 === contentTypes.length) {
-    return <NoContentTypes/>;
+    return <NoContentTypes space={space} environment={environment} />;
   }
 
   return contentTypes.map(({ sys, name }) => (
@@ -49,20 +66,30 @@ export const ContentTypesList = ({ contentTypes, enabledContentTypes, onContentT
   ));
 };
 
-const ContentTypesPanel = ({ contentTypes, enabledContentTypes, onContentTypeToggle }) => (
+const ContentTypesPanel = ({
+  contentTypes,
+  enabledContentTypes,
+  onContentTypeToggle,
+  space,
+  environment,
+}) => (
   <Typography>
     <Heading>Content Types</Heading>
     <Paragraph>
-      Select content types that will show the Gatsby Cloud functionality in the sidebar.
+      Select content types that will show the Gatsby Cloud functionality in the
+      sidebar.
     </Paragraph>
     <div className={styles.checks}>
       <FieldGroup>
-        <ContentTypesList contentTypes={contentTypes}
-                          enabledContentTypes={enabledContentTypes}
-                          onContentTypeToggle={onContentTypeToggle}/>
+        <ContentTypesList
+          space={space}
+          environment={environment}
+          contentTypes={contentTypes}
+          enabledContentTypes={enabledContentTypes}
+          onContentTypeToggle={onContentTypeToggle}
+        />
       </FieldGroup>
     </div>
-
   </Typography>
 );
 

--- a/apps/gatsby/src/AppConfig/ContentTypesPanel.spec.js
+++ b/apps/gatsby/src/AppConfig/ContentTypesPanel.spec.js
@@ -1,48 +1,70 @@
-import React from 'react';
-import { ContentTypesList } from './ContentTypesPanel';
-import { cleanup, render } from '@testing-library/react';
+import React from "react";
+import { ContentTypesList } from "./ContentTypesPanel";
+import { cleanup, render } from "@testing-library/react";
 
-describe('ContentTypesList', function () {
+describe("ContentTypesList", function() {
   let contentTypeId = 1;
-  const contentType = name => ({ sys: { id: String(++contentTypeId) }, name });
-  const queryByInputName = name => (_, element) => element.tagName.toLowerCase() === 'input' && element.name === name;
+  const environment = "master";
+  const space = "12512asfasf";
+
+  const contentType = (name) => ({
+    sys: { id: String(++contentTypeId) },
+    name,
+  });
+  const queryByInputName = (name) => (_, element) =>
+    element.tagName.toLowerCase() === "input" && element.name === name;
 
   afterEach(cleanup);
 
-  it('should show Skeleton on nil values', () => {
-    const { container } = render(<ContentTypesList contentTypes={null}/>);
+  it("should show Skeleton on nil values", () => {
+    const { container } = render(<ContentTypesList contentTypes={null} />);
 
     expect(container).toMatchSnapshot();
   });
 
-  it('should show a Note if there are no content types', () => {
-    const { container } = render(<ContentTypesList contentTypes={[]}/>);
+  it("should show a Note if there are no content types", () => {
+    const { container } = render(
+      <ContentTypesList
+        contentTypes={[]}
+        space={space}
+        environment={environment}
+      />
+    );
 
     expect(container).toMatchSnapshot();
   });
 
-  it('should show checkboxes per content type', () => {
-    const contentTypes = [
-      contentType('posts'),
-      contentType('authors'),
-    ];
-    const { queryByText } = render(<ContentTypesList contentTypes={contentTypes}
-                                                     enabledContentTypes={[]}/>);
+  it("should show checkboxes per content type", () => {
+    const contentTypes = [contentType("posts"), contentType("authors")];
+    const { queryByText } = render(
+      <ContentTypesList
+        contentTypes={contentTypes}
+        enabledContentTypes={[]}
+        space={space}
+        environment={environment}
+      />
+    );
 
-    expect(queryByText('posts')).toBeDefined();
-    expect(queryByText('authors')).toBeDefined();
+    expect(queryByText("posts")).toBeDefined();
+    expect(queryByText("authors")).toBeDefined();
   });
 
-  it('should check enabled content types', () => {
-    const posts = contentType('posts');
-    const authors = contentType('authors');
+  it("should check enabled content types", () => {
+    const posts = contentType("posts");
+    const authors = contentType("authors");
     const contentTypes = [posts, authors];
     const enabledTypes = [posts.sys.id];
-    const { queryByText } = render(<ContentTypesList contentTypes={contentTypes}
-                                                     enabledContentTypes={enabledTypes}/>);
+    const { queryByText } = render(
+      <ContentTypesList
+        contentTypes={contentTypes}
+        enabledContentTypes={enabledTypes}
+        environment={environment}
+        space={space}
+      />
+    );
 
-    const postsElement = queryByText(queryByInputName('posts'));
-    const authorsElement = queryByText(queryByInputName('authors'));
+    const postsElement = queryByText(queryByInputName("posts"));
+    const authorsElement = queryByText(queryByInputName("authors"));
 
     expect(postsElement).toBeChecked();
     expect(authorsElement).not.toBeChecked();

--- a/apps/gatsby/src/AppConfig/__snapshots__/ContentTypesPanel.spec.js.snap
+++ b/apps/gatsby/src/AppConfig/__snapshots__/ContentTypesPanel.spec.js.snap
@@ -127,11 +127,12 @@ exports[`ContentTypesList should show a Note if there are no content types 1`] =
     </div>
     <div>
       <div>
-        There are no content types available in this environment. 
+        There are no content types available in this environment. You can add one in your
+         
         <a
           class="TextLink__TextLink___1biUr a11y__focus-outline--default___2hwb1 TextLink__TextLink--primary___2Vc9F"
           data-test-id="cf-ui-text-link"
-          href="https://www.contentful.com/faq/basics/#how-do-i-add-a-new-content-type"
+          href="https://app.contentful.com/spaces/undefined/environments/undefined/content_types"
           rel="noopener noreferrer"
           target="_blank"
         >
@@ -139,9 +140,11 @@ exports[`ContentTypesList should show a Note if there are no content types 1`] =
             class="TabFocusTrap__TabFocusTrap___39Vty"
             tabindex="-1"
           >
-            How do I add a new content type?
+            content model
           </span>
         </a>
+         
+        and assign it to the app from this screen.
       </div>
     </div>
   </div>

--- a/apps/gatsby/src/AppConfig/__snapshots__/ContentTypesPanel.spec.js.snap
+++ b/apps/gatsby/src/AppConfig/__snapshots__/ContentTypesPanel.spec.js.snap
@@ -127,12 +127,12 @@ exports[`ContentTypesList should show a Note if there are no content types 1`] =
     </div>
     <div>
       <div>
-        There are no content types available in this environment. You can add one in your
+        There are no content types available in this environment. You can add one
          
         <a
           class="TextLink__TextLink___1biUr a11y__focus-outline--default___2hwb1 TextLink__TextLink--primary___2Vc9F"
           data-test-id="cf-ui-text-link"
-          href="https://app.contentful.com/spaces/undefined/environments/undefined/content_types"
+          href="https://app.contentful.com/spaces/12512asfasf/content_types"
           rel="noopener noreferrer"
           target="_blank"
         >
@@ -140,7 +140,7 @@ exports[`ContentTypesList should show a Note if there are no content types 1`] =
             class="TabFocusTrap__TabFocusTrap___39Vty"
             tabindex="-1"
           >
-            content model
+            content type
           </span>
         </a>
          

--- a/apps/jira/jira-app/package-lock.json
+++ b/apps/jira/jira-app/package-lock.json
@@ -1151,11 +1151,11 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.4.tgz",
-      "integrity": "sha512-IvfvnMdSaLBateu0jfsYIpZTxAc2cKEXEMiezGGN75QcBcecDUKd3PgLAncT0oOgxKy8dd8hrJKj9MfzgfZd6g==",
+      "version": "7.10.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+      "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
       "requires": {
-        "regenerator-runtime": "^0.12.0"
+        "regenerator-runtime": "^0.13.4"
       }
     },
     "@babel/template": {
@@ -1592,13 +1592,12 @@
       }
     },
     "@contentful/forma-36-react-components": {
-      "version": "3.24.0",
-      "resolved": "https://registry.npmjs.org/@contentful/forma-36-react-components/-/forma-36-react-components-3.24.0.tgz",
-      "integrity": "sha512-6LaXTp8Y442XpszgbNHbHoE51Brvaz4ZTiTigRZMmmo4pBLs5fcQ57U12y+AIpFtvV+c0HtQxQrLGwAfIRtaXQ==",
+      "version": "3.39.7",
+      "resolved": "https://registry.npmjs.org/@contentful/forma-36-react-components/-/forma-36-react-components-3.39.7.tgz",
+      "integrity": "sha512-0vLarT/UU29D6AoLYwcDmD69aH2MCDamO7odVtw3HND9VHYp3LpzFVgBg3N3eT9U1Imyv6UrSChCIMvcRPYazQ==",
       "requires": {
         "@babel/runtime": "^7.3.4",
         "classnames": "^2.2.6",
-        "prop-types": "^15.7.2",
         "react-animate-height": "^2.0.7",
         "react-copy-to-clipboard": "^5.0.1",
         "react-modal": "3.6.1",
@@ -5474,9 +5473,9 @@
       "dev": true
     },
     "copy-to-clipboard": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.2.0.tgz",
-      "integrity": "sha512-eOZERzvCmxS8HWzugj4Uxl8OJxa7T2k1Gi0X5qavwydHIfuSHq2dTD09LOg/XyGq4Zpb5IsR/2OJ5lbOegz78w==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz",
+      "integrity": "sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==",
       "requires": {
         "toggle-selection": "^1.0.6"
       }
@@ -7166,9 +7165,9 @@
       }
     },
     "fetch-mock": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-8.0.1.tgz",
-      "integrity": "sha512-omxXRmQJDWLbOpA907JMFNdjLkHAfOGIqcyS/1dJ/0EEyi19iIyYjT2nveT+4Nwmuh/HgRSsNwRl+HP690ZdGQ==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-8.3.2.tgz",
+      "integrity": "sha512-RUdLbhIBTvECX20I8htNhmLRrCplCiOP62srst8UQsSV0m8taJe31PBsQybL7OIq5fEf6tnqVGvQ62ZnZ4IFfQ==",
       "dev": true,
       "requires": {
         "babel-runtime": "^6.26.0",
@@ -7181,9 +7180,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "3.4.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.4.7.tgz",
-          "integrity": "sha512-qaPVGw30J1wQ0GR3GvoPqlGf9GZfKKF4kFC7kiHlcsPTqH3txrs9crCp3ZiMAXuSenhz89Jnl4GZs/67S5VOSg==",
+          "version": "3.6.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+          "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
           "dev": true
         },
         "glob-to-regexp": {
@@ -16545,9 +16544,9 @@
       }
     },
     "react-animate-height": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/react-animate-height/-/react-animate-height-2.0.17.tgz",
-      "integrity": "sha512-cumTv/vCZ1MudkqXsLXGW6XO7EbGWIV0uZzkZVBf5HlHQ7n1GkbCsQl44SVo9nlA9/p+4XqWh4yn1Cc37Gri6A==",
+      "version": "2.0.21",
+      "resolved": "https://registry.npmjs.org/react-animate-height/-/react-animate-height-2.0.21.tgz",
+      "integrity": "sha512-CZHdjMD8qqp10tYtWmauWYASXxxv9vYeljxFGFtbcrbNXhsUv0w3IjxVK+0yCnyfk7769WfMZKHra4vRcbMnQg==",
       "requires": {
         "classnames": "^2.2.5",
         "prop-types": "^15.6.1"
@@ -16776,9 +16775,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
     },
     "regenerator-transform": {
       "version": "0.14.1",

--- a/apps/jira/jira-app/package.json
+++ b/apps/jira/jira-app/package.json
@@ -19,7 +19,7 @@
     "contentful-cli": "1.2.12",
     "cssnano": "4.1.10",
     "eslint": "^6.0.1",
-    "fetch-mock": "^8.0.1",
+    "fetch-mock": "^8.3.2",
     "node-fetch": "^2.6.0",
     "prettier": "1.19.1",
     "sass": "^1.23.7",
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@contentful/forma-36-fcss": "^0.0.20",
-    "@contentful/forma-36-react-components": "^3.11.3",
+    "@contentful/forma-36-react-components": "^3.39.7",
     "@contentful/forma-36-tokens": "^0.3.3",
     "contentful-ui-extensions-sdk": "^3.10.6",
     "lodash.debounce": "^4.0.8",

--- a/apps/jira/jira-app/src/__snapshots__/index.spec.tsx.snap
+++ b/apps/jira/jira-app/src/__snapshots__/index.spec.tsx.snap
@@ -744,7 +744,7 @@ Object {
                             class="TabFocusTrap__TabFocusTrap___39Vty"
                             tabindex="-1"
                           >
-                            content model
+                            content type
                           </span>
                         </a>
                          
@@ -963,7 +963,7 @@ Object {
                           class="TabFocusTrap__TabFocusTrap___39Vty"
                           tabindex="-1"
                         >
-                          content model
+                          content type
                         </span>
                       </a>
                        

--- a/apps/jira/jira-app/src/__snapshots__/index.spec.tsx.snap
+++ b/apps/jira/jira-app/src/__snapshots__/index.spec.tsx.snap
@@ -589,10 +589,10 @@ Object {
                   data-test-id="instance-step"
                 >
                   <div
-                    class="Select__Select__wrapper___2pBIz Select__Select--full___7ei7d selector"
+                    class="Select__Select__wrapper___2mbYV Select__Select--full___AENS4 selector"
                   >
                     <select
-                      class="Select__Select___31Z46 a11y__focus-border--default___60AXp"
+                      class="Select__Select___2Gi9N a11y__focus-border--default___60AXp"
                       data-test-id="instance-selector"
                     >
                       <option
@@ -603,7 +603,7 @@ Object {
                       </option>
                     </select>
                     <svg
-                      class="Icon__Icon___38Epv Icon__Icon--small___1yGZK Icon__Icon--muted___3egnD Select__Select__icon___boRAZ"
+                      class="Icon__Icon___38Epv Icon__Icon--small___1yGZK Icon__Icon--muted___3egnD Select__Select__icon___OBmvS"
                       data-test-id="cf-ui-icon"
                       height="24"
                       viewBox="0 0 24 24"
@@ -702,9 +702,56 @@ Object {
                   data-test-id="content-types"
                 >
                   <div
-                    class="FieldGroup__FieldGroup___2mLmO"
-                    data-test-id="cf-ui-field-group"
-                  />
+                    class="Note__Note___2eSKN Note__Note--warning___3X53I"
+                    data-test-id="cf-ui-note"
+                  >
+                    <div
+                      class="Note__Note__icon___20RqC"
+                    >
+                      <svg
+                        class="Icon__Icon___38Epv Icon__Icon--small___1yGZK Icon__Icon--warning___39Bnz"
+                        data-test-id="cf-ui-icon"
+                        height="18"
+                        viewBox="0 0 24 24"
+                        width="18"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M0 0h24v24H0z"
+                          fill="none"
+                        />
+                        <path
+                          d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"
+                        />
+                      </svg>
+                    </div>
+                    <div>
+                      <div>
+                        There are 
+                        <strong>
+                          no content types
+                        </strong>
+                         in this environment. You can add a
+                         
+                        <a
+                          class="TextLink__TextLink___1biUr a11y__focus-outline--default___2hwb1 TextLink__TextLink--primary___2Vc9F"
+                          data-test-id="cf-ui-text-link"
+                          href="https://app.contentful.com/spaces/test-space/content_types"
+                          rel="noopener noreferrer"
+                          target="_blank"
+                        >
+                          <span
+                            class="TabFocusTrap__TabFocusTrap___39Vty"
+                            tabindex="-1"
+                          >
+                            content model
+                          </span>
+                        </a>
+                         
+                        and assign it to the app from this screen.
+                      </div>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
@@ -761,10 +808,10 @@ Object {
                 data-test-id="instance-step"
               >
                 <div
-                  class="Select__Select__wrapper___2pBIz Select__Select--full___7ei7d selector"
+                  class="Select__Select__wrapper___2mbYV Select__Select--full___AENS4 selector"
                 >
                   <select
-                    class="Select__Select___31Z46 a11y__focus-border--default___60AXp"
+                    class="Select__Select___2Gi9N a11y__focus-border--default___60AXp"
                     data-test-id="instance-selector"
                   >
                     <option
@@ -775,7 +822,7 @@ Object {
                     </option>
                   </select>
                   <svg
-                    class="Icon__Icon___38Epv Icon__Icon--small___1yGZK Icon__Icon--muted___3egnD Select__Select__icon___boRAZ"
+                    class="Icon__Icon___38Epv Icon__Icon--small___1yGZK Icon__Icon--muted___3egnD Select__Select__icon___OBmvS"
                     data-test-id="cf-ui-icon"
                     height="24"
                     viewBox="0 0 24 24"
@@ -874,9 +921,56 @@ Object {
                 data-test-id="content-types"
               >
                 <div
-                  class="FieldGroup__FieldGroup___2mLmO"
-                  data-test-id="cf-ui-field-group"
-                />
+                  class="Note__Note___2eSKN Note__Note--warning___3X53I"
+                  data-test-id="cf-ui-note"
+                >
+                  <div
+                    class="Note__Note__icon___20RqC"
+                  >
+                    <svg
+                      class="Icon__Icon___38Epv Icon__Icon--small___1yGZK Icon__Icon--warning___39Bnz"
+                      data-test-id="cf-ui-icon"
+                      height="18"
+                      viewBox="0 0 24 24"
+                      width="18"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M0 0h24v24H0z"
+                        fill="none"
+                      />
+                      <path
+                        d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"
+                      />
+                    </svg>
+                  </div>
+                  <div>
+                    <div>
+                      There are 
+                      <strong>
+                        no content types
+                      </strong>
+                       in this environment. You can add a
+                       
+                      <a
+                        class="TextLink__TextLink___1biUr a11y__focus-outline--default___2hwb1 TextLink__TextLink--primary___2Vc9F"
+                        data-test-id="cf-ui-text-link"
+                        href="https://app.contentful.com/spaces/test-space/content_types"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <span
+                          class="TabFocusTrap__TabFocusTrap___39Vty"
+                          tabindex="-1"
+                        >
+                          content model
+                        </span>
+                      </a>
+                       
+                      and assign it to the app from this screen.
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -955,7 +1049,7 @@ Object {
     <div>
       <div>
         <div
-          class="Card__Card___xXJsT jira-ticket Card__Card--padding-default___b6Brl"
+          class="Card__Card___1_26G jira-ticket Card__Card--padding-default___xgDF9"
           data-test-id="cf-ui-card"
         >
           <div
@@ -971,11 +1065,13 @@ Object {
                 To Do
               </div>
               <div
-                class="Dropdown__Dropdown___1qyn8"
-                data-test-id="cf-ui-dropdown"
+                class="Dropdown__Dropdown___nAsJ-"
+                data-test-id="cf-ui-card-actions"
                 position="bottom-right"
               >
                 <button
+                  aria-expanded="false"
+                  aria-haspopup="menu"
                   class="IconButton__IconButton___1_XeU a11y__focus-outline--default___2hwb1 IconButton__IconButton--secondary___3Gc3d"
                   data-test-id="cf-ui-icon-button"
                   type="button"
@@ -1085,7 +1181,7 @@ Object {
           </div>
         </div>
         <div
-          class="Card__Card___xXJsT jira-ticket Card__Card--padding-default___b6Brl"
+          class="Card__Card___1_26G jira-ticket Card__Card--padding-default___xgDF9"
           data-test-id="cf-ui-card"
         >
           <div
@@ -1101,11 +1197,13 @@ Object {
                 To Do
               </div>
               <div
-                class="Dropdown__Dropdown___1qyn8"
-                data-test-id="cf-ui-dropdown"
+                class="Dropdown__Dropdown___nAsJ-"
+                data-test-id="cf-ui-card-actions"
                 position="bottom-right"
               >
                 <button
+                  aria-expanded="false"
+                  aria-haspopup="menu"
                   class="IconButton__IconButton___1_XeU a11y__focus-outline--default___2hwb1 IconButton__IconButton--secondary___3Gc3d"
                   data-test-id="cf-ui-icon-button"
                   type="button"
@@ -1230,119 +1328,17 @@ Object {
         </div>
       </div>
     </div>
-    <div>
-      <div
-        aria-hidden="true"
-        class="Tooltip__Tooltip___32xAi Tooltip__Tooltip--place-right___H8LiN Tooltip__Tooltip--hidden___3uqEe"
-        contenteditable="false"
-        data-test-id="cf-ui-tooltip"
-        role="tooltip"
-        style="max-width: 360px;"
-      >
-        <div
-          class="InViewport__InViewport___2o6g4"
-          data-test-id="cf-ui-in-viewport"
-          offset="0"
-        >
-          Task
-        </div>
-      </div>
-    </div>
-    <div>
-      <div
-        aria-hidden="true"
-        class="Tooltip__Tooltip___32xAi Tooltip__Tooltip--place-right___H8LiN Tooltip__Tooltip--hidden___3uqEe"
-        contenteditable="false"
-        data-test-id="cf-ui-tooltip"
-        role="tooltip"
-        style="max-width: 360px;"
-      >
-        <div
-          class="InViewport__InViewport___2o6g4"
-          data-test-id="cf-ui-in-viewport"
-          offset="0"
-        >
-          Medium priority
-        </div>
-      </div>
-    </div>
-    <div>
-      <div
-        aria-hidden="true"
-        class="Tooltip__Tooltip___32xAi Tooltip__Tooltip--place-left___1_Rl2 Tooltip__Tooltip--hidden___3uqEe"
-        contenteditable="false"
-        data-test-id="cf-ui-tooltip"
-        role="tooltip"
-        style="max-width: 360px;"
-      >
-        <div
-          class="InViewport__InViewport___2o6g4"
-          data-test-id="cf-ui-in-viewport"
-          offset="0"
-        >
-          Assignee: Dean Anderson
-        </div>
-      </div>
-    </div>
-    <div>
-      <div
-        aria-hidden="true"
-        class="Tooltip__Tooltip___32xAi Tooltip__Tooltip--place-right___H8LiN Tooltip__Tooltip--hidden___3uqEe"
-        contenteditable="false"
-        data-test-id="cf-ui-tooltip"
-        role="tooltip"
-        style="max-width: 360px;"
-      >
-        <div
-          class="InViewport__InViewport___2o6g4"
-          data-test-id="cf-ui-in-viewport"
-          offset="0"
-        >
-          Story
-        </div>
-      </div>
-    </div>
-    <div>
-      <div
-        aria-hidden="true"
-        class="Tooltip__Tooltip___32xAi Tooltip__Tooltip--place-right___H8LiN Tooltip__Tooltip--hidden___3uqEe"
-        contenteditable="false"
-        data-test-id="cf-ui-tooltip"
-        role="tooltip"
-        style="max-width: 360px;"
-      >
-        <div
-          class="InViewport__InViewport___2o6g4"
-          data-test-id="cf-ui-in-viewport"
-          offset="0"
-        >
-          Medium priority
-        </div>
-      </div>
-    </div>
-    <div>
-      <div
-        aria-hidden="true"
-        class="Tooltip__Tooltip___32xAi Tooltip__Tooltip--place-left___1_Rl2 Tooltip__Tooltip--hidden___3uqEe"
-        contenteditable="false"
-        data-test-id="cf-ui-tooltip"
-        role="tooltip"
-        style="max-width: 360px;"
-      >
-        <div
-          class="InViewport__InViewport___2o6g4"
-          data-test-id="cf-ui-in-viewport"
-          offset="0"
-        >
-          Assignee: Fabian Schultz
-        </div>
-      </div>
-    </div>
+    <div />
+    <div />
+    <div />
+    <div />
+    <div />
+    <div />
   </body>,
   "container": <div>
     <div>
       <div
-        class="Card__Card___xXJsT jira-ticket Card__Card--padding-default___b6Brl"
+        class="Card__Card___1_26G jira-ticket Card__Card--padding-default___xgDF9"
         data-test-id="cf-ui-card"
       >
         <div
@@ -1358,11 +1354,13 @@ Object {
               To Do
             </div>
             <div
-              class="Dropdown__Dropdown___1qyn8"
-              data-test-id="cf-ui-dropdown"
+              class="Dropdown__Dropdown___nAsJ-"
+              data-test-id="cf-ui-card-actions"
               position="bottom-right"
             >
               <button
+                aria-expanded="false"
+                aria-haspopup="menu"
                 class="IconButton__IconButton___1_XeU a11y__focus-outline--default___2hwb1 IconButton__IconButton--secondary___3Gc3d"
                 data-test-id="cf-ui-icon-button"
                 type="button"
@@ -1472,7 +1470,7 @@ Object {
         </div>
       </div>
       <div
-        class="Card__Card___xXJsT jira-ticket Card__Card--padding-default___b6Brl"
+        class="Card__Card___1_26G jira-ticket Card__Card--padding-default___xgDF9"
         data-test-id="cf-ui-card"
       >
         <div
@@ -1488,11 +1486,13 @@ Object {
               To Do
             </div>
             <div
-              class="Dropdown__Dropdown___1qyn8"
-              data-test-id="cf-ui-dropdown"
+              class="Dropdown__Dropdown___nAsJ-"
+              data-test-id="cf-ui-card-actions"
               position="bottom-right"
             >
               <button
+                aria-expanded="false"
+                aria-haspopup="menu"
                 class="IconButton__IconButton___1_XeU a11y__focus-outline--default___2hwb1 IconButton__IconButton--secondary___3Gc3d"
                 data-test-id="cf-ui-icon-button"
                 type="button"
@@ -1702,7 +1702,7 @@ Object {
             />
           </div>
           <div
-            class="Card__Card___xXJsT search-card Card__Card--padding-none___1Jrxi Card__Card--is-interactive___dMQtf"
+            class="Card__Card___1_26G search-card Card__Card--padding-none___1_Xu1 Card__Card--is-interactive___3nFqr"
             data-test-id="search-result-issue"
           >
             <div>
@@ -1723,24 +1723,7 @@ Object {
         </div>
       </div>
     </div>
-    <div>
-      <div
-        aria-hidden="true"
-        class="Tooltip__Tooltip___32xAi Tooltip__Tooltip--place-bottom___3qAh6 Tooltip__Tooltip--hidden___3uqEe"
-        contenteditable="false"
-        data-test-id="cf-ui-tooltip"
-        role="tooltip"
-        style="max-width: 360px;"
-      >
-        <div
-          class="InViewport__InViewport___2o6g4"
-          data-test-id="cf-ui-in-viewport"
-          offset="0"
-        >
-          Story: MKE-1389
-        </div>
-      </div>
-    </div>
+    <div />
   </body>,
   "container": <div>
     <div>
@@ -1769,7 +1752,7 @@ Object {
           />
         </div>
         <div
-          class="Card__Card___xXJsT search-card Card__Card--padding-none___1Jrxi Card__Card--is-interactive___dMQtf"
+          class="Card__Card___1_26G search-card Card__Card--padding-none___1_Xu1 Card__Card--is-interactive___3nFqr"
           data-test-id="search-result-issue"
         >
           <div>
@@ -1851,7 +1834,7 @@ Object {
     <div>
       <div>
         <div
-          class="Card__Card___xXJsT jira-ticket Card__Card--padding-default___b6Brl"
+          class="Card__Card___1_26G jira-ticket Card__Card--padding-default___xgDF9"
           data-test-id="cf-ui-card"
         >
           <div
@@ -1867,11 +1850,13 @@ Object {
                 In progress
               </div>
               <div
-                class="Dropdown__Dropdown___1qyn8"
-                data-test-id="cf-ui-dropdown"
+                class="Dropdown__Dropdown___nAsJ-"
+                data-test-id="cf-ui-card-actions"
                 position="bottom-right"
               >
                 <button
+                  aria-expanded="false"
+                  aria-haspopup="menu"
                   class="IconButton__IconButton___1_XeU a11y__focus-outline--default___2hwb1 IconButton__IconButton--secondary___3Gc3d"
                   data-test-id="cf-ui-icon-button"
                   type="button"
@@ -1996,65 +1981,14 @@ Object {
         </div>
       </div>
     </div>
-    <div>
-      <div
-        aria-hidden="true"
-        class="Tooltip__Tooltip___32xAi Tooltip__Tooltip--place-right___H8LiN Tooltip__Tooltip--hidden___3uqEe"
-        contenteditable="false"
-        data-test-id="cf-ui-tooltip"
-        role="tooltip"
-        style="max-width: 360px;"
-      >
-        <div
-          class="InViewport__InViewport___2o6g4"
-          data-test-id="cf-ui-in-viewport"
-          offset="0"
-        >
-          Story
-        </div>
-      </div>
-    </div>
-    <div>
-      <div
-        aria-hidden="true"
-        class="Tooltip__Tooltip___32xAi Tooltip__Tooltip--place-right___H8LiN Tooltip__Tooltip--hidden___3uqEe"
-        contenteditable="false"
-        data-test-id="cf-ui-tooltip"
-        role="tooltip"
-        style="max-width: 360px;"
-      >
-        <div
-          class="InViewport__InViewport___2o6g4"
-          data-test-id="cf-ui-in-viewport"
-          offset="0"
-        >
-          Medium priority
-        </div>
-      </div>
-    </div>
-    <div>
-      <div
-        aria-hidden="true"
-        class="Tooltip__Tooltip___32xAi Tooltip__Tooltip--place-left___1_Rl2 Tooltip__Tooltip--hidden___3uqEe"
-        contenteditable="false"
-        data-test-id="cf-ui-tooltip"
-        role="tooltip"
-        style="max-width: 360px;"
-      >
-        <div
-          class="InViewport__InViewport___2o6g4"
-          data-test-id="cf-ui-in-viewport"
-          offset="0"
-        >
-          Assignee: Dean Anderson
-        </div>
-      </div>
-    </div>
+    <div />
+    <div />
+    <div />
   </body>,
   "container": <div>
     <div>
       <div
-        class="Card__Card___xXJsT jira-ticket Card__Card--padding-default___b6Brl"
+        class="Card__Card___1_26G jira-ticket Card__Card--padding-default___xgDF9"
         data-test-id="cf-ui-card"
       >
         <div
@@ -2070,11 +2004,13 @@ Object {
               In progress
             </div>
             <div
-              class="Dropdown__Dropdown___1qyn8"
-              data-test-id="cf-ui-dropdown"
+              class="Dropdown__Dropdown___nAsJ-"
+              data-test-id="cf-ui-card-actions"
               position="bottom-right"
             >
               <button
+                aria-expanded="false"
+                aria-haspopup="menu"
                 class="IconButton__IconButton___1_XeU a11y__focus-outline--default___2hwb1 IconButton__IconButton--secondary___3Gc3d"
                 data-test-id="cf-ui-icon-button"
                 type="button"

--- a/apps/jira/jira-app/src/components/App/Config.tsx
+++ b/apps/jira/jira-app/src/components/App/Config.tsx
@@ -54,7 +54,6 @@ export default class Config extends React.Component<Props, State> {
       const configResourceExistsInResources = !!this.state.resources.find(r => r.id === resourceId);
       const { project } = await JiraClient.getProjectById(resourceId, this.props.token, projectId);
 
-
       // only use the saved config if the resource exists
       // we can assume the projectId is also invalid if it doesn't exist
       if (configResourceExistsInResources) {
@@ -184,6 +183,10 @@ export default class Config extends React.Component<Props, State> {
   };
 
   render() {
+    const { sdk } = this.props;
+    const {
+      ids: { space, environment }
+    } = sdk;
     return (
       <div className="configuration" data-test-id="configuration">
         <InstanceStep
@@ -197,6 +200,8 @@ export default class Config extends React.Component<Props, State> {
         />
         <JiraStep />
         <ContentTypeStep
+          space={space}
+          environment={environment}
           contentTypes={this.state.contentTypes}
           selectCt={this.toggleCtSelection}
           selectedContentTypes={this.state.selectedContentTypes}

--- a/apps/jira/jira-app/src/components/App/Steps/ContentTypeStep.tsx
+++ b/apps/jira/jira-app/src/components/App/Steps/ContentTypeStep.tsx
@@ -4,16 +4,20 @@ import {
   Heading,
   FieldGroup,
   CheckboxField,
-  Paragraph
+  Paragraph,
+  Note,
+  TextLink
 } from '@contentful/forma-36-react-components';
 
 interface Props {
+  space: string;
+  environment: string;
   selectCt: (id: string) => void;
   selectedContentTypes: string[];
   contentTypes: { name: string; id: string }[];
 }
 
-export default ({ contentTypes, selectCt, selectedContentTypes }: Props) => {
+export default ({ contentTypes, selectCt, selectedContentTypes, space, environment }: Props) => {
   const ctMap: { [key: string]: string } = contentTypes.reduce((acc, ct) => {
     return {
       ...acc,
@@ -33,20 +37,38 @@ export default ({ contentTypes, selectCt, selectedContentTypes }: Props) => {
       <Heading>Assign to content types</Heading>
       <Paragraph>Pick the content types where Jira will install to the sidebar.</Paragraph>
       <div className="content-types-config" data-test-id="content-types">
-        <FieldGroup>
-          {sortedContentTypes.map(ct => (
-            <CheckboxField
-              onChange={() => selectCt(ct.id)}
-              labelText={ct.name}
-              name={ct.name}
-              checked={selectedContentTypes.includes(ct.id)}
-              value={ct.id}
-              id={ct.name}
-              key={ct.id}
-              data-test-id={`ct-item-${ct.id}`}
-            />
-          ))}
-        </FieldGroup>
+        {sortedContentTypes.length === 0 ? (
+          <Note noteType="warning">
+            There are <strong>no content types</strong> in this environment. You can add a{' '}
+            <TextLink
+              linkType="primary"
+              target="_blank"
+              rel="noopener noreferrer"
+              href={
+                environment === 'master'
+                  ? `https://app.contentful.com/spaces/${space}/content_types`
+                  : `https://app.contentful.com/spaces/${space}/environments/${environment}/content_types`
+              }>
+              content model
+            </TextLink>{' '}
+            and assign it to the app from this screen.
+          </Note>
+        ) : (
+          <FieldGroup>
+            {sortedContentTypes.map(ct => (
+              <CheckboxField
+                onChange={() => selectCt(ct.id)}
+                labelText={ct.name}
+                name={ct.name}
+                checked={selectedContentTypes.includes(ct.id)}
+                value={ct.id}
+                id={ct.name}
+                key={ct.id}
+                data-test-id={`ct-item-${ct.id}`}
+              />
+            ))}
+          </FieldGroup>
+        )}
       </div>
     </Typography>
   );

--- a/apps/jira/jira-app/src/components/App/Steps/ContentTypeStep.tsx
+++ b/apps/jira/jira-app/src/components/App/Steps/ContentTypeStep.tsx
@@ -49,7 +49,7 @@ export default ({ contentTypes, selectCt, selectedContentTypes, space, environme
                   ? `https://app.contentful.com/spaces/${space}/content_types`
                   : `https://app.contentful.com/spaces/${space}/environments/${environment}/content_types`
               }>
-              content model
+              content type
             </TextLink>{' '}
             and assign it to the app from this screen.
           </Note>

--- a/apps/jira/jira-app/src/components/App/Steps/ContentTypeStep.tsx
+++ b/apps/jira/jira-app/src/components/App/Steps/ContentTypeStep.tsx
@@ -32,43 +32,49 @@ export default ({ contentTypes, selectCt, selectedContentTypes, space, environme
       id: ctMap[ctName]
     }));
 
+  let contentToRender;
+  if (sortedContentTypes.length === 0) {
+    contentToRender = (
+      <Note noteType="warning">
+        There are <strong>no content types</strong> in this environment. You can add a{' '}
+        <TextLink
+          linkType="primary"
+          target="_blank"
+          rel="noopener noreferrer"
+          href={
+            environment === 'master'
+              ? `https://app.contentful.com/spaces/${space}/content_types`
+              : `https://app.contentful.com/spaces/${space}/environments/${environment}/content_types`
+          }>
+          content type
+        </TextLink>{' '}
+        and assign it to the app from this screen.
+      </Note>
+    );
+  } else {
+    contentToRender = (
+      <FieldGroup>
+        {sortedContentTypes.map(ct => (
+          <CheckboxField
+            onChange={() => selectCt(ct.id)}
+            labelText={ct.name}
+            name={ct.name}
+            checked={selectedContentTypes.includes(ct.id)}
+            value={ct.id}
+            id={ct.name}
+            key={ct.id}
+            data-test-id={`ct-item-${ct.id}`}
+          />
+        ))}
+      </FieldGroup>
+    );
+  }
   return (
     <Typography>
       <Heading>Assign to content types</Heading>
       <Paragraph>Pick the content types where Jira will install to the sidebar.</Paragraph>
       <div className="content-types-config" data-test-id="content-types">
-        {sortedContentTypes.length === 0 ? (
-          <Note noteType="warning">
-            There are <strong>no content types</strong> in this environment. You can add a{' '}
-            <TextLink
-              linkType="primary"
-              target="_blank"
-              rel="noopener noreferrer"
-              href={
-                environment === 'master'
-                  ? `https://app.contentful.com/spaces/${space}/content_types`
-                  : `https://app.contentful.com/spaces/${space}/environments/${environment}/content_types`
-              }>
-              content type
-            </TextLink>{' '}
-            and assign it to the app from this screen.
-          </Note>
-        ) : (
-          <FieldGroup>
-            {sortedContentTypes.map(ct => (
-              <CheckboxField
-                onChange={() => selectCt(ct.id)}
-                labelText={ct.name}
-                name={ct.name}
-                checked={selectedContentTypes.includes(ct.id)}
-                value={ct.id}
-                id={ct.name}
-                key={ct.id}
-                data-test-id={`ct-item-${ct.id}`}
-              />
-            ))}
-          </FieldGroup>
-        )}
+        {contentToRender}
       </div>
     </Typography>
   );

--- a/apps/netlify/src/app/netlify-content-types.js
+++ b/apps/netlify/src/app/netlify-content-types.js
@@ -49,6 +49,56 @@ export default class NetlifyContentTypes extends React.Component {
 
     const allSelected = contentTypes.length === enabledContentTypes.length;
 
+    let contentToRender;
+    if (contentTypes.length === 0) {
+      contentToRender = (
+        <Note noteType="warning">
+          There are <strong>no content types</strong> in this environment. You
+          can add a{" "}
+          <TextLink
+            linkType="primary"
+            target="_blank"
+            rel="noopener noreferrer"
+            href={
+              environment === "master"
+                ? `https://app.contentful.com/spaces/${space}/content_types`
+                : `https://app.contentful.com/spaces/${space}/environments/${environment}/content_types`
+            }
+          >
+            content type
+          </TextLink>{" "}
+          and assign it to the app from this screen.
+        </Note>
+      );
+    } else {
+      contentToRender = (
+        <div>
+          <FieldGroup>
+            <CheckboxField
+              id="selectAll"
+              labelText="Select all"
+              disabled={disabled}
+              onChange={this.onToggleSelect}
+              checked={allSelected}
+            />
+          </FieldGroup>
+          <FieldGroup>
+            {contentTypes.map(([id, name]) => (
+              <CheckboxField
+                key={id}
+                id={`ct-box-${id}`}
+                labelIsLight
+                labelText={name}
+                onChange={(e) => this.onChange(e.target.checked, id)}
+                disabled={disabled}
+                checked={enabledContentTypes.includes(id)}
+              />
+            ))}
+          </FieldGroup>
+        </div>
+      );
+    }
+
     return (
       <Typography>
         <Heading>Content Types</Heading>
@@ -56,50 +106,7 @@ export default class NetlifyContentTypes extends React.Component {
           Select which content types will show the Netlify functionality in the
           sidebar.
         </Paragraph>
-        {contentTypes.length === 0 ? (
-          <Note noteType="warning">
-            There are <strong>no content types</strong> in this environment. You
-            can add a{" "}
-            <TextLink
-              linkType="primary"
-              target="_blank"
-              rel="noopener noreferrer"
-              href={
-                environment === "master"
-                  ? `https://app.contentful.com/spaces/${space}/content_types`
-                  : `https://app.contentful.com/spaces/${space}/environments/${environment}/content_types`
-              }
-            >
-              content type
-            </TextLink>{" "}
-            and assign it to the app from this screen.
-          </Note>
-        ) : (
-          <div>
-            <FieldGroup>
-              <CheckboxField
-                id="selectAll"
-                labelText="Select all"
-                disabled={disabled}
-                onChange={this.onToggleSelect}
-                checked={allSelected}
-              />
-            </FieldGroup>
-            <FieldGroup>
-              {contentTypes.map(([id, name]) => (
-                <CheckboxField
-                  key={id}
-                  id={`ct-box-${id}`}
-                  labelIsLight
-                  labelText={name}
-                  onChange={(e) => this.onChange(e.target.checked, id)}
-                  disabled={disabled}
-                  checked={enabledContentTypes.includes(id)}
-                />
-              ))}
-            </FieldGroup>
-          </div>
-        )}
+        {contentToRender}
       </Typography>
     );
   }

--- a/apps/netlify/src/app/netlify-content-types.js
+++ b/apps/netlify/src/app/netlify-content-types.js
@@ -1,20 +1,24 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React from "react";
+import PropTypes from "prop-types";
 
 import {
   Typography,
+  Note,
+  TextLink,
   Heading,
   Paragraph,
   FieldGroup,
-  CheckboxField
-} from '@contentful/forma-36-react-components';
+  CheckboxField,
+} from "@contentful/forma-36-react-components";
 
 export default class NetlifyContentTypes extends React.Component {
   static propTypes = {
     disabled: PropTypes.bool.isRequired,
+    space: PropTypes.string.isRequired,
+    environment: PropTypes.string.isRequired,
     contentTypes: PropTypes.array.isRequired,
     enabledContentTypes: PropTypes.array.isRequired,
-    onEnabledContentTypesChange: PropTypes.func.isRequired
+    onEnabledContentTypesChange: PropTypes.func.isRequired,
   };
 
   onToggleSelect = () => {
@@ -30,12 +34,18 @@ export default class NetlifyContentTypes extends React.Component {
   onChange = (checked, id) => {
     const enabled = this.props.enabledContentTypes;
     this.props.onEnabledContentTypesChange(
-      checked ? enabled.concat([id]) : enabled.filter(cur => cur !== id)
+      checked ? enabled.concat([id]) : enabled.filter((cur) => cur !== id)
     );
   };
 
   render() {
-    const { disabled, contentTypes, enabledContentTypes } = this.props;
+    const {
+      disabled,
+      contentTypes,
+      enabledContentTypes,
+      space,
+      environment,
+    } = this.props;
 
     const allSelected = contentTypes.length === enabledContentTypes.length;
 
@@ -43,30 +53,53 @@ export default class NetlifyContentTypes extends React.Component {
       <Typography>
         <Heading>Content Types</Heading>
         <Paragraph>
-          Select which content types will show the Netlify functionality in the sidebar.
+          Select which content types will show the Netlify functionality in the
+          sidebar.
         </Paragraph>
-        <FieldGroup>
-          <CheckboxField
-            id="selectAll"
-            labelText="Select all"
-            disabled={disabled}
-            onChange={this.onToggleSelect}
-            checked={allSelected}
-          />
-        </FieldGroup>
-        <FieldGroup>
-          {contentTypes.map(([id, name]) => (
-            <CheckboxField
-              key={id}
-              id={`ct-box-${id}`}
-              labelIsLight
-              labelText={name}
-              onChange={e => this.onChange(e.target.checked, id)}
-              disabled={disabled}
-              checked={enabledContentTypes.includes(id)}
-            />
-          ))}
-        </FieldGroup>
+        {contentTypes.length === 0 ? (
+          <Note noteType="warning">
+            There are <strong>no content types</strong> in this environment. You
+            can add a{" "}
+            <TextLink
+              linkType="primary"
+              target="_blank"
+              rel="noopener noreferrer"
+              href={
+                environment === "master"
+                  ? `https://app.contentful.com/spaces/${space}/content_types`
+                  : `https://app.contentful.com/spaces/${space}/environments/${environment}/content_types`
+              }
+            >
+              content type
+            </TextLink>{" "}
+            and assign it to the app from this screen.
+          </Note>
+        ) : (
+          <div>
+            <FieldGroup>
+              <CheckboxField
+                id="selectAll"
+                labelText="Select all"
+                disabled={disabled}
+                onChange={this.onToggleSelect}
+                checked={allSelected}
+              />
+            </FieldGroup>
+            <FieldGroup>
+              {contentTypes.map(([id, name]) => (
+                <CheckboxField
+                  key={id}
+                  id={`ct-box-${id}`}
+                  labelIsLight
+                  labelText={name}
+                  onChange={(e) => this.onChange(e.target.checked, id)}
+                  disabled={disabled}
+                  checked={enabledContentTypes.includes(id)}
+                />
+              ))}
+            </FieldGroup>
+          </div>
+        )}
       </Typography>
     );
   }

--- a/apps/smartling/frontend/src/AppConfig.tsx
+++ b/apps/smartling/frontend/src/AppConfig.tsx
@@ -7,7 +7,8 @@ import {
   FieldGroup,
   CheckboxField,
   TextField,
-  TextLink
+  TextLink,
+  Note
 } from '@contentful/forma-36-react-components';
 import get from 'lodash.get';
 // @ts-ignore 2307
@@ -106,6 +107,10 @@ export default class AppConfig extends React.Component<Props, State> {
   }
 
   render() {
+    const { sdk } = this.props;
+    const {
+      ids: { space, environment }
+    } = sdk;
     return (
       <div className="app">
         <div className="background" />
@@ -115,7 +120,14 @@ export default class AppConfig extends React.Component<Props, State> {
               <Typography>
                 <Heading>About Smartling</Heading>
                 <Paragraph className="about-p">
-                  The <TextLink href="https://dashboard.smartling.com" target="_blank" rel="noopener noreferrer">Smartling</TextLink> app allows you to view the status of your translation without leaving Contentful.
+                  The{' '}
+                  <TextLink
+                    href="https://dashboard.smartling.com"
+                    target="_blank"
+                    rel="noopener noreferrer">
+                    Smartling
+                  </TextLink>{' '}
+                  app allows you to view the status of your translation without leaving Contentful.
                 </Paragraph>
               </Typography>
               <hr />
@@ -138,24 +150,40 @@ export default class AppConfig extends React.Component<Props, State> {
               />
               <Typography>
                 <Heading>Assign to content types</Heading>
-                <Paragraph>
-                  Select which content types to use with Smartling.
-                </Paragraph>
+                <Paragraph>Select which content types to use with Smartling.</Paragraph>
               </Typography>
-              <FieldGroup>
-                {this.state.contentTypes.map(ct => (
-                  <CheckboxField
-                    onChange={() => this.toggleCt(ct.id)}
-                    labelText={ct.name}
-                    name={ct.name}
-                    checked={this.state.selectedContentTypes.includes(ct.id)}
-                    value={ct.id}
-                    id={ct.name}
-                    key={ct.id}
-                    data-test-id={`ct-item-${ct.id}`}
-                  />
-                ))}
-              </FieldGroup>
+              {this.state.contentTypes.length === 0 ? (
+                <Note noteType="warning">
+                  There are <strong>no content types</strong> in this environment. You can add one{' '}
+                  <TextLink
+                    linkType="primary"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    href={
+                      environment === 'master'
+                        ? `https://app.contentful.com/spaces/${space}/content_types`
+                        : `https://app.contentful.com/spaces/${space}/environments/${environment}/content_types`
+                    }>
+                    content type
+                  </TextLink>{' '}
+                  and assign it to the app from this screen.
+                </Note>
+              ) : (
+                <FieldGroup>
+                  {this.state.contentTypes.map(ct => (
+                    <CheckboxField
+                      onChange={() => this.toggleCt(ct.id)}
+                      labelText={ct.name}
+                      name={ct.name}
+                      checked={this.state.selectedContentTypes.includes(ct.id)}
+                      value={ct.id}
+                      id={ct.name}
+                      key={ct.id}
+                      data-test-id={`ct-item-${ct.id}`}
+                    />
+                  ))}
+                </FieldGroup>
+              )}
             </div>
           </div>
         </div>

--- a/apps/smartling/frontend/src/__snapshots__/index.spec.tsx.snap
+++ b/apps/smartling/frontend/src/__snapshots__/index.spec.tsx.snap
@@ -107,7 +107,7 @@ Object {
                 class="date"
               >
                 Submitted 
-                Jan 29, 2020, 2:05 PM
+                Jan 29, 2020, 3:05 PM
               </div>
             </div>
           </div>
@@ -261,7 +261,7 @@ Object {
               class="date"
             >
               Submitted 
-              Jan 29, 2020, 2:05 PM
+              Jan 29, 2020, 3:05 PM
             </div>
           </div>
         </div>
@@ -398,7 +398,8 @@ Object {
                   class="Paragraph__Paragraph___2aO-9 about-p f36-margin-bottom--m"
                   data-test-id="cf-ui-paragraph"
                 >
-                  The 
+                  The
+                   
                   <a
                     class="TextLink__TextLink___1biUr a11y__focus-outline--default___2hwb1 TextLink__TextLink--primary___2Vc9F"
                     data-test-id="cf-ui-text-link"
@@ -413,7 +414,8 @@ Object {
                       Smartling
                     </span>
                   </a>
-                   app allows you to view the status of your translation without leaving Contentful.
+                   
+                  app allows you to view the status of your translation without leaving Contentful.
                 </p>
               </div>
               <hr />
@@ -895,7 +897,8 @@ Object {
                 class="Paragraph__Paragraph___2aO-9 about-p f36-margin-bottom--m"
                 data-test-id="cf-ui-paragraph"
               >
-                The 
+                The
+                 
                 <a
                   class="TextLink__TextLink___1biUr a11y__focus-outline--default___2hwb1 TextLink__TextLink--primary___2Vc9F"
                   data-test-id="cf-ui-text-link"
@@ -910,7 +913,8 @@ Object {
                     Smartling
                   </span>
                 </a>
-                 app allows you to view the status of your translation without leaving Contentful.
+                 
+                app allows you to view the status of your translation without leaving Contentful.
               </p>
             </div>
             <hr />

--- a/apps/smartling/frontend/src/__snapshots__/index.spec.tsx.snap
+++ b/apps/smartling/frontend/src/__snapshots__/index.spec.tsx.snap
@@ -107,7 +107,7 @@ Object {
                 class="date"
               >
                 Submitted 
-                Jan 29, 2020, 3:05 PM
+                Jan 29, 2020, 2:05 PM
               </div>
             </div>
           </div>
@@ -261,7 +261,7 @@ Object {
               class="date"
             >
               Submitted 
-              Jan 29, 2020, 3:05 PM
+              Jan 29, 2020, 2:05 PM
             </div>
           </div>
         </div>

--- a/apps/typeform/frontend/src/AppConfig/AppConfig.tsx
+++ b/apps/typeform/frontend/src/AppConfig/AppConfig.tsx
@@ -8,7 +8,8 @@ import {
   TextLink,
   Select,
   Option,
-  FormLabel
+  FormLabel,
+  Note
 } from '@contentful/forma-36-react-components';
 import FieldSelector from './FieldSelector';
 import {
@@ -164,6 +165,11 @@ export class AppConfig extends React.Component<Props, State> {
       workspaces
     } = this.state;
 
+    const { sdk } = this.props;
+    const {
+      ids: { space, environment }
+    } = sdk;
+
     return (
       <div>
         <div className={styles.background('#262627')} />
@@ -225,9 +231,22 @@ export class AppConfig extends React.Component<Props, State> {
                     />
                   </>
                 ) : (
-                  <Paragraph>
-                    No content types with fields of type <strong>Short Text</strong> were found.
-                  </Paragraph>
+                  <Note noteType="warning">
+                    There are <strong>no content types with fields of type Short Text</strong>{' '}
+                    fields in this environment. You can add one in your{' '}
+                    <TextLink
+                      linkType="primary"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      href={
+                        environment === 'master'
+                          ? `https://app.contentful.com/spaces/${space}/content_types`
+                          : `https://app.contentful.com/spaces/${space}/environments/${environment}/content_types`
+                      }>
+                      content model
+                    </TextLink>{' '}
+                    and assign it to the app from this screen.
+                  </Note>
                 )}
               </Typography>
             </div>

--- a/lib/shared-dam-app/src/AppConfig/AppConfig.tsx
+++ b/lib/shared-dam-app/src/AppConfig/AppConfig.tsx
@@ -287,6 +287,7 @@ export default class AppConfig extends React.Component<Props, State> {
                 <TextLink
                   linkType="primary"
                   target="_blank"
+                  rel="noopener noreferrer"
                   href={
                     environment === "master"
                       ? `https://app.contentful.com/spaces/${space}/content_types`

--- a/lib/shared-dam-app/src/AppConfig/AppConfig.tsx
+++ b/lib/shared-dam-app/src/AppConfig/AppConfig.tsx
@@ -1,6 +1,9 @@
-import * as React from 'react';
+import * as React from "react";
 
-import { AppExtensionSDK, CollectionResponse } from 'contentful-ui-extensions-sdk';
+import {
+  AppExtensionSDK,
+  CollectionResponse,
+} from "contentful-ui-extensions-sdk";
 import {
   Heading,
   Paragraph,
@@ -9,14 +12,15 @@ import {
   TextField,
   Form,
   SelectField,
-  Option
-} from '@contentful/forma-36-react-components';
-import tokens from '@contentful/forma-36-tokens';
-import { css } from 'emotion';
+  Option,
+  TextLink,
+} from "@contentful/forma-36-react-components";
+import tokens from "@contentful/forma-36-tokens";
+import { css } from "emotion";
 
-import FieldSelector from './FieldSelector';
+import FieldSelector from "./FieldSelector";
 
-import { toInputParameters, toExtensionParameters } from './parameters';
+import { toInputParameters, toExtensionParameters } from "./parameters";
 
 import {
   getCompatibleFields,
@@ -25,10 +29,10 @@ import {
   EditorInterface,
   ContentType,
   CompatibleFields,
-  SelectedFields
-} from './fields';
+  SelectedFields,
+} from "./fields";
 
-import { Hash, ValidateParametersFn } from '../interfaces';
+import { Hash, ValidateParametersFn } from "../interfaces";
 
 interface Props {
   sdk: AppExtensionSDK;
@@ -49,46 +53,46 @@ interface State {
 
 const styles = {
   body: css({
-    height: 'auto',
-    minHeight: '65vh',
-    margin: '0 auto',
+    height: "auto",
+    minHeight: "65vh",
+    margin: "0 auto",
     marginTop: tokens.spacingXl,
     padding: `${tokens.spacingXl} ${tokens.spacing2Xl}`,
     maxWidth: tokens.contentWidthText,
     backgroundColor: tokens.colorWhite,
     zIndex: 2,
-    boxShadow: '0px 0px 20px rgba(0, 0, 0, 0.1)',
-    borderRadius: '2px'
+    boxShadow: "0px 0px 20px rgba(0, 0, 0, 0.1)",
+    borderRadius: "2px",
   }),
   background: (color: string) =>
     css({
-      display: 'block',
-      position: 'absolute',
+      display: "block",
+      position: "absolute",
       zIndex: -1,
       top: 0,
-      width: '100%',
-      height: '300px',
-      backgroundColor: color
+      width: "100%",
+      height: "300px",
+      backgroundColor: color,
     }),
   section: css({
-    margin: `${tokens.spacingXl} 0`
+    margin: `${tokens.spacingXl} 0`,
   }),
   splitter: css({
     marginTop: tokens.spacingL,
     marginBottom: tokens.spacingL,
     border: 0,
-    height: '1px',
-    backgroundColor: tokens.colorElementMid
+    height: "1px",
+    backgroundColor: tokens.colorElementMid,
   }),
   icon: css({
-    display: 'flex',
-    justifyContent: 'center',
-    '> img': {
-      display: 'block',
-      width: '70px',
-      margin: `${tokens.spacingXl} 0`
-    }
-  })
+    display: "flex",
+    justifyContent: "center",
+    "> img": {
+      display: "block",
+      width: "70px",
+      margin: `${tokens.spacingXl} 0`,
+    },
+  }),
 };
 
 export default class AppConfig extends React.Component<Props, State> {
@@ -96,7 +100,7 @@ export default class AppConfig extends React.Component<Props, State> {
     contentTypes: [] as ContentType[],
     compatibleFields: ({} as any) as CompatibleFields,
     selectedFields: ({} as any) as SelectedFields,
-    parameters: toInputParameters(this.props.parameterDefinitions, null)
+    parameters: toInputParameters(this.props.parameterDefinitions, null),
   };
 
   componentDidMount() {
@@ -111,14 +115,18 @@ export default class AppConfig extends React.Component<Props, State> {
     const [contentTypesResponse, eisResponse, parameters] = await Promise.all([
       space.getContentTypes() as Promise<CollectionResponse<ContentType>>,
       space.getEditorInterfaces(),
-      app.getParameters()
+      app.getParameters(),
     ]);
 
-    const contentTypes = (contentTypesResponse as CollectionResponse<ContentType>).items
-    const editorInterfaces = (eisResponse as CollectionResponse<EditorInterface>).items;
+    const contentTypes = (contentTypesResponse as CollectionResponse<
+      ContentType
+    >).items;
+    const editorInterfaces = (eisResponse as CollectionResponse<
+      EditorInterface
+    >).items;
 
     const compatibleFields = getCompatibleFields(contentTypes);
-    const filteredContentTypes = contentTypes.filter(ct => {
+    const filteredContentTypes = contentTypes.filter((ct) => {
       const fields = compatibleFields[ct.sys.id];
       return fields && fields.length > 0;
     });
@@ -127,8 +135,14 @@ export default class AppConfig extends React.Component<Props, State> {
       {
         contentTypes: filteredContentTypes,
         compatibleFields,
-        selectedFields: editorInterfacesToSelectedFields(editorInterfaces, ids.app),
-        parameters: toInputParameters(this.props.parameterDefinitions, parameters)
+        selectedFields: editorInterfacesToSelectedFields(
+          editorInterfaces,
+          ids.app
+        ),
+        parameters: toInputParameters(
+          this.props.parameterDefinitions,
+          parameters
+        ),
       },
       () => app.setReady()
     );
@@ -144,8 +158,11 @@ export default class AppConfig extends React.Component<Props, State> {
     }
 
     return {
-      parameters: toExtensionParameters(this.props.parameterDefinitions, parameters),
-      targetState: selectedFieldsToTargetState(contentTypes, selectedFields)
+      parameters: toExtensionParameters(
+        this.props.parameterDefinitions,
+        parameters
+      ),
+      targetState: selectedFieldsToTargetState(contentTypes, selectedFields),
     };
   };
 
@@ -171,9 +188,9 @@ export default class AppConfig extends React.Component<Props, State> {
   onParameterChange = (key: string, e: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = e.currentTarget;
 
-    this.setState(state => ({
+    this.setState((state) => ({
       ...state,
-      parameters: { ...state.parameters, [key]: value }
+      parameters: { ...state.parameters, [key]: value },
     }));
   };
 
@@ -181,57 +198,75 @@ export default class AppConfig extends React.Component<Props, State> {
     this.setState({ selectedFields });
   };
 
-  buildSelectField = (key: string, def: Record<string, any>) =>{
-    const values = def.value.split(',');
+  buildSelectField = (key: string, def: Record<string, any>) => {
+    const values = def.value.split(",");
     return (
       <SelectField
-          labelText={def.name}
-          id={key}
-          name={key}
-          required={def.required}
-          helpText={def.description}
-          key={key}
-          onChange={this.onParameterChange.bind(this, def.id)}
-          value={this.state.parameters[def.id]}
-          >
-            {values.map((currValue: string) => <Option value={currValue} key={currValue}>{currValue}</Option>)}
+        labelText={def.name}
+        id={key}
+        name={key}
+        required={def.required}
+        helpText={def.description}
+        key={key}
+        onChange={this.onParameterChange.bind(this, def.id)}
+        value={this.state.parameters[def.id]}
+      >
+        {values.map((currValue: string) => (
+          <Option value={currValue} key={currValue}>
+            {currValue}
+          </Option>
+        ))}
       </SelectField>
-    )
-  }
+    );
+  };
 
   renderApp() {
-    const { contentTypes, compatibleFields, selectedFields, parameters } = this.state;
-    const { parameterDefinitions } = this.props;
-    const hasConfigurationOptions = parameterDefinitions && parameterDefinitions.length > 0;
+    const {
+      contentTypes,
+      compatibleFields,
+      selectedFields,
+      parameters,
+    } = this.state;
+    const { parameterDefinitions, sdk } = this.props;
+    const {
+      user: {
+        spaceMembership: {
+          sys: { id },
+        },
+      },
+    } = sdk;
+
+    const hasConfigurationOptions =
+      parameterDefinitions && parameterDefinitions.length > 0;
     return (
       <>
         {hasConfigurationOptions && (
           <Typography>
             <Heading>Configuration</Heading>
             <Form>
-              {parameterDefinitions.map(def => {
+              {parameterDefinitions.map((def) => {
                 const key = `config-input-${def.id}`;
-                if (def.type==="List"){
+                if (def.type === "List") {
                   return this.buildSelectField(key, def);
-                }else {
-                    return (
-                      <TextField
-                        required={def.required}
-                        key={key}
-                        id={key}
-                        name={key}
-                        labelText={def.name}
-                        textInputProps={{
-                          width: def.type === 'Symbol' ? 'large' : 'medium',
-                          type: def.type === 'Symbol' ? 'text' : 'number',
-                          maxLength: 255
-                        }}
-                        helpText={def.description}
-                        value={parameters[def.id]}
-                        onChange={this.onParameterChange.bind(this, def.id)}
-                      />
-                    );
-                  }
+                } else {
+                  return (
+                    <TextField
+                      required={def.required}
+                      key={key}
+                      id={key}
+                      name={key}
+                      labelText={def.name}
+                      textInputProps={{
+                        width: def.type === "Symbol" ? "large" : "medium",
+                        type: def.type === "Symbol" ? "text" : "number",
+                        maxLength: 255,
+                      }}
+                      helpText={def.description}
+                      value={parameters[def.id]}
+                      onChange={this.onParameterChange.bind(this, def.id)}
+                    />
+                  );
+                }
               })}
             </Form>
             <hr className={styles.splitter} />
@@ -241,17 +276,29 @@ export default class AppConfig extends React.Component<Props, State> {
           <Heading>Assign to fields</Heading>
           {contentTypes.length > 0 ? (
             <Paragraph>
-              This app can only be used with <strong>JSON object</strong> fields. Select which JSON
-              fields you’d like to enable for this app.
+              This app can only be used with <strong>JSON object</strong>{" "}
+              fields. Select which JSON fields you’d like to enable for this
+              app.
             </Paragraph>
           ) : (
             <>
               <Paragraph>
-                This app can be used only with <strong>JSON object</strong> fields.
+                This app can be used only with <strong>JSON object</strong>{" "}
+                fields.
               </Paragraph>
               <Note noteType="warning">
-                There are <strong>no content types with JSON object</strong> fields in this
-                environment. You can add one in your content model and assign it to the app here.
+                There are <strong>no content types with JSON object</strong>{" "}
+                fields in this environment. You can add one in your{" "}
+                <TextLink
+                  linkType="primary"
+                  target="_blank"
+                  href={`https://app.contentful.com/spaces/${
+                    id.split("-")[0]
+                  }/content_types`}
+                >
+                  content model
+                </TextLink>{" "}
+                and assign it to the app from this screen.
               </Note>
             </>
           )}

--- a/lib/shared-dam-app/src/AppConfig/AppConfig.tsx
+++ b/lib/shared-dam-app/src/AppConfig/AppConfig.tsx
@@ -228,13 +228,8 @@ export default class AppConfig extends React.Component<Props, State> {
       parameters,
     } = this.state;
     const { parameterDefinitions, sdk } = this.props;
-    const {
-      user: {
-        spaceMembership: {
-          sys: { id },
-        },
-      },
-    } = sdk;
+    const { ids } = sdk;
+    const { space, environment } = ids;
 
     const hasConfigurationOptions =
       parameterDefinitions && parameterDefinitions.length > 0;
@@ -292,9 +287,11 @@ export default class AppConfig extends React.Component<Props, State> {
                 <TextLink
                   linkType="primary"
                   target="_blank"
-                  href={`https://app.contentful.com/spaces/${
-                    id.split("-")[0]
-                  }/content_types`}
+                  href={
+                    environment === "master"
+                      ? `https://app.contentful.com/spaces/${space}/content_types`
+                      : `https://app.contentful.com/spaces/${space}/environments/${environment}/content_types`
+                  }
                 >
                   content model
                 </TextLink>{" "}

--- a/lib/shared-sku-app/src/AppConfig/AppConfig.tsx
+++ b/lib/shared-sku-app/src/AppConfig/AppConfig.tsx
@@ -7,7 +7,8 @@ import {
   Note,
   Typography,
   TextField,
-  Form
+  Form,
+  TextLink
 } from '@contentful/forma-36-react-components';
 import tokens from '@contentful/forma-36-tokens';
 import { css } from 'emotion';
@@ -112,8 +113,8 @@ export default class AppConfig extends React.Component<Props, State> {
       app.getParameters()
     ]);
 
-    const contentTypes = (contentTypesResponse as CollectionResponse<ContentType>).items
-    const editorInterfaces = (eisResponse as CollectionResponse<EditorInterface>).items
+    const contentTypes = (contentTypesResponse as CollectionResponse<ContentType>).items;
+    const editorInterfaces = (eisResponse as CollectionResponse<EditorInterface>).items;
 
     const compatibleFields = getCompatibleFields(contentTypes);
     const filteredContentTypes = contentTypes.filter(ct => {
@@ -180,7 +181,10 @@ export default class AppConfig extends React.Component<Props, State> {
 
   renderApp() {
     const { contentTypes, compatibleFields, selectedFields, parameters } = this.state;
-    const { parameterDefinitions } = this.props;
+    const { parameterDefinitions, sdk } = this.props;
+    const {
+      ids: { space, environment }
+    } = sdk;
     const hasConfigurationOptions = parameterDefinitions && parameterDefinitions.length > 0;
 
     return (
@@ -230,7 +234,18 @@ export default class AppConfig extends React.Component<Props, State> {
               </Paragraph>
               <Note noteType="warning">
                 There are <strong>no content types with Short text or Short text, list</strong>{' '}
-                fields in this environment. You can add one in your content model and assign it to the app here.
+                fields in this environment. You can add one in your{' '}
+                <TextLink
+                  linkType="primary"
+                  target="_blank"
+                  href={
+                    environment === 'master'
+                      ? `https://app.contentful.com/spaces/${space}/content_types`
+                      : `https://app.contentful.com/spaces/${space}/environments/${environment}/content_types`
+                  }>
+                  content model
+                </TextLink>{' '}
+                and assign it to the app from this screen.
               </Note>
             </>
           )}

--- a/lib/shared-sku-app/src/AppConfig/AppConfig.tsx
+++ b/lib/shared-sku-app/src/AppConfig/AppConfig.tsx
@@ -238,6 +238,7 @@ export default class AppConfig extends React.Component<Props, State> {
                 <TextLink
                   linkType="primary"
                   target="_blank"
+                  rel="noopener noreferrer"
                   href={
                     environment === 'master'
                       ? `https://app.contentful.com/spaces/${space}/content_types`


### PR DESCRIPTION
## Purpose of the PR

When there a no valid content types available in an environment where the app is going to be installed, we should display an empty state and provide a link to the user to add a content type or edit an existing content model.

Ticket: https://contentful.atlassian.net/secure/RapidBoard.jspa?rapidView=38&projectKey=EXT&modal=detail&selectedIssue=EXT-1960
