### PR TITLE
GA4: Require key file at install [INTEG-91]

### DIFF
--- a/apps/google-analytics-4/src/components/FormControlServiceAccountKey.tsx
+++ b/apps/google-analytics-4/src/components/FormControlServiceAccountKey.tsx
@@ -35,6 +35,7 @@ interface FormControlServideAccountKeyFileProps {
   setServiceAccountKey: (serviceAccountKey: ServiceAccountKey | null) => void;
   setServiceAccountKeyId: (serviceAccountKey: ServiceAccountKeyId | null) => void;
   setIsInvalid: (isInvalid: boolean) => void;
+  isRequired: boolean;
   currentServiceAccountKeyId: ServiceAccountKeyId | null;
   className?: string;
 }
@@ -60,6 +61,7 @@ const FormControlServiceAccountKey = ({
   setServiceAccountKey,
   setServiceAccountKeyId,
   setIsInvalid,
+  isRequired,
   currentServiceAccountKeyId,
   className,
 }: FormControlServideAccountKeyFileProps) => {
@@ -143,8 +145,13 @@ const FormControlServiceAccountKey = ({
   };
 
   const formControl = (
-    <FormControl marginTop="spacingL" id="accountCredentialsFile">
-      <FormControl.Label>Google Service Account Key File</FormControl.Label>
+    <FormControl
+      marginTop="spacingL"
+      id="accountCredentialsFile"
+      isInvalid={formControlState.isInvalid}
+      isRequired={isRequired}
+    >
+      <FormControl.Label isRequired={isRequired}>Google Service Account Key File</FormControl.Label>
       <Textarea
         name="accountCredentialsFile"
         placeholder={placeholderText}
@@ -152,24 +159,23 @@ const FormControlServiceAccountKey = ({
         className={styles.credentialsInput}
         value={serviceAccountKeyFile}
         onChange={onKeyFileTextareaChange}
-        isInvalid={formControlState.isInvalid}
       />
       {formControlState.isInvalid ? (
         <FormControl.ValidationMessage>
           Error: {formControlState.errorMessage}
         </FormControl.ValidationMessage>
+      ) : serviceAccountKeyFile ? (
+        <Flex marginTop="spacingXs" alignItems="center">
+          <Flex isInline={true} alignItems="center">
+            <CheckCircleIcon variant="positive" />{' '}
+            <Text as="p" marginLeft="spacing2Xs" fontColor="gray700">
+              Service account key file is valid
+            </Text>
+          </Flex>
+        </Flex>
       ) : (
         <FormControl.HelpText>
-          {serviceAccountKeyFile ? (
-            <Flex isInline={true} alignItems="center">
-              <CheckCircleIcon variant="positive" />{' '}
-              <Text marginLeft="spacing2Xs" fontColor="gray700">
-                Service account key file is valid
-              </Text>
-            </Flex>
-          ) : (
-            'Paste the contents of your service account key file above'
-          )}
+          Paste the contents of your service account key file above
         </FormControl.HelpText>
       )}
 

--- a/apps/google-analytics-4/src/components/FormControlServiceAccountKey.tsx
+++ b/apps/google-analytics-4/src/components/FormControlServiceAccountKey.tsx
@@ -151,7 +151,7 @@ const FormControlServiceAccountKey = ({
       isInvalid={formControlState.isInvalid}
       isRequired={isRequired}
     >
-      <FormControl.Label isRequired={isRequired}>Google Service Account Key File</FormControl.Label>
+      <FormControl.Label>Google Service Account Key File</FormControl.Label>
       <Textarea
         name="accountCredentialsFile"
         placeholder={placeholderText}

--- a/apps/google-analytics-4/src/components/FormControlServiceAccountKey.tsx
+++ b/apps/google-analytics-4/src/components/FormControlServiceAccountKey.tsx
@@ -225,6 +225,7 @@ const FormControlServiceAccountKey = ({
         icon={isExpanded ? <ChevronDownIcon /> : <ChevronRightIcon />}
         alignIcon="start"
         onClick={() => setIsExpanded(!isExpanded)}
+        testId="keyFileFieldExpander"
       >
         Replace with new Service Account Key
       </TextLink>

--- a/apps/google-analytics-4/src/locations/ConfigScreen.spec.tsx
+++ b/apps/google-analytics-4/src/locations/ConfigScreen.spec.tsx
@@ -1,13 +1,22 @@
 import React from 'react';
 import ConfigScreen from './ConfigScreen';
-import { act, render, screen } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { mockCma, mockSdk, validServiceKeyFile } from '../../test/mocks';
+
+import type { ServiceAccountKey, ServiceAccountKeyId } from '../types';
 
 jest.mock('@contentful/react-apps-toolkit', () => ({
   useSDK: () => mockSdk,
   useCMA: () => mockCma,
 }));
+
+const validServiceKeyId: ServiceAccountKeyId = {
+  id: validServiceKeyFile.private_key_id,
+  clientId: validServiceKeyFile.client_id,
+  clientEmail: validServiceKeyFile.client_id,
+  projectId: validServiceKeyFile.project_id,
+};
 
 // Helper to mock users clicking "save" -- return result of the callback passed to onConfigure()
 const saveAppInstallation = async () => {
@@ -15,19 +24,22 @@ const saveAppInstallation = async () => {
   return await mockSdk.app.onConfigure.mock.calls.slice(-1)[0][0]();
 };
 
-describe('Config Screen component', () => {
-  it('can render the basic form', () => {
-    const renderedComponent = render(<ConfigScreen />);
-    const { getByText } = renderedComponent;
+describe('Config Screen component (not installed)', () => {
+  it('can render the basic form', async () => {
+    await act(async () => {
+      render(<ConfigScreen />);
+    });
 
-    expect(getByText('About Google Analytics for Contentful')).toBeInTheDocument();
+    expect(screen.getByText('About Google Analytics for Contentful')).toBeInTheDocument();
   });
 
   it('allows the app to be installed with a valid service key file', async () => {
     const user = userEvent.setup();
-    render(<ConfigScreen />);
+    await act(async () => {
+      render(<ConfigScreen />);
+    });
 
-    const keyFileInputBox = screen.getByLabelText('Google Service Account Key File');
+    const keyFileInputBox = screen.getByLabelText(/Service Account Key File/i);
 
     // user.type() got confused by the JSON string chars, so we'll just click and paste -- this
     // actually better recreates likely user behavior as a bonus
@@ -51,11 +63,13 @@ describe('Config Screen component', () => {
     );
   });
 
-  it('prevents the app from being installed with an valid service key file', async () => {
+  it('prevents the app from being installed with invalid service key file', async () => {
     const user = userEvent.setup();
-    render(<ConfigScreen />);
+    await act(async () => {
+      render(<ConfigScreen />);
+    });
 
-    const keyFileInputBox = screen.getByLabelText('Google Service Account Key File');
+    const keyFileInputBox = screen.getByLabelText(/Service Account Key File/i);
 
     // user.type() got confused by the JSON string chars, so we'll just click and paste -- this
     // actually better recreates likely user behavior as a bonus
@@ -67,7 +81,99 @@ describe('Config Screen component', () => {
       result = await saveAppInstallation();
     });
 
+    console.log(mockSdk.app.getParameters());
+
     // false result prevents parameters save
     expect(result).toEqual(false);
+  });
+
+  it('prevents the app from being installed if no service key file is provided', async () => {
+    await act(async () => {
+      render(<ConfigScreen />);
+    });
+
+    let result;
+    await act(async () => {
+      result = await saveAppInstallation();
+    });
+
+    // false result prevents parameters save
+    expect(result).toEqual(false);
+  });
+});
+
+describe('Config Screen component (installed)', () => {
+  beforeEach(() => {
+    mockSdk.app.getParameters.mockReturnValue({
+      serviceAccountKey: validServiceKeyFile,
+      serviceAccountKeyId: validServiceKeyId,
+    });
+  });
+
+  it('can render the basic form', async () => {
+    await act(async () => {
+      render(<ConfigScreen />);
+    });
+
+    expect(screen.getByText('About Google Analytics for Contentful')).toBeInTheDocument();
+  });
+
+  it('overrides the saved values if a new key file is provided', async () => {
+    const user = userEvent.setup();
+    await act(async () => {
+      render(<ConfigScreen />);
+    });
+
+    const fieldExpander = screen.getByTestId('keyFileFieldExpander');
+
+    await user.click(fieldExpander);
+    const keyFileInputBox = screen.getByLabelText(/Service Account Key File/i);
+    await waitFor(() => user.click(keyFileInputBox));
+
+    const newServiceKeyFile: ServiceAccountKey = {
+      ...validServiceKeyFile,
+      private_key_id: 'new_private_key_id',
+    };
+    await user.paste(JSON.stringify(newServiceKeyFile));
+
+    let result;
+    await act(async () => {
+      result = await saveAppInstallation();
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        parameters: expect.objectContaining({
+          serviceAccountKey: expect.objectContaining(newServiceKeyFile),
+          serviceAccountKeyId: expect.objectContaining({
+            id: 'new_private_key_id',
+          }),
+        }),
+      })
+    );
+  });
+
+  it('does not require key file on save', async () => {
+    await act(async () => {
+      render(<ConfigScreen />);
+    });
+
+    let result;
+    await act(async () => {
+      result = await saveAppInstallation();
+    });
+
+    // result should reflect the same parameters that were loaded, since no change
+    // was made by the user
+    expect(result).toEqual(
+      expect.objectContaining({
+        parameters: expect.objectContaining({
+          serviceAccountKey: expect.objectContaining(validServiceKeyFile),
+          serviceAccountKeyId: expect.objectContaining({
+            id: validServiceKeyFile.private_key_id,
+          }),
+        }),
+      })
+    );
   });
 });

--- a/apps/google-analytics-4/src/locations/ConfigScreen.spec.tsx
+++ b/apps/google-analytics-4/src/locations/ConfigScreen.spec.tsx
@@ -81,8 +81,6 @@ describe('Config Screen component (not installed)', () => {
       result = await saveAppInstallation();
     });
 
-    console.log(mockSdk.app.getParameters());
-
     // false result prevents parameters save
     expect(result).toEqual(false);
   });

--- a/apps/google-analytics-4/src/locations/ConfigScreen.tsx
+++ b/apps/google-analytics-4/src/locations/ConfigScreen.tsx
@@ -77,6 +77,8 @@ const ConfigScreen = () => {
   );
   const [isInvalidServiceAccountKeyFile, setIsInvalidServiceAccountKeyFile] =
     useState<boolean>(false);
+  const [serviceAccountKeyFileIsRequired, setServiceAccountKeyFileIsRequired] =
+    useState<boolean>(false);
 
   const sdk = useSDK<AppExtensionSDK>();
 
@@ -85,6 +87,11 @@ const ConfigScreen = () => {
 
     if (isInvalidServiceAccountKeyFile) {
       sdk.notifier.error('Invalid service account key file. See field error for details');
+      return false;
+    }
+
+    if (serviceAccountKeyFileIsRequired && !newServiceAccountKeyId) {
+      sdk.notifier.error('A valid service account key file is required');
       return false;
     }
 
@@ -100,6 +107,7 @@ const ConfigScreen = () => {
     );
 
     setParameters(newParameters);
+    setServiceAccountKeyFileIsRequired(false);
 
     return {
       parameters: newParameters,
@@ -108,6 +116,7 @@ const ConfigScreen = () => {
   }, [
     newServiceAccountKey,
     newServiceAccountKeyId,
+    serviceAccountKeyFileIsRequired,
     isInvalidServiceAccountKeyFile,
     parameters,
     sdk,
@@ -123,6 +132,11 @@ const ConfigScreen = () => {
 
       if (currentParameters) {
         setParameters(currentParameters);
+        setServiceAccountKeyFileIsRequired(false);
+      } else {
+        // per the documentation, `null` means app is not installed, thus we will require
+        // the key file
+        setServiceAccountKeyFileIsRequired(true);
       }
 
       sdk.app.setReady();
@@ -156,6 +170,7 @@ const ConfigScreen = () => {
             setServiceAccountKeyId={setNewServiceAccountKeyId}
             setIsInvalid={setIsInvalidServiceAccountKeyFile}
             currentServiceAccountKeyId={parameters.serviceAccountKeyId}
+            isRequired={serviceAccountKeyFileIsRequired}
             className={styles.serviceAccountKeyFormControl}
           />
 


### PR DESCRIPTION
## Purpose

When installing the GA4 app, the credentials key file is required. Once the app is installed, the key file field is no longer required (since it should only be populated when replacing the key)

## Approach

* Conditionally pass an is required value down to note field is required
* Throw an error on save if the field is required but no key file is present
* Add tests for this as well as more for when saving form on already installed app

### Static Screenshot

![screenshot-keyfile-require](https://user-images.githubusercontent.com/235836/208184019-854bbbae-eb65-462d-a16d-3ac2868b0ce3.png)

### Screen recording

![screen-recording-keyfile-require](https://user-images.githubusercontent.com/235836/208184055-5e4b87cd-0277-4fab-a14d-5aed7b5e69e3.gif)

## Dependencies and/or References

* Builds directly off of #2195 

## Deployment
<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
