### PR TITLE
fix: remove the 25 color limit

### DIFF
--- a/apps/color-picker/src/locations/ConfigScreen.tsx
+++ b/apps/color-picker/src/locations/ConfigScreen.tsx
@@ -164,12 +164,7 @@ const ConfigScreen = () => {
               />
             ))}
 
-            <Button
-              size="small"
-              startIcon={<PlusIcon />}
-              onClick={addSwatch}
-              isDisabled={parameters.themes[0].colors.length >= 25}
-            >
+            <Button size="small" startIcon={<PlusIcon />} onClick={addSwatch}>
               Add color
             </Button>
           </div>


### PR DESCRIPTION
We currently limit the number of colors to 25. There is no real reason for it as the 512kB installation parameter limit won't be reached anyway with normal usage of the app.

closes #2037