### PR TITLE
[INTEG-209 & INTEG-249]  Error types are misnamed (they all say error) and throw generic error e for Sentry

### DIFF
--- a/apps/google-analytics-4/frontend/src/apis/apiTypes.ts
+++ b/apps/google-analytics-4/frontend/src/apis/apiTypes.ts
@@ -68,26 +68,19 @@ export type RunReportData = z.infer<typeof ZRunReportData>;
 // NOTE: This needs to be in sync with the lambda - ie copy and pasted
 export const ERROR_TYPE_MAP = {
   unknown: 'Unknown',
-  unexpected: 'Unexpected Response from Server',
-  failedFetch: 'Failed fetch',
-  malformedApiResponse: 'Invalid response API',
-  invalidJson: 'Invalid json from API',
-  disabledAdminApi: 'Disabled Admin Api',
-  disabledDataApi: 'Disabled Data Api',
-  noAccountsOrPropertiesFound: 'No accounts/properties found',
-  invalidServiceAccount: 'Invalid service account',
+  unexpected: 'Unexpected',
+  failedFetch: 'FailedFetch',
+  malformedApiResponse: 'MalformedApiResponse',
+  invalidJson: 'InvalidJson',
+  disabledAdminApi: 'DisabledAdminApi',
+  disabledDataApi: 'DisabledDataApi',
+  noAccountsOrPropertiesFound: 'NoAccountsOrPropertiesFound',
+  invalidServiceAccount: 'InvalidServiceAccount',
 };
-
-const ZErrorTypesType = z.union([
-  z.literal(ERROR_TYPE_MAP.unknown),
-  z.literal(ERROR_TYPE_MAP.disabledAdminApi),
-  z.literal(ERROR_TYPE_MAP.disabledDataApi),
-  z.literal(ERROR_TYPE_MAP.noAccountsOrPropertiesFound),
-]);
 
 export const ZApiError = z.object({
   details: z.any(),
-  errorType: ZErrorTypesType,
+  errorType: z.string(),
   message: z.string(),
   status: z.number(),
 });

