### PR TITLE
[INTEG-242] Fix incorrect parsing of server errors

### DIFF
--- a/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/DisplayServiceAccountCard.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/DisplayServiceAccountCard.tsx
@@ -173,7 +173,10 @@ const DisplayServiceAccountCard = (props: Props) => {
       );
     } else if (unknownError) {
       return (
-        <RenderSimpleBadgeNote badgeLabel="Unknown Error" noteMessage={unknownError.message} />
+        <RenderSimpleBadgeNote
+          badgeLabel="Unknown Error"
+          noteMessage={'An unexpected error has occurred.'}
+        />
       );
     }
 

--- a/apps/google-analytics-4/lambda/src/controllers/apiController.ts
+++ b/apps/google-analytics-4/lambda/src/controllers/apiController.ts
@@ -2,6 +2,9 @@ import { NextFunction, Request, Response } from 'express';
 import { RunReportParamsType } from '../types';
 import { GoogleApiService } from '../services/googleApiService';
 
+const formatArrays = (param: string | string[]) =>
+  Array.isArray(param) ? param : param.split(',');
+
 const ApiController = {
   credentials: (_req: Request, res: Response) => {
     // TODO: actually verify the credentials
@@ -33,22 +36,22 @@ const ApiController = {
       const { propertyId, slug, startDate, endDate, dimensions, metrics } =
         req.query as unknown as RunReportParamsType;
 
-      const formatArrays = (param: string | string[]) =>
-        Array.isArray(param) ? param : param.split(',');
-
       // intentional runtime error because the middleware already handles this. typescript
       // just doesn't realize
       if (serviceAccountKeyFile === undefined) throw new Error('missing service account key value');
 
       const googleApi = GoogleApiService.fromServiceAccountKeyFile(serviceAccountKeyFile);
-      const result = await googleApi.runReport(
-        propertyId,
-        slug,
-        startDate,
-        endDate,
-        formatArrays(dimensions),
-        formatArrays(metrics)
-      );
+      const result =
+        dimensions && metrics
+          ? await googleApi.runReport(
+              propertyId,
+              slug,
+              startDate,
+              endDate,
+              formatArrays(dimensions),
+              formatArrays(metrics)
+            )
+          : await googleApi.runReport(propertyId, slug, startDate, endDate);
       res.status(200).json(result);
     } catch (err) {
       // pass to apiErrorHandler


### PR DESCRIPTION
## Purpose
[JIRA TICKET](https://contentful.atlassian.net/browse/INTEG-242)
Fixes bug with run_report throwing parsing errors and updates UI to handle unexpected errors

## Approach
Issue was with a change that was made with the run_report controller without testing the config page. This fix makes it so that the parsing only occurs when it is called from the sidebar, or anytime the params are passed. 

The config page passes no params because it only checks to see if the run_report endpoint throws some API related error.
