### PR TITLE
DRAFT Add chart.js and react-chartjs-2 to package

### DIFF
--- a/apps/google-analytics-4/frontend/package-lock.json
+++ b/apps/google-analytics-4/frontend/package-lock.json
@@ -14,10 +14,12 @@
         "@contentful/react-apps-toolkit": "1.2.10",
         "@testing-library/user-event": "14.4.3",
         "@types/lodash": "4.14.191",
+        "chart.js": "^4.2.1",
         "contentful-management": "10.21.6",
         "emotion": "10.0.27",
         "lodash": "4.17.21",
         "react": "17.0.2",
+        "react-chartjs-2": "^5.2.0",
         "react-dom": "17.0.2",
         "react-scripts": "5.0.1",
         "zod": "3.20.2"
@@ -3888,6 +3890,11 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.2.tgz",
+      "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw=="
+    },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
@@ -6621,6 +6628,17 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
+    },
+    "node_modules/chart.js": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.2.1.tgz",
+      "integrity": "sha512-6YbpQ0nt3NovAgOzbkSSeeAQu/3za1319dPUQTXn9WcOpywM8rGKxJHrhS8V8xEkAlk8YhEfjbuAPfUyp6jIsw==",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": "^7.0.0"
+      }
     },
     "node_modules/check-types": {
       "version": "11.2.2",
@@ -15524,6 +15542,15 @@
         "node": ">=14"
       }
     },
+    "node_modules/react-chartjs-2": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.2.0.tgz",
+      "integrity": "sha512-98iN5aguJyVSxp5U3CblRLH67J8gkfyGNbiK3c+l1QI/G4irHMPQw44aEPmjVag+YKTyQ260NcF82GTQ3bdscA==",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-clientside-effect": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.6.tgz",
@@ -21494,6 +21521,11 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "@kurkle/color": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.2.tgz",
+      "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw=="
+    },
     "@leichtgewicht/ip-codec": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
@@ -23571,6 +23603,14 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
+    },
+    "chart.js": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.2.1.tgz",
+      "integrity": "sha512-6YbpQ0nt3NovAgOzbkSSeeAQu/3za1319dPUQTXn9WcOpywM8rGKxJHrhS8V8xEkAlk8YhEfjbuAPfUyp6jIsw==",
+      "requires": {
+        "@kurkle/color": "^0.3.0"
+      }
     },
     "check-types": {
       "version": "11.2.2",
@@ -29991,6 +30031,12 @@
         "regenerator-runtime": "^0.13.9",
         "whatwg-fetch": "^3.6.2"
       }
+    },
+    "react-chartjs-2": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.2.0.tgz",
+      "integrity": "sha512-98iN5aguJyVSxp5U3CblRLH67J8gkfyGNbiK3c+l1QI/G4irHMPQw44aEPmjVag+YKTyQ260NcF82GTQ3bdscA==",
+      "requires": {}
     },
     "react-clientside-effect": {
       "version": "1.2.6",

--- a/apps/google-analytics-4/frontend/package.json
+++ b/apps/google-analytics-4/frontend/package.json
@@ -9,10 +9,12 @@
     "@contentful/react-apps-toolkit": "1.2.10",
     "@testing-library/user-event": "14.4.3",
     "@types/lodash": "4.14.191",
+    "chart.js": "^4.2.1",
     "contentful-management": "10.21.6",
     "emotion": "10.0.27",
     "lodash": "4.17.21",
     "react": "17.0.2",
+    "react-chartjs-2": "^5.2.0",
     "react-dom": "17.0.2",
     "react-scripts": "5.0.1",
     "zod": "3.20.2"


### PR DESCRIPTION
## Purpose
In order to add a data visualization component as part of the Google Analytics 4 app, a third party charting library needs to be added. 

## Approach
The [Chart.js](https://www.chartjs.org/) library as well as the React specific integration, [react-chartjs-2](https://react-chartjs-2.js.org/) have been added as packages. Per the documentation, I believe that there is little if any configuration that needs to be done beyond installing the libraries, especially given the React integration. 

A, perhaps out of scope for this task, local POC fleshes out the functionality itself: 

## Dependencies and/or References
<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment
<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
