### PR TITLE
fix: increase minimum forma 36 version

### DIFF
--- a/packages/dam-app-base/package-lock.json
+++ b/packages/dam-app-base/package-lock.json
@@ -690,152 +690,146 @@
       "integrity": "sha512-YE/NIMeNRyAHKVT6kt2acdLbo9LEX/PSCo2cdOM0wdy7yhQWegjeKO7zm/9n3Q9em8Mc8GjbMtR8XdjHOOjbeA=="
     },
     "@contentful/f36-accordion": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.2.1.tgz",
-      "integrity": "sha512-kCrGicnlxeFeheUHqpJmpQOIRz8gjnX8Lx/f7XnSV3NmV0ee6BQeK6R8sMkyd06KuCEmyb+fpTcTP+rN93uvpg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.8.0.tgz",
+      "integrity": "sha512-QC1ETuNpm60il9mS2gluafJ2LyA5tJPS2L7vSvw/P52K9/v7vPrwJZjUtXDSQ3Hs6PJOuJHh+2UusImhaA3T1A==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-collapse": "^4.2.3",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-icons": "^4.1.1",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-typography": "^4.2.0",
+        "@contentful/f36-collapse": "^4.8.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-icons": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-typography": "^4.8.0",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-asset": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.1.5.tgz",
-      "integrity": "sha512-i7aW+CIl5EYl+r+8gHVsN/WsOn2Kq4/ynuLG3UKkCV0NDhFPbRZdUcAlKdYiEN4XZtGN4pVm4JTjorBhZCQMFg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.8.0.tgz",
+      "integrity": "sha512-Rf7VJvhM3cNxZOUuVw9qk1iwOl/FuChcvBPRX9OXjBEniTFYH+KqAU60FMedEJh5EhhJbSYcZb+DS+3dfvXc/A==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-icon": "^4.1.2",
-        "@contentful/f36-icons": "^4.1.1",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-typography": "^4.2.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-icon": "^4.8.0",
+        "@contentful/f36-icons": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-typography": "^4.8.0",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-autocomplete": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.2.4.tgz",
-      "integrity": "sha512-3f1VehY2BRt0s37dE/9oUJfq8uM7Kx+TcBAjJ8MkBZr5FZR0ik4GMjaK5+n6WiDTdNBWwsLST1NdngT9jyejJA==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.8.0.tgz",
+      "integrity": "sha512-5BjNmcWW9rXk2y0l0JEv6S/V+cRrdpI+NSlduA5bOuHaUFuoJq0BG8qpKXj2RWMm2KJeFJZpkbQ4u5hBk8svQA==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-button": "^4.3.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-forms": "^4.3.1",
-        "@contentful/f36-icons": "^4.1.1",
-        "@contentful/f36-popover": "^4.2.1",
-        "@contentful/f36-skeleton": "^4.1.2",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-typography": "^4.2.0",
-        "@contentful/f36-utils": "^4.0.0",
+        "@contentful/f36-button": "^4.8.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-forms": "^4.8.0",
+        "@contentful/f36-icons": "^4.8.0",
+        "@contentful/f36-popover": "^4.8.0",
+        "@contentful/f36-skeleton": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-typography": "^4.8.0",
+        "@contentful/f36-utils": "^4.8.0",
         "downshift": "^6.1.7",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-badge": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.1.5.tgz",
-      "integrity": "sha512-mwnP9aWHvLsKiek73KhApz7KwCb8RXiJy8tziSRLUy3fglummkuJjzBpHQ/uQkjQyPIPnAHrYTQ4XmBVNZyKbA==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.8.0.tgz",
+      "integrity": "sha512-zzFe99EWTFapfLV+oiG5WFAvtvKngZR0jN2hm6WcKM4GwuY1yK+GDZSS0zKLkaAumRMPiUvwVS6toTnF719Xzw==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-tokens": "^4.0.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-button": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.3.2.tgz",
-      "integrity": "sha512-slMZjWC3aYGX0z9SeE1STNLzycUHIz9h74a2ECsB6VBC7JFuUuh4I2yIBhaPHu5cFTahmDu5IcvjALqs2N8/IQ==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.8.0.tgz",
+      "integrity": "sha512-8KurohD6FbLzNCxYFqwNIwhwimXOXTXhnm2nTIazUf1LjMGWLKzwP9pJkNXbshAYgpcKJCFMUIWPvU/UWx6cjQ==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-spinner": "^4.1.3",
-        "@contentful/f36-tokens": "^4.0.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-spinner": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-card": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.3.1.tgz",
-      "integrity": "sha512-JGBLsIKvupkYSEGFN0IC4euBGTe4DZbk2kXLNrO85mfIv2PUh6ztpTgtA5IyJY2zVhbhSGnR6mmFmjks4JebBA==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.8.0.tgz",
+      "integrity": "sha512-/zTOXhyZP1T5BoouBOWBoJls557x7QhfBnPg5H0SxhMEBz+EaPIi3RspNUdmwE+UOqtbvXyBdU45c0EkEgEv4w==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-asset": "^4.1.5",
-        "@contentful/f36-badge": "^4.1.5",
-        "@contentful/f36-button": "^4.3.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-drag-handle": "^4.1.5",
-        "@contentful/f36-icon": "^4.1.2",
-        "@contentful/f36-icons": "^4.1.1",
-        "@contentful/f36-menu": "^4.2.4",
-        "@contentful/f36-skeleton": "^4.1.2",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-tooltip": "^4.1.2",
-        "@contentful/f36-typography": "^4.2.0",
+        "@contentful/f36-asset": "^4.8.0",
+        "@contentful/f36-badge": "^4.8.0",
+        "@contentful/f36-button": "^4.8.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-drag-handle": "^4.8.0",
+        "@contentful/f36-icon": "^4.8.0",
+        "@contentful/f36-icons": "^4.8.0",
+        "@contentful/f36-menu": "^4.8.0",
+        "@contentful/f36-skeleton": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-tooltip": "^4.8.0",
+        "@contentful/f36-typography": "^4.8.0",
         "emotion": "^10.0.17",
-        "truncate": "^2.0.1"
-      },
-      "dependencies": {
-        "truncate": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/truncate/-/truncate-2.1.0.tgz",
-          "integrity": "sha512-em3E3SUDONOjTBcZ36DTm3RvDded3IRU9rX32oHwwXNt3rJD5MVaFlJTQvs8tJoHRoeYP36OuQ1eL/Q7bNEWIQ=="
-        }
+        "truncate": "^3.0.0"
       }
     },
     "@contentful/f36-collapse": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.2.3.tgz",
