### PR TITLE
fix: add argument type to error on catch clause

### DIFF
--- a/examples/default-values-backend/src/index.ts
+++ b/examples/default-values-backend/src/index.ts
@@ -161,7 +161,7 @@ const addDefaultDataOnEntryCreation = async (request: Hapi.Request, h: Hapi.Resp
     } else {
       throw new Error('failed to set default values' + (await res.text()));
     }
-  } catch (e) {
+  } catch (e: any) {
     console.error(e);
     throw new Error(e);
   }


### PR DESCRIPTION
Hi, 

I get an error once I run `start` command. This is related to argument type being unknown on `e` as the strict property is set on `tsconfig.json`. The pull request should be fix the issue for good.
```
error TS2345: Argument of type 'unknown' is not assignable to parameter of type 'string | undefined'.

166     throw new Error(e);
```