### PR TITLE
SLS 3 

### DIFF
--- a/apps/google-analytics-4/lambda/package-lock.json
+++ b/apps/google-analytics-4/lambda/package-lock.json
@@ -37,9 +37,9 @@
         "mocha": "^10.2.0",
         "nodemon": "^2.0.20",
         "rimraf": "^3.0.2",
-        "serverless": "3.28.1",
+        "serverless": "^3.28.1",
         "serverless-domain-manager": "^6.4.4",
-        "serverless-offline": "12.0.4",
+        "serverless-offline": "^12.0.4",
         "sinon": "^15.0.1",
         "ts-node": "^10.9.1",
         "typescript": "^4.9.4"
@@ -1093,9 +1093,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.21.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.2.tgz",
-      "integrity": "sha512-URpaIJQwEkEC2T9Kn+Ai6Xe/02iNaVCuT/PtoRz3GPVJVDpPd7mLo+VddTbhCRU9TXqW5mSrQfXZyi8kDKOVpQ==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.7.tgz",
+      "integrity": "sha512-T3Z9oHybU+0vZlY9CiDSJQTD5ZapcW18ZctFMi0MOAl/4BjFF4ul7NVSARLdbGO5vDqy9eQiGTV0LtKfvCYvcg==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -1155,9 +1155,9 @@
       }
     },
     "node_modules/@google-analytics/admin": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@google-analytics/admin/-/admin-4.6.0.tgz",
-      "integrity": "sha512-DrFYdSalwCXuMyfqMTHTsaQ8U6HaYhvonDIHL1AFx6b2LjHqmsLaSlL+hGYVqjN2QM1vngjtw1zzUvFq8nessg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@google-analytics/admin/-/admin-4.3.1.tgz",
+      "integrity": "sha512-Ncl6BwNRqxk4DDhNzQMPjQn5UmDyYv/hXEbCOKP4kspp7r1OQglajVXhtCx0jH9QP0+cw6B7gWDWwaCDNDgQvw==",
       "dependencies": {
         "google-auth-library": "^8.0.2",
         "google-gax": "^3.5.2",
@@ -1179,9 +1179,9 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.8.11",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.11.tgz",
-      "integrity": "sha512-f/xC+6Z2QKsRJ+VSSFlt4hA5KSRm+PKvMWV8kMPkMgGlFidR6PeIkXrOasIY2roe+WROM6GFQLlgDKfeEZo2YQ==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.4.tgz",
+      "integrity": "sha512-oaETBotls7FTBpySg5dhyUCyXSxSeCMmkBBXHXG1iw57MiNoB6D7VRhkrXYbwyHM3Q3Afjp4KlsBX0Zb+ELZXw==",
       "dependencies": {
         "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"
@@ -1595,17 +1595,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
-    "node_modules/@jsdoc/salty": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.4.tgz",
-      "integrity": "sha512-HRBmslXHM6kpZOfGf0o41NUlGYGER0NoUBcT2Sik4rxzAN7f7+si7ad57SFSFpftvaMVnUaY7YlJuv3v5G80ZA==",
-      "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "engines": {
-        "node": ">=v12.0.0"
       }
     },
     "node_modules/@kwsites/file-exists": {
@@ -2099,15 +2088,6 @@
         "@types/range-parser": "*"
       }
     },
-    "node_modules/@types/glob": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.1.0.tgz",
-      "integrity": "sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==",
-      "dependencies": {
-        "@types/minimatch": "^5.1.2",
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
@@ -2163,11 +2143,6 @@
       "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
       "dev": true
     },
-    "node_modules/@types/minimatch": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
-      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA=="
-    },
     "node_modules/@types/mocha": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.1.tgz",
@@ -2209,15 +2184,6 @@
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
       "dev": true
