### PR TITLE
INTEG-133/ ga-4 domain management and API gateway

### DIFF
--- a/apps/google-analytics-4/lambda/package.json
+++ b/apps/google-analytics-4/lambda/package.json
@@ -12,7 +12,6 @@
     "test": "TS_NODE_TRANSPILE_ONLY=1 mocha",
     "test:debug": "TS_NODE_TRANSPILE_ONLY=1 mocha -- --inspect --inspect-brk",
     "test:watch": "TS_NODE_TRANSPILE_ONLY=1 mocha --watch --watch-files src --watch-files test",
-    // "deploy": "sls deploy",
     "deploy:test": "SLS_DEBUG=* STAGE=test sls deploy"
   },
   "keywords": [],

--- a/apps/google-analytics-4/lambda/package.json
+++ b/apps/google-analytics-4/lambda/package.json
@@ -11,7 +11,9 @@
     "start:dev": "nodemon",
     "test": "TS_NODE_TRANSPILE_ONLY=1 mocha",
     "test:debug": "TS_NODE_TRANSPILE_ONLY=1 mocha -- --inspect --inspect-brk",
-    "test:watch": "TS_NODE_TRANSPILE_ONLY=1 mocha --watch --watch-files src --watch-files test"
+    "test:watch": "TS_NODE_TRANSPILE_ONLY=1 mocha --watch --watch-files src --watch-files test",
+    // "deploy": "sls deploy",
+    "deploy:test": "SLS_DEBUG=* STAGE=test sls deploy"
   },
   "keywords": [],
   "author": "",

--- a/apps/google-analytics-4/lambda/serverless.yml
+++ b/apps/google-analytics-4/lambda/serverless.yml
@@ -26,6 +26,9 @@ custom:
     createRoute53Record: true
     endpointType: 'edge'
     securityPolicy: tls_1_2
+  frontendUrl: 
+    prd: 'https://ga4.ctfapps.net/index.html'
+    test: 'http://localhost:3000'
   serverless-offline:
     httpPort: 8080
 
@@ -60,13 +63,12 @@ functions:
       GA4_CLIENT_ID: ${self:custom.oauthCredentials.client_id}
       GA4_CLIENT_SECRET: ${self:custom.oauthCredentials.client_secret}
       GA4_SIGNING_SECRET: ${self:custom.ga4SigningSecret.signing_secret}
-      FRONTEND_URL: ${self:custom.frontendUrl}
+      FRONTEND_URL: ${self:custom.frontendUrl.${env:STAGE, 'test'}}
       WORKFLOWS_URL: ${self:custom.workflowsUrl}
       BACKEND_URL: https://${self:custom.customDomain.domainName}/api
       SIGNING_SECRET: ${self:custom.signingSecret.signing_secret}
       PRIVATE_APP_KEY: ${self:custom.app.privateKey}
-      APP_ID: ${self:custom.app.id}
-      SERVERLESS_PATH_PREFIX: ${self:custom.serverless.pathPrefix}
+      APP_ID: ${self:custom.appDefinitionId.prd}
       BASE_URL: ${self:custom.baseUrl}
     handler: build/src/index.handler
     events:

--- a/apps/google-analytics-4/lambda/serverless.yml
+++ b/apps/google-analytics-4/lambda/serverless.yml
@@ -29,7 +29,7 @@ provider:
   timeout: 30
   deploymentBucket:
     name: cf-apps-serverless-deployment
-  deploymentPrefix: sls-apps-ga4-build
+  deploymentPrefix: sls-apps-ga4
 
 functions:
   api:

--- a/apps/google-analytics-4/lambda/serverless.yml
+++ b/apps/google-analytics-4/lambda/serverless.yml
@@ -18,7 +18,7 @@ custom:
     prd: ga4-build.ctfapps.net
     test: ga4-build-test.ctfapps.net
   appDefinitionId:
-    prd: 5eHTUt9pILTGjYk3VFE9ta
+    prd: 5DlxOS0KvGS1Wk362xgvbN
     test: yourTestId
   customDomain:
     domainName: ${self:custom.domainName.${env:STAGE, 'test'}}

--- a/apps/google-analytics-4/lambda/serverless.yml
+++ b/apps/google-analytics-4/lambda/serverless.yml
@@ -1,26 +1,105 @@
 service: google-analytics
