### PR TITLE
chore: change vault key type [EXT-4121]

### DIFF
--- a/.contentful/vault-secrets.yaml
+++ b/.contentful/vault-secrets.yaml
@@ -5,6 +5,6 @@ services:
       - dependabot
   circleci:
     policies:
-      - npm-read
+      - semantic-release
       - aws-push-artifacts:
           account-id: "017078452822"


### PR DESCRIPTION
## Purpose
Using NPM publish role cause we're also publishing in the CCI file and not only reading npm libraries. This is part of using vault for better security

## Approach
Previously we were using read-only token which wasn't sufficient with what we needed to do in .cicleci/config.yml tasks esp with deploying after building.

## Dependencies and/or References
Read more here: https://contentful.atlassian.net/browse/EXT-4121

## Deployment
No need to deploy anything
