### PR TITLE
fix lambda-offline conf

### DIFF
--- a/apps/google-analytics-4/lambda/serverless.yml
+++ b/apps/google-analytics-4/lambda/serverless.yml
@@ -14,9 +14,8 @@ provider:
 
 functions:
   api:
-    handler: build/index.handler
+    handler: build/src/index.handler
     events:
       - http:
           path: /{any+}
           method: ANY
-


### PR DESCRIPTION
## Purpose
fix dev env issue:
![image](https://user-images.githubusercontent.com/492573/213738724-6fc097d8-a505-4e64-ad99-3aa4be00d545.png)


## Approach
properly reference new handler path after `test` was added – our understanding is that it used to be implicitly in the build/ root dir and now it's nested because there are both `src` and `test` within it after the changes made here:
https://github.com/contentful/apps/blob/4e6d6d98f604953ba027ec2bb94eaf736c98476c/apps/google-analytics-4/lambda/tsconfig.json#L6