### PR TITLE
chore: use `fix:` prefix for dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,7 @@ updates:
     time: "00:00"
     timezone: UTC
   open-pull-requests-limit: 15
+  commit-message:
+    prefix: "fix"
+    prefix-development: "chore"
+    include: "scope"


### PR DESCRIPTION
Dependabot currently uses `chore:` as prefix for all dependencies. For our `...-app-base` packages this means that we release a new version without any changelog entry.
See https://github.com/contentful/apps/blob/master/packages/ecommerce-app-base/CHANGELOG.md

With this change, all regular dependencies use `fix:` as prefix. All dev dependencies still use `chore:`

Docs: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#commit-message