### PR TITLE
fix: add flex wrap to handle many references

### DIFF
--- a/apps/optimizely/src/AppPage/ContentTypes.js
+++ b/apps/optimizely/src/AppPage/ContentTypes.js
@@ -33,7 +33,8 @@ const styles = {
   }),
   refList: css({
     display: 'flex',
-    flexDirection: 'row'
+    flexDirection: 'row',
+    flexWrap: 'wrap'
   }),
   sectionHeading: css({
     marginTop: tokens.spacingL,


### PR DESCRIPTION
A content type with many references, and long field names for those references would cut off some of the inputs. This Pr just ensures that they will wrap onto the next line

before: 
![image](https://user-images.githubusercontent.com/20307225/86464596-18c70f00-bd30-11ea-9c07-f2ab1407cd13.png)

After:
![image](https://user-images.githubusercontent.com/20307225/86464666-4ca23480-bd30-11ea-83fb-7e2d306a34de.png)

