### PR TITLE
Add some Chart + Error handling styling fixes

### DIFF
--- a/apps/google-analytics-4/frontend/src/components/main-app/ChartContent.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/ChartContent.tsx
@@ -26,8 +26,8 @@ const ChartContent = (props: Props) => {
       <LineChart
         dataValues={parseRowViews()}
         xAxisLabels={parseRowDates()}
-        tooltipMetricLabel='Page views'
-        accessibilityLabel='Analytics line chart'
+        tooltipMetricLabel="Page views"
+        accessibilityLabel="Analytics line chart"
       />
     </>
   );

--- a/apps/google-analytics-4/frontend/src/components/main-app/ChartContent.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/ChartContent.tsx
@@ -26,8 +26,8 @@ const ChartContent = (props: Props) => {
       <LineChart
         dataValues={parseRowViews()}
         xAxisLabels={parseRowDates()}
-        tooltipMetricLabel="Page views"
-        accessibilityLabel="Analytics line chart"
+        tooltipMetricLabel='Page views'
+        accessibilityLabel='Analytics line chart'
       />
     </>
   );

--- a/apps/google-analytics-4/frontend/src/components/main-app/ChartContent.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/ChartContent.tsx
@@ -26,8 +26,8 @@ const ChartContent = (props: Props) => {
       <LineChart
         dataValues={parseRowViews()}
         xAxisLabels={parseRowDates()}
-        tooltipMetricLabel={''}
-        accessibilityLabel={'Analytics line chart'}
+        tooltipMetricLabel="Page views"
+        accessibilityLabel="Analytics line chart"
       />
     </>
   );

--- a/apps/google-analytics-4/frontend/src/components/main-app/analytics-app/AnalyticsApp.styles.ts
+++ b/apps/google-analytics-4/frontend/src/components/main-app/analytics-app/AnalyticsApp.styles.ts
@@ -39,4 +39,15 @@ export const styles = {
     width: '100px',
     margin: 'auto',
   }),
+  note: css({
+    overflow: 'hidden',
+    marginBottom: tokens.spacingM,
+  }),
+  noteContent: css({
+    textOverflow: 'ellipsis',
+    overflow: 'hidden',
+    display: '-webkit-box',
+    '-webkit-line-clamp': '4',
+    '-webkit-box-orient': 'vertical',
+  }),
 };

