### PR TITLE
correctly set `ratio` on contentful object

### DIFF
--- a/apps/mux/src/index.tsx
+++ b/apps/mux/src/index.tsx
@@ -210,6 +210,7 @@ export class App extends React.Component<AppProps, AppState> {
       uploadId: undefined,
       assetId: undefined,
       playbackId: undefined,
+      signedPlaybackId: undefined,
       ready: undefined,
       ratio: undefined,
       error: undefined,
@@ -398,7 +399,7 @@ export class App extends React.Component<AppProps, AppState> {
       playbackId: (publicPlayback && publicPlayback.id) || undefined,
       signedPlaybackId: (signedPlayback && signedPlayback.id) || undefined,
       ready: asset.status === 'ready',
-      ratio: asset.ratio,
+      ratio: asset.aspect_ratio,
       error: assetError,
     });
 


### PR DESCRIPTION
* we were using `asset.ratio` but the correct property on the mux asset is `asset.aspect_ratio`. As a result - `ratio` on the Contentful object was never being set, which conflicts with the documentation we have.
* also fix up resetField() to also set signedPlaybackId to `undefined`