### PR TITLE
env refactor

### DIFF
--- a/apps/google-analytics-4/lambda/config/serverless-env.prd.yml
+++ b/apps/google-analytics-4/lambda/config/serverless-env.prd.yml
@@ -1,1 +1,2 @@
-SIGNING_SECRET: ${env:SIGNING_SECRET}
+SIGNING_SECRET: ${ssm:/aws/reference/secretsmanager/ci/apps/google-analytics-4-action/prd/signing-secret}
+DOMAIN_NAME: google-analytics-4.ctfapps.net

--- a/apps/google-analytics-4/lambda/config/serverless-env.test.yml
+++ b/apps/google-analytics-4/lambda/config/serverless-env.test.yml
@@ -1,1 +1,2 @@
-SIGNING_SECRET: ${env:SIGNING_SECRET}
+SIGNING_SECRET: ${ssm:/aws/reference/secretsmanager/ci/apps/google-analytics-4-action/test/signing-secret}
+DOMAIN_NAME: google-analytics-4-test.ctfapps.net

--- a/apps/google-analytics-4/lambda/serverless.yml
+++ b/apps/google-analytics-4/lambda/serverless.yml
@@ -1,23 +1,37 @@
-service: google-analytics
+service: sls-apps-google-analytics-4
 frameworkVersion: '3'
 
 plugins:
+  - serverless-domain-manager
   - serverless-offline
 
+environment: ${file(./config/serverless-env.${opt:stage, 'dev'}.yml)}
+
 custom:
-  environment: ${file(./config/serverless-env.${opt:stage, 'dev'}.yml)}
+  customDomain:
+    domainName: ${self:environment.DOMAIN_NAME}
+    stage: ${opt:stage, 'dev'}
+    createRoute53Record: true
+    endpointType: 'edge'
+    securityPolicy: tls_1_2
   serverless-offline:
     httpPort: 8080
 
 provider:
   name: aws
-  stage: ${opt:stage, 'dev'}
   runtime: nodejs18.x
+  stage: ${opt:stage, 'dev'}
+  region: 'us-east-1'
+  timeout: 30
+  deploymentBucket:
+    name: cf-apps-serverless-deployment
+  deploymentPrefix: sls-apps-google-analytics-4
 
 functions:
   api:
+    description: GA4 App Backend
     environment:
-      SIGNING_SECRET: ${self:custom.environment.SIGNING_SECRET}
+      SIGNING_SECRET: ${self:environment.SIGNING_SECRET}
       STAGE: ${opt:stage, 'dev'}
     handler: build/src/index.handler
     events:


### PR DESCRIPTION
## Purpose
This is an attempted refactor to handle env vars in a way that will support both development work locally as well as correct env configuration for our prod and test environments.

## Approach
Currently attempting to branch to a different config.yml file depending on stage name, vs storing all information about every env in the ga4 serverless file.