-      "integrity": "sha512-mj+Itb7mDXx+Ji0C1Thrg81f1+/9CEyz1jjHRnsUFuSGGM2unuNqEcTzjKUQu558TzDwLJO6V11jDwVjUl/vgQ==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.8.0.tgz",
+      "integrity": "sha512-hPrHlJl31QewgFho7O00J5Hc3qQsES+iCjyrIQF8yzBcT3UlT0NvuPhaScsQO6tKvgFvIrQmWjCumd6Z/gaHEA==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-tokens": "^4.0.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-components": {
-      "version": "4.0.33",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.0.33.tgz",
-      "integrity": "sha512-C7XjQ6m0Zo9JAgbfsDx36bqz3NiFjv6ByIK67dCw/1aof36Pxcd1g998Ay/TIUZuxnlHPjY7IjEdt7SNoJa1Cg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.8.0.tgz",
+      "integrity": "sha512-DHp0UUp9K8i+z0ScrZs0sDxoNHo3hEhwDyyMKgMX1MSrpA/RR3LpT517+UUdC/0C29cOCRazcaavTj15E/TWuQ==",
       "requires": {
         "@babel/runtime": "^7.3.4",
-        "@contentful/f36-accordion": "^4.2.1",
-        "@contentful/f36-asset": "^4.1.5",
-        "@contentful/f36-autocomplete": "^4.2.4",
-        "@contentful/f36-badge": "^4.1.5",
-        "@contentful/f36-button": "^4.3.2",
-        "@contentful/f36-card": "^4.3.1",
-        "@contentful/f36-collapse": "^4.2.3",
-        "@contentful/f36-copybutton": "^4.2.0",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-datetime": "^4.3.0",
-        "@contentful/f36-drag-handle": "^4.1.5",
-        "@contentful/f36-entity-list": "^4.1.18",
-        "@contentful/f36-forms": "^4.3.1",
-        "@contentful/f36-icon": "^4.1.2",
-        "@contentful/f36-icons": "^4.1.1",
-        "@contentful/f36-list": "^4.1.2",
-        "@contentful/f36-menu": "^4.2.4",
-        "@contentful/f36-modal": "^4.2.4",
-        "@contentful/f36-note": "^4.2.12",
-        "@contentful/f36-notification": "^4.0.14",
-        "@contentful/f36-pill": "^4.1.12",
-        "@contentful/f36-popover": "^4.2.1",
-        "@contentful/f36-skeleton": "^4.1.2",
-        "@contentful/f36-spinner": "^4.1.3",
-        "@contentful/f36-table": "^4.1.2",
-        "@contentful/f36-tabs": "^4.1.3",
-        "@contentful/f36-text-link": "^4.2.0",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-tooltip": "^4.1.2",
-        "@contentful/f36-typography": "^4.2.0",
-        "@contentful/f36-utils": "^4.0.0",
+        "@contentful/f36-accordion": "^4.8.0",
+        "@contentful/f36-asset": "^4.8.0",
+        "@contentful/f36-autocomplete": "^4.8.0",
+        "@contentful/f36-badge": "^4.8.0",
+        "@contentful/f36-button": "^4.8.0",
+        "@contentful/f36-card": "^4.8.0",
+        "@contentful/f36-collapse": "^4.8.0",
+        "@contentful/f36-copybutton": "^4.8.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-datetime": "^4.8.0",
+        "@contentful/f36-drag-handle": "^4.8.0",
+        "@contentful/f36-entity-list": "^4.8.0",
+        "@contentful/f36-forms": "^4.8.0",
+        "@contentful/f36-icon": "^4.8.0",
+        "@contentful/f36-icons": "^4.8.0",
+        "@contentful/f36-list": "^4.8.0",
+        "@contentful/f36-menu": "^4.8.0",
+        "@contentful/f36-modal": "^4.8.0",
+        "@contentful/f36-note": "^4.8.0",
+        "@contentful/f36-notification": "^4.8.0",
+        "@contentful/f36-pagination": "^4.8.0",
+        "@contentful/f36-pill": "^4.8.0",
+        "@contentful/f36-popover": "^4.8.0",
+        "@contentful/f36-skeleton": "^4.8.0",
+        "@contentful/f36-spinner": "^4.8.0",
+        "@contentful/f36-table": "^4.8.0",
+        "@contentful/f36-tabs": "^4.8.0",
+        "@contentful/f36-text-link": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-tooltip": "^4.8.0",
+        "@contentful/f36-typography": "^4.8.0",
+        "@contentful/f36-utils": "^4.8.0",
         "@types/react": "16.14.22",
         "@types/react-dom": "16.9.14"
       },
@@ -861,264 +855,280 @@
       }
     },
     "@contentful/f36-copybutton": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.2.0.tgz",
-      "integrity": "sha512-i+1WpHypTJCoSDvFnF3sDYjz0tmwr7aU/ThP0jJ4dioNDAnZGSJXdx9Km6EOftdAHf0pemaMnarOzF8FCA26Eg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.8.0.tgz",
+      "integrity": "sha512-W6SsnEz6fu4SCw5Wmbkttr56rsM2gnFjJztPSuYqrbDCVkehE44F7DmB5WnAVZNaARutRdvaYyH3xBja4fUk5Q==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-icons": "^4.1.1",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-tooltip": "^4.1.2",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-icons": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-tooltip": "^4.8.0",
         "emotion": "^10.0.17",
         "react-copy-to-clipboard": "^5.0.3"
       }
     },
     "@contentful/f36-core": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.2.0.tgz",
-      "integrity": "sha512-szKh8XehsDmFd5MRL73oqaAfLyorwA9nY5kPVc/kBs9PVmcsjSgFBBUjCjTLZTSqrf/26yakQC0T1XMU4Ht8GA==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.8.0.tgz",
+      "integrity": "sha512-0jhyTXYsdEkk7poOTBy48K1JrIsi6g1rRbyd/y0xzkznbjYeKmLnzRTGq76cRkkXAJD4eZRpmz/6hQlu2McMQw==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-tokens": "^4.0.0",
+        "@contentful/f36-tokens": "^4.0.1",
         "@emotion/core": "^10.1.1",
         "@emotion/is-prop-valid": "^1.1.0",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-datetime": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.3.0.tgz",
-      "integrity": "sha512-FULxlSPBC+PYmYe2A+mY7jlOt2MkwOxPZNxK9JaWWh0mSzvelx10f+9rV7UyWH2TtrMlvZECxhRbQ5dbpC441Q==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.8.0.tgz",
+      "integrity": "sha512-x7lHSf6vvi96C84c4yryLI/XDGClTu5Lf2kkxLApyWfP3HLqPnNgl5BHJ7uZrlk3AVOIP7B7AiTgYIzmOl6t0A==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-tokens": "^4.0.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
         "dayjs": "^1.10.6",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-drag-handle": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.1.5.tgz",
-      "integrity": "sha512-TQtlOGKNUp64eUY+u/4UmXDOJ9CjyRi/LsEEb5OehlzhmRHut8GX0nCI6x1/lBmATZFqIxk1/c6RikhGiLJCEw==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.8.0.tgz",
+      "integrity": "sha512-+QoYwGnsRiIdkThGFIR0YnqywNxlHp2upd2RvYxzr+KxVxy26yYtMYyzYhYUrhIGNfiJEm4iXWRWKigZAAwVCw==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-icons": "^4.1.1",
-        "@contentful/f36-tokens": "^4.0.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-icons": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-entity-list": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.1.18.tgz",
-      "integrity": "sha512-buvY/M7ZfzgOKxD8iXTOBf0jLqTv7oh9jKLc36rAqRdIUjF2ip+AjoEepDTeECGrYvhDRTAGg4HLaqxS6ENHOg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.8.0.tgz",
+      "integrity": "sha512-ucQ/VdOmpnljF2EyKdBo/pNgd6OeCgjGutKvh7HNgZqr0+K5/mmV4FQjScPt6FQSxkhsdnU6jzW1QAIgkGXj9g==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-badge": "^4.1.5",
-        "@contentful/f36-button": "^4.3.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-drag-handle": "^4.1.5",
-        "@contentful/f36-icon": "^4.1.2",
-        "@contentful/f36-icons": "^4.1.1",
-        "@contentful/f36-menu": "^4.2.4",
-        "@contentful/f36-skeleton": "^4.1.2",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-typography": "^4.2.0",
+        "@contentful/f36-badge": "^4.8.0",
+        "@contentful/f36-button": "^4.8.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-drag-handle": "^4.8.0",
+        "@contentful/f36-icon": "^4.8.0",
+        "@contentful/f36-icons": "^4.8.0",
+        "@contentful/f36-menu": "^4.8.0",
+        "@contentful/f36-skeleton": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-typography": "^4.8.0",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-forms": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.3.1.tgz",
-      "integrity": "sha512-uBo7XAnj283DZG20Ou8fKmbH4oTCulfE+4B2K+obV5jBCB6BtoauvT2WTAZdHt0uJd5Wk/PV5CdWQEMNm4Lv3g==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.8.0.tgz",
+      "integrity": "sha512-eqVlD3Pns6VJCac1zfEZoKmcZivEtJERk1RjdwE3VPgF1qxtQWJZoCEkTJ1oeWhdt8LD8XPHy3vu2dg8E0RMvQ==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-icons": "^4.1.1",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-typography": "^4.2.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-icons": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-typography": "^4.8.0",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-icon": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.1.2.tgz",
-      "integrity": "sha512-neAawUOsc+gt2z6FG4cgkQnQT09SX3E+L8tAgLQ+XhRRejecmvfjrO1b1yKqK3ddBYpeD/AVSHXsYyJdWhexOg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.8.0.tgz",
+      "integrity": "sha512-ywvPKV1vJWdYdO2SgidSLZtIlEn1v+QPtI3cL6YqDLfF57u0jgLlqFpq46h/tVQ7C3aKeX4P6JDeNKIeIW7c3A==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-tokens": "^4.0.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-icons": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-4.1.1.tgz",
-      "integrity": "sha512-I4SZ5i/cinsrxVVGESKGAFdii4mWAM/eL3vryFHi4n5AnL+VWsOpzfr86skq/GVY+WyMpTAYsnZfLr0Sz7EwiQ==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-4.8.0.tgz",
+      "integrity": "sha512-84MkUrcL4SjFTbfs2oeSK8itxP5rSDbqQ7IcUN70WHIIYyq+zNSbVaVY/aqHAXul7zYZvhvJ0m17rSZvIa6+tg==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-icon": "^4.1.2",
-        "@contentful/f36-tokens": "^4.0.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-icon": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-list": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.1.2.tgz",
-      "integrity": "sha512-4IbTKRDPOvkEU9eNGFJDXe8F9apPPVUO10aqQCmQIPwP8JfdhsAH8/sn87ue/FZWwP0RVB9I5qH2xnPrPjlhmg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.8.0.tgz",
+      "integrity": "sha512-G/tpeDUcuq5cZX3T5vsPF71z42ZYeDOlOCwd2sHuy/6qP6Yjk7MwiL16Mniks/NzFKFJcSKSqcGsK/qWSkunjw==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-tokens": "^4.0.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-menu": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.2.4.tgz",
-      "integrity": "sha512-AbH8HXjdUkCE+DD/HimLuQaTvi0+SdzyvQ1xdv5wGZ4upxxwkbpIhM6ECR+6gqLvChghuvLtKU/THwu7bMaJEg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.8.0.tgz",
+      "integrity": "sha512-/fM3c3RfDXxjZAgzv8x3+Igci3bDgL1vWrB6VgOciQ2ENP0nVEFsXZl9RfGva8UNACXeCOSvBZPISNIs5r2vpw==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-icons": "^4.1.1",
-        "@contentful/f36-popover": "^4.2.1",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-typography": "^4.2.0",
-        "@contentful/f36-utils": "^4.0.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-icons": "^4.8.0",
+        "@contentful/f36-popover": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-typography": "^4.8.0",
+        "@contentful/f36-utils": "^4.8.0",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-modal": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.2.4.tgz",
-      "integrity": "sha512-W7JcPiIBx/IX6aIK2Y/a0N3jbDO56eYluUhwxA/utVv8uzgkz9/WMI2mGC6H1SP77RkhCdljyBNn3J0EzK3jvg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.8.0.tgz",
+      "integrity": "sha512-FosGSj07bHx2i56SVHjQhOPtfI0ggynG2Ux43SGXuqgUtIWE8YFO/JWB3XAE3ao95gTFauLjHdbptszZBtZBng==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-button": "^4.3.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-icons": "^4.1.1",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-typography": "^4.2.0",
+        "@contentful/f36-button": "^4.8.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-icons": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-typography": "^4.8.0",
         "@types/react-modal": "^3.12.1",
         "emotion": "^10.0.17",
         "react-modal": "^3.14.3"
       }
     },
     "@contentful/f36-note": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.2.12.tgz",
