### PR TITLE
fix: clear token when workspace fetching returns 401 or 403 [EXT-3944]

### DIFF
--- a/apps/typeform/frontend/src/AppConfig/AppConfig.tsx
+++ b/apps/typeform/frontend/src/AppConfig/AppConfig.tsx
@@ -28,11 +28,14 @@ import {
   selectedFieldsToTargetState,
   validateParameters,
   getToken,
+  resetLocalStorage,
 } from '../utils';
 import { styles } from './styles';
 
 // @ts-ignore 2307
 import logo from './config-screen-logo.svg';
+
+const AUTH_ERROR_CODES = [401, 403];
 
 interface Props {
   sdk: AppExtensionSDK;
@@ -100,6 +103,13 @@ export class AppConfig extends React.Component<Props, State> {
           Authorization: `Bearer ${this.state.accessToken}`,
         },
       });
+
+      if (AUTH_ERROR_CODES.includes(response.status)) {
+        resetLocalStorage();
+        this.setState({ accessToken: '' });
+        return;
+      }
+
       const result: WorkspacesResponse = await response.json();
       this.setState({ workspaces: this.normalizeWorkspaceResponse(result) });
     } catch (_error) {


### PR DESCRIPTION
Currently, when the token is invalid, the user only sees an error message but doesn't have the option to sign in again.

Now, whenever we receive a 401 or 403, the local token is cleared and the sign-in is offered to the user.