### PR TITLE
chore: open preview to open site

### DIFF
--- a/apps/netlify/src/sidebar/index.js
+++ b/apps/netlify/src/sidebar/index.js
@@ -79,7 +79,7 @@ export default class NetlifySidebar extends React.Component {
           rel="noopener noreferrer"
           buttonType="muted"
           isFullWidth>
-          <div className={styles.previewContent}>Open preview</div>
+          <div className={styles.previewContent}>Open site</div>
         </Button>
       </>
     );


### PR DESCRIPTION
Open preview was a misleading description, as the button just links to the netlify site. This PR changes the button copy to `open site` - which should be clearer.