### PR TITLE
fix: [EXT-3929] version ranges for node and npm

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-engine-strict=true
+engine-strict = true

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "@contentful/apps",
   "private": true,
   "engines": {
-    "node": ">=14.0.0 && < 16.0.0",
-    "npm": "=> 6.0.0 && < 7.0.0" 
+    "node": ">=14.0.0 < 16.0.0",
+    "npm": ">= 6.0.0 < 7.0.0"
   },
   "devDependencies": {
     "prettier": "2.7.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@contentful/apps",
   "private": true,
+  "engines": {
+    "node": ">=14.0.0 && < 16.0.0",
+    "npm": "=> 6.0.0 && < 7.0.0" 
+  },
   "devDependencies": {
     "prettier": "2.7.1",
     "husky": "^8.0.0",


### PR DESCRIPTION
Prevent people from installing deps with the wrong node or npm versions, so we avoid situations where the deployment pipeline breaks.