### PR TITLE
fix(Optimizely): remove index.js script tag

### DIFF
--- a/apps/optimizely/public/index.html
+++ b/apps/optimizely/public/index.html
@@ -5,6 +5,5 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="text/javascript" src="./index.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Create React App adds all required script tags itself. This seems like a leftover from when we didn't use CRA
