### PR TITLE
fix: change bynder button copy

### DIFF
--- a/apps/bynder/src/index.js
+++ b/apps/bynder/src/index.js
@@ -6,7 +6,7 @@ import logo from './logo.svg';
 const BYNDER_SDK_URL =
   'https://d8ejoa1fys2rk.cloudfront.net/modules/compactview/includes/js/client-1.5.0.min.js';
 
-const CTA = 'Select or upload a file on Bynder';
+const CTA = 'Select a file on Bynder';
 
 const FIELDS_TO_PERSIST = [
   'archive',


### PR DESCRIPTION
## Context

Bynder confirmed they won't allow update functionality in Compact View, so the copy of the affected button is misleading.

### Current Copy

![image](https://user-images.githubusercontent.com/17052868/94433264-57862d00-0198-11eb-81b8-6a3008adf9c0.png)

### Expected Copy

![image](https://user-images.githubusercontent.com/17052868/94433365-7a184600-0198-11eb-8285-97b008d8383a.png)