-frameworkVersion: '3'
+frameworkVersion: '3' #might need to switch to '>=2.0.0 <3.0.0'
+
+variablesResolutionMode: 20210326
 
 plugins:
+  - serverless-domain-manager
   - serverless-offline
 
 custom:
-  environment: ${file(./config/serverless-env.${opt:stage, 'dev'}.yml)}
+  signingSecret:
+    prd: ${ssm:/aws/reference/secretsmanager/ci/apps/ga4-build-action/prd/signing-secret} #assuming these will exist
+    test: ${ssm:/aws/reference/secretsmanager/ci/apps/ga4-build-action/test/signing-secret}
+  appIdentityKey:
+    prd: ${ssm:/aws/reference/secretsmanager/ci/apps/ga4-build-action/prd/app-identity-key}
+    test: ${ssm:/aws/reference/secretsmanager/ci/apps/ga4-build-action/test/app-identity-key}
+  domainName:
+    prd: ga4-build.ctfapps.net
+    test: ga4-build-test.ctfapps.net
+  appDefinitionId:
+    prd: 5eHTUt9pILTGjYk3VFE9ta
+    test: yourTestId
+  customDomain:
+    domainName: ${self:custom.domainName.${env:STAGE, 'test'}} # do we need this?
+    stage: ${env:STAGE, 'test'}
+    createRoute53Record: true
+    endpointType: 'edge'
+    securityPolicy: tls_1_2
   serverless-offline:
     httpPort: 8080
 
 provider:
   name: aws
-  stage: ${opt:stage, 'dev'}
   runtime: nodejs18.x
+  stage: ${env:STAGE, 'test'}
+  region: 'us-east-1'
+  timeout: 30
+  lambdaHashingVersion: 20201221 # is this the correct version
+  deploymentBucket: # what is this, do we need it?
+    name: cf-apps-serverless-deployment
+  deploymentPrefix: sls-apps-ga4-build
+  # iam:
+  #   role:
+  #     statements:
+  #       - Effect: Allow
+  #         Action:
+  #           - dynamodb:DescribeTable
+  #           - dynamodb:GetItem
+  #           - dynamodb:PutItem
+  #           - dynamodb:UpdateItem
+  #           - dynamodb:Query
+  #         Resource: 'arn:aws:dynamodb:*:*:table/${self:custom.tableName}*'
 
 functions:
   api:
+    description: GA4 App Backend
     environment:
-      SIGNING_SECRET: ${self:custom.environment.SIGNING_SECRET}
-      STAGE: ${opt:stage, 'dev'}
+      # DYNAMO_ENDPOINT: ${self:custom.dynamoEndpoint}
+      # DYNAMO_TABLE_NAME: ${self:custom.tableName}
+      GA4_CLIENT_ID: ${self:custom.oauthCredentials.client_id}
+      GA4_CLIENT_SECRET: ${self:custom.oauthCredentials.client_secret}
+      GA4_SIGNING_SECRET: ${self:custom.ga4SigningSecret.signing_secret}
+      FRONTEND_URL: ${self:custom.frontendUrl}
+      WORKFLOWS_URL: ${self:custom.workflowsUrl}
+      BACKEND_URL: https://${self:custom.customDomain.domainName}/api
+      SIGNING_SECRET: ${self:custom.signingSecret.signing_secret}
+      PRIVATE_APP_KEY: ${self:custom.app.privateKey}
+      APP_ID: ${self:custom.app.id}
+      SERVERLESS_PATH_PREFIX: ${self:custom.serverless.pathPrefix}
+      BASE_URL: ${self:custom.baseUrl}
     handler: build/src/index.handler
     events:
       - http:
           path: /{any+}
           method: ANY
