### PR TITLE
fix request signing verification

### DIFF
--- a/apps/google-analytics-4/lambda/src/middlewares/verifySignedRequests.ts
+++ b/apps/google-analytics-4/lambda/src/middlewares/verifySignedRequests.ts
@@ -1,13 +1,8 @@
 import * as NodeAppsToolkit from '@contentful/node-apps-toolkit';
-import {
-  CanonicalRequest,
-  ContentfulContextHeader,
-  ContentfulHeader,
-} from '@contentful/node-apps-toolkit/lib/requests/typings';
+import { CanonicalRequest } from '@contentful/node-apps-toolkit/lib/requests/typings';
 import { NextFunction, Request, Response } from 'express';
 import { InvalidSignature } from '../errors/invalidSignature';
 import { UnableToVerifyRequest } from '../errors/unableToVerifyRequest';
-import { IncomingHttpHeaders } from 'http';
 
 export const verifySignedRequestMiddleware = (req: Request, _res: Response, next: NextFunction) => {
   const signingSecret = (process.env.SIGNING_SECRET || '').trim();
@@ -37,47 +32,19 @@ export const verifySignedRequestMiddleware = (req: Request, _res: Response, next
 };
 
 const makeCanonicalReq = (req: Request) => {
-  const requiredHeaders = requestSigningHeaders(req.headers);
+  const headers = { ...req.headers };
+
+  // coerce all headers to strings
+  Object.keys(headers).forEach((key) => {
+    headers[key] = headers[key]?.toString();
+  });
 
   // TODO: make this stage prefixing logic better? (yuck)
-  const pathPrefix = process.env.STAGE !== 'prd' ? `/${process.env.stage}` : '';
+  const pathPrefix = process.env.STAGE !== 'prd' ? `/${process.env.STAGE}` : '';
 
   return <CanonicalRequest>{
     method: req.method,
     path: `${pathPrefix}${req.originalUrl}`, // note: req.originalUrl starts with a `/`
-    headers: requiredHeaders,
+    headers: headers,
   };
 };
-
-const contentfulSigningHeaderKeys = [
-  ...Object.values(ContentfulHeader),
-  ...Object.values(ContentfulContextHeader),
-];
-
-interface ContentfulSignedHeaders {
-  'x-contentful-timestamp': string;
-  'x-contentful-signed-headers': string;
-  'x-contentful-signature': string;
-  'x-contentful-user-id': string;
-  'x-contentful-space-id': string;
-  'x-contentful-environment-id': string;
-  'x-contentful-app-id': string;
-  [key: string]: string;
-}
-
-function requestSigningHeaders(headers: IncomingHttpHeaders): ContentfulSignedHeaders {
-  const requiredSignatureHeaders = {} as ContentfulSignedHeaders;
-  for (const header of contentfulSigningHeaderKeys) {
-    if (!headers[header]) {
-      throw new UnableToVerifyRequest(`Missing requiredSignatureHeader: ${header}`);
-    }
-
-    if (typeof headers[header] === 'string') {
-      requiredSignatureHeaders[header] = headers[header] as string;
-    } else {
-      throw new UnableToVerifyRequest(`Header ${header} is not a string`);
-    }
-  }
-
-  return requiredSignatureHeaders;
-}


### PR DESCRIPTION
## Purpose
fix request signing verification

## Approach
coerce all headers back to strings to undo what serverless does with headers like `Content-Length`, etc and let the node-apps-toolkit do the header filtering as usual

## Dependencies and/or References
<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment
<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
