### PR TITLE
chore(deploy): fix app names and version to avoid clash []

### DIFF
--- a/apps/jira/functions/package.json
+++ b/apps/jira/functions/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@contentful/functions",
-  "version": "1.4.106",
+  "name": "@contentful/jira-functions",
+  "version": "1.4.107",
   "main": "index.js",
   "private": true,
   "scripts": {

--- a/apps/slack/lambda/package.json
+++ b/apps/slack/lambda/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "lambda",
+  "name": "slack-lambda",
   "private": true,
   "version": "1.1.9",
   "main": "index.js",


### PR DESCRIPTION
## Purpose
We keep trying to tag an existing tag. Manually update it for now to unblock things

## Approach
Also changing names to make it easier to manually catch what app is breaking as opposed to just seeing `lambda`


