### PR TITLE
fix: only handle messages events of relevant sources [EXT-2675]

### DIFF
--- a/apps/brandfolder/src/index.js
+++ b/apps/brandfolder/src/index.js
@@ -38,23 +38,32 @@ function renderDialog(sdk) {
   const container = document.createElement('div');
   const bf_embed_url = config.bf_api_key ? BF_EMBED_URL + `&apiKey=${config.bf_api_key}&hideLogout=true` : BF_EMBED_URL;
 
-  container.innerHTML = `<iframe id='brandfolder-embed' class='iframe-container' src='${bf_embed_url}' width=400 height=650 style='border:none;'/>`;
+  const iframe = document.createElement('iframe');
+  iframe.id = 'brandfolder-embed';
+  iframe.className="iframe-container";
+  iframe.src = bf_embed_url;
+  iframe.width = 400;
+  iframe.height = 650;
+  iframe.style.border = 'none'
+  container.appendChild(iframe)
+
   document.body.appendChild(container);
 
   sdk.window.startAutoResizer();
 
   window.addEventListener('message', e => {
-    const { data, origin } = e;
-    if (origin === 'https://integration-panel-ui.brandfolder-svc.com') {
-      const { event, payload } = data;
-      if (event === 'selectedAttachment') {
-        sdk.close([payload]);
-      } else if (data.event === 'selectedAsset' && payload.attachments.length !== 0) {
-        const att_id = payload.attachments[0].id;
-        const attachment = payload.included.find(att => att.id === att_id);
-        if (attachment) {
-          sdk.close([attachment]);
-        }
+    if (e.source !== iframe.contentWindow) {
+      return ;
+    }
+
+    const { event, payload } = e.data;
+    if (event === 'selectedAttachment') {
+      sdk.close([payload]);
+    } else if (data.event === 'selectedAsset' && payload.attachments.length !== 0) {
+      const att_id = payload.attachments[0].id;
+      const attachment = payload.included.find(att => att.id === att_id);
+      if (attachment) {
+        sdk.close([attachment]);
       }
     }
   });

--- a/apps/brandfolder/src/index.js
+++ b/apps/brandfolder/src/index.js
@@ -7,21 +7,21 @@ const BF_EMBED_URL = `https://integration-panel-ui.brandfolder-svc.com?channel=m
 const CTA = 'Select an asset on Brandfolder';
 
 const FIELDS_TO_PERSIST = [
-        'asset',
-        'cdn_url',
-        'extension',
-        'filename',
-        'height',
-        'id',
-        'included',
-        'mimetype',
-        'position',
-        'relationships',
-        'size',
-        'thumbnail_url',
-        'type',
-        'url',
-        'width',
+  'asset',
+  'cdn_url',
+  'extension',
+  'filename',
+  'height',
+  'id',
+  'included',
+  'mimetype',
+  'position',
+  'relationships',
+  'size',
+  'thumbnail_url',
+  'type',
+  'url',
+  'width'
 ];
 
 function makeThumbnail(attachment) {
@@ -36,16 +36,18 @@ function renderDialog(sdk) {
   const config = sdk.parameters.invocation;
 
   const container = document.createElement('div');
-  const bf_embed_url = config.bf_api_key ? BF_EMBED_URL + `&apiKey=${config.bf_api_key}&hideLogout=true` : BF_EMBED_URL;
+  const bf_embed_url = config.bf_api_key
+    ? BF_EMBED_URL + `&apiKey=${config.bf_api_key}&hideLogout=true`
+    : BF_EMBED_URL;
 
   const iframe = document.createElement('iframe');
   iframe.id = 'brandfolder-embed';
-  iframe.className="iframe-container";
+  iframe.className = 'iframe-container';
   iframe.src = bf_embed_url;
   iframe.width = 400;
   iframe.height = 650;
-  iframe.style.border = 'none'
-  container.appendChild(iframe)
+  iframe.style.border = 'none';
+  container.appendChild(iframe);
 
   document.body.appendChild(container);
 
@@ -59,7 +61,7 @@ function renderDialog(sdk) {
     const { event, payload } = e.data;
     if (event === 'selectedAttachment') {
       sdk.close([payload]);
-    } else if (data.event === 'selectedAsset' && payload.attachments.length !== 0) {
+    } else if (event === 'selectedAsset' && payload.attachments.length !== 0) {
       const att_id = payload.attachments[0].id;
       const attachment = payload.included.find(att => att.id === att_id);
       if (attachment) {
@@ -114,11 +116,12 @@ setup({
     'The Brandfolder app is a widget that allows editors to select media from their Brandfolder account. Select a file on Brandfolder and designate the assets that you want your entry to reference.',
   parameterDefinitions: [
     {
-      "id": "bf_api_key",
-      "type": "Symbol",
-      "name": "Brandfolder API key",
-      "description": "If you want to use just one API key (https://brandfolder.com/profile#integrations) for all users, enter it here.",
-      "required": false
+      id: 'bf_api_key',
+      type: 'Symbol',
+      name: 'Brandfolder API key',
+      description:
+        'If you want to use just one API key (https://brandfolder.com/profile#integrations) for all users, enter it here.',
+      required: false
     }
   ],
   validateParameters: () => {},

--- a/apps/brandfolder/src/index.js
+++ b/apps/brandfolder/src/index.js
@@ -53,7 +53,7 @@ function renderDialog(sdk) {
 
   window.addEventListener('message', e => {
     if (e.source !== iframe.contentWindow) {
-      return ;
+      return;
     }
 
     const { event, payload } = e.data;

--- a/apps/frontify/src/index.js
+++ b/apps/frontify/src/index.js
@@ -61,6 +61,10 @@ function renderDialog(sdk) {
 
   // cross document messaging
   window.addEventListener('message', e => {
+    if (e.source !== chooser) {
+      return;
+    }
+
     if (!e.data) return;
 
     if (e.data.error) {

--- a/apps/jira/jira-app/src/components/Auth/OAuth.tsx
+++ b/apps/jira/jira-app/src/components/Auth/OAuth.tsx
@@ -27,8 +27,12 @@ export default class OAuth extends React.Component<Props> {
 
     const oauthWindow = window.open(url, 'Jira Contentful', 'left=150,top=10,width=800,height=900');
 
-    window.addEventListener('message', ({ data }) => {
-      const { token, error } = data;
+    window.addEventListener('message', (e) => {
+      if (e.source !== oauthWindow) {
+        return ;
+      }
+
+      const { token, error } = e.data;
 
       if (error) {
         this.props.notifyError('There was an error authenticating. Please refresh and try again.');

--- a/apps/jira/jira-app/src/index.spec.tsx
+++ b/apps/jira/jira-app/src/index.spec.tsx
@@ -76,7 +76,7 @@ describe('The Jira App Components', () => {
       const oauthButton = wrapper.getByTestId('oauth-button');
       const token = '123';
 
-      const source: MessageEventSource = 'source' as any;
+      const source: MessageEventSource = { close: jest.fn() } as any;
       (window.open as jest.Mock).mockReturnValue(source);
 
       fireEvent.click(oauthButton);
@@ -98,7 +98,7 @@ describe('The Jira App Components', () => {
       const oauthButton = wrapper.getByTestId('oauth-button');
       const error = '123';
 
-      const source: MessageEventSource = 'source' as any;
+      const source: MessageEventSource = { close: jest.fn() } as any;
       (window.open as jest.Mock).mockReturnValue(source);
 
       fireEvent.click(oauthButton);

--- a/apps/jira/jira-app/src/index.spec.tsx
+++ b/apps/jira/jira-app/src/index.spec.tsx
@@ -76,8 +76,11 @@ describe('The Jira App Components', () => {
       const oauthButton = wrapper.getByTestId('oauth-button');
       const token = '123';
 
+      const source: MessageEventSource = 'source' as any;
+      (window.open as jest.Mock).mockReturnValue(source);
+
       fireEvent.click(oauthButton);
-      fireEvent(window, new MessageEvent('message', { data: { token } }));
+      fireEvent(window, new MessageEvent('message', { data: { token }, source }));
 
       expect(window.open).toHaveBeenCalledWith(
         'https://auth.atlassian.com/authorize?audience=api.atlassian.com&client_id=XD9k9QU9VT4Rt26u6lbO3NM0fOqvvXan&scope=read%3Ajira-user%20read%3Ajira-work%20write%3Ajira-work&redirect_uri=https%3A%2F%2Fapi.jira.ctfapps.net%2Fauth&response_type=code&state=http%3A%2F%2Flocalhost%2F&prompt=consent',
@@ -95,8 +98,11 @@ describe('The Jira App Components', () => {
       const oauthButton = wrapper.getByTestId('oauth-button');
       const error = '123';
 
+      const source: MessageEventSource = 'source' as any;
+      (window.open as jest.Mock).mockReturnValue(source);
+
       fireEvent.click(oauthButton);
-      fireEvent(window, new MessageEvent('message', { data: { error } }));
+      fireEvent(window, new MessageEvent('message', { data: { error }, source }));
 
       expect(mockSdk.notifier.error).toHaveBeenCalledWith(
         'There was an error authenticating. Please refresh and try again.'
@@ -137,7 +143,9 @@ describe('The Jira App Components', () => {
       });
 
       const instanceSelector = wrapper.getByTestId('instance-selector');
-      const projectSearchInput: HTMLInputElement = wrapper.getByTestId('cf-ui-text-input') as HTMLInputElement;
+      const projectSearchInput: HTMLInputElement = wrapper.getByTestId(
+        'cf-ui-text-input'
+      ) as HTMLInputElement;
 
       // expect instance data to load into the first <select>
       expect(instanceSelector.textContent).toEqual(

--- a/apps/smartling/frontend/src/Sidebar.tsx
+++ b/apps/smartling/frontend/src/Sidebar.tsx
@@ -147,7 +147,11 @@ export default class Sidebar extends React.Component<Props, State> {
     } else if (refresh.failed) {
       const smartlingWindow = window.open('/openauth', '', 'height=600,width=600,top=50,left=50');
 
-      const listener = ({ data }: any) => {
+      const listener = ({ data, source }: any) => {
+        if (source !== smartlingWindow) {
+          return;
+        }
+
         const { token, refreshToken } = data;
 
         if (token) {


### PR DESCRIPTION
Currently, the message event handler is also triggered for messages being sent from the web app to the app iframe. This simple condition excludes those messages and ensures the handler only handles messages coming from the frontify iframe.

Question: Should we also include this condition in other apps to avoid infinite loops as they happed with frontify?