### PR TITLE
Update helper text for MultiSelect

### DIFF
--- a/apps/bynder/src/index.js
+++ b/apps/bynder/src/index.js
@@ -244,7 +244,7 @@ setup({
       type: 'List',
       value: 'MultiSelect,SingleSelectFile',
       default: 'MultiSelect',
-      description: '"MultiSelect is the best choice for most customers. If you specifically need access to transformations, use SingleSelectFile. Note that you will need to change your frontend to use transform base URLs to load images in SingleSelectFile mode."',
+      description: '"MultiSelect is the best choice for most customers. If you specifically need access to dynamic transformations, use SingleSelectFile mode. (Note that with SingleSelectFile mode, you will likely need to change your frontend to reference the specific transformations chosen by your content editors.)',
       required: true,
     },
   ],

--- a/apps/bynder/src/index.js
+++ b/apps/bynder/src/index.js
@@ -244,7 +244,7 @@ setup({
       type: 'List',
       value: 'MultiSelect,SingleSelectFile',
       default: 'MultiSelect',
-      description: '"SingleSelectFile" allows you to select a specific derivative.',
+      description: '"MultiSelect is the best choice for most customers. If you specifically need access to transformations, use SingleSelectFile. Note that you will need to change your frontend to use transform base URLs to load images in SingleSelectFile mode."',
       required: true,
     },
   ],


### PR DESCRIPTION
Added additional context around when to use SingleSelectFile and the ramifications

## Purpose
Reaction to inconsistencies between the two Bynder selection modes.

## Approach
This is the cheapest version of this change until better documentation and/or a new feature exists.

## Dependencies and/or References
N/A

## Deployment
N/A