### PR TITLE
fix: use latest version of shopify-buy

### DIFF
--- a/apps/shopify/package-lock.json
+++ b/apps/shopify/package-lock.json
@@ -13795,9 +13795,9 @@
 			"optional": true
 		},
 		"shopify-buy": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/shopify-buy/-/shopify-buy-2.8.1.tgz",
-			"integrity": "sha512-dO2CkcSqUFrZQQzcOGT3rQQPvAsWi8ADPgBYD/Te1HN+KPsO7gTlBCy3G7+RdHvD+iO9BAVjobWUbOkcQGBoKg=="
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/shopify-buy/-/shopify-buy-2.11.0.tgz",
+			"integrity": "sha512-bGjS1b/VCPvCjazSstlKwgLtK1WBotWom06/12loja8yfo/cWkLuJsakBbQe1uEIDiOLhKaR0M0CAXZFheYDug=="
 		},
 		"signal-exit": {
 			"version": "3.0.2",

--- a/apps/shopify/package.json
+++ b/apps/shopify/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@contentful/ecommerce-app-base": "1.0.4",
     "core-js": "3.4.1",
-    "shopify-buy": "^2.8.1"
+    "shopify-buy": "2.11.0"
   },
   "scripts": {
     "start": "contentful-extension-scripts start --serve-only",


### PR DESCRIPTION
The current version of `shopify-buy` uses API `2019-10` which times out after 15s. The latest version uses the latest API version which allows request that take over 30 seconds.

For customers with a large list of products, the Shopify app currently fails to render the product picker.