### PR TITLE
docs: add missing double dash for npm init

### DIFF
--- a/examples/blog-post-metrics/README.md
+++ b/examples/blog-post-metrics/README.md
@@ -9,7 +9,7 @@ Execute create-contentful-app with npm, npx or yarn to bootstrap the example:
 npx create-contentful-app --example blog-post-metrics
 
 # npm
-npm init contentful-app --example blog-post-metrics
+npm init contentful-app -- --example blog-post-metrics
 
 # Yarn
 yarn create contentful-app --example blog-post-metrics

--- a/examples/custom-validation/README.md
+++ b/examples/custom-validation/README.md
@@ -10,13 +10,13 @@ Execute create-contentful-app with npm, npx or yarn to bootstrap the example:
 
 ```bash
 # npx
-npx create-contentful-app  --example custom-validation
+npx create-contentful-app --example custom-validation
 
 # npm
-npm init contentful-app  --example custom-validation
+npm init contentful-app -- --example custom-validation
 
 # Yarn
-yarn create contentful-app  --example custom-validation
+yarn create contentful-app --example custom-validation
 ```
 
 ## Problem description

--- a/examples/dam-app/README.md
+++ b/examples/dam-app/README.md
@@ -9,10 +9,10 @@ Execute create-contentful-app with npm, npx or yarn to bootstrap the example:
 npx create-contentful-app --example dam-app
 
 # npm
-npm init contentful-app  --example dam-app
+npm init contentful-app -- --example dam-app
 
 # Yarn
-yarn create contentful-app  --example dam-app
+yarn create contentful-app --example dam-app
 ```
 
 Learn more about how to use [`@contentful/dam-app-base`](https://www.npmjs.com/package/@contentful/dam-app-base) in our [documentation](https://www.contentful.com/developers/docs/extensibility/app-framework/libraries/).

--- a/examples/default-values-backend/README.md
+++ b/examples/default-values-backend/README.md
@@ -6,13 +6,13 @@ Execute create-contentful-app with npm, npx or yarn to bootstrap the example:
 
 ```bash
 # npx
-npx create-contentful-app  --example default-values-backend
+npx create-contentful-app --example default-values-backend
 
 # npm
 npm init contentful-app -- --example default-values-backend
 
 # Yarn
-yarn create contentful-app  --example default-values-backend
+yarn create contentful-app --example default-values-backend
 ```
 
 A demo App that will prefill certain values when an entry is created.

--- a/examples/ecommerce-app/README.md
+++ b/examples/ecommerce-app/README.md
@@ -6,13 +6,13 @@ Execute create-contentful-app with npm, npx or yarn to bootstrap the example:
 
 ```bash
 # npx
-npx create-contentful-app  --example ecommerce-app
+npx create-contentful-app --example ecommerce-app
 
 # npm
-npm init contentful-app  --example ecommerce-app
+npm init contentful-app -- --example ecommerce-app
 
 # Yarn
-yarn create contentful-app  --example ecommerce-app
+yarn create contentful-app --example ecommerce-app
 ```
 
 Learn more about how to use [`@contentful/ecommerce-app-base`](https://www.npmjs.com/package/@contentful/ecommerce-app-base) in our [documentation](https://www.contentful.com/developers/docs/extensibility/app-framework/libraries/).

--- a/examples/editor-assignment/README.md
+++ b/examples/editor-assignment/README.md
@@ -8,13 +8,13 @@ Execute create-contentful-app with npm, npx or yarn to bootstrap the example:
 
 ```bash
 # npx
-npx create-contentful-app  --example editor-assignment
+npx create-contentful-app --example editor-assignment
 
 # npm
-npm init contentful-app  --example editor-assignment
+npm init contentful-app -- --example editor-assignment
 
 # Yarn
-yarn create contentful-app  --example editor-assignment
+yarn create contentful-app --example editor-assignment
 ```
 
 

--- a/examples/home-location/README.md
+++ b/examples/home-location/README.md
@@ -11,10 +11,10 @@ Execute create-contentful-app with npm, npx or yarn to bootstrap the example:
 npx create-contentful-app --example home-location
 
 # npm
-npm init contentful-app  --example home-location
+npm init contentful-app -- --example home-location
 
 # Yarn
-yarn create contentful-app  --example home-location
+yarn create contentful-app --example home-location
 ```
 
 ## Available Scripts

--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -6,13 +6,13 @@ Execute create-contentful-app with npm, npx or yarn to bootstrap the example:
 
 ```bash
 # npx
-npx create-contentful-app  --example nextjs
+npx create-contentful-app --example nextjs
 
 # npm
-npm init contentful-app  --example nextjs
+npm init contentful-app -- --example nextjs
 
 # Yarn
-yarn create contentful-app  --example nextjs
+yarn create contentful-app --example nextjs
 ```
 
 ## Config Location

--- a/examples/page-location/README.md
+++ b/examples/page-location/README.md
@@ -7,13 +7,13 @@ Execute create-contentful-app with npm, npx or yarn to bootstrap the example:
 
 ```bash
 # npx
-npx create-contentful-app  --example page-location
+npx create-contentful-app --example page-location
 
 # npm
 npm init contentful-app -- --example page-location
 
 # Yarn
-yarn create contentful-app  --example page-location
+yarn create contentful-app --example page-location
 ```
 
 ## How to use

--- a/examples/page-location/README.md
+++ b/examples/page-location/README.md
@@ -7,13 +7,13 @@ Execute create-contentful-app with npm, npx or yarn to bootstrap the example:
 
 ```bash
 # npx
-npx create-contentful-app   --example page-location
+npx create-contentful-app  --example page-location
 
 # npm
-npm init contentful-app   --example page-location
+npm init contentful-app -- --example page-location
 
 # Yarn
-yarn create contentful-app   --example page-location
+yarn create contentful-app  --example page-location
 ```
 
 ## How to use

--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -6,13 +6,13 @@ Execute create-contentful-app with npm, npx or yarn to bootstrap the example:
 
 ```bash
 # npx
-npx create-contentful-app  --typescript
+npx create-contentful-app --typescript
 
 # npm
-npm init contentful-app  --typescript
+npm init contentful-app -- --typescript
 
 # Yarn
-yarn create contentful-app  --typescript
+yarn create contentful-app --typescript
 ```
 
 ## Available Scripts

--- a/examples/vite-react/README.md
+++ b/examples/vite-react/README.md
@@ -6,13 +6,13 @@ Execute create-contentful-app with npm, npx or yarn to bootstrap the example:
 
 ```bash
 # npx
-npx create-contentful-app  --example vite-react
+npx create-contentful-app --example vite-react
 
 # npm
-npm init contentful-app  --example vite-react
+npm init contentful-app --example vite-react
 
 # Yarn
-yarn create contentful-app  --example vite-react
+yarn create contentful-app --example vite-react
 ```
 
 ## Available Scripts

--- a/examples/vue/README.md
+++ b/examples/vue/README.md
@@ -8,13 +8,13 @@ Execute create-contentful-app with npm, npx or yarn to bootstrap the example:
 
 ```bash
 # npx
-npx create-contentful-app  --example vue
+npx create-contentful-app --example vue
 
 # npm
-npm init contentful-app  --example vue
+npm init contentful-app -- --example vue
 
 # Yarn
-yarn create contentful-app  --example vue
+yarn create contentful-app --example vue
 ```
 
 ## Type Support for `.vue` Imports in TS


### PR DESCRIPTION
Follow-up of #1722

The `npm init` command is wrong in every template. We need to add a `--` for it to work.

This PR also removes additional spaces in the other commands.