### PR TITLE
chore: more explicit CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,26 @@
-* @contentful/team-integrations @contentful/team-extensibility
-package.json @ghost
-package-lock.json @ghost
+apps/ai-image-tagging @contentful/team-extensibility
+apps/brandfolder @contentful/team-integrations
+apps/bynder @contentful/team-integrations
+apps/cloudinary @contentful/team-integrations
+apps/color-picker @contentful/team-extensibility
+apps/commercetools @contentful/team-integrations
+apps/dropbox @contentful/team-integrations
+apps/frontify @contentful/team-integrations
+apps/gatsby @contentful/team-integrations
+apps/google-analytics @contentful/team-integrations
+apps/google-analytics-4 @contentful/team-integrations
+apps/graphql-playground @contentful/team-extensibility
+apps/image-focal-point @contentful/team-extensibility
+apps/jira @contentful/team-integrations
+apps/mux @contentful/team-integrations
+apps/netlify @contentful/team-integrations
+apps/optimizely @contentful/team-integrations
+apps/saleor @contentful/team-integrations
+apps/shopify @contentful/team-integrations
+apps/slack @contentful/team-integrations
+apps/smartling @contentful/team-integrations
+apps/typeform @contentful/team-integrations
+apps/wistia-videos @contentful/team-integrations
+
+examples @contentful/team-extensibility
+packages @contentful/team-extensibility


### PR DESCRIPTION
Currently, both teams are auto-assigned for all changes in the `apps` repo. I updated the CODEOWNERS file to be more explicit about which team owns what, so we can reduce some noise.