### PR TITLE
chore: separate staging vs prod []

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,8 @@ commands:
           command: |
             STATIC_S3_BASE="s3://cf-apps-static-dev/apps-test-$CIRCLE_SHA1" \
                 STATIC_JIRA_S3_BASE="s3://cf-apps-static-dev/apps-test-$CIRCLE_SHA1/jira" \
+                REACT_APP_BACKEND_BASE_URL=$BACKEND_BASE_URL_TEST \
+                REACT_APP_SLACK_CLIENT_ID=$SLACK_CLIENT_ID_TEST \
                 STAGE='test' npm run deploy:test
       - run:
           name: Invalidate Slack staging cloudfront distribution
@@ -45,6 +47,8 @@ commands:
           command: |
             STATIC_S3_BASE="s3://cf-apps-static/apps" \
                 STATIC_JIRA_S3_BASE="s3://cf-apps-jira" \
+                REACT_APP_BACKEND_BASE_URL=$REACT_APP_SLACK_BACKEND_BASE_URL \
+                REACT_APP_SLACK_CLIENT_ID=$REACT_APP_SLACK_CLIENT_ID \
                 STAGE='prd' npm run deploy
       - run:
           name: Invalidate Slack cloudfront distribution

--- a/apps/slack/frontend/package.json
+++ b/apps/slack/frontend/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "start": "PORT=1234 cross-env BROWSER=none react-scripts start",
-    "build": "REACT_APP_BACKEND_BASE_URL=$REACT_APP_SLACK_BACKEND_BASE_URL react-scripts build",
+    "build": "react-scripts build",
     "test": "SKIP_PREFLIGHT_CHECK=true react-scripts test",
     "eject": "react-scripts eject",
     "lint": "eslint --ext .ts,.tsx,.js,.jsx,.svg ./",


### PR DESCRIPTION
## Purpose
Separating prod vs staging deployment processes

## Approach
Previously on https://github.com/contentful/apps/pull/2383, we hardcoded slack env vars which were the same regardless of deployment stage. We now separate env vars depending on the stage (i.e: staging vs prod)

