### PR TITLE
chore: proxy requests to frontend dev server in development [INTEGRATE-41]

### DIFF
--- a/apps/smartling/lambda/package.json
+++ b/apps/smartling/lambda/package.json
@@ -3,7 +3,7 @@
   "version": "1.4.43",
   "private": true,
   "scripts": {
-    "start": "LOCAL_DEV=true ts-node src/index.ts",
+    "start": "LOCAL_DEV=true FRONTEND_URL=http://localhost:3000 ts-node src/index.ts",
     "build": "rimraf built && tsc",
     "lint": "tslint --project ./tsconfig.json",
     "test": "jest --watch",


### PR DESCRIPTION
In development mode, proxy requests to the running frontend development server rather than to the build

## Purpose

Since the frontend for this app is mounted to the backend (at `/frontend`), the front end is actually served via the build during normal operation.

This is annoying for local development, since you have to build every time before you refresh and see the result of your work.

## Approach

* Write a simple proxier that forwards requests back to the given URL and path
* Add middleware for `/frontend` (where the app is served from on the backend)
* Also add middleware for `/static` since the development server specifies at relative paths (which get served from `http://localhost:8080/static/...` in local development
* Only use the middlewares in development, otherwise fallback to the same static middleware

## Dependencies and/or References
<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment
<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
