### PR TITLE
Allow users of the Bynder app to select what types of assets can be selected

### DIFF
--- a/apps/bynder/src/index.js
+++ b/apps/bynder/src/index.js
@@ -31,6 +31,8 @@ const FIELDS_TO_PERSIST = [
   'width'
 ];
 
+const validAssetTypes = ['image', 'audio', 'document', 'video'];
+
 function makeThumbnail(resource) {
   const thumbnail = (resource.thumbnails && resource.thumbnails.webimage) || resource.src;
   const url = typeof thumbnail === 'string' ? thumbnail : undefined;
@@ -39,12 +41,20 @@ function makeThumbnail(resource) {
   return [url, alt];
 }
 
-function prepareBynderHTML(bynderURL) {
+function prepareBynderHTML({ bynderURL, assetTypes }) {
+  let types = '';
+  if (!assetTypes) {
+    // We deault to just images in this fallback since this is the behavior the App had in its initial release
+    types = 'image';
+  } else {
+    types = assetType.trim().split(',').map(type => type.trim()).join('');
+  }
+
   return `
     <div class="dialog-container">
       <div
         id="bynder-compactview"
-        data-assetTypes="image"
+        data-assetTypes="${types}"
         data-autoload="true"
         data-button="Load media from bynder.com"
         data-collections="true"
@@ -64,7 +74,7 @@ function renderDialog(sdk) {
   const config = sdk.parameters.invocation;
 
   const container = document.createElement('div');
-  container.innerHTML = prepareBynderHTML(config.bynderURL);
+  container.innerHTML = prepareBynderHTML(config);
   document.body.appendChild(container);
 
   const script = document.createElement('script');
@@ -103,15 +113,23 @@ function isDisabled() {
   return false;
 }
 
-function validateParameters({ bynderURL }) {
+function validateParameters({ bynderURL, assetTypes }) {
   const hasValidProtocol = bynderURL.startsWith('https://');
   const isHTMLSafe = ['"', '<', '>'].every(unsafe => !bynderURL.includes(unsafe));
 
-  if (hasValidProtocol && isHTMLSafe) {
-    return null;
-  } else {
+  if (!hasValidProtocol || !isHTMLSafe) {
     return 'Provide a valid Bynder URL.';
   }
+
+
+  const types = assetType.trim().split(',').map(type => type.trim());
+  const isAssetTypesValid = types.every(type => validAssetTypes.includes(type));
+
+  if (!isAssetTypesValid) {
+    return `Only valid asset types may be selected: ${validAssetTypes.join(',')}`
+  }
+
+  return null;
 }
 
 setup({
@@ -127,6 +145,14 @@ setup({
       "type": "Symbol",
       "name": "Bynder URL",
       "description": "Provide Bynder URL of your account.",
+      "required": true
+    },
+    {
+      "id": "assetTypes",
+      "type": "Symbol",
+      "name": "Asset types",
+      "description": "Choose which types of assets can be selected.",
+      "default": validAssetTypes.join(','),
       "required": true
     }
   ],


### PR DESCRIPTION
Behavior:
- For existing users, unless they update the configuration, the behavior will continue to be only images are updated
- For new installations, and updates of the configuration, the default is to allow all types of assets

The implementation is not perfect. It'd much better to use checkboxes. Unfortunately we don't have an implementation for that in `shared-dam-app`. An alternative would be to use a `select` with the `multiple` attribute set. As far as I can tell the [Forma 36 `select` component](https://forma-36-react-components.netlify.app/?path=/story/components-select--default) does _not_ support this.

A great improvement in the future would be to allow users to override this on a field level. If/when field level parameters are implemented this can be revisited.