### PR TITLE
Add duration to Mux asset json

### DIFF
--- a/apps/mux/CHANGELOG.md
+++ b/apps/mux/CHANGELOG.md
@@ -16,14 +16,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package mux-contentful-uploader
 
 
-- Adds additional "duration" field to stored data and response from Contentful
-
-
-## [1.5.4](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.5.3...mux-contentful-uploader@1.5.4) (2021-10-18)
-
-**Note:** Version bump only for package mux-contentful-uploader
-
-
 
 
 

--- a/apps/mux/CHANGELOG.md
+++ b/apps/mux/CHANGELOG.md
@@ -16,606 +16,315 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 **Note:** Version bump only for package mux-contentful-uploader
 
 
+- Adds additional "duration" field to stored data and response from Contentful
 
+## [1.5.4](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.5.3...mux-contentful-uploader@1.5.4) (2021-10-18)
 
+**Note:** Version bump only for package mux-contentful-uploader
 
 ## [1.5.3](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.5.2...mux-contentful-uploader@1.5.3) (2021-10-18)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
-
-
-
-
 ## [1.5.2](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.5.1...mux-contentful-uploader@1.5.2) (2021-10-15)
 
 **Note:** Version bump only for package mux-contentful-uploader
-
-
-
-
 
 ## [1.5.1](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.5.0...mux-contentful-uploader@1.5.1) (2021-10-14)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
-
-
-
-
 # [1.5.0](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.43...mux-contentful-uploader@1.5.0) (2021-10-13)
-
 
 ### Features
 