-      "integrity": "sha512-hkM2+Azwkls+JILrqD1CyX++nXi88N36IDA+0l8LP7AjWlwO1bVpjatnUtNM6LNB0fzwmbvOPUZtQ8hFXUDOWg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.8.0.tgz",
+      "integrity": "sha512-7atrGA48EHCip291U6+7koEcwGx3ntDv9Y+DtPDZNiV4czuPe0vbecositMHTPR4Mnw44hcJLex5qJ0E1NPBHA==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-button": "^4.3.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-icon": "^4.1.2",
-        "@contentful/f36-icons": "^4.1.1",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-typography": "^4.2.0",
+        "@contentful/f36-button": "^4.8.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-icon": "^4.8.0",
+        "@contentful/f36-icons": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-typography": "^4.8.0",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-notification": {
-      "version": "4.0.14",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.0.14.tgz",
-      "integrity": "sha512-ROJw1zXHby4bCy290L4OwHva46Yfu5KYhTiF/cWAZWAkkCt/8ynKM9+2McxNlD2vTM5TuwABUHVPCbYtQuNZoA==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.8.0.tgz",
+      "integrity": "sha512-tJhpD9H5py7bVCH8+Lyn5+UrV7L5siqywFo0FUSSfvqDyv0mnzMfXcTGFUYZPWUn/5uk9RgQVrdeOn1nEL4l7w==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-button": "^4.3.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-icons": "^4.1.1",
-        "@contentful/f36-text-link": "^4.2.0",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-typography": "^4.2.0",
+        "@contentful/f36-button": "^4.8.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-icons": "^4.8.0",
+        "@contentful/f36-text-link": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-typography": "^4.8.0",
+        "@swc/helpers": "^0.3.8",
         "emotion": "^10.0.17",
         "react-animate-height": "^2.0.23"
       }
     },
-    "@contentful/f36-pill": {
-      "version": "4.1.12",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.1.12.tgz",
-      "integrity": "sha512-I/7/+LJz4XbZMqcWgHysTFbyG/NBTmfQ9ahHIxssZgiJDgGYorN0nY96RRMK94LaSaZNnE/1kRXL1Wbh46DGwg==",
+    "@contentful/f36-pagination": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.8.0.tgz",
+      "integrity": "sha512-TM2QIT3ez+PKYKdG1cKAAJVCb19dX1PDqZbscCxtZhaDNqmvl7wiDN2hA24WHnlahVGs7cmBe/XVtuJyMtf8CA==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-button": "^4.3.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-icons": "^4.1.1",
+        "@contentful/f36-button": "^4.8.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-forms": "^4.8.0",
+        "@contentful/f36-icons": "^4.8.0",
         "@contentful/f36-tokens": "^4.0.0",
+        "@contentful/f36-typography": "^4.8.0",
+        "emotion": "^10.0.17"
+      }
+    },
+    "@contentful/f36-pill": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.8.0.tgz",
+      "integrity": "sha512-1nWLwAr3noXV6KgZ60ifmAVYILlQZ7jmKcuIoqDSQSQEnGgA3oW5zJmOcaVIPYdxrLXpinGy6+mVgKTqHB0Xpw==",
+      "requires": {
+        "@babel/runtime": "^7.6.2",
+        "@contentful/f36-button": "^4.8.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-icons": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-popover": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.2.1.tgz",
-      "integrity": "sha512-kY6MrffjgMPjGOv1nC+xo7lS4FkUhc+Rnft1pxhIl+gd9+MO2eOC6Pgqj8d222gGrJFZKcjuVeQhRGwRC0+0IQ==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.8.0.tgz",
+      "integrity": "sha512-zZNyxxbhKmIrUIgRIgz4YiVlsYybsET5TsDbOTYgYfDwJBVyKBgV3nYpzU/Q3B40hLCYKak2chdxy5hu9H1/Cg==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-utils": "^4.0.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-utils": "^4.8.0",
         "@popperjs/core": "^2.4.4",
         "emotion": "^10.0.17",
         "react-popper": "^2.2.3"
       }
     },
     "@contentful/f36-skeleton": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.1.2.tgz",
-      "integrity": "sha512-KiOONz9UehNYlxXiWsw4nApA4n79FXT7nSEUmlfvI6FHP5xFLpjVvJNh/ouOkprz7Wg9jP/vGE2KTv+amBGkXg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.8.0.tgz",
+      "integrity": "sha512-mj0nrSipGBasny8+ZbcHFwRmZ+s31NE1EsUXuWSiaXlzN1bDqDSDfVP0SPAn3Wb5l1evzCInaD3EfpOhyadVkg==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-table": "^4.1.2",
-        "@contentful/f36-tokens": "^4.0.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-table": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-spinner": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.1.3.tgz",
-      "integrity": "sha512-ESh9wWO1nyyng20KH0qjvJ/rK4GzUL7zZa9fdpNf4bElOx0TQxRNX7zC1pN1y9ts3tgvkxMvCYFwvkasvB8Ueg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.8.0.tgz",
+      "integrity": "sha512-bqAM/6SUpC2+0plK4Dy5OU7L2FsHC8gRhp5dDe3iEAsJww3B8heoEME9L7QTpZ4b4hR2BfvzkzkzWE4axsjUtQ==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-tokens": "^4.0.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-table": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.1.2.tgz",
-      "integrity": "sha512-6bfNBvzCowKoWsWIWLZZ/B4c/zgWS6HvomRXV0la+B2bOUyBMyhzOER3GLEfHYQjEaN/pgzO0F/C7hWMkzoRcQ==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.8.0.tgz",
+      "integrity": "sha512-Uqbx062ku79llFbzw3tMJ6kYHfktLtSWih7Xx/DL1fVSbNyeLBT/NuPO5rJRBO8MkgvA65T3tK1KnhVQ4KZRMg==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-tokens": "^4.0.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-tabs": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.1.3.tgz",
-      "integrity": "sha512-aKW0KeCDMsMN7eominpxKcmIwUBtHLDjJHMRdnUj62zdPVHqNkYkP3ik+7FQNK+GRfQzBJvFaT9ho5xntRphpg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.8.0.tgz",
+      "integrity": "sha512-I29mwBBIDZL/Y31v3lqST6TQ4j707Tk7F0B8MW+YnWcCCEKqbHB1u7AA+vuASGMUEyb0UO/MEScr0uwFOYgXaA==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-tokens": "^4.0.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
         "@radix-ui/react-tabs": "0.1.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-text-link": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.2.0.tgz",
-      "integrity": "sha512-rwIO+3JuTLbWFGTPR3PUFR5kVKR/3rk2I3p/xmBklN8saD1d/SVlnP26ZFyb+NpyfnBRs9SbhmiTq0zuZF1+nw==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.8.0.tgz",
+      "integrity": "sha512-mJEyJqPhXxgVx5Rr/X3+qBPcbCSntuYRBHPxYqHYtLtfJwd9YkD/+eLZzVIg5uPN7DP+EwH3/thVNsILTpUItA==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-tokens": "^4.0.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       }
     },
