### PR TITLE
chore: do not create dependabot PRs for major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,9 @@ updates:
     time: "00:00"
     timezone: UTC
   open-pull-requests-limit: 15
+  update_types:
+    - "semver:patch"
+    - "semver:minor"
   commit-message:
     prefix: "fix"
     prefix-development: "chore"
@@ -20,6 +23,9 @@ updates:
     time: "00:00"
     timezone: UTC
   open-pull-requests-limit: 15
+  update_types:
+    - "semver:patch"
+    - "semver:minor"
   commit-message:
     prefix: "fix"
     prefix-development: "chore"
@@ -36,6 +42,9 @@ updates:
     time: "00:00"
     timezone: UTC
   open-pull-requests-limit: 15
+  update_types:
+    - "semver:patch"
+    - "semver:minor"
   commit-message:
     prefix: "fix"
     prefix-development: "chore"


### PR DESCRIPTION
The goal is to prevent automatic merges of major updates.
With the current setup our bot automatically approves all dependabot PRs including major updates.

The easiest way to reach our goal is to simply avoid all major updates and enforce a manual update. We anyway do not keep up with all dependency changes (e.g. pubnub was only updated after 6 months). Therefore I think we do not loose too much with this approach.