### PR TITLE
fix: remove compactViewMode parameter defintion [INTEGRATE-56]

### DIFF
--- a/apps/bynder/src/index.js
+++ b/apps/bynder/src/index.js
@@ -126,6 +126,10 @@ function checkMessageEvent(e) {
 
 function renderDialog(sdk) {
   const config = sdk.parameters.invocation;
+
+  // Important: `compactViewMode` is a legacy config parameter that was removed from the parameterDefinitions
+  // list. It is referenced here for temporary backward compatibility, for apps that previously chose a configuration
+  // value.
   const { assetTypes, bynderURL, compactViewMode } = config;
 
   let types = [];
@@ -160,7 +164,12 @@ function renderDialog(sdk) {
   script.addEventListener('load', () => {
     window.BynderCompactView.open({
       language: 'en_US',
+
+      // Note: `compactViewMode` is a deprecated parameter which will be removed in the near future. It is
+      // still used here for backwards compatibility -- our view mode respects any previous configuration
+      // a customer made. Later, we will just use `'MultiSelect'` for everyone.
       mode: compactViewMode ?? 'MultiSelect',
+
       assetTypes: types,
       portal: { url: bynderURL, editable: true },
       assetFieldSelection: FIELD_SELECTION,
@@ -236,15 +245,6 @@ setup({
       name: 'Asset types',
       description: 'Choose which types of assets can be selected.',
       default: validAssetTypes.join(','),
-      required: true,
-    },
-    {
-      id: 'compactViewMode',
-      name: 'Compact View Mode',
-      type: 'List',
-      value: 'MultiSelect,SingleSelectFile',
-      default: 'MultiSelect',
-      description: '"SingleSelectFile" allows you to select a specific derivative.',
       required: true,
     },
   ],


### PR DESCRIPTION
## Purpose

In a recent PR (https://github.com/contentful/apps/pull/1664), we introduced a configuration option to allow customers to specify a different "view mode" for the Bynder app.

Specifically, we gave customer the ability to choose `SingleSelectFile` instead of the previous default `MultiSelect` (read more about the difference [here](https://developer-docs.bynder.com/ui-components)). The purpose was to allow some customers to opt to use `SingleSelectFile`, which allows editors to specify a specific image transformation (aka "size") instead of just the main source image.

This ended up creating confusion for some customers, and also involved changes in the delivery API response which were inconsistent with previous results. Our team also worked with Bynder to better understand the intent behind the transformation selection mode, and will work to restore the capability to specify transformations in a way that causes less confusion.
 
## Approach

* Just remove the parameter definition but keep the reference to the config value. This means customers who have already selected `SingleSelectMode` will continue to have that capability for the time being, but everyone else will have MultiSelect.
* In testing, environment cloning preserves the config value in the new environment (as expected). Saving the app config screen removes the config value and the selector reverts to using MultiSelect (as expected).
* In a subsequent PR we will revert fully back to MultiSelect. This change allows us to prevent more customers from using the now deprecated option, while preserving existing functionality while we communicate the change.