@@ -1128,14 +1138,14 @@
       "integrity": "sha512-NTyMAQcfvhPP8kJgOK5mtjKpErg799iglEb9B45ii4N7aMdph2GNqgv7KBgpogfbTEGBrlKIoH8MUDSV9YNREg=="
     },
     "@contentful/f36-tooltip": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.1.2.tgz",
-      "integrity": "sha512-7FGXq+deotowfpN/JEsPLiuFMKErEGqV8l9anzXUVDSGY3g4QW8TrOAb9aBXE+xI6kl1tRIeHA69Cwz5tmvzHQ==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.8.0.tgz",
+      "integrity": "sha512-6TY5tBkaW0HcU2+xWcZ3N925+TvP2k4LPgT8y5jBc4hWyEmVHOqhb/vFVMxrIC23nnuc6fHT8cIy6mDJ37jgwA==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-utils": "^4.0.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-utils": "^4.8.0",
         "@popperjs/core": "^2.4.4",
         "csstype": "^3.0.5",
         "emotion": "^10.0.17",
@@ -1143,20 +1153,20 @@
       }
     },
     "@contentful/f36-typography": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.2.0.tgz",
-      "integrity": "sha512-kYgXYxwZS1GpWAH2gE4cCOzDOh9Jvo9wDfn6E14kFWWr9Kcd7lyYVWftOFYm+B7ozbsVr9ZYEk3D4ghnsTd3Ng==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.8.0.tgz",
+      "integrity": "sha512-K+Qr9i1vpTKrjuFQHyrJCWWaj48KnyjBs1K1m3QHQmTMlqV1kMu2uq+dvN+imGvLe5Z8K9UlKeK2+VvVJhKEmQ==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-tokens": "^4.0.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-utils": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-utils/-/f36-utils-4.0.0.tgz",
-      "integrity": "sha512-7+N4LQOwxzu+tF23Arvb9NCYvVVVufvcrh4Iw1fP9Uy5udQGlwplW3PenzFI4dGuuY6f9Tn4I677SSFuZQwPAw==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-utils/-/f36-utils-4.8.0.tgz",
+      "integrity": "sha512-pAmwMjX2e3lXSqaqVZD1SzvE4ZualUZsbPLakqwExdo55zf2uaoDdSYH/KAYGJ+9/eqn5ea9NzwuL9108y66JA==",
       "requires": {
         "@babel/runtime": "^7.6.2",
         "emotion": "^10.0.17"
@@ -2276,9 +2286,9 @@
       }
     },
     "@popperjs/core": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.2.tgz",
-      "integrity": "sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA=="
+      "version": "2.11.5",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
+      "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw=="
     },
     "@radix-ui/primitive": {
       "version": "0.1.0",
@@ -2289,9 +2299,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.17.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
-          "integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
+          "version": "7.17.9",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
+          "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -2311,9 +2321,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.17.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
-          "integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
+          "version": "7.17.9",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
+          "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -2329,9 +2339,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.17.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
-          "integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
+          "version": "7.17.9",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
+          "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -2347,9 +2357,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.17.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
-          "integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
+          "version": "7.17.9",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
+          "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -2366,9 +2376,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.17.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
-          "integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
+          "version": "7.17.9",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
+          "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -2385,9 +2395,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.17.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
-          "integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
+          "version": "7.17.9",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
+          "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -2411,9 +2421,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.17.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
-          "integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
+          "version": "7.17.9",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
+          "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -2430,9 +2440,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.17.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
-          "integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
+          "version": "7.17.9",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
+          "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -2455,9 +2465,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.17.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
-          "integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
+          "version": "7.17.9",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
+          "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -2473,9 +2483,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.17.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
-          "integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
+          "version": "7.17.9",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
+          "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -2492,9 +2502,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.17.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
-          "integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
+          "version": "7.17.9",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
+          "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -2517,6 +2527,14 @@
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@swc/helpers": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.3.13.tgz",
+      "integrity": "sha512-A1wswJhnqaLRn8uYVQ8YiNTtY5i/JIPmV08EXXjjTresIkUVUEUaFv/wXVhGXfRNYMvHPkuoMR1Nb6NgpxGjNg==",
+      "requires": {
+        "tslib": "^2.4.0"
       }
     },
     "@testing-library/dom": {
@@ -3402,9 +3420,9 @@
       }
     },
     "dayjs": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.0.tgz",
-      "integrity": "sha512-JLC809s6Y948/FuCZPm5IX8rRhQwOiyMb2TfVVQEixG7P8Lm/gt5S7yoQZmC8x1UehI9Pb7sksEt4xx14m+7Ug=="
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.1.tgz",
+      "integrity": "sha512-ER7EjqVAMkRRsxNCC5YqJ9d9VQYuWdGt7aiH2qA5R5wt8ZmWaP2dLUSIK6y/kVzLMlmh1Tvu5xUf4M/wdGJ5KA=="
     },
     "debug": {
       "version": "4.3.3",
@@ -3486,9 +3504,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.17.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
-          "integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
+          "version": "7.17.9",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
+          "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -7362,21 +7380,33 @@
       }
     },
     "react-animate-height": {
-      "version": "2.0.23",
-      "resolved": "https://registry.npmjs.org/react-animate-height/-/react-animate-height-2.0.23.tgz",
-      "integrity": "sha512-DucSC/1QuxWEFzR9IsHMzrf2nrcZ6qAmLIFoENa2kLK7h72XybcMA9o073z7aHccFzdMEW0/fhAdnQG7a4rDow==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/react-animate-height/-/react-animate-height-2.1.2.tgz",
+      "integrity": "sha512-A9jfz/4CTdsIsE7WCQtO9UkOpMBcBRh8LxyHl2eoZz1ki02jpyUL5xt58gabd0CyeLQ8fRyQ+s2lyV2Ufu8Owg==",
       "requires": {
         "classnames": "^2.2.5",
         "prop-types": "^15.6.1"
       }
     },
     "react-copy-to-clipboard": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/react-copy-to-clipboard/-/react-copy-to-clipboard-5.0.4.tgz",
-      "integrity": "sha512-IeVAiNVKjSPeGax/Gmkqfa/+PuMTBhutEvFUaMQLwE2tS0EXrAdgOpWDX26bWTXF3HrioorR7lr08NqeYUWQCQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/react-copy-to-clipboard/-/react-copy-to-clipboard-5.1.0.tgz",
+      "integrity": "sha512-k61RsNgAayIJNoy9yDsYzDe/yAZAzEbEgcz3DZMhF686LEyukcE1hzurxe85JandPUG+yTfGVFzuEw3xt8WP/A==",
       "requires": {
-        "copy-to-clipboard": "^3",
-        "prop-types": "^15.5.8"
+        "copy-to-clipboard": "^3.3.1",
+        "prop-types": "^15.8.1"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.8.1",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+          "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.13.1"
+          }
+        }
       }
     },
     "react-dom": {
@@ -7406,9 +7436,9 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "react-modal": {
-      "version": "3.14.4",
-      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.14.4.tgz",
-      "integrity": "sha512-8surmulejafYCH9wfUmFyj4UfbSJwjcgbS9gf3oOItu4Hwd6ivJyVBETI0yHRhpJKCLZMUtnhzk76wXTsNL6Qg==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.15.1.tgz",
+      "integrity": "sha512-duB9bxOaYg7Zt6TMFldIFxQRtSP+Dg3F1ZX3FXxSUn+3tZZ/9JCgeAQKDg7rhZSAqopq8TFRw3yIbnx77gyFTw==",
       "requires": {
         "exenv": "^1.2.0",
         "prop-types": "^15.7.2",
@@ -7417,9 +7447,9 @@
       }
     },
     "react-popper": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.2.5.tgz",
-      "integrity": "sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
+      "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
       "requires": {
         "react-fast-compare": "^3.0.1",
         "warning": "^4.0.2"
@@ -7797,6 +7827,11 @@
         "punycode": "^2.1.1"
       }
     },
+    "truncate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/truncate/-/truncate-3.0.0.tgz",
+      "integrity": "sha512-C+0Xojw7wZPl6MDq5UjMTuxZvBPK04mtdFet7k+GSZPINcvLZFCXg+15kWIL4wAqDB7CksIsKiRLbQ1wa7rKdw=="
+    },
     "ts-jest": {
       "version": "27.1.4",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-27.1.4.tgz",
@@ -7825,9 +7860,9 @@
       }
     },
     "tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "type-check": {
       "version": "0.3.2",

