### PR TITLE
fix(jira): start auto resizer when not authenticated

### DIFF
--- a/apps/jira/jira-app/src/components/Jira/index.tsx
+++ b/apps/jira/jira-app/src/components/Jira/index.tsx
@@ -33,7 +33,6 @@ export default class Jira extends React.Component<Props, State> {
   }
 
   async componentDidMount() {
-    this.props.sdk.window.startAutoResizer();
     await this.getIssues();
 
     this.issueInterval = setInterval(this.getIssues, 30000);

--- a/apps/jira/jira-app/src/index.tsx
+++ b/apps/jira/jira-app/src/index.tsx
@@ -27,6 +27,7 @@ if (window.location.search.includes('token')) {
     }
 
     if (sdk.location.is(locations.LOCATION_ENTRY_SIDEBAR)) {
+      (sdk as SidebarExtensionSDK).window.startAutoResizer()
       renderAtRoot(
         <Auth
           notifyError={sdk.notifier.error}


### PR DESCRIPTION
When the user is not authenticated with the jira app installed, we currently leave quite some space under the button as we do not resize the iframe:

![image](https://user-images.githubusercontent.com/4947671/144621897-855ab81c-b053-428f-b6a4-8dd51b2d45ea.png)

We only start the auto resizer once the user has authenticated. With this PR we always start the resizer when the app is rendered in the sidebar.

![image](https://user-images.githubusercontent.com/4947671/144622256-9ba89569-bed3-4dc1-b27b-fa4de7410fe7.png)
