### PR TITLE
chore: don't publish when changing docs or tests

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -9,5 +9,11 @@
       "message": "chore: publish [skip ci]",
       "conventionalCommits": true
     }
-  }
+  },
+  "ignoreChanges": [
+    "**/*.md",
+    "**/*.spec.*",
+    "**/test/**",
+    "packages/*/package-lock.json"
+  ]
 }


### PR DESCRIPTION
We do not want to publish a new package version for every change to the docs. (e.g. https://github.com/contentful/apps/pull/186)

This can be tested locally by committing a change and running `lerna changed`.

Also, with this PR changes to tests and updating the package-lock.json (which might happen more frequently with dependabot) will be ignored.
We don't really care about bumping the app's versions as they are not published to npm.