### PR TITLE
[INTEG-169] Render view list for content type, slug, and url path

### DIFF
--- a/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage.tsx
@@ -6,6 +6,7 @@ import ApiAccessPage from 'components/config-screen/api-access/ApiAccessPage';
 import AboutSection from 'components/config-screen/header/AboutSection';
 import { AccountSummariesType } from 'types';
 import { Box } from '@contentful/f36-components';
+import AssignContentTypePage from 'components/config-screen/assign-content-type/AssignContentTypePage';
 
 const GoogleAnalyticsConfigPage = () => {
   // Adding this because this be resolved and used in INTEG-168
@@ -24,6 +25,7 @@ const GoogleAnalyticsConfigPage = () => {
         <Splitter />
         <ApiAccessPage onAccountSummariesChange={handleAccountSummariesChange} />
         <Splitter />
+        <AssignContentTypePage />
       </Box>
 
       <GoogleAnalyticsIcon />

--- a/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage.tsx
@@ -4,11 +4,11 @@ import { AppExtensionSDK } from '@contentful/app-sdk';
 import GoogleAnalyticsIcon from 'components/common/GoogleAnalyticsIcon';
 import { styles } from 'components/config-screen/GoogleAnalytics.styles';
 import Splitter from 'components/common/Splitter';
-import ApiAccessPage from 'components/config-screen/api-access/ApiAccessPage';
+import ApiAccessSection from 'components/config-screen/api-access/ApiAccessSection';
 import AboutSection from 'components/config-screen/header/AboutSection';
 import { AccountSummariesType } from 'types';
 import { Box } from '@contentful/f36-components';
-import AssignContentTypePage from 'components/config-screen/assign-content-type/AssignContentTypePage';
+import AssignContentTypeSection from 'components/config-screen/assign-content-type/AssignContentTypeSection';
 
 const GoogleAnalyticsConfigPage = () => {
   // Adding this because this be resolved and used in INTEG-168
@@ -50,11 +50,11 @@ const GoogleAnalyticsConfigPage = () => {
       <Box className={styles.body}>
         <AboutSection />
         <Splitter />
-        <ApiAccessPage onAccountSummariesChange={handleAccountSummariesChange} />
+        <ApiAccessSection onAccountSummariesChange={handleAccountSummariesChange} />
         {isAppInstalled && (
           <>
             <Splitter />
-            <AssignContentTypePage />
+            <AssignContentTypeSection />
           </>
         )}
       </Box>

--- a/apps/google-analytics-4/frontend/src/components/config-screen/api-access/ApiAccessSection.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/api-access/ApiAccessSection.spec.tsx
@@ -1,5 +1,5 @@
 import { act, render, screen, waitFor } from '@testing-library/react';
-import ApiAccessPage from './ApiAccessPage';
+import ApiAccessSection from './ApiAccessSection';
 import { mockSdk, mockCma, validServiceKeyFile, validServiceKeyId } from '../../../../test/mocks';
 import userEvent from '@testing-library/user-event';
 import { ServiceAccountKey } from '@/types';
@@ -18,7 +18,7 @@ const saveAppInstallation = async () => {
 describe('Config Screen component (not installed)', () => {
   it('can render the about section', async () => {
     await act(async () => {
-      render(<ApiAccessPage onAccountSummariesChange={() => {}} />);
+      render(<ApiAccessSection onAccountSummariesChange={() => {}} />);
     });
 
     expect(screen.getByText('API Access')).toBeInTheDocument();
@@ -29,7 +29,7 @@ describe('Config Screen component (not installed)', () => {
   it('allows the app to be installed with a valid service key file', async () => {
     const user = userEvent.setup();
     await act(async () => {
-      render(<ApiAccessPage onAccountSummariesChange={() => {}} />);
+      render(<ApiAccessSection onAccountSummariesChange={() => {}} />);
     });
 
     const keyFileInputBox = screen.getByLabelText(/Private Key File/i);
@@ -59,7 +59,7 @@ describe('Config Screen component (not installed)', () => {
   it('prevents the app from being installed with invalid service key file', async () => {
     const user = userEvent.setup();
     await act(async () => {
-      render(<ApiAccessPage onAccountSummariesChange={() => {}} />);
+      render(<ApiAccessSection onAccountSummariesChange={() => {}} />);
     });
 
     const keyFileInputBox = screen.getByLabelText(/Private Key File/i);
@@ -80,7 +80,7 @@ describe('Config Screen component (not installed)', () => {
 
   it('prevents the app from being installed if no service key file is provided', async () => {
     await act(async () => {
-      render(<ApiAccessPage onAccountSummariesChange={() => {}} />);
+      render(<ApiAccessSection onAccountSummariesChange={() => {}} />);
     });
 
     let result;
@@ -90,7 +90,11 @@ describe('Config Screen component (not installed)', () => {
 
     // false result prevents parameters save
     expect(result).toEqual({
-      parameters: { serviceAccountKey: undefined, serviceAccountKeyId: undefined },
+      parameters: {
+        serviceAccountKey: undefined,
+        serviceAccountKeyId: undefined,
+        contentTypes: {},
+      },
       targetState: undefined,
     });
   });
@@ -107,7 +111,7 @@ describe('Installed Service Account Key', () => {
   it('overrides the saved values if a new key file is provided', async () => {
     const user = userEvent.setup();
     await act(async () => {
-      render(<ApiAccessPage onAccountSummariesChange={() => {}} />);
+      render(<ApiAccessSection onAccountSummariesChange={() => {}} />);
     });
 
     const editServiceAccountButton = screen.getByTestId('editServiceAccountButton');
@@ -141,7 +145,7 @@ describe('Installed Service Account Key', () => {
 
   it('does not require key file on save', async () => {
     await act(async () => {
-      render(<ApiAccessPage onAccountSummariesChange={() => {}} />);
+      render(<ApiAccessSection onAccountSummariesChange={() => {}} />);
     });
 
     let result;
@@ -150,7 +154,7 @@ describe('Installed Service Account Key', () => {
     });
 
     await act(async () => {
-      render(<ApiAccessPage onAccountSummariesChange={() => {}} />);
+      render(<ApiAccessSection onAccountSummariesChange={() => {}} />);
     });
   });
 });

--- a/apps/google-analytics-4/frontend/src/components/config-screen/api-access/ApiAccessSection.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/api-access/ApiAccessSection.tsx
@@ -8,7 +8,7 @@ interface Props {
   onAccountSummariesChange: Function;
 }
 
-const ApiAccessPage = (props: Props) => {
+const ApiAccessSection = (props: Props) => {
   const { onAccountSummariesChange } = props;
 
   const {
@@ -72,4 +72,4 @@ const ApiAccessPage = (props: Props) => {
   );
 };
 
-export default ApiAccessPage;
+export default ApiAccessSection;

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeCard.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeCard.spec.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react';
+import { AllContentTypes, ContentTypeEntries } from '@/types';
+import AssignContentTypeCard from 'components/config-screen/assign-content-type/AssignContentTypeCard';
+
+const allContentTypes: AllContentTypes = {
+  course: {
+    name: 'Course',
+    fields: [
+      {
+        id: 'slug',
+        name: 'Slug',
+        type: 'Symbol',
+      },
+    ],
+  },
+};
+
+const contentTypeEntries: ContentTypeEntries = {
+  course: {
+    slugField: 'slug',
+    urlPrefix: '/about',
+  },
+};
+
+describe('Assign Content Type Card for Config Screen', () => {
+  it('can render the add content type button when there is no saved content type entry', () => {
+    render(
+      <AssignContentTypeCard
+        allContentTypes={{}}
+        contentTypeEntries={{}}
+        onContentTypeChange={() => {}}
+        onContentTypeFieldChange={() => {}}
+        onAddContentType={() => {}}
+        onRemoveContentType={() => {}}
+      />
+    );
+
+    expect(screen.getByText('Add a content type')).toBeVisible();
+  });
+
+  it('can render the field labels when there is a saved content type entry', () => {
+    render(
+      <AssignContentTypeCard
+        allContentTypes={allContentTypes}
+        contentTypeEntries={contentTypeEntries}
+        onContentTypeChange={() => {}}
+        onContentTypeFieldChange={() => {}}
+        onAddContentType={() => {}}
+        onRemoveContentType={() => {}}
+      />
+    );
+
+    expect(screen.getByText('Content type')).toBeVisible();
+    expect(screen.getByText('Slug field')).toBeVisible();
+    expect(screen.getByText('URL prefix')).toBeVisible();
+  });
+});

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeCard.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeCard.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { AllContentTypes, ContentTypeEntries } from '@/types';
+import { AllContentTypes, AllContentTypeEntries, ContentTypes, ContentTypeEntries } from '@/types';
 import AssignContentTypeCard from 'components/config-screen/assign-content-type/AssignContentTypeCard';
 
 const allContentTypes: AllContentTypes = {
@@ -15,19 +15,26 @@ const allContentTypes: AllContentTypes = {
   },
 };
 
-const contentTypeEntries: ContentTypeEntries = {
+const allContentTypeEntries: AllContentTypeEntries = Object.entries(allContentTypes);
+
+const contentTypes: ContentTypes = {
   course: {
     slugField: 'slug',
     urlPrefix: '/about',
   },
 };
 
+const contentTypeEntries: ContentTypeEntries = Object.entries(contentTypes);
+
 describe('Assign Content Type Card for Config Screen', () => {
   it('can render the add content type button when there is no saved content type entry', () => {
     render(
       <AssignContentTypeCard
         allContentTypes={{}}
-        contentTypeEntries={{}}
+        allContentTypeEntries={[]}
+        contentTypes={{}}
+        hasContentTypes={false}
+        contentTypeEntries={[]}
         onContentTypeChange={() => {}}
         onContentTypeFieldChange={() => {}}
         onAddContentType={() => {}}
@@ -42,6 +49,9 @@ describe('Assign Content Type Card for Config Screen', () => {
     render(
       <AssignContentTypeCard
         allContentTypes={allContentTypes}
+        allContentTypeEntries={allContentTypeEntries}
+        contentTypes={contentTypes}
+        hasContentTypes={true}
         contentTypeEntries={contentTypeEntries}
         onContentTypeChange={() => {}}
         onContentTypeFieldChange={() => {}}

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeCard.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeCard.tsx
@@ -1,0 +1,138 @@
+import {
+  Box,
+  Button,
+  Card,
+  FormControl,
+  Select,
+  Stack,
+  TextInput,
+  TextLink,
+} from '@contentful/f36-components';
+import { css } from 'emotion';
+import { AllContentTypes, ContentTypeEntries } from 'types';
+
+interface Props {
+  allContentTypes: AllContentTypes;
+  contentTypeEntries: ContentTypeEntries;
+  onContentTypeChange: (prevKey: string, newKey: string) => void;
+  onContentTypeFieldChange: (key: string, field: string, value: string) => void;
+  onAddContentType: () => void;
+  onRemoveContentType: (key: string) => void;
+}
+
+const styles = {
+  contentTypeItem: css({
+    flexBasis: '100%',
+  }),
+  hidden: css({
+    visibility: 'hidden',
+  }),
+};
+
+const AssignContentTypeCard = (props: Props) => {
+  const {
+    allContentTypes,
+    contentTypeEntries,
+    onContentTypeChange,
+    onContentTypeFieldChange,
+    onAddContentType,
+    onRemoveContentType,
+  } = props;
+
+  return (
+    <Card>
+      {Object.keys(contentTypeEntries).length ? (
+        <Stack marginBottom="none" spacing="spacingXs">
+          <Box className={styles.contentTypeItem}>
+            <FormControl marginBottom="none">
+              <FormControl.Label>Content type</FormControl.Label>
+            </FormControl>
+          </Box>
+          <Box className={styles.contentTypeItem}>
+            <FormControl marginBottom="none">
+              <FormControl.Label>Slug field</FormControl.Label>
+            </FormControl>
+          </Box>
+          <Box className={styles.contentTypeItem}>
+            <FormControl marginBottom="none">
+              <FormControl.Label>URL prefix</FormControl.Label>
+            </FormControl>
+          </Box>
+          <Box>
+            <TextLink className={styles.hidden}>Remove</TextLink>
+          </Box>
+        </Stack>
+      ) : null}
+      {Object.entries(contentTypeEntries).map(([key, { slugField, urlPrefix }], index) => {
+        return (
+          <Stack spacing="spacingXs" paddingBottom="spacingS" key={key}>
+            <Box className={styles.contentTypeItem}>
+              <Select
+                id={`contentType-${index}`}
+                name={`contentType-${index}`}
+                onChange={(event: React.ChangeEvent<HTMLSelectElement>) =>
+                  onContentTypeChange(key, event.target.value)
+                }
+                value={key}>
+                <Select.Option value="" isDisabled>
+                  Select content type
+                </Select.Option>
+                {Object.entries(allContentTypes)
+                  .filter(([type]) => type === key || !contentTypeEntries[type])
+                  .map(([type, { name: typeName }]) => {
+                    return (
+                      <Select.Option value={type} key={`type-${type}`}>
+                        {typeName}
+                      </Select.Option>
+                    );
+                  })}
+              </Select>
+            </Box>
+            <Box className={styles.contentTypeItem}>
+              <Select
+                id={`slugField-${index}`}
+                name={`slugField-${index}`}
+                isDisabled={!key}
+                isInvalid={key ? !slugField : false}
+                onChange={(event: React.ChangeEvent<HTMLSelectElement>) =>
+                  onContentTypeFieldChange(key, 'slugField', event.target.value)
+                }
+                value={slugField}>
+                <Select.Option value="" isDisabled>
+                  Select slug field
+                </Select.Option>
+                {key &&
+                  allContentTypes[key]?.fields?.map((field) => (
+                    <Select.Option key={`${key}.${field.id}`} value={field.id}>
+                      {field.name}
+                    </Select.Option>
+                  ))}
+              </Select>
+            </Box>
+            <Box className={styles.contentTypeItem}>
+              <TextInput
+                id={`urlPrefix-${index}`}
+                name={`urlPrefix-${index}`}
+                isDisabled={!key}
+                onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+                  onContentTypeFieldChange(key, 'urlPrefix', event.target.value)
+                }
+                value={urlPrefix}
+              />
+            </Box>
+            <Box>
+              <TextLink onClick={() => onRemoveContentType(key)}>Remove</TextLink>
+            </Box>
+          </Stack>
+        );
+      })}
+      <Button
+        onClick={onAddContentType}
+        isDisabled={Object.values(contentTypeEntries).some((entries) => !entries.slugField)}>
+        {Object.keys(contentTypeEntries).length ? 'Add another content type' : 'Add a content type'}
+      </Button>
+    </Card>
+  );
+};
+
+export default AssignContentTypeCard;

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeCard.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeCard.tsx
@@ -22,10 +22,10 @@ interface Props {
 
 const styles = {
   contentTypeItem: css({
-    flexBasis: '100%',
+    flex: 4,
   }),
-  hidden: css({
-    visibility: 'hidden',
+  removeItem: css({
+    flex: 1,
   }),
 };
 
@@ -58,9 +58,7 @@ const AssignContentTypeCard = (props: Props) => {
               <FormControl.Label>URL prefix</FormControl.Label>
             </FormControl>
           </Box>
-          <Box>
-            <TextLink className={styles.hidden}>Remove</TextLink>
-          </Box>
+          <Box className={styles.removeItem}></Box>
         </Stack>
       ) : null}
       {Object.entries(contentTypeEntries).map(([key, { slugField, urlPrefix }], index) => {
@@ -120,7 +118,7 @@ const AssignContentTypeCard = (props: Props) => {
                 value={urlPrefix}
               />
             </Box>
-            <Box>
+            <Box className={styles.removeItem}>
               <TextLink onClick={() => onRemoveContentType(key)}>Remove</TextLink>
             </Box>
           </Stack>

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeCard.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeCard.tsx
@@ -9,15 +9,22 @@ import {
   TextLink,
 } from '@contentful/f36-components';
 import { css } from 'emotion';
-import { AllContentTypes, ContentTypeEntries } from 'types';
+import { AllContentTypes, AllContentTypeEntries, ContentTypes, ContentTypeEntries } from 'types';
 
-interface Props {
+interface AssignContentTypeCardProps {
   allContentTypes: AllContentTypes;
+  allContentTypeEntries: AllContentTypeEntries;
+  contentTypes: ContentTypes;
+  hasContentTypes: boolean;
   contentTypeEntries: ContentTypeEntries;
   onContentTypeChange: (prevKey: string, newKey: string) => void;
   onContentTypeFieldChange: (key: string, field: string, value: string) => void;
   onAddContentType: () => void;
   onRemoveContentType: (key: string) => void;
+}
+
+interface HeaderLabelProps {
+  label: string;
 }
 
 const styles = {
@@ -29,9 +36,12 @@ const styles = {
   }),
 };
 
-const AssignContentTypeCard = (props: Props) => {
+const AssignContentTypeCard = (props: AssignContentTypeCardProps) => {
   const {
     allContentTypes,
+    allContentTypeEntries,
+    contentTypes,
+    hasContentTypes,
     contentTypeEntries,
     onContentTypeChange,
     onContentTypeFieldChange,
@@ -41,27 +51,15 @@ const AssignContentTypeCard = (props: Props) => {
 
   return (
     <Card>
-      {Object.keys(contentTypeEntries).length ? (
+      {hasContentTypes ? (
         <Stack marginBottom="none" spacing="spacingXs">
-          <Box className={styles.contentTypeItem}>
-            <FormControl marginBottom="none">
-              <FormControl.Label>Content type</FormControl.Label>
-            </FormControl>
-          </Box>
-          <Box className={styles.contentTypeItem}>
-            <FormControl marginBottom="none">
-              <FormControl.Label>Slug field</FormControl.Label>
-            </FormControl>
-          </Box>
-          <Box className={styles.contentTypeItem}>
-            <FormControl marginBottom="none">
-              <FormControl.Label>URL prefix</FormControl.Label>
-            </FormControl>
-          </Box>
+          <HeaderLabel label="Content type" />
+          <HeaderLabel label="Slug field" />
+          <HeaderLabel label="URL prefix" />
           <Box className={styles.removeItem}></Box>
         </Stack>
       ) : null}
-      {Object.entries(contentTypeEntries).map(([key, { slugField, urlPrefix }], index) => {
+      {contentTypeEntries.map(([key, { slugField, urlPrefix }], index) => {
         return (
           <Stack spacing="spacingXs" paddingBottom="spacingS" key={key}>
             <Box className={styles.contentTypeItem}>
@@ -75,8 +73,8 @@ const AssignContentTypeCard = (props: Props) => {
                 <Select.Option value="" isDisabled>
                   Select content type
                 </Select.Option>
-                {Object.entries(allContentTypes)
-                  .filter(([type]) => type === key || !contentTypeEntries[type])
+                {allContentTypeEntries
+                  .filter(([type]) => type === key || !contentTypes[type])
                   .map(([type, { name: typeName }]) => {
                     return (
                       <Select.Option value={type} key={`type-${type}`}>
@@ -124,12 +122,22 @@ const AssignContentTypeCard = (props: Props) => {
           </Stack>
         );
       })}
-      <Button
-        onClick={onAddContentType}
-        isDisabled={Object.values(contentTypeEntries).some((entries) => !entries.slugField)}>
-        {Object.keys(contentTypeEntries).length ? 'Add another content type' : 'Add a content type'}
+      <Button onClick={onAddContentType}>
+        {hasContentTypes ? 'Add another content type' : 'Add a content type'}
       </Button>
     </Card>
+  );
+};
+
+const HeaderLabel = (props: HeaderLabelProps) => {
+  const { label } = props;
+
+  return (
+    <Box className={styles.contentTypeItem}>
+      <FormControl marginBottom="none">
+        <FormControl.Label>{label}</FormControl.Label>
+      </FormControl>
+    </Box>
   );
 };
 

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypePage.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypePage.tsx
@@ -1,0 +1,170 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Paragraph, Stack, Subheading } from '@contentful/f36-components';
+import {
+  AppInstallationParameters,
+  ContentTypeEntries,
+  ContentTypeEntry,
+  AllContentTypes,
+} from 'types';
+import AssignContentTypeCard from 'components/config-screen/assign-content-type/AssignContentTypeCard';
+import omitBy from 'lodash/omitBy';
+import sortBy from 'lodash/sortBy';
+import { useSDK } from '@contentful/react-apps-toolkit';
+import { AppExtensionSDK } from '@contentful/app-sdk';
+import { ContentTypeProps, createClient } from 'contentful-management';
+
+const AssignContentTypePage = () => {
+  const [parameters, setParameters] = useState<AppInstallationParameters>(
+    {} as AppInstallationParameters
+  );
+  const [allContentTypes, setAllContentTypes] = useState<AllContentTypes>({} as AllContentTypes);
+  const [contentTypeEntries, setContentTypeEntries] = useState<ContentTypeEntries>(
+    {} as ContentTypeEntries
+  );
+
+  const sdk = useSDK<AppExtensionSDK>();
+
+  const onConfigure = useCallback(async () => {
+    const currentState = await sdk.app.getCurrentState();
+
+    const newParameters = Object.assign(
+      {},
+      parameters,
+      omitBy(
+        {
+          contentTypes: contentTypeEntries,
+        },
+        (val) => val === null
+      )
+    );
+
+    setParameters(newParameters);
+
+    return {
+      parameters: newParameters,
+      targetState: currentState,
+    };
+  }, [contentTypeEntries, parameters, sdk]);
+
+  useEffect(() => {
+    sdk.app.onConfigure(() => onConfigure());
+  }, [sdk, onConfigure]);
+
+  useEffect(() => {
+    const setupAppInstallationParameters = async () => {
+      const currentParameters: AppInstallationParameters =
+        (await sdk.app.getParameters()) ?? ({} as AppInstallationParameters);
+
+      if (currentParameters) {
+        setParameters(currentParameters);
+        if (currentParameters?.contentTypes) {
+          setContentTypeEntries(currentParameters.contentTypes);
+        }
+      }
+
+      sdk.app.setReady();
+    };
+
+    setupAppInstallationParameters();
+  }, [sdk]);
+
+  useEffect(() => {
+    const getContentTypes = async () => {
+      const cma = createClient({ apiAdapter: sdk.cmaAdapter });
+      const space = await cma.getSpace(sdk.ids.space);
+      const environment = await space.getEnvironment(sdk.ids.environment);
+      const contentTypes = await environment.getContentTypes();
+      const contentTypeItems = contentTypes.items as ContentTypeProps[];
+
+      const sortedContentTypes = sortBy(contentTypeItems, ['name']);
+
+      const formattedContentTypes = sortedContentTypes.reduce(
+        (acc: AllContentTypes, contentType) => {
+          // only include short text fields in the slug field dropdown
+          const fields = sortBy(
+            contentType.fields.filter((field) => field.type === 'Symbol'),
+            ['name']
+          );
+
+          if (fields.length) {
+            acc[contentType.sys.id] = {
+              ...contentType,
+              fields,
+            };
+          }
+
+          return acc;
+        },
+        {}
+      );
+
+      setAllContentTypes(formattedContentTypes);
+    };
+
+    getContentTypes();
+  }, [sdk]);
+
+  const handleContentTypeChange = (prevKey: string, newKey: string) => {
+    const newContentTypes: ContentTypeEntries = {};
+
+    for (const [prop, value] of Object.entries(contentTypeEntries)) {
+      if (prop === prevKey) {
+        newContentTypes[newKey as keyof typeof contentTypeEntries] = {
+          slugField: '',
+          urlPrefix: value.urlPrefix,
+        };
+      } else {
+        newContentTypes[prop] = value;
+      }
+    }
+
+    setContentTypeEntries(newContentTypes);
+  };
+
+  const handleContentTypeFieldChange = (key: string, field: string, value: string) => {
+    const currentContentTypeFields: ContentTypeEntry = contentTypeEntries[key];
+
+    setContentTypeEntries({
+      ...contentTypeEntries,
+      [key]: {
+        ...currentContentTypeFields,
+        [field]: value,
+      },
+    });
+  };
+
+  const handleAddContentType = () => {
+    setContentTypeEntries({
+      ...contentTypeEntries,
+      '': { slugField: '', urlPrefix: '' },
+    });
+  };
+
+  const handleRemoveContentType = (key: string) => {
+    const updatedContentTypeEntries = { ...contentTypeEntries };
+    delete updatedContentTypeEntries[key];
+
+    setContentTypeEntries(updatedContentTypeEntries);
+  };
+
+  return (
+    <Stack spacing="spacingL" flexDirection="column" alignItems="flex-start">
+      <Subheading marginBottom="none">Assign to content types</Subheading>
+      <Paragraph marginBottom="none">
+        Select which content types will show the Google Analytics functionality in the sidebar.
+        Specify the slug field that is used for URL generation in your application. Optionally,
+        specify a prefix for the slug.
+      </Paragraph>
+      <AssignContentTypeCard
+        allContentTypes={allContentTypes}
+        contentTypeEntries={contentTypeEntries}
+        onContentTypeChange={handleContentTypeChange}
+        onContentTypeFieldChange={handleContentTypeFieldChange}
+        onAddContentType={handleAddContentType}
+        onRemoveContentType={handleRemoveContentType}
+      />
+    </Stack>
+  );
+};
+
+export default AssignContentTypePage;

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Paragraph, Stack, Subheading } from '@contentful/f36-components';
-import { AllContentTypes } from 'types';
+import { AllContentTypes, AllContentTypeEntries, ContentTypeEntries } from 'types';
 import AssignContentTypeCard from 'components/config-screen/assign-content-type/AssignContentTypeCard';
 import sortBy from 'lodash/sortBy';
 import { useSDK } from '@contentful/react-apps-toolkit';
@@ -8,9 +8,9 @@ import { AppExtensionSDK } from '@contentful/app-sdk';
 import { ContentTypeProps, createClient } from 'contentful-management';
 import useKeyService from 'hooks/useKeyService';
 
-const AssignContentTypePage = () => {
+const AssignContentTypeSection = () => {
   const {
-    contentTypeEntries,
+    contentTypes,
     handleContentTypeChange,
     handleContentTypeFieldChange,
     handleAddContentType,
@@ -18,6 +18,13 @@ const AssignContentTypePage = () => {
   } = useKeyService({});
 
   const [allContentTypes, setAllContentTypes] = useState<AllContentTypes>({} as AllContentTypes);
+  const [allContentTypeEntries, setAllContentTypeEntries] = useState<AllContentTypeEntries>(
+    [] as AllContentTypeEntries
+  );
+  const [hasContentTypes, setHasContentTypes] = useState<boolean>(false);
+  const [contentTypeEntries, setHasContentTypeEntries] = useState<ContentTypeEntries>(
+    [] as ContentTypeEntries
+  );
 
   const sdk = useSDK<AppExtensionSDK>();
 
@@ -52,10 +59,16 @@ const AssignContentTypePage = () => {
       );
 
       setAllContentTypes(formattedContentTypes);
+      setAllContentTypeEntries(Object.entries(formattedContentTypes));
     };
 
     getContentTypes();
   }, [sdk]);
+
+  useEffect(() => {
+    setHasContentTypes(Object.keys(contentTypes).length ? true : false);
+    setHasContentTypeEntries(Object.entries(contentTypes));
+  }, [contentTypes]);
 
   return (
     <Stack spacing="spacingL" flexDirection="column" alignItems="flex-start">
@@ -67,6 +80,9 @@ const AssignContentTypePage = () => {
       </Paragraph>
       <AssignContentTypeCard
         allContentTypes={allContentTypes}
+        allContentTypeEntries={allContentTypeEntries}
+        contentTypes={contentTypes}
+        hasContentTypes={hasContentTypes}
         contentTypeEntries={contentTypeEntries}
         onContentTypeChange={handleContentTypeChange}
         onContentTypeFieldChange={handleContentTypeFieldChange}
@@ -77,4 +93,4 @@ const AssignContentTypePage = () => {
   );
 };
 
-export default AssignContentTypePage;
+export default AssignContentTypeSection;

--- a/apps/google-analytics-4/frontend/src/hooks/useKeyService.tsx
+++ b/apps/google-analytics-4/frontend/src/hooks/useKeyService.tsx
@@ -5,8 +5,8 @@ import {
   AppInstallationParameters,
   ServiceAccountKey,
   ServiceAccountKeyId,
-  ContentTypeEntries,
-  ContentTypeEntry,
+  ContentTypes,
+  ContentTypeValue,
 } from 'types';
 import {
   convertServiceAccountKeyToServiceAccountKeyId,
@@ -20,7 +20,7 @@ interface KeyServiceInfoType {
   serviceAccountKeyFileErrorMessage: string;
   serviceAccountKeyFileIsValid: boolean;
   serviceAccountKeyFileIsRequired: boolean;
-  contentTypeEntries: ContentTypeEntries;
+  contentTypes: ContentTypes;
   handleKeyFileChange: Function;
   handleContentTypeChange: (prevKey: string, newKey: string) => void;
   handleContentTypeFieldChange: (key: string, field: string, value: string) => void;
@@ -47,9 +47,7 @@ export default function useKeyService(props: Props): KeyServiceInfoType {
   const [serviceAccountKeyFileIsRequired, setServiceAccountKeyFileIsRequired] =
     useState<boolean>(false);
 
-  const [contentTypeEntries, setContentTypeEntries] = useState<ContentTypeEntries>(
-    {} as ContentTypeEntries
-  );
+  const [contentTypes, setContentTypes] = useState<ContentTypes>({} as ContentTypes);
 
   const sdk = useSDK<AppExtensionSDK>();
 
@@ -69,7 +67,7 @@ export default function useKeyService(props: Props): KeyServiceInfoType {
     const newInstallationParameters = {
       serviceAccountKey: newServiceAccountKey ?? parameters.serviceAccountKey,
       serviceAccountKeyId: newServiceAccountKeyId ?? parameters.serviceAccountKeyId,
-      contentTypes: contentTypeEntries,
+      contentTypes: contentTypes,
     };
 
     setParameters(newInstallationParameters);
@@ -90,7 +88,7 @@ export default function useKeyService(props: Props): KeyServiceInfoType {
     newServiceAccountKey,
     parameters,
     onSaveGoogleAccountDetails,
-    contentTypeEntries,
+    contentTypes,
   ]);
 
   useEffect(() => {
@@ -106,7 +104,7 @@ export default function useKeyService(props: Props): KeyServiceInfoType {
         setParameters(currentParameters);
         setServiceAccountKeyFileIsRequired(false);
         if (currentParameters?.contentTypes) {
-          setContentTypeEntries(currentParameters.contentTypes);
+          setContentTypes(currentParameters.contentTypes);
         }
       } else {
         // per the documentation, `null` means app is not installed, thus we will require
@@ -162,11 +160,11 @@ export default function useKeyService(props: Props): KeyServiceInfoType {
   };
 
   const handleContentTypeChange = (prevKey: string, newKey: string) => {
-    const newContentTypes: ContentTypeEntries = {};
+    const newContentTypes: ContentTypes = {};
 
-    for (const [prop, value] of Object.entries(contentTypeEntries)) {
+    for (const [prop, value] of Object.entries(contentTypes)) {
       if (prop === prevKey) {
-        newContentTypes[newKey as keyof typeof contentTypeEntries] = {
+        newContentTypes[newKey as keyof typeof contentTypes] = {
           slugField: '',
           urlPrefix: value.urlPrefix,
         };
@@ -175,14 +173,14 @@ export default function useKeyService(props: Props): KeyServiceInfoType {
       }
     }
 
-    setContentTypeEntries(newContentTypes);
+    setContentTypes(newContentTypes);
   };
 
   const handleContentTypeFieldChange = (key: string, field: string, value: string) => {
-    const currentContentTypeFields: ContentTypeEntry = contentTypeEntries[key];
+    const currentContentTypeFields: ContentTypeValue = contentTypes[key];
 
-    setContentTypeEntries({
-      ...contentTypeEntries,
+    setContentTypes({
+      ...contentTypes,
       [key]: {
         ...currentContentTypeFields,
         [field]: value,
@@ -191,17 +189,17 @@ export default function useKeyService(props: Props): KeyServiceInfoType {
   };
 
   const handleAddContentType = () => {
-    setContentTypeEntries({
-      ...contentTypeEntries,
+    setContentTypes({
+      ...contentTypes,
       '': { slugField: '', urlPrefix: '' },
     });
   };
 
   const handleRemoveContentType = (key: string) => {
-    const updatedContentTypeEntries = { ...contentTypeEntries };
-    delete updatedContentTypeEntries[key];
+    const updatedContentTypes = { ...contentTypes };
+    delete updatedContentTypes[key];
 
-    setContentTypeEntries(updatedContentTypeEntries);
+    setContentTypes(updatedContentTypes);
   };
 
   return {
@@ -210,7 +208,7 @@ export default function useKeyService(props: Props): KeyServiceInfoType {
     serviceAccountKeyFileErrorMessage,
     serviceAccountKeyFileIsValid,
     serviceAccountKeyFileIsRequired,
-    contentTypeEntries,
+    contentTypes,
     handleKeyFileChange,
     handleContentTypeChange,
     handleContentTypeFieldChange,

--- a/apps/google-analytics-4/frontend/src/hooks/useKeyService.tsx
+++ b/apps/google-analytics-4/frontend/src/hooks/useKeyService.tsx
@@ -1,13 +1,18 @@
 import { useCallback, useState, useEffect } from 'react';
 import { AppExtensionSDK } from '@contentful/app-sdk';
 import { useSDK } from '@contentful/react-apps-toolkit';
-import { AppInstallationParameters, ServiceAccountKey, ServiceAccountKeyId } from 'types';
+import {
+  AppInstallationParameters,
+  ServiceAccountKey,
+  ServiceAccountKeyId,
+  ContentTypeEntries,
+  ContentTypeEntry,
+} from 'types';
 import {
   convertServiceAccountKeyToServiceAccountKeyId,
   convertKeyFileToServiceAccountKey,
   AssertionError,
 } from 'utils/serviceAccountKey';
-import omitBy from 'lodash/omitBy';
 
 interface KeyServiceInfoType {
   parameters: AppInstallationParameters;
@@ -15,7 +20,12 @@ interface KeyServiceInfoType {
   serviceAccountKeyFileErrorMessage: string;
   serviceAccountKeyFileIsValid: boolean;
   serviceAccountKeyFileIsRequired: boolean;
+  contentTypeEntries: ContentTypeEntries;
   handleKeyFileChange: Function;
+  handleContentTypeChange: (prevKey: string, newKey: string) => void;
+  handleContentTypeFieldChange: (key: string, field: string, value: string) => void;
+  handleAddContentType: () => void;
+  handleRemoveContentType: (key: string) => void;
 }
 
 interface Props {
@@ -37,6 +47,10 @@ export default function useKeyService(props: Props): KeyServiceInfoType {
   const [serviceAccountKeyFileIsRequired, setServiceAccountKeyFileIsRequired] =
     useState<boolean>(false);
 
+  const [contentTypeEntries, setContentTypeEntries] = useState<ContentTypeEntries>(
+    {} as ContentTypeEntries
+  );
+
   const sdk = useSDK<AppExtensionSDK>();
 
   const onConfigure = useCallback(async () => {
@@ -52,24 +66,19 @@ export default function useKeyService(props: Props): KeyServiceInfoType {
       return false;
     }
 
-    const newServiceKeyParameters = {
-      serviceAccountKey: newServiceAccountKey,
-      serviceAccountKeyId: newServiceAccountKeyId,
+    const newInstallationParameters = {
+      serviceAccountKey: newServiceAccountKey ?? parameters.serviceAccountKey,
+      serviceAccountKeyId: newServiceAccountKeyId ?? parameters.serviceAccountKeyId,
+      contentTypes: contentTypeEntries,
     };
 
-    const newParameters = Object.assign(
-      {},
-      parameters,
-      omitBy(newServiceKeyParameters, (val) => val === null)
-    );
-
-    setParameters(newParameters);
+    setParameters(newInstallationParameters);
     if (onSaveGoogleAccountDetails) onSaveGoogleAccountDetails();
     setServiceAccountKeyFileIsRequired(false);
     setServiceAccountKeyFile('');
 
     return {
-      parameters: newParameters,
+      parameters: newInstallationParameters,
       targetState: currentState,
     };
   }, [
@@ -81,6 +90,7 @@ export default function useKeyService(props: Props): KeyServiceInfoType {
     newServiceAccountKey,
     parameters,
     onSaveGoogleAccountDetails,
+    contentTypeEntries,
   ]);
 
   useEffect(() => {
@@ -95,6 +105,9 @@ export default function useKeyService(props: Props): KeyServiceInfoType {
       if (currentParameters) {
         setParameters(currentParameters);
         setServiceAccountKeyFileIsRequired(false);
+        if (currentParameters?.contentTypes) {
+          setContentTypeEntries(currentParameters.contentTypes);
+        }
       } else {
         // per the documentation, `null` means app is not installed, thus we will require
         // the key file
@@ -148,12 +161,60 @@ export default function useKeyService(props: Props): KeyServiceInfoType {
     }
   };
 
+  const handleContentTypeChange = (prevKey: string, newKey: string) => {
+    const newContentTypes: ContentTypeEntries = {};
+
+    for (const [prop, value] of Object.entries(contentTypeEntries)) {
+      if (prop === prevKey) {
+        newContentTypes[newKey as keyof typeof contentTypeEntries] = {
+          slugField: '',
+          urlPrefix: value.urlPrefix,
+        };
+      } else {
+        newContentTypes[prop] = value;
+      }
+    }
+
+    setContentTypeEntries(newContentTypes);
+  };
+
+  const handleContentTypeFieldChange = (key: string, field: string, value: string) => {
+    const currentContentTypeFields: ContentTypeEntry = contentTypeEntries[key];
+
+    setContentTypeEntries({
+      ...contentTypeEntries,
+      [key]: {
+        ...currentContentTypeFields,
+        [field]: value,
+      },
+    });
+  };
+
+  const handleAddContentType = () => {
+    setContentTypeEntries({
+      ...contentTypeEntries,
+      '': { slugField: '', urlPrefix: '' },
+    });
+  };
+
+  const handleRemoveContentType = (key: string) => {
+    const updatedContentTypeEntries = { ...contentTypeEntries };
+    delete updatedContentTypeEntries[key];
+
+    setContentTypeEntries(updatedContentTypeEntries);
+  };
+
   return {
-    parameters: parameters,
-    serviceAccountKeyFile: serviceAccountKeyFile,
-    serviceAccountKeyFileErrorMessage: serviceAccountKeyFileErrorMessage,
-    serviceAccountKeyFileIsValid: serviceAccountKeyFileIsValid,
-    serviceAccountKeyFileIsRequired: serviceAccountKeyFileIsRequired,
-    handleKeyFileChange: handleKeyFileChange,
+    parameters,
+    serviceAccountKeyFile,
+    serviceAccountKeyFileErrorMessage,
+    serviceAccountKeyFileIsValid,
+    serviceAccountKeyFileIsRequired,
+    contentTypeEntries,
+    handleKeyFileChange,
+    handleContentTypeChange,
+    handleContentTypeFieldChange,
+    handleAddContentType,
+    handleRemoveContentType,
   };
 }

--- a/apps/google-analytics-4/frontend/src/types.ts
+++ b/apps/google-analytics-4/frontend/src/types.ts
@@ -3,7 +3,7 @@ import { IdsAPI } from '@contentful/app-sdk';
 export interface AppInstallationParameters {
   serviceAccountKey: ServiceAccountKey;
   serviceAccountKeyId: ServiceAccountKeyId;
-  contentTypes: ContentTypeEntries;
+  contentTypes: ContentTypes;
 }
 
 // TODO: get this exported from the SDK
@@ -92,22 +92,28 @@ export interface PropertySummariesType {
   propertyType: string;
 }
 
-export interface ContentTypeEntry {
+export interface ContentTypeValue {
   slugField: string;
   urlPrefix: string;
 }
 
-export interface ContentTypeEntries {
-  [key: string]: ContentTypeEntry;
+export interface ContentTypes {
+  [key: string]: ContentTypeValue;
+}
+
+export type ContentTypeEntries = [string, ContentTypeValue][];
+
+interface AllContentTypeValue {
+  name: string;
+  fields: {
+    id: string;
+    name: string;
+    type: string;
+  }[];
 }
 
 export interface AllContentTypes {
-  [key: string]: {
-    name: string;
-    fields: {
-      id: string;
-      name: string;
-      type: string;
-    }[];
-  };
+  [key: string]: AllContentTypeValue;
 }
+
+export type AllContentTypeEntries = [string, AllContentTypeValue][];

--- a/apps/google-analytics-4/frontend/src/types.ts
+++ b/apps/google-analytics-4/frontend/src/types.ts
@@ -3,6 +3,7 @@ import { IdsAPI } from '@contentful/app-sdk';
 export interface AppInstallationParameters {
   serviceAccountKey: ServiceAccountKey;
   serviceAccountKeyId: ServiceAccountKeyId;
+  contentTypes: ContentTypeEntries;
 }
 
 // TODO: get this exported from the SDK
@@ -89,4 +90,24 @@ export interface PropertySummariesType {
   displayName: string;
   property: string;
   propertyType: string;
+}
+
+export interface ContentTypeEntry {
+  slugField: string;
+  urlPrefix: string;
+}
+
+export interface ContentTypeEntries {
+  [key: string]: ContentTypeEntry;
+}
+
+export interface AllContentTypes {
+  [key: string]: {
+    name: string;
+    fields: {
+      id: string;
+      name: string;
+      type: string;
+    }[];
+  };
 }


### PR DESCRIPTION
## Purpose
Space Admins need a way to select which content types will show the GA4 app in the sidebar. They should also be able to specify a slug field and a URL prefix.

## Approach
The `AssignContentTypePage` component contains the logic for accessing all content types and saving selected content types as installation parameters. The `AssignContentTypeCard` component displays the input fields for each content type (Content type, Slug field, and URL Prefix) and allows users to remove and add content types. Any changes to content types are saved when the user clicks "Install" or "Save" for the app.

Empty state - no content types selected
![Screenshot 2023-03-08 at 4 30 13 PM](https://user-images.githubusercontent.com/62958907/223882745-bcc7614b-d4c8-46bf-b657-2d7923294761.png)

Content types selected
![Screenshot 2023-03-08 at 4 29 56 PM](https://user-images.githubusercontent.com/62958907/223882769-27173553-8b84-46d3-81cd-165308ef8d51.png)
