### PR TITLE
fix: slack base URL for prod []

### DIFF
--- a/apps/slack/frontend/package.json
+++ b/apps/slack/frontend/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "start": "PORT=1234 cross-env BROWSER=none react-scripts start",
-    "build": "react-scripts build",
+    "build": "REACT_APP_BACKEND_BASE_URL=$REACT_APP_SLACK_BACKEND_BASE_URL react-scripts build",
     "test": "SKIP_PREFLIGHT_CHECK=true react-scripts test",
     "eject": "react-scripts eject",
     "lint": "eslint --ext .ts,.tsx,.js,.jsx,.svg ./",


### PR DESCRIPTION
## Purpose
The env var in CI was not matching env var used in code. Hardcoding the env var for now when building and will follow up with correct env var usage in staging vs prod

