### PR TITLE
[INTEG-181] Add lambda proxy endpoint for run-report through data API

### DIFF
--- a/apps/google-analytics-4/lambda/package-lock.json
+++ b/apps/google-analytics-4/lambda/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@google-analytics/admin": "^4.3.1",
+        "@google-analytics/data": "^3.2.1",
         "@grpc/grpc-js": "^1.8.4",
         "express": "^4.18.2",
         "google-auth-library": "^8.7.0",
@@ -1162,6 +1163,17 @@
         "google-auth-library": "^8.0.2",
         "google-gax": "^3.5.2",
         "server-destroy": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@google-analytics/data": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@google-analytics/data/-/data-3.2.1.tgz",
+      "integrity": "sha512-xk2VObLqCXvsdgh43ta2xBMDkd7Uu04BJBzgFoEw5/JoS0sxQb5jsiRd8gqYScaY5euU0ZL3V1Q35TSIJzx0cA==",
+      "dependencies": {
+        "google-gax": "^3.5.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -11634,6 +11646,14 @@
         "google-auth-library": "^8.0.2",
         "google-gax": "^3.5.2",
         "server-destroy": "^1.0.1"
+      }
+    },
+    "@google-analytics/data": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@google-analytics/data/-/data-3.2.1.tgz",
+      "integrity": "sha512-xk2VObLqCXvsdgh43ta2xBMDkd7Uu04BJBzgFoEw5/JoS0sxQb5jsiRd8gqYScaY5euU0ZL3V1Q35TSIJzx0cA==",
+      "requires": {
+        "google-gax": "^3.5.2"
       }
     },
     "@grpc/grpc-js": {

--- a/apps/google-analytics-4/lambda/package.json
+++ b/apps/google-analytics-4/lambda/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "@google-analytics/admin": "^4.3.1",
+    "@google-analytics/data": "^3.2.1",
     "@grpc/grpc-js": "^1.8.4",
     "express": "^4.18.2",
     "google-auth-library": "^8.7.0",

--- a/apps/google-analytics-4/lambda/src/app.spec.ts
+++ b/apps/google-analytics-4/lambda/src/app.spec.ts
@@ -11,6 +11,7 @@ import {
 import app from './app';
 import { GoogleApi } from './services/google-api';
 import * as NodeAppsToolkit from '@contentful/node-apps-toolkit';
+import { BetaAnalyticsDataClient } from '@google-analytics/data';
 
 chai.use(chaiHttp);
 
@@ -20,7 +21,8 @@ const serviceAccountKeyHeaders = {
 };
 
 describe('app', () => {
-  let mockClient: SinonStubbedInstance<AnalyticsAdminServiceClient>;
+  let mockAdminClient: SinonStubbedInstance<AnalyticsAdminServiceClient>;
+  let mockDataClient: SinonStubbedInstance<BetaAnalyticsDataClient>;
 
   beforeEach(() => {
     // TODO: set headers and fully test signature verification later
@@ -54,12 +56,13 @@ describe('app', () => {
     });
   });
 
+  // TODO: These test need to be updated once we have everything configured
   describe('GET /api/account_summaries', () => {
     let googleApi: GoogleApi;
 
     beforeEach(() => {
-      mockClient = mockAnalyticsAdminServiceClient();
-      googleApi = new GoogleApi(validServiceAccountKeyFile, mockClient);
+      mockAdminClient = mockAnalyticsAdminServiceClient();
+      googleApi = new GoogleApi(validServiceAccountKeyFile, mockAdminClient, mockDataClient);
       sinon.stub(GoogleApi, 'fromServiceAccountKeyFile').returns(googleApi);
     });
 
@@ -80,7 +83,9 @@ describe('app', () => {
     });
   });
 
-  describe('GET /sampleData/runReportResponse', () => {
+  describe('GET /api/run_report', () => {
+
+
     it('responds with 200 for sample with views data', async () => {
       const response = await chai.request(app).get('/sampleData/runReportResponseHasViews.json');
       expect(response).to.have.status(200);

--- a/apps/google-analytics-4/lambda/src/services/google-api.spec.ts
+++ b/apps/google-analytics-4/lambda/src/services/google-api.spec.ts
@@ -1,4 +1,5 @@
 import { AnalyticsAdminServiceClient } from '@google-analytics/admin';
+import { BetaAnalyticsDataClient } from '@google-analytics/data';
 import { expect } from 'chai';
 import { Status } from 'google-gax';
 import { SinonStubbedInstance } from 'sinon';
@@ -18,11 +19,12 @@ import {
 
 describe('GoogleApi', () => {
   let googleApi: GoogleApi;
-  let mockClient: SinonStubbedInstance<AnalyticsAdminServiceClient>;
+  let mockAdminClient: SinonStubbedInstance<AnalyticsAdminServiceClient>;
+  let mockDataClient: SinonStubbedInstance<BetaAnalyticsDataClient>;
 
   beforeEach(() => {
-    mockClient = mockAnalyticsAdminServiceClient();
-    googleApi = new GoogleApi(validServiceAccountKeyFile, mockClient);
+    mockAdminClient = mockAnalyticsAdminServiceClient();
+    googleApi = new GoogleApi(validServiceAccountKeyFile, mockAdminClient, mockDataClient);
   });
 
   describe('listAccountSummaries', () => {
@@ -36,9 +38,9 @@ describe('GoogleApi', () => {
     const someError = new Error('boom!');
 
     beforeEach(() => {
-      mockClient = mockAnalyticsAdminServiceClient();
-      mockClient.listAccountSummaries.rejects(someError);
-      googleApi = new GoogleApi(validServiceAccountKeyFile, mockClient);
+      mockAdminClient = mockAnalyticsAdminServiceClient();
+      mockAdminClient.listAccountSummaries.rejects(someError);
+      googleApi = new GoogleApi(validServiceAccountKeyFile, mockAdminClient, mockDataClient);
     });
 
     it('throws a GoogleApiServerError', async () => {


### PR DESCRIPTION
## Purpose
[JIRA Ticket](https://contentful.atlassian.net/browse/INTEG-181)
The Run Report function in GA4 is what gets the GA4 data for a given web page. This endpoint is needed so that we get that data.

## Approach
Just following the existing pattern of fetching account summaries.

## Dependencies and/or References
Adds Data GA4 dependency (changes shown in package.json file)
