### PR TITLE
[INTEG-171] add sentry deploy job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,8 +159,6 @@ jobs:
           command: cd examples/javascript && npm run test
   
   notify-sentry-deploy:
-    executor:
-    # Specify executor for running deploy job
     environment:
       SENTRY_ORG: contenful
       SENTRY_PROJECT: marketplace-apps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,6 +157,26 @@ jobs:
       - run:
           name: Test
           command: cd examples/javascript && npm run test
+  
+  notify-sentry-deploy:
+    executor:
+    # Specify executor for running deploy job
+    environment:
+      SENTRY_ORG: contenful
+      SENTRY_PROJECT: marketplace-apps
+      SENTRY_ENVIRONMENT: production
+    steps:
+      - checkout
+      - run:
+          name: Create release and notify Sentry of deploy
+          command: |
+            curl -sL https://sentry.io/get-cli/ | bash
+            export SENTRY_RELEASE=$(sentry-cli releases propose-version)
+            sentry-cli releases new -p $SENTRY_PROJECT $SENTRY_RELEASE
+            sentry-cli releases set-commits $SENTRY_RELEASE --auto
+            sentry-cli releases files $SENTRY_RELEASE upload-sourcemaps path-to-sourcemaps-if-applicable
+            sentry-cli releases finalize $SENTRY_RELEASE
+            sentry-cli releases deploys $SENTRY_RELEASE new -e $SENTRY_ENVIRONMENT
 
 workflows:
   version: 2
@@ -180,6 +200,15 @@ workflows:
             - vault
           requires:
             - apps-test
+          filters:
+            branches:
+              only:
+                - master
+      - notify-sentry-deploy:
+          context:
+            - vault
+          requires:
+            - deploy-prod
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,6 +159,8 @@ jobs:
           command: cd examples/javascript && npm run test
   
   notify-sentry-deploy:
+    docker:
+      - image: cimg/base:stable
     environment:
       SENTRY_ORG: contenful
       SENTRY_PROJECT: marketplace-apps


### PR DESCRIPTION
## Purpose
Adds a new job for notifying sentry of a deploy, to collect and upload artifacts. 

## Approach
We followed the instructions from [Sentry's documentation on CircleCI integration](https://docs.sentry.io/product/releases/setup/release-automation/circleci/)

## Dependencies and/or References
[JIRA](https://contentful.atlassian.net/browse/INTEG-171)
