### PR TITLE
feat: [EXT-3415] move all package names to @contentful

### DIFF
--- a/apps/ai-image-tagging/frontend/package-lock.json
+++ b/apps/ai-image-tagging/frontend/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "ai-image-tagging-frontend",
+	"name": "@contentful/ai-image-tagging-frontend",
 	"version": "1.4.1",
 	"lockfileVersion": 1,
 	"requires": true,

--- a/apps/ai-image-tagging/frontend/package.json
+++ b/apps/ai-image-tagging/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ai-image-tagging-frontend",
+  "name": "@contentful/ai-image-tagging-frontend",
   "version": "1.4.1",
   "private": true,
   "main": "build/index.html",

--- a/apps/ai-image-tagging/lambda/app.js
+++ b/apps/ai-image-tagging/lambda/app.js
@@ -19,7 +19,7 @@ const deps = {
 
 const app = express();
 
-const FRONTEND = path.dirname(require.resolve('ai-image-tagging-frontend'));
+const FRONTEND = path.dirname(require.resolve('@contentful/ai-image-tagging-frontend'));
 
 app.use('/tags', async (req, res) => {
   const { status, body } = await handle(req.method, req.path, deps);

--- a/apps/ai-image-tagging/lambda/package-lock.json
+++ b/apps/ai-image-tagging/lambda/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "ai-image-tagging-lambda",
+	"name": "@contentful/ai-image-tagging-lambda",
 	"version": "1.3.6",
 	"lockfileVersion": 1,
 	"requires": true,

--- a/apps/ai-image-tagging/lambda/package.json
+++ b/apps/ai-image-tagging/lambda/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ai-image-tagging-lambda",
+  "name": "@contentful/ai-image-tagging-lambda",
   "private": true,
   "version": "1.3.6",
   "author": "Contentful GmbH",
@@ -19,7 +19,7 @@
     "serverless-domain-manager": "3.3.1"
   },
   "dependencies": {
-    "ai-image-tagging-frontend": "^1.4.1",
+    "@contentful/ai-image-tagging-frontend": "^1.4.1",
     "aws-serverless-express": "3.3.6",
     "express": "4.17.1",
     "luxon": "1.22.0",

--- a/apps/ai-image-tagging/lambda/serverless.yml
+++ b/apps/ai-image-tagging/lambda/serverless.yml
@@ -40,7 +40,7 @@ provider:
 
 package:
   patterns:
-    - "!node_modules/ai-image-tagging-frontend/node_modules/**"
+    - "!node_modules/@contentful/ai-image-tagging-frontend/node_modules/**"
 
 functions:
   app:

--- a/apps/brandfolder/package-lock.json
+++ b/apps/brandfolder/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "brandfolder-assets",
+  "name": "@contentful/brandfolder-assets",
   "version": "1.8.93",
   "lockfileVersion": 1,
   "requires": true,

--- a/apps/brandfolder/package.json
+++ b/apps/brandfolder/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "brandfolder-assets",
+  "name": "@contentful/brandfolder-assets",
   "version": "1.8.93",
   "private": true,
   "devDependencies": {

--- a/apps/bynder/package-lock.json
+++ b/apps/bynder/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "bynder-assets",
+  "name": "@contentful/bynder-assets",
   "version": "1.7.86",
   "lockfileVersion": 1,
   "requires": true,

--- a/apps/bynder/package.json
+++ b/apps/bynder/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "bynder-assets",
+  "name": "@contentful/bynder-assets",
   "version": "1.7.86",
   "private": true,
   "devDependencies": {

--- a/apps/cloudinary/package-lock.json
+++ b/apps/cloudinary/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "cloudinary-assets",
+  "name": "@contentful/cloudinary-assets",
   "version": "1.4.86",
   "lockfileVersion": 1,
   "requires": true,

--- a/apps/cloudinary/package.json
+++ b/apps/cloudinary/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cloudinary-assets",
+  "name": "@contentful/cloudinary-assets",
   "version": "1.4.86",
   "private": true,
   "devDependencies": {

--- a/apps/commercelayer/package-lock.json
+++ b/apps/commercelayer/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "commercelayer-products",
+	"name": "@contentful/commercelayer-products",
 	"version": "1.4.111",
 	"lockfileVersion": 1,
 	"requires": true,

--- a/apps/commercelayer/package.json
+++ b/apps/commercelayer/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "commercelayer-products",
+  "name": "@contentful/commercelayer-products",
   "version": "1.4.111",
   "private": true,
   "devDependencies": {

--- a/apps/commercetools/package-lock.json
+++ b/apps/commercetools/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "commercetools",
+	"name": "@contentful/commercetools",
 	"version": "1.7.3",
 	"lockfileVersion": 1,
 	"requires": true,

--- a/apps/commercetools/package.json
+++ b/apps/commercetools/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "commercetools",
+  "name": "@contentful/commercetools",
   "version": "1.7.3",
   "private": true,
   "devDependencies": {

--- a/apps/dropbox/package-lock.json
+++ b/apps/dropbox/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "dropbox-assets",
+  "name": "@contentful/dropbox-assets",
   "version": "1.5.86",
   "lockfileVersion": 1,
   "requires": true,

--- a/apps/dropbox/package.json
+++ b/apps/dropbox/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dropbox-assets",
+  "name": "@contentful/dropbox-assets",
   "version": "1.5.86",
   "private": true,
   "devDependencies": {

--- a/apps/frontify/package-lock.json
+++ b/apps/frontify/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "frontify-assets",
+	"name": "@contentful/frontify-assets",
 	"version": "1.4.85",
 	"lockfileVersion": 1,
 	"requires": true,

--- a/apps/frontify/package.json
+++ b/apps/frontify/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "frontify-assets",
+  "name": "@contentful/frontify-assets",
   "version": "1.4.85",
   "private": true,
   "devDependencies": {

--- a/apps/gatsby/package-lock.json
+++ b/apps/gatsby/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "gatsby-preview",
+	"name": "@contentful/gatsby-preview",
 	"version": "1.10.11",
 	"lockfileVersion": 1,
 	"requires": true,

--- a/apps/gatsby/package.json
+++ b/apps/gatsby/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gatsby-preview",
+  "name": "@contentful/gatsby-preview",
   "version": "1.10.11",
   "private": true,
   "devDependencies": {

--- a/apps/google-analytics/package-lock.json
+++ b/apps/google-analytics/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "google-analytics",
+	"name": "@contentful/google-analytics",
 	"version": "1.4.4",
 	"lockfileVersion": 1,
 	"requires": true,

--- a/apps/google-analytics/package.json
+++ b/apps/google-analytics/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "google-analytics",
+  "name": "@contentful/google-analytics",
   "version": "1.4.4",
   "private": true,
   "devDependencies": {

--- a/apps/image-focal-point/package-lock.json
+++ b/apps/image-focal-point/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "image-focal-point",
+	"name": "@contentful/image-focal-point",
 	"version": "1.5.1",
 	"lockfileVersion": 1,
 	"requires": true,

--- a/apps/image-focal-point/package.json
+++ b/apps/image-focal-point/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "image-focal-point",
+  "name": "@contentful/image-focal-point",
   "version": "1.5.1",
   "private": true,
   "devDependencies": {

--- a/apps/jira/functions/package-lock.json
+++ b/apps/jira/functions/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "functions",
+  "name": "@contentful/functions",
   "version": "1.3.2",
   "lockfileVersion": 1,
   "requires": true,

--- a/apps/jira/functions/package.json
+++ b/apps/jira/functions/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "functions",
+  "name": "@contentful/functions",
   "version": "1.3.2",
   "main": "index.js",
   "private": true,

--- a/apps/jira/jira-app/package-lock.json
+++ b/apps/jira/jira-app/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "jira-app",
+	"name": "@contentful/jira-app",
 	"version": "1.5.3",
 	"lockfileVersion": 1,
 	"requires": true,

--- a/apps/jira/jira-app/package.json
+++ b/apps/jira/jira-app/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "jira-app",
+  "name": "@contentful/jira-app",
   "version": "1.5.3",
   "private": true,
   "devDependencies": {

--- a/apps/jira/package-lock.json
+++ b/apps/jira/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "jira",
+  "name": "@contentful/jira",
   "version": "1.7.3",
   "lockfileVersion": 1,
   "requires": true,

--- a/apps/jira/package.json
+++ b/apps/jira/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "jira",
+  "name": "@contentful/jira",
   "version": "1.7.3",
   "private": true,
   "devDependencies": {

--- a/apps/mux/package-lock.json
+++ b/apps/mux/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "mux-contentful-uploader",
+  "name": "@contentful/mux-contentful-uploader",
   "version": "1.5.37",
   "lockfileVersion": 1,
   "requires": true,

--- a/apps/mux/package.json
+++ b/apps/mux/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mux-contentful-uploader",
+  "name": "@contentful/mux-contentful-uploader",
   "version": "1.5.37",
   "private": true,
   "devDependencies": {

--- a/apps/netlify/package-lock.json
+++ b/apps/netlify/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "netlify-build-and-preview",
+	"name": "@contentful/netlify-build-and-preview",
 	"version": "1.5.1",
 	"lockfileVersion": 1,
 	"requires": true,

--- a/apps/netlify/package.json
+++ b/apps/netlify/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "netlify-build-and-preview",
+  "name": "@contentful/netlify-build-and-preview",
   "version": "1.5.1",
   "private": true,
   "devDependencies": {

--- a/apps/optimizely/package-lock.json
+++ b/apps/optimizely/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "optimizely",
+	"name": "@contentful/optimizely",
 	"version": "1.5.2",
 	"lockfileVersion": 1,
 	"requires": true,

--- a/apps/optimizely/package.json
+++ b/apps/optimizely/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "optimizely",
+  "name": "@contentful/optimizely",
   "version": "1.5.2",
   "private": true,
   "devDependencies": {

--- a/apps/saleor/package-lock.json
+++ b/apps/saleor/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "saleor",
+  "name": "@contentful/saleor",
   "version": "1.5.54",
   "lockfileVersion": 1,
   "requires": true,

--- a/apps/saleor/package.json
+++ b/apps/saleor/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "saleor",
+  "name": "@contentful/saleor",
   "version": "1.5.54",
   "private": true,
   "devDependencies": {

--- a/apps/shopify/package-lock.json
+++ b/apps/shopify/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "shopify-sku",
+	"name": "@contentful/shopify-sku",
 	"version": "1.7.87",
 	"lockfileVersion": 1,
 	"requires": true,

--- a/apps/shopify/package.json
+++ b/apps/shopify/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "shopify-sku",
+  "name": "@contentful/shopify-sku",
   "version": "1.7.87",
   "private": true,
   "devDependencies": {

--- a/apps/smartling/frontend/package-lock.json
+++ b/apps/smartling/frontend/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "smartling-frontend",
+  "name": "@contentful/smartling-frontend",
   "version": "1.6.2",
   "lockfileVersion": 1,
   "requires": true,

--- a/apps/smartling/frontend/package.json
+++ b/apps/smartling/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "smartling-frontend",
+  "name": "@contentful/smartling-frontend",
   "version": "1.6.2",
   "main": "build/index.html",
   "devDependencies": {

--- a/apps/smartling/lambda/package-lock.json
+++ b/apps/smartling/lambda/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "smartling-lambda",
+  "name": "@contentful/smartling-lambda",
   "version": "1.3.8",
   "lockfileVersion": 1,
   "requires": true,

--- a/apps/smartling/lambda/package.json
+++ b/apps/smartling/lambda/package.json
@@ -19,11 +19,7 @@
     "rimraf": "^3.0.1",
     "serverless": "2.57.0",
     "serverless-express": "^2.0.11",
-<<<<<<< HEAD
-    "smartling-frontend": "^1.6.2",
-=======
-    "@contentful/smartling-frontend": "^1.6.1",
->>>>>>> feat: [EXT-3415] move all package names to @contentful
+    "@contentful/smartling-frontend": "^1.6.2",
     "typescript": "^3.7.5"
   },
   "devDependencies": {

--- a/apps/smartling/lambda/package.json
+++ b/apps/smartling/lambda/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "smartling-lambda",
+  "name": "@contentful/smartling-lambda",
   "version": "1.3.8",
   "private": true,
   "scripts": {
@@ -19,7 +19,11 @@
     "rimraf": "^3.0.1",
     "serverless": "2.57.0",
     "serverless-express": "^2.0.11",
+<<<<<<< HEAD
     "smartling-frontend": "^1.6.2",
+=======
+    "@contentful/smartling-frontend": "^1.6.1",
+>>>>>>> feat: [EXT-3415] move all package names to @contentful
     "typescript": "^3.7.5"
   },
   "devDependencies": {

--- a/apps/smartling/lambda/serverless.yml
+++ b/apps/smartling/lambda/serverless.yml
@@ -29,7 +29,7 @@ package:
     - 'built/**'
     - '!.git/**'
     - '!**/*.ts'
-    - '!node_modules/smartling-frontend/node_modules/**'
+    - '!node_modules/@contentful/smartling-frontend/node_modules/**'
 
 functions:
   app:

--- a/apps/smartling/lambda/src/index.ts
+++ b/apps/smartling/lambda/src/index.ts
@@ -21,7 +21,7 @@ export function makeApp(fetchFn: any, issuer: any) {
 
     return new Client({
       client_id: process.env.CLIENT_ID,
-      client_secret: process.env.CLIENT_SECRET
+      client_secret: process.env.CLIENT_SECRET,
     });
   }
 
@@ -92,8 +92,8 @@ export function makeApp(fetchFn: any, issuer: any) {
       {
         headers: {
           Authorization: req.headers.authorization || '',
-          'content-type': 'application/json'
-        }
+          'content-type': 'application/json',
+        },
       }
     );
 
@@ -107,9 +107,10 @@ export function makeApp(fetchFn: any, issuer: any) {
     );
   });
 
-  app.use('/frontend', express.static(path.dirname(
-    require.resolve('smartling-frontend')
-  )));
+  app.use(
+    '/frontend',
+    express.static(path.dirname(require.resolve('@contentful/smartling-frontend')))
+  );
 
   app.use((_req, res) => res.status(404).send('Not found'));
 

--- a/apps/typeform/frontend/package-lock.json
+++ b/apps/typeform/frontend/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "typeform-frontend",
+	"name": "@contentful/typeform-frontend",
 	"version": "1.4.1",
 	"lockfileVersion": 1,
 	"requires": true,

--- a/apps/typeform/frontend/package.json
+++ b/apps/typeform/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "typeform-frontend",
+  "name": "@contentful/typeform-frontend",
   "version": "1.4.1",
   "private": true,
   "main": "build/index.html",

--- a/apps/typeform/lambda/app.js
+++ b/apps/typeform/lambda/app.js
@@ -13,7 +13,7 @@ const deps = {
 
 const app = express();
 
-const FRONTEND = path.dirname(require.resolve('typeform-frontend'));
+const FRONTEND = path.dirname(require.resolve('@contentful/typeform-frontend'));
 
 app.use('/forms', async (req, res) => {
   const { authorization } = req.headers;

--- a/apps/typeform/lambda/package-lock.json
+++ b/apps/typeform/lambda/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "typeform-lambda",
+  "name": "@contentful/typeform-lambda",
   "version": "1.4.5",
   "lockfileVersion": 1,
   "requires": true,

--- a/apps/typeform/lambda/package.json
+++ b/apps/typeform/lambda/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "typeform-lambda",
+  "name": "@contentful/typeform-lambda",
   "private": true,
   "version": "1.4.5",
   "author": "Contentful GmbH",
@@ -24,6 +24,6 @@
     "express": "4.17.1",
     "luxon": "1.22.0",
     "node-fetch": "2.6.0",
-    "typeform-frontend": "^1.4.1"
+    "@contentful/typeform-frontend": "^1.4.1"
   }
 }

--- a/apps/typeform/lambda/serverless.yml
+++ b/apps/typeform/lambda/serverless.yml
@@ -26,7 +26,7 @@ provider:
 package:
   patterns:
     - '!.git/**'
-    - '!node_modules/typeform-frontend/node_modules/**'
+    - '!node_modules/@contentful/typeform-frontend/node_modules/**'
 
 functions:
   app:

--- a/examples/blog-post-metrics/package.json
+++ b/examples/blog-post-metrics/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "blog-post-metrics",
+  "name": "@contentful/blog-post-metrics",
   "version": "0.1.0",
   "private": true,
   "dependencies": {

--- a/examples/default-values-backend/package.json
+++ b/examples/default-values-backend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "backend_app_demo",
+  "name": "@contentful/backend_app_demo",
   "version": "1.0.0",
   "main": "src/index.ts",
   "scripts": {

--- a/examples/page-location/package.json
+++ b/examples/page-location/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "page-location-example",
+  "name": "@contentful/page-location-example",
   "version": "0.1.0",
   "private": true,
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "apps",
+  "name": "@contentful/apps",
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "apps",
+  "name": "@contentful/apps",
   "private": true,
   "devDependencies": {
     "prettier": "2.5.1",


### PR DESCRIPTION
Because the package names we were using were never claimed on
npm, there is a danger that a malicious actor could upload
something to one of the names. Then someone who is new to the
ecosystem might have tried to install one of these packages.

This PR adds `@contentful/` in front of all package names. This
means that no one outside of the Contentful org on NPM is able to
claim any of these names.