### PR TITLE
fix: stop simultaneous recursive chains

### DIFF
--- a/apps/shopify/src/Pagination.js
+++ b/apps/shopify/src/Pagination.js
@@ -25,8 +25,13 @@ class Pagination {
     this.shopifyClient = await makeShopifyClient(this.sdk);
   }
 
-  async fetchNext(search) {
+  async fetchNext(search, recursing = false) {
     const searchHasChanged = search !== this.prevSearch;
+    const shouldStop = searchHasChanged && recursing;
+    if (shouldStop) {
+      return;
+    }
+
     if (searchHasChanged) {
       this.prevSearch = search;
       this._resetPagination();
@@ -55,7 +60,7 @@ class Pagination {
     // When there are not enough variants to fill the page, we need to fetch more products,
     // extract their variants and then call this method recursively to render the next page.
     await this._fetchMoreProducts(search);
-    return this.fetchNext(search);
+    return this.fetchNext(search, true);
   }
 
   /**

--- a/packages/ecommerce-app-base/src/SkuPicker/SkuPicker.tsx
+++ b/packages/ecommerce-app-base/src/SkuPicker/SkuPicker.tsx
@@ -82,8 +82,12 @@ export class SkuPicker extends Component<Props, State> {
         search
       } = this.state;
       const offset = (activePage - 1) * limit;
-      const { pagination, products } = await this.props.fetchProducts(search, { offset });
-      this.setState({ pagination, products });
+      const fetched = await this.props.fetchProducts(search, { offset });
+      // If the request has been cancelled because a new one has been launched
+      // then fetchProducts will return null
+      if (fetched && fetched.pagination && fetched.products) {
+        this.setState({ pagination: fetched.pagination, products: fetched.products });
+      }
     } catch (error) {
       this.props.sdk.notifier.error('There was an error fetching the product list.');
     }


### PR DESCRIPTION
Sometimes the calls made in shopify can take a long time to resolve. Because of the way the pagination code is structured, this could lead to there being multiple recursive chains of calls for the function `fetchNext` happening simultaneously. Each time the function is invoked we checked whether the search term had changed, and if so, assumed that this was a new search term and that we should start fetching from scratch. If two requests became active at once, they would both repeatedly reset, as with each call it would be appear that the search term had changed. 