### PR TITLE
fix: [] external product link built with provided url (Commercetools)

### DIFF
--- a/apps/commercetools/src/api/products.ts
+++ b/apps/commercetools/src/api/products.ts
@@ -5,12 +5,13 @@ import { createClient } from './client';
 
 const MAX_LIMIT = 500;
 
-function productTransformer({ projectKey, locale, apiEndpoint }: ConfigurationParameters) {
-  const baseUrl = apiEndpoint?.split('api.')[1];
+function productTransformer({ projectKey, locale, mcUrl }: ConfigurationParameters) {
   return (item: ProductProjection): Product => {
+    const merchantCenterBaseUrl =
+      mcUrl && mcUrl.length > 0 ? mcUrl : 'https://mc.europe-west1.gcp.commercetools.com';
     const id = item.id ?? '';
     const externalLink =
-      (projectKey && id && `https://mc.${baseUrl}/${projectKey}/products/${id}/general`) || '';
+      (projectKey && id && `${merchantCenterBaseUrl}/${projectKey}/products/${id}/general`) || '';
     return {
       id,
       image: item.masterVariant?.images?.[0]?.url ?? '',

--- a/apps/commercetools/src/api/products.ts
+++ b/apps/commercetools/src/api/products.ts
@@ -5,14 +5,12 @@ import { createClient } from './client';
 
 const MAX_LIMIT = 500;
 
-function productTransformer({ projectKey, locale }: ConfigurationParameters) {
+function productTransformer({ projectKey, locale, apiEndpoint }: ConfigurationParameters) {
+  const baseUrl = apiEndpoint?.split('api.')[1];
   return (item: ProductProjection): Product => {
     const id = item.id ?? '';
     const externalLink =
-      (projectKey &&
-        id &&
-        `https://mc.europe-west1.gcp.commercetools.com/${projectKey}/products/${id}/general`) ||
-      '';
+      (projectKey && id && `https://mc.${baseUrl}/${projectKey}/products/${id}/general`) || '';
     return {
       id,
       image: item.masterVariant?.images?.[0]?.url ?? '',

--- a/apps/commercetools/src/config.ts
+++ b/apps/commercetools/src/config.ts
@@ -38,6 +38,14 @@ export const PARAMETER_DEFINITIONS: ParameterDefinition[] = [
     required: true,
   },
   {
+    id: 'mcUrl',
+    name: 'Merchant Center URL',
+    description:
+      'The Merchant Center URL. Defaults to https://mc.europe-west1.gcp.commercetools.com',
+    type: 'Symbol',
+    required: false,
+  },
+  {
     id: 'locale',
     name: 'commercetools data locale',
     description: 'The commercetools data locale to display',

--- a/apps/commercetools/src/types.ts
+++ b/apps/commercetools/src/types.ts
@@ -4,6 +4,7 @@ export interface ConfigurationParameters {
   clientSecret?: string;
   apiEndpoint?: string;
   authApiEndpoint?: string;
+  mcUrl?: string;
   locale?: string;
   skuTypes?: Record<string, Record<string, SkuType | undefined> | undefined>;
 }


### PR DESCRIPTION
The external link for the Commercetools components were being hardcoded with the address for their Western European servers. This uses the api url provided in the config page by the user to get the correct base url for the external link. 

I don't see a way to do this more cleanly with the data we have on hand, but if anyone has an idea, I'm happy to hear it :)