### PR TITLE
use full root-relative URL for request signing (fullpath + query string)

### DIFF
--- a/apps/google-analytics-4/frontend/src/helpers/signed-requests.ts
+++ b/apps/google-analytics-4/frontend/src/helpers/signed-requests.ts
@@ -14,6 +14,8 @@ async function fetchWithSignedRequest(
     headers: {},
   };
 
+  const rootRelativeUrl = req.url.pathname + req.url.search;
+
   // add request verification signing secret to request headers
   const { additionalHeaders: signedHeaders } = await cma.appSignedRequest.create(
     {
@@ -22,7 +24,7 @@ async function fetchWithSignedRequest(
     {
       method: req.method,
       headers: req.headers,
-      path: new URL(req.url).pathname,
+      path: rootRelativeUrl,
     }
   );
   Object.assign(req.headers, unsignedHeaders, signedHeaders);

--- a/apps/google-analytics-4/lambda/src/middlewares/verifySignedRequests.ts
+++ b/apps/google-analytics-4/lambda/src/middlewares/verifySignedRequests.ts
@@ -42,7 +42,7 @@ const makeCanonicalReq = (req: Request) => {
 
   return <CanonicalRequest>{
     method: req.method,
-    path: `${pathPrefix}${req.originalUrl}`, // note: req.originalUrl starts with a `/`
+    path: `${pathPrefix}${req.originalUrl}`, // note: req.originalUrl starts with a `/` and includes the full path & query string
     headers: headers,
   };
 };


### PR DESCRIPTION
## Purpose
fix request verification to work with query params

## Approach
use the fullpath + query string for request signing

## Dependencies and/or References
<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment
<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
