### PR TITLE
feat(gatsby): use new sdk.entry.save() api in Previews instead of doing slow/hacky loop to check last save time

### DIFF
--- a/apps/gatsby/src/Sidebar.spec.js
+++ b/apps/gatsby/src/Sidebar.spec.js
@@ -38,6 +38,7 @@ const getMockSdk = () => ({
         getValue: jest.fn(() => 'preview-slug'),
       },
     },
+    save: jest.fn(() => Promise.resolve()),
   },
   window: {
     startAutoResizer: jest.fn(),
@@ -82,6 +83,7 @@ describe('Gatsby App Sidebar', () => {
     );
 
     await new Promise((res) => setTimeout(res, 2000));
+    expect(mockSdk.entry.save).not.toBeCalled()
     expect(mockFetch).toBeCalledWith(WEBHOOK_URL, expect.anything());
     expect(mockWindowOpen).toBeCalledWith(PREVIEW_URL);
   });
@@ -105,8 +107,8 @@ describe('Gatsby App Sidebar', () => {
       })
     );
 
-    await new Promise((res) => setTimeout(res, 3000));
-
+    await new Promise((res) => setTimeout(res, 1));
+    expect(mockSdk.entry.save).toBeCalled()
     expect(mockFetch).toBeCalledWith(WEBHOOK_URL, expect.anything());
     /**
      * The expected url should be in the form of:


### PR DESCRIPTION
Before this PR:

https://user-images.githubusercontent.com/14190743/179321438-2db023d4-28ef-4805-a1d2-46b4b1bf80f4.mov

With this PR:

https://user-images.githubusercontent.com/14190743/179321462-31fc55fc-5cc2-4641-a4b6-670520b6b67a.mov


You can see that the experience of opening a preview is between 3 - 8 seconds faster every time a user presses "Open Preview". 🎉 