-    },
-    "node_modules/@types/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==",
-      "dependencies": {
-        "@types/glob": "*",
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/semver": {
       "version": "7.3.13",
@@ -2261,16 +2227,15 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.54.0.tgz",
-      "integrity": "sha512-+hSN9BdSr629RF02d7mMtXhAJvDTyCbprNYJKrXETlul/Aml6YZwd90XioVbjejQeHbb3R8Dg0CkRgoJDxo8aw==",
+      "version": "5.48.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.48.1.tgz",
+      "integrity": "sha512-9nY5K1Rp2ppmpb9s9S2aBiF3xo5uExCehMDmYmmFqqyxgenbHJ3qbarcLt4ITgaD6r/2ypdlcFRdcuVPnks+fQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.54.0",
-        "@typescript-eslint/type-utils": "5.54.0",
-        "@typescript-eslint/utils": "5.54.0",
+        "@typescript-eslint/scope-manager": "5.48.1",
+        "@typescript-eslint/type-utils": "5.48.1",
+        "@typescript-eslint/utils": "5.48.1",
         "debug": "^4.3.4",
-        "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
         "natural-compare-lite": "^1.4.0",
         "regexpp": "^3.2.0",
@@ -2294,62 +2259,15 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.54.0.tgz",
-      "integrity": "sha512-VTPYNZ7vaWtYna9M4oD42zENOBrb+ZYyCNdFs949GcN8Miwn37b8b7eMj+EZaq7VK9fx0Jd+JhmkhjFhvnovhg==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.54.0",
-        "@typescript-eslint/visitor-keys": "5.54.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.54.0.tgz",
-      "integrity": "sha512-nExy+fDCBEgqblasfeE3aQ3NuafBUxZxgxXcYfzYRZFHdVvk5q60KhCSkG0noHgHRo/xQ/BOzURLZAafFpTkmQ==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.54.0.tgz",
-      "integrity": "sha512-xu4wT7aRCakGINTLGeyGqDn+78BwFlggwBjnHa1ar/KaGagnmwLYmlrXIrgAaQ3AE1Vd6nLfKASm7LrFHNbKGA==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.54.0",
-        "eslint-visitor-keys": "^3.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.54.0.tgz",
-      "integrity": "sha512-aAVL3Mu2qTi+h/r04WI/5PfNWvO6pdhpeMRWk9R7rEV4mwJNzoWf5CCU5vDKBsPIFQFjEq1xg7XBI2rjiMXQbQ==",
+      "version": "5.48.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.48.1.tgz",
+      "integrity": "sha512-4yg+FJR/V1M9Xoq56SF9Iygqm+r5LMXvheo6DQ7/yUWynQ4YfCRnsKuRgqH4EQ5Ya76rVwlEpw4Xu+TgWQUcdA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.54.0",
-        "@typescript-eslint/types": "5.54.0",
-        "@typescript-eslint/typescript-estree": "5.54.0",
+        "@typescript-eslint/scope-manager": "5.48.1",
+        "@typescript-eslint/types": "5.48.1",
+        "@typescript-eslint/typescript-estree": "5.48.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2368,71 +2286,14 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.54.0.tgz",
-      "integrity": "sha512-VTPYNZ7vaWtYna9M4oD42zENOBrb+ZYyCNdFs949GcN8Miwn37b8b7eMj+EZaq7VK9fx0Jd+JhmkhjFhvnovhg==",
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.48.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.48.1.tgz",
+      "integrity": "sha512-S035ueRrbxRMKvSTv9vJKIWgr86BD8s3RqoRZmsSh/s8HhIs90g6UlK8ZabUSjUZQkhVxt7nmZ63VJ9dcZhtDQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.54.0",
-        "@typescript-eslint/visitor-keys": "5.54.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.54.0.tgz",
-      "integrity": "sha512-nExy+fDCBEgqblasfeE3aQ3NuafBUxZxgxXcYfzYRZFHdVvk5q60KhCSkG0noHgHRo/xQ/BOzURLZAafFpTkmQ==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.54.0.tgz",
-      "integrity": "sha512-X2rJG97Wj/VRo5YxJ8Qx26Zqf0RRKsVHd4sav8NElhbZzhpBI8jU54i6hfo9eheumj4oO4dcRN1B/zIVEqR/MQ==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.54.0",
-        "@typescript-eslint/visitor-keys": "5.54.0",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.54.0.tgz",
-      "integrity": "sha512-xu4wT7aRCakGINTLGeyGqDn+78BwFlggwBjnHa1ar/KaGagnmwLYmlrXIrgAaQ3AE1Vd6nLfKASm7LrFHNbKGA==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.54.0",
-        "eslint-visitor-keys": "^3.3.0"
+        "@typescript-eslint/types": "5.48.1",
+        "@typescript-eslint/visitor-keys": "5.48.1"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2443,13 +2304,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.54.0.tgz",
-      "integrity": "sha512-WI+WMJ8+oS+LyflqsD4nlXMsVdzTMYTxl16myXPaCXnSgc7LWwMsjxQFZCK/rVmTZ3FN71Ct78ehO9bRC7erYQ==",
+      "version": "5.48.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.48.1.tgz",
+      "integrity": "sha512-Hyr8HU8Alcuva1ppmqSYtM/Gp0q4JOp1F+/JH5D1IZm/bUBrV0edoewQZiEc1r6I8L4JL21broddxK8HAcZiqQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.54.0",
-        "@typescript-eslint/utils": "5.54.0",
+        "@typescript-eslint/typescript-estree": "5.48.1",
+        "@typescript-eslint/utils": "5.48.1",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -2469,10 +2330,10 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.54.0.tgz",
-      "integrity": "sha512-nExy+fDCBEgqblasfeE3aQ3NuafBUxZxgxXcYfzYRZFHdVvk5q60KhCSkG0noHgHRo/xQ/BOzURLZAafFpTkmQ==",
+    "node_modules/@typescript-eslint/types": {
+      "version": "5.48.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.48.1.tgz",
+      "integrity": "sha512-xHyDLU6MSuEEdIlzrrAerCGS3T7AA/L8Hggd0RCYBi0w3JMvGYxlLlXHeg50JI9Tfg5MrtsfuNxbS/3zF1/ATg==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2482,14 +2343,14 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.54.0.tgz",
-      "integrity": "sha512-X2rJG97Wj/VRo5YxJ8Qx26Zqf0RRKsVHd4sav8NElhbZzhpBI8jU54i6hfo9eheumj4oO4dcRN1B/zIVEqR/MQ==",
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.48.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.48.1.tgz",
+      "integrity": "sha512-Hut+Osk5FYr+sgFh8J/FHjqX6HFcDzTlWLrFqGoK5kVUN3VBHF/QzZmAsIXCQ8T/W9nQNBTqalxi1P3LSqWnRA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.54.0",
-        "@typescript-eslint/visitor-keys": "5.54.0",
+        "@typescript-eslint/types": "5.48.1",
+        "@typescript-eslint/visitor-keys": "5.48.1",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -2509,34 +2370,17 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.54.0.tgz",
-      "integrity": "sha512-xu4wT7aRCakGINTLGeyGqDn+78BwFlggwBjnHa1ar/KaGagnmwLYmlrXIrgAaQ3AE1Vd6nLfKASm7LrFHNbKGA==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.54.0",
-        "eslint-visitor-keys": "^3.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.54.0.tgz",
-      "integrity": "sha512-cuwm8D/Z/7AuyAeJ+T0r4WZmlnlxQ8wt7C7fLpFlKMR+dY6QO79Cq1WpJhvZbMA4ZeZGHiRWnht7ZJ8qkdAunw==",
+      "version": "5.48.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.48.1.tgz",
+      "integrity": "sha512-SmQuSrCGUOdmGMwivW14Z0Lj8dxG1mOFZ7soeJ0TQZEJcs3n5Ndgkg0A4bcMFzBELqLJ6GTHnEU+iIoaD6hFGA==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.54.0",
-        "@typescript-eslint/types": "5.54.0",
-        "@typescript-eslint/typescript-estree": "5.54.0",
+        "@typescript-eslint/scope-manager": "5.48.1",
+        "@typescript-eslint/types": "5.48.1",
+        "@typescript-eslint/typescript-estree": "5.48.1",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0",
         "semver": "^7.3.7"
@@ -2552,70 +2396,13 @@
         "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.54.0.tgz",
-      "integrity": "sha512-VTPYNZ7vaWtYna9M4oD42zENOBrb+ZYyCNdFs949GcN8Miwn37b8b7eMj+EZaq7VK9fx0Jd+JhmkhjFhvnovhg==",
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.48.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.48.1.tgz",
+      "integrity": "sha512-Ns0XBwmfuX7ZknznfXozgnydyR8F6ev/KEGePP4i74uL3ArsKbEhJ7raeKr1JSa997DBDwol/4a0Y+At82c9dA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.54.0",
-        "@typescript-eslint/visitor-keys": "5.54.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.54.0.tgz",
-      "integrity": "sha512-nExy+fDCBEgqblasfeE3aQ3NuafBUxZxgxXcYfzYRZFHdVvk5q60KhCSkG0noHgHRo/xQ/BOzURLZAafFpTkmQ==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.54.0.tgz",
-      "integrity": "sha512-X2rJG97Wj/VRo5YxJ8Qx26Zqf0RRKsVHd4sav8NElhbZzhpBI8jU54i6hfo9eheumj4oO4dcRN1B/zIVEqR/MQ==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.54.0",
-        "@typescript-eslint/visitor-keys": "5.54.0",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.54.0.tgz",
-      "integrity": "sha512-xu4wT7aRCakGINTLGeyGqDn+78BwFlggwBjnHa1ar/KaGagnmwLYmlrXIrgAaQ3AE1Vd6nLfKASm7LrFHNbKGA==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.54.0",
+        "@typescript-eslint/types": "5.48.1",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -4034,9 +3821,9 @@
       "dev": true
     },
     "node_modules/cron-parser": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.7.1.tgz",
-      "integrity": "sha512-WguFaoQ0hQ61SgsCZLHUcNbAvlK0lypKXu62ARguefYmjzaOXIVRNrAmyXzabTwUn4sQvQLkk6bjH+ipGfw8bA==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.8.0.tgz",
+      "integrity": "sha512-VjwVZx26j7lukZmG3gtAvPYkD6wuMuIdYhEzrmpHtSGO9dvKkv+EhReFY7HQPsGuGUfy+by3IOriuzyrzxl9MQ==",
       "dev": true,
       "dependencies": {
         "luxon": "^3.2.1"
@@ -5968,14 +5755,13 @@
       }
     },
     "node_modules/google-gax": {
-      "version": "3.5.7",
-      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-3.5.7.tgz",
-      "integrity": "sha512-taDGwR9Ry5y6NkcPYKe0B3wr7rCwaImZZIuWajUcFe9Y8L71eBtaq0+ZJ62JByzr/2cJkd9EN1rr52rD6V/UDA==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-3.5.2.tgz",
+      "integrity": "sha512-AyP53w0gHcWlzxm+jSgqCR3Xu4Ld7EpSjhtNBnNhzwwWaIUyphH9kBGNIEH+i4UGkTUXOY29K/Re8EiAvkBRGw==",
       "dependencies": {
-        "@grpc/grpc-js": "~1.8.0",
+        "@grpc/grpc-js": "~1.7.0",
         "@grpc/proto-loader": "^0.7.0",
         "@types/long": "^4.0.0",
-        "@types/rimraf": "^3.0.2",
         "abort-controller": "^3.0.0",
         "duplexify": "^4.0.0",
         "fast-text-encoding": "^1.0.3",
@@ -5984,8 +5770,8 @@
         "node-fetch": "^2.6.1",
         "object-hash": "^3.0.0",
         "proto3-json-serializer": "^1.0.0",
-        "protobufjs": "7.2.2",
-        "protobufjs-cli": "1.1.1",
+        "protobufjs": "7.1.2",
+        "protobufjs-cli": "1.0.2",
         "retry-request": "^5.0.0"
       },
       "bin": {
@@ -5994,6 +5780,18 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/google-gax/node_modules/@grpc/grpc-js": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.7.3.tgz",
+      "integrity": "sha512-H9l79u4kJ2PVSxUNA08HMYAnUBLj9v6KjYQ7SQ71hOZcEXhShE/y5iQCesP8+6/Ik/7i2O0a10bPquIcYfufog==",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.0",
+        "@types/node": ">=12.12.47"
+      },
+      "engines": {
+        "node": "^8.13.0 || >=10.10.0"
       }
     },
     "node_modules/google-p12-pem": {
@@ -6848,12 +6646,11 @@
       }
     },
     "node_modules/jsdoc": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.2.tgz",
