### PR TITLE
feat: add `hideSearch` option to SkuPicker

### DIFF
--- a/packages/ecommerce-app-base/src/SkuPicker/SkuPicker.tsx
+++ b/packages/ecommerce-app-base/src/SkuPicker/SkuPicker.tsx
@@ -27,6 +27,7 @@ export interface Props {
   searchDelay?: number;
   skuType?: string;
   makeSaveBtnText?: MakeSaveBtnTextFn;
+  hideSearch?: boolean;
 }
 
 interface State {
@@ -154,7 +155,7 @@ export class SkuPicker extends Component<Props, State> {
 
   render() {
     const { search, pagination, products, selectedProducts, selectedSKUs } = this.state;
-    const { makeSaveBtnText = defaultGetSaveBtnText, skuType } = this.props;
+    const { makeSaveBtnText = defaultGetSaveBtnText, skuType, hideSearch = false } = this.props;
     const infiniteScrollingPaginationMode = 'hasNextPage' in pagination;
     const pageCount = Math.ceil(pagination.total / pagination.limit);
 
@@ -162,16 +163,20 @@ export class SkuPicker extends Component<Props, State> {
       <>
         <header className={styles.header}>
           <div className={styles.leftsideControls}>
-            <TextInput
-              placeholder="Search for a product..."
-              type="search"
-              name="sku-search"
-              id="sku-search"
-              testId="sku-search"
-              value={search}
-              onChange={(event) => this.setSearch((event.target as HTMLInputElement).value)}
-            />
-            <SearchIcon variant="muted" />
+            {!hideSearch && (
+              <>
+                <TextInput
+                  placeholder="Search for a product..."
+                  type="search"
+                  name="sku-search"
+                  id="sku-search"
+                  testId="sku-search"
+                  value={search}
+                  onChange={(event) => this.setSearch((event.target as HTMLInputElement).value)}
+                />
+                <SearchIcon variant="muted" />
+              </>
+            )}
             {!!pagination.total && (
               <span className={styles.total}>
                 Total results: {pagination.total.toLocaleString()}

--- a/packages/ecommerce-app-base/src/SkuPicker/renderSkuPicker.tsx
+++ b/packages/ecommerce-app-base/src/SkuPicker/renderSkuPicker.tsx
@@ -11,11 +11,20 @@ interface Props {
   searchDelay?: number;
   skuType?: string;
   makeSaveBtnText?: MakeSaveBtnTextFn;
+  hideSearch?: boolean;
 }
 
 export function renderSkuPicker(
   elementId: string,
-  { sdk, fetchProductPreviews, fetchProducts, searchDelay, skuType, makeSaveBtnText }: Props
+  {
+    sdk,
+    fetchProductPreviews,
+    fetchProducts,
+    searchDelay,
+    skuType,
+    makeSaveBtnText,
+    hideSearch,
+  }: Props
 ): void {
   const root = document.getElementById(elementId);
 
@@ -27,6 +36,7 @@ export function renderSkuPicker(
       searchDelay={searchDelay}
       skuType={skuType}
       makeSaveBtnText={makeSaveBtnText}
+      hideSearch={hideSearch}
     />,
     root
   );


### PR DESCRIPTION
Some ecommerce providers (e.g. commercetools) do not provide a search for all available sku types. Therefore, we need to hide the search here and only provide a list

unblocks https://github.com/contentful/apps/pull/1281