### PR TITLE
feat: add reset button for image focal point [EXT-2413]

### DIFF
--- a/apps/image-focal-point/src/__snapshots__/index.spec.js.snap
+++ b/apps/image-focal-point/src/__snapshots__/index.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`App #render should render the extension field view 1`] = `
 <div>
   <div
-    class="css-1yp4ln"
+    class="css-70qvj9"
   >
     <div
       class="TextInput__TextInput___36-K- css-93644d TextInput__TextInput--large___KwY4O TextInput__TextInput--disabled___2t7VS"
@@ -18,7 +18,7 @@ exports[`App #render should render the extension field view 1`] = `
       />
     </div>
     <button
-      class="Button__Button___1ZfFj a11y__focus-border--default___60AXp css-1f2k2gl Button__Button--muted___2Wair"
+      class="Button__Button___1ZfFj a11y__focus-border--default___60AXp css-dp0f2t Button__Button--muted___2Wair"
       data-test-id="cf-ui-button"
       type="button"
     >
@@ -31,6 +31,18 @@ exports[`App #render should render the extension field view 1`] = `
         >
           Set focal point
         </span>
+      </span>
+    </button>
+    <button
+      class="TextLink__TextLink___1biUr a11y__focus-outline--default___2hwb1 TextLink__TextLink--primary___2Vc9F"
+      data-test-id="cf-ui-text-link"
+      type="button"
+    >
+      <span
+        class="TabFocusTrap__TabFocusTrap___39Vty"
+        tabindex="-1"
+      >
+        Reset focal point
       </span>
     </button>
   </div>

--- a/apps/image-focal-point/src/components/FocalPointView/FocalPointView.js
+++ b/apps/image-focal-point/src/components/FocalPointView/FocalPointView.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button, TextInput } from '@contentful/forma-36-react-components';
+import { Button, TextInput, TextLink } from '@contentful/forma-36-react-components';
 
 import { styles } from './styles';
 
-const FocalPointView = ({ focalPoint, showFocalPointDialog }) => {
+const FocalPointView = ({ focalPoint, showFocalPointDialog, resetFocalPoint }) => {
   const value = focalPoint ? `x: ${focalPoint.x}px / y: ${focalPoint.y}px` : 'Focal point not set';
 
   return (
@@ -21,6 +21,9 @@ const FocalPointView = ({ focalPoint, showFocalPointDialog }) => {
       <Button className={styles.button} buttonType="muted" onClick={showFocalPointDialog}>
         Set focal point
       </Button>
+      <TextLink linkType="primary" onClick={() => resetFocalPoint()}>
+        Reset focal point
+      </TextLink>
     </div>
   );
 };
@@ -30,7 +33,8 @@ FocalPointView.propTypes = {
     x: PropTypes.number.isRequired,
     y: PropTypes.number.isRequired
   }),
-  showFocalPointDialog: PropTypes.func.isRequired
+  showFocalPointDialog: PropTypes.func.isRequired,
+  resetFocalPoint: PropTypes.func.isRequired
 };
 
 FocalPointView.defaultProps = {

--- a/apps/image-focal-point/src/components/FocalPointView/FocalPointView.spec.js
+++ b/apps/image-focal-point/src/components/FocalPointView/FocalPointView.spec.js
@@ -8,7 +8,8 @@ const props = {
     x: 10,
     y: 30
   },
-  showFocalPointDialog: jest.fn()
+  showFocalPointDialog: jest.fn(),
+  resetFocalPoint: jest.fn()
 };
 
 describe('FocalPointView', () => {

--- a/apps/image-focal-point/src/components/FocalPointView/__snapshots__/FocalPointView.spec.js.snap
+++ b/apps/image-focal-point/src/components/FocalPointView/__snapshots__/FocalPointView.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`FocalPointView should render the focal point field view 1`] = `
 <div>
   <div
-    class="css-1yp4ln"
+    class="css-70qvj9"
   >
     <div
       class="TextInput__TextInput___36-K- css-93644d TextInput__TextInput--large___KwY4O TextInput__TextInput--disabled___2t7VS"
@@ -18,7 +18,7 @@ exports[`FocalPointView should render the focal point field view 1`] = `
       />
     </div>
     <button
-      class="Button__Button___1ZfFj a11y__focus-border--default___60AXp css-1f2k2gl Button__Button--muted___2Wair"
+      class="Button__Button___1ZfFj a11y__focus-border--default___60AXp css-dp0f2t Button__Button--muted___2Wair"
       data-test-id="cf-ui-button"
       type="button"
     >
@@ -31,6 +31,18 @@ exports[`FocalPointView should render the focal point field view 1`] = `
         >
           Set focal point
         </span>
+      </span>
+    </button>
+    <button
+      class="TextLink__TextLink___1biUr a11y__focus-outline--default___2hwb1 TextLink__TextLink--primary___2Vc9F"
+      data-test-id="cf-ui-text-link"
+      type="button"
+    >
+      <span
+        class="TabFocusTrap__TabFocusTrap___39Vty"
+        tabindex="-1"
+      >
+        Reset focal point
       </span>
     </button>
   </div>

--- a/apps/image-focal-point/src/components/FocalPointView/styles.js
+++ b/apps/image-focal-point/src/components/FocalPointView/styles.js
@@ -4,12 +4,13 @@ import tokens from '@contentful/forma-36-tokens';
 export const styles = {
   container: css({
     display: 'flex',
-    alignItems: 'flex-start'
+    alignItems: 'center'
   }),
   input: css({
     maxWidth: '280px'
   }),
   button: css({
-    marginLeft: tokens.spacingXs
+    marginLeft: tokens.spacingXs,
+    marginRight: tokens.spacingXs
   })
 };

--- a/apps/image-focal-point/src/index.js
+++ b/apps/image-focal-point/src/index.js
@@ -66,6 +66,10 @@ export class App extends React.Component {
     return this.props.sdk.field.locale;
   }
 
+  resetFocalPoint = () => {
+    this.setFocalPoint(null);
+  };
+
   setFocalPoint = focalPoint => {
     this.setState(
       oldState => ({
@@ -127,6 +131,7 @@ export class App extends React.Component {
         <FocalPointView
           showFocalPointDialog={this.showFocalPointDialog}
           focalPoint={this.state.value.focalPoint}
+          resetFocalPoint={this.resetFocalPoint}
         />
       );
     }


### PR DESCRIPTION
## Purpose

A customer asked if it is possible to reset the focal point of a given image. Right now it is only to possible to reset a focal point if you create a new entry which is really inconvenient.

<img width="863" alt="Screenshot 2020-12-22 at 10 39 34" src="https://user-images.githubusercontent.com/4083285/102873938-0e194700-4442-11eb-93ea-752725d996f9.png">
