### PR TITLE
fix: update GHA workflow to only deploy commits to master or main

### DIFF
--- a/examples/typescript-github-action/.github/workflows/deploy.yml
+++ b/examples/typescript-github-action/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ jobs:
   deploy_job:
     runs-on: ubuntu-latest
     name: Deploy app to Contentful
+    if: contains(github.ref, 'main') || contains(github.ref, 'master')
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js 16.x


### PR DESCRIPTION

Added a filter so Action will only run when commits are done on either master or main branches