-      "integrity": "sha512-e8cIg2z62InH7azBBi3EsSEqrKx+nUtAS5bBcYTSpZFA+vhNPyhv8PTFZ0WsjOPDj04/dOLlm08EDcQJDqaGQg==",
+      "version": "3.6.11",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.11.tgz",
+      "integrity": "sha512-8UCU0TYeIYD9KeLzEcAu2q8N/mx9O3phAGl32nmHlE0LpaJL71mMkP4d+QE5zWfNt50qheHtOZ0qoxVrsX5TUg==",
       "dependencies": {
-        "@babel/parser": "^7.20.15",
-        "@jsdoc/salty": "^0.2.1",
+        "@babel/parser": "^7.9.4",
         "@types/markdown-it": "^12.2.3",
         "bluebird": "^3.7.2",
         "catharsis": "^0.9.0",
@@ -6866,6 +6663,7 @@
         "mkdirp": "^1.0.4",
         "requizzle": "^0.2.3",
         "strip-json-comments": "^3.1.0",
+        "taffydb": "2.6.2",
         "underscore": "~1.13.2"
       },
       "bin": {
@@ -7370,9 +7168,9 @@
       }
     },
     "node_modules/luxon": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.2.1.tgz",
-      "integrity": "sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.3.0.tgz",
+      "integrity": "sha512-An0UCfG/rSiqtAIiBPO0Y9/zAnHUZxAMiCpTd5h2smgsj7GGmcenvrvww2cqNA8/4A5ZrD1gJpHN2mIHZQF+Mg==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -7424,9 +7222,9 @@
       }
     },
     "node_modules/markdown-it-anchor": {
-      "version": "8.6.7",
-      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.7.tgz",
-      "integrity": "sha512-FlCHFwNnutLgVTflOYHPW2pPcl2AACqVzExlkGQNsi4CJgqOHN7YTgDd4LuhgN1BFO3TS0vLAruV1Td6dwWPJA==",
+      "version": "8.6.6",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.6.tgz",
+      "integrity": "sha512-jRW30YGywD2ESXDc+l17AiritL0uVaSnWsb26f+68qaW9zgbIIr1f4v2Nsvc0+s0Z2N3uX6t/yAw7BwCQ1wMsA==",
       "peerDependencies": {
         "@types/markdown-it": "*",
         "markdown-it": "*"
@@ -7572,9 +7370,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -8613,9 +8411,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.2.tgz",
-      "integrity": "sha512-++PrQIjrom+bFDPpfmqXfAGSQs40116JRrqqyf53dymUMvvb5d/LMRyicRoF1AUKoXVS1/IgJXlEgcpr4gTF3Q==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.1.2.tgz",
+      "integrity": "sha512-4ZPTPkXCdel3+L81yw3dG6+Kq3umdWKh7Dc7GW/CpNk4SX3hK58iPCWeCyhVTDrbkNeKrYNZ7EojM5WDaEWTLQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -8636,16 +8434,16 @@
       }
     },
     "node_modules/protobufjs-cli": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/protobufjs-cli/-/protobufjs-cli-1.1.1.tgz",
