### PR TITLE
fix: add check for sys object on select maps

### DIFF
--- a/apps/gatsby/src/AppConfig/ContentTypesPanel.js
+++ b/apps/gatsby/src/AppConfig/ContentTypesPanel.js
@@ -119,7 +119,12 @@ export const ContentTypesSelection = ({
   return ( 
     <>
     {/* Selectors for existing enabled content types */}
-      {fullEnabledTypes.map(({ sys }, index) => (
+    {fullEnabledTypes.map((item, index) => {
+      const sys = item.sys;
+      return !sys ? (
+        null
+      ):
+      (
       <Flex marginBottom="spacingM">
         <Flex marginRight = "spacingS" flexDirection="column">
           <Select
@@ -153,7 +158,7 @@ export const ContentTypesSelection = ({
           </TextLink>
         </Flex>
       </Flex>
-      ))}
+      )})}
 
       {/* Selector triggered by add content type button */}
       {selectorType && (


### PR DESCRIPTION
Breaking Gatsby app config page in production. Can't reproduce locally, so adding a naive check as a bandaid.