### PR TITLE
chore(lerna): avoid pushing git tags []

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "lerna run test:ci --concurrency=1 --stream",
     "deploy": "lerna run deploy --concurrency=3",
     "deploy:test": "lerna run deploy:test --concurrency=3",
-    "publish-packages": "lerna version --conventional-commits --create-release github --yes && lerna publish from-git --yes",
+    "publish-packages": "lerna version --no-git-tag-version --conventional-commits --yes && lerna publish from-packages --yes",
     "prettier": "prettier --no-editorconfig --no-error-on-unmatched-pattern --write {apps,packages,examples}/**/*.{js,jsx,ts,tsx}",
     "prepare": "husky install"
   },


### PR DESCRIPTION
## Purpose
It's becoming impractical to catch up to all git tag conflicts and in turn we can't deploy any changes. We only need publishing for app packages which do not upgrade as often. The conflicts are usually in apps directory which doesn't need any tagging.

## Approach
Remove lerna git tagging and instead use default lerna publishing. 

- [x] Qn: will this still publish without tags?
