### PR TITLE
fix(Gatsby): Check the updated at time repeatedly to wait for a save to happen

### DIFF
--- a/apps/gatsby/src/Sidebar.js
+++ b/apps/gatsby/src/Sidebar.js
@@ -243,8 +243,8 @@ export default class Sidebar extends React.Component {
       let totalLoopsWaited = 0;
       while (waitForSave) {
         contentfulSavedRecently = this.entryWasUpdatedInLastXSeconds(5);
-        // 60 loops === 6 seconds (100 ms * 60)
-        if (totalLoopsWaited >= 60 || contentfulSavedRecently) {
+        // 50 totalLoopsWaited === 5 seconds === (100 ms * 60)
+        if (totalLoopsWaited >= 50 || contentfulSavedRecently) {
           waitForSave = false;
         } else {
           totalLoopsWaited++;

--- a/apps/gatsby/src/Sidebar.js
+++ b/apps/gatsby/src/Sidebar.js
@@ -71,6 +71,20 @@ export default class Sidebar extends React.Component {
     this.buildSlug();
   };
 
+  entryWasUpdatedInLastXSeconds = (seconds) => {
+    const maxMillis = seconds * 1000;
+
+    const content = this.props.sdk.entry.getSys();
+
+    // updatedAt has the timezone on it as an iso8601 date, so getTime() will return unix time
+    const updatedTime = new Date(content.updatedAt).getTime();
+    const now = Date.now();
+
+    const millisSinceUpdated = now - updatedTime;
+
+    return millisSinceUpdated <= maxMillis;
+  };
+
   legacyOnSysChanged = () => {
     this.buildSlug();
     if (this.debounceInterval) {
@@ -222,8 +236,23 @@ export default class Sidebar extends React.Component {
 
     this.setState({ buttonDisabled: true });
 
-    // Contentful takes a few seconds to save. If we do not wait a bit for this, then the Gatsby preview may be started and finish before any content is even saved on the Contentful side
-    await new Promise((resolve) => setTimeout(resolve, 3000));
+    let contentfulSavedRecently = this.entryWasUpdatedInLastXSeconds(5);
+
+    if (!contentfulSavedRecently) {
+      let waitForSave = true;
+      let totalLoopsWaited = 0;
+      while (waitForSave) {
+        contentfulSavedRecently = this.entryWasUpdatedInLastXSeconds(5);
+        // 60 loops === 6 seconds (100 ms * 60)
+        if (totalLoopsWaited >= 60 || contentfulSavedRecently) {
+          waitForSave = false;
+        } else {
+          totalLoopsWaited++;
+          // Contentful takes a few seconds to save. If we do not wait a bit for this, then the Gatsby preview may be started and finish before any content is even saved on the Contentful side
+          await new Promise((resolve) => setTimeout(resolve, 100));
+        }
+      }
+    }
 
     this.refreshPreview();
 
@@ -231,28 +260,32 @@ export default class Sidebar extends React.Component {
     console.info(`opening preview url ${previewUrl}`);
     window.open(previewUrl, GATSBY_PREVIEW_TAB_ID);
 
-    // Wait to see if Contentful saves new data async
-    const interval = setInterval(() => {
-      const newPreviewUrl = this.getPreviewUrl();
+    if (!contentfulSavedRecently) {
+      // Wait to see if Contentful saves new data async
+      const interval = setInterval(() => {
+        const newPreviewUrl = this.getPreviewUrl();
 
-      if (previewUrl !== newPreviewUrl) {
+        if (previewUrl !== newPreviewUrl) {
+          clearInterval(interval);
+
+          previewUrl = newPreviewUrl;
+
+          console.info(`new preview url ${newPreviewUrl}`);
+          window.open(previewUrl, GATSBY_PREVIEW_TAB_ID);
+
+          this.refreshPreview();
+          this.setState({ buttonDisabled: false });
+        }
+      }, 1000);
+
+      // after 5 seconds stop waiting for Contentful to save data
+      setTimeout(() => {
         clearInterval(interval);
-
-        previewUrl = newPreviewUrl;
-
-        console.info(`new preview url ${newPreviewUrl}`);
-        window.open(previewUrl, GATSBY_PREVIEW_TAB_ID);
-
-        this.refreshPreview();
         this.setState({ buttonDisabled: false });
-      }
-    }, 1000);
-
-    // after 10 seconds stop waiting for Contentful to save data
-    setTimeout(() => {
-      clearInterval(interval);
+      }, 5000);
+    } else {
       this.setState({ buttonDisabled: false });
-    }, 10000);
+    }
   };
 
   render = () => {


### PR DESCRIPTION
This PR fixes a bug where we would open a new preview tab and then refresh that tab after a few seconds once Contentful saved entry data. In some cases the refresh would happen after the user was already redirected to the frontend and it looks really buggy.

In this PR we now wait for 5 seconds, checking every 100ms to see if a save happened. As soon as a save happens we open the preview window 1 time and don't need to refresh it.
In the event that somehow Contentful's entry save took longer than 5 seconds (maybe a slow network or a busy day) the old logic is still there to wait an additional 5 seconds after opening the preview window to see if a save happened afterwards and we still need to refresh the window.

In the event that a save happened earlier than that (perhaps hours even), the user has to wait 5 seconds for the preview to open since we don't know if a save is about to happen or not. For now that's the tradeoff we have to make until there's a Contentful API where we can save entry data from our custom button. We need to wait for the latest data to be saved as we send some entry data as part of the url opened by the "Open Preview" button. If we don't wait for a save the url will have outdated data and Gatsby's preview service wont work properly.