### PR TITLE
chore: add semver []

### DIFF
--- a/.contentful/vault-secrets.yaml
+++ b/.contentful/vault-secrets.yaml
@@ -5,6 +5,6 @@ services:
       - dependabot
   circleci:
     policies:
-      - semantic-release
+      - semantic-release-ecosystem
       - aws-push-artifacts:
           account-id: "017078452822"


### PR DESCRIPTION
## Purpose
Due to failures in releases in master - we should use the correct vault orb as other public repos

## Approach
semantic-release-ecosystem is the preferred way to go forward.

