### PR TITLE
INTEG-205 Fix GA4 FE url

### DIFF
--- a/apps/google-analytics-4/frontend/.env
+++ b/apps/google-analytics-4/frontend/.env
@@ -1,3 +1,3 @@
-REACT_APP_BACKEND_API_URL=https://google-analytics.ctfapps.net
+REACT_APP_BACKEND_API_URL=https://google-analytics-4.ctfapps.net
 REACT_APP_VERSION=$npm_package_version
 REACT_APP_SENTRY_DSN=https://b8f524eae7c446fb8071476431426640@o2239.ingest.sentry.io/4504725335834624


### PR DESCRIPTION
## Purpose
The GA4 frontend needs the correct production url for app configuration to work. Now that we know what that is we can set it.

## Approach
N/A

## Dependencies and/or References
[jira](https://contentful.atlassian.net/jira/software/c/projects/INTEG/boards/454?modal=detail&selectedIssue=INTEG-205)