--- a/packages/dam-app-base/package.json
+++ b/packages/dam-app-base/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@contentful/app-sdk": "^4.0.0",
-    "@contentful/f36-components": "^4.0.0",
+    "@contentful/f36-components": "^4.0.42",
     "@contentful/f36-tokens": "^4.0.0",
     "array-move": "^3.0.0",
     "contentful-management": "^10.0.0",

--- a/packages/ecommerce-app-base/package-lock.json
+++ b/packages/ecommerce-app-base/package-lock.json
@@ -497,16 +497,16 @@
       "integrity": "sha512-YE/NIMeNRyAHKVT6kt2acdLbo9LEX/PSCo2cdOM0wdy7yhQWegjeKO7zm/9n3Q9em8Mc8GjbMtR8XdjHOOjbeA=="
     },
     "@contentful/f36-accordion": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.2.1.tgz",
-      "integrity": "sha512-kCrGicnlxeFeheUHqpJmpQOIRz8gjnX8Lx/f7XnSV3NmV0ee6BQeK6R8sMkyd06KuCEmyb+fpTcTP+rN93uvpg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.8.0.tgz",
+      "integrity": "sha512-QC1ETuNpm60il9mS2gluafJ2LyA5tJPS2L7vSvw/P52K9/v7vPrwJZjUtXDSQ3Hs6PJOuJHh+2UusImhaA3T1A==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-collapse": "^4.2.3",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-icons": "^4.1.1",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-typography": "^4.2.0",
+        "@contentful/f36-collapse": "^4.8.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-icons": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-typography": "^4.8.0",
         "emotion": "^10.0.17"
       },
       "dependencies": {
@@ -526,16 +526,16 @@
       }
     },
     "@contentful/f36-asset": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.1.5.tgz",
-      "integrity": "sha512-i7aW+CIl5EYl+r+8gHVsN/WsOn2Kq4/ynuLG3UKkCV0NDhFPbRZdUcAlKdYiEN4XZtGN4pVm4JTjorBhZCQMFg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.8.0.tgz",
+      "integrity": "sha512-Rf7VJvhM3cNxZOUuVw9qk1iwOl/FuChcvBPRX9OXjBEniTFYH+KqAU60FMedEJh5EhhJbSYcZb+DS+3dfvXc/A==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-icon": "^4.1.2",
-        "@contentful/f36-icons": "^4.1.1",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-typography": "^4.2.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-icon": "^4.8.0",
+        "@contentful/f36-icons": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-typography": "^4.8.0",
         "emotion": "^10.0.17"
       },
       "dependencies": {
@@ -555,20 +555,20 @@
       }
     },
     "@contentful/f36-autocomplete": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.2.4.tgz",
-      "integrity": "sha512-3f1VehY2BRt0s37dE/9oUJfq8uM7Kx+TcBAjJ8MkBZr5FZR0ik4GMjaK5+n6WiDTdNBWwsLST1NdngT9jyejJA==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.8.0.tgz",
+      "integrity": "sha512-5BjNmcWW9rXk2y0l0JEv6S/V+cRrdpI+NSlduA5bOuHaUFuoJq0BG8qpKXj2RWMm2KJeFJZpkbQ4u5hBk8svQA==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-button": "^4.3.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-forms": "^4.3.1",
-        "@contentful/f36-icons": "^4.1.1",
-        "@contentful/f36-popover": "^4.2.1",
-        "@contentful/f36-skeleton": "^4.1.2",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-typography": "^4.2.0",
-        "@contentful/f36-utils": "^4.0.0",
+        "@contentful/f36-button": "^4.8.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-forms": "^4.8.0",
+        "@contentful/f36-icons": "^4.8.0",
+        "@contentful/f36-popover": "^4.8.0",
+        "@contentful/f36-skeleton": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-typography": "^4.8.0",
+        "@contentful/f36-utils": "^4.8.0",
         "downshift": "^6.1.7",
         "emotion": "^10.0.17"
       },
@@ -589,13 +589,13 @@
       }
     },
     "@contentful/f36-badge": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.1.5.tgz",
-      "integrity": "sha512-mwnP9aWHvLsKiek73KhApz7KwCb8RXiJy8tziSRLUy3fglummkuJjzBpHQ/uQkjQyPIPnAHrYTQ4XmBVNZyKbA==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.8.0.tgz",
+      "integrity": "sha512-zzFe99EWTFapfLV+oiG5WFAvtvKngZR0jN2hm6WcKM4GwuY1yK+GDZSS0zKLkaAumRMPiUvwVS6toTnF719Xzw==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-tokens": "^4.0.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
       "dependencies": {
@@ -615,14 +615,14 @@
       }
     },
     "@contentful/f36-button": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.3.2.tgz",
-      "integrity": "sha512-slMZjWC3aYGX0z9SeE1STNLzycUHIz9h74a2ECsB6VBC7JFuUuh4I2yIBhaPHu5cFTahmDu5IcvjALqs2N8/IQ==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.8.0.tgz",
+      "integrity": "sha512-8KurohD6FbLzNCxYFqwNIwhwimXOXTXhnm2nTIazUf1LjMGWLKzwP9pJkNXbshAYgpcKJCFMUIWPvU/UWx6cjQ==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-spinner": "^4.1.3",
-        "@contentful/f36-tokens": "^4.0.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-spinner": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
       "dependencies": {
@@ -642,25 +642,25 @@
       }
     },
     "@contentful/f36-card": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.3.1.tgz",
-      "integrity": "sha512-JGBLsIKvupkYSEGFN0IC4euBGTe4DZbk2kXLNrO85mfIv2PUh6ztpTgtA5IyJY2zVhbhSGnR6mmFmjks4JebBA==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.8.0.tgz",
+      "integrity": "sha512-/zTOXhyZP1T5BoouBOWBoJls557x7QhfBnPg5H0SxhMEBz+EaPIi3RspNUdmwE+UOqtbvXyBdU45c0EkEgEv4w==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-asset": "^4.1.5",
-        "@contentful/f36-badge": "^4.1.5",
-        "@contentful/f36-button": "^4.3.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-drag-handle": "^4.1.5",
-        "@contentful/f36-icon": "^4.1.2",
-        "@contentful/f36-icons": "^4.1.1",
-        "@contentful/f36-menu": "^4.2.4",
-        "@contentful/f36-skeleton": "^4.1.2",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-tooltip": "^4.1.2",
-        "@contentful/f36-typography": "^4.2.0",
+        "@contentful/f36-asset": "^4.8.0",
+        "@contentful/f36-badge": "^4.8.0",
+        "@contentful/f36-button": "^4.8.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-drag-handle": "^4.8.0",
+        "@contentful/f36-icon": "^4.8.0",
+        "@contentful/f36-icons": "^4.8.0",
+        "@contentful/f36-menu": "^4.8.0",
+        "@contentful/f36-skeleton": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-tooltip": "^4.8.0",
+        "@contentful/f36-typography": "^4.8.0",
         "emotion": "^10.0.17",
-        "truncate": "^2.0.1"
+        "truncate": "^3.0.0"
       },
       "dependencies": {
         "@babel/runtime": {
@@ -675,22 +675,17 @@
           "version": "0.13.9",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
           "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
-        },
-        "truncate": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/truncate/-/truncate-2.1.0.tgz",
-          "integrity": "sha512-em3E3SUDONOjTBcZ36DTm3RvDded3IRU9rX32oHwwXNt3rJD5MVaFlJTQvs8tJoHRoeYP36OuQ1eL/Q7bNEWIQ=="
         }
       }
     },
     "@contentful/f36-collapse": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.2.3.tgz",
