### PR TITLE
fix: pin template dependencies

### DIFF
--- a/examples/javascript/package.json
+++ b/examples/javascript/package.json
@@ -3,15 +3,15 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@contentful/app-sdk": "^4.3.7",
-    "@contentful/f36-components": "^4.7.0",
-    "@contentful/f36-tokens": "^4.0.1",
-    "@contentful/react-apps-toolkit": "^1.0.3",
-    "contentful-management": "^10.1.3",
-    "emotion": "^10.0.27",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "react-scripts": "^5.0.1"
+    "@contentful/app-sdk": "4.3.7",
+    "@contentful/f36-components": "4.7.0",
+    "@contentful/f36-tokens": "4.0.1",
+    "@contentful/react-apps-toolkit": "1.0.3",
+    "contentful-management": "10.1.3",
+    "emotion": "10.0.27",
+    "react": "17.0.2",
+    "react-dom": "17.0.2",
+    "react-scripts": "5.0.1"
   },
   "scripts": {
     "start": "cross-env BROWSER=none react-scripts start",
@@ -38,10 +38,10 @@
     ]
   },
   "devDependencies": {
-    "@contentful/app-scripts": "^1.0.2",
-    "@testing-library/jest-dom": "^5.16.4",
-    "@testing-library/react": "^12.1.5",
-    "cross-env": "^7.0.3"
+    "@contentful/app-scripts": "1.0.2",
+    "@testing-library/jest-dom": "5.16.4",
+    "@testing-library/react": "12.1.5",
+    "cross-env": "7.0.3"
   },
   "homepage": "."
 }

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -3,15 +3,15 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@contentful/app-sdk": "^4.3.7",
-    "@contentful/f36-components": "^4.7.0",
-    "@contentful/f36-tokens": "^4.0.1",
-    "@contentful/react-apps-toolkit": "^1.0.3",
-    "contentful-management": "^10.1.3",
-    "emotion": "^10.0.27",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "react-scripts": "^5.0.1"
+    "@contentful/app-sdk": "4.3.7",
+    "@contentful/f36-components": "4.7.0",
+    "@contentful/f36-tokens": "4.0.1",
+    "@contentful/react-apps-toolkit": "1.0.3",
+    "contentful-management": "10.1.3",
+    "emotion": "10.0.27",
+    "react": "17.0.2",
+    "react-dom": "17.0.2",
+    "react-scripts": "5.0.1"
   },
   "scripts": {
     "start": "cross-env BROWSER=none react-scripts start",
@@ -38,16 +38,16 @@
     ]
   },
   "devDependencies": {
-    "@contentful/app-scripts": "^1.0.2",
-    "@testing-library/jest-dom": "^5.16.4",
-    "@testing-library/react": "^12.1.5",
-    "@tsconfig/create-react-app": "^1.0.2",
-    "@types/jest": "^27.4.1",
-    "@types/node": "^17.0.29",
-    "@types/react": "^18.0.8",
-    "@types/react-dom": "^18.0.2",
-    "cross-env": "^7.0.3",
-    "typescript": "^4.6.3"
+    "@contentful/app-scripts": "1.0.2",
+    "@testing-library/jest-dom": "5.16.4",
+    "@testing-library/react": "12.1.5",
+    "@tsconfig/create-react-app": "1.0.2",
+    "@types/jest": "27.4.1",
+    "@types/node": "17.0.29",
+    "@types/react": "18.0.8",
+    "@types/react-dom": "18.0.2",
+    "cross-env": "7.0.3",
+    "typescript": "4.6.3"
   },
   "homepage": "."
 }


### PR DESCRIPTION
The dependencies of our most used templates are currently not pinned. Therefore, a broken patch or minor release is getting installed on the user's machines without having passed any tests. This PR pins the `javascript` and `typescript` dependencies. That way we have more control over what is installed by the CCA users.

Ideally, we'd pin all dependencies except for the two packages within `packages`. Should I do that?