### PR TITLE
fix(docs): add double dash to treat positional arguments

### DIFF
--- a/examples/default-values-backend/README.md
+++ b/examples/default-values-backend/README.md
@@ -9,7 +9,7 @@ Execute create-contentful-app with npm, npx or yarn to bootstrap the example:
 npx create-contentful-app  --example default-values-backend
 
 # npm
-npm init contentful-app  --example default-values-backend
+npm init contentful-app -- --example default-values-backend
 
 # Yarn
 yarn create contentful-app  --example default-values-backend


### PR DESCRIPTION
Hi, 

I ran into the issue of creating a contentful backend app through the example but the command using `npm` behaved different from other mentioned commands. Thanks to @andipaetzold, he hinted me on Slack that there was a missing double dash as npm was trying `--example` as an option rather than a positional argument. 