### PR TITLE
fix: [] change to start script in vue

### DIFF
--- a/examples/vue/package.json
+++ b/examples/vue/package.json
@@ -2,7 +2,7 @@
   "name": "vue-template",
   "version": "0.0.0",
   "scripts": {
-    "dev": "vite",
+    "start": "vite",
     "build": "vue-tsc --noEmit && vite build",
     "preview": "vite preview --port 5050",
     "test:unit": "vitest --environment jsdom",


### PR DESCRIPTION
We recommend to run `npm start` after the cca script, but there is no start script in the vue template.

