### PR TITLE
fix(smartling): bump version [EXT-4239]

### DIFF
--- a/apps/smartling/frontend/package-lock.json
+++ b/apps/smartling/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@contentful/smartling-frontend",
-  "version": "1.7.65",
+  "version": "1.7.67",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@contentful/smartling-frontend",
-      "version": "1.7.65",
+      "version": "1.7.67",
       "dependencies": {
         "@contentful/app-sdk": "4.13.0",
         "@contentful/forma-36-fcss": "^0.3.5",

--- a/apps/smartling/frontend/package.json
+++ b/apps/smartling/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/smartling-frontend",
-  "version": "1.7.65",
+  "version": "1.7.67",
   "main": "build/index.html",
   "devDependencies": {
     "@testing-library/react": "8.0.4",


### PR DESCRIPTION
## Purpose
Force bumping version for smartling to diagnose building failures

## Approach
We have had a couple of failures in building of the project in master branch. Most seem due to tag conflicts with smartling app version. This bumps the version to a conflict free one.


