### PR TITLE
fix(ImageFocalPoint): handle multi locale []

### DIFF
--- a/apps/image-focal-point/src/index.js
+++ b/apps/image-focal-point/src/index.js
@@ -59,11 +59,11 @@ export class App extends React.Component {
   };
 
   findProperLocale() {
-    if (this.props.sdk.entry.fields[this.props.sdk.field.id].type === 'Link') {
-      return this.props.sdk.locales.default;
-    }
+    const imageField = this.props.sdk.entry.fields[IMAGE_FIELD_ID];
 
-    return this.props.sdk.field.locale;
+    return imageField.locales.includes(this.props.sdk.field.locale)
+      ? this.props.sdk.field.locale
+      : this.props.sdk.locales.default;
   }
 
   resetFocalPoint = () => {
@@ -90,7 +90,9 @@ export class App extends React.Component {
     try {
       const imageField = entry.fields[IMAGE_FIELD_ID];
       const asset = await space.getAsset(imageField.getValue(this.findProperLocale()).sys.id);
-      const file = asset.fields.file[this.props.sdk.locales.default];
+      const file =
+        asset.fields.file[this.findProperLocale()] ??
+        asset.fields.file[this.props.sdk.locales.default];
       const imageUrl = file.url;
       const isOfImageMimeType = /image\/.*/.test(file.contentType);
 

--- a/apps/image-focal-point/src/index.js
+++ b/apps/image-focal-point/src/index.js
@@ -52,9 +52,9 @@ export class App extends React.Component {
     const value = e.currentTarget.value;
     this.setState({ value });
     if (value) {
-      this.props.sdk.field.setValue(value, this.findProperLocale());
+      this.props.sdk.field.setValue(value);
     } else {
-      this.props.sdk.field.removeValue(this.findProperLocale());
+      this.props.sdk.field.removeValue();
     }
   };
 
@@ -78,7 +78,7 @@ export class App extends React.Component {
           focalPoint,
         },
       }),
-      () => this.props.sdk.field.setValue(this.state.value, this.findProperLocale())
+      () => this.props.sdk.field.setValue(this.state.value)
     );
   };
 

--- a/apps/image-focal-point/src/index.js
+++ b/apps/image-focal-point/src/index.js
@@ -52,9 +52,9 @@ export class App extends React.Component {
     const value = e.currentTarget.value;
     this.setState({ value });
     if (value) {
-      this.props.sdk.field.setValue(value);
+      this.props.sdk.field.setValue(value, this.findProperLocale());
     } else {
-      this.props.sdk.field.removeValue();
+      this.props.sdk.field.removeValue(this.findProperLocale());
     }
   };
 
@@ -78,7 +78,7 @@ export class App extends React.Component {
           focalPoint,
         },
       }),
-      () => this.props.sdk.field.setValue(this.state.value)
+      () => this.props.sdk.field.setValue(this.state.value, this.findProperLocale())
     );
   };
 
@@ -89,8 +89,8 @@ export class App extends React.Component {
 
     try {
       const imageField = entry.fields[IMAGE_FIELD_ID];
-      const asset = await space.getAsset(imageField.getValue().sys.id);
-      const file = asset.fields.file[this.findProperLocale()];
+      const asset = await space.getAsset(imageField.getValue(this.findProperLocale()).sys.id);
+      const file = asset.fields.file[this.props.sdk.locales.default];
       const imageUrl = file.url;
       const isOfImageMimeType = /image\/.*/.test(file.contentType);
 


### PR DESCRIPTION
## Purpose
Image focal point does not handle multi locale. Lets fix it

## Approach
As usual, JS `this` property bit us again. `findProperLocale` would not refer to current field and not the asset's

## Dependencies and/or References
Fixes #1932 
