### PR TITLE
fix: [] preview button incorrectly hidden

### DIFF
--- a/apps/gatsby/src/Sidebar.js
+++ b/apps/gatsby/src/Sidebar.js
@@ -261,7 +261,7 @@ export default class Sidebar extends React.Component {
 
     previewUrl = this.getPreviewUrl();
 
-    if (contentSyncUrl && !(webhookUrl || previewWebhookUrl)) {
+    if (contentSyncUrl && !previewWebhookUrl) {
       return (
         <div className="extension">
           <div className="flexcontainer">

--- a/apps/gatsby/src/Sidebar.js
+++ b/apps/gatsby/src/Sidebar.js
@@ -263,10 +263,14 @@ export default class Sidebar extends React.Component {
 
     if (contentSyncUrl && !(webhookUrl || previewWebhookUrl)) {
       return (
-        <HelpText style={STATUS_STYLE}>
-          <Icon icon="Warning" color="negative" style={ICON_STYLE} /> Please add a Preview Webhook
-          URL to your Gatsby App settings.
-        </HelpText>
+        <div className="extension">
+          <div className="flexcontainer">
+            <HelpText style={STATUS_STYLE}>
+              <Icon icon="Warning" color="negative" style={ICON_STYLE} /> Please add a Preview
+              Webhook URL to your Gatsby App settings.
+            </HelpText>
+          </div>
+        </div>
       );
     }
 

--- a/apps/gatsby/src/Sidebar.js
+++ b/apps/gatsby/src/Sidebar.js
@@ -255,32 +255,35 @@ export default class Sidebar extends React.Component {
   };
 
   render = () => {
-    let { contentSyncUrl, authToken, previewUrl, webhookUrl } = this.sdk.parameters.installation;
+    let { contentSyncUrl, authToken, previewUrl, webhookUrl, previewWebhookUrl } =
+      this.sdk.parameters.installation;
     const { slug } = this.state;
 
     previewUrl = this.getPreviewUrl();
 
+    if (contentSyncUrl && !(webhookUrl || previewWebhookUrl)) {
+      return (
+        <HelpText style={STATUS_STYLE}>
+          <Icon icon="Warning" color="negative" style={ICON_STYLE} /> Please add a Preview Webhook
+          URL to your Gatsby App settings.
+        </HelpText>
+      );
+    }
+
     return (
       <div className="extension">
         <div className="flexcontainer">
-          {webhookUrl ? (
-            <>
-              <ExtensionUI
-                disabled={this.state.buttonDisabled}
-                disablePreviewOpen={!!contentSyncUrl}
-                contentSlug={!!slug && slug}
-                previewUrl={previewUrl}
-                authToken={authToken}
-                onOpenPreviewButtonClick={!!contentSyncUrl ? this.handleContentSync : () => {}}
-              />
-              {!!this.state.buttonDisabled && <Spinner />}
-            </>
-          ) : (
-            <HelpText style={STATUS_STYLE}>
-              <Icon icon="Warning" color="negative" style={ICON_STYLE} /> Please add a Preview
-              Webhook URL to your Gatsby App settings.
-            </HelpText>
-          )}
+          <>
+            <ExtensionUI
+              disabled={this.state.buttonDisabled}
+              disablePreviewOpen={!!contentSyncUrl}
+              contentSlug={!!slug && slug}
+              previewUrl={previewUrl}
+              authToken={authToken}
+              onOpenPreviewButtonClick={!!contentSyncUrl ? this.handleContentSync : () => {}}
+            />
+            {!!this.state.buttonDisabled && <Spinner />}
+          </>
 
           {!!webhookUrl && !contentSyncUrl && this.renderRefreshStatus()}
         </div>

--- a/apps/gatsby/src/Sidebar.spec.js
+++ b/apps/gatsby/src/Sidebar.spec.js
@@ -90,6 +90,7 @@ describe('Gatsby App Sidebar', () => {
 
     const contentSyncUrl = 'https://content-sync.com/content-sync/fake-site-id';
     mockSdk.parameters.installation.contentSyncUrl = contentSyncUrl;
+    mockSdk.parameters.installation.previewWebhookUrl = WEBHOOK_URL;
 
     const { getByText } = render(<Sidebar sdk={mockSdk} />);
 


### PR DESCRIPTION
Before the recent gatsby update, if the user didn't have a webhook URL in their installation params we would still show them the preview button. This causes issues for some users who just have a CMS preview URL.

This PR makes it so we only hide the button if there is a content Sync URL but no valid preview URL. This hopefully means that the behaviour for customers with older configs should not be impacted.
