### PR TITLE
fix: [] Fix Shopify not displaying missing SKUs for collections/products

### DIFF
--- a/apps/shopify/src/skuResolvers.js
+++ b/apps/shopify/src/skuResolvers.js
@@ -41,7 +41,19 @@ export const fetchCollectionPreviews = async (skus, config) => {
     skus.includes(collection.id)
   );
 
-  return collections.map(collection => collectionDataTransformer(collection, config.apiEndpoint));
+  return skus.map((sku) => {
+    const collection = collections.find((collection) => collection.id === sku)
+
+    return collection
+      ? collectionDataTransformer(collection, config.apiEndpoint)
+      : {
+          sku,
+          isMissing: true,
+          image: '',
+          id: sku,
+          name: '',
+        }
+  })
 };
 
 /**
@@ -59,7 +71,19 @@ export const fetchProductPreviews = async (skus, config) => {
   const shopifyClient = await makeShopifyClient(config);
   const products = await shopifyClient.product.fetchMultiple(skus);
 
-  return products.map(product => productDataTransformer(product, config.apiEndpoint));
+  return skus.map((sku) => {
+    const product = products.find((product) => product?.id === sku)
+
+    return product
+      ? productDataTransformer(product, config.apiEndpoint)
+      : {
+          sku,
+          isMissing: true,
+          image: '',
+          id: sku,
+          name: '',
+        }
+  })
 };
 
 /**

--- a/apps/shopify/src/skuResolvers.js
+++ b/apps/shopify/src/skuResolvers.js
@@ -37,7 +37,7 @@ export const fetchCollectionPreviews = async (skus, config) => {
   }
 
   const shopifyClient = await makeShopifyClient(config);
-  const collections = (await shopifyClient.collection.fetchAll()).filter(collection =>
+  const collections = (await shopifyClient.collection.fetchAll(250)).filter(collection =>
     skus.includes(collection.id)
   );
 

--- a/packages/ecommerce-app-base/src/Editor/SortableComponent.tsx
+++ b/packages/ecommerce-app-base/src/Editor/SortableComponent.tsx
@@ -75,6 +75,7 @@ export class SortableComponent extends React.Component<Props, State> {
         productPreviews={this.state.productPreviews}
         deleteFn={this.deleteItem}
         useDragHandle
+        skuType={this.props.skuType}
       />
     );
   }

--- a/packages/ecommerce-app-base/src/Editor/SortableList.tsx
+++ b/packages/ecommerce-app-base/src/Editor/SortableList.tsx
@@ -7,10 +7,11 @@ export interface Props {
   disabled: boolean;
   productPreviews: Product[];
   deleteFn: DeleteFn;
+  skuType?: string;
 }
 
 export const SortableList = SortableContainer<Props>(
-  ({ disabled, deleteFn, productPreviews }: Props) => {
+  ({ disabled, deleteFn, productPreviews, skuType }: Props) => {
     const itemsAreSortable = productPreviews.length > 1;
     return (
       <div>
@@ -23,6 +24,7 @@ export const SortableList = SortableContainer<Props>(
               index={index}
               onDelete={() => deleteFn(index)}
               isSortable={itemsAreSortable}
+              skuType={skuType}
             />
           );
         })}

--- a/packages/ecommerce-app-base/src/Editor/SortableListItem.tsx
+++ b/packages/ecommerce-app-base/src/Editor/SortableListItem.tsx
@@ -121,7 +121,7 @@ const CardDragHandle = SortableHandle(() => (
 export const SortableListItem = SortableElement<Props>(
   ({ product, disabled, isSortable, onDelete, skuType }: Props) => {
     const [imageHasLoaded, setImageLoaded] = useState(false);
-    const [imageHasErrored, setImageHasErrored] = useState(!product.image);
+    const [imageHasErrored, setImageHasErrored] = useState(false);
     const productIsMissing = !product.name;
 
     return (
@@ -133,12 +133,11 @@ export const SortableListItem = SortableElement<Props>(
               <SkeletonImage width={IMAGE_SIZE} height={IMAGE_SIZE} />
             </SkeletonContainer>
           )}
-          {imageHasErrored && (
+          {!product.image || imageHasErrored ? (
             <div className={styles.errorImage}>
               <Icon icon={productIsMissing ? 'ErrorCircle' : 'Asset'} />
             </div>
-          )}
-          {!imageHasErrored && (
+          ) : (
             <div className={styles.imageWrapper(imageHasLoaded)}>
               <img
                 style={{ display: imageHasLoaded ? 'block' : 'none' }}

--- a/packages/ecommerce-app-base/src/Editor/SortableListItem.tsx
+++ b/packages/ecommerce-app-base/src/Editor/SortableListItem.tsx
@@ -120,7 +120,7 @@ const CardDragHandle = SortableHandle(() => (
 export const SortableListItem = SortableElement<Props>(
   ({ product, disabled, isSortable, onDelete }: Props) => {
     const [imageHasLoaded, setImageLoaded] = useState(false);
-    const [imageHasErrored, setImageHasErrored] = useState(false);
+    const [imageHasErrored, setImageHasErrored] = useState(product.image !== '');
     const productIsMissing = !product.name;
 
     return (

--- a/packages/ecommerce-app-base/src/Editor/SortableListItem.tsx
+++ b/packages/ecommerce-app-base/src/Editor/SortableListItem.tsx
@@ -21,6 +21,7 @@ export interface Props {
   disabled: boolean;
   onDelete: () => void;
   isSortable: boolean;
+  skuType?: string;
 }
 
 const IMAGE_SIZE = 48;
@@ -118,7 +119,7 @@ const CardDragHandle = SortableHandle(() => (
 ));
 
 export const SortableListItem = SortableElement<Props>(
-  ({ product, disabled, isSortable, onDelete }: Props) => {
+  ({ product, disabled, isSortable, onDelete, skuType }: Props) => {
     const [imageHasLoaded, setImageLoaded] = useState(false);
     const [imageHasErrored, setImageHasErrored] = useState(product.image !== '');
     const productIsMissing = !product.name;
@@ -155,7 +156,7 @@ export const SortableListItem = SortableElement<Props>(
                 {productIsMissing ? product.sku : product.name}
               </Heading>
               {productIsMissing ? (
-                <Tag tagType="negative">Product missing</Tag>
+                <Tag tagType="negative">{skuType ?? 'Product'} missing</Tag>
               ) : (
                 <Subheading className={styles.sku}>{product.displaySKU ?? product.sku}</Subheading>
               )}

--- a/packages/ecommerce-app-base/src/Editor/SortableListItem.tsx
+++ b/packages/ecommerce-app-base/src/Editor/SortableListItem.tsx
@@ -128,7 +128,7 @@ export const SortableListItem = SortableElement<Props>(
       <Card className={styles.card}>
         <>
           {isSortable && <CardDragHandle />}
-          {!imageHasLoaded && !imageHasErrored && (
+          {!imageHasLoaded && !imageHasErrored && product.image && (
             <SkeletonContainer className={styles.skeletonImage}>
               <SkeletonImage width={IMAGE_SIZE} height={IMAGE_SIZE} />
             </SkeletonContainer>

--- a/packages/ecommerce-app-base/src/Editor/SortableListItem.tsx
+++ b/packages/ecommerce-app-base/src/Editor/SortableListItem.tsx
@@ -121,7 +121,7 @@ const CardDragHandle = SortableHandle(() => (
 export const SortableListItem = SortableElement<Props>(
   ({ product, disabled, isSortable, onDelete, skuType }: Props) => {
     const [imageHasLoaded, setImageLoaded] = useState(false);
-    const [imageHasErrored, setImageHasErrored] = useState(product.image !== '');
+    const [imageHasErrored, setImageHasErrored] = useState(!product.image);
     const productIsMissing = !product.name;
 
     return (

--- a/packages/ecommerce-app-base/src/Editor/__snapshots__/SortableListItem.spec.tsx.snap
+++ b/packages/ecommerce-app-base/src/Editor/__snapshots__/SortableListItem.spec.tsx.snap
@@ -267,7 +267,8 @@ exports[`SortableListItem should render successfully the error variation for mis
           class="Tag__Tag___Y-myd Tag__Tag--negative___12luW"
           data-test-id="cf-ui-tag"
         >
-          Product missing
+          Product
+           missing
         </div>
       </div>
     </section>


### PR DESCRIPTION
Hello, this PR solves three issues:

1.) For collections preview we were fetching first 20 collections meaning that for stores with more than 20 collections the preview would break. I have increased that limit to 250 (max) as Shopify unfortunately does not support fetching multiple collections by ids

2.) This PR also makes sure that missing collections/products (if they are deleted for example) still show up in the interface. This was always the case for product variants, but I missed adding it for products/collections.

3.) I have also amended the `ecommerce-app-base` to display the correct sku type in the "missing" tag.

Thanks :)