-      "integrity": "sha512-VPWMgIcRNyQwWUv8OLPyGQ/0lQY/QTQAVN5fh+XzfDwsVw1FZ2L3DM/bcBf8WPiRz2tNpaov9lPZfNcmNo6LXA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/protobufjs-cli/-/protobufjs-cli-1.0.2.tgz",
+      "integrity": "sha512-cz9Pq9p/Zs7okc6avH20W7QuyjTclwJPgqXG11jNaulfS3nbVisID8rC+prfgq0gbZE0w9LBFd1OKFF03kgFzg==",
       "dependencies": {
         "chalk": "^4.0.0",
         "escodegen": "^1.13.0",
         "espree": "^9.0.0",
         "estraverse": "^5.1.0",
         "glob": "^8.0.0",
-        "jsdoc": "^4.0.0",
+        "jsdoc": "^3.6.3",
         "minimist": "^1.2.0",
         "semver": "^7.1.2",
         "tmp": "^0.2.1",
@@ -9927,6 +9725,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/taffydb": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
+      "integrity": "sha512-y3JaeRSplks6NYQuCOj3ZFMO3j60rTwbuKCvZxsAraGYH2epusatvZ0baZYA01WsGqJBq/Dl6vOrMUJqyMj8kA=="
     },
     "node_modules/tar": {
       "version": "6.1.13",
@@ -11769,9 +11572,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.21.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.2.tgz",
-      "integrity": "sha512-URpaIJQwEkEC2T9Kn+Ai6Xe/02iNaVCuT/PtoRz3GPVJVDpPd7mLo+VddTbhCRU9TXqW5mSrQfXZyi8kDKOVpQ=="
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.7.tgz",
+      "integrity": "sha512-T3Z9oHybU+0vZlY9CiDSJQTD5ZapcW18ZctFMi0MOAl/4BjFF4ul7NVSARLdbGO5vDqy9eQiGTV0LtKfvCYvcg=="
     },
     "@contentful/node-apps-toolkit": {
       "version": "2.0.4",
@@ -11813,9 +11616,9 @@
       }
     },
     "@google-analytics/admin": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@google-analytics/admin/-/admin-4.6.0.tgz",
-      "integrity": "sha512-DrFYdSalwCXuMyfqMTHTsaQ8U6HaYhvonDIHL1AFx6b2LjHqmsLaSlL+hGYVqjN2QM1vngjtw1zzUvFq8nessg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@google-analytics/admin/-/admin-4.3.1.tgz",
+      "integrity": "sha512-Ncl6BwNRqxk4DDhNzQMPjQn5UmDyYv/hXEbCOKP4kspp7r1OQglajVXhtCx0jH9QP0+cw6B7gWDWwaCDNDgQvw==",
       "requires": {
         "google-auth-library": "^8.0.2",
         "google-gax": "^3.5.2",
@@ -11831,9 +11634,9 @@
       }
     },
     "@grpc/grpc-js": {
-      "version": "1.8.11",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.11.tgz",
-      "integrity": "sha512-f/xC+6Z2QKsRJ+VSSFlt4hA5KSRm+PKvMWV8kMPkMgGlFidR6PeIkXrOasIY2roe+WROM6GFQLlgDKfeEZo2YQ==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.4.tgz",
+      "integrity": "sha512-oaETBotls7FTBpySg5dhyUCyXSxSeCMmkBBXHXG1iw57MiNoB6D7VRhkrXYbwyHM3Q3Afjp4KlsBX0Zb+ELZXw==",
       "requires": {
         "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"
@@ -12210,14 +12013,6 @@
       "requires": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
-    "@jsdoc/salty": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.4.tgz",
-      "integrity": "sha512-HRBmslXHM6kpZOfGf0o41NUlGYGER0NoUBcT2Sik4rxzAN7f7+si7ad57SFSFpftvaMVnUaY7YlJuv3v5G80ZA==",
-      "requires": {
-        "lodash": "^4.17.21"
       }
     },
     "@kwsites/file-exists": {
@@ -12665,15 +12460,6 @@
         "@types/range-parser": "*"
       }
     },
