### PR TITLE
chore: suppress sourcemap creation during mux build [INTEGRATE-6]

### DIFF
--- a/apps/mux/package.json
+++ b/apps/mux/package.json
@@ -33,7 +33,7 @@
   },
   "scripts": {
     "start": "cross-env BROWSER=none react-scripts start",
-    "build": "react-scripts build",
+    "build": "GENERATE_SOURCEMAP=false react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "create-app-definition": "contentful-app-scripts create-app-definition",


### PR DESCRIPTION
Do not generate source maps during the build for the mux app

## Purpose

* Builds have been breaking for the last few days with an error message "The uploaded archive was too large once uncompressed." It seems like one of the recent dependency updates pushed the mux app over our 10mb limit.

## Approach

* Source maps are big, and not really needed for published apps, so the easy fix is just to suppress them during the mux build step

## Dependencies and/or References

* Failed build example: https://app.circleci.com/pipelines/github/contentful/apps/10255/workflows/77570533-e07b-4f03-834a-a4b73b07c862/jobs/22098