+
+# resources:
+#   Resources:
+#     TokenTable:
+#       Type: AWS::DynamoDB::Table
+#       Properties:
+#         TableName: ${self:custom.tableName}
+#         AttributeDefinitions:
+#           - AttributeName: uuid
+#             AttributeType: S
+#           - AttributeName: typ
+#             AttributeType: S
+#           - AttributeName: ga4WorkspaceId
+#             AttributeType: S
+#         KeySchema:
+#           - AttributeName: uuid
+#             KeyType: HASH
+#           - AttributeName: typ
+#             KeyType: RANGE
+#         GlobalSecondaryIndexes: #no idea past here
+#           - IndexName: by-ga4-workspace-id
+#             KeySchema:
+#               - AttributeName: typ
+#                 KeyType: HASH
+#               - AttributeName: ga4WorkspaceId
+#                 KeyType: RANGE
+#             Projection:
+#               ProjectionType: ALL
+
+#         BillingMode: PAY_PER_REQUEST

--- a/apps/google-analytics-4/lambda/serverless.yml
+++ b/apps/google-analytics-4/lambda/serverless.yml
@@ -1,5 +1,5 @@
 service: google-analytics
-frameworkVersion: '3' #might need to switch to '>=2.0.0 <3.0.0'
+frameworkVersion: '3'
 
 variablesResolutionMode: 20210326
 
@@ -9,7 +9,7 @@ plugins:
 
 custom:
   signingSecret:
-    prd: ${ssm:/aws/reference/secretsmanager/ci/apps/ga4-build-action/prd/signing-secret} #assuming these will exist
+    prd: ${ssm:/aws/reference/secretsmanager/ci/apps/ga4-build-action/prd/signing-secret}
     test: ${ssm:/aws/reference/secretsmanager/ci/apps/ga4-build-action/test/signing-secret}
   appIdentityKey:
     prd: ${ssm:/aws/reference/secretsmanager/ci/apps/ga4-build-action/prd/app-identity-key}
@@ -21,7 +21,7 @@ custom:
     prd: 5eHTUt9pILTGjYk3VFE9ta
     test: yourTestId
   customDomain:
-    domainName: ${self:custom.domainName.${env:STAGE, 'test'}} # do we need this?
+    domainName: ${self:custom.domainName.${env:STAGE, 'test'}}
     stage: ${env:STAGE, 'test'}
     createRoute53Record: true
     endpointType: 'edge'
@@ -35,8 +35,8 @@ provider:
   stage: ${env:STAGE, 'test'}
   region: 'us-east-1'
   timeout: 30
-  lambdaHashingVersion: 20201221 # is this the correct version
-  deploymentBucket: # what is this, do we need it?
+  lambdaHashingVersion: 20201221
+  deploymentBucket:
     name: cf-apps-serverless-deployment
   deploymentPrefix: sls-apps-ga4-build
   # iam:

--- a/apps/google-analytics-4/lambda/serverless.yml
+++ b/apps/google-analytics-4/lambda/serverless.yml
@@ -9,26 +9,26 @@ plugins:
 
 custom:
   signingSecret:
-    prd: ${ssm:/aws/reference/secretsmanager/ci/apps/ga4-build-action/prd/signing-secret}
-    test: ${ssm:/aws/reference/secretsmanager/ci/apps/ga4-build-action/test/signing-secret}
-  appIdentityKey:
-    prd: ${ssm:/aws/reference/secretsmanager/ci/apps/ga4-build-action/prd/app-identity-key}
-    test: ${ssm:/aws/reference/secretsmanager/ci/apps/ga4-build-action/test/app-identity-key}
+    prd: ${ssm:/aws/reference/secretsmanager/ci/apps/google-analytics-4-action/prd/signing-secret}
+    test: ${ssm:/aws/reference/secretsmanager/ci/apps/google-analytics-4-action/test/signing-secret}
+  # appIdentityKey:
+  #   prd: ${ssm:/aws/reference/secretsmanager/ci/apps/google-analytics-4-action/prd/app-identity-key}
+  #   test: ${ssm:/aws/reference/secretsmanager/ci/apps/google-analytics-4-action/test/app-identity-key}
   domainName:
-    prd: ga4-build.ctfapps.net
-    test: ga4-build-test.ctfapps.net
-  appDefinitionId:
-    prd: 5DlxOS0KvGS1Wk362xgvbN
-    test: yourTestId
+    prd: google-analytics-4.ctfapps.net
+    test: google-analytics-4-test.ctfapps.net
+  # appDefinitionId:
+  #   prd: 5DlxOS0KvGS1Wk362xgvbN
+  #   test: yourTestId
   customDomain:
     domainName: ${self:custom.domainName.${env:STAGE, 'test'}}
     stage: ${env:STAGE, 'test'}
     createRoute53Record: true
     endpointType: 'edge'
     securityPolicy: tls_1_2
