### PR TITLE
fix: bug where preview button wouldn't show up for users

### DIFF
--- a/apps/gatsby/src/AppConfig/AppConfig.js
+++ b/apps/gatsby/src/AppConfig/AppConfig.js
@@ -67,6 +67,12 @@ export class AppConfig extends React.Component {
     selectorType: false,
     urlConstructors: [],
     previewUrl: '',
+    /**
+     * The Preview Webhook Url was historically named "webhookUrl" which is a *bit* confusing
+     * since you might expect it to be called "previewWebhookUrl" In order to keep backwards
+     * compatibility for users not yet using Content Sync, we must continue using the
+     * variable / keyname "webhookUrl"
+     */
     webhookUrl: '',
     contentSyncUrl: '',
     authToken: '',
@@ -96,7 +102,6 @@ export class AppConfig extends React.Component {
         urlConstructors: params.urlConstructors || [],
         previewUrl: params.previewUrl || '',
         webhookUrl: params.webhookUrl || '',
-        previewWebhookUrl: params.previewWebhookUrl || '',
         contentSyncUrl: params.contentSyncUrl || '',
         authToken: params.authToken || '',
       },
@@ -114,22 +119,19 @@ export class AppConfig extends React.Component {
       previewUrl,
       contentSyncUrl,
       webhookUrl,
-      previewWebhookUrl,
       authToken,
     } = this.state;
 
     const validPreview = !previewUrl || isValidUrl(previewUrl);
     const validContentSync = !contentSyncUrl || isValidUrl(contentSyncUrl);
     const validWebhook = !webhookUrl || isValidUrl(webhookUrl);
-    const validPreviewWebhook = !previewWebhookUrl || isValidUrl(previewWebhookUrl);
 
-    const valid = !!validPreview && !!validContentSync && !!validWebhook && !!validPreviewWebhook;
+    const valid = !!validPreview && !!validContentSync && !!validWebhook;
 
     this.setState({
       validPreview: validPreview,
       validContentSync: validContentSync,
       validWebhook: validWebhook,
-      validPreviewWebhook: validPreviewWebhook,
     });
 
     if (!valid) {
@@ -145,7 +147,6 @@ export class AppConfig extends React.Component {
         previewUrl,
         contentSyncUrl,
         webhookUrl,
-        previewWebhookUrl,
         authToken,
         urlConstructors,
       },
@@ -170,10 +171,6 @@ export class AppConfig extends React.Component {
     this.setState({ webhookUrl: e.target.value, validWebhook: true });
   };
 
-  updatePreviewWebhookUrl = (e) => {
-    this.setState({ previewWebhookUrl: e.target.value, validPreviewWebhook: true });
-  };
-
   updateAuthToken = (e) => {
     this.setState({ authToken: e.target.value });
   };
@@ -195,14 +192,6 @@ export class AppConfig extends React.Component {
   validateWebhookUrl = () => {
     if (this.state.webhookUrl && !this.state.webhookUrl.startsWith('http')) {
       this.setState({ validWebhook: false });
-    }
-  };
-
-  validatePreviewWebhookUrl = () => {
-    if (this.state.previewWebhookUrl) {
-      this.setState({
-        validPreviewWebhook: isValidUrl(this.state.previewWebhookUrl),
-      });
     }
   };
 

--- a/apps/gatsby/src/AppConfig/AppConfig.spec.js
+++ b/apps/gatsby/src/AppConfig/AppConfig.spec.js
@@ -8,10 +8,8 @@ function delay(ms) {
 
 function makeMockSdk({
   onConfigure = () => {},
-  getParameters = () => {},
   previewUrl = 'https://preview.de',
   webhookUrl = 'https://webhook.de',
-  previewWebhookUrl = 'https://preview-webhook.de',
   contentSyncUrl = 'https://content-sync-url.de',
 }) {
   return {
@@ -28,7 +26,6 @@ function makeMockSdk({
       getParameters: () => ({
         previewUrl,
         webhookUrl,
-        previewWebhookUrl,
         contentSyncUrl,
       }),
       getCurrentState: () => ({ EditorInterface: {} }),
@@ -85,7 +82,6 @@ describe('<AppConfig />', () => {
       expect(configureResult).toBeTruthy();
       expect(parameters.previewUrl).toEqual('https://preview.de');
       expect(parameters.webhookUrl).toEqual('https://webhook.de');
-      expect(parameters.previewWebhookUrl).toEqual('https://preview-webhook.de');
       expect(parameters.contentSyncUrl).toEqual('https://content-sync-url.de');
     });
 
@@ -113,23 +109,6 @@ describe('<AppConfig />', () => {
           configure = cb;
         }),
         webhookUrl: 'not-a-real-url',
-      });
-
-      render(<AppConfig sdk={mockSdk} />);
-
-      await delay(500);
-      const configureResult = await configure();
-
-      expect(configureResult).toEqual(false);
-    });
-
-    it('returns false if previewWebhookUrl is invalid', async () => {
-      let configure;
-      const mockSdk = makeMockSdk({
-        onConfigure: jest.fn((cb) => {
-          configure = cb;
-        }),
-        previewWebhookUrl: 'not-a-real-url',
       });
 
       render(<AppConfig sdk={mockSdk} />);

--- a/apps/gatsby/src/Sidebar.js
+++ b/apps/gatsby/src/Sidebar.js
@@ -161,12 +161,10 @@ export default class Sidebar extends React.Component {
       return;
     }
 
-    const previewWebhookUrl =
-      this.sdk.parameters.installation.previewWebhookUrl ||
-      this.sdk.parameters.installation.webhookUrl;
+    const { webhookUrl } = this.sdk.parameters.installation;
 
-    if (previewWebhookUrl) {
-      callWebhook(previewWebhookUrl, authToken);
+    if (webhookUrl) {
+      callWebhook(webhookUrl, authToken);
     } else {
       console.warn(`Please add a Preview Webhook URL to your Gatsby Cloud App settings.`);
     }
@@ -255,13 +253,13 @@ export default class Sidebar extends React.Component {
   };
 
   render = () => {
-    let { contentSyncUrl, authToken, previewUrl, webhookUrl, previewWebhookUrl } =
+    let { contentSyncUrl, authToken, previewUrl, webhookUrl } =
       this.sdk.parameters.installation;
     const { slug } = this.state;
 
     previewUrl = this.getPreviewUrl();
 
-    if (contentSyncUrl && !previewWebhookUrl) {
+    if (contentSyncUrl && !webhookUrl) {
       return (
         <div className="extension">
           <div className="flexcontainer">

--- a/apps/gatsby/src/Sidebar.spec.js
+++ b/apps/gatsby/src/Sidebar.spec.js
@@ -90,7 +90,6 @@ describe('Gatsby App Sidebar', () => {
 
     const contentSyncUrl = 'https://content-sync.com/content-sync/fake-site-id';
     mockSdk.parameters.installation.contentSyncUrl = contentSyncUrl;
-    mockSdk.parameters.installation.previewWebhookUrl = WEBHOOK_URL;
 
     const { getByText } = render(<Sidebar sdk={mockSdk} />);
 


### PR DESCRIPTION
Due to some confusing naming that is in place to ensure backwards compatibility for Gatsby users who have not yet moved to Content Sync preview, we accidentally introduced a regression through #569. This happened because we had references to a configuration value called `previewWebookUrl` which was essentially unused. The correct name for the preview webhook url in the config object is `webhookUrl` (this is the confusing backwards compatibility naming.)

This bug is causing a missing url warning to display even if the "Preview Url" field in the config is filled out since that field is mapped to the `webhookUrl` and not the `previewWebhookUrl` config value.

![contentful](https://user-images.githubusercontent.com/21110659/139918587-b019bb58-c272-47ca-9b04-3bc8730c60dc.png)

This PR fixes that bug and also removes references to the superfluous config item `previewWebhookUrl`. @Jwhiles sorry for any confusion here and with your recent fix! I should have caught that in your PR but had already forgotten about the historical context around `webhookUrl` (naming is important :sweat_smile:)  and I'm hoping that these changes help us to avoid a similar mistake in the future. 