-    "@types/glob": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.1.0.tgz",
-      "integrity": "sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==",
-      "requires": {
-        "@types/minimatch": "^5.1.2",
-        "@types/node": "*"
-      }
-    },
     "@types/http-cache-semantics": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
@@ -12729,11 +12515,6 @@
       "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
       "dev": true
     },
-    "@types/minimatch": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
-      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA=="
-    },
     "@types/mocha": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.1.tgz",
@@ -12775,15 +12556,6 @@
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
       "dev": true
-    },
-    "@types/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==",
-      "requires": {
-        "@types/glob": "*",
-        "@types/node": "*"
-      }
     },
     "@types/semver": {
       "version": "7.3.13",
@@ -12827,208 +12599,101 @@
       }
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.54.0.tgz",
-      "integrity": "sha512-+hSN9BdSr629RF02d7mMtXhAJvDTyCbprNYJKrXETlul/Aml6YZwd90XioVbjejQeHbb3R8Dg0CkRgoJDxo8aw==",
+      "version": "5.48.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.48.1.tgz",
+      "integrity": "sha512-9nY5K1Rp2ppmpb9s9S2aBiF3xo5uExCehMDmYmmFqqyxgenbHJ3qbarcLt4ITgaD6r/2ypdlcFRdcuVPnks+fQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.54.0",
-        "@typescript-eslint/type-utils": "5.54.0",
-        "@typescript-eslint/utils": "5.54.0",
+        "@typescript-eslint/scope-manager": "5.48.1",
+        "@typescript-eslint/type-utils": "5.48.1",
+        "@typescript-eslint/utils": "5.48.1",
         "debug": "^4.3.4",
-        "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
         "natural-compare-lite": "^1.4.0",
         "regexpp": "^3.2.0",
         "semver": "^7.3.7",
         "tsutils": "^3.21.0"
-      },
-      "dependencies": {
-        "@typescript-eslint/scope-manager": {
-          "version": "5.54.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.54.0.tgz",
-          "integrity": "sha512-VTPYNZ7vaWtYna9M4oD42zENOBrb+ZYyCNdFs949GcN8Miwn37b8b7eMj+EZaq7VK9fx0Jd+JhmkhjFhvnovhg==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.54.0",
-            "@typescript-eslint/visitor-keys": "5.54.0"
-          }
-        },
-        "@typescript-eslint/types": {
-          "version": "5.54.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.54.0.tgz",
-          "integrity": "sha512-nExy+fDCBEgqblasfeE3aQ3NuafBUxZxgxXcYfzYRZFHdVvk5q60KhCSkG0noHgHRo/xQ/BOzURLZAafFpTkmQ==",
-          "dev": true
-        },
-        "@typescript-eslint/visitor-keys": {
-          "version": "5.54.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.54.0.tgz",
-          "integrity": "sha512-xu4wT7aRCakGINTLGeyGqDn+78BwFlggwBjnHa1ar/KaGagnmwLYmlrXIrgAaQ3AE1Vd6nLfKASm7LrFHNbKGA==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.54.0",
-            "eslint-visitor-keys": "^3.3.0"
-          }
-        }
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.54.0.tgz",
-      "integrity": "sha512-aAVL3Mu2qTi+h/r04WI/5PfNWvO6pdhpeMRWk9R7rEV4mwJNzoWf5CCU5vDKBsPIFQFjEq1xg7XBI2rjiMXQbQ==",
+      "version": "5.48.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.48.1.tgz",
+      "integrity": "sha512-4yg+FJR/V1M9Xoq56SF9Iygqm+r5LMXvheo6DQ7/yUWynQ4YfCRnsKuRgqH4EQ5Ya76rVwlEpw4Xu+TgWQUcdA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.54.0",
-        "@typescript-eslint/types": "5.54.0",
-        "@typescript-eslint/typescript-estree": "5.54.0",
+        "@typescript-eslint/scope-manager": "5.48.1",
+        "@typescript-eslint/types": "5.48.1",
+        "@typescript-eslint/typescript-estree": "5.48.1",
         "debug": "^4.3.4"