-* use App SDK v4 ([#528](https://github.com/contentful/apps/issues/528)) ([5fb634a](https://github.com/contentful/apps/commit/5fb634a0679de8af4ada0de3d571a8a5e5564090))
-
-
-
-
+- use App SDK v4 ([#528](https://github.com/contentful/apps/issues/528)) ([5fb634a](https://github.com/contentful/apps/commit/5fb634a0679de8af4ada0de3d571a8a5e5564090))
 
 ## [1.4.43](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.42...mux-contentful-uploader@1.4.43) (2021-10-13)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
-
-
-
-
 ## [1.4.42](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.41...mux-contentful-uploader@1.4.42) (2021-10-13)
 
 **Note:** Version bump only for package mux-contentful-uploader
-
-
-
-
 
 ## [1.4.41](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.40...mux-contentful-uploader@1.4.41) (2021-10-11)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
-
-
-
-
 ## [1.4.40](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.39...mux-contentful-uploader@1.4.40) (2021-10-07)
-
 
 ### Bug Fixes
 
-* remove unused dependencies ([#523](https://github.com/contentful/apps/issues/523)) ([a1af1dd](https://github.com/contentful/apps/commit/a1af1dd07726c1119e0c16fcbdfb3bea4f88dae2))
-
-
-
-
+- remove unused dependencies ([#523](https://github.com/contentful/apps/issues/523)) ([a1af1dd](https://github.com/contentful/apps/commit/a1af1dd07726c1119e0c16fcbdfb3bea4f88dae2))
 
 ## [1.4.39](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.38...mux-contentful-uploader@1.4.39) (2021-10-07)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
-
-
-
-
 ## [1.4.38](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.37...mux-contentful-uploader@1.4.38) (2021-10-06)
 
 **Note:** Version bump only for package mux-contentful-uploader
-
-
-
-
 
 ## [1.4.37](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.36...mux-contentful-uploader@1.4.37) (2021-10-04)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
-
-
-
-
 ## [1.4.36](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.35...mux-contentful-uploader@1.4.36) (2021-09-30)
 
 **Note:** Version bump only for package mux-contentful-uploader
-
-
-
-
 
 ## [1.4.35](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.34...mux-contentful-uploader@1.4.35) (2021-09-29)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
-
-
-
-
 ## [1.4.34](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.33...mux-contentful-uploader@1.4.34) (2021-09-27)
 
 **Note:** Version bump only for package mux-contentful-uploader
-
-
-
-
 
 ## [1.4.33](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.32...mux-contentful-uploader@1.4.33) (2021-09-24)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
-
-
-
-
 ## [1.4.32](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.31...mux-contentful-uploader@1.4.32) (2021-09-22)
 
 **Note:** Version bump only for package mux-contentful-uploader
-
-
-
-
 
 ## [1.4.31](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.30...mux-contentful-uploader@1.4.31) (2021-09-22)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
-
-
-
-
 ## [1.4.30](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.29...mux-contentful-uploader@1.4.30) (2021-09-21)
 
 **Note:** Version bump only for package mux-contentful-uploader
-
-
-
-
 
 ## [1.4.29](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.28...mux-contentful-uploader@1.4.29) (2021-09-21)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
-
-
-
-
 ## [1.4.28](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.27...mux-contentful-uploader@1.4.28) (2021-09-20)
 
 **Note:** Version bump only for package mux-contentful-uploader
-
-
-
-
 
 ## [1.4.27](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.26...mux-contentful-uploader@1.4.27) (2021-09-20)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
-
-
-
-
 ## [1.4.26](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.25...mux-contentful-uploader@1.4.26) (2021-09-17)
 
 **Note:** Version bump only for package mux-contentful-uploader
-
-
-
-
 
 ## [1.4.25](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.24...mux-contentful-uploader@1.4.25) (2021-09-17)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
-
-
-
-
 ## [1.4.24](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.23...mux-contentful-uploader@1.4.24) (2021-09-17)
 
 **Note:** Version bump only for package mux-contentful-uploader
-
-
-
-
 
 ## [1.4.23](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.22...mux-contentful-uploader@1.4.23) (2021-09-16)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
-
-
-
-
 ## [1.4.22](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.21...mux-contentful-uploader@1.4.22) (2021-09-16)
-
 
 ### Bug Fixes
 
-* move react to peer dependency & unpin dependencies ([#475](https://github.com/contentful/apps/issues/475)) ([981e177](https://github.com/contentful/apps/commit/981e177092fafdcce211822277d3ee0dad7ae689))
-
-
-
-
+- move react to peer dependency & unpin dependencies ([#475](https://github.com/contentful/apps/issues/475)) ([981e177](https://github.com/contentful/apps/commit/981e177092fafdcce211822277d3ee0dad7ae689))
 
 ## [1.4.21](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.20...mux-contentful-uploader@1.4.21) (2021-09-13)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
-
-
-
-
 ## [1.4.20](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.19...mux-contentful-uploader@1.4.20) (2021-09-10)
 
 **Note:** Version bump only for package mux-contentful-uploader
-
-
-
-
 
 ## [1.4.19](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.18...mux-contentful-uploader@1.4.19) (2021-09-10)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
-
-
-
-
 ## [1.4.18](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.17...mux-contentful-uploader@1.4.18) (2021-09-06)
 
 **Note:** Version bump only for package mux-contentful-uploader
-
-
-
-
 
 ## [1.4.17](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.16...mux-contentful-uploader@1.4.17) (2021-09-03)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
-
-
-
-
 ## [1.4.16](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.15...mux-contentful-uploader@1.4.16) (2021-09-03)
 
 **Note:** Version bump only for package mux-contentful-uploader
-
-
-
-
 
 ## [1.4.15](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.14...mux-contentful-uploader@1.4.15) (2021-09-03)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
-
-
-
-
 ## [1.4.14](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.13...mux-contentful-uploader@1.4.14) (2021-09-02)
 
 **Note:** Version bump only for package mux-contentful-uploader
-
-
-
-
 
 ## [1.4.13](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.12...mux-contentful-uploader@1.4.13) (2021-08-31)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
-
-
-
-
 ## [1.4.12](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.11...mux-contentful-uploader@1.4.12) (2021-08-30)
 
 **Note:** Version bump only for package mux-contentful-uploader
-
-
-
-
 
 ## [1.4.11](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.10...mux-contentful-uploader@1.4.11) (2021-08-25)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
-
-
-
-
 ## [1.4.10](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.9...mux-contentful-uploader@1.4.10) (2021-08-20)
 
 **Note:** Version bump only for package mux-contentful-uploader
-
-
-
-
 
 ## [1.4.9](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.8...mux-contentful-uploader@1.4.9) (2021-08-18)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
-
-
-
-
 ## [1.4.8](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.7...mux-contentful-uploader@1.4.8) (2021-08-16)
 
 **Note:** Version bump only for package mux-contentful-uploader
-
-
-
-
 
 ## [1.4.7](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.6...mux-contentful-uploader@1.4.7) (2021-08-13)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
-
-
-
-
 ## [1.4.6](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.5...mux-contentful-uploader@1.4.6) (2021-08-11)
-
 
 ### Reverts
 
-* Revert "Revert "feat: [EXT-2717] use app hosting for MUX (#363)" (#384)" (#393) ([0361287](https://github.com/contentful/apps/commit/0361287d14597d608622c69a6656034b434000f3)), closes [#363](https://github.com/contentful/apps/issues/363) [#384](https://github.com/contentful/apps/issues/384) [#393](https://github.com/contentful/apps/issues/393)
-
-
-
-
+- Revert "Revert "feat: [EXT-2717] use app hosting for MUX (#363)" (#384)" (#393) ([0361287](https://github.com/contentful/apps/commit/0361287d14597d608622c69a6656034b434000f3)), closes [#363](https://github.com/contentful/apps/issues/363) [#384](https://github.com/contentful/apps/issues/384) [#393](https://github.com/contentful/apps/issues/393)
 
 ## [1.4.5](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.4...mux-contentful-uploader@1.4.5) (2021-08-11)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
-
-
-
-
 ## [1.4.4](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.3...mux-contentful-uploader@1.4.4) (2021-08-10)
 
 **Note:** Version bump only for package mux-contentful-uploader
-
-
-
-
 
 ## [1.4.3](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.2...mux-contentful-uploader@1.4.3) (2021-08-09)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
-
-
-
-
 ## [1.4.2](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.1...mux-contentful-uploader@1.4.2) (2021-08-06)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
-
-
-
-
 ## [1.4.1](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.0...mux-contentful-uploader@1.4.1) (2021-08-05)
-
 
 ### Reverts
 
-* Revert "feat: [EXT-2717] use app hosting for MUX (#363)" (#384) ([52d6d1c](https://github.com/contentful/apps/commit/52d6d1cec64675ecadc741fc3853e4f13d61f7ae)), closes [#363](https://github.com/contentful/apps/issues/363) [#384](https://github.com/contentful/apps/issues/384)
-
-
-
-
+- Revert "feat: [EXT-2717] use app hosting for MUX (#363)" (#384) ([52d6d1c](https://github.com/contentful/apps/commit/52d6d1cec64675ecadc741fc3853e4f13d61f7ae)), closes [#363](https://github.com/contentful/apps/issues/363) [#384](https://github.com/contentful/apps/issues/384)
 
 # [1.4.0](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.3.13...mux-contentful-uploader@1.4.0) (2021-08-05)
 
-
 ### Features
 
-* [EXT-2717] use app hosting for MUX ([#363](https://github.com/contentful/apps/issues/363)) ([4232d1f](https://github.com/contentful/apps/commit/4232d1f586d13519eccff7f05be02b0852a07c49))
-
-
-
-
+- [EXT-2717] use app hosting for MUX ([#363](https://github.com/contentful/apps/issues/363)) ([4232d1f](https://github.com/contentful/apps/commit/4232d1f586d13519eccff7f05be02b0852a07c49))
 
 ## [1.3.13](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.3.12...mux-contentful-uploader@1.3.13) (2021-08-05)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
-
-
-
-
 ## [1.3.12](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.3.11...mux-contentful-uploader@1.3.12) (2021-08-05)
 
 **Note:** Version bump only for package mux-contentful-uploader
-
-
-
-
 
 ## [1.3.11](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.3.10...mux-contentful-uploader@1.3.11) (2021-08-02)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
-
-
-
-
 ## [1.3.10](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.3.9...mux-contentful-uploader@1.3.10) (2021-08-02)
 
 **Note:** Version bump only for package mux-contentful-uploader
-
-
-
-
 
 ## [1.3.9](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.3.8...mux-contentful-uploader@1.3.9) (2021-07-29)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
-
-
-
-
 ## [1.3.8](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.3.7...mux-contentful-uploader@1.3.8) (2021-07-28)
 
 **Note:** Version bump only for package mux-contentful-uploader
-
-
-
-
 
 ## [1.3.7](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.3.6...mux-contentful-uploader@1.3.7) (2021-07-28)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
-
-
-
-
 ## [1.3.6](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.3.5...mux-contentful-uploader@1.3.6) (2021-07-28)
 
 **Note:** Version bump only for package mux-contentful-uploader
-
-
-
-
 
 ## [1.3.5](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.3.4...mux-contentful-uploader@1.3.5) (2021-07-28)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
-
-
-
-
 ## [1.3.4](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.3.3...mux-contentful-uploader@1.3.4) (2021-07-28)
 
 **Note:** Version bump only for package mux-contentful-uploader
-
-
-
-
 
 ## [1.3.3](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.3.2...mux-contentful-uploader@1.3.3) (2021-07-28)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
-
-
-
-
 ## [1.3.2](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.3.1...mux-contentful-uploader@1.3.2) (2021-07-26)
 
 **Note:** Version bump only for package mux-contentful-uploader
-
-
-
-
 
 ## [1.3.1](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.3.0...mux-contentful-uploader@1.3.1) (2021-06-22)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
-
-
-
-
 # [1.3.0](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.2.1...mux-contentful-uploader@1.3.0) (2021-06-21)
-
 
 ### Features
 
-* [] build mux with react-scripts ([#299](https://github.com/contentful/apps/issues/299)) ([c32c3e1](https://github.com/contentful/apps/commit/c32c3e12faea3eea6e88303811d9eac63f6c1361))
-
-
-
-
+- [] build mux with react-scripts ([#299](https://github.com/contentful/apps/issues/299)) ([c32c3e1](https://github.com/contentful/apps/commit/c32c3e12faea3eea6e88303811d9eac63f6c1361))
 
 ## [1.2.1](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.2.0...mux-contentful-uploader@1.2.1) (2021-05-10)
 
-
 ### Reverts
 
-* Revert "feat: [EXT-2533] use new version of ecommerce base app (#239)" (#251) ([dae2ae6](https://github.com/contentful/apps/commit/dae2ae66181543a93981b1b97cc9dfc71e5abf16)), closes [#239](https://github.com/contentful/apps/issues/239) [#251](https://github.com/contentful/apps/issues/251)
-
-
-
-
+- Revert "feat: [EXT-2533] use new version of ecommerce base app (#239)" (#251) ([dae2ae6](https://github.com/contentful/apps/commit/dae2ae66181543a93981b1b97cc9dfc71e5abf16)), closes [#239](https://github.com/contentful/apps/issues/239) [#251](https://github.com/contentful/apps/issues/251)
 
 # [1.2.0](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.1.0...mux-contentful-uploader@1.2.0) (2021-05-10)
 
-
 ### Features
 
-* [EXT-2533] use new version of ecommerce base app ([#239](https://github.com/contentful/apps/issues/239)) ([b4f398f](https://github.com/contentful/apps/commit/b4f398f7fe4fb2952e8505a7657b876861fe3a24))
-
-
-
-
+- [EXT-2533] use new version of ecommerce base app ([#239](https://github.com/contentful/apps/issues/239)) ([b4f398f](https://github.com/contentful/apps/commit/b4f398f7fe4fb2952e8505a7657b876861fe3a24))
 
 # [1.1.0](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.0.6...mux-contentful-uploader@1.1.0) (2021-05-05)
 
-
 ### Features
 
-* [EXT-2722] use contentful hosting for image focal point app ([#238](https://github.com/contentful/apps/issues/238)) ([11b57ae](https://github.com/contentful/apps/commit/11b57ae3e4fb5dd376544d89056430b71883517c))
-
-
-
-
+- [EXT-2722] use contentful hosting for image focal point app ([#238](https://github.com/contentful/apps/issues/238)) ([11b57ae](https://github.com/contentful/apps/commit/11b57ae3e4fb5dd376544d89056430b71883517c))
 
 ## [1.0.6](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.0.5...mux-contentful-uploader@1.0.6) (2021-03-17)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
-
-
-
-
 ## [1.0.5](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.0.4...mux-contentful-uploader@1.0.5) (2021-02-16)
 
 **Note:** Version bump only for package mux-contentful-uploader
-
-
-
-
 
 ## [1.0.4](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.0.3...mux-contentful-uploader@1.0.4) (2021-02-02)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
-
-
-
-
 ## [1.0.3](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.0.2...mux-contentful-uploader@1.0.3) (2021-01-14)
 
 **Note:** Version bump only for package mux-contentful-uploader
-
-
-
-
 
 ## [1.0.2](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.0.1...mux-contentful-uploader@1.0.2) (2021-01-14)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
-
-
-
-
 ## 1.0.1 (2021-01-12)
 
-
-
 ## 1.0.1 (2021-01-11)
-
-
 
 # 1.0.0 (2021-01-08)
 

--- a/apps/mux/CHANGELOG.md
+++ b/apps/mux/CHANGELOG.md
@@ -18,313 +18,612 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 - Adds additional "duration" field to stored data and response from Contentful
 
+
 ## [1.5.4](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.5.3...mux-contentful-uploader@1.5.4) (2021-10-18)
 
 **Note:** Version bump only for package mux-contentful-uploader
+
+
+
+
 
 ## [1.5.3](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.5.2...mux-contentful-uploader@1.5.3) (2021-10-18)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
+
+
+
+
 ## [1.5.2](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.5.1...mux-contentful-uploader@1.5.2) (2021-10-15)
 
 **Note:** Version bump only for package mux-contentful-uploader
+
+
+
+
 
 ## [1.5.1](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.5.0...mux-contentful-uploader@1.5.1) (2021-10-14)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
+
+
+
+
 # [1.5.0](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.43...mux-contentful-uploader@1.5.0) (2021-10-13)
+
 
 ### Features
 
-- use App SDK v4 ([#528](https://github.com/contentful/apps/issues/528)) ([5fb634a](https://github.com/contentful/apps/commit/5fb634a0679de8af4ada0de3d571a8a5e5564090))
+* use App SDK v4 ([#528](https://github.com/contentful/apps/issues/528)) ([5fb634a](https://github.com/contentful/apps/commit/5fb634a0679de8af4ada0de3d571a8a5e5564090))
+
+
+
+
 
 ## [1.4.43](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.42...mux-contentful-uploader@1.4.43) (2021-10-13)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
+
+
+
+
 ## [1.4.42](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.41...mux-contentful-uploader@1.4.42) (2021-10-13)
 
 **Note:** Version bump only for package mux-contentful-uploader
+
+
+
+
 
 ## [1.4.41](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.40...mux-contentful-uploader@1.4.41) (2021-10-11)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
+
+
+
+
 ## [1.4.40](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.39...mux-contentful-uploader@1.4.40) (2021-10-07)
+
 
 ### Bug Fixes
 
-- remove unused dependencies ([#523](https://github.com/contentful/apps/issues/523)) ([a1af1dd](https://github.com/contentful/apps/commit/a1af1dd07726c1119e0c16fcbdfb3bea4f88dae2))
+* remove unused dependencies ([#523](https://github.com/contentful/apps/issues/523)) ([a1af1dd](https://github.com/contentful/apps/commit/a1af1dd07726c1119e0c16fcbdfb3bea4f88dae2))
+
+
+
+
 
 ## [1.4.39](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.38...mux-contentful-uploader@1.4.39) (2021-10-07)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
+
+
+
+
 ## [1.4.38](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.37...mux-contentful-uploader@1.4.38) (2021-10-06)
 
 **Note:** Version bump only for package mux-contentful-uploader
+
+
+
+
 
 ## [1.4.37](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.36...mux-contentful-uploader@1.4.37) (2021-10-04)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
+
+
+
+
 ## [1.4.36](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.35...mux-contentful-uploader@1.4.36) (2021-09-30)
 
 **Note:** Version bump only for package mux-contentful-uploader
+
+
+
+
 
 ## [1.4.35](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.34...mux-contentful-uploader@1.4.35) (2021-09-29)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
+
+
+
+
 ## [1.4.34](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.33...mux-contentful-uploader@1.4.34) (2021-09-27)
 
 **Note:** Version bump only for package mux-contentful-uploader
+
+
+
+
 
 ## [1.4.33](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.32...mux-contentful-uploader@1.4.33) (2021-09-24)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
+
+
+
+
 ## [1.4.32](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.31...mux-contentful-uploader@1.4.32) (2021-09-22)
 
 **Note:** Version bump only for package mux-contentful-uploader
+
+
+
+
 
 ## [1.4.31](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.30...mux-contentful-uploader@1.4.31) (2021-09-22)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
+
+
+
+
 ## [1.4.30](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.29...mux-contentful-uploader@1.4.30) (2021-09-21)
 
 **Note:** Version bump only for package mux-contentful-uploader
+
+
+
+
 
 ## [1.4.29](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.28...mux-contentful-uploader@1.4.29) (2021-09-21)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
+
+
+
+
 ## [1.4.28](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.27...mux-contentful-uploader@1.4.28) (2021-09-20)
 
 **Note:** Version bump only for package mux-contentful-uploader
+
+
+
+
 
 ## [1.4.27](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.26...mux-contentful-uploader@1.4.27) (2021-09-20)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
+
+
+
+
 ## [1.4.26](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.25...mux-contentful-uploader@1.4.26) (2021-09-17)
 
 **Note:** Version bump only for package mux-contentful-uploader
+
+
+
+
 
 ## [1.4.25](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.24...mux-contentful-uploader@1.4.25) (2021-09-17)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
+
+
+
+
 ## [1.4.24](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.23...mux-contentful-uploader@1.4.24) (2021-09-17)
 
 **Note:** Version bump only for package mux-contentful-uploader
+
+
+
+
 
 ## [1.4.23](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.22...mux-contentful-uploader@1.4.23) (2021-09-16)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
+
+
+
+
 ## [1.4.22](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.21...mux-contentful-uploader@1.4.22) (2021-09-16)
+
 
 ### Bug Fixes
 
-- move react to peer dependency & unpin dependencies ([#475](https://github.com/contentful/apps/issues/475)) ([981e177](https://github.com/contentful/apps/commit/981e177092fafdcce211822277d3ee0dad7ae689))
+* move react to peer dependency & unpin dependencies ([#475](https://github.com/contentful/apps/issues/475)) ([981e177](https://github.com/contentful/apps/commit/981e177092fafdcce211822277d3ee0dad7ae689))
+
+
+
+
 
 ## [1.4.21](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.20...mux-contentful-uploader@1.4.21) (2021-09-13)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
+
+
+
+
 ## [1.4.20](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.19...mux-contentful-uploader@1.4.20) (2021-09-10)
 
 **Note:** Version bump only for package mux-contentful-uploader
+
+
+
+
 
 ## [1.4.19](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.18...mux-contentful-uploader@1.4.19) (2021-09-10)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
+
+
+
+
 ## [1.4.18](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.17...mux-contentful-uploader@1.4.18) (2021-09-06)
 
 **Note:** Version bump only for package mux-contentful-uploader
+
+
+
+
 
 ## [1.4.17](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.16...mux-contentful-uploader@1.4.17) (2021-09-03)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
+
+
+
+
 ## [1.4.16](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.15...mux-contentful-uploader@1.4.16) (2021-09-03)
 
 **Note:** Version bump only for package mux-contentful-uploader
+
+
+
+
 
 ## [1.4.15](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.14...mux-contentful-uploader@1.4.15) (2021-09-03)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
+
+
+
+
 ## [1.4.14](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.13...mux-contentful-uploader@1.4.14) (2021-09-02)
 
 **Note:** Version bump only for package mux-contentful-uploader
+
+
+
+
 
 ## [1.4.13](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.12...mux-contentful-uploader@1.4.13) (2021-08-31)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
+
+
+
+
 ## [1.4.12](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.11...mux-contentful-uploader@1.4.12) (2021-08-30)
 
 **Note:** Version bump only for package mux-contentful-uploader
+
+
+
+
 
 ## [1.4.11](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.10...mux-contentful-uploader@1.4.11) (2021-08-25)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
+
+
+
+
 ## [1.4.10](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.9...mux-contentful-uploader@1.4.10) (2021-08-20)
 
 **Note:** Version bump only for package mux-contentful-uploader
+
+
+
+
 
 ## [1.4.9](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.8...mux-contentful-uploader@1.4.9) (2021-08-18)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
+
+
+
+
 ## [1.4.8](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.7...mux-contentful-uploader@1.4.8) (2021-08-16)
 
 **Note:** Version bump only for package mux-contentful-uploader
+
+
+
+
 
 ## [1.4.7](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.6...mux-contentful-uploader@1.4.7) (2021-08-13)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
+
+
+
+
 ## [1.4.6](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.5...mux-contentful-uploader@1.4.6) (2021-08-11)
+
 
 ### Reverts
 
-- Revert "Revert "feat: [EXT-2717] use app hosting for MUX (#363)" (#384)" (#393) ([0361287](https://github.com/contentful/apps/commit/0361287d14597d608622c69a6656034b434000f3)), closes [#363](https://github.com/contentful/apps/issues/363) [#384](https://github.com/contentful/apps/issues/384) [#393](https://github.com/contentful/apps/issues/393)
+* Revert "Revert "feat: [EXT-2717] use app hosting for MUX (#363)" (#384)" (#393) ([0361287](https://github.com/contentful/apps/commit/0361287d14597d608622c69a6656034b434000f3)), closes [#363](https://github.com/contentful/apps/issues/363) [#384](https://github.com/contentful/apps/issues/384) [#393](https://github.com/contentful/apps/issues/393)
+
+
+
+
 
 ## [1.4.5](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.4...mux-contentful-uploader@1.4.5) (2021-08-11)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
+
+
+
+
 ## [1.4.4](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.3...mux-contentful-uploader@1.4.4) (2021-08-10)
 
 **Note:** Version bump only for package mux-contentful-uploader
+
+
+
+
 
 ## [1.4.3](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.2...mux-contentful-uploader@1.4.3) (2021-08-09)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
+
+
+
+
 ## [1.4.2](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.1...mux-contentful-uploader@1.4.2) (2021-08-06)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
+
+
+
+
 ## [1.4.1](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.4.0...mux-contentful-uploader@1.4.1) (2021-08-05)
+
 
 ### Reverts
 
-- Revert "feat: [EXT-2717] use app hosting for MUX (#363)" (#384) ([52d6d1c](https://github.com/contentful/apps/commit/52d6d1cec64675ecadc741fc3853e4f13d61f7ae)), closes [#363](https://github.com/contentful/apps/issues/363) [#384](https://github.com/contentful/apps/issues/384)
+* Revert "feat: [EXT-2717] use app hosting for MUX (#363)" (#384) ([52d6d1c](https://github.com/contentful/apps/commit/52d6d1cec64675ecadc741fc3853e4f13d61f7ae)), closes [#363](https://github.com/contentful/apps/issues/363) [#384](https://github.com/contentful/apps/issues/384)
+
+
+
+
 
 # [1.4.0](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.3.13...mux-contentful-uploader@1.4.0) (2021-08-05)
 
+
 ### Features
 
-- [EXT-2717] use app hosting for MUX ([#363](https://github.com/contentful/apps/issues/363)) ([4232d1f](https://github.com/contentful/apps/commit/4232d1f586d13519eccff7f05be02b0852a07c49))
+* [EXT-2717] use app hosting for MUX ([#363](https://github.com/contentful/apps/issues/363)) ([4232d1f](https://github.com/contentful/apps/commit/4232d1f586d13519eccff7f05be02b0852a07c49))
+
+
+
+
 
 ## [1.3.13](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.3.12...mux-contentful-uploader@1.3.13) (2021-08-05)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
+
+
+
+
 ## [1.3.12](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.3.11...mux-contentful-uploader@1.3.12) (2021-08-05)
 
 **Note:** Version bump only for package mux-contentful-uploader
+
+
+
+
 
 ## [1.3.11](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.3.10...mux-contentful-uploader@1.3.11) (2021-08-02)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
+
+
+
+
 ## [1.3.10](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.3.9...mux-contentful-uploader@1.3.10) (2021-08-02)
 
 **Note:** Version bump only for package mux-contentful-uploader
+
+
+
+
 
 ## [1.3.9](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.3.8...mux-contentful-uploader@1.3.9) (2021-07-29)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
+
+
+
+
 ## [1.3.8](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.3.7...mux-contentful-uploader@1.3.8) (2021-07-28)
 
 **Note:** Version bump only for package mux-contentful-uploader
+
+
+
+
 
 ## [1.3.7](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.3.6...mux-contentful-uploader@1.3.7) (2021-07-28)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
+
+
+
+
 ## [1.3.6](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.3.5...mux-contentful-uploader@1.3.6) (2021-07-28)
 
 **Note:** Version bump only for package mux-contentful-uploader
+
+
+
+
 
 ## [1.3.5](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.3.4...mux-contentful-uploader@1.3.5) (2021-07-28)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
+
+
+
+
 ## [1.3.4](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.3.3...mux-contentful-uploader@1.3.4) (2021-07-28)
 
 **Note:** Version bump only for package mux-contentful-uploader
+
+
+
+
 
 ## [1.3.3](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.3.2...mux-contentful-uploader@1.3.3) (2021-07-28)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
+
+
+
+
 ## [1.3.2](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.3.1...mux-contentful-uploader@1.3.2) (2021-07-26)
 
 **Note:** Version bump only for package mux-contentful-uploader
+
+
+
+
 
 ## [1.3.1](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.3.0...mux-contentful-uploader@1.3.1) (2021-06-22)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
+
+
+
+
 # [1.3.0](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.2.1...mux-contentful-uploader@1.3.0) (2021-06-21)
+
 
 ### Features
 
-- [] build mux with react-scripts ([#299](https://github.com/contentful/apps/issues/299)) ([c32c3e1](https://github.com/contentful/apps/commit/c32c3e12faea3eea6e88303811d9eac63f6c1361))
+* [] build mux with react-scripts ([#299](https://github.com/contentful/apps/issues/299)) ([c32c3e1](https://github.com/contentful/apps/commit/c32c3e12faea3eea6e88303811d9eac63f6c1361))
+
+
+
+
 
 ## [1.2.1](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.2.0...mux-contentful-uploader@1.2.1) (2021-05-10)
 
+
 ### Reverts
 
-- Revert "feat: [EXT-2533] use new version of ecommerce base app (#239)" (#251) ([dae2ae6](https://github.com/contentful/apps/commit/dae2ae66181543a93981b1b97cc9dfc71e5abf16)), closes [#239](https://github.com/contentful/apps/issues/239) [#251](https://github.com/contentful/apps/issues/251)
+* Revert "feat: [EXT-2533] use new version of ecommerce base app (#239)" (#251) ([dae2ae6](https://github.com/contentful/apps/commit/dae2ae66181543a93981b1b97cc9dfc71e5abf16)), closes [#239](https://github.com/contentful/apps/issues/239) [#251](https://github.com/contentful/apps/issues/251)
+
+
+
+
 
 # [1.2.0](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.1.0...mux-contentful-uploader@1.2.0) (2021-05-10)
 
+
 ### Features
 
-- [EXT-2533] use new version of ecommerce base app ([#239](https://github.com/contentful/apps/issues/239)) ([b4f398f](https://github.com/contentful/apps/commit/b4f398f7fe4fb2952e8505a7657b876861fe3a24))
+* [EXT-2533] use new version of ecommerce base app ([#239](https://github.com/contentful/apps/issues/239)) ([b4f398f](https://github.com/contentful/apps/commit/b4f398f7fe4fb2952e8505a7657b876861fe3a24))
+
+
+
+
 
 # [1.1.0](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.0.6...mux-contentful-uploader@1.1.0) (2021-05-05)
 
+
 ### Features
 
-- [EXT-2722] use contentful hosting for image focal point app ([#238](https://github.com/contentful/apps/issues/238)) ([11b57ae](https://github.com/contentful/apps/commit/11b57ae3e4fb5dd376544d89056430b71883517c))
+* [EXT-2722] use contentful hosting for image focal point app ([#238](https://github.com/contentful/apps/issues/238)) ([11b57ae](https://github.com/contentful/apps/commit/11b57ae3e4fb5dd376544d89056430b71883517c))
+
+
+
+
 
 ## [1.0.6](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.0.5...mux-contentful-uploader@1.0.6) (2021-03-17)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
+
+
+
+
 ## [1.0.5](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.0.4...mux-contentful-uploader@1.0.5) (2021-02-16)
 
 **Note:** Version bump only for package mux-contentful-uploader
+
+
+
+
 
 ## [1.0.4](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.0.3...mux-contentful-uploader@1.0.4) (2021-02-02)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
+
+
+
+
 ## [1.0.3](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.0.2...mux-contentful-uploader@1.0.3) (2021-01-14)
 
 **Note:** Version bump only for package mux-contentful-uploader
+
+
+
+
 
 ## [1.0.2](https://github.com/contentful/apps/compare/mux-contentful-uploader@1.0.1...mux-contentful-uploader@1.0.2) (2021-01-14)
 
 **Note:** Version bump only for package mux-contentful-uploader
 
+
+
+
+
 ## 1.0.1 (2021-01-12)
 
+
+
 ## 1.0.1 (2021-01-11)
+
+
 
 # 1.0.0 (2021-01-08)
 

--- a/apps/mux/src/index.tsx
+++ b/apps/mux/src/index.tsx
@@ -48,6 +48,7 @@ interface MuxContentfulObject {
   ready: boolean;
   ratio: string;
   error: string;
+  duration: number;
 }
 
 interface AppState {
@@ -214,6 +215,7 @@ export class App extends React.Component<AppProps, AppState> {
       ready: undefined,
       ratio: undefined,
       error: undefined,
+      duration: undefined,
     });
     this.setState({ error: false, errorShowResetAction: false });
   };
@@ -401,6 +403,7 @@ export class App extends React.Component<AppProps, AppState> {
       ready: asset.status === 'ready',
       ratio: asset.aspect_ratio,
       error: assetError,
+      duration: asset.duration,
     });
 
     if (publicPlayback) {

--- a/apps/mux/src/index.tsx
+++ b/apps/mux/src/index.tsx
@@ -83,6 +83,17 @@ export class App extends React.Component<AppProps, AppState> {
 
   detachExternalChangeHandler: Function | null = null;
 
+  syncDuration = async (assetDuration: number) => {
+    const currentValue: MuxContentfulObject = await this.props.sdk.field.getValue();
+
+    if (currentValue.duration !== assetDuration) {
+      await this.props.sdk.field.setValue({
+        ...currentValue,
+        duration: assetDuration,
+      })
+    }
+  }
+
   checkForValidAsset = async () => {
     if (!(this.state.value && this.state.value.assetId)) return false;
     const res = await this.apiClient.get(
@@ -112,6 +123,12 @@ export class App extends React.Component<AppProps, AppState> {
       });
       return false;
     }
+
+    const asset = await res.json();
+    if (asset.data.duration) {
+      this.syncDuration(asset.data.duration)
+    }
+
     return true;
   };
 


### PR DESCRIPTION
## Description
Adds "duration" to the Mux asset JSON that comes back from Contentful for videos that are uploaded via the Mux app. This is purely additive, so should be backwards compatible.

This is helpful when you want to display a thumbnail with a duration for a Mux asset, for instance, but aren't actually playing the video (where you would get duration for free in the video player). 

I ran the app with these changes on localhost in our Contentful instance and opened a video that was uploaded with the production version of the Mux app. Here was the resulting JSON (temporarily switched the view type of this field to raw JSON to take this screenshot)...
![Screen Shot 2021-10-19 at 4 43 15 PM](https://user-images.githubusercontent.com/11556475/137995380-fc418550-1585-40c0-96ea-2b92c13e4d08.png)

## List of changes
- added `duration` as a field on the `MuxContentfulObject` interface
- sets the duration for newly-uploaded videos when setting the app field initially
- when checking an asset's validity, syncs the duration to the field if it differs from what's already there