### PR TITLE
Set up frontend deploy scripts [INTEG-132]

### DIFF
--- a/apps/google-analytics-4/frontend/package.json
+++ b/apps/google-analytics-4/frontend/package.json
@@ -26,8 +26,8 @@
     "test-ci": "CI=true react-scripts test",
     "eject": "react-scripts eject",
     "create-app-definition": "contentful-app-scripts create-app-definition",
-    "upload": "contentful-app-scripts upload --bundle-dir ./build",
-    "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN"
+    "deploy": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEFINITIONS_ORG_ID} --definition-id 5DlxOS0KvGS1Wk362xgvbN --token ${CONTENTFUL_CMA_TOKEN}",
+    "deploy:test": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${TEST_ORG_ID} --definition-id ${TEST_APP_ID} --token ${CONTENTFUL_CMA_TOKEN}"
   },
   "eslintConfig": {
     "extends": "react-app"


### PR DESCRIPTION
## Purpose

The current upload scripts are just created from the template. We need to adjust them to deploy our frontend to the actual correct production app definition.

## Approach

* Point the main `deploy` to the production app definition living in the main definitions org

## Dependencies and/or References
<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment
<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
