### PR TITLE
feat: [] Extend Shopify app support to products and collections

### DIFF
--- a/apps/shopify/src/collectionPagination.js
+++ b/apps/shopify/src/collectionPagination.js
@@ -1,0 +1,96 @@
+import differenceBy from 'lodash/differenceBy';
+import { collectionDataTransformer } from './dataTransformer';
+import { makeShopifyClient } from './skuResolvers';
+
+const PER_PAGE = 20;
+
+class Pagination {
+  freshSearch = true;
+
+  hasNextProductPage = false;
+  collections = [];
+
+  prevSearch = '';
+
+  constructor(sdk) {
+    this.sdk = sdk;
+  }
+
+  async init() {
+    this.shopifyClient = await makeShopifyClient(this.sdk.parameters.installation);
+  }
+
+  async fetchNext(search) {
+    const searchHasChanged = search !== this.prevSearch;
+
+    if (searchHasChanged) {
+      this.prevSearch = search;
+      this._resetPagination();
+    }
+
+    const collections = await this._fetchMoreCollections(search);
+
+    return {
+      pagination: {
+        hasNextPage: this.hasNextProductPage
+      },
+      products: collections.map(collectionDataTransformer)
+    };
+  }
+
+  /**
+   * This method will either fetch the first batch of collections or the next page
+   * in the pagination based on the user search and depending on whether the user
+   * has already requested an initial batch of collections or not
+   */
+  async _fetchMoreCollections(search) {
+    const noProductsFetchedYet = this.collections.length === 0;
+    const nextCollections = noProductsFetchedYet
+      ? await this._fetchCollections(search)
+      : await this._fetchNextPage(this.collections);
+    this.hasNextProductPage = nextCollections.length === PER_PAGE;
+    this.freshSearch = false;
+
+    const newCollections = differenceBy(nextCollections, this.collections, 'id');
+
+    this.collections = [...this.collections, ...newCollections];
+
+    return newCollections;
+  }
+
+  /**
+   * This method is used when the user is fetching collections for the first time.
+   * i.e. when they just opened the product picker widget or when they just applied
+   * a new search term.
+   */
+  async _fetchCollections(search) {
+    const query = { query: search };
+    return await this.shopifyClient.collection.fetchQuery({
+      first: PER_PAGE,
+      sortBy: 'TITLE',
+      reverse: true,
+      ...(search.length && query)
+    });
+  }
+
+  /**
+   * This method is used when the user has already fetched a batch of collections
+   * and now want to render the next page.
+   */
+  async _fetchNextPage(collections) {
+    return (await this.shopifyClient.fetchNextPage(collections)).model;
+  }
+
+  _resetPagination() {
+    this.collections = [];
+    this.freshSearch = true;
+  }
+}
+
+const makePagination = async sdk => {
+  const pagination = new Pagination(sdk);
+  await pagination.init();
+  return pagination;
+};
+
+export default makePagination;

--- a/apps/shopify/src/constants.js
+++ b/apps/shopify/src/constants.js
@@ -1,0 +1,4 @@
+// If one creates product with no variants in SHopify, a default variant is
+// returned with this unfortunate title, and there is no other way to check
+// whether the returned variant is the default one or not
+export const DEFAULT_SHOPIFY_VARIANT_TITLE = 'Default Title';

--- a/apps/shopify/src/constants.js
+++ b/apps/shopify/src/constants.js
@@ -2,3 +2,19 @@
 // returned with this unfortunate title, and there is no other way to check
 // whether the returned variant is the default one or not
 export const DEFAULT_SHOPIFY_VARIANT_TITLE = 'Default Title';
+
+export const SKU_TYPES = [
+  {
+    id: 'product',
+    name: 'Product'
+  },
+  {
+    id: 'variant',
+    name: 'Product variant',
+    default: true
+  },
+  {
+    id: 'collection',
+    name: 'Collection'
+  }
+];

--- a/apps/shopify/src/dataTransformer.js
+++ b/apps/shopify/src/dataTransformer.js
@@ -1,6 +1,7 @@
 import get from 'lodash/get';
 import last from 'lodash/last';
 import flatten from 'lodash/flatten';