-  frontendUrl: 
-    prd: 'https://ga4.ctfapps.net/index.html'
-    test: 'http://localhost:3000'
+  # frontendUrl: 
+  #   prd: 'https://ga4.ctfapps.net/index.html'
+  #   test: 'http://localhost:3000'
   serverless-offline:
     httpPort: 8080
 
@@ -60,16 +60,14 @@ functions:
     environment:
       # DYNAMO_ENDPOINT: ${self:custom.dynamoEndpoint}
       # DYNAMO_TABLE_NAME: ${self:custom.tableName}
-      GA4_CLIENT_ID: ${self:custom.oauthCredentials.client_id}
-      GA4_CLIENT_SECRET: ${self:custom.oauthCredentials.client_secret}
-      GA4_SIGNING_SECRET: ${self:custom.ga4SigningSecret.signing_secret}
-      FRONTEND_URL: ${self:custom.frontendUrl.${env:STAGE, 'test'}}
-      WORKFLOWS_URL: ${self:custom.workflowsUrl}
-      BACKEND_URL: https://${self:custom.customDomain.domainName}/api
-      SIGNING_SECRET: ${self:custom.signingSecret.signing_secret}
-      PRIVATE_APP_KEY: ${self:custom.app.privateKey}
-      APP_ID: ${self:custom.appDefinitionId.prd}
-      BASE_URL: ${self:custom.baseUrl}
+      # GA4_CLIENT_ID: ${self:custom.oauthCredentials.client_id}
+      # GA4_CLIENT_SECRET: ${self:custom.oauthCredentials.client_secret}
+      # FRONTEND_URL: ${self:custom.frontendUrl.${env:STAGE, 'test'}}
+      # BACKEND_URL: https://${self:custom.customDomain.domainName}/${env:STAGE, 'test'}/api
+      SIGNING_SECRET: ${self:custom.signingSecret.${env:STAGE, 'test'}}
+      # PRIVATE_APP_KEY: ${self:custom.app.privateKey}
+      # APP_ID: ${self:custom.appDefinitionId.prd}
+      STAGE: ${env:STAGE, 'test'}
     handler: build/src/index.handler
     events:
       - http:

--- a/apps/google-analytics-4/lambda/serverless.yml
+++ b/apps/google-analytics-4/lambda/serverless.yml
@@ -1,8 +1,6 @@
 service: google-analytics
 frameworkVersion: '3'
 
-# variablesResolutionMode: 20210326 # only needed for framework v >3
-
 plugins:
   - serverless-domain-manager
   - serverless-offline
@@ -11,24 +9,15 @@ custom:
   signingSecret:
     prd: ${ssm:/aws/reference/secretsmanager/ci/apps/google-analytics-4-action/prd/signing-secret}
     test: ${ssm:/aws/reference/secretsmanager/ci/apps/google-analytics-4-action/test/signing-secret}
-  # appIdentityKey:
-  #   prd: ${ssm:/aws/reference/secretsmanager/ci/apps/google-analytics-4-action/prd/app-identity-key}
-  #   test: ${ssm:/aws/reference/secretsmanager/ci/apps/google-analytics-4-action/test/app-identity-key}
   domainName:
     prd: google-analytics-4.ctfapps.net
     test: google-analytics-4-test.ctfapps.net
-  # appDefinitionId:
-  #   prd: 5DlxOS0KvGS1Wk362xgvbN
-  #   test: yourTestId
   customDomain:
     domainName: ${self:custom.domainName.${env:STAGE, 'test'}}
     stage: ${env:STAGE, 'test'}
     createRoute53Record: true
     endpointType: 'edge'
     securityPolicy: tls_1_2
-  # frontendUrl: 
-  #   prd: 'https://ga4.ctfapps.net/index.html'
-  #   test: 'http://localhost:3000'
   serverless-offline:
     httpPort: 8080
 
@@ -38,68 +27,18 @@ provider:
   stage: ${env:STAGE, 'test'}
   region: 'us-east-1'
   timeout: 30
