### PR TITLE
chore: serverless v3 deprecations

### DIFF
--- a/apps/ai-image-tagging/lambda/serverless.yml
+++ b/apps/ai-image-tagging/lambda/serverless.yml
@@ -1,6 +1,6 @@
 service: sls-apps-ai-image-tagging
 
-frameworkVersion: '>=2.0.0 <3.0.0'
+frameworkVersion: ">=2.0.0 <3.0.0"
 
 plugins:
   - serverless-domain-manager
@@ -11,34 +11,36 @@ custom:
     domainName: ai-image-tagging.ctfapps.net
     stage: prd
     createRoute53Record: true
-    endpointType: 'edge'
+    endpointType: "edge"
     securityPolicy: tls_1_2
 
 provider:
   name: aws
   runtime: nodejs12.x
   stage: ${opt:stage, 'test'}
-  region: 'us-east-1'
+  region: "us-east-1"
   deploymentBucket:
     name: cf-apps-serverless-deployment
   deploymentPrefix: sls-apps-ai-image-tagging
-  iamRoleStatements:
-    - Effect: "Allow"
-      Action:
-       - rekognition:DetectLabels
-      Resource: "*"
-    - Effect: Allow
-      Action:
-        - dynamodb:DescribeTable
-        - dynamodb:GetItem
-        - dynamodb:PutItem
-        - dynamodb:UpdateItem
-      Resource: "arn:aws:dynamodb:*:*:table/sls*" # TODO limit to the usage table
-#         - "Fn::GetAtt": [ UsageTable, Arn ]
+  iam:
+    role:
+      statements:
+        - Effect: "Allow"
+          Action:
+            - rekognition:DetectLabels
+          Resource: "*"
+        - Effect: Allow
+          Action:
+            - dynamodb:DescribeTable
+            - dynamodb:GetItem
+            - dynamodb:PutItem
+            - dynamodb:UpdateItem
+          Resource: "arn:aws:dynamodb:*:*:table/sls*" # TODO limit to the usage table
+    #         - "Fn::GetAtt": [ UsageTable, Arn ]
 
 package:
   patterns:
-    - '!node_modules/ai-image-tagging-frontend/node_modules/**'
+    - "!node_modules/ai-image-tagging-frontend/node_modules/**"
 
 functions:
   app:
@@ -52,7 +54,6 @@ functions:
       - http:
           path: /{proxy+}
           method: ANY
-
 # resources:
 #   Resources:
 #     UsageTable:

--- a/apps/ai-image-tagging/lambda/serverless.yml
+++ b/apps/ai-image-tagging/lambda/serverless.yml
@@ -37,8 +37,8 @@ provider:
 #         - "Fn::GetAtt": [ UsageTable, Arn ]
 
 package:
-  exclude:
-    - node_modules/ai-image-tagging-frontend/node_modules/**
+  patterns:
+    - '!node_modules/ai-image-tagging-frontend/node_modules/**'
 
 functions:
   app:

--- a/apps/ai-image-tagging/lambda/serverless.yml
+++ b/apps/ai-image-tagging/lambda/serverless.yml
@@ -1,5 +1,4 @@
-service:
-  name: sls-apps-ai-image-tagging
+service: sls-apps-ai-image-tagging
 
 frameworkVersion: '>=2.0.0 <3.0.0'
 

--- a/apps/jira/functions/serverless.yml
+++ b/apps/jira/functions/serverless.yml
@@ -1,5 +1,4 @@
-service:
-  name: sls-apps-jira-backend
+service: sls-apps-jira-backend
 
 frameworkVersion: '>=2.0.0 <3.0.0'
 

--- a/apps/jira/functions/serverless.yml
+++ b/apps/jira/functions/serverless.yml
@@ -35,11 +35,10 @@ provider:
   deploymentPrefix: sls-apps-jira-backend
 
 package:
-  include:
-    - built/**
-  exclude:
-    - .git/**
-    - "**/*.ts"
+  patterns:
+    - 'built/**'
+    - '!.git/**'
+    - '!**/*.ts'
 
 functions:
   oauth:

--- a/apps/smartling/lambda/serverless.yml
+++ b/apps/smartling/lambda/serverless.yml
@@ -1,5 +1,4 @@
-service:
-  name: sls-apps-smartling
+service: sls-apps-smartling
 
 frameworkVersion: '>=2.0.0 <3.0.0'
 

--- a/apps/smartling/lambda/serverless.yml
+++ b/apps/smartling/lambda/serverless.yml
@@ -25,12 +25,11 @@ provider:
   deploymentPrefix: sls-apps-smartling
 
 package:
-  include:
-    - built/**
-  exclude:
-    - .git/**
-    - "**/*.ts"
-    - node_modules/smartling-frontend/node_modules/**
+  patterns:
+    - 'built/**'
+    - '!.git/**'
+    - '!**/*.ts'
+    - '!node_modules/smartling-frontend/node_modules/**'
 
 functions:
   app:

--- a/apps/typeform/lambda/serverless.yml
+++ b/apps/typeform/lambda/serverless.yml
@@ -1,5 +1,4 @@
-service:
-  name: sls-apps-typeform
+service: sls-apps-typeform
 
 frameworkVersion: '>=2.0.0 <3.0.0'
 

--- a/apps/typeform/lambda/serverless.yml
+++ b/apps/typeform/lambda/serverless.yml
@@ -24,9 +24,9 @@ provider:
   deploymentPrefix: sls-apps-typeform
 
 package:
-  exclude:
-    - .git/**
-    - node_modules/typeform-frontend/node_modules/**
+  patterns:
+    - '!.git/**'
+    - '!node_modules/typeform-frontend/node_modules/**'
 
 functions:
   app:


### PR DESCRIPTION
With serverless v3 there will be a few changes to the `serverless.yml`. I adjusted the code already to remove a few warnings

The explanations of each change are in the respective commit message.

I didn't do anything about the Lambda hash algorithm change warning:

```
Resolution of lambda version hashes was improved with better algorithm, which will be used in next major release.
Switch to it now by setting "provider.lambdaHashingVersion" to "20201221"
More Info: https://www.serverless.com/framework/docs/deprecations/#LAMBDA_HASHING_VERSION_V2
```