### PR TITLE
feat(color-picker): Allow removal of color chosen

### DIFF
--- a/apps/color-picker/src/components/SelectColorButton.tsx
+++ b/apps/color-picker/src/components/SelectColorButton.tsx
@@ -15,8 +15,7 @@ const styles = {
     width: '70px',
     display: 'inline-block',
     textAlign: 'left',
-  }),
-  buttonGroup: css({width: '100%'})
+  })
 };
 
 interface MenuButtonProps {
@@ -35,7 +34,7 @@ function _SelectColorButton(
   const allowRemoval = sdk.parameters.instance.allowRemoval;
 
   return (
-    <ButtonGroup withDivider className={styles.buttonGroup}>
+    <ButtonGroup withDivider>
       <Button
         endIcon={showChevron ? <ChevronDownIcon /> : undefined}
         isFullWidth

--- a/apps/color-picker/src/components/SelectColorButton.tsx
+++ b/apps/color-picker/src/components/SelectColorButton.tsx
@@ -16,6 +16,7 @@ const styles = {
     display: 'inline-block',
     textAlign: 'left',
   }),
+  buttonGroup: css({width: '100%'})
 };
 
 interface MenuButtonProps {
@@ -34,7 +35,7 @@ function _SelectColorButton(
   const allowRemoval = sdk.parameters.instance.allowRemoval;
 
   return (
-    <ButtonGroup withDivider>
+    <ButtonGroup withDivider className={styles.buttonGroup}>
       <Button
         endIcon={showChevron ? <ChevronDownIcon /> : undefined}
         isFullWidth

--- a/apps/color-picker/src/components/SelectColorButton.tsx
+++ b/apps/color-picker/src/components/SelectColorButton.tsx
@@ -1,6 +1,8 @@
-import { Button, Flex } from '@contentful/f36-components';
-import { ChevronDownIcon } from '@contentful/f36-icons';
+import { FieldExtensionSDK } from '@contentful/app-sdk';
+import { Button, ButtonGroup, Flex } from '@contentful/f36-components';
+import { ChevronDownIcon, CloseIcon } from '@contentful/f36-icons';
 import tokens from '@contentful/f36-tokens';
+import { useSDK } from '@contentful/react-apps-toolkit';
 import { css } from 'emotion';
 import { forwardRef, Ref } from 'react';
 import { Color } from '../types';
@@ -21,29 +23,40 @@ interface MenuButtonProps {
   name: string;
   value?: Color | string;
   onClick?: () => void;
+  onRemovalClick?: () => void;
 }
 
 function _SelectColorButton(
-  { showChevron, name, value, onClick }: MenuButtonProps,
+  { showChevron, name, value, onClick, onRemovalClick }: MenuButtonProps,
   ref: Ref<HTMLButtonElement>
 ) {
+  const sdk = useSDK<FieldExtensionSDK>();
+  const allowRemoval = sdk.parameters.instance.allowRemoval;
+
   return (
-    <Button
-      endIcon={showChevron ? <ChevronDownIcon /> : undefined}
-      isFullWidth
-      onClick={onClick}
-      ref={ref}
-    >
-      <Flex alignItems="center" gap="spacingXs">
-        <ColorBox color={value} />
-        <Flex gap="spacing2Xs">
-          {name}{' '}
-          <span className={styles.hexValue}>
-            {(typeof value === 'string' ? value : value?.value) ?? ''}
-          </span>
+    <ButtonGroup withDivider>
+      <Button
+        endIcon={showChevron ? <ChevronDownIcon /> : undefined}
+        isFullWidth
+        onClick={onClick}
+        ref={ref}
+      >
+        <Flex alignItems="center" gap="spacingXs">
+          <ColorBox color={value} />
+          <Flex gap="spacing2Xs">
+            {name}{' '}
+            <span className={styles.hexValue}>
+              {(typeof value === 'string' ? value : value?.value) ?? ''}
+            </span>
+          </Flex>
         </Flex>
-      </Flex>
-    </Button>
+      </Button>
+      {allowRemoval && 
+        <Button variant="secondary" startIcon={<CloseIcon />} onClick={onRemovalClick}>
+          Clear
+        </Button>
+      }
+    </ButtonGroup>
   );
 }
 

--- a/apps/color-picker/src/components/SelectColorButton.tsx
+++ b/apps/color-picker/src/components/SelectColorButton.tsx
@@ -15,7 +15,15 @@ const styles = {
     width: '70px',
     display: 'inline-block',
     textAlign: 'left',
-  })
+  }),
+  buttonGroup: css({
+    width: '100%',
+    justifyContent: 'stretch',
+  }),
+  pickerButton: css({
+    maxWidth: '100%',
+    flexGrow: 1,
+  }),
 };
 
 interface MenuButtonProps {
@@ -23,21 +31,20 @@ interface MenuButtonProps {
   name: string;
   value?: Color | string;
   onClick?: () => void;
-  onRemovalClick?: () => void;
+  onClearClick?: () => void;
 }
 
 function _SelectColorButton(
-  { showChevron, name, value, onClick, onRemovalClick }: MenuButtonProps,
+  { showChevron, name, value, onClick, onClearClick }: MenuButtonProps,
   ref: Ref<HTMLButtonElement>
 ) {
   const sdk = useSDK<FieldExtensionSDK>();
-  const allowRemoval = sdk.parameters.instance.allowRemoval;
 
   return (
-    <ButtonGroup withDivider>
+    <ButtonGroup withDivider className={styles.buttonGroup}>
       <Button
         endIcon={showChevron ? <ChevronDownIcon /> : undefined}
-        isFullWidth
+        className={styles.pickerButton}
         onClick={onClick}
         ref={ref}
       >
@@ -51,11 +58,15 @@ function _SelectColorButton(
           </Flex>
         </Flex>
       </Button>
-      {allowRemoval && 
-        <Button variant="secondary" startIcon={<CloseIcon />} onClick={onRemovalClick}>
+      {!sdk.field.required && value !== undefined && (
+        <Button
+          variant="secondary"
+          startIcon={<CloseIcon />}
+          onClick={onClearClick}
+        >
           Clear
         </Button>
-      }
+      )}
     </ButtonGroup>
   );
 }

--- a/apps/color-picker/src/locations/Field.tsx
+++ b/apps/color-picker/src/locations/Field.tsx
@@ -69,10 +69,16 @@ const Field = () => {
         return value.name;
 
       case 'undefined':
+        if (sdk.field.required) {
+          return 'Invalid';
+        } else {
+          return 'Select a color…';
+        }
+
       default:
         return 'Invalid';
     }
-  }, [allowCustomValue, theme.colors, value]);
+  }, [allowCustomValue, sdk.field.required, theme.colors, value]);
 
   return (
     <Form>
@@ -81,7 +87,7 @@ const Field = () => {
           name={name}
           value={value}
           onClick={() => customColorPicker?.current?.click()}
-          onRemovalClick={() => setValue(undefined)}
+          onClearClick={() => setValue(undefined)}
         />
       ) : (
         <Menu
@@ -90,10 +96,12 @@ const Field = () => {
           onClose={() => setIsOpen(false)}
         >
           <Menu.Trigger>
-            <SelectColorButton 
-              showChevron name={name} 
+            <SelectColorButton
+              showChevron
+              name={name}
               value={value}
-              onRemovalClick={() => setValue(undefined)} />
+              onClearClick={() => setValue(undefined)}
+            />
           </Menu.Trigger>
           <Menu.List className={styles.menuList}>
             {theme.colors.map((color: Color) => (

--- a/apps/color-picker/src/locations/Field.tsx
+++ b/apps/color-picker/src/locations/Field.tsx
@@ -32,7 +32,7 @@ const Field = () => {
 
   const storeHexValue = sdk.field.type === 'Symbol';
   const allowCustomValue = sdk.parameters.instance.withCustomValue;
-
+  const allowRemoval = sdk.parameters.instance.allowRemoval;
   // @ts-ignore
   const theme: Theme = sdk.parameters.installation.themes[0];
 
@@ -77,7 +77,7 @@ const Field = () => {
 
   return (
     <Form>
-      {theme.colors.length === 0 ? (
+      {theme.colors.length === 0 || !allowRemoval ? (
         <SelectColorButton
           name={name}
           value={value}
@@ -107,6 +107,11 @@ const Field = () => {
             {allowCustomValue && (
               <Menu.Item onClick={() => customColorPicker?.current?.click()}>
                 Custom...
+              </Menu.Item>
+            )}
+            {allowRemoval && (
+              <Menu.Item onClick={() => setValue(undefined)}>
+                Remove Selection
               </Menu.Item>
             )}
           </Menu.List>

--- a/apps/color-picker/src/locations/Field.tsx
+++ b/apps/color-picker/src/locations/Field.tsx
@@ -32,7 +32,6 @@ const Field = () => {
 
   const storeHexValue = sdk.field.type === 'Symbol';
   const allowCustomValue = sdk.parameters.instance.withCustomValue;
-  const allowRemoval = sdk.parameters.instance.allowRemoval;
   // @ts-ignore
   const theme: Theme = sdk.parameters.installation.themes[0];
 
@@ -77,11 +76,12 @@ const Field = () => {
 
   return (
     <Form>
-      {theme.colors.length === 0 || !allowRemoval ? (
+      {theme.colors.length === 0 ? (
         <SelectColorButton
           name={name}
           value={value}
           onClick={() => customColorPicker?.current?.click()}
+          onRemovalClick={() => setValue(undefined)}
         />
       ) : (
         <Menu
@@ -90,7 +90,10 @@ const Field = () => {
           onClose={() => setIsOpen(false)}
         >
           <Menu.Trigger>
-            <SelectColorButton showChevron name={name} value={value} />
+            <SelectColorButton 
+              showChevron name={name} 
+              value={value}
+              onRemovalClick={() => setValue(undefined)} />
           </Menu.Trigger>
           <Menu.List className={styles.menuList}>
             {theme.colors.map((color: Color) => (
@@ -107,11 +110,6 @@ const Field = () => {
             {allowCustomValue && (
               <Menu.Item onClick={() => customColorPicker?.current?.click()}>
                 Custom...
-              </Menu.Item>
-            )}
-            {allowRemoval && (
-              <Menu.Item onClick={() => setValue(undefined)}>
-                Remove Selection
               </Menu.Item>
             )}
           </Menu.List>


### PR DESCRIPTION
## Purpose
<!-- Why are we introducing this change now? What problem does it solve? What is the story/background for it? -->
We love the colorpicker tool and it really does work great. However, we have not found a way to remove a selection after it was made (for optional fields). This adds a button to the dropdown if you configure Allow Removal to Yes that allows you to remove your selection.

## Approach
<!-- Why did we do it the way we did? Did we consider alternatives? What other implementation details or artifacts (screenshots etc.) would help reviewers contextualize change? -->
<img width="878" alt="Screenshot 2023-01-06 at 3 29 58 PM" src="https://user-images.githubusercontent.com/4616177/211110740-3d000b75-a2d1-4577-a826-0e0e9fe76fc4.png">
The approach then looks at that boolean and will then render the `Remove Selection` menu item. 

## Dependencies and/or References
<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->
I do not have any references to the need yet. But please feel free to close this if you would not like your change in your color-picker. We've already created a custom app with my forked code to do it for us. 

## Deployment
<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
This will need a parameter change to the app to add an `allowRemoval` field that is a boolean.

