### PR TITLE
fix: disable sourcemaps

### DIFF
--- a/apps/mux/package.json
+++ b/apps/mux/package.json
@@ -36,7 +36,7 @@
   },
   "scripts": {
     "start": "cross-env BROWSER=none react-scripts start",
-    "build": "react-scripts build",
+    "build": "GENERATE_SOURCEMAP=false react-scripts build",
     "tsc": "tsc -p ./ --noEmit",
     "test": "TZ=UTC react-scripts test",
     "test:ci": "react-scripts test",


### PR DESCRIPTION
With source maps the bundle becomes too big and the upload fails

Mux only