### PR TITLE
configure sourcemaps with typescript

### DIFF
--- a/apps/google-analytics-4/frontend/tsconfig.json
+++ b/apps/google-analytics-4/frontend/tsconfig.json
@@ -5,7 +5,11 @@
     "paths": {
       "@/*": ["./*"],
       "@shared/*": ["../../shared/*"]
-    }
+    },
+    "sourceMap": true,
+    "inlineSources": true,
+    "sourceRoot": "/src"
   },
-  "include": ["src"]
+  "include": ["src", "test"],
+  "exclude": ["node_modules"]
 }

--- a/apps/google-analytics-4/lambda/tsconfig.json
+++ b/apps/google-analytics-4/lambda/tsconfig.json
@@ -5,7 +5,10 @@
     "paths": {
       "@/*": ["./*"],
       "@shared/*": ["../shared/*"]
-    }
+    },
+    "sourceMap": true,
+    "inlineSources": true,
+    "sourceRoot": "/src"
   },
   "include": ["src", "test"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Purpose
Sentry uses [releases](https://docs.sentry.io/product/releases/) to match the correct source maps to your events. If you're using TypeScript (tsc) to compile your project, you should configure TypeScript to generate source maps, and use Sentry CLI to create the release and upload the generated source maps.

## Approach
configure sourcemaps in tsconfig

## Dependencies and/or References
https://docs.sentry.io/platforms/javascript/sourcemaps/uploading/typescript/

## Deployment
- [ ] confirm sourcemaps are properly configured and uploaded in CI via sentry CLI