-      "integrity": "sha512-mj+Itb7mDXx+Ji0C1Thrg81f1+/9CEyz1jjHRnsUFuSGGM2unuNqEcTzjKUQu558TzDwLJO6V11jDwVjUl/vgQ==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.8.0.tgz",
+      "integrity": "sha512-hPrHlJl31QewgFho7O00J5Hc3qQsES+iCjyrIQF8yzBcT3UlT0NvuPhaScsQO6tKvgFvIrQmWjCumd6Z/gaHEA==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-tokens": "^4.0.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
       "dependencies": {
@@ -710,42 +705,43 @@
       }
     },
     "@contentful/f36-components": {
-      "version": "4.0.33",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.0.33.tgz",
-      "integrity": "sha512-C7XjQ6m0Zo9JAgbfsDx36bqz3NiFjv6ByIK67dCw/1aof36Pxcd1g998Ay/TIUZuxnlHPjY7IjEdt7SNoJa1Cg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.8.0.tgz",
+      "integrity": "sha512-DHp0UUp9K8i+z0ScrZs0sDxoNHo3hEhwDyyMKgMX1MSrpA/RR3LpT517+UUdC/0C29cOCRazcaavTj15E/TWuQ==",
       "requires": {
         "@babel/runtime": "^7.3.4",
-        "@contentful/f36-accordion": "^4.2.1",
-        "@contentful/f36-asset": "^4.1.5",
-        "@contentful/f36-autocomplete": "^4.2.4",
-        "@contentful/f36-badge": "^4.1.5",
-        "@contentful/f36-button": "^4.3.2",
-        "@contentful/f36-card": "^4.3.1",
-        "@contentful/f36-collapse": "^4.2.3",
-        "@contentful/f36-copybutton": "^4.2.0",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-datetime": "^4.3.0",
-        "@contentful/f36-drag-handle": "^4.1.5",
-        "@contentful/f36-entity-list": "^4.1.18",
-        "@contentful/f36-forms": "^4.3.1",
-        "@contentful/f36-icon": "^4.1.2",
-        "@contentful/f36-icons": "^4.1.1",
-        "@contentful/f36-list": "^4.1.2",
-        "@contentful/f36-menu": "^4.2.4",
-        "@contentful/f36-modal": "^4.2.4",
-        "@contentful/f36-note": "^4.2.12",
-        "@contentful/f36-notification": "^4.0.14",
-        "@contentful/f36-pill": "^4.1.12",
-        "@contentful/f36-popover": "^4.2.1",
-        "@contentful/f36-skeleton": "^4.1.2",
-        "@contentful/f36-spinner": "^4.1.3",
-        "@contentful/f36-table": "^4.1.2",
-        "@contentful/f36-tabs": "^4.1.3",
-        "@contentful/f36-text-link": "^4.2.0",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-tooltip": "^4.1.2",
-        "@contentful/f36-typography": "^4.2.0",
-        "@contentful/f36-utils": "^4.0.0",
+        "@contentful/f36-accordion": "^4.8.0",
+        "@contentful/f36-asset": "^4.8.0",
+        "@contentful/f36-autocomplete": "^4.8.0",
+        "@contentful/f36-badge": "^4.8.0",
+        "@contentful/f36-button": "^4.8.0",
+        "@contentful/f36-card": "^4.8.0",
+        "@contentful/f36-collapse": "^4.8.0",
+        "@contentful/f36-copybutton": "^4.8.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-datetime": "^4.8.0",
+        "@contentful/f36-drag-handle": "^4.8.0",
+        "@contentful/f36-entity-list": "^4.8.0",
+        "@contentful/f36-forms": "^4.8.0",
+        "@contentful/f36-icon": "^4.8.0",
+        "@contentful/f36-icons": "^4.8.0",
+        "@contentful/f36-list": "^4.8.0",
+        "@contentful/f36-menu": "^4.8.0",
+        "@contentful/f36-modal": "^4.8.0",
+        "@contentful/f36-note": "^4.8.0",
+        "@contentful/f36-notification": "^4.8.0",
+        "@contentful/f36-pagination": "^4.8.0",
+        "@contentful/f36-pill": "^4.8.0",
+        "@contentful/f36-popover": "^4.8.0",
+        "@contentful/f36-skeleton": "^4.8.0",
+        "@contentful/f36-spinner": "^4.8.0",
+        "@contentful/f36-table": "^4.8.0",
+        "@contentful/f36-tabs": "^4.8.0",
+        "@contentful/f36-text-link": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-tooltip": "^4.8.0",
+        "@contentful/f36-typography": "^4.8.0",
+        "@contentful/f36-utils": "^4.8.0",
         "@types/react": "16.14.22",
         "@types/react-dom": "16.9.14"
       },
@@ -771,15 +767,15 @@
       }
     },
     "@contentful/f36-copybutton": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.2.0.tgz",
-      "integrity": "sha512-i+1WpHypTJCoSDvFnF3sDYjz0tmwr7aU/ThP0jJ4dioNDAnZGSJXdx9Km6EOftdAHf0pemaMnarOzF8FCA26Eg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.8.0.tgz",
+      "integrity": "sha512-W6SsnEz6fu4SCw5Wmbkttr56rsM2gnFjJztPSuYqrbDCVkehE44F7DmB5WnAVZNaARutRdvaYyH3xBja4fUk5Q==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-icons": "^4.1.1",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-tooltip": "^4.1.2",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-icons": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-tooltip": "^4.8.0",
         "emotion": "^10.0.17",
         "react-copy-to-clipboard": "^5.0.3"
       },
@@ -800,12 +796,12 @@
       }
     },
     "@contentful/f36-core": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.2.0.tgz",
-      "integrity": "sha512-szKh8XehsDmFd5MRL73oqaAfLyorwA9nY5kPVc/kBs9PVmcsjSgFBBUjCjTLZTSqrf/26yakQC0T1XMU4Ht8GA==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.8.0.tgz",
+      "integrity": "sha512-0jhyTXYsdEkk7poOTBy48K1JrIsi6g1rRbyd/y0xzkznbjYeKmLnzRTGq76cRkkXAJD4eZRpmz/6hQlu2McMQw==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-tokens": "^4.0.0",
+        "@contentful/f36-tokens": "^4.0.1",
         "@emotion/core": "^10.1.1",
         "@emotion/is-prop-valid": "^1.1.0",
         "emotion": "^10.0.17"
@@ -827,13 +823,13 @@
       }
     },
     "@contentful/f36-datetime": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.3.0.tgz",
-      "integrity": "sha512-FULxlSPBC+PYmYe2A+mY7jlOt2MkwOxPZNxK9JaWWh0mSzvelx10f+9rV7UyWH2TtrMlvZECxhRbQ5dbpC441Q==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.8.0.tgz",
+      "integrity": "sha512-x7lHSf6vvi96C84c4yryLI/XDGClTu5Lf2kkxLApyWfP3HLqPnNgl5BHJ7uZrlk3AVOIP7B7AiTgYIzmOl6t0A==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-tokens": "^4.0.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
         "dayjs": "^1.10.6",
         "emotion": "^10.0.17"
       },
@@ -854,14 +850,14 @@
       }
     },
     "@contentful/f36-drag-handle": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.1.5.tgz",
-      "integrity": "sha512-TQtlOGKNUp64eUY+u/4UmXDOJ9CjyRi/LsEEb5OehlzhmRHut8GX0nCI6x1/lBmATZFqIxk1/c6RikhGiLJCEw==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.8.0.tgz",
+      "integrity": "sha512-+QoYwGnsRiIdkThGFIR0YnqywNxlHp2upd2RvYxzr+KxVxy26yYtMYyzYhYUrhIGNfiJEm4iXWRWKigZAAwVCw==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-icons": "^4.1.1",
-        "@contentful/f36-tokens": "^4.0.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-icons": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
       "dependencies": {
@@ -881,21 +877,21 @@
       }
     },
     "@contentful/f36-entity-list": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.1.18.tgz",
-      "integrity": "sha512-buvY/M7ZfzgOKxD8iXTOBf0jLqTv7oh9jKLc36rAqRdIUjF2ip+AjoEepDTeECGrYvhDRTAGg4HLaqxS6ENHOg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.8.0.tgz",
+      "integrity": "sha512-ucQ/VdOmpnljF2EyKdBo/pNgd6OeCgjGutKvh7HNgZqr0+K5/mmV4FQjScPt6FQSxkhsdnU6jzW1QAIgkGXj9g==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-badge": "^4.1.5",
-        "@contentful/f36-button": "^4.3.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-drag-handle": "^4.1.5",
-        "@contentful/f36-icon": "^4.1.2",
-        "@contentful/f36-icons": "^4.1.1",
-        "@contentful/f36-menu": "^4.2.4",
-        "@contentful/f36-skeleton": "^4.1.2",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-typography": "^4.2.0",
+        "@contentful/f36-badge": "^4.8.0",
+        "@contentful/f36-button": "^4.8.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-drag-handle": "^4.8.0",
+        "@contentful/f36-icon": "^4.8.0",
+        "@contentful/f36-icons": "^4.8.0",
+        "@contentful/f36-menu": "^4.8.0",
+        "@contentful/f36-skeleton": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-typography": "^4.8.0",
         "emotion": "^10.0.17"
       },
       "dependencies": {
@@ -915,15 +911,15 @@
       }
     },
     "@contentful/f36-forms": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.3.1.tgz",
-      "integrity": "sha512-uBo7XAnj283DZG20Ou8fKmbH4oTCulfE+4B2K+obV5jBCB6BtoauvT2WTAZdHt0uJd5Wk/PV5CdWQEMNm4Lv3g==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.8.0.tgz",
+      "integrity": "sha512-eqVlD3Pns6VJCac1zfEZoKmcZivEtJERk1RjdwE3VPgF1qxtQWJZoCEkTJ1oeWhdt8LD8XPHy3vu2dg8E0RMvQ==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-icons": "^4.1.1",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-typography": "^4.2.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-icons": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-typography": "^4.8.0",
         "emotion": "^10.0.17"
       },
       "dependencies": {
@@ -943,13 +939,13 @@
       }
     },
     "@contentful/f36-icon": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.1.2.tgz",
