### PR TITLE
fix: render thumbnail correctly when quality/format transformation is disabled

### DIFF
--- a/apps/cloudinary/src/index.js
+++ b/apps/cloudinary/src/index.js
@@ -51,7 +51,7 @@ function makeThumbnail(resource, config) {
   });
 
   let url;
-  resource.raw_transformation ||= "";
+  resource.raw_transformation = resource.raw_transformation || "";
   const alt = [resource.public_id, ...(resource.tags || [])].join(', ');
   let transformations = `${resource.raw_transformation}/c_fill,h_100,w_150`;
 

--- a/apps/cloudinary/src/index.js
+++ b/apps/cloudinary/src/index.js
@@ -51,6 +51,7 @@ function makeThumbnail(resource, config) {
   });
 
   let url;
+  resource.raw_transformation ||= "";
   const alt = [resource.public_id, ...(resource.tags || [])].join(', ');
   let transformations = `${resource.raw_transformation}/c_fill,h_100,w_150`;
 


### PR DESCRIPTION
When "Format" and "Media Quality" from the Cloudinary App settings are set to "None" and an original asset is inserted via the Media Library Widget, no "derived" key would be present in the returned JSON. This results in the `resource.raw_transformation` called in `makeThumbnail` to be `undefined` which leads to thumbnail URLs to have a transformation of `undefined/c_fill,h_100,w_150`. As this is not a valid Cloudinary transformation/URL, no thumbnail is displayed for those inserted assets. If `raw_transformation` is undefined then we can default to an empty string and the Cloudinary `url` method would handle the transformation when it comes in as `/c_fill,h_100,w_150`.