### PR TITLE
fix: learn missing token []

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ commands:
           command: |
             echo $'@contentful:registry=https://registry.npmjs.org/
             //registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> ~/.npmrc
+      - run: export GH_TOKEN=${GITHUB_TOKEN}
       - run: git config --global user.email "${GIT_AUTHOR_EMAIL}"
       - run: git config --global user.name "${GIT_AUTHOR_NAME}"
       - run:


### PR DESCRIPTION
## Purpose
Apps are not deploying due to lerna cryptic error `E404`

## Approach
From quick research, looks like lerna expects `GH_TOKEN` instead of `GITHUB_TOKEN` env var. We now export the correct var name in circleCI