-      "integrity": "sha512-neAawUOsc+gt2z6FG4cgkQnQT09SX3E+L8tAgLQ+XhRRejecmvfjrO1b1yKqK3ddBYpeD/AVSHXsYyJdWhexOg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.8.0.tgz",
+      "integrity": "sha512-ywvPKV1vJWdYdO2SgidSLZtIlEn1v+QPtI3cL6YqDLfF57u0jgLlqFpq46h/tVQ7C3aKeX4P6JDeNKIeIW7c3A==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-tokens": "^4.0.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
       "dependencies": {
@@ -969,14 +965,14 @@
       }
     },
     "@contentful/f36-icons": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-4.1.1.tgz",
-      "integrity": "sha512-I4SZ5i/cinsrxVVGESKGAFdii4mWAM/eL3vryFHi4n5AnL+VWsOpzfr86skq/GVY+WyMpTAYsnZfLr0Sz7EwiQ==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-4.8.0.tgz",
+      "integrity": "sha512-84MkUrcL4SjFTbfs2oeSK8itxP5rSDbqQ7IcUN70WHIIYyq+zNSbVaVY/aqHAXul7zYZvhvJ0m17rSZvIa6+tg==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-icon": "^4.1.2",
-        "@contentful/f36-tokens": "^4.0.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-icon": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
       "dependencies": {
@@ -996,13 +992,13 @@
       }
     },
     "@contentful/f36-list": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.1.2.tgz",
-      "integrity": "sha512-4IbTKRDPOvkEU9eNGFJDXe8F9apPPVUO10aqQCmQIPwP8JfdhsAH8/sn87ue/FZWwP0RVB9I5qH2xnPrPjlhmg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.8.0.tgz",
+      "integrity": "sha512-G/tpeDUcuq5cZX3T5vsPF71z42ZYeDOlOCwd2sHuy/6qP6Yjk7MwiL16Mniks/NzFKFJcSKSqcGsK/qWSkunjw==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-tokens": "^4.0.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
       "dependencies": {
@@ -1022,17 +1018,17 @@
       }
     },
     "@contentful/f36-menu": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.2.4.tgz",
-      "integrity": "sha512-AbH8HXjdUkCE+DD/HimLuQaTvi0+SdzyvQ1xdv5wGZ4upxxwkbpIhM6ECR+6gqLvChghuvLtKU/THwu7bMaJEg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.8.0.tgz",
+      "integrity": "sha512-/fM3c3RfDXxjZAgzv8x3+Igci3bDgL1vWrB6VgOciQ2ENP0nVEFsXZl9RfGva8UNACXeCOSvBZPISNIs5r2vpw==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-icons": "^4.1.1",
-        "@contentful/f36-popover": "^4.2.1",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-typography": "^4.2.0",
-        "@contentful/f36-utils": "^4.0.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-icons": "^4.8.0",
+        "@contentful/f36-popover": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-typography": "^4.8.0",
+        "@contentful/f36-utils": "^4.8.0",
         "emotion": "^10.0.17"
       },
       "dependencies": {
@@ -1052,16 +1048,16 @@
       }
     },
     "@contentful/f36-modal": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.2.4.tgz",
-      "integrity": "sha512-W7JcPiIBx/IX6aIK2Y/a0N3jbDO56eYluUhwxA/utVv8uzgkz9/WMI2mGC6H1SP77RkhCdljyBNn3J0EzK3jvg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.8.0.tgz",
+      "integrity": "sha512-FosGSj07bHx2i56SVHjQhOPtfI0ggynG2Ux43SGXuqgUtIWE8YFO/JWB3XAE3ao95gTFauLjHdbptszZBtZBng==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-button": "^4.3.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-icons": "^4.1.1",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-typography": "^4.2.0",
+        "@contentful/f36-button": "^4.8.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-icons": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-typography": "^4.8.0",
         "@types/react-modal": "^3.12.1",
         "emotion": "^10.0.17",
         "react-modal": "^3.14.3"
@@ -1083,17 +1079,17 @@
       }
     },
     "@contentful/f36-note": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.2.12.tgz",
-      "integrity": "sha512-hkM2+Azwkls+JILrqD1CyX++nXi88N36IDA+0l8LP7AjWlwO1bVpjatnUtNM6LNB0fzwmbvOPUZtQ8hFXUDOWg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.8.0.tgz",
+      "integrity": "sha512-7atrGA48EHCip291U6+7koEcwGx3ntDv9Y+DtPDZNiV4czuPe0vbecositMHTPR4Mnw44hcJLex5qJ0E1NPBHA==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-button": "^4.3.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-icon": "^4.1.2",
-        "@contentful/f36-icons": "^4.1.1",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-typography": "^4.2.0",
+        "@contentful/f36-button": "^4.8.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-icon": "^4.8.0",
+        "@contentful/f36-icons": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-typography": "^4.8.0",
         "emotion": "^10.0.17"
       },
       "dependencies": {
@@ -1113,17 +1109,18 @@
       }
     },
     "@contentful/f36-notification": {
-      "version": "4.0.14",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.0.14.tgz",
-      "integrity": "sha512-ROJw1zXHby4bCy290L4OwHva46Yfu5KYhTiF/cWAZWAkkCt/8ynKM9+2McxNlD2vTM5TuwABUHVPCbYtQuNZoA==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.8.0.tgz",
+      "integrity": "sha512-tJhpD9H5py7bVCH8+Lyn5+UrV7L5siqywFo0FUSSfvqDyv0mnzMfXcTGFUYZPWUn/5uk9RgQVrdeOn1nEL4l7w==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-button": "^4.3.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-icons": "^4.1.1",
-        "@contentful/f36-text-link": "^4.2.0",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-typography": "^4.2.0",
+        "@contentful/f36-button": "^4.8.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-icons": "^4.8.0",
+        "@contentful/f36-text-link": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-typography": "^4.8.0",
+        "@swc/helpers": "^0.3.8",
         "emotion": "^10.0.17",
         "react-animate-height": "^2.0.23"
       },
@@ -1143,16 +1140,46 @@
         }
       }
     },
-    "@contentful/f36-pill": {
-      "version": "4.1.12",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.1.12.tgz",
-      "integrity": "sha512-I/7/+LJz4XbZMqcWgHysTFbyG/NBTmfQ9ahHIxssZgiJDgGYorN0nY96RRMK94LaSaZNnE/1kRXL1Wbh46DGwg==",
+    "@contentful/f36-pagination": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.8.0.tgz",
+      "integrity": "sha512-TM2QIT3ez+PKYKdG1cKAAJVCb19dX1PDqZbscCxtZhaDNqmvl7wiDN2hA24WHnlahVGs7cmBe/XVtuJyMtf8CA==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-button": "^4.3.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-icons": "^4.1.1",
+        "@contentful/f36-button": "^4.8.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-forms": "^4.8.0",
+        "@contentful/f36-icons": "^4.8.0",
         "@contentful/f36-tokens": "^4.0.0",
+        "@contentful/f36-typography": "^4.8.0",
+        "emotion": "^10.0.17"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.17.9",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
+          "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.9",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+          "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+        }
+      }
+    },
+    "@contentful/f36-pill": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.8.0.tgz",
+      "integrity": "sha512-1nWLwAr3noXV6KgZ60ifmAVYILlQZ7jmKcuIoqDSQSQEnGgA3oW5zJmOcaVIPYdxrLXpinGy6+mVgKTqHB0Xpw==",
+      "requires": {
+        "@babel/runtime": "^7.6.2",
+        "@contentful/f36-button": "^4.8.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-icons": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
       "dependencies": {
@@ -1172,14 +1199,14 @@
       }
     },
     "@contentful/f36-popover": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.2.1.tgz",
-      "integrity": "sha512-kY6MrffjgMPjGOv1nC+xo7lS4FkUhc+Rnft1pxhIl+gd9+MO2eOC6Pgqj8d222gGrJFZKcjuVeQhRGwRC0+0IQ==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.8.0.tgz",
+      "integrity": "sha512-zZNyxxbhKmIrUIgRIgz4YiVlsYybsET5TsDbOTYgYfDwJBVyKBgV3nYpzU/Q3B40hLCYKak2chdxy5hu9H1/Cg==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-utils": "^4.0.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-utils": "^4.8.0",
         "@popperjs/core": "^2.4.4",
         "emotion": "^10.0.17",
         "react-popper": "^2.2.3"
