### PR TITLE
chore: update to node 14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ commands:
 jobs:
   all:
     docker:
-      - image: circleci/node:12-stretch
+      - image: circleci/node:14-stretch
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,10 +18,10 @@ commands:
     steps:
       - run:
           name: Install pip
-          command: sudo apt-get install python-pip python-dev
+          command: sudo apt-get install python3-pip python3-dev
       - run:
           name: Install awscli
-          command: sudo pip install awscli
+          command: sudo pip3 install awscli
       - run:
           name: Deploy apps to test
           command: |
@@ -41,6 +41,14 @@ jobs:
       - image: circleci/node:14-stretch
     steps:
       - checkout
+      # Temp block for testing 
+      - run:
+          name: Install pip
+          command: sudo apt-get install python3-pip python3-dev
+      - run:
+          name: Install awscli
+          command: sudo pip3 install awscli
+      # END of temp block for testing
       - run:
           name: Install dependencies
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,14 +41,6 @@ jobs:
       - image: circleci/node:14-stretch
     steps:
       - checkout
-      # Temp block for testing 
-      - run:
-          name: Install pip
-          command: sudo apt-get install python3-pip python3-dev
-      - run:
-          name: Install awscli
-          command: sudo pip3 install awscli
-      # END of temp block for testing
       - run:
           name: Install dependencies
           command: |


### PR DESCRIPTION
## Context

Upgrade our CI pipeline to make use of Node 14 and remove the dependency on Python 2 (EOL as of this year)