### PR TITLE
Add Readme to Commerce Layer example.

### DIFF
--- a/examples/commercelayer/README.md
+++ b/examples/commercelayer/README.md
@@ -2,4 +2,4 @@
 
 This example shows how you can build an application on top of [@contentful/ecommerce-app-base](https://github.com/contentful/apps/tree/master/packages/ecommerce-app-base).
 
-Historically this codebase powered the the [commerce layer application](https://www.contentful.com/marketplace/app/commercelayer/) that is on Contentfuls Marketplace. However today commerce layer maintains the app themselves and the latest code can be found at https://github.com/commercelayer/contentful-app .
+Historically this codebase powered the [Commerce Layer application](https://www.contentful.com/marketplace/app/commercelayer/) that is on Contentful's Marketplace. However today Commerce Layer maintains the app themselves and the latest code can be found at https://github.com/commercelayer/contentful-app .

--- a/examples/commercelayer/README.md
+++ b/examples/commercelayer/README.md
@@ -1,0 +1,5 @@
+# Commerce Layer
+
+This example shows how you can build an application on top of [@contentful/ecommerce-app-base](https://github.com/contentful/apps/tree/master/packages/ecommerce-app-base).
+
+Historically this codebase powered the the [commerce layer application](https://www.contentful.com/marketplace/app/commercelayer/) that is on Contentfuls Marketplace. However today commerce layer maintains the app themselves and the latest code can be found at https://github.com/commercelayer/contentful-app .


### PR DESCRIPTION
Adding the readme to explain why this codebase is still useful and where people can find the current code of the marketplace app.