### PR TITLE
fix: [] Typeform app: reset loading state on state reset

### DIFF
--- a/apps/typeform/frontend/src/Field/TypeFormField.tsx
+++ b/apps/typeform/frontend/src/Field/TypeFormField.tsx
@@ -96,6 +96,7 @@ export function TypeFormField({ sdk }: Props) {
         sdk.field.removeValue();
         return {
           ...state,
+          loading: false,
           value: '',
           hasStaleData: false,
           selectedForm: initialState.selectedForm,


### PR DESCRIPTION
## Purpose
Addressing customer issue. Loading form and getting bad response leads to execution of `resetLocalStorage` method and dispatching a `RESET` action, which leaves `loading: true` as it is and we're in a deadlock with no opportunity to set it to false.

## Approach
Reset `loading` property when we reset form state.