+import { DEFAULT_SHOPIFY_VARIANT_TITLE } from './constants';
 
 /**
  * Transforms the API response of Shopify into
@@ -28,13 +29,22 @@ export const productsToVariantsTransformer = products =>
         variantSKU: variant.sku,
         sku: variant.id,
         productId: product.id,
-        title: product.title,
+        title:
+          variant.title === DEFAULT_SHOPIFY_VARIANT_TITLE
+            ? product.title
+            : `${product.title} (${variant.title})`
       }));
       return variants;
     })
   );
 
-export const previewsToVariants = ({ apiEndpoint }) => ({ sku, id, image, product }) => {
+export const previewsToVariants = ({ apiEndpoint }) => ({
+  sku,
+  id,
+  image,
+  product,
+  title: variantTitle
+}) => {
   const productIdDecoded = atob(product.id);
   const productId =
     productIdDecoded && productIdDecoded.slice(productIdDecoded.lastIndexOf('/') + 1);
@@ -47,7 +57,10 @@ export const previewsToVariants = ({ apiEndpoint }) => ({ sku, id, image, produc
     sku: id,
     displaySKU: sku !== '' ? `SKU: ${sku}` : `Product ID: ${id}`,
     productId: product.id,
-    name: product.title,
+    name:
+      variantTitle === DEFAULT_SHOPIFY_VARIANT_TITLE
+        ? product.title
+        : `${product.title} (${variantTitle})`,
     ...(apiEndpoint &&
       productId && {
         externalLink: `https://${apiEndpoint}${

--- a/apps/shopify/src/dataTransformer.js
+++ b/apps/shopify/src/dataTransformer.js
@@ -4,6 +4,40 @@ import flatten from 'lodash/flatten';
 import { DEFAULT_SHOPIFY_VARIANT_TITLE } from './constants';
 
 /**
+ * Transforms the API response of Shopify collections into
+ * the product schema expected by the SkuPicker component
+ */
+export const collectionDataTransformer = (collection, apiEndpoint) => {
+  const image = get(collection, ['image', 'src'], '');
+  const handle = get(collection, ['handle'], undefined);
+
+  let externalLink;
+
+  if (apiEndpoint) {
+    try {
+      const collectionIdDecoded = atob(collection.id);
+      const collectionId =
+        collectionIdDecoded && collectionIdDecoded.slice(collectionIdDecoded.lastIndexOf('/') + 1);
+
+      if (apiEndpoint && collectionId) {
+        externalLink = `https://${apiEndpoint}${
+          last(apiEndpoint) === '/' ? '' : '/'
+        }admin/collections/${collectionId}`;
+      }
+    } catch {}
+  }
+
+  return {
+    id: collection.id,
+    image,
+    name: collection.title,
+    displaySKU: handle ? `Handle: ${handle}` : `Collection ID: ${collection.id}`,
+    sku: collection.id,
+    ...(externalLink ? { externalLink } : {})
+  };
+};
+
+/**
  * Transforms the API response of Shopify products into
  * the product schema expected by the SkuPicker component
  */

--- a/apps/shopify/src/index.js
+++ b/apps/shopify/src/index.js
@@ -1,12 +1,60 @@
 import { setup, renderSkuPicker } from '@contentful/ecommerce-app-base';
-import { fetchProductPreviews, makeProductSearchResolver } from './productResolvers';
+import { fetchProductVariantPreviews, fetchProductPreviews, makeSkuResolver } from './skuResolvers';
+import { SKU_TYPES } from './constants';
 
 import logo from './logo.svg';
 
 const DIALOG_ID = 'dialog-root';
 
