### PR TITLE
chore: introduce pull request template [INTEGRATE-7]

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+_A one or two sentence high-level summary of the change_
+
+## Purpose
+
+_Why are we introducing this change now? What problem does it solve? What is the story/background for it?_
+
+## Approach
+
+_Why did we do it the way we did? Did we consider alternatives? What other implementation details or artifacts (screenshots etc.) would help reviewers contextualize change?_
+
+## Deployment
+
+_Are there any deployment-related tasks, concerns or risks we should be mindful of?_
+
+## Dependencies and/or References
+
+_Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs) Any related PRs?_
+
+## Reminders
+
+* [Write good pull requests!](https://seesparkbox.com/foundry/github_pull_requests_for_everyone) 👼
+* [Be a good reviewer!](https://seesparkbox.com/foundry/stop_giving_depressing_code_reviews) 🧐

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,22 +1,11 @@
-_A one or two sentence high-level summary of the change_
-
 ## Purpose
-
-_Why are we introducing this change now? What problem does it solve? What is the story/background for it?_
+<!-- Why are we introducing this change now? What problem does it solve? What is the story/background for it? -->
 
 ## Approach
-
-_Why did we do it the way we did? Did we consider alternatives? What other implementation details or artifacts (screenshots etc.) would help reviewers contextualize change?_
-
-## Deployment
-
-_Are there any deployment-related tasks, concerns or risks we should be mindful of?_
+<!-- Why did we do it the way we did? Did we consider alternatives? What other implementation details or artifacts (screenshots etc.) would help reviewers contextualize change? -->
 
 ## Dependencies and/or References
+<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->
 
-_Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs) Any related PRs?_
-
-## Reminders
-
-* [Write good pull requests!](https://seesparkbox.com/foundry/github_pull_requests_for_everyone) 👼
-* [Be a good reviewer!](https://seesparkbox.com/foundry/stop_giving_depressing_code_reviews) 🧐
+## Deployment
+<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->


### PR DESCRIPTION
Note: This description reflects the proposed new template. 

## Purpose
<!-- Why are we introducing this change now? What problem does it solve? What is the story/background for it? -->

It's helpful for PR submitters to provide context and background for a change. Using a simple streamlined template encourages that. At the same time we don't want a template that's so heavy that it becomes burdensome.

## Approach
<!-- Why did we do it the way we did? Did we consider alternatives? What other implementation details or artifacts (screenshots etc.) would help reviewers contextualize change? -->

* Add a template with a few basic sections.
* Include super brief instructions within the template

## Dependencies and/or References
<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

* https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository

## Deployment
<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->

Nothing is normally needed here (can be left empty or removed)