### PR TITLE
feat: Add Gatsby Cloud (Content Sync) eager redirects support

### DIFF
--- a/apps/gatsby/src/Sidebar.js
+++ b/apps/gatsby/src/Sidebar.js
@@ -205,8 +205,11 @@ export default class Sidebar extends React.Component {
     let { previewUrl, contentSyncUrl } = this.props.sdk.parameters.installation;
     const { manifestId } = this.state;
 
+    // contentId is used in Gatsby Cloud Content Sync to redirect a user as soon as possible. The content id is stored in localStorage and mapped to a redirect url after the first preview. On subsequent previews, we check if the redirect url still exists and then eagerly redirect there. Once on the frontend of the site, Preview UI takes over and handles showing a preview building message.
+    const contentId = btoa(this.props.sdk.ids.contentType + this.props.sdk.ids.entry);
+
     if (contentSyncUrl && manifestId) {
-      previewUrl = `${contentSyncUrl}/gatsby-source-contentful/${manifestId}`;
+      previewUrl = `${contentSyncUrl}/gatsby-source-contentful/${manifestId}/${contentId}`;
     }
 
     return previewUrl;
@@ -253,8 +256,7 @@ export default class Sidebar extends React.Component {
   };
 
   render = () => {
-    let { contentSyncUrl, authToken, previewUrl, webhookUrl } =
-      this.sdk.parameters.installation;
+    let { contentSyncUrl, authToken, previewUrl, webhookUrl } = this.sdk.parameters.installation;
     const { slug } = this.state;
 
     previewUrl = this.getPreviewUrl();

--- a/apps/gatsby/src/Sidebar.js
+++ b/apps/gatsby/src/Sidebar.js
@@ -206,7 +206,13 @@ export default class Sidebar extends React.Component {
     const { manifestId } = this.state;
 
     // contentId is used in Gatsby Cloud Content Sync to redirect a user as soon as possible. The content id is stored in localStorage and mapped to a redirect url after the first preview. On subsequent previews, we check if the redirect url still exists and then eagerly redirect there. Once on the frontend of the site, Preview UI takes over and handles showing a preview building message.
-    const contentId = btoa(this.props.sdk.ids.contentType + this.props.sdk.ids.entry);
+    const contentType = this.props?.sdk?.ids?.contentType;
+    const entryId = this.props?.sdk?.ids?.entry;
+    const contentId =
+      contentType && entryId
+        ? // base64 encode purely for URL aesthetics
+          btoa(contentType + entryId)
+        : ``;
 
     if (contentSyncUrl && manifestId) {
       previewUrl = `${contentSyncUrl}/gatsby-source-contentful/${manifestId}/${contentId}`;

--- a/apps/gatsby/src/Sidebar.js
+++ b/apps/gatsby/src/Sidebar.js
@@ -206,13 +206,7 @@ export default class Sidebar extends React.Component {
     const { manifestId } = this.state;
 
     // contentId is used in Gatsby Cloud Content Sync to redirect a user as soon as possible. The content id is stored in localStorage and mapped to a redirect url after the first preview. On subsequent previews, we check if the redirect url still exists and then eagerly redirect there. Once on the frontend of the site, Preview UI takes over and handles showing a preview building message.
-    const contentType = this.props?.sdk?.ids?.contentType;
-    const entryId = this.props?.sdk?.ids?.entry;
-    const contentId =
-      contentType && entryId
-        ? // base64 encode purely for URL aesthetics
-          btoa(contentType + entryId)
-        : ``;
+    const contentId = btoa(this.props.sdk.ids.contentType + this.props.sdk.ids.entry);
 
     if (contentSyncUrl && manifestId) {
       previewUrl = `${contentSyncUrl}/gatsby-source-contentful/${manifestId}/${contentId}`;

--- a/apps/gatsby/src/Sidebar.spec.js
+++ b/apps/gatsby/src/Sidebar.spec.js
@@ -92,7 +92,7 @@ describe('Gatsby App Sidebar', () => {
     global.fetch = mockFetch;
     global.open = mockWindowOpen;
 
-    const contentSyncUrl = 'https://content-sync.com/content-sync/fake-site-id/';
+    const contentSyncUrl = 'https://content-sync.com/content-sync/fake-site-id';
     mockSdk.parameters.installation.contentSyncUrl = contentSyncUrl;
 
     const { getByText } = render(<Sidebar sdk={mockSdk} />);

--- a/apps/gatsby/src/Sidebar.spec.js
+++ b/apps/gatsby/src/Sidebar.spec.js
@@ -42,6 +42,10 @@ const getMockSdk = () => ({
   window: {
     startAutoResizer: jest.fn(),
   },
+  ids: {
+    contentType: `content-type`,
+    entry: `entry-id`,
+  },
 });
 
 describe('Gatsby App Sidebar', () => {
@@ -88,7 +92,7 @@ describe('Gatsby App Sidebar', () => {
     global.fetch = mockFetch;
     global.open = mockWindowOpen;
 
-    const contentSyncUrl = 'https://content-sync.com/content-sync/fake-site-id';
+    const contentSyncUrl = 'https://content-sync.com/content-sync/fake-site-id/';
     mockSdk.parameters.installation.contentSyncUrl = contentSyncUrl;
 
     const { getByText } = render(<Sidebar sdk={mockSdk} />);
@@ -110,7 +114,8 @@ describe('Gatsby App Sidebar', () => {
      */
     const pluginName = 'gatsby-source-contentful';
     const expectedManifestId = '123-456-2390-08-23T15:27:27.861Z';
-    const expectedUrl = `${contentSyncUrl}/${pluginName}/${expectedManifestId}`;
+    const contentId = btoa(`content-typeentry-id`);
+    const expectedUrl = `${contentSyncUrl}/${pluginName}/${expectedManifestId}/${contentId}`;
     expect(mockWindowOpen).toBeCalledWith(expectedUrl, `GATSBY_TAB`);
   });
 });


### PR DESCRIPTION
This PR enables a new feature in Content Sync (Gatsby preview), called "eager redirects".

The first time a user previews a content entry they will wait on the preview loading screen for the entire build duration. The second time they press "Open Preview" for that entry, they will be immediately redirected to the frontend where they'll see a loading state in a floating sidebar item (Gatsby Cloud Preview UI).