### PR TITLE
Updating wording in Gatsby manual save

### DIFF
--- a/apps/gatsby/src/Sidebar.js
+++ b/apps/gatsby/src/Sidebar.js
@@ -97,19 +97,19 @@ export default class Sidebar extends React.Component {
         {busy && (
           <>
             <Spinner />
-            {' '}Updating preview...
+            {' '}Sending entry data...
           </>
         )}
         {!busy && (ok === true) && (
           <>
             <Icon icon="CheckCircle" color="positive" style={ICON_STYLE} />
-            {' '}Preview up to date!
+            {' '}Entry data in Gatsby up to date!
           </>
         )}
         {!busy && (ok === false) && (
           <>
             <Icon icon="Warning" color="negative" style={ICON_STYLE} />
-            {' '}Last update of the preview failed.
+            {' '}Last update failed.
           </>
         )}
       </HelpText>


### PR DESCRIPTION
This update comes from a report on a bit of confusion about what it means for our sidebar app to show an updating status.

When the Contentful entry is saved, our sidebar reports that the preview is updated. However, this is not the case. The preview gets sent new information which is then used to build a new preview. We simply report whether or not the new entry data was sent so a new preview could be built.