### PR TITLE
capture non-ApiErrors and send to sentry in ApiErrorHandler

### DIFF
--- a/apps/google-analytics-4/lambda/src/middlewares/apiErrorHandler.ts
+++ b/apps/google-analytics-4/lambda/src/middlewares/apiErrorHandler.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/node';
 import { ErrorRequestHandler } from 'express';
 import { isApiError, ApiError } from '../errors/apiError';
 
@@ -14,6 +15,8 @@ export const apiErrorHandler: ErrorRequestHandler = (error, _request, response, 
     if (isApiError(error)) {
       response.status(error.status).send({ errors: error.toJSON() });
     } else {
+      console.error('ERROR: ', error);
+      Sentry.captureException(error);
       response.status(500).send({
         errors: { errorType: 'ServerError', message: 'Internal Server Error', details: null },
       });


### PR DESCRIPTION
## Purpose
adds logging and sends [unknown/unmapped] internal server errors to sentry

## Approach
use Sentry.captureException in custom ApiErrorHandler