### PR TITLE
fix(Shopify): 'load more' button was wrongly displayed in some edge cases

### DIFF
--- a/apps/shopify/src/Pagination.js
+++ b/apps/shopify/src/Pagination.js
@@ -44,7 +44,7 @@ class Pagination {
       return {
         pagination: {
           // There is going to be a next page in the following two complimentary cases:
-          // A). The product corresponding to the last variant belongs is tagged as having a next page
+          // A). There are more products to fetch via the Shopify API
           // B). There are variants left to consume in the in-memory variants list
           hasNextPage: this.hasNextProductPage || this.variants.length > 0
         },

--- a/apps/shopify/src/Pagination.js
+++ b/apps/shopify/src/Pagination.js
@@ -10,6 +10,7 @@ const PER_PAGE = 20;
 class Pagination {
   freshSearch = true;
 
+  hasNextProductPage = false;
   products = [];
 
   variants = [];
@@ -40,13 +41,13 @@ class Pagination {
     const hasEnoughVariantsToConsume = this.variants.length >= PER_PAGE || nothingLeftToFetch;
     if (hasEnoughVariantsToConsume) {
       const variants = this.variants.splice(0, PER_PAGE);
-      const lastProduct = this.products.find(product => product.id === last(variants).productId);
+      // const lastProduct = this.products.find(product => product.id === last(variants).productId);
       return {
         pagination: {
           // There is going to be a next page in the following two complimentary cases:
           // A). The product corresponding to the last variant belongs is tagged as having a next page
           // B). There are variants left to consume in the in-memory variants list
-          hasNextPage: get(lastProduct, ['hasNextPage'], false) || this.variants.length > 0
+          hasNextPage: this.hasNextProductPage || this.variants.length > 0
         },
         products: variants.map(dataTransformer)
       };
@@ -68,6 +69,9 @@ class Pagination {
     const nextProducts = noProductsFetchedYet
       ? await this._fetchProducts(search)
       : await this._fetchNextPage(this.products);
+    this.hasNextProductPage =
+      nextProducts.length > 0 && nextProducts.every(product => product.hasNextPage);
+
     const nextVariants = productsToVariantsTransformer(nextProducts);
     this.products = uniqBy([...this.products, ...nextProducts], 'id');
     this.variants = sortBy(uniqBy([...this.variants, ...nextVariants], 'id'), ['title', 'sku']);

--- a/apps/shopify/src/Pagination.js
+++ b/apps/shopify/src/Pagination.js
@@ -41,7 +41,6 @@ class Pagination {
     const hasEnoughVariantsToConsume = this.variants.length >= PER_PAGE || nothingLeftToFetch;
     if (hasEnoughVariantsToConsume) {
       const variants = this.variants.splice(0, PER_PAGE);
-      // const lastProduct = this.products.find(product => product.id === last(variants).productId);
       return {
         pagination: {
           // There is going to be a next page in the following two complimentary cases:

--- a/apps/shopify/src/dataTransformer.js
+++ b/apps/shopify/src/dataTransformer.js
@@ -27,9 +27,7 @@ export const productsToVariantsTransformer = products =>
         sku: variant.id,
         productId: product.id,
         title: product.title,
-        hasNextPage: false
       }));
-      variants[variants.length - 1].hasNextPage = product.hasNextPage;
       return variants;
     })
   );


### PR DESCRIPTION
In some rare cases the "Load more" button was displayed even though there was no new page with products/variants available. The root cause of this issue is that we get an unsorted list of products and only one of them had `hasNextPage=false`. So we now check whether any of the newly loaded products has this flag set to false and then hide the button.