### PR TITLE
fix: retrieve all content types from space

### DIFF
--- a/apps/gatsby/src/AppConfig/AppConfig.js
+++ b/apps/gatsby/src/AppConfig/AppConfig.js
@@ -15,7 +15,6 @@ import styles from "../styles";
 function editorInterfacesToEnabledContentTypes(eis, appId) {
   const findAppWidget = (item) =>
     item.widgetNamespace === "app" && item.widgetId === appId;
-
   return eis
     .filter((ei) => !!get(ei, ["sidebar"], []).find(findAppWidget))
     .map((ei) => get(ei, ["sys", "contentType", "sys", "id"]))
@@ -58,7 +57,7 @@ export class AppConfig extends React.Component {
     const [installationParams, eisRes, contentTypesRes] = await Promise.all([
       app.getParameters(),
       space.getEditorInterfaces(),
-      space.getContentTypes(),
+      space.getContentTypes({limit: 1000}),
     ]);
 
     const params = installationParams || {};

--- a/apps/gatsby/src/AppConfig/ContentTypesPanel.js
+++ b/apps/gatsby/src/AppConfig/ContentTypesPanel.js
@@ -119,46 +119,43 @@ export const ContentTypesSelection = ({
   return ( 
     <>
     {/* Selectors for existing enabled content types */}
-    {fullEnabledTypes.map((item, index) => {
-      const sys = item.sys;
-      return !sys ? (
-        null
-      ):
-      (
-      <Flex marginBottom="spacingM">
-        <Flex marginRight = "spacingS" flexDirection="column">
-          <Select
-            key={`enabledSelect-${index}`}
-            value={sys.id} 
-            onFocus={(event) => changeFocus(event.target.value)}
-            onChange={(event)=> {
-              onContentTypeToggle(event.target.value, focusValue)
-              event.target.blur() //Have to blur target for correct focus value in the case dropdown is changed multiple times
-            }}
-            width={"medium"}
-          >
-            {sortedContentTypes.map(({name, sys}) => 
-              <Option key={`option - ${sys.id}`} value={sys.id} label={name}>
-                {name}
-              </Option>
-            )}
-          </Select>
+    {fullEnabledTypes.map(({ sys }, index) => {
+      return (
+        <Flex marginBottom="spacingM">
+          <Flex marginRight = "spacingS" flexDirection="column">
+            <Select
+              key={`enabledSelect-${index}`}
+              value={sys.id} 
+              onFocus={(event) => changeFocus(event.target.value)}
+              onChange={(event)=> {
+                onContentTypeToggle(event.target.value, focusValue)
+                event.target.blur() //Have to blur target for correct focus value in the case dropdown is changed multiple times
+              }}
+              width={"medium"}
+            >
+              {sortedContentTypes.map(({name, sys}) => 
+                <Option key={`option - ${sys.id}`} value={sys.id} label={name}>
+                  {name}
+                </Option>
+              )}
+            </Select>
+          </Flex>
+          <Flex fullWidth flexDirection="column" marginRight = "spacingS">
+            <UrlInput 
+              id={sys.id} 
+              onSlugInput={onSlugInput} 
+              urlConstructors={urlConstructors} 
+              placeholder={'(Optional) slug'}
+            />
+          </Flex>
+          <Flex>
+            <TextLink linkType="negative" onClick={() => updateModalState({open: true, id: sys.id})}>
+              Remove
+            </TextLink>
+          </Flex>
         </Flex>
-        <Flex fullWidth flexDirection="column" marginRight = "spacingS">
-          <UrlInput 
-            id={sys.id} 
-            onSlugInput={onSlugInput} 
-            urlConstructors={urlConstructors} 
-            placeholder={'(Optional) slug'}
-          />
-        </Flex>
-        <Flex>
-          <TextLink linkType="negative" onClick={() => updateModalState({open: true, id: sys.id})}>
-            Remove
-          </TextLink>
-        </Flex>
-      </Flex>
-      )})}
+      )}
+    )}
 
       {/* Selector triggered by add content type button */}
       {selectorType && (

--- a/apps/gatsby/src/AppConfig/ContentTypesPanel.js
+++ b/apps/gatsby/src/AppConfig/ContentTypesPanel.js
@@ -90,7 +90,7 @@ export const ContentTypesSelection = ({
   if (0 === contentTypes.length) {
     return <NoContentTypes space={space} environment={environment} />;
   }
-  
+
   const fullEnabledTypes = enabledContentTypes.map(enabledType => {
     const fullType = contentTypes.find(type => type.sys.id === enabledType)
     return fullType


### PR DESCRIPTION
App was only returning 100 content types from a space. This means that if the app was installed with certain content types, and then new content types were introduced, it could bump old content types out of the data returned from `space.getContentTypes`. This caused two bugs:

- Made some types unavailable in the config page.
- Returned undefined for some types when matching enabled ids to their full content type.

Raised the limit for getting content types to 1000.