### PR TITLE
replace straight quotes with curly (a.k.a. smart)

### DIFF
--- a/apps/google-analytics-4/frontend/src/locations/ConfigScreen.tsx
+++ b/apps/google-analytics-4/frontend/src/locations/ConfigScreen.tsx
@@ -213,8 +213,8 @@ const ConfigScreen = () => {
       <div className={styles.body}>
         <Heading>About Google Analytics for Contentful</Heading>
         <Paragraph>
-          The Google Analytics app displays realtime page-based analytics data from your
-          organization's Google Analytics properties alongside relevant content entries.
+          The Google Analytics app displays real-time page-based analytics data from your
+          organization’s Google Analytics properties alongside relevant content entries.
         </Paragraph>
 
         <hr className={styles.splitter} />
@@ -224,7 +224,7 @@ const ConfigScreen = () => {
             Authorization Credentials
           </Heading>
           <Paragraph>
-            Authorize this application to access page analytics data from your organization's Google
+            Authorize this application to access page analytics data from your organization’s Google
             Analytics account.
           </Paragraph>
 


### PR DESCRIPTION
## Purpose

> Curly quotes are typically preferred by writers today because they're more legible and flow better with the content. Straight quotes rarely have a place in any type of modern writing or typography, the technique, and art of arranging type.

Also fixes grammatical issue with `realtime` – a common misspelling of `real time` (noun) or `real-time` (adjective). In this case we are using the adjective to describe that the information is communicated or presented at the same time as it happens.

## Approach
Always use "smart quotes" (a.k.a. curly quotes) in copywriting.