-  # lambdaHashingVersion: 20201221  # only needed for framework v >3
   deploymentBucket:
     name: cf-apps-serverless-deployment
   deploymentPrefix: sls-apps-ga4-build
-  # iam:
-  #   role:
-  #     statements:
-  #       - Effect: Allow
-  #         Action:
-  #           - dynamodb:DescribeTable
-  #           - dynamodb:GetItem
-  #           - dynamodb:PutItem
-  #           - dynamodb:UpdateItem
-  #           - dynamodb:Query
-  #         Resource: 'arn:aws:dynamodb:*:*:table/${self:custom.tableName}*'
 
 functions:
   api:
     description: GA4 App Backend
     environment:
-      # DYNAMO_ENDPOINT: ${self:custom.dynamoEndpoint}
-      # DYNAMO_TABLE_NAME: ${self:custom.tableName}
-      # GA4_CLIENT_ID: ${self:custom.oauthCredentials.client_id}
-      # GA4_CLIENT_SECRET: ${self:custom.oauthCredentials.client_secret}
-      # FRONTEND_URL: ${self:custom.frontendUrl.${env:STAGE, 'test'}}
-      # BACKEND_URL: https://${self:custom.customDomain.domainName}/${env:STAGE, 'test'}/api
       SIGNING_SECRET: ${self:custom.signingSecret.${env:STAGE, 'test'}}
-      # PRIVATE_APP_KEY: ${self:custom.app.privateKey}
-      # APP_ID: ${self:custom.appDefinitionId.prd}
       STAGE: ${env:STAGE, 'test'}
     handler: build/src/index.handler
     events:
       - http:
           path: /{any+}
           method: ANY
-
-# resources:
-#   Resources:
-#     TokenTable:
-#       Type: AWS::DynamoDB::Table
-#       Properties:
-#         TableName: ${self:custom.tableName}
-#         AttributeDefinitions:
-#           - AttributeName: uuid
-#             AttributeType: S
-#           - AttributeName: typ
-#             AttributeType: S
-#           - AttributeName: ga4WorkspaceId
-#             AttributeType: S
-#         KeySchema:
-#           - AttributeName: uuid
-#             KeyType: HASH
-#           - AttributeName: typ
-#             KeyType: RANGE
-#         GlobalSecondaryIndexes: #no idea past here
-#           - IndexName: by-ga4-workspace-id
-#             KeySchema:
-#               - AttributeName: typ
-#                 KeyType: HASH
-#               - AttributeName: ga4WorkspaceId
-#                 KeyType: RANGE
-#             Projection:
-#               ProjectionType: ALL
-
-#         BillingMode: PAY_PER_REQUEST

--- a/apps/google-analytics-4/lambda/serverless.yml
+++ b/apps/google-analytics-4/lambda/serverless.yml
@@ -1,7 +1,7 @@
 service: google-analytics
 frameworkVersion: '3'
 
-variablesResolutionMode: 20210326
+# variablesResolutionMode: 20210326 # only needed for framework v >3
 
 plugins:
   - serverless-domain-manager
@@ -38,7 +38,7 @@ provider:
   stage: ${env:STAGE, 'test'}
   region: 'us-east-1'
   timeout: 30
-  lambdaHashingVersion: 20201221
+  # lambdaHashingVersion: 20201221  # only needed for framework v >3
   deploymentBucket:
     name: cf-apps-serverless-deployment
   deploymentPrefix: sls-apps-ga4-build


### PR DESCRIPTION
## Purpose
[JIRA ticket](https://contentful.atlassian.net/jira/software/c/projects/INTEG/boards/454?modal=detail&selectedIssue=INTEG-133)
Sets up serverless configuration so that we can deploy GA-4 to production, securely.

## Approach
Mostly constructed off existing slack/netlify serverless.yml files. In the future, we may implement dynamodb to host some of the secrets we'll use here.

## Dependencies and/or References
[AWS notes from discussion with Extensibility](https://docs.google.com/document/d/1PQhyT2gnQ5Q-BO19x2xfZlE282KESRiFvjzhT0RsdUE/edit?usp=sharing)

## Deployment
Deployment of deployment configuration files is always a bit more complex, no known concerns at this time though.
