### PR TITLE
Fix serve path on Wistia app []

### DIFF
--- a/apps/wistia-videos/package.json
+++ b/apps/wistia-videos/package.json
@@ -1,6 +1,7 @@
 {
   "name": "wistia-videos",
   "version": "0.1.0",
+  "homepage": "./",
   "private": true,
   "dependencies": {
     "@contentful/app-sdk": "^4.16.0",

--- a/apps/wistia-videos/src/components/ConfigScreen.tsx
+++ b/apps/wistia-videos/src/components/ConfigScreen.tsx
@@ -217,7 +217,7 @@ const Config = (props: ConfigProps) => {
                   </Paragraph>
                 </Flex>
                 {!!parameters.excludedProjects?.length && (
-                  <Flex marginBottom="spacingM" flexWrap="wrap" fullHeight>
+                  <Flex marginBottom="spacingM" flexWrap="wrap">
                     {parameters.excludedProjects.map((item) => (
                       <Pill
                         style={{ width: 200, marginRight: 10, marginBottom: 10 }}


### PR DESCRIPTION
## Purpose

The Wistia app production deploy was broken because assets were being served from the root (`/static/css...`) instead of a relative path (`./static/css...`). Because app bundles are deployed in a subfolder (under the deploy bundle id on the CDN) this was breaking the app.

## Approach

* Just add homepage to package.json

## Dependencies and/or References

* https://create-react-app.dev/docs/deployment/#building-for-relative-paths
* 
## Deployment
<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
