### PR TITLE
test: add tests for onConfigure hook in Gatsby app

### DIFF
--- a/apps/gatsby/src/AppConfig/AppConfig.spec.js
+++ b/apps/gatsby/src/AppConfig/AppConfig.spec.js
@@ -60,11 +60,6 @@ function makeContentTypes() {
   ];
 }
 
-function makeEnabledContentTypes() {
-  return ['page'];
-};
-
-
 describe('<AppConfig />', () => {
   /** 
    * Because the Contentful SDK takes care of calling configure, we need to follow an atypical

--- a/apps/gatsby/src/AppConfig/AppConfig.spec.js
+++ b/apps/gatsby/src/AppConfig/AppConfig.spec.js
@@ -1,7 +1,52 @@
-import { enabledContentTypesToTargetState } from './AppConfig';
+import React from 'react';
+import { render } from '@testing-library/react';
+import { enabledContentTypesToTargetState, AppConfig } from './AppConfig';
 
-describe('enabledContentTypesToTargetState', () => {
-  const contentTypes = [
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function makeMockSdk({
+  onConfigure = () => {},
+  getParameters = () => {},
+  previewUrl = 'https://preview.de',
+  webhookUrl = 'https://webhook.de',
+  previewWebhookUrl = 'https://preview-webhook.de',
+  contentSyncUrl = 'https://content-sync-url.de',
+}) {
+  return {
+    space: {
+      getEditorInterfaces: () => ({
+        items: [],
+      }),
+      getContentTypes: () => ({
+        items: [],
+      }),
+    },
+    app: {
+      onConfigure,
+      getParameters: () => ({
+        previewUrl,
+        webhookUrl,
+        previewWebhookUrl,
+        contentSyncUrl,
+      }),
+      getCurrentState: () => ({ EditorInterface: {} }),
+      setReady: () => {},
+    },
+    ids: {
+      app: '1234',
+      space: '1234',
+      environment: '1234',
+    },
+    notifier: {
+      error: () => {},
+    },
+  }
+}
+
+function makeContentTypes() {
+  return [
     {
       sys: {
         id: 'page',
@@ -13,6 +58,114 @@ describe('enabledContentTypesToTargetState', () => {
       },
     },
   ];
+}
+
+function makeEnabledContentTypes() {
+  return ['page'];
+};
+
+
+describe('<AppConfig />', () => {
+  /** 
+   * Because the Contentful SDK takes care of calling configure, we need to follow an atypical
+   * pattern for the following tests. This includes adding a delay to ensure that the component is fully
+   * mounted before manually calling the configure method and then asserting that its return value
+   * is correct
+   */ 
+  describe('configure callback validation', () => {
+    it('validates url fields and returns correct values if valid', async () => {
+      let configure;
+      const mockSdk = makeMockSdk({
+        onConfigure: jest.fn((cb) => {
+          configure = cb;
+        }),
+      });
+
+      render(<AppConfig sdk={mockSdk} />);
+
+      await delay(500);
+      const configureResult = await configure();
+      const { parameters } = configureResult;
+
+      expect(configureResult).toBeTruthy();
+      expect(parameters.previewUrl).toEqual('https://preview.de');
+      expect(parameters.webhookUrl).toEqual('https://webhook.de');
+      expect(parameters.previewWebhookUrl).toEqual('https://preview-webhook.de');
+      expect(parameters.contentSyncUrl).toEqual('https://content-sync-url.de');
+    });
+
+    it('returns false if previewUrl is invalid', async () => {
+      let configure;
+      const mockSdk = makeMockSdk({
+        onConfigure: jest.fn((cb) => {
+          configure = cb;
+        }),
+        previewUrl: 'not-a-real-url',
+      });
+
+      render(<AppConfig sdk={mockSdk} />);
+
+      await delay(500);
+      const configureResult = await configure();
+
+      expect(configureResult).toEqual(false);
+    });
+
+    it('returns false if webhookUrl is invalid', async () => {
+      let configure;
+      const mockSdk = makeMockSdk({
+        onConfigure: jest.fn((cb) => {
+          configure = cb;
+        }),
+        webhookUrl: 'not-a-real-url',
+      });
+
+      render(<AppConfig sdk={mockSdk} />);
+
+      await delay(500);
+      const configureResult = await configure();
+
+      expect(configureResult).toEqual(false);
+    });
+
+    it('returns false if previewWebhookUrl is invalid', async () => {
+      let configure;
+      const mockSdk = makeMockSdk({
+        onConfigure: jest.fn((cb) => {
+          configure = cb;
+        }),
+        previewWebhookUrl: 'not-a-real-url',
+      });
+
+      render(<AppConfig sdk={mockSdk} />);
+
+      await delay(500);
+      const configureResult = await configure();
+
+      expect(configureResult).toEqual(false);
+    });
+
+    it('returns false if contentSyncUrl is invalid', async () => {
+      let configure;
+      const mockSdk = makeMockSdk({
+        onConfigure: jest.fn((cb) => {
+          configure = cb;
+        }),
+        contentSyncUrl: 'not-a-real-url',
+      });
+
+      render(<AppConfig sdk={mockSdk} />);
+
+      await delay(500);
+      const configureResult = await configure();
+
+      expect(configureResult).toEqual(false);
+    });
+  })
+});
+
+describe('enabledContentTypesToTargetState', () => {
+  const contentTypes = makeContentTypes();
   const enabledContentTypes = ['page'];
   describe('when the content type already has the app assigned', () => {
     it('does not overwrite the existing position', () => {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "bootstrap": "lerna bootstrap --no-ci",
     "bootstrap:ci": "lerna bootstrap --ci --concurrency=3",
+    "clean": "lerna clean",
     "lint": "lerna run lint --concurrency=3",
     "build": "lerna run build --concurrency=1 --stream",
     "test": "lerna run test:ci --concurrency=1 --stream",


### PR DESCRIPTION
We recently discovered a bug where we were not validating all of the url fields in the Gatsby app config component. This adds tests to help ensure that the `onConfigure` callback validates all urls before persisting configuration.
