### PR TITLE
fix: [] v4 update fixes

### DIFF
--- a/packages/ecommerce-app-base/src/AppConfig/FieldSelector.tsx
+++ b/packages/ecommerce-app-base/src/AppConfig/FieldSelector.tsx
@@ -20,6 +20,13 @@ interface State {
   changedSkuTypes: Record<string, Record<string, boolean>>;
 }
 
+const styles = {
+  helpText: css({
+    marginLeft: tokens.spacingL,
+    marginTop: tokens.spacingS
+  })
+}
+
 export default class FieldSelector extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
@@ -99,7 +106,7 @@ export default class FieldSelector extends React.Component<Props, State> {
             <Subheading>{ct.name}</Subheading>
             <Form>
               {compatibleFields[ct.sys.id].map((field) => (
-                <Flex flexDirection="column" gap="spacingXs" key={field.id}>
+                <Flex marginTop="spacingM" flexDirection="column" gap="spacingXs" key={field.id}>
                   <Checkbox
                     id={`field-box-${ct.sys.id}-${field.id}`}
                     helpText={`${
@@ -112,7 +119,7 @@ export default class FieldSelector extends React.Component<Props, State> {
                   </Checkbox>
                   {skuTypes.length > 0 && (selectedFields[ct.sys.id] || []).includes(field.id) ? (
                     <>
-                      <Flex>
+                      <Flex gap="spacingL">
                         {skuTypes.map((skuType) => (
                           <Radio
                             id={`skuType-${ct.sys.id}-${field.id}-${skuType.id}`}
@@ -123,14 +130,13 @@ export default class FieldSelector extends React.Component<Props, State> {
                               skuType.id
                             }
                             onChange={this.onFieldSkuTypesChange.bind(this, ct.sys.id, field.id)}
-                            className="f36-margin-left--l"
                           >
                             {skuType.name}
                           </Radio>
                         ))}
                       </Flex>
                       {changedSkuTypes?.[ct.sys.id]?.[field.id] === true ? (
-                        <Paragraph className="f36-margin-left--l f36-margin-top--s">
+                        <Paragraph className={styles.helpText}>
                           Note: Changing SKU type can cause problems with existing entries relying
                           on the old SKU type.
                         </Paragraph>

--- a/packages/ecommerce-app-base/src/AppConfig/FieldSelector.tsx
+++ b/packages/ecommerce-app-base/src/AppConfig/FieldSelector.tsx
@@ -23,9 +23,9 @@ interface State {
 const styles = {
   helpText: css({
     marginLeft: tokens.spacingL,
-    marginTop: tokens.spacingS
-  })
-}
+    marginTop: tokens.spacingS,
+  }),
+};
 
 export default class FieldSelector extends React.Component<Props, State> {
   constructor(props: Props) {
@@ -122,6 +122,7 @@ export default class FieldSelector extends React.Component<Props, State> {
                       <Flex gap="spacingL">
                         {skuTypes.map((skuType) => (
                           <Radio
+                            key={`skuType-${ct.sys.id}-${field.id}-${skuType.id}`}
                             id={`skuType-${ct.sys.id}-${field.id}-${skuType.id}`}
                             name={`skuType-${ct.sys.id}-${field.id}`}
                             value={skuType.id}

--- a/packages/ecommerce-app-base/src/Editor/SortableListItem.tsx
+++ b/packages/ecommerce-app-base/src/Editor/SortableListItem.tsx
@@ -180,7 +180,7 @@ export const SortableListItem = SortableElement<Props>(
             <IconButton
               aria-label="Delete"
               icon={<CloseIcon />}
-              variant="secondary"
+              variant="transparent"
               onClick={onDelete}
             />
           </div>

--- a/packages/ecommerce-app-base/src/Editor/SortableListItem.tsx
+++ b/packages/ecommerce-app-base/src/Editor/SortableListItem.tsx
@@ -129,6 +129,8 @@ export const SortableListItem = SortableElement<Props>(
       <Card
         data-testid="sortable-list-item"
         className={styles.card}
+        // @ts-ignore
+        withDragHandle
         dragHandleRender={isSortable ? ({ drag }) => <CardDragHandle drag={drag} /> : undefined}
       >
         <div className={styles.cardInner}>

--- a/packages/ecommerce-app-base/src/Editor/SortableListItem.tsx
+++ b/packages/ecommerce-app-base/src/Editor/SortableListItem.tsx
@@ -26,12 +26,14 @@ const IMAGE_SIZE = 48;
 
 const styles = {
   card: css({
-    display: 'flex',
     padding: 0,
     position: 'relative',
     ':not(:first-of-type)': css({
       marginTop: tokens.spacingXs,
     }),
+  }),
+  cardInner: css({
+    display: 'flex',
   }),
   imageWrapper: (imageHasLoaded: boolean) =>
     css({
@@ -129,7 +131,7 @@ export const SortableListItem = SortableElement<Props>(
         className={styles.card}
         dragHandleRender={isSortable ? ({ drag }) => <CardDragHandle drag={drag} /> : undefined}
       >
-        <>
+        <div className={styles.cardInner}>
           {!imageHasLoaded && !imageHasErrored && product.image && (
             <SkeletonContainer className={styles.skeletonImage}>
               <SkeletonImage width={IMAGE_SIZE} height={IMAGE_SIZE} />
@@ -165,7 +167,7 @@ export const SortableListItem = SortableElement<Props>(
               <Subheading className={styles.sku}>{product.displaySKU ?? product.sku}</Subheading>
             )}
           </section>
-        </>
+        </div>
         {!disabled && (
           <div className={styles.actions}>
             {product.externalLink && (


### PR DESCRIPTION
Fixing two bugs from the forma upgrade. In the ecomerce-app-base the card was added a `display: flex` to aligh the items. 
However in formav4 the styles added to the `Card` component are attached to the outer component and therefore the flex was not working anymore for the card content. : 

Here you can see the difference (the upper one is the fixed version): 

<img width="802" alt="Screen Shot 2022-05-04 at 15 30 13" src="https://user-images.githubusercontent.com/34910067/166691415-047ccce0-58e6-4c53-b996-39003e355f09.png">

To fix this I added an inner element with the layout styles. 

The other thing was that in the config screen the radio buttons were not aligned correctly: 
<img width="377" alt="Screen Shot 2022-05-04 at 14 16 31" src="https://user-images.githubusercontent.com/34910067/166691286-219e9527-7094-4f0e-af7c-cde9462eaf73.png">

