### PR TITLE
fix post-deploy script issue with shallow clones in CI

### DIFF
--- a/apps/google-analytics-4/frontend/package.json
+++ b/apps/google-analytics-4/frontend/package.json
@@ -33,7 +33,7 @@
     "deploy": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEFINITIONS_ORG_ID} --definition-id 5DlxOS0KvGS1Wk362xgvbN --token ${CONTENTFUL_CMA_TOKEN}",
     "deploy:test": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${TEST_ORG_ID} --definition-id ${TEST_APP_ID} --token ${CONTENTFUL_CMA_TOKEN}",
     "sentry-create-release": "REACT_APP_RELEASE=$(git rev-parse --short HEAD); sentry-cli releases --log-level=debug new -p marketplace-apps $REACT_APP_RELEASE",
-    "sentry-set-commits": "REACT_APP_RELEASE=$(git rev-parse --short HEAD); sentry-cli releases --log-level=debug set-commits --auto $REACT_APP_RELEASE",
+    "sentry-set-commits": "REACT_APP_RELEASE=$(git rev-parse --short HEAD); sentry-cli releases --log-level=debug set-commits --auto --ignore-missing $REACT_APP_RELEASE",
     "sentry-upload-source-maps": "REACT_APP_RELEASE=$(git rev-parse --short HEAD); sentry-cli releases --log-level=debug files $REACT_APP_RELEASE upload-sourcemaps --ext ts --ext tsx --ext map ./src ./build",
     "sentry-finalize-release": "REACT_APP_RELEASE=$(git rev-parse --short HEAD); sentry-cli releases --log-level=debug finalize $REACT_APP_RELEASE",
     "sentry-deploy": "REACT_APP_RELEASE=$(git rev-parse --short HEAD); sentry-cli releases --log-level=debug deploys $REACT_APP_RELEASE new -e production",

--- a/apps/google-analytics-4/lambda/package.json
+++ b/apps/google-analytics-4/lambda/package.json
@@ -17,7 +17,7 @@
     "deploy": "NODE_ENV=production CIRCLE_SHA1=$(git rev-parse --short HEAD) sls deploy --stage $STAGE",
     "verify-config": "STAGE=$(test \"$CIRCLE_BRANCH\" = 'master' && echo 'prd' || echo 'test'); sls print --stage $STAGE",
     "sentry-create-release": "sentry-cli releases --log-level=debug new -p marketplace-apps $CIRCLE_SHA1",
-    "sentry-set-commits": "sentry-cli releases --log-level=debug set-commits --auto $CIRCLE_SHA1",
+    "sentry-set-commits": "sentry-cli releases --log-level=debug set-commits --auto --ignore-missing $CIRCLE_SHA1",
     "sentry-upload-source-maps": "sentry-cli releases --log-level=debug files $CIRCLE_SHA1 upload-sourcemaps --ext ts --ext tsx --ext map ./src ./build",
     "sentry-finalize-release": "sentry-cli releases --log-level=debug finalize $CIRCLE_SHA1",
     "sentry-deploy": "sentry-cli releases --log-level=debug deploys $CIRCLE_SHA1 new -e production",


### PR DESCRIPTION
## Purpose
resolves error in post-deploy with shallow git clone in circleCI:

```
error: Could not find the SHA of the previous release in the git
history. If you limit the clone depth, try to increase it. Otherwise,
it means that the commit we are looking for was amended or squashed
and cannot be retrieved. Use --ignore-missing flag to skip it and
create a new release with the default commits count.
```

[example build](https://app.circleci.com/pipelines/github/contentful/apps/16771/workflows/c2911b54-a8ee-48b0-9147-14de1927472d/jobs/40469) for reference

## Approach
use `--ignore-missing` CLI argument

## Dependencies and/or References
https://docs.sentry.io/product/cli/releases/#dealing-with-missing-commits 

## Deployment
<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