-      },
-      "dependencies": {
-        "@typescript-eslint/scope-manager": {
-          "version": "5.54.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.54.0.tgz",
-          "integrity": "sha512-VTPYNZ7vaWtYna9M4oD42zENOBrb+ZYyCNdFs949GcN8Miwn37b8b7eMj+EZaq7VK9fx0Jd+JhmkhjFhvnovhg==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.54.0",
-            "@typescript-eslint/visitor-keys": "5.54.0"
-          }
-        },
-        "@typescript-eslint/types": {
-          "version": "5.54.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.54.0.tgz",
-          "integrity": "sha512-nExy+fDCBEgqblasfeE3aQ3NuafBUxZxgxXcYfzYRZFHdVvk5q60KhCSkG0noHgHRo/xQ/BOzURLZAafFpTkmQ==",
-          "dev": true
-        },
-        "@typescript-eslint/typescript-estree": {
-          "version": "5.54.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.54.0.tgz",
-          "integrity": "sha512-X2rJG97Wj/VRo5YxJ8Qx26Zqf0RRKsVHd4sav8NElhbZzhpBI8jU54i6hfo9eheumj4oO4dcRN1B/zIVEqR/MQ==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.54.0",
-            "@typescript-eslint/visitor-keys": "5.54.0",
-            "debug": "^4.3.4",
-            "globby": "^11.1.0",
-            "is-glob": "^4.0.3",
-            "semver": "^7.3.7",
-            "tsutils": "^3.21.0"
-          }
-        },
-        "@typescript-eslint/visitor-keys": {
-          "version": "5.54.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.54.0.tgz",
-          "integrity": "sha512-xu4wT7aRCakGINTLGeyGqDn+78BwFlggwBjnHa1ar/KaGagnmwLYmlrXIrgAaQ3AE1Vd6nLfKASm7LrFHNbKGA==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.54.0",
-            "eslint-visitor-keys": "^3.3.0"
-          }
-        }
+      }
+    },
+    "@typescript-eslint/scope-manager": {
+      "version": "5.48.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.48.1.tgz",
+      "integrity": "sha512-S035ueRrbxRMKvSTv9vJKIWgr86BD8s3RqoRZmsSh/s8HhIs90g6UlK8ZabUSjUZQkhVxt7nmZ63VJ9dcZhtDQ==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "5.48.1",
+        "@typescript-eslint/visitor-keys": "5.48.1"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.54.0.tgz",
-      "integrity": "sha512-WI+WMJ8+oS+LyflqsD4nlXMsVdzTMYTxl16myXPaCXnSgc7LWwMsjxQFZCK/rVmTZ3FN71Ct78ehO9bRC7erYQ==",
+      "version": "5.48.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.48.1.tgz",
+      "integrity": "sha512-Hyr8HU8Alcuva1ppmqSYtM/Gp0q4JOp1F+/JH5D1IZm/bUBrV0edoewQZiEc1r6I8L4JL21broddxK8HAcZiqQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "5.54.0",
-        "@typescript-eslint/utils": "5.54.0",
+        "@typescript-eslint/typescript-estree": "5.48.1",
+        "@typescript-eslint/utils": "5.48.1",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
-      },
-      "dependencies": {
-        "@typescript-eslint/types": {
-          "version": "5.54.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.54.0.tgz",
-          "integrity": "sha512-nExy+fDCBEgqblasfeE3aQ3NuafBUxZxgxXcYfzYRZFHdVvk5q60KhCSkG0noHgHRo/xQ/BOzURLZAafFpTkmQ==",
-          "dev": true
-        },
-        "@typescript-eslint/typescript-estree": {
-          "version": "5.54.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.54.0.tgz",
-          "integrity": "sha512-X2rJG97Wj/VRo5YxJ8Qx26Zqf0RRKsVHd4sav8NElhbZzhpBI8jU54i6hfo9eheumj4oO4dcRN1B/zIVEqR/MQ==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.54.0",
-            "@typescript-eslint/visitor-keys": "5.54.0",
-            "debug": "^4.3.4",
-            "globby": "^11.1.0",
-            "is-glob": "^4.0.3",
-            "semver": "^7.3.7",
-            "tsutils": "^3.21.0"
-          }
-        },
-        "@typescript-eslint/visitor-keys": {
-          "version": "5.54.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.54.0.tgz",
-          "integrity": "sha512-xu4wT7aRCakGINTLGeyGqDn+78BwFlggwBjnHa1ar/KaGagnmwLYmlrXIrgAaQ3AE1Vd6nLfKASm7LrFHNbKGA==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.54.0",
-            "eslint-visitor-keys": "^3.3.0"
-          }
-        }
+      }
+    },
+    "@typescript-eslint/types": {
+      "version": "5.48.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.48.1.tgz",
+      "integrity": "sha512-xHyDLU6MSuEEdIlzrrAerCGS3T7AA/L8Hggd0RCYBi0w3JMvGYxlLlXHeg50JI9Tfg5MrtsfuNxbS/3zF1/ATg==",
+      "dev": true
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "5.48.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.48.1.tgz",
+      "integrity": "sha512-Hut+Osk5FYr+sgFh8J/FHjqX6HFcDzTlWLrFqGoK5kVUN3VBHF/QzZmAsIXCQ8T/W9nQNBTqalxi1P3LSqWnRA==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "5.48.1",
+        "@typescript-eslint/visitor-keys": "5.48.1",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.54.0.tgz",
-      "integrity": "sha512-cuwm8D/Z/7AuyAeJ+T0r4WZmlnlxQ8wt7C7fLpFlKMR+dY6QO79Cq1WpJhvZbMA4ZeZGHiRWnht7ZJ8qkdAunw==",
+      "version": "5.48.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.48.1.tgz",
+      "integrity": "sha512-SmQuSrCGUOdmGMwivW14Z0Lj8dxG1mOFZ7soeJ0TQZEJcs3n5Ndgkg0A4bcMFzBELqLJ6GTHnEU+iIoaD6hFGA==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.54.0",
-        "@typescript-eslint/types": "5.54.0",
-        "@typescript-eslint/typescript-estree": "5.54.0",
+        "@typescript-eslint/scope-manager": "5.48.1",
+        "@typescript-eslint/types": "5.48.1",
+        "@typescript-eslint/typescript-estree": "5.48.1",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0",
         "semver": "^7.3.7"
-      },
-      "dependencies": {
-        "@typescript-eslint/scope-manager": {
-          "version": "5.54.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.54.0.tgz",
-          "integrity": "sha512-VTPYNZ7vaWtYna9M4oD42zENOBrb+ZYyCNdFs949GcN8Miwn37b8b7eMj+EZaq7VK9fx0Jd+JhmkhjFhvnovhg==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.54.0",
-            "@typescript-eslint/visitor-keys": "5.54.0"
-          }
-        },
-        "@typescript-eslint/types": {
-          "version": "5.54.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.54.0.tgz",
-          "integrity": "sha512-nExy+fDCBEgqblasfeE3aQ3NuafBUxZxgxXcYfzYRZFHdVvk5q60KhCSkG0noHgHRo/xQ/BOzURLZAafFpTkmQ==",
-          "dev": true
-        },
-        "@typescript-eslint/typescript-estree": {
-          "version": "5.54.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.54.0.tgz",
-          "integrity": "sha512-X2rJG97Wj/VRo5YxJ8Qx26Zqf0RRKsVHd4sav8NElhbZzhpBI8jU54i6hfo9eheumj4oO4dcRN1B/zIVEqR/MQ==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.54.0",
-            "@typescript-eslint/visitor-keys": "5.54.0",
-            "debug": "^4.3.4",
-            "globby": "^11.1.0",
-            "is-glob": "^4.0.3",
-            "semver": "^7.3.7",
-            "tsutils": "^3.21.0"
-          }
-        },
-        "@typescript-eslint/visitor-keys": {
-          "version": "5.54.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.54.0.tgz",
-          "integrity": "sha512-xu4wT7aRCakGINTLGeyGqDn+78BwFlggwBjnHa1ar/KaGagnmwLYmlrXIrgAaQ3AE1Vd6nLfKASm7LrFHNbKGA==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.54.0",
-            "eslint-visitor-keys": "^3.3.0"
-          }
-        }
+      }
+    },
+    "@typescript-eslint/visitor-keys": {
+      "version": "5.48.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.48.1.tgz",
+      "integrity": "sha512-Ns0XBwmfuX7ZknznfXozgnydyR8F6ev/KEGePP4i74uL3ArsKbEhJ7raeKr1JSa997DBDwol/4a0Y+At82c9dA==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "5.48.1",
+        "eslint-visitor-keys": "^3.3.0"
       }
     },
     "2-thenable": {
@@ -14086,9 +13751,9 @@
       "dev": true
     },
     "cron-parser": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.7.1.tgz",
