### PR TITLE
staging branch name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,6 +169,7 @@ workflows:
             branches:
               only:
                 - master
+                - staging
       - deploy-prod:
           context:
             - vault


### PR DESCRIPTION
## Purpose
Adds `staging` as a new branch name that will kick off the `deploy-staging` circleci workflow.

## Approach
We are doing this to create a flow to test the apps ga4 deployment in a way that will not break other devs.