--- a/apps/google-analytics-4/frontend/src/components/main-app/analytics-app/AnalyticsApp.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/analytics-app/AnalyticsApp.tsx
@@ -80,9 +80,17 @@ const AnalyticsApp = () => {
 
   const renderChartContent = () => {
     if (error) {
-      return <Note variant="negative">{error?.message || DEFAULT_ERR_MSG}</Note>;
+      return (
+        <Note className={styles.note} variant="negative">
+          <p className={styles.noteContent}>{error?.message || DEFAULT_ERR_MSG}</p>
+        </Note>
+      );
     } else if (!pageViewData.rowCount) {
-      return <Note variant="warning">{EMPTY_DATA_MSG}</Note>;
+      return (
+        <Note className={styles.note} variant="warning">
+          <p className={styles.noteContent}>{EMPTY_DATA_MSG}</p>
+        </Note>
+      );
     }
 
     return <ChartContent pageViewData={pageViewData} />;

--- a/apps/google-analytics-4/frontend/src/components/main-app/line-chart/LineChart.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/line-chart/LineChart.tsx
@@ -34,12 +34,7 @@ interface Props {
 }
 
 const LineChart = (props: Props) => {
-  const {
-    dataValues,
-    xAxisLabels,
-    tooltipMetricLabel = 'Page views',
-    accessibilityLabel = 'Analytics line chart',
-  } = props;
+  const { dataValues, xAxisLabels, tooltipMetricLabel, accessibilityLabel } = props;
 
   const data: ChartData<'line'> = {
     labels: xAxisLabels,

--- a/apps/google-analytics-4/frontend/src/components/main-app/line-chart/LineChart.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/line-chart/LineChart.tsx
@@ -18,7 +18,9 @@ const ACCESSIBILITY_LABEL = 'Analytics line chart';
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip);
 
-ChartJS.defaults.font.size = parseRemToPxInt(tokens.fontSizeS);
+const defaultFontSize = parseRemToPxInt(tokens.fontSizeS);
+
+ChartJS.defaults.font.size = defaultFontSize;
 ChartJS.defaults.font.family = tokens.fontStackPrimary;
 ChartJS.defaults.font.weight = tokens.fontWeightMedium.toString();
 ChartJS.defaults.borderColor = tokens.gray200;
@@ -27,12 +29,17 @@ ChartJS.defaults.datasets.line.borderColor = tokens.colorPrimary;
 interface Props {
   dataValues: number[];
   xAxisLabels: string[];
-  tooltipMetricLabel: string;
-  accessibilityLabel: string;
+  tooltipMetricLabel?: string;
+  accessibilityLabel?: string;
 }
 
 const LineChart = (props: Props) => {
-  const { dataValues, xAxisLabels, tooltipMetricLabel, accessibilityLabel } = props;
+  const {
+    dataValues,
+    xAxisLabels,
+    tooltipMetricLabel = 'Page views',
+    accessibilityLabel = 'Analytics line chart',
+  } = props;
 
   const data: ChartData<'line'> = {
     labels: xAxisLabels,
@@ -52,16 +59,16 @@ const LineChart = (props: Props) => {
         padding: parseRemToPxInt(tokens.spacingXs),
         titleMarginBottom: parseRemToPxInt(tokens.spacing2Xs),
         titleFont: {
-          size: 9,
+          size: defaultFontSize,
         },
         bodyFont: {
-          size: 8,
+          size: defaultFontSize,
           // TO:DO once font weight is added to F36, replace with token
           weight: '700',
         },
         displayColors: false,
         callbacks: {
-          beforeBody: () => tooltipMetricLabel,
+          title: () => tooltipMetricLabel,
         },
       },
     },


### PR DESCRIPTION
## Purpose
This PR adds some styling fixes (as per some suggestions from Hande) to the `LineChart` component as well as the `AnalyticsApp` component in the case of errors or warnings that might arise, as I noticed some unhandled text overflow. 

I am a bit blocked on the more pressing ticket right now hence why this small styling fix PR fix.

## Approach
#### `LineChart` component: 

- Made the font sizes of the tooltip larger (at least 12px so they are readable). Also removed unnecessary noise within the Tooltip to save space. 
- Hande emphasized that this chart component does not have to be 'perfect' because ideally the user would click the link to view it more extensively in the Google Analytics app. I think this is an interesting point to keep in mind. 

### **Before**: 
![Screenshot 2023-03-07 at 3 53 12 PM](https://user-images.githubusercontent.com/58186851/223572518-4189c4eb-7907-4a0b-8ef8-f8b4bab71538.png)

### **After**: 
![Screenshot 2023-03-07 at 3 06 45 PM](https://user-images.githubusercontent.com/58186851/223570079-0e77a454-571a-44c6-9209-a3bb45076c43.png)

### `AnalyticsApp` component: 

- Handled overflow of error or warning messages by hiding the overflow and adding ellipsis of the text content. 
- This is a good example of a component we an make ourselves to add to the Storybook component library as I feel the F36 Note component doesn't add a lot of ability to customize styling. For now this styling is just in the `AnalyticsApp` component, but would like to migrate it eventually to its own file. 

### **Before**: 
![Screenshot 2023-03-06 at 1 57 07 PM](https://user-images.githubusercontent.com/58186851/223569770-bbc1a89d-ebe3-4f2d-b7d9-ecfb1e2b9ed3.png)

### **After**: 
![Screenshot 2023-03-07 at 2 08 27 PM](https://user-images.githubusercontent.com/58186851/223569786-fceed2ed-2a4b-4867-87a8-d519cde4af3d.png)

Would appreciate any and all thoughts as usual!! 💡 🚀 
