### PR TITLE
fix: wait for one of error or token to close the window

### DIFF
--- a/apps/jira/jira-app/src/components/Auth/OAuth.tsx
+++ b/apps/jira/jira-app/src/components/Auth/OAuth.tsx
@@ -36,7 +36,7 @@ export default class OAuth extends React.Component<Props> {
         this.props.setToken(token);
       }
 
-      if (oauthWindow) {
+      if (oauthWindow && (token || error)) {
         oauthWindow.close();
       }
     });


### PR DESCRIPTION
## Context

Jira changed the amount of the messages we get from the window we open. 
Now we get a lot of messages without a payload 🤷 and we need to filter them in order for the rest of the flow to work as expected and allow storing the token and the expiration in localStorage.