### PR TITLE
Add team-integrations as co-codeowner [INTEGRATE-19]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-* @contentful/team-extensibility
+* @contentful/team-integrations @contentful/team-extensibility
 package.json @ghost
 package-lock.json @ghost


### PR DESCRIPTION
Adds team-integrations to CODEOWNER file
 
## Purpose

Team Integrations is moving toward ownership of this repository and thus should also get flagged on PR reviews etc. -- even though Team Extensibility will still carry most responsibility for maintenance.

## Approach

* Add team-integrations but keep team-extensibliity -- for now treat as coowners.

## References

* https://contentful.atlassian.net/browse/INTEGRATE-19