--- a/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/DisplayServiceAccountCard.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/DisplayServiceAccountCard.tsx
@@ -47,9 +47,6 @@ const DisplayServiceAccountCard = (props: Props) => {
 
   const handleApiError = (error: ApiErrorType) => {
     switch (error.errorType) {
-      case ERROR_TYPE_MAP.unknown:
-        setUnknownError(error);
-        throw new Error(error.message);
       case ERROR_TYPE_MAP.invalidServiceAccount:
         setInvalidServiceAccountError(error);
         break;
@@ -65,7 +62,7 @@ const DisplayServiceAccountCard = (props: Props) => {
         break;
       default:
         setUnknownError(error);
-        throw new Error('Unhandled error exception');
+        throw error;
     }
   };
 
@@ -79,7 +76,7 @@ const DisplayServiceAccountCard = (props: Props) => {
       if (isApiErrorType(e)) handleApiError(e);
       else {
         setUnknownError(e);
-        throw new Error('Unhandled error exception');
+        throw e;
       }
     } finally {
       setIsLoading(false);
@@ -104,7 +101,7 @@ const DisplayServiceAccountCard = (props: Props) => {
       if (isApiErrorType(e)) handleApiError(e);
       else {
         setUnknownError(e);
-        throw new Error('Unhandled error exception');
+        throw e;
       }
     } finally {
       setIsLoading(false);
@@ -181,7 +178,9 @@ const DisplayServiceAccountCard = (props: Props) => {
       return (
         <RenderSimpleBadgeNote
           badgeLabel="Unknown Error"
-          noteMessage={'An unexpected error has occurred.'}
+          noteMessage={
+            'An unknown error occurred. You can try the action again in a few minutes, or contact support if the error persists.'
+          }
         />
       );
     }

--- a/apps/google-analytics-4/lambda/src/apiErrorMap.ts
+++ b/apps/google-analytics-4/lambda/src/apiErrorMap.ts
@@ -10,9 +10,11 @@ import { GoogleApiError } from './services/googleApiUtils';
 
 export const apiErrorMap: ApiErrorMap = {
   GoogleApiError: (e: GoogleApiError) => new ApiError(e.details, e.errorType, e.status),
-  InvalidSignature: (e: InvalidSignature) => new ApiError(e.message, e.name, 403),
-  UnableToVerifyRequest: (e: UnableToVerifyRequest) => new ApiError(e.message, e.name, 422),
+  InvalidSignature: (e: InvalidSignature) => new ApiError(e.message, 'InvalidSignature', 403),
+  UnableToVerifyRequest: (e: UnableToVerifyRequest) =>
+    new ApiError(e.message, 'UnableToVerifyRequest', 422),
   MissingServiceAccountKeyHeader: (e: MissingServiceAccountKeyHeader) =>
-    new ApiError(e.message, e.name, 400),
-  InvalidServiceAccountKey: (e: InvalidServiceAccountKey) => new ApiError(e.message, e.name, 400),
+    new ApiError(e.message, 'MissingServiceAccountKeyHeader', 400),
+  InvalidServiceAccountKey: (e: InvalidServiceAccountKey) =>
+    new ApiError(e.message, 'InvalidServiceAccountKey', 400),
 };

--- a/apps/google-analytics-4/lambda/src/errors/apiError.ts
+++ b/apps/google-analytics-4/lambda/src/errors/apiError.ts
@@ -2,14 +2,14 @@
 // NOTE: This needs to be in sync with the frontend client - ie copy and pasted
 export const ERROR_TYPE_MAP = {
   unknown: 'Unknown',
-  unexpected: 'Unexpected Response from Server',
-  failedFetch: 'Failed fetch',
-  malformedApiResponse: 'Invalid response API',
-  invalidJson: 'Invalid json from API',
-  disabledAdminApi: 'Disabled Admin Api',
-  disabledDataApi: 'Disabled Data Api',
-  noAccountsOrPropertiesFound: 'No accounts/properties found',
-  invalidServiceAccount: 'Invalid service account',
+  unexpected: 'Unexpected',
+  failedFetch: 'FailedFetch',
+  malformedApiResponse: 'MalformedApiResponse',
+  invalidJson: 'InvalidJson',
+  disabledAdminApi: 'DisabledAdminApi',
+  disabledDataApi: 'DisabledDataApi',
+  noAccountsOrPropertiesFound: 'NoAccountsOrPropertiesFound',
+  invalidServiceAccount: 'InvalidServiceAccount',
 };
 
 export class ApiError<T extends Record<string, unknown>> extends Error {

--- a/apps/google-analytics-4/lambda/src/middlewares/apiErrorHandler.ts
+++ b/apps/google-analytics-4/lambda/src/middlewares/apiErrorHandler.ts
@@ -15,7 +15,12 @@ export const apiErrorHandler: ErrorRequestHandler = (error, _request, response, 
       response.status(error.status).send({ errors: error.toJSON() });
     } else {
       response.status(500).send({
-        errors: { errorType: 'ServerError', message: 'Internal Server Error', details: null },
+        errors: {
+          errorType: 'ServerError',
+          message: 'Internal Server Error',
+          details: null,
+          status: 500,
+        },
       });
     }
   }


### PR DESCRIPTION
## Purpose
[JIRA Link](https://contentful.atlassian.net/browse/INTEG-209) - Fix error mapper
[JIRA Link](https://contentful.atlassian.net/browse/INTEG-249) - Throw errors instead of modifying the message so that sentry prints out what the actual error was.

- Also update ERROR TYPE MAP to use PascalCasing
- Updates zod error typing to only check for strings in fetchApi validate response instead of specific error types

## Approach
The two tickets were small enough related tasks to throw into one PR.
Using `constructor.name` did not work for the error map. It still printed out Error, so string literals were used instead
