### PR TITLE
refactor: [EXT-2590] update bynder version with required changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 build
 dist
 .cache
+.idea
 tags
 **/.coverage/**
 lerna-debug.log

--- a/apps/bynder/src/index.html
+++ b/apps/bynder/src/index.html
@@ -24,7 +24,6 @@
     </style>
   </head>
   <body>
-    <script src="https://d8ejoa1fys2rk.cloudfront.net/5.0.5/modules/compactview/bynder-compactview-2-latest.js"></script>
     <div id="root"></div>
     <script src="./index.js"></script>
   </body>

--- a/apps/bynder/src/index.html
+++ b/apps/bynder/src/index.html
@@ -22,6 +22,7 @@
     </style>
   </head>
   <body>
+    <script src="https://d8ejoa1fys2rk.cloudfront.net/5.0.5/modules/compactview/bynder-compactview-2-latest.js"></script>
     <div id="root"></div>
     <script src="./index.js"></script>
   </body>

--- a/apps/bynder/src/index.html
+++ b/apps/bynder/src/index.html
@@ -16,7 +16,9 @@
       }
 
       .dialog-container {
-        height: 800px;
+        height: 600px;
+        display: flex;
+        justify-content: center;
         position: relative;
       }
     </style>

--- a/apps/bynder/src/index.js
+++ b/apps/bynder/src/index.js
@@ -74,6 +74,15 @@ function prepareBynderHTML({ bynderURL, assetTypes }) {
 }
 
 function transformAsset(asset) {
+  const thumbnails = {
+    "webimage": asset.files.webImage?.url,
+    "thul": asset.files.thumbnail?.url
+  }
+
+  Object.entries(asset.files)
+      .filter(([name]) => !["webImage", "thumbnail"].includes(name))
+      .forEach(([key, value]) => thumbnails[key] = value?.url);
+
   return ({
     "id": asset.databaseId,
     "orientation": asset.orientation.toLowerCase(),
@@ -94,12 +103,7 @@ function transformAsset(asset) {
     "limited": asset.isLimitedUse ? 1 : 0,
     "isPublic": asset.isPublic ? 1 : 0,
     "brandId": asset.brandId,
-    "thumbnails": {
-      "contentful": asset.files.contentful.url,
-      "mini": asset.files.mini.url,
-      "webimage": asset.files.webImage.url,
-      "thul": asset.files.thumbnail.url
-    }
+    "thumbnails": thumbnails
   })
 }
 

--- a/apps/bynder/src/index.js
+++ b/apps/bynder/src/index.js
@@ -47,6 +47,7 @@ isPublic
 brandId
 name
 publishedAt
+updatedAt
 createdAt
 files
 `;
@@ -89,11 +90,11 @@ function transformAsset(asset) {
     "height": asset.height,
     "width": asset.width,
     "copyright": asset.copyright,
-    "extension": asset.extenstions,
+    "extension": asset.extensions,
     "userCreated": asset.createdBy,
     "datePublished": asset.publishedAt,
     "dateCreated": asset.createdAt,
-    "dateModified": asset.modifiedAt,
+    "dateModified": asset.updatedAt,
     "watermarked": asset.isWatermarked ? 1 : 0,
     "limited": asset.isLimitedUse ? 1 : 0,
     "isPublic": asset.isPublic ? 1 : 0,

--- a/apps/bynder/src/index.js
+++ b/apps/bynder/src/index.js
@@ -122,6 +122,12 @@ function renderDialog(sdk) {
     sdk.close(Array.isArray(assets) ? assets.map(transformAsset) : []);
   }
 
+  window.addEventListener("message", (e) => {
+    if (e.origin === 'https://app.contentful.com') {
+      e.stopImmediatePropagation()
+    }
+  })
+
 
   BynderCompactView.open({
     language: "en_US",

--- a/apps/bynder/src/index.js
+++ b/apps/bynder/src/index.js
@@ -63,14 +63,6 @@ function makeThumbnail(resource) {
 }
 
 function prepareBynderHTML({ bynderURL, assetTypes }) {
-  let types = '';
-  if (!assetTypes) {
-    // We deault to just images in this fallback since this is the behavior the App had in its initial release
-    types = 'image';
-  } else {
-    types = assetTypes.trim().split(',').map(type => type.trim()).join(',');
-  }
-
   return `
     <div class="dialog-container">
       <div id="bynder-compactview" />
@@ -112,7 +104,7 @@ function renderDialog(sdk) {
   const config = sdk.parameters.invocation;
   const { assetTypes, bynderURL } = config
 
-  let types = '';
+  let types = [];
   if (!assetTypes) {
     // We deault to just images in this fallback since this is the behavior the App had in its initial release
     types = ['IMAGE'];

--- a/apps/bynder/src/index.js
+++ b/apps/bynder/src/index.js
@@ -5,8 +5,8 @@ import logo from './logo.svg';
 
 const CTA = 'Select a file on Bynder';
 
-const BYNDER_SDK_URL =
-    "https://d8ejoa1fys2rk.cloudfront.net/5.0.5/modules/compactview/bynder-compactview-2-latest.js";
+const BYNDER_SDK_DOMAIN = "https://d8ejoa1fys2rk.cloudfront.net";
+const BYNDER_SDK_URL = `${BYNDER_SDK_DOMAIN}/5.0.5/modules/compactview/bynder-compactview-2-latest.js`;
 
 const FIELDS_TO_PERSIST = [
   'archive',
@@ -108,7 +108,7 @@ function transformAsset(asset) {
 }
 
 function checkMessageEvent(e) {
-  if (e.origin === 'https://app.contentful.com') {
+  if (e.origin !== BYNDER_SDK_DOMAIN) {
     e.stopImmediatePropagation()
   }
 }
@@ -119,7 +119,7 @@ function renderDialog(sdk) {
 
   let types = [];
   if (!assetTypes) {
-    // We deault to just images in this fallback since this is the behavior the App had in its initial release
+    // We default to just images in this fallback since this is the behavior the App had in its initial release
     types = ['IMAGE'];
   } else {
     types = assetTypes.trim().split(',').map((type) => type.toUpperCase());


### PR DESCRIPTION
Updating bynder app according to https://developer-docs.bynder.com/ui-components migration steps. 

All fields that are not there with the new version were added through `assetFieldSelection` and then tied together with `transformAsset`, to be in the shape how it was before to ensure backwards compatibility. 