-      "integrity": "sha512-WguFaoQ0hQ61SgsCZLHUcNbAvlK0lypKXu62ARguefYmjzaOXIVRNrAmyXzabTwUn4sQvQLkk6bjH+ipGfw8bA==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.8.0.tgz",
+      "integrity": "sha512-VjwVZx26j7lukZmG3gtAvPYkD6wuMuIdYhEzrmpHtSGO9dvKkv+EhReFY7HQPsGuGUfy+by3IOriuzyrzxl9MQ==",
       "dev": true,
       "requires": {
         "luxon": "^3.2.1"
@@ -15569,14 +15234,13 @@
       }
     },
     "google-gax": {
-      "version": "3.5.7",
-      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-3.5.7.tgz",
-      "integrity": "sha512-taDGwR9Ry5y6NkcPYKe0B3wr7rCwaImZZIuWajUcFe9Y8L71eBtaq0+ZJ62JByzr/2cJkd9EN1rr52rD6V/UDA==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-3.5.2.tgz",
+      "integrity": "sha512-AyP53w0gHcWlzxm+jSgqCR3Xu4Ld7EpSjhtNBnNhzwwWaIUyphH9kBGNIEH+i4UGkTUXOY29K/Re8EiAvkBRGw==",
       "requires": {
-        "@grpc/grpc-js": "~1.8.0",
+        "@grpc/grpc-js": "~1.7.0",
         "@grpc/proto-loader": "^0.7.0",
         "@types/long": "^4.0.0",
-        "@types/rimraf": "^3.0.2",
         "abort-controller": "^3.0.0",
         "duplexify": "^4.0.0",
         "fast-text-encoding": "^1.0.3",
@@ -15585,9 +15249,20 @@
         "node-fetch": "^2.6.1",
         "object-hash": "^3.0.0",
         "proto3-json-serializer": "^1.0.0",
-        "protobufjs": "7.2.2",
-        "protobufjs-cli": "1.1.1",
+        "protobufjs": "7.1.2",
+        "protobufjs-cli": "1.0.2",
         "retry-request": "^5.0.0"
+      },
+      "dependencies": {
+        "@grpc/grpc-js": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.7.3.tgz",
+          "integrity": "sha512-H9l79u4kJ2PVSxUNA08HMYAnUBLj9v6KjYQ7SQ71hOZcEXhShE/y5iQCesP8+6/Ik/7i2O0a10bPquIcYfufog==",
+          "requires": {
+            "@grpc/proto-loader": "^0.7.0",
+            "@types/node": ">=12.12.47"
+          }
+        }
       }
     },
     "google-p12-pem": {
@@ -16196,12 +15871,11 @@
       }
     },
     "jsdoc": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.2.tgz",
-      "integrity": "sha512-e8cIg2z62InH7azBBi3EsSEqrKx+nUtAS5bBcYTSpZFA+vhNPyhv8PTFZ0WsjOPDj04/dOLlm08EDcQJDqaGQg==",
+      "version": "3.6.11",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.11.tgz",
+      "integrity": "sha512-8UCU0TYeIYD9KeLzEcAu2q8N/mx9O3phAGl32nmHlE0LpaJL71mMkP4d+QE5zWfNt50qheHtOZ0qoxVrsX5TUg==",
       "requires": {
-        "@babel/parser": "^7.20.15",
-        "@jsdoc/salty": "^0.2.1",
+        "@babel/parser": "^7.9.4",
         "@types/markdown-it": "^12.2.3",
         "bluebird": "^3.7.2",
         "catharsis": "^0.9.0",
@@ -16214,6 +15888,7 @@
         "mkdirp": "^1.0.4",
         "requizzle": "^0.2.3",
         "strip-json-comments": "^3.1.0",
+        "taffydb": "2.6.2",
         "underscore": "~1.13.2"
       },
       "dependencies": {
@@ -16661,9 +16336,9 @@
       }
     },
     "luxon": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.2.1.tgz",
