### PR TITLE
chore: change env vars for react []

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
           command: |
             STATIC_S3_BASE="s3://cf-apps-static/apps" \
                 STATIC_JIRA_S3_BASE="s3://cf-apps-jira" \
-                REACT_APP_BACKEND_BASE_URL=$PROD_APP_SLACK_BACKEND_BASE_URL \
+                REACT_APP_BACKEND_BASE_URL=$APP_SLACK_BACKEND_BASE_URL_PROD \
                 REACT_APP_SLACK_CLIENT_ID=$SLACK_CLIENT_ID_PROD \
                 STAGE='prd' npm run deploy
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,8 @@ jobs:
       - image: cimg/base:stable
     resource_class: medium+
     steps:
+        - checkout
+        - node/install
         - vault/get-secrets:
             template-preset: "aws-push-artifacts"
         - run:
@@ -82,6 +84,8 @@ jobs:
     steps:
       - vault/get-secrets:
           template-preset: "aws-push-artifacts"
+      - checkout
+      - node/install
       - run:
           name: Install awscli
           command: |
@@ -94,6 +98,7 @@ jobs:
                 REACT_APP_BACKEND_BASE_URL=$APP_SLACK_BACKEND_BASE_URL_PROD \
                 REACT_APP_SLACK_CLIENT_ID=$SLACK_CLIENT_ID_PROD \
                 npm run build
+      - publish
       - run:
           name: Deploy apps to prod
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ commands:
           command: |
             STATIC_S3_BASE="s3://cf-apps-static/apps" \
                 STATIC_JIRA_S3_BASE="s3://cf-apps-jira" \
-                REACT_APP_BACKEND_BASE_URL=$REACT_APP_SLACK_BACKEND_BASE_URL \
+                REACT_APP_BACKEND_BASE_URL=$PROD_APP_SLACK_BACKEND_BASE_URL \
                 REACT_APP_SLACK_CLIENT_ID=$REACT_APP_SLACK_CLIENT_ID \
                 STAGE='prd' npm run deploy
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
       - run:
           name: Build
           command: |
-                REACT_APP_BACKEND_BASE_URL=$PROD_APP_SLACK_BACKEND_BASE_URL \
+                REACT_APP_BACKEND_BASE_URL=$APP_SLACK_BACKEND_BASE_URL_PROD \
                 REACT_APP_SLACK_CLIENT_ID=$SLACK_CLIENT_ID_PROD \
                 npm run build
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ jobs:
           name: Build
           command: |
                 REACT_APP_BACKEND_BASE_URL=$PROD_APP_SLACK_BACKEND_BASE_URL \
-                REACT_APP_SLACK_CLIENT_ID=$REACT_APP_SLACK_CLIENT_ID \
+                REACT_APP_SLACK_CLIENT_ID=$SLACK_CLIENT_ID_PROD \
                 npm run build
       - run:
           name: Deploy apps to prod
@@ -100,7 +100,7 @@ jobs:
             STATIC_S3_BASE="s3://cf-apps-static/apps" \
                 STATIC_JIRA_S3_BASE="s3://cf-apps-jira" \
                 REACT_APP_BACKEND_BASE_URL=$PROD_APP_SLACK_BACKEND_BASE_URL \
-                REACT_APP_SLACK_CLIENT_ID=$REACT_APP_SLACK_CLIENT_ID \
+                REACT_APP_SLACK_CLIENT_ID=$SLACK_CLIENT_ID_PROD \
                 STAGE='prd' npm run deploy
       - run:
           name: Invalidate Slack cloudfront distribution

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,41 +21,8 @@ commands:
           name: Publish packages
           command: npm run publish-packages
 
-  deploy:
-    steps:
-      - vault/get-secrets:
-          template-preset: "aws-push-artifacts"
-      - run:
-          name: Install awscli
-          command: |
-            sudo apt-get update
-            sudo apt-get install python3-pip python3-dev
-            sudo pip3 install awscli
-      - run:
-          name: Deploy apps to test
-          command: |
-            STATIC_S3_BASE="s3://cf-apps-static-dev/apps-test-$CIRCLE_SHA1" \
-                STATIC_JIRA_S3_BASE="s3://cf-apps-static-dev/apps-test-$CIRCLE_SHA1/jira" \
-                REACT_APP_BACKEND_BASE_URL=$BACKEND_BASE_URL_TEST \
-                REACT_APP_SLACK_CLIENT_ID=$SLACK_CLIENT_ID_TEST \
-                STAGE='test' npm run deploy:test
-      - run:
-          name: Invalidate Slack staging cloudfront distribution
-          command: aws cloudfront create-invalidation --distribution-id $SLACK_TEST_CLOUDFRONT_DIST_ID --paths "/*"
-      - run:
-          name: Deploy apps to prod
-          command: |
-            STATIC_S3_BASE="s3://cf-apps-static/apps" \
-                STATIC_JIRA_S3_BASE="s3://cf-apps-jira" \
-                REACT_APP_BACKEND_BASE_URL=$PROD_APP_SLACK_BACKEND_BASE_URL \
-                REACT_APP_SLACK_CLIENT_ID=$REACT_APP_SLACK_CLIENT_ID \
-                STAGE='prd' npm run deploy
-      - run:
-          name: Invalidate Slack cloudfront distribution
-          command: aws cloudfront create-invalidation --distribution-id $SLACK_PRD_CLOUDFRONT_DIST_ID --paths "/*"
-
 jobs:
