### PR TITLE
feat(cloudinary): only fetch media library when required

### DIFF
--- a/apps/cloudinary/public/index.html
+++ b/apps/cloudinary/public/index.html
@@ -24,7 +24,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script src="https://media-library.cloudinary.com/global/all.js"></script>
   </body>
 </html>
 

--- a/apps/cloudinary/src/index.js
+++ b/apps/cloudinary/src/index.js
@@ -2,6 +2,7 @@ import pick from 'lodash/pick';
 import { Cloudinary as cloudinaryCore } from 'cloudinary-core';
 
 import { setup } from '@contentful/dam-app-base';
+import { loadScript } from './utils';
 
 import logo from './logo.svg';
 
@@ -70,7 +71,9 @@ function makeThumbnail(resource, config) {
   return [url, alt];
 }
 
-function renderDialog(sdk) {
+async function renderDialog(sdk) {
+  await loadScript('https://media-library.cloudinary.com/global/all.js');
+
   const { cloudinary } = window;
   const config = sdk.parameters.invocation;
 

--- a/apps/cloudinary/src/utils.js
+++ b/apps/cloudinary/src/utils.js
@@ -1,0 +1,14 @@
+export function loadScript(src) {
+  return new Promise((resolve, reject) => {
+    const scripts = document.getElementsByTagName('script')[0];
+    const script = document.createElement('script');
+
+    script.type = 'text/javascript';
+    script.src = src;
+
+    script.addEventListener('load', () => resolve());
+    script.addEventListener('error', (e) => reject(e));
+
+    scripts.parentNode.insertBefore(script, scripts);
+  });
+}


### PR DESCRIPTION
We currently always fetch `https://media-library.cloudinary.com/global/all.js` when the app is rendered. The script is actually only required within the dialog. This PR removes the script from index.html and only loads it within the dialog.

That way we remove an unnecessary request and reduce the number of scripts that need to be executed.