### PR TITLE
Update prettier to use common merge base instead of origin/master

### DIFF
--- a/.circleci/prettier-check.sh
+++ b/.circleci/prettier-check.sh
@@ -6,7 +6,8 @@
 # kill switch if for some reason this script inadvertently blocks the build
 test -n "$SKIP_PRETTIER_CHECK" && exit 0
 
-CHANGED_FILES=$(git diff --name-only HEAD origin/master | egrep --color=no "\.[jt]s(x)?$" | xargs)
+MERGE_BASE=$(git merge-base HEAD origin/master)
+CHANGED_FILES=$(git diff --name-only HEAD $MERGE_BASE | egrep --color=no "\.[jt]s(x)?$" | xargs)
 echo $CHANGED_FILES
 
 test -z "$CHANGED_FILES" && echo "No files for prettier to check. Skipping..." && exit 0


### PR DESCRIPTION
## Purpose

The first iteration of ./prettier-config.sh was naive about comparisons: We looked at the diff of file changes between `your_branch` and `origin/master` and ran the prettier verification against that changeset.

This works great if you're branch is up to date, but if your branch is out of date from master it ends up with a much larger changeset which is inaccurate. Forcing rebasing here is just annoying and beyond the intention of this simple script.

What we need instead is a way to look at the changes _your PR introduced_ and ignore anything else.

## Approach

* Use `git merge-base` to find the common ancestor of your branch and origin/master. This should reliably give us only the files you changed, even if other changes were added to master in the meantime. If your branch is up to date this should resolve to the same commit as origin/master.

## Dependencies and/or References
<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment
<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
