### PR TITLE
fix: [EXT-3622] handle existing netlify configs

### DIFF
--- a/apps/netlify/frontend/src/config.js
+++ b/apps/netlify/frontend/src/config.js
@@ -42,9 +42,11 @@ export function configToParameters(config) {
         return {
           ...flatEvents,
           [buildHookId]: {
-            cts: Array.isArray(contentTypes) ? flat.events[buildHookId].cts.join(',') : contentTypes,
+            cts: Array.isArray(contentTypes)
+              ? flat.events[buildHookId].cts.join(',')
+              : contentTypes,
             assets: flat.events[buildHookId].assets,
-          }
+          },
         };
       }, {});
       acc = { ...acc, events: flatEvents };
@@ -64,12 +66,17 @@ export function parametersToConfig(parameters) {
   const siteNames = readCsvParam(parameters.siteNames);
   const siteUrls = readCsvParam(parameters.siteUrls);
 
+  // Older installations don't have an events property, so we default
+  // to an empty object if the key is falsey
+  const events = parameters.events || {};
+
   return {
     netlifyHookIds: readCsvParam(parameters.notificationHookIds),
     sites: buildHookIds.map((buildHookId, i) => {
-      const selectedContentTypes = parameters.events[buildHookId]?.cts === '*' ?
-      parameters.events[buildHookId]?.cts :
-      readCsvParam(parameters.events[buildHookId]?.cts);
+      const selectedContentTypes =
+        events[buildHookId]?.cts === '*'
+          ? events[buildHookId]?.cts
+          : readCsvParam(events[buildHookId]?.cts);
 
       return {
         buildHookId,
@@ -78,7 +85,7 @@ export function parametersToConfig(parameters) {
         netlifySiteName: siteNames[i],
         netlifySiteUrl: siteUrls[i],
         selectedContentTypes,
-        assetDeploysOn: parameters.events[buildHookId]?.assets || false,
+        assetDeploysOn: events[buildHookId]?.assets || false,
       };
     }),
   };

--- a/apps/netlify/frontend/src/config.spec.js
+++ b/apps/netlify/frontend/src/config.spec.js
@@ -39,15 +39,16 @@ const parameters = {
   names: 'Site 1,Site 2,Site 3',
   siteIds: 'id1,id2,id3',
   siteNames: 'foo-bar,bar-baz,foo-bar-baz',
-  siteUrls: 'https://foo-bar.netlify.com,https://bar-baz.netlify.com,https://foo-bar-baz.netlify.com',
+  siteUrls:
+    'https://foo-bar.netlify.com,https://bar-baz.netlify.com,https://foo-bar-baz.netlify.com',
   events: {
-    'bh1': {
+    bh1: {
       assets: true,
     },
-    'bh2': {
+    bh2: {
       cts: 'type1,type2',
     },
-    'bh3': {
+    bh3: {
       cts: '*',
       assets: true,
     },
@@ -73,6 +74,22 @@ describe('config', () => {
           names: '    Site 1   ,,   Site 2,,,, Site 3',
         })
       ).toEqual(config);
+    });
+
+    it('Returns empty selectedContentTypes when events key is missing', () => {
+      // This is the state that would come from an older version of the app.
+      // The key thing is that it doesn't crash
+
+      const { events, ...localParameters } = parameters;
+      const result = parametersToConfig({
+        ...localParameters,
+      });
+
+      result.sites.map(({ selectedContentTypes }) => expect(selectedContentTypes).toEqual([]));
+
+      expect(result.sites.length).toEqual(3);
+
+      expect(result.netlifyHookIds).toEqual(['hook1', 'hook2']);
     });
   });
 });


### PR DESCRIPTION
The new version of the app would crash with old style configs, because the code expects there to always be an `events` key in the installation parameters. This PR handles the case that the key is missing.