### PR TITLE
Feature/INTEG-139: Replace link to Google documentation with help center link

### DIFF
--- a/apps/google-analytics-4/frontend/src/components/FormControlServiceAccountKey.tsx
+++ b/apps/google-analytics-4/frontend/src/components/FormControlServiceAccountKey.tsx
@@ -103,7 +103,7 @@ const FormControlServiceAccountKey = ({
           <TextLink
             icon={<ExternalLinkTrimmedIcon />}
             alignIcon="end"
-            href="https://cloud.google.com/iam/docs/understanding-service-accounts"
+            href="https://www.contentful.com/help/google-analytics-service-account-setup/"
             target="_blank"
             rel="noopener noreferrer"
           >
@@ -118,7 +118,7 @@ const FormControlServiceAccountKey = ({
           <TextLink
             icon={<ExternalLinkTrimmedIcon />}
             alignIcon="end"
-            href="https://cloud.google.com/iam/docs/understanding-service-accounts"
+            href="https://www.contentful.com/help/google-analytics-service-account-setup/"
             target="_blank"
             rel="noopener noreferrer"
           >


### PR DESCRIPTION
## Purpose
Replacing the link in the Config screen to point to the help center doc instead of pointing to the Google documentation (which is confusing and voluminous). 

## Dependencies and/or References
[<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->](https://contentful.atlassian.net/browse/INTEG-139)