-function makeCTA(fieldType) {
-  return fieldType === 'Array' ? 'Select products' : 'Select a product';
+function makeCTA(fieldType, skuType) {
+  if (skuType === 'product') {
+    return fieldType === 'Array' ? 'Select products' : 'Select a product';
+  }
+
+  if (skuType === 'collection') {
+    return fieldType === 'Array' ? 'Select collections' : 'Select a collection';
+  }
+
+  return fieldType === 'Array' ? 'Select product variants' : 'Select a product variant';
+}
+
+function getSaveBtnText(skuType) {
+  if (skuType === 'product') {
+    return selectedSKUs => {
+      switch (selectedSKUs.length) {
+        case 0:
+          return 'Save products';
+        case 1:
+          return 'Save 1 product';
+        default:
+          return `Save ${selectedSKUs.length} products`;
+      }
+    };
+  }
+
+  if (skuType === 'collection') {
+    return selectedSKUs => {
+      switch (selectedSKUs.length) {
+        case 0:
+          return 'Save collections';
+        case 1:
+          return 'Save 1 collection';
+        default:
+          return `Save ${selectedSKUs.length} collections`;
+      }
+    };
+  }
+
+  return selectedSKUs => {
+    switch (selectedSKUs.length) {
+      case 0:
+        return 'Save product variants';
+      case 1:
+        return 'Save 1 product variant';
+      default:
+        return `Save ${selectedSKUs.length} product variants`;
+    }
+  };
 }
 
 export function validateParameters(parameters) {
@@ -21,6 +69,14 @@ export function validateParameters(parameters) {
   return null;
 }
 
+function fetchPreviews(skus, config, skuType) {
+  if (skuType === 'product') {
+    return fetchProductPreviews(skus, config);
+  }
+
+  return fetchProductVariantPreviews(skus, config);
+}
+
 async function renderDialog(sdk) {
   const container = document.createElement('div');
   container.id = DIALOG_ID;
@@ -28,11 +84,15 @@ async function renderDialog(sdk) {
   container.style.flexDirection = 'column';
   document.body.appendChild(container);
 
+  const skuType = sdk.parameters?.invocation?.skuType;
+
   renderSkuPicker(DIALOG_ID, {
     sdk,
-    fetchProductPreviews,
-    fetchProducts: await makeProductSearchResolver(sdk),
-    searchDelay: 750
+    fetchProductPreviews: fetchPreviews,
+    fetchProducts: await makeSkuResolver(sdk, skuType),
+    searchDelay: 750,
+    skuType,
+    getSaveBtnText: getSaveBtnText(skuType)
   });
 
   sdk.window.startAutoResizer();
@@ -80,7 +140,8 @@ setup({
       required: true
     }
   ],
-  fetchProductPreviews,
+  skuTypes: SKU_TYPES,
+  fetchProductPreviews: fetchPreviews,
   renderDialog,
   openDialog,
   isDisabled,

--- a/apps/shopify/src/index.js
+++ b/apps/shopify/src/index.js
@@ -1,5 +1,10 @@
 import { setup, renderSkuPicker } from '@contentful/ecommerce-app-base';
-import { fetchProductVariantPreviews, fetchProductPreviews, makeSkuResolver } from './skuResolvers';
+import {
+  fetchProductVariantPreviews,
+  fetchProductPreviews,
+  fetchCollectionPreviews,
+  makeSkuResolver
+} from './skuResolvers';
 import { SKU_TYPES } from './constants';
 
 import logo from './logo.svg';
@@ -74,6 +79,10 @@ function fetchPreviews(skus, config, skuType) {
     return fetchProductPreviews(skus, config);
   }
 
+  if (skuType === 'collection') {
+    return fetchCollectionPreviews(skus, config);
+  }
+
   return fetchProductVariantPreviews(skus, config);
 }
 
@@ -102,7 +111,7 @@ async function openDialog(sdk, currentValue, config) {
   const skus = await sdk.dialogs.openCurrentApp({
     allowHeightOverflow: true,
     position: 'center',
-    title: makeCTA(sdk.field.type),
+    title: makeCTA(sdk.field.type, config.skuType),
     shouldCloseOnOverlayClick: true,
     shouldCloseOnEscapePress: true,
     parameters: config,

--- a/apps/shopify/src/productPagination.js
+++ b/apps/shopify/src/productPagination.js
@@ -1,0 +1,96 @@
+import differenceBy from 'lodash/differenceBy';
+import { productDataTransformer } from './dataTransformer';
+import { makeShopifyClient } from './skuResolvers';
+
+const PER_PAGE = 20;
+
+class Pagination {
+  freshSearch = true;
+
+  hasNextProductPage = false;
+  products = [];
+
+  prevSearch = '';
+
+  constructor(sdk) {
+    this.sdk = sdk;
+  }
+
+  async init() {
+    this.shopifyClient = await makeShopifyClient(this.sdk.parameters.installation);
+  }
+
+  async fetchNext(search) {
+    const searchHasChanged = search !== this.prevSearch;
+
+    if (searchHasChanged) {
+      this.prevSearch = search;
+      this._resetPagination();
+    }
+
+    const products = await this._fetchMoreProducts(search);
+
+    return {
+      pagination: {
+        hasNextPage: this.hasNextProductPage
+      },
+      products: products.map(productDataTransformer)
+    };
+  }
+
+  /**
+   * This method will either fetch the first batch of products or the next page
+   * in the pagination based on the user search and depending on whether the user
+   * has already requested an initial batch of products or not
+   */
+  async _fetchMoreProducts(search) {
+    const noProductsFetchedYet = this.products.length === 0;
+    const nextProducts = noProductsFetchedYet
+      ? await this._fetchProducts(search)
+      : await this._fetchNextPage(this.products);
+    this.hasNextProductPage = nextProducts.length === PER_PAGE;
+    this.freshSearch = false;
+
+    const newProducts = differenceBy(nextProducts, this.products, 'id');
+
+    this.products = [...this.products, ...newProducts];
+
+    return newProducts;
+  }
+
+  /**
+   * This method is used when the user is fetching products for the first time.
+   * i.e. when they just opened the product picker widget or when they just applied
+   * a new search term.
+   */
+  async _fetchProducts(search) {
+    const query = { query: `variants:['sku:${search}'] OR title:${search}` };
+    return await this.shopifyClient.product.fetchQuery({
+      first: PER_PAGE,
+      sortBy: 'TITLE',
+      reverse: true,
+      ...(search.length && query)
+    });
+  }
+
+  /**
+   * This method is used when the user has already fetched a batch of products
+   * and now want to render the next page.
+   */
+  async _fetchNextPage(products) {
+    return (await this.shopifyClient.fetchNextPage(products)).model;
+  }
+
+  _resetPagination() {
+    this.products = [];
+    this.freshSearch = true;
+  }
+}
+
+const makePagination = async sdk => {
+  const pagination = new Pagination(sdk);
+  await pagination.init();
+  return pagination;
+};
+
+export default makePagination;

--- a/apps/shopify/src/productPagination.js
+++ b/apps/shopify/src/productPagination.js
@@ -5,8 +5,6 @@ import { makeShopifyClient } from './skuResolvers';
 const PER_PAGE = 20;
 
 class Pagination {
-  freshSearch = true;
-
   hasNextProductPage = false;
   products = [];
 
@@ -49,7 +47,6 @@ class Pagination {
       ? await this._fetchProducts(search)
       : await this._fetchNextPage(this.products);
     this.hasNextProductPage = nextProducts.length === PER_PAGE;
-    this.freshSearch = false;
 
     const newProducts = differenceBy(nextProducts, this.products, 'id');
 
@@ -83,7 +80,6 @@ class Pagination {
 
   _resetPagination() {
     this.products = [];
-    this.freshSearch = true;
   }
 }
 

--- a/apps/shopify/src/productVariantPagination.js
+++ b/apps/shopify/src/productVariantPagination.js
@@ -1,8 +1,8 @@
 import last from 'lodash/last';
 import uniqBy from 'lodash/uniqBy';
 import sortBy from 'lodash/sortBy';
-import { dataTransformer, productsToVariantsTransformer } from './dataTransformer';
-import { makeShopifyClient } from './productResolvers';
+import { productVariantDataTransformer, productsToVariantsTransformer } from './dataTransformer';
+import { makeShopifyClient } from './skuResolvers';
 
 const PER_PAGE = 20;
 
@@ -21,7 +21,7 @@ class Pagination {
   }
 
   async init() {
-    this.shopifyClient = await makeShopifyClient(this.sdk);
+    this.shopifyClient = await makeShopifyClient(this.sdk.parameters.installation);
   }
 
   async fetchNext(search, recursing = false) {
@@ -52,7 +52,7 @@ class Pagination {
           // B). There are variants left to consume in the in-memory variants list
           hasNextPage: this.hasNextProductPage || this.variants.length > 0
         },
-        products: variants.map(dataTransformer)
+        products: variants.map(productVariantDataTransformer)
       };
     }
 

--- a/apps/shopify/src/skuResolvers.js
+++ b/apps/shopify/src/skuResolvers.js
@@ -27,9 +27,9 @@ export async function makeShopifyClient(config) {
 /**
  * Fetches the collection previews for the collections selected by the user.
  *
- * Note: currently there is no way to cover the edge case where the user
- *       would have more than 250 collections selected. In such a case their
- *       selection would be cut off after collection no. 250.
+ * Note: currently there is no way to fetch multiple collections by id
+ * so we use fetchAll instead and then filter on the client. Besides the obvious disadvantage,
+ * this could also fail if there are mo collections in the stroe than the pagination limit
  */
 export const fetchCollectionPreviews = async (skus, config) => {
   if (!skus.length) {
@@ -37,7 +37,9 @@ export const fetchCollectionPreviews = async (skus, config) => {
   }
 
   const shopifyClient = await makeShopifyClient(config);
-  const collections = await shopifyClient.collection.fetchMultiple(skus);
+  const collections = (await shopifyClient.collection.fetchAll()).filter(collection =>
+    skus.includes(collection.id)
+  );
 
   return collections.map(collection => collectionDataTransformer(collection, config.apiEndpoint));
 };

--- a/packages/ecommerce-app-base/src/AppConfig/FieldSelector.tsx
+++ b/packages/ecommerce-app-base/src/AppConfig/FieldSelector.tsx
@@ -1,15 +1,27 @@
 import * as React from 'react';
 import tokens from '@contentful/forma-36-tokens';
 import { css } from '@emotion/css';
-import { Form, Subheading, CheckboxField, Typography } from '@contentful/forma-36-react-components';
+import {
+  Form,
+  Subheading,
+  CheckboxField,
+  Typography,
+  FieldGroup,
+  Flex,
+  RadioButtonField
+} from '@contentful/forma-36-react-components';
 
-import { ContentType, CompatibleFields, SelectedFields } from './fields';
+import { ContentType, CompatibleFields, SelectedFields, FieldsSkuTypes } from './fields';
+import { Integration } from '../interfaces';
 
 interface Props {
   contentTypes: ContentType[];
   compatibleFields: CompatibleFields;
   selectedFields: SelectedFields;
   onSelectedFieldsChange: Function;
+  fieldSkuTypes: FieldsSkuTypes;
+  onFieldSkuTypesChange: (fieldSkuTypes: FieldsSkuTypes) => void;
+  skuTypes?: Integration['skuTypes'];
 }
 
 export default class FieldSelector extends React.Component<Props> {
@@ -29,8 +41,32 @@ export default class FieldSelector extends React.Component<Props> {
     this.props.onSelectedFieldsChange(updated);
   };
 
+  onFieldSkuTypesChange = (
+    ctId: string,
+    fieldId: string,
+    e: React.ChangeEvent<HTMLInputElement>
+  ): void => {
+    const updated = { ...this.props.fieldSkuTypes };
+
+    if (updated[ctId] === undefined) {
+      updated[ctId] = {};
+    }
+
+    updated[ctId][fieldId] = e.target.value;
+
+    this.props.onFieldSkuTypesChange(updated);
+  };
+
   render() {
-    const { compatibleFields, contentTypes, selectedFields } = this.props;
+    const {
+      compatibleFields,
+      contentTypes,
+      selectedFields,
+      fieldSkuTypes,
+      skuTypes = []
+    } = this.props;
+
+    const defaultSkuType = skuTypes.find(skuType => skuType.default === true)?.id;
 
     return (
       <Typography>
@@ -41,16 +77,36 @@ export default class FieldSelector extends React.Component<Props> {
               <Subheading>{ct.name}</Subheading>
               <Form>
                 {fields.map(field => (
-                  <CheckboxField
-                    key={field.id}
-                    id={`field-box-${ct.sys.id}-${field.id}`}
-                    labelText={field.name}
-                    helpText={`${
-                      field.type === 'Symbol' ? 'Short text' : 'Short text, list'
-                    } · Field ID: ${field.id}`}
-                    checked={(selectedFields[ct.sys.id] || []).includes(field.id)}
-                    onChange={this.onSelectedFieldChange.bind(this, ct.sys.id, field.id)}
-                  />
+                  <FieldGroup key={field.id}>
+                    <CheckboxField
+                      id={`field-box-${ct.sys.id}-${field.id}`}
+                      labelText={field.name}
+                      helpText={`${
+                        field.type === 'Symbol' ? 'Short text' : 'Short text, list'
+                      } · Field ID: ${field.id}`}
+                      checked={(selectedFields[ct.sys.id] || []).includes(field.id)}
+                      onChange={this.onSelectedFieldChange.bind(this, ct.sys.id, field.id)}
+                    />
+                    {skuTypes.length > 0 && (selectedFields[ct.sys.id] || []).includes(field.id) ? (
+                      <Flex>
+                        {skuTypes.map(skuType => (
+                          <RadioButtonField
+                            key={skuType.id}
+                            id={`skuType-${ct.sys.id}-${field.id}-${skuType.id}`}
+                            name={`skuType-${ct.sys.id}-${field.id}`}
+                            value={skuType.id}
+                            labelText={skuType.name}
+                            className="f36-margin-left--l"
+                            checked={
+                              (fieldSkuTypes[ct.sys.id]?.[field.id] ?? defaultSkuType) ===
+                              skuType.id
+                            }
+                            onChange={this.onFieldSkuTypesChange.bind(this, ct.sys.id, field.id)}
+                          />
+                        ))}
+                      </Flex>
+                    ) : null}
+                  </FieldGroup>
                 ))}
               </Form>
             </div>

--- a/packages/ecommerce-app-base/src/AppConfig/fields.ts
+++ b/packages/ecommerce-app-base/src/AppConfig/fields.ts
@@ -21,6 +21,7 @@ interface Control {
   fieldId: string;
   widgetNamespace: string;
   widgetId: string;
+  settings?: Record<string, string>;
 }
 
 export interface EditorInterface {
@@ -30,6 +31,10 @@ export interface EditorInterface {
 
 export type CompatibleFields = Record<string, Field[]>;
 export type SelectedFields = Record<string, string[] | undefined>;
+
+export interface FieldsSkuTypes {
+  [key: string]: Record<string, string>;
+}
 
 function isCompatibleField(field: Field) {
   const isArray = field.type === 'Array';

--- a/packages/ecommerce-app-base/src/Editor/SortableComponent.tsx
+++ b/packages/ecommerce-app-base/src/Editor/SortableComponent.tsx
@@ -14,6 +14,7 @@ interface Props {
   config: Config;
   skus: string[];
   fetchProductPreviews: ProductPreviewsFn;
+  skuType?: string;
 }
 
 interface State {
@@ -40,9 +41,9 @@ export class SortableComponent extends React.Component<Props, State> {
 
   updateProductPreviews = async (shouldRefetch: boolean = true) => {
     try {
-      const { fetchProductPreviews, skus, config } = this.props;
+      const { fetchProductPreviews, skus, config, skuType } = this.props;
       const productPreviewsUnsorted = shouldRefetch
-        ? await fetchProductPreviews(skus, config)
+        ? await fetchProductPreviews(skus, config, skuType)
         : this.state.productPreviews;
       const productPreviews = mapSort(productPreviewsUnsorted, skus, 'sku');
       this.setState({ productPreviews });

--- a/packages/ecommerce-app-base/src/SkuPicker/SkuPicker.tsx
+++ b/packages/ecommerce-app-base/src/SkuPicker/SkuPicker.tsx
@@ -69,7 +69,6 @@ export class SkuPicker extends Component<Props, State> {
     super(props);
     this.setSearchCallback = debounce(() => {
       this.setActivePage(1);
-      this.updateProducts();
     }, this.props.searchDelay || DEFAULT_SEARCH_DELAY);
   }
 

--- a/packages/ecommerce-app-base/src/SkuPicker/SkuPicker.tsx
+++ b/packages/ecommerce-app-base/src/SkuPicker/SkuPicker.tsx
@@ -6,7 +6,13 @@ import { Button, TextInput, Icon } from '@contentful/forma-36-react-components';
 import { DialogExtensionSDK } from '@contentful/app-sdk';
 import { ProductList } from './ProductList';
 import { Paginator } from './Paginator';
-import { Pagination, Product, ProductPreviewsFn, ProductsFn } from '../interfaces';
+import {
+  GetSaveBtnTextFn,
+  Pagination,
+  Product,
+  ProductPreviewsFn,
+  ProductsFn
+} from '../interfaces';
 import { ProductSelectionList } from './ProductSelectionList';
 import { styles } from './styles';
 import { mapSort } from '../utils';
@@ -16,6 +22,8 @@ export interface Props {
   fetchProductPreviews: ProductPreviewsFn;
   fetchProducts: ProductsFn;
   searchDelay?: number;
+  skuType?: string;
+  getSaveBtnText?: GetSaveBtnTextFn;
 }
 
 interface State {
@@ -29,7 +37,7 @@ interface State {
 
 const DEFAULT_SEARCH_DELAY = 250;
 
-function getSaveBtnText(selectedSKUs: string[]): string {
+function defaultGetSaveBtnText(selectedSKUs: string[]): string {
   switch (selectedSKUs.length) {
     case 0:
       return 'Save products';
@@ -96,8 +104,9 @@ export class SkuPicker extends Component<Props, State> {
   updateSelectedProducts = async () => {
     try {
       const { selectedSKUs } = this.state;
-      const config = this.props.sdk.parameters.installation;
-      const selectedProductsUnsorted = await this.props.fetchProductPreviews(selectedSKUs, config);
+      const { sdk, skuType, fetchProductPreviews } = this.props;
+      const config = sdk.parameters.installation;
+      const selectedProductsUnsorted = await fetchProductPreviews(selectedSKUs, config, skuType);
       const selectedProducts = mapSort(selectedProductsUnsorted, selectedSKUs, 'sku');
       this.setState({ selectedProducts });
     } catch (error) {
@@ -143,6 +152,7 @@ export class SkuPicker extends Component<Props, State> {
 
   render() {
     const { search, pagination, products, selectedProducts, selectedSKUs } = this.state;
+    const { getSaveBtnText = defaultGetSaveBtnText, skuType } = this.props;
     const infiniteScrollingPaginationMode = 'hasNextPage' in pagination;
     const pageCount = Math.ceil(pagination.total / pagination.limit);
 
@@ -174,7 +184,7 @@ export class SkuPicker extends Component<Props, State> {
               buttonType="primary"
               onClick={() => this.props.sdk.close(selectedSKUs)}
               disabled={selectedSKUs.length === 0}>
-              {getSaveBtnText(selectedSKUs)}
+              {getSaveBtnText(selectedSKUs, skuType)}
             </Button>
           </div>
         </header>

--- a/packages/ecommerce-app-base/src/SkuPicker/renderSkuPicker.tsx
+++ b/packages/ecommerce-app-base/src/SkuPicker/renderSkuPicker.tsx
@@ -2,26 +2,31 @@ import React from 'react';
 import { DialogExtensionSDK } from '@contentful/app-sdk';
 import { render } from 'react-dom';
 import { SkuPicker } from './SkuPicker';
-import { ProductPreviewsFn, ProductsFn } from '../interfaces';
+import { GetSaveBtnTextFn, ProductPreviewsFn, ProductsFn } from '../interfaces';
 
 interface Props {
   sdk: DialogExtensionSDK;
   fetchProductPreviews: ProductPreviewsFn;
   fetchProducts: ProductsFn;
   searchDelay?: number;
+  skuType?: string;
+  getSaveBtnText?: GetSaveBtnTextFn;
 }
 
 export function renderSkuPicker(
   elementId: string,
-  { sdk, fetchProductPreviews, fetchProducts, searchDelay }: Props
+  { sdk, fetchProductPreviews, fetchProducts, searchDelay, skuType, getSaveBtnText }: Props
 ): void {
   const root = document.getElementById(elementId);
+
   render(
     <SkuPicker
       sdk={sdk}
       fetchProductPreviews={fetchProductPreviews}
       fetchProducts={fetchProducts}
       searchDelay={searchDelay}
+      skuType={skuType}
+      getSaveBtnText={getSaveBtnText}
     />,
     root
   );

--- a/packages/ecommerce-app-base/src/index.tsx
+++ b/packages/ecommerce-app-base/src/index.tsx
@@ -34,6 +34,7 @@ export function setup(integration: Integration) {
           fetchProductPreviews={integration.fetchProductPreviews}
           openDialog={integration.openDialog}
           isDisabled={integration.isDisabled}
+          skuTypes={integration.skuTypes}
         />,
         root
       );
@@ -49,6 +50,7 @@ export function setup(integration: Integration) {
           logo={integration.logo}
           color={integration.color}
           description={integration.description}
+          skuTypes={integration.skuTypes}
         />,
         root
       );

--- a/packages/ecommerce-app-base/src/interfaces.ts
+++ b/packages/ecommerce-app-base/src/interfaces.ts
@@ -74,9 +74,18 @@ export type ProductsFn = (
  * Returns the text that is displayed on the button in the field location.
  *
  * @param fieldType Type of the field the app is used for.
+ * @param skuType SKU type of the current field. Undefined if only a single SKU type is supported by the app.
  * @returns Text that should be displayed on the button
  */
-export type MakeCTAFn = (fieldType: string) => string;
+export type MakeCTAFn = (fieldType: string, skuType?: string) => string;
+
+/**
+ * Returns the text that is used for confirming the dialog selection.
+ *
+ * @param selectedSKUs An array of SKUs chosen.
+ * @returns Text that should be displayed on the button
+ */
+export type GetSaveBtnTextFn = (selectedSKUs: string[], skuType?: string) => string;
 
 /**
  * Custom code that validates installation parameters that is run before saving.
@@ -91,9 +100,14 @@ export type ValidateParametersFn = (parameters: Record<string, string>) => strin
  *
  * @param skus List of skus
  * @param config App configuration
+ * @param skuType SKU type of the current field. Undefined if only a single SKU type is supported by the app.
  * @returns List of Products which is used to render a preview.
  */
-export type ProductPreviewsFn = (skus: string[], config: Config) => Promise<Product[]>;
+export type ProductPreviewsFn = (
+  skus: string[],
+  config: Config,
+  skuType?: string
+) => Promise<Product[]>;
 export type DeleteFn = (index: number) => void;
 
 /**
@@ -247,4 +261,10 @@ export interface Integration {
    * @returns true, if the button in the field location should be disabled. false, if the button should be enabled
    */
   isDisabled: DisabledPredicateFn;
+
+  /**
+   * If your app supports multiple sku types (for example - product, product variant, category...) you can provide a list here.
+   * This configuration will be stored under the skuTypes key in your installation parameters.
+   */
+  skuTypes?: { id: string; name: string; default?: boolean }[];
 }


### PR DESCRIPTION
👋🏻  Hello,

This pull request adds support for picking products and collections to the Shopify app, which right now only supports picking product variants.

I had to extend the `ecommerce-app-base` as well to add support for multiple SKUs. I did my best to make sure that changes I made are backwards compatible, so other ecommerce apps using it as a base should continue to just work.

The pull request introduces a concept of SKU types to the `ecommerce-app-base` (think what commercetools app has now where one can choose between picking products, product variants, or collections).

The chosen sku type is then passed to various functions of the consumer app and an appropriate decision can be made about fetching, UI labels etc.

I did my best to follow the current project structure when extending the app, and changes made to the Shopify app should be backwards compatible as well (product variant picker is the default for any existing and new fields).

Feedback welcome, thanks!