@@ -1201,14 +1228,14 @@
       }
     },
     "@contentful/f36-skeleton": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.1.2.tgz",
-      "integrity": "sha512-KiOONz9UehNYlxXiWsw4nApA4n79FXT7nSEUmlfvI6FHP5xFLpjVvJNh/ouOkprz7Wg9jP/vGE2KTv+amBGkXg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.8.0.tgz",
+      "integrity": "sha512-mj0nrSipGBasny8+ZbcHFwRmZ+s31NE1EsUXuWSiaXlzN1bDqDSDfVP0SPAn3Wb5l1evzCInaD3EfpOhyadVkg==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-table": "^4.1.2",
-        "@contentful/f36-tokens": "^4.0.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-table": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
       "dependencies": {
@@ -1228,13 +1255,13 @@
       }
     },
     "@contentful/f36-spinner": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.1.3.tgz",
-      "integrity": "sha512-ESh9wWO1nyyng20KH0qjvJ/rK4GzUL7zZa9fdpNf4bElOx0TQxRNX7zC1pN1y9ts3tgvkxMvCYFwvkasvB8Ueg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.8.0.tgz",
+      "integrity": "sha512-bqAM/6SUpC2+0plK4Dy5OU7L2FsHC8gRhp5dDe3iEAsJww3B8heoEME9L7QTpZ4b4hR2BfvzkzkzWE4axsjUtQ==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-tokens": "^4.0.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
       "dependencies": {
@@ -1254,13 +1281,13 @@
       }
     },
     "@contentful/f36-table": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.1.2.tgz",
-      "integrity": "sha512-6bfNBvzCowKoWsWIWLZZ/B4c/zgWS6HvomRXV0la+B2bOUyBMyhzOER3GLEfHYQjEaN/pgzO0F/C7hWMkzoRcQ==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.8.0.tgz",
+      "integrity": "sha512-Uqbx062ku79llFbzw3tMJ6kYHfktLtSWih7Xx/DL1fVSbNyeLBT/NuPO5rJRBO8MkgvA65T3tK1KnhVQ4KZRMg==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-tokens": "^4.0.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
       "dependencies": {
@@ -1280,13 +1307,13 @@
       }
     },
     "@contentful/f36-tabs": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.1.3.tgz",
-      "integrity": "sha512-aKW0KeCDMsMN7eominpxKcmIwUBtHLDjJHMRdnUj62zdPVHqNkYkP3ik+7FQNK+GRfQzBJvFaT9ho5xntRphpg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.8.0.tgz",
+      "integrity": "sha512-I29mwBBIDZL/Y31v3lqST6TQ4j707Tk7F0B8MW+YnWcCCEKqbHB1u7AA+vuASGMUEyb0UO/MEScr0uwFOYgXaA==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-tokens": "^4.0.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
         "@radix-ui/react-tabs": "0.1.1",
         "emotion": "^10.0.17"
       },
@@ -1307,13 +1334,13 @@
       }
     },
     "@contentful/f36-text-link": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.2.0.tgz",
-      "integrity": "sha512-rwIO+3JuTLbWFGTPR3PUFR5kVKR/3rk2I3p/xmBklN8saD1d/SVlnP26ZFyb+NpyfnBRs9SbhmiTq0zuZF1+nw==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.8.0.tgz",
+      "integrity": "sha512-mJEyJqPhXxgVx5Rr/X3+qBPcbCSntuYRBHPxYqHYtLtfJwd9YkD/+eLZzVIg5uPN7DP+EwH3/thVNsILTpUItA==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-tokens": "^4.0.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
       "dependencies": {
@@ -1338,14 +1365,14 @@
       "integrity": "sha512-NTyMAQcfvhPP8kJgOK5mtjKpErg799iglEb9B45ii4N7aMdph2GNqgv7KBgpogfbTEGBrlKIoH8MUDSV9YNREg=="
     },
     "@contentful/f36-tooltip": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.1.2.tgz",
-      "integrity": "sha512-7FGXq+deotowfpN/JEsPLiuFMKErEGqV8l9anzXUVDSGY3g4QW8TrOAb9aBXE+xI6kl1tRIeHA69Cwz5tmvzHQ==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.8.0.tgz",
+      "integrity": "sha512-6TY5tBkaW0HcU2+xWcZ3N925+TvP2k4LPgT8y5jBc4hWyEmVHOqhb/vFVMxrIC23nnuc6fHT8cIy6mDJ37jgwA==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-utils": "^4.0.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-utils": "^4.8.0",
         "@popperjs/core": "^2.4.4",
         "csstype": "^3.0.5",
         "emotion": "^10.0.17",
@@ -1368,13 +1395,13 @@
       }
     },
     "@contentful/f36-typography": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.2.0.tgz",
-      "integrity": "sha512-kYgXYxwZS1GpWAH2gE4cCOzDOh9Jvo9wDfn6E14kFWWr9Kcd7lyYVWftOFYm+B7ozbsVr9ZYEk3D4ghnsTd3Ng==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.8.0.tgz",
+      "integrity": "sha512-K+Qr9i1vpTKrjuFQHyrJCWWaj48KnyjBs1K1m3QHQmTMlqV1kMu2uq+dvN+imGvLe5Z8K9UlKeK2+VvVJhKEmQ==",
       "requires": {
         "@babel/runtime": "^7.6.2",
-        "@contentful/f36-core": "^4.2.0",
-        "@contentful/f36-tokens": "^4.0.0",
+        "@contentful/f36-core": "^4.8.0",
+        "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
       "dependencies": {
@@ -1394,9 +1421,9 @@
       }
     },
     "@contentful/f36-utils": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-utils/-/f36-utils-4.0.0.tgz",
-      "integrity": "sha512-7+N4LQOwxzu+tF23Arvb9NCYvVVVufvcrh4Iw1fP9Uy5udQGlwplW3PenzFI4dGuuY6f9Tn4I677SSFuZQwPAw==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-utils/-/f36-utils-4.8.0.tgz",
+      "integrity": "sha512-pAmwMjX2e3lXSqaqVZD1SzvE4ZualUZsbPLakqwExdo55zf2uaoDdSYH/KAYGJ+9/eqn5ea9NzwuL9108y66JA==",
       "requires": {
         "@babel/runtime": "^7.6.2",
         "emotion": "^10.0.17"
@@ -2819,6 +2846,14 @@
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@swc/helpers": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.3.13.tgz",
+      "integrity": "sha512-A1wswJhnqaLRn8uYVQ8YiNTtY5i/JIPmV08EXXjjTresIkUVUEUaFv/wXVhGXfRNYMvHPkuoMR1Nb6NgpxGjNg==",
+      "requires": {
+        "tslib": "^2.4.0"
       }
     },
     "@testing-library/dom": {
@@ -7921,9 +7956,9 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "react-modal": {
-      "version": "3.14.4",
-      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.14.4.tgz",
-      "integrity": "sha512-8surmulejafYCH9wfUmFyj4UfbSJwjcgbS9gf3oOItu4Hwd6ivJyVBETI0yHRhpJKCLZMUtnhzk76wXTsNL6Qg==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.15.1.tgz",
+      "integrity": "sha512-duB9bxOaYg7Zt6TMFldIFxQRtSP+Dg3F1ZX3FXxSUn+3tZZ/9JCgeAQKDg7rhZSAqopq8TFRw3yIbnx77gyFTw==",
       "requires": {
         "exenv": "^1.2.0",
         "prop-types": "^15.7.2",
@@ -7932,9 +7967,9 @@
       }
     },
     "react-popper": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.2.5.tgz",
-      "integrity": "sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
+      "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
       "requires": {
         "react-fast-compare": "^3.0.1",
         "warning": "^4.0.2"
@@ -8333,6 +8368,11 @@
       "requires": {
         "punycode": "^2.1.1"
       }
+    },
+    "truncate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/truncate/-/truncate-3.0.0.tgz",
+      "integrity": "sha512-C+0Xojw7wZPl6MDq5UjMTuxZvBPK04mtdFet7k+GSZPINcvLZFCXg+15kWIL4wAqDB7CksIsKiRLbQ1wa7rKdw=="
     },
     "ts-jest": {
       "version": "27.1.4",

--- a/packages/ecommerce-app-base/package.json
+++ b/packages/ecommerce-app-base/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@contentful/app-sdk": "^4.0.0",
-    "@contentful/f36-components": "^4.0.0",
+    "@contentful/f36-components": "^4.0.42",
     "@contentful/f36-tokens": "^4.0.0",
     "array-move": "^3.0.0",
     "contentful-management": "^10.0.0",


### PR DESCRIPTION
In earlier versions of forma 36, the auto resizer does not work because of `min-height` being part of the global styles.

This PR increases the minimum version to include the fix (https://github.com/contentful/forma-36/pull/1937)