### PR TITLE
move sentryDSN out of environment specific variables

### DIFF
--- a/apps/google-analytics-4/lambda/config/serverless-env.dev.yml.example
+++ b/apps/google-analytics-4/lambda/config/serverless-env.dev.yml.example
@@ -1,3 +1,2 @@
 signingSecret: <APP_SIGNING_KEY_GOES_HERE>
 domainName: google-analytics-4-test.ctfapps.net
-sentryDSN: https://b8f524eae7c446fb8071476431426640@o2239.ingest.sentry.io/4504725335834624

--- a/apps/google-analytics-4/lambda/serverless.yml
+++ b/apps/google-analytics-4/lambda/serverless.yml
@@ -7,7 +7,7 @@ plugins:
   - serverless-offline
 
 custom:
-  sentryDSN: ${file(./config/serverless-env.${opt:stage, 'dev'}.yml):sentryDSN}
+  sentryDSN: https://b8f524eae7c446fb8071476431426640@o2239.ingest.sentry.io/4504725335834624
   signingSecret: ${file(./config/serverless-env.${opt:stage, 'dev'}.yml):signingSecret}
   customDomain:
     domainName: ${file(./config/serverless-env.${opt:stage, 'dev'}.yml):domainName}


### PR DESCRIPTION
## Purpose
fix failing master build

## Approach
sentry DSN is not a secret and is not [currently] environment specific. simply put this in serverless.yml with no per-env abstraction