-  apps:
+  apps-test:
     docker:
       - image: cimg/base:stable
     resource_class: medium+
@@ -76,14 +43,68 @@ jobs:
       - run:
           name: Test
           command: npm run test
+
+  deploy-staging:
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium+
+    steps:
+        - vault/get-secrets:
+            template-preset: "aws-push-artifacts"
+        - run:
+            name: Install awscli
+            command: |
+              sudo apt-get update
+              sudo apt-get install python3-pip python3-dev
+              sudo pip3 install awscli
+        - run:
+            name: Build
+            command: |
+                  REACT_APP_BACKEND_BASE_URL=$BACKEND_BASE_URL_TEST \
+                  REACT_APP_SLACK_CLIENT_ID=$SLACK_CLIENT_ID_TEST \
+                  npm run build
+        - run:
+            name: Deploy apps to staging
+            command: |
+              STATIC_S3_BASE="s3://cf-apps-static-dev/apps-test-$CIRCLE_SHA1" \
+                  STATIC_JIRA_S3_BASE="s3://cf-apps-static-dev/apps-test-$CIRCLE_SHA1/jira" \
+                  REACT_APP_BACKEND_BASE_URL=$BACKEND_BASE_URL_TEST \
+                  REACT_APP_SLACK_CLIENT_ID=$SLACK_CLIENT_ID_TEST \
+                  STAGE='test' npm run deploy:test
+        - run:
+            name: Invalidate Slack staging cloudfront distribution
+            command: aws cloudfront create-invalidation --distribution-id $SLACK_TEST_CLOUDFRONT_DIST_ID --paths "/*"
+
+  deploy-prod:
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium+
+    steps:
+      - vault/get-secrets:
+          template-preset: "aws-push-artifacts"
       - run:
-          name: Exit successfully if not in master
+          name: Install awscli
           command: |
-            if [ "$CIRCLE_BRANCH" != "master" ]; then
-                circleci-agent step halt
-            fi
-      - publish
-      - deploy
+            sudo apt-get update
+            sudo apt-get install python3-pip python3-dev
+            sudo pip3 install awscli
+      - run:
+          name: Build
+          command: |
+                REACT_APP_BACKEND_BASE_URL=$PROD_APP_SLACK_BACKEND_BASE_URL \
+                REACT_APP_SLACK_CLIENT_ID=$REACT_APP_SLACK_CLIENT_ID \
+                npm run build
+      - run:
+          name: Deploy apps to prod
+          command: |
+            STATIC_S3_BASE="s3://cf-apps-static/apps" \
+                STATIC_JIRA_S3_BASE="s3://cf-apps-jira" \
+                REACT_APP_BACKEND_BASE_URL=$PROD_APP_SLACK_BACKEND_BASE_URL \
+                REACT_APP_SLACK_CLIENT_ID=$REACT_APP_SLACK_CLIENT_ID \
+                STAGE='prd' npm run deploy
+      - run:
+          name: Invalidate Slack cloudfront distribution
+          command: aws cloudfront create-invalidation --distribution-id $SLACK_PRD_CLOUDFRONT_DIST_ID --paths "/*"
 
   test-ts-example:
     docker:
@@ -121,8 +142,26 @@ workflows:
   version: 2
   test-deploy:
     jobs:
-      - apps:
+      - apps-test:
           context:
             - vault
+      - deploy-staging:
+          context:
+            - vault
+          requires:
+            - apps-test
+          filters:
+            branches:
+              only:
+                - master
+      - deploy-prod:
+          context:
+            - vault
+          requires:
+            - apps-test
+          filters:
+            branches:
+              only:
+                - master
       - test-ts-example
       - test-js-example


### PR DESCRIPTION
## Purpose
Fixing slack app URL by removing CRA prefix.

## Approach
For some reason build process was linking the URL as:

```js
const backendURL = {
   REACT_APP_SLACK_BACKEND_BASE_URL: "http://someURL"
}.REACT_APP_BACKEND_BASE_URL
```
Note the difference between the two property names. Any [`REACT_APP_` prefix will be exposed in the build process](https://create-react-app.dev/docs/adding-custom-environment-variables/#adding-development-environment-variables-in-env). This avoids the whole problem

Also adding a cleaner and more efficient deployment process.

## Dependencies and/or References
<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment
<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
