### PR TITLE
fix: add Google Analytics deprecation notice [INTEGRATE-15]

### DIFF
--- a/apps/google-analytics/src/AppConfig.tsx
+++ b/apps/google-analytics/src/AppConfig.tsx
@@ -10,6 +10,7 @@ import {
   Select,
   FormLabel,
   TextInput,
+  Note,
 } from '@contentful/forma-36-react-components';
 import styles from './styles';
 import { AppConfigParams, AppConfigState, AllContentTypes, ContentTypes } from './typings';
@@ -223,6 +224,40 @@ export default class AppConfig extends React.Component<AppConfigParams, AppConfi
           <div>
             <Typography>
               <Heading className={styles.spaced}>About Google Analytics</Heading>
+
+              <Note noteType="negative" title="Deprecation notice" className={styles.spaced}>
+                <Paragraph className={styles.slimSpaced}>
+                  Google has{' '}
+                  <TextLink
+                    href="https://developers.googleblog.com/2021/08/gsi-jsweb-deprecation.html"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    deprecated the library
+                  </TextLink>{' '}
+                  Contentful uses to link your Contentful space to a Google Analytics dashboard and
+                  display page view reports alongside your Contentful entries.
+                </Paragraph>
+
+                <Paragraph className={styles.slimSpaced}>
+                  As a result,{' '}
+                  <strong>
+                    the Google Analytics app will no longer function correctly if you're installing
+                    it after July 29, 2022
+                  </strong>
+                  . Existing installations are not affected by this deprecation.
+                </Paragraph>
+
+                <Paragraph>
+                  <TextLink
+                    href="https://www.contentful.com/help/deprecation-notice-google-analytics-app/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Read more details here.
+                  </TextLink>
+                </Paragraph>
+              </Note>
 
               <Paragraph>
                 This app allows you to view pageview analytics of a Contentful entry in the editor

--- a/apps/google-analytics/src/styles.ts
+++ b/apps/google-analytics/src/styles.ts
@@ -12,23 +12,23 @@ const styles = {
     backgroundColor: tokens.colorWhite,
     zIndex: 2,
     boxShadow: '0px 0px 20px rgba(0, 0, 0, 0.1)',
-    borderRadius: '2px'
+    borderRadius: '2px',
   }),
   lightText: css({
-    color: tokens.gray600
+    color: tokens.gray600,
   }),
   signInButton: css({
     textAlign: 'center',
     dispay: 'none',
     margin: 'auto',
-    cursor: 'pointer'
+    cursor: 'pointer',
   }),
   splitter: css({
     marginTop: tokens.spacingL,
     marginBottom: tokens.spacingL,
     border: 0,
     height: '1px',
-    backgroundColor: tokens.gray300
+    backgroundColor: tokens.gray300,
   }),
   background: css({
     display: 'block',
@@ -37,15 +37,15 @@ const styles = {
     top: '0',
     width: '100%',
     height: '300px',
-    backgroundColor: '#f8ab00'
+    backgroundColor: '#f8ab00',
   }),
   contentTypeGrid: css({
     display: 'grid',
     gridTemplateColumns: 'repeat(3, 1fr) max-content',
-    gridGap: tokens.spacingXs
+    gridGap: tokens.spacingXs,
   }),
   contentTypeGridInputs: css({
-    marginBottom: tokens.spacingM
+    marginBottom: tokens.spacingM,
   }),
   header: css({
     display: 'grid',
@@ -53,45 +53,48 @@ const styles = {
     gridColumnGap: tokens.spacing2Xs,
     width: '100%',
     alignItems: 'self-end',
-    marginBottom: tokens.spacingXs
+    marginBottom: tokens.spacingXs,
   }),
   invisible: css({
-    visibility: 'hidden'
+    visibility: 'hidden',
   }),
   hidden: css({
-    display: 'none'
+    display: 'none',
   }),
   slug: css({
     color: tokens.gray600,
     fontSize: tokens.fontSizeS,
-    marginBottom: tokens.spacingM
+    marginBottom: tokens.spacingM,
   }),
   spaced: css({
-    marginBottom: tokens.spacingL
+    marginBottom: tokens.spacingL,
+  }),
+  slimSpaced: css({
+    marginBottom: tokens.spacingM,
   }),
   timeline: css({
-    position: 'relative'
+    position: 'relative',
   }),
   timelineChart: css({
-    minHeight: '200px'
+    minHeight: '200px',
   }),
   timelineSkeleton: css({
     position: 'absolute',
     top: 0,
-    left: 0
+    left: 0,
   }),
   pageViews: css({
     opacity: 1,
-    transition: `opacity ${tokens.transitionDurationShort}`
+    transition: `opacity ${tokens.transitionDurationShort}`,
   }),
   pageViewsLoading: css({
     opacity: 0,
-    transition: `opacity ${tokens.transitionDurationShort}`
+    transition: `opacity ${tokens.transitionDurationShort}`,
   }),
   logo: css({
     display: 'flex',
     justifyContent: 'center',
-    margin: `${tokens.spacing2Xl} 0 ${tokens.spacing4Xl}`
-  })
+    margin: `${tokens.spacing2Xl} 0 ${tokens.spacing4Xl}`,
+  }),
 };
-export default styles
+export default styles;


### PR DESCRIPTION
Adds a deprecation notice to the top of the Google Analytics app configuration screen.

## Purpose

* Google has deprecated several libraries behind the Analytics App and/or is no longer supporting them
* We need to let customers know when they are configuring the app that it will not work for new installations.

## Approach

* Add a `Note` of type `negative` to make this clear and unambiguous
* Provide a link to relevant documentation / explanation in the help center

![image](https://user-images.githubusercontent.com/235836/198152556-cc004eb4-78f9-4863-aec5-7ca250003678.png)


## Dependencies and/or References

* Original ticket: https://contentful.atlassian.net/browse/INTEGRATE-8
* Help center page: https://www.contentful.com/help/deprecation-notice-google-analytics-app/
* Google notice 1: https://developers.google.com/identity/sign-in/web/sign-in
* Google notice 2: https://developers.googleblog.com/2021/08/gsi-jsweb-deprecation.html
* Google notice 3: https://support.google.com/analytics/answer/11583528
* Stackoverflow that indicates Google no longer supported (see comment): https://stackoverflow.com/questions/72961705/google-analytics-embed-api-with-new-google-login-authorization-flow-i-e-google#comment128881973_72968672