### PR TITLE
chore: fix config of publish commit message

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,8 +4,10 @@
     "packages/*"
   ],
   "version": "independent",
-  "publish": {
-    "message": "chore: publish %s [skip ci]",
-    "conventionalCommits": true
+  "command": {
+    "publish": {
+      "message": "chore: publish [skip ci]",
+      "conventionalCommits": true
+    }
   }
 }


### PR DESCRIPTION
Config of `publish` command has to be nested under `command`