### PR TITLE
chore: version packages independently

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
     "apps/**/*",
     "packages/*"
   ],
-  "version": "1.0.1",
+  "version": "independent",
   "publish": {
     "message": "chore: publish %s [skip ci]",
     "conventionalCommits": true

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "lerna run build --concurrency=1",
     "test": "lerna run test:ci --concurrency=2",
     "deploy": "lerna run deploy --concurrency=2",
-    "publish-packages": "lerna publish from-git --yes"
+    "publish-packages": "lerna version --conventional-commits --create-release github --yes && lerna publish from-git --yes"
   },
   "dependencies": {
     "lerna": "^3.20.2"


### PR DESCRIPTION
Another fix...

I used `from-git` without actually updating the git tags. Now, the versions/tags should be set correctly. The package versions are updated independently.