### PR TITLE
Prd deploy command

### DIFF
--- a/apps/google-analytics-4/lambda/package.json
+++ b/apps/google-analytics-4/lambda/package.json
@@ -12,7 +12,8 @@
     "test": "TS_NODE_TRANSPILE_ONLY=1 mocha",
     "test:debug": "TS_NODE_TRANSPILE_ONLY=1 mocha -- --inspect --inspect-brk",
     "test:watch": "TS_NODE_TRANSPILE_ONLY=1 mocha --watch --watch-files src --watch-files test",
-    "deploy:test": "sls deploy --stage test"
+    "deploy:test": "sls deploy --stage test",
+    "deploy": "sls deploy --stage $STAGE"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Purpose
This adds a `deploy` command to the ga4 lambda package.json. This will be collected by lerna when the repo is deployed and cause the ga4 lambda to be deployed to prod. 

## Approach
This is our existing standard for prod deploy infra.

## Dependencies and/or References
[jira](https://contentful.atlassian.net/jira/software/c/projects/INTEG/boards/454?modal=detail&selectedIssue=INTEG-133)

## Deployment
🚨 we need to execute `sls create_domain` before merging this to create the r53 record