-      "integrity": "sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.3.0.tgz",
+      "integrity": "sha512-An0UCfG/rSiqtAIiBPO0Y9/zAnHUZxAMiCpTd5h2smgsj7GGmcenvrvww2cqNA8/4A5ZrD1gJpHN2mIHZQF+Mg==",
       "dev": true
     },
     "make-dir": {
@@ -16702,9 +16377,9 @@
       }
     },
     "markdown-it-anchor": {
-      "version": "8.6.7",
-      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.7.tgz",
-      "integrity": "sha512-FlCHFwNnutLgVTflOYHPW2pPcl2AACqVzExlkGQNsi4CJgqOHN7YTgDd4LuhgN1BFO3TS0vLAruV1Td6dwWPJA==",
+      "version": "8.6.6",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.6.tgz",
+      "integrity": "sha512-jRW30YGywD2ESXDc+l17AiritL0uVaSnWsb26f+68qaW9zgbIIr1f4v2Nsvc0+s0Z2N3uX6t/yAw7BwCQ1wMsA==",
       "requires": {}
     },
     "marked": {
@@ -16808,9 +16483,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g=="
     },
     "minipass": {
       "version": "4.0.0",
@@ -17560,9 +17235,9 @@
       }
     },
     "protobufjs": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.2.tgz",
-      "integrity": "sha512-++PrQIjrom+bFDPpfmqXfAGSQs40116JRrqqyf53dymUMvvb5d/LMRyicRoF1AUKoXVS1/IgJXlEgcpr4gTF3Q==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.1.2.tgz",
+      "integrity": "sha512-4ZPTPkXCdel3+L81yw3dG6+Kq3umdWKh7Dc7GW/CpNk4SX3hK58iPCWeCyhVTDrbkNeKrYNZ7EojM5WDaEWTLQ==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -17586,16 +17261,16 @@
       }
     },
     "protobufjs-cli": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/protobufjs-cli/-/protobufjs-cli-1.1.1.tgz",
-      "integrity": "sha512-VPWMgIcRNyQwWUv8OLPyGQ/0lQY/QTQAVN5fh+XzfDwsVw1FZ2L3DM/bcBf8WPiRz2tNpaov9lPZfNcmNo6LXA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/protobufjs-cli/-/protobufjs-cli-1.0.2.tgz",
+      "integrity": "sha512-cz9Pq9p/Zs7okc6avH20W7QuyjTclwJPgqXG11jNaulfS3nbVisID8rC+prfgq0gbZE0w9LBFd1OKFF03kgFzg==",
       "requires": {
         "chalk": "^4.0.0",
         "escodegen": "^1.13.0",
         "espree": "^9.0.0",
         "estraverse": "^5.1.0",
         "glob": "^8.0.0",
-        "jsdoc": "^4.0.0",
+        "jsdoc": "^3.6.3",
         "minimist": "^1.2.0",
         "semver": "^7.1.2",
         "tmp": "^0.2.1",
@@ -18549,6 +18224,11 @@
       "requires": {
         "has-flag": "^4.0.0"
       }
+    },
+    "taffydb": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
+      "integrity": "sha512-y3JaeRSplks6NYQuCOj3ZFMO3j60rTwbuKCvZxsAraGYH2epusatvZ0baZYA01WsGqJBq/Dl6vOrMUJqyMj8kA=="
     },
     "tar": {
       "version": "6.1.13",

--- a/apps/google-analytics-4/lambda/package.json
+++ b/apps/google-analytics-4/lambda/package.json
@@ -34,9 +34,9 @@
     "mocha": "^10.2.0",
     "nodemon": "^2.0.20",
     "rimraf": "^3.0.2",
-    "serverless": "3.28.1",
+    "serverless": "^3.28.1",
     "serverless-domain-manager": "^6.4.4",
-    "serverless-offline": "12.0.4",
+    "serverless-offline": "^12.0.4",
     "sinon": "^15.0.1",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.4"

--- a/apps/google-analytics-4/lambda/serverless.yml
+++ b/apps/google-analytics-4/lambda/serverless.yml
@@ -1,15 +1,6 @@
 service: sls-apps-google-analytics-4
 
-# At the time of writing, there is a known issue with serverless variable resolution
-# in repos with multiple serverless.yml files and external configuration files.
-# variablesResolutionMode: 20210326 simulates serverless 3 var res, w/o
-# introducing this bug.
-# In the future this can likely be changed to:
-# frameworkVersion: '>=3.0.0 <4.0.0'
-# + package.json version changes to serverless, serverless-domain-manager,
-# and serverless-offline.
-frameworkVersion: '>=2.0.0 <3.0.0'
-variablesResolutionMode: 20210326
+frameworkVersion: '>=3.0.0 <4.0.0'
 
 plugins:
   - serverless-domain-manager
@@ -31,7 +22,6 @@ provider:
   runtime: nodejs18.x
   stage: ${opt:stage, 'dev'}
   region: 'us-east-1'
-  lambdaHashingVersion: 20201221
   timeout: 30
   deploymentBucket:
     name: cf-apps-serverless-deployment


### PR DESCRIPTION
## Purpose
In order to not restrict our dependabot and general module upgrades, we need to upgrade serverless to v3. This is known to have some file pathing issues in repos like ours with multiple package.json files, but is worth testing out anyway.

## Approach
Upgrades serverless, serverless-domain-manager, and serverless-offline to their most recent versions. Also removes some compatibility flags for preparing sls 2 to be upgraded.

## Dependencies and/or References
[JIRA](https://contentful.atlassian.net/browse/INTEG-199)
