### PR TITLE
feature: add info icon that shows status on hover [INTEGRATE-20]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+.envrc
 .DS_Store
 build
 dist

--- a/apps/smartling/frontend/src/Sidebar.tsx
+++ b/apps/smartling/frontend/src/Sidebar.tsx
@@ -12,6 +12,7 @@ import {
   SkeletonImage,
   Spinner,
   Note,
+  Flex,
 } from '@contentful/forma-36-react-components';
 import smartlingClient from './smartlingClient';
 
@@ -115,6 +116,29 @@ function sortSubs(a: Submission, b: Submission) {
   }
 
   return 0;
+}
+
+function submissionStatusLongText(status: string) {
+  switch (status.toLowerCase()) {
+    case 'not translated':
+      return `The asset has never been submitted for translation`;
+    case 'new':
+      return `The asset is in the process of being sent for a new translation request. For example, if changes
+        were made to the source content and your Contentful Connector is configured to automatically send the
+        new content for translation. The asset could be sitting in submission queue or sitting in Awaiting Authorization`;
+    case 'in progress':
+    case 'in_progress':
+      return 'The asset has been successfully sent to Smartling from Contentful, and the translation process has commenced but is not yet completed. If there is a case where translations are complete, but a network issue occurs, the translations will remain in progress until the Contentful Connector delivers the translations to Contentful on a successful retry.';
+    case 'canceled':
+    case 'cancelled':
+      return 'The job associated with this asset has been cancelled';
+    case 'completed':
+      return 'Translations were successfully delivered from Smartling to Contentful.';
+    case 'failed':
+      return 'The asset submission failed, or the translation delivery failed. A number of reasons can result in a failed status, but some of the most common are due to invalid regex causing placeholder issues, or the target languages are disabled in Contentful.';
+    default:
+      return 'This status is unknown';
+  }
 }
 
 function formatSmartlingEntry(entry: SmartlingContentfulEntry): SmartlingContentfulEntry {
@@ -259,9 +283,18 @@ export default class Sidebar extends React.Component<Props, State> {
         : smartlingEntry.translationSubmissions.slice(0, SUBS_TO_SHOW);
 
       statusTag = (
-        <Tag className="job-status" tagType={getStatusColor(smartlingEntry.assetStatus)}>
-          {smartlingEntry.assetStatus}
-        </Tag>
+        <Flex justifyContent="start" alignItems="bottom">
+          <Tag className="job-status" tagType={getStatusColor(smartlingEntry.assetStatus)}>
+            {smartlingEntry.assetStatus}
+          </Tag>
+          <Tooltip
+            place="top"
+            targetWrapperClassName="tooltip"
+            content={submissionStatusLongText(smartlingEntry.assetStatus)}
+          >
+            <Icon icon="InfoCircle" />
+          </Tooltip>
+        </Flex>
       );
 
       if (subsToShow.length) {
@@ -340,6 +373,16 @@ export default class Sidebar extends React.Component<Props, State> {
         </div>
         {requestButton}
         {smartlingBody}
+        <Paragraph className="smartling-more-info">
+          <TextLink
+            href="https://help.smartling.com/hc/en-us/articles/360000546974-Contentful-Connector-Overview"
+            target="_blank"
+            rel="noopener"
+          >
+            Learn how Smartling works with Contentful&nbsp;
+            <Icon size="tiny" icon="ExternalLink" color="secondary" />
+          </TextLink>
+        </Paragraph>
       </>
     );
   }

--- a/apps/smartling/frontend/src/Sidebar.tsx
+++ b/apps/smartling/frontend/src/Sidebar.tsx
@@ -130,8 +130,8 @@ function submissionStatusLongText(status: string) {
     case 'in_progress':
       return `The asset has been successfully sent to Smartling from Contentful, and the translation process
         has commenced but is not yet completed. If there is a case where translations are complete, but a network
-        issue occurs, the translations will remain in progress until the Contentful Connector delivers the translations
-        to Contentful on a successful retry.`;
+        issue occurs, the translations will remain in progress until Smartling delivers the translations to Contentful
+        on a successful retry.`;
     case 'canceled':
     case 'cancelled':
       return 'The job associated with this asset has been cancelled.';

--- a/apps/smartling/frontend/src/Sidebar.tsx
+++ b/apps/smartling/frontend/src/Sidebar.tsx
@@ -125,19 +125,24 @@ function submissionStatusLongText(status: string) {
     case 'new':
       return `The asset is in the process of being sent for a new translation request. For example, if changes
         were made to the source content and your Contentful Connector is configured to automatically send the
-        new content for translation. The asset could be sitting in submission queue or sitting in Awaiting Authorization`;
+        new content for translation. The asset could be sitting in submission queue or sitting in Awaiting Authorization.`;
     case 'in progress':
     case 'in_progress':
-      return 'The asset has been successfully sent to Smartling from Contentful, and the translation process has commenced but is not yet completed. If there is a case where translations are complete, but a network issue occurs, the translations will remain in progress until the Contentful Connector delivers the translations to Contentful on a successful retry.';
+      return `The asset has been successfully sent to Smartling from Contentful, and the translation process
+        has commenced but is not yet completed. If there is a case where translations are complete, but a network
+        issue occurs, the translations will remain in progress until the Contentful Connector delivers the translations
+        to Contentful on a successful retry.`;
     case 'canceled':
     case 'cancelled':
-      return 'The job associated with this asset has been cancelled';
+      return 'The job associated with this asset has been cancelled.';
     case 'completed':
       return 'Translations were successfully delivered from Smartling to Contentful.';
     case 'failed':
-      return 'The asset submission failed, or the translation delivery failed. A number of reasons can result in a failed status, but some of the most common are due to invalid regex causing placeholder issues, or the target languages are disabled in Contentful.';
+      return `The asset submission failed, or the translation delivery failed. A number of reasons can result in a
+        failed status, but some of the most common are due to invalid regex causing placeholder issues, or the target
+        languages are disabled in Contentful.`;
     default:
-      return 'This status is unknown';
+      return 'This status is unknown.';
   }
 }
 

--- a/apps/smartling/frontend/src/__snapshots__/index.spec.tsx.snap
+++ b/apps/smartling/frontend/src/__snapshots__/index.spec.tsx.snap
@@ -18,10 +18,35 @@ Object {
         </div>
         <div>
           <div
-            class="Tag__Tag___Y-myd job-status Tag__Tag--primary___2Hk3I"
-            data-test-id="cf-ui-tag"
+            class="Flex__Flex___Cpju1"
+            data-test-id="cf-ui-flex"
+            style="justify-content: start; align-items: bottom;"
           >
-            In Progress
+            <div
+              class="Tag__Tag___Y-myd job-status Tag__Tag--primary___2Hk3I"
+              data-test-id="cf-ui-tag"
+            >
+              In Progress
+            </div>
+            <span
+              class="Tooltip__TooltipContainer___3YlPf tooltip"
+            >
+              <svg
+                class="Icon__Icon___38Epv Icon__Icon--small___1yGZK Icon__Icon--primary___3M4Il"
+                data-test-id="cf-ui-icon"
+                height="1em"
+                viewBox="0 0 24 24"
+                width="1em"
+              >
+                <path
+                  d="M0 0h24v24H0z"
+                  fill="none"
+                />
+                <path
+                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
+                />
+              </svg>
+            </span>
           </div>
         </div>
       </div>
@@ -143,6 +168,40 @@ Object {
           </div>
         </div>
       </div>
+      <p
+        class="Paragraph__Paragraph___2aO-9 smartling-more-info"
+        data-test-id="cf-ui-paragraph"
+      >
+        <a
+          class="TextLink__TextLink___1biUr a11y__focus-outline--default___2hwb1 TextLink__TextLink--primary___2Vc9F"
+          data-test-id="cf-ui-text-link"
+          href="https://help.smartling.com/hc/en-us/articles/360000546974-Contentful-Connector-Overview"
+          rel="noopener"
+          target="_blank"
+        >
+          <span
+            class="TabFocusTrap__TabFocusTrap___39Vty"
+            tabindex="-1"
+          >
+            Learn how Smartling works with Contentful 
+            <svg
+              class="Icon__Icon___38Epv Icon__Icon--tiny___V4Pr9 Icon__Icon--secondary___1ztcw"
+              data-test-id="cf-ui-icon"
+              height="1em"
+              viewBox="0 0 24 24"
+              width="1em"
+            >
+              <path
+                d="M19 19H5V5h7V3H5a2 2 0 00-2 2v14a2 2 0 002 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"
+              />
+              <path
+                d="M0 0h24v24H0z"
+                fill="none"
+              />
+            </svg>
+          </span>
+        </a>
+      </p>
     </div>
   </body>,
   "container": <div>
@@ -159,10 +218,35 @@ Object {
       </div>
       <div>
         <div
-          class="Tag__Tag___Y-myd job-status Tag__Tag--primary___2Hk3I"
-          data-test-id="cf-ui-tag"
+          class="Flex__Flex___Cpju1"
+          data-test-id="cf-ui-flex"
+          style="justify-content: start; align-items: bottom;"
         >
-          In Progress
+          <div
+            class="Tag__Tag___Y-myd job-status Tag__Tag--primary___2Hk3I"
+            data-test-id="cf-ui-tag"
+          >
+            In Progress
+          </div>
+          <span
+            class="Tooltip__TooltipContainer___3YlPf tooltip"
+          >
+            <svg
+              class="Icon__Icon___38Epv Icon__Icon--small___1yGZK Icon__Icon--primary___3M4Il"
+              data-test-id="cf-ui-icon"
+              height="1em"
+              viewBox="0 0 24 24"
+              width="1em"
+            >
+              <path
+                d="M0 0h24v24H0z"
+                fill="none"
+              />
+              <path
+                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
+              />
+            </svg>
+          </span>
         </div>
       </div>
     </div>
@@ -284,6 +368,40 @@ Object {
         </div>
       </div>
     </div>
+    <p
+      class="Paragraph__Paragraph___2aO-9 smartling-more-info"
+      data-test-id="cf-ui-paragraph"
+    >
+      <a
+        class="TextLink__TextLink___1biUr a11y__focus-outline--default___2hwb1 TextLink__TextLink--primary___2Vc9F"
+        data-test-id="cf-ui-text-link"
+        href="https://help.smartling.com/hc/en-us/articles/360000546974-Contentful-Connector-Overview"
+        rel="noopener"
+        target="_blank"
+      >
+        <span
+          class="TabFocusTrap__TabFocusTrap___39Vty"
+          tabindex="-1"
+        >
+          Learn how Smartling works with Contentful 
+          <svg
+            class="Icon__Icon___38Epv Icon__Icon--tiny___V4Pr9 Icon__Icon--secondary___1ztcw"
+            data-test-id="cf-ui-icon"
+            height="1em"
+            viewBox="0 0 24 24"
+            width="1em"
+          >
+            <path
+              d="M19 19H5V5h7V3H5a2 2 0 00-2 2v14a2 2 0 002 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"
+            />
+            <path
+              d="M0 0h24v24H0z"
+              fill="none"
+            />
+          </svg>
+        </span>
+      </a>
+    </p>
   </div>,
   "debug": [Function],
   "findAllByAltText": [Function],
@@ -2197,6 +2315,40 @@ Object {
           </div>
         </div>
       </div>
+      <p
+        class="Paragraph__Paragraph___2aO-9 smartling-more-info"
+        data-test-id="cf-ui-paragraph"
+      >
+        <a
+          class="TextLink__TextLink___1biUr a11y__focus-outline--default___2hwb1 TextLink__TextLink--primary___2Vc9F"
+          data-test-id="cf-ui-text-link"
+          href="https://help.smartling.com/hc/en-us/articles/360000546974-Contentful-Connector-Overview"
+          rel="noopener"
+          target="_blank"
+        >
+          <span
+            class="TabFocusTrap__TabFocusTrap___39Vty"
+            tabindex="-1"
+          >
+            Learn how Smartling works with Contentful 
+            <svg
+              class="Icon__Icon___38Epv Icon__Icon--tiny___V4Pr9 Icon__Icon--secondary___1ztcw"
+              data-test-id="cf-ui-icon"
+              height="1em"
+              viewBox="0 0 24 24"
+              width="1em"
+            >
+              <path
+                d="M19 19H5V5h7V3H5a2 2 0 00-2 2v14a2 2 0 002 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"
+              />
+              <path
+                d="M0 0h24v24H0z"
+                fill="none"
+              />
+            </svg>
+          </span>
+        </a>
+      </p>
     </div>
   </body>,
   "container": <div>
@@ -2304,6 +2456,40 @@ Object {
         </div>
       </div>
     </div>
+    <p
+      class="Paragraph__Paragraph___2aO-9 smartling-more-info"
+      data-test-id="cf-ui-paragraph"
+    >
+      <a
+        class="TextLink__TextLink___1biUr a11y__focus-outline--default___2hwb1 TextLink__TextLink--primary___2Vc9F"
+        data-test-id="cf-ui-text-link"
+        href="https://help.smartling.com/hc/en-us/articles/360000546974-Contentful-Connector-Overview"
+        rel="noopener"
+        target="_blank"
+      >
+        <span
+          class="TabFocusTrap__TabFocusTrap___39Vty"
+          tabindex="-1"
+        >
+          Learn how Smartling works with Contentful 
+          <svg
+            class="Icon__Icon___38Epv Icon__Icon--tiny___V4Pr9 Icon__Icon--secondary___1ztcw"
+            data-test-id="cf-ui-icon"
+            height="1em"
+            viewBox="0 0 24 24"
+            width="1em"
+          >
+            <path
+              d="M19 19H5V5h7V3H5a2 2 0 00-2 2v14a2 2 0 002 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"
+            />
+            <path
+              d="M0 0h24v24H0z"
+              fill="none"
+            />
+          </svg>
+        </span>
+      </a>
+    </p>
   </div>,
   "debug": [Function],
   "findAllByAltText": [Function],

--- a/apps/smartling/frontend/src/index.scss
+++ b/apps/smartling/frontend/src/index.scss
@@ -61,6 +61,10 @@ body {
   }
 }
 
+.smartling-more-info {
+  margin-top: var(--spacing-m);
+}
+
 .signin {
   margin-bottom: var(--spacing-xs);
 }


### PR DESCRIPTION
## Purpose
<!-- Why are we introducing this change now? What problem does it solve? What is the story/background for it? -->
* We had a few user reports of “bugs” in the Smartling app. Further investigation revealed that there was no bug at all – it’s just that users believed (incorrectly) that the status was wrong
* Ultimately, the users need to visit Smartling to contextualize the status. The “submissions” list does an okay job of providing more granular context but it’s not perfect
* The status experience today is confusing not because the status is wrong but because users don’t really understand what it means in the context of Smartling

## Approach

* Add an info icon with tooltip to display status details. Use copy directly from [Smartling help page](https://help.smartling.com/hc/en-us/articles/360000546974-Contentful-Connector-Overview) (see "Smartling Status")
  * See /apps/smartling/frontend/src/Sidebar.tsx#L121-L142 to read the copy that will be displayed in the tooltip
* Provide a link at the bottom where users can get more details about how Smartling works with Contentful

![smartling-status](https://user-images.githubusercontent.com/235836/199563744-defe73cf-5853-47c9-87fc-d05badee2257.gif)

## Dependencies and/or References

* https://help.smartling.com/hc/en-us/articles/360000546974-Contentful-Connector-Overview