### PR TITLE
fix: [] Scale SVG images properly in Image Focal Point app

### DIFF
--- a/apps/image-focal-point/src/components/FocalPointDialog/__snapshots__/FocalPointDialog.spec.js.snap
+++ b/apps/image-focal-point/src/components/FocalPointDialog/__snapshots__/FocalPointDialog.spec.js.snap
@@ -57,7 +57,7 @@ exports[`FocalPointDialog should render the focal point dialog 1`] = `
           class="css-1biw769"
         >
           <div
-            class="css-1njnee2"
+            class="css-bwgqaq"
             role="button"
             tabindex="-1"
           >

--- a/apps/image-focal-point/src/components/FocalPointDialog/styles.js
+++ b/apps/image-focal-point/src/components/FocalPointDialog/styles.js
@@ -21,9 +21,10 @@ export const styles = {
       cursor: 'crosshair',
       display: 'block',
       margin: '0 auto',
-      maxWidth: '100%',
-      maxHeight: '100%',
+      width: '100%',
+      height: '100%',
       outline: 0,
+      objectFit: 'contain',
     },
   }),
   focalPointDemo: css({


### PR DESCRIPTION
## Purpose
Support SVG images in Image Focal Point app.

## Approach
SVG images are not always scaled properly, so we force proper scaling with 100% width and height + CSS `object-fit: contain` property.

## Dependencies and/or References
Based on [issue](https://github.com/contentful/apps/issues/2170)