### PR TITLE
fix: fail config persistence if preview webhook url is not valid

### DIFF
--- a/apps/gatsby/src/AppConfig/AppConfig.js
+++ b/apps/gatsby/src/AppConfig/AppConfig.js
@@ -63,7 +63,7 @@ export class AppConfig extends React.Component {
 
   state = {
     contentTypes: null,
-    enabledContentTypes: {},
+    enabledContentTypes: [],
     selectorType: false,
     urlConstructors: [],
     previewUrl: '',


### PR DESCRIPTION
We are not validating the `previewWebhookUrl` if it has been added to the Gatsby app config. This means that the user could enter any old string and successfully save. We want to ensure that only valid urls are added to ensure a good user experience.