### PR TITLE
Increase Slack notifications limit to 15

### DIFF
--- a/apps/slack/frontend/src/components/NotificationsPanel.tsx
+++ b/apps/slack/frontend/src/components/NotificationsPanel.tsx
@@ -25,7 +25,7 @@ import { useCMA, useSDK } from '@contentful/react-apps-toolkit';
 import { AppExtensionSDK } from '@contentful/app-sdk';
 import { byChannelName } from '../utils';
 
-const NOTIFICATION_LIMIT = 8;
+const NOTIFICATION_LIMIT = 15;
 
 interface Props {
   workspace: ConnectedWorkspace;


### PR DESCRIPTION
## Purpose
We currently limit Slack notifications to 8, which can easily be hit by enterprise companies. This limit is arbitrary and was selected generally to reduce potential infrastructure costs. We're proposing boosting this limit to 15 notifications, which is expected to produce a nominal increase in infrastructure spend (sub $100/mo) and ease direct customer concerns. Over time, we can evaluate if a higher limited is needed.

## Approach
I roughly doubled the number of concurrent notifications. No real approach or strategy to this - more an experiment to see if anyone needs more than 15 and why.

## Dependencies and/or References
https://contentful.slack.com/archives/C043PUB0339/p1675092171997299

## Deployment
