### PR TITLE
Feature/INTEG-86: Add listAccountSummaries Endpoint and Handle API errors

### DIFF
--- a/apps/google-analytics-4/frontend/src/components/InstalledServiceAccountKey.tsx
+++ b/apps/google-analytics-4/frontend/src/components/InstalledServiceAccountKey.tsx
@@ -44,7 +44,6 @@ const InstalledServiceAccountKey = ({
   serviceAccountKeyId,
   serviceAccountKey,
 }: InstalledServiceAccountKeyProps) => {
-  const [credentialsData, setCredentialsData] = useState<Credentials | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -56,16 +55,12 @@ const InstalledServiceAccountKey = ({
   useEffect(() => {
     (async () => {
       try {
-        const credentials = await api.getCredentials();
-        setCredentialsData(credentials);
-
         const accountSummaries = await api.listAccountSummaries();
         if (accountSummaries.length === 0 ) {
-          throw new ApiError("")
+          throw new ApiError("You need to make sure your service account is added to the property you want to connect this space to. Right now, your service account isn't connected to any Analytics properties.")
         }
         else setError(null);
       } catch (e) {
-        setCredentialsData(null);
         if (e instanceof ApiError) {
           setError(e.message);
         } else {
@@ -110,8 +105,8 @@ const InstalledServiceAccountKey = ({
             <Skeleton.Container svgHeight={21}>
               <Skeleton.DisplayText lineHeight={21} />
             </Skeleton.Container>
-          ) : error === null ? (
-            <Badge variant="positive">{credentialsData?.status}</Badge>
+          ) : !error ? (
+            <Badge variant="positive">Active</Badge>
           ) : (
             <>
               <Badge variant="warning">Inactive</Badge>

--- a/apps/google-analytics-4/frontend/src/components/InstalledServiceAccountKey.tsx
+++ b/apps/google-analytics-4/frontend/src/components/InstalledServiceAccountKey.tsx
@@ -1,4 +1,4 @@
-import { Badge, Box, Flex, Heading, Skeleton, TextLink } from '@contentful/f36-components';
+import { Badge, Box, Flex, Heading, Skeleton, TextLink, Note } from '@contentful/f36-components';
 import { ExternalLinkTrimmedIcon } from '@contentful/f36-icons';
 import tokens from '@contentful/f36-tokens';
 import { css } from 'emotion';
@@ -30,6 +30,9 @@ const styles = {
       marginBottom: tokens.spacingS,
     },
   }),
+  errorNote: css({
+    marginTop: tokens.spacing2Xs
+  })
 };
 
 interface InstalledServiceAccountKeyProps {
@@ -53,9 +56,13 @@ const InstalledServiceAccountKey = ({
   useEffect(() => {
     (async () => {
       try {
-        const response = await api.getCredentials();
-        setCredentialsData(response);
-        setError(null);
+        const credentials = await api.getCredentials();
+        const accountSummaries = await api.listAccountSummaries();
+        setCredentialsData(credentials);
+        if (accountSummaries.length === 0 ) {
+          throw new ApiError("You need to make sure your service account is added to the property you want to connect this space to. Right now, your service account isn't connected to any Analytics properties.")
+        }
+        else setError(null);
       } catch (e) {
         setCredentialsData(null);
         if (e instanceof ApiError) {
@@ -105,8 +112,11 @@ const InstalledServiceAccountKey = ({
           ) : error === null ? (
             <Badge variant="positive">{credentialsData?.status}</Badge>
           ) : (
-            <Badge variant="secondary">unknown</Badge>
-          )}
+            <>
+              <Badge variant="warning">Inactive</Badge>
+              <Note variant="neutral" className={styles.errorNote}>{error}</Note>
+            </>
+          ) }
         </dd>
       </dl>
     </Box>

--- a/apps/google-analytics-4/frontend/src/components/InstalledServiceAccountKey.tsx
+++ b/apps/google-analytics-4/frontend/src/components/InstalledServiceAccountKey.tsx
@@ -57,10 +57,11 @@ const InstalledServiceAccountKey = ({
     (async () => {
       try {
         const credentials = await api.getCredentials();
-        const accountSummaries = await api.listAccountSummaries();
         setCredentialsData(credentials);
+
+        const accountSummaries = await api.listAccountSummaries();
         if (accountSummaries.length === 0 ) {
-          throw new ApiError("You need to make sure your service account is added to the property you want to connect this space to. Right now, your service account isn't connected to any Analytics properties.")
+          throw new ApiError("")
         }
         else setError(null);
       } catch (e) {

--- a/apps/google-analytics-4/frontend/src/components/InstalledServiceAccountKey.tsx
+++ b/apps/google-analytics-4/frontend/src/components/InstalledServiceAccountKey.tsx
@@ -3,7 +3,7 @@ import { ExternalLinkTrimmedIcon } from '@contentful/f36-icons';
 import tokens from '@contentful/f36-tokens';
 import { css } from 'emotion';
 import { useEffect, useState } from 'react';
-import { ApiError, Credentials } from '../services/api';
+import { ApiError } from '../services/api';
 
 import type { ServiceAccountKey, ServiceAccountKeyId } from '../types';
 import { useApi } from '../hooks/useApi';
@@ -106,7 +106,7 @@ const InstalledServiceAccountKey = ({
               <Skeleton.DisplayText lineHeight={21} />
             </Skeleton.Container>
           ) : !error ? (
-            <Badge variant="positive">Active</Badge>
+            <Badge variant="positive">active</Badge>
           ) : (
             <>
               <Badge variant="warning">Inactive</Badge>

--- a/apps/google-analytics-4/frontend/src/services/api.spec.ts
+++ b/apps/google-analytics-4/frontend/src/services/api.spec.ts
@@ -118,8 +118,10 @@ describe('Api', () => {
   });
 
   describe('listAccountSummaries()', () => {
+    const appDefinitionId = 'abc123xyz';
+
     it('returns a set of credentials', async () => {
-      const api = new Api();
+      const api = new Api(appDefinitionId, mockCma, validServiceKeyId, validServiceKeyFile);
       const result = await api.listAccountSummaries();
       expect(result).toEqual(expect.arrayContaining([expect.objectContaining(mockAccountSummary)]));
     });

--- a/apps/google-analytics-4/frontend/src/services/api.spec.ts
+++ b/apps/google-analytics-4/frontend/src/services/api.spec.ts
@@ -3,6 +3,7 @@ import { rest } from 'msw';
 import { server } from '../../test/mocks/api/server';
 import { Api, ApiClientError, ApiError, ApiServerError, fetchFromApi } from './api';
 import { mockCma, validServiceKeyFile, validServiceKeyId } from '../../test/mocks';
+import { mockAccountSummary } from '../../test/mocks/api/mockData';
 
 describe('fetchFromApi()', () => {
   const ZSomeSchema = z.object({ foo: z.string() });
@@ -113,6 +114,14 @@ describe('Api', () => {
       const api = new Api(appDefinitionId, mockCma, validServiceKeyId, validServiceKeyFile);
       const result = await api.getCredentials();
       expect(result).toEqual(expect.objectContaining({ status: 'active' }));
+    });
+  });
+
+  describe('listAccountSummaries()', () => {
+    it('returns a set of credentials', async () => {
+      const api = new Api();
+      const result = await api.listAccountSummaries();
+      expect(result).toEqual(expect.arrayContaining([expect.objectContaining(mockAccountSummary)]));
     });
   });
 });

--- a/apps/google-analytics-4/frontend/src/services/api.ts
+++ b/apps/google-analytics-4/frontend/src/services/api.ts
@@ -56,11 +56,16 @@ async function fetchResponse(
   headers: Headers
 ): Promise<Response> {
   try {
-    return await fetchWithSignedRequest(url, appDefinitionId, cma, 'GET', headers);
+    const signedResponse = await fetchWithSignedRequest(url, appDefinitionId, cma, 'GET', headers);
+    if (!signedResponse.ok) {
+      const { errors } = await signedResponse.json();
+      throw new ApiError(errors.message);
+    }
+    else return signedResponse;
+
   } catch (e) {
     if (e instanceof TypeError) {
       const errorMessage = e.message;
-      console.error(e);
       throw new ApiError(errorMessage);
     }
     throw e;

--- a/apps/google-analytics-4/frontend/src/services/api.ts
+++ b/apps/google-analytics-4/frontend/src/services/api.ts
@@ -8,6 +8,25 @@ const ZCredentials = z.object({
   status: z.string(),
 });
 
+const ZPropertySummary = z.object({
+  property: z.string(),
+  displayName: z.string(),
+  propertyType: z.string(),
+});
+export type PropertySummary = z.infer<typeof ZPropertySummary>;
+
+const ZAccountSummary = z.object({
+  name: z.string(),
+  account: z.string(),
+  displayName: z.string(),
+  propertySummaries: z.array(ZPropertySummary),
+});
+
+export type AccountSummary = z.infer<typeof ZAccountSummary>;
+
+const ZAccountSummaries = z.array(ZAccountSummary);
+export type AccountSummaries = z.infer<typeof ZAccountSummaries>;
+
 type Headers = Record<string, string>;
 
 export type Credentials = z.infer<typeof ZCredentials>;
@@ -120,6 +139,16 @@ export class Api {
   private requestUrl(apiPath: string): URL {
     const url = `${this.baseUrl}/${apiPath}`;
     return new URL(url);
+  }
+
+  async listAccountSummaries(): Promise<AccountSummaries> {
+    return await fetchFromApi<AccountSummaries>(
+      this.requestUrl('api/account_summaries'),
+      ZAccountSummaries,
+      this.appDefinitionId,
+      this.cma,
+      this.serviceAccountKeyHeaders
+    );
   }
 
   private get serviceAccountKeyHeaders(): Headers {

--- a/apps/google-analytics-4/frontend/test/mocks/api/handlers.ts
+++ b/apps/google-analytics-4/frontend/test/mocks/api/handlers.ts
@@ -1,5 +1,6 @@
 import { rest } from 'msw';
 import { config } from '../../../src/config';
+import { mockAccountSummary } from './mockData';
 
 const apiRoot = config.backendApiUrl;
 
@@ -10,5 +11,9 @@ export const apiPath = (path: string) => {
 export const handlers = [
   rest.get(apiPath('/api/credentials'), (_req, res, ctx) => {
     return res(ctx.json({ status: 'active' }));
+  }),
+
+  rest.get(apiPath('/api/account_summaries'), (_req, res, ctx) => {
+    return res(ctx.json([mockAccountSummary]));
   }),
 ];

--- a/apps/google-analytics-4/frontend/test/mocks/api/mockData.ts
+++ b/apps/google-analytics-4/frontend/test/mocks/api/mockData.ts
@@ -1,0 +1,19 @@
+export const mockAccountSummary = {
+    propertySummaries: [
+      {
+        property: 'properties/34567890',
+        displayName: 'Property 2',
+        propertyType: 'PROPERTY_TYPE_ORDINARY',
+        parent: 'accounts/12345678',
+      },
+      {
+        property: 'properties/23456789',
+        displayName: 'Property 2',
+        propertyType: 'PROPERTY_TYPE_ORDINARY',
+        parent: 'accounts/12345678',
+      },
+    ],
+    name: 'accountSummaries/12345678',
+    account: 'accounts/12345678',
+    displayName: 'Account',
+  };

--- a/apps/google-analytics-4/lambda/src/app.ts
+++ b/apps/google-analytics-4/lambda/src/app.ts
@@ -70,18 +70,23 @@ app.get('/api/credentials', (_req, res) => {
   res.status(200).json({ status: 'active' });
 });
 
-app.get('/api/account_summaries', async (req, res) => {
-  const serviceAccountKeyFile = req.serviceAccountKey;
+app.get('/api/account_summaries', async (req, res, next) => {
+  try {
+    const serviceAccountKeyFile = req.serviceAccountKey;
 
-  if (serviceAccountKeyFile === undefined) {
-    // intentional runtime error because the middleware already handles this. typescript
-    // just doesn't realize
-    throw new Error('missing service account key value');
+    if (serviceAccountKeyFile === undefined) {
+      // intentional runtime error because the middleware already handles this. typescript
+      // just doesn't realize
+      throw new Error('missing service account key value');
+    }
+
+    const googleApi = GoogleApi.fromServiceAccountKeyFile(serviceAccountKeyFile);
+    const result = await googleApi.listAccountSummaries();
+    res.status(200).json(result);
+  } catch (err) {
+    // pass to apiErrorHandler
+    next(err)
   }
-
-  const googleApi = GoogleApi.fromServiceAccountKeyFile(serviceAccountKeyFile);
-  const result = await googleApi.listAccountSummaries();
-  res.status(200).json(result);
 });
 
 // catch and handle errors

--- a/apps/google-analytics-4/lambda/src/lib/errors/middlewares.spec.ts
+++ b/apps/google-analytics-4/lambda/src/lib/errors/middlewares.spec.ts
@@ -35,9 +35,10 @@ describe('apiErrorHandler', () => {
     it('returns a generic 500 error', async () => {
       const response = await chai.request(app).get('/test');
       expect(response).to.have.status(500);
-      expect(response.body).to.have.property('errorType', 'ServerError');
-      expect(response.body).to.have.property('message', 'Internal Server Error');
-      expect(response.body).to.have.property('details');
+      console.log(response.body)
+      expect(response.body.errors).to.have.property('errorType', 'ServerError');
+      expect(response.body.errors).to.have.property('message', 'Internal Server Error');
+      expect(response.body.errors).to.have.property('details');
     });
   });
 
@@ -51,9 +52,9 @@ describe('apiErrorHandler', () => {
     it('returns an error with the same status code and properties', async () => {
       const response = await chai.request(app).get('/test');
       expect(response).to.have.status(403);
-      expect(response.body).to.have.property('errorType', 'MyError');
-      expect(response.body).to.have.property('message', 'boom!');
-      expect(response.body.details).to.have.property('foo', 'bar');
+      expect(response.body.errors).to.have.property('errorType', 'MyError');
+      expect(response.body.errors).to.have.property('message', 'boom!');
+      expect(response.body.errors.details).to.have.property('foo', 'bar');
     });
   });
 });

--- a/apps/google-analytics-4/lambda/src/lib/errors/middlewares.spec.ts
+++ b/apps/google-analytics-4/lambda/src/lib/errors/middlewares.spec.ts
@@ -35,7 +35,6 @@ describe('apiErrorHandler', () => {
     it('returns a generic 500 error', async () => {
       const response = await chai.request(app).get('/test');
       expect(response).to.have.status(500);
-      console.log(response.body)
       expect(response.body.errors).to.have.property('errorType', 'ServerError');
       expect(response.body.errors).to.have.property('message', 'Internal Server Error');
       expect(response.body.errors).to.have.property('details');

--- a/apps/google-analytics-4/lambda/src/lib/verify-signed-request-middleware.spec.ts
+++ b/apps/google-analytics-4/lambda/src/lib/verify-signed-request-middleware.spec.ts
@@ -31,7 +31,7 @@ describe('verifySignedRequestMiddleware', () => {
     it('returns 403 Unauthorized', async () => {
       const response = await chai.request(app).get('/api/credentials');
       expect(response).to.have.status(403);
-      expect(response.body).to.have.property(
+      expect(response.body.errors).to.have.property(
         'message',
         'Request does not have a valid request signature. See: https://www.contentful.com/developers/docs/extensibility/app-framework/request-verification/'
       );


### PR DESCRIPTION
## Purpose
We want to provide actionable feedback to space admins if their service account is missing access to any Google Analytics properties.

## Approach
I adjusted some of the error handling on the lambda side so we could destructure the data/errors out of the `fetch()` call. Also piggy backed on the current errors we have on the lambda side instead of custom ones, with the exception of the case where the service account user is not added to any analytics dashboards yet, in which case we have a custom error text on the frontend for this. 
