### PR TITLE
doc: [] add create scripts to all readmes

### DIFF
--- a/examples/blog-post-metrics/README.md
+++ b/examples/blog-post-metrics/README.md
@@ -1,5 +1,20 @@
 This project was bootstrapped with [Create Contentful App](https://github.com/contentful/create-contentful-app).
 
+## How to use
+
+Execute create-contentful-app with npm, npx or yarn to bootstrap the example:
+
+```bash
+# npx
+npx create-contentful-app <app-name> --example blog-post-metrics
+
+# npm
+npm init contentful-app <app-name> --example blog-post-metrics
+
+# Yarn
+yarn create contentful-app <app-name> --example blog-post-metrics
+```
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/examples/custom-validation/README.md
+++ b/examples/custom-validation/README.md
@@ -4,6 +4,21 @@ When accessing data via Contentful it is important that the consumer can expect 
 
 This example shows how a custom app can be used to build a custom entry validation.
 
+## How to use
+
+Execute create-contentful-app with npm, npx or yarn to bootstrap the example:
+
+```bash
+# npx
+npx create-contentful-app <app-name> --example custom-validation
+
+# npm
+npm init contentful-app <app-name> --example custom-validation
+
+# Yarn
+yarn create contentful-app <app-name> --example custom-validation
+```
+
 ## Problem description
 
 Our example content type has three fields:

--- a/examples/dam-app/README.md
+++ b/examples/dam-app/README.md
@@ -1,3 +1,18 @@
 # Contentful DAM Demo App
 
+## How to use
+
+Execute create-contentful-app with npm, npx or yarn to bootstrap the example:
+
+```bash
+# npx
+npx create-contentful-app <app-name> --example dam-app
+
+# npm
+npm init contentful-app <app-name> --example dam-app
+
+# Yarn
+yarn create contentful-app <app-name> --example dam-app
+```
+
 Learn more about how to use [`@contentful/dam-app-base`](https://www.npmjs.com/package/@contentful/dam-app-base) in our [documentation](https://www.contentful.com/developers/docs/extensibility/app-framework/libraries/).

--- a/examples/default-values-backend/README.md
+++ b/examples/default-values-backend/README.md
@@ -1,5 +1,20 @@
 # Contentful Backend Demo APP
 
+## How to use
+
+Execute create-contentful-app with npm, npx or yarn to bootstrap the example:
+
+```bash
+# npx
+npx create-contentful-app <app-name> --example default-values-backend
+
+# npm
+npm init contentful-app <app-name> --example default-values-backend
+
+# Yarn
+yarn create contentful-app <app-name> --example default-values-backend
+```
+
 A demo App that will prefill certain values when an entry is created.
 
 The purpose of this demo is to show how backend Apps can be setup and used.

--- a/examples/ecommerce-app/README.md
+++ b/examples/ecommerce-app/README.md
@@ -1,3 +1,18 @@
 # Contentful E-Commerce Demo App
 
+## How to use
+
+Execute create-contentful-app with npm, npx or yarn to bootstrap the example:
+
+```bash
+# npx
+npx create-contentful-app <app-name> --example ecommerce-app
+
+# npm
+npm init contentful-app <app-name> --example ecommerce-app
+
+# Yarn
+yarn create contentful-app <app-name> --example ecommerce-app
+```
+
 Learn more about how to use [`@contentful/ecommerce-app-base`](https://www.npmjs.com/package/@contentful/ecommerce-app-base) in our [documentation](https://www.contentful.com/developers/docs/extensibility/app-framework/libraries/).

--- a/examples/editor-assignment/README.md
+++ b/examples/editor-assignment/README.md
@@ -2,6 +2,21 @@
 This project was bootstrapped with [Create Contentful App](https://github.com/contentful/create-contentful-app).
 !["Config screen view"](https://user-images.githubusercontent.com/3318312/163389377-2e6c8148-a98f-4627-a099-65b7141b1182.png)
 
+## How to use
+
+Execute create-contentful-app with npm, npx or yarn to bootstrap the example:
+
+```bash
+# npx
+npx create-contentful-app <app-name> --example editor-assignment
+
+# npm
+npm init contentful-app <app-name> --example editor-assignment
+
+# Yarn
+yarn create contentful-app <app-name> --example editor-assignment
+```
+
 
 ## Available Scripts
 

--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -1,5 +1,20 @@
 This project was bootstrapped with [Create Contentful App](https://github.com/contentful/create-contentful-app).
 
+## How to use
+
+Execute create-contentful-app with npm, npx or yarn to bootstrap the example:
+
+```bash
+# npx
+npx create-contentful-app <app-name> --example nextjs
+
+# npm
+npm init contentful-app <app-name> --example nextjs
+
+# Yarn
+yarn create contentful-app <app-name> --example nextjs
+```
+
 ## Config Location
 
 Due to a bug in Next.js, the config location doesn't load in development mode. The bug has been reported in Next.js' GitHub repository: https://github.com/vercel/next.js/issues/18028.

--- a/examples/page-location/README.md
+++ b/examples/page-location/README.md
@@ -3,6 +3,21 @@ This example shows how an app with a page location can be built. It creates a si
 
 ## How to use
 
+Execute create-contentful-app with npm, npx or yarn to bootstrap the example:
+
+```bash
+# npx
+npx create-contentful-app <app-name> --example page-location
+
+# npm
+npm init contentful-app <app-name> --example page-location
+
+# Yarn
+yarn create contentful-app <app-name> --example page-location
+```
+
+## How to use
+
 Install it and run:
 
 ```bash

--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -1,5 +1,20 @@
 This project was bootstrapped with [Create Contentful App](https://github.com/contentful/create-contentful-app).
 
+## How to use
+
+Execute create-contentful-app with npm, npx or yarn to bootstrap the example:
+
+```bash
+# npx
+npx create-contentful-app <app-name> --typescript
+
+# npm
+npm init contentful-app <app-name> --typescript
+
+# Yarn
+yarn create contentful-app <app-name> --typescript
+```
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/examples/vite-react/README.md
+++ b/examples/vite-react/README.md
@@ -1,5 +1,20 @@
 This project was bootstrapped with [Create Contentful App](https://github.com/contentful/create-contentful-app).
 
+## How to use
+
+Execute create-contentful-app with npm, npx or yarn to bootstrap the example:
+
+```bash
+# npx
+npx create-contentful-app <app-name> --example vite-react
+
+# npm
+npm init contentful-app <app-name> --example vite-react
+
+# Yarn
+yarn create contentful-app <app-name> --example vite-react
+```
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/examples/vue/README.md
+++ b/examples/vue/README.md
@@ -2,6 +2,21 @@
 
 This template should help get you started developing an app for Contentful with Vue 3 in Vite.
 
+## How to use
+
+Execute create-contentful-app with npm, npx or yarn to bootstrap the example:
+
+```bash
+# npx
+npx create-contentful-app <app-name> --example vue
+
+# npm
+npm init contentful-app <app-name> --example vue
+
+# Yarn
+yarn create contentful-app <app-name> --example vue
+```
+
 ## Type Support for `.vue` Imports in TS
 
 TypeScript cannot handle type information for `.vue` imports by default, so we replace the `tsc` CLI with `vue-tsc` for type checking. In editors, we need [TypeScript Vue Plugin (Volar)](https://marketplace.visualstudio.com/items?itemName=johnsoncodehk.vscode-typescript-vue-plugin) to make the TypeScript language service aware of `.vue` types.


### PR DESCRIPTION
To have a smooth start when browsing the examples, this adds the create script to all examples. 

With that checking out an example you can just copy-paste the command to get immediately started

