### PR TITLE
Integ 221 sidebar querying should make use of content types and property saved in app installation parameters

### DIFF
--- a/apps/google-analytics-4/frontend/src/components/main-app/analytics-app/AnalyticsApp.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/analytics-app/AnalyticsApp.spec.tsx
@@ -62,19 +62,6 @@ describe('AnalyticsApp', () => {
     expect(noteText).toBeVisible();
   });
 
-  it('mounts with error message when error thrown', async () => {
-    mockApi.mockRejectedValue(() => new Error('api error'));
-    renderAnalyticsApp();
-
-    const dropdown = await findByTestId(SELECT_TEST_ID);
-    const warningNote = getByTestId(NOTE_TEST_ID);
-    const noteText = getByText('api error');
-
-    expect(dropdown).toBeVisible();
-    expect(warningNote).toBeVisible();
-    expect(noteText).toBeVisible();
-  });
-
   it('renders nothing when it has no response', async () => {
     renderAnalyticsApp();
 

--- a/apps/google-analytics-4/frontend/src/components/main-app/analytics-app/AnalyticsApp.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/analytics-app/AnalyticsApp.spec.tsx
@@ -1,5 +1,6 @@
 import AnalyticsApp from './AnalyticsApp';
 import { act, render, screen } from '@testing-library/react';
+import { Api } from 'apis/api';
 import { mockSdk, mockCma, validServiceKeyFile, validServiceKeyId } from '../../../../test/mocks';
 import runReportResponseHasViews from '../../../../../lambda/public/sampleData/runReportResponseHasViews.json';
 import runReportResponseNoView from '../../../../../lambda/public/sampleData/runReportResponseNoViews.json';
@@ -12,11 +13,11 @@ jest.mock('@contentful/react-apps-toolkit', () => ({
 }));
 
 const mockApi = jest.fn();
-jest.mock('hooks/useApi', () => ({
-  useApi: () => ({
-    runReports: mockApi,
-  }),
-}));
+// jest.mock('hooks/useApi', () => ({
+//   useApi: () => ({
+//     runReports: mockApi,
+//   }),
+// }));
 
 const { findByTestId, getByTestId, getByText, findByText } = screen;
 
@@ -26,12 +27,7 @@ const NOTE_TEST_ID = 'cf-ui-note';
 const renderAnalyticsApp = async () =>
   await act(async () => {
     render(
-      <AnalyticsApp
-        serviceAccountKeyId={validServiceKeyId}
-        serviceAccountKey={validServiceKeyFile}
-        propertyId=""
-        reportSlug=""
-      />
+      <AnalyticsApp api={{ runReports: mockApi } as unknown as Api} propertyId="" reportSlug="" />
     );
   });
 

--- a/apps/google-analytics-4/frontend/src/components/main-app/analytics-app/AnalyticsApp.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/analytics-app/AnalyticsApp.spec.tsx
@@ -14,7 +14,7 @@ jest.mock('@contentful/react-apps-toolkit', () => ({
 
 const mockApi = jest.fn();
 
-const { findByTestId, getByTestId, getByText, findByText } = screen;
+const { findByTestId, getByTestId, getByText } = screen;
 
 const SELECT_TEST_ID = 'cf-ui-select';
 const NOTE_TEST_ID = 'cf-ui-note';

--- a/apps/google-analytics-4/frontend/src/components/main-app/analytics-app/AnalyticsApp.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/analytics-app/AnalyticsApp.spec.tsx
@@ -62,6 +62,19 @@ describe('AnalyticsApp', () => {
     expect(noteText).toBeVisible();
   });
 
+  it('mounts with error message when error thrown', async () => {
+    mockApi.mockRejectedValue(() => new Error('api error'));
+    renderAnalyticsApp();
+
+    const dropdown = await findByTestId(SELECT_TEST_ID);
+    const warningNote = getByTestId(NOTE_TEST_ID);
+    const noteText = getByText('api error');
+
+    expect(dropdown).toBeVisible();
+    expect(warningNote).toBeVisible();
+    expect(noteText).toBeVisible();
+  });
+
   it('renders nothing when it has no response', async () => {
     renderAnalyticsApp();
 

--- a/apps/google-analytics-4/frontend/src/components/main-app/analytics-app/AnalyticsApp.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/analytics-app/AnalyticsApp.spec.tsx
@@ -13,11 +13,6 @@ jest.mock('@contentful/react-apps-toolkit', () => ({
 }));
 
 const mockApi = jest.fn();
-// jest.mock('hooks/useApi', () => ({
-//   useApi: () => ({
-//     runReports: mockApi,
-//   }),
-// }));
 
 const { findByTestId, getByTestId, getByText, findByText } = screen;
 
@@ -57,6 +52,19 @@ describe('AnalyticsApp', () => {
     const dropdown = await findByTestId(SELECT_TEST_ID);
     const warningNote = getByTestId(NOTE_TEST_ID);
     const noteText = getByText('There are no page views to show for this range');
+
+    expect(dropdown).toBeVisible();
+    expect(warningNote).toBeVisible();
+    expect(noteText).toBeVisible();
+  });
+
+  it('mounts with error message when error thrown', async () => {
+    mockApi.mockRejectedValue(() => new Error('api error'));
+    renderAnalyticsApp();
+
+    const dropdown = await findByTestId(SELECT_TEST_ID);
+    const warningNote = getByTestId(NOTE_TEST_ID);
+    const noteText = getByText('api error');
 
     expect(dropdown).toBeVisible();
     expect(warningNote).toBeVisible();

--- a/apps/google-analytics-4/frontend/src/components/main-app/analytics-app/AnalyticsApp.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/analytics-app/AnalyticsApp.spec.tsx
@@ -22,7 +22,11 @@ const NOTE_TEST_ID = 'cf-ui-note';
 const renderAnalyticsApp = async () =>
   await act(async () => {
     render(
-      <AnalyticsApp api={{ runReports: mockApi } as unknown as Api} propertyId="" reportSlug="" />
+      <AnalyticsApp
+        api={{ runReports: mockApi } as unknown as Api}
+        propertyId=""
+        slugFieldInfo={{ slugField: 'title', urlPrefix: '' }}
+      />
     );
   });
 

--- a/apps/google-analytics-4/frontend/src/components/main-app/analytics-app/AnalyticsApp.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/analytics-app/AnalyticsApp.tsx
@@ -2,10 +2,10 @@ import { useAutoResizer, useFieldValue } from '@contentful/react-apps-toolkit';
 import ChartFooter from 'components/main-app/ChartFooter';
 import ChartHeader from 'components/main-app/ChartHeader';
 import { useEffect, useState, useMemo } from 'react';
-import { useApi } from 'hooks/useApi';
+import { Api } from 'apis/api';
 import getRangeDates from 'helpers/DateRangeHelpers/DateRangeHelpers';
 import ChartContent from '../ChartContent';
-import { DateRangeType, ServiceAccountKeyId, ServiceAccountKey } from 'types';
+import { DateRangeType } from 'types';
 import { styles } from './AnalyticsApp.styles';
 import { Flex, Note } from '@contentful/f36-components';
 import { RunReportData } from 'apis/apiTypes';
@@ -14,21 +14,18 @@ const DEFAULT_ERR_MSG = 'Oops! Cannot display the analytics data at this time.';
 const EMPTY_DATA_MSG = 'There are no page views to show for this range';
 
 interface Props {
-  serviceAccountKeyId: ServiceAccountKeyId;
-  serviceAccountKey: ServiceAccountKey;
+  api: Api;
   propertyId: string;
   reportSlug: string;
 }
 const AnalyticsApp = (props: Props) => {
-  const { serviceAccountKeyId, serviceAccountKey, propertyId, reportSlug } = props;
+  const { api, propertyId, reportSlug } = props;
   const [runReportResponse, setRunReportResponse] = useState<RunReportData>({} as RunReportData);
   const [dateRange, setDateRange] = useState<DateRangeType>('lastWeek');
   const [startEndDates, setStartEndDates] = useState<any>(getRangeDates('lastWeek')); // TYPE
   const [slugValue] = useFieldValue<string>('slug');
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<Error>();
-
-  const api = useApi(serviceAccountKeyId, serviceAccountKey);
 
   useAutoResizer();
 

--- a/apps/google-analytics-4/frontend/src/components/main-app/analytics-app/AnalyticsApp.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/analytics-app/AnalyticsApp.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState, useMemo } from 'react';
 import { Api } from 'apis/api';
 import getRangeDates from 'helpers/DateRangeHelpers/DateRangeHelpers';
 import ChartContent from '../ChartContent';
-import { DateRangeType } from 'types';
+import { DateRangeType, ContentTypeValue } from 'types';
 import { styles } from './AnalyticsApp.styles';
 import { Flex, Note } from '@contentful/f36-components';
 import { RunReportData } from 'apis/apiTypes';
@@ -16,18 +16,21 @@ const EMPTY_DATA_MSG = 'There are no page views to show for this range';
 interface Props {
   api: Api;
   propertyId: string;
-  reportSlug: string;
+  slugFieldInfo: ContentTypeValue;
 }
 const AnalyticsApp = (props: Props) => {
-  const { api, propertyId, reportSlug } = props;
+  const { api, propertyId, slugFieldInfo } = props;
+  const { slugField, urlPrefix } = slugFieldInfo;
   const [runReportResponse, setRunReportResponse] = useState<RunReportData>({} as RunReportData);
   const [dateRange, setDateRange] = useState<DateRangeType>('lastWeek');
   const [startEndDates, setStartEndDates] = useState<any>(getRangeDates('lastWeek')); // TYPE
-  const [slugValue] = useFieldValue<string>('slug');
+  const [slugValue] = useFieldValue<string>(slugField);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<Error>();
 
   useAutoResizer();
+
+  const reportSlug = `${urlPrefix || ''}${slugValue || ''}`;
 
   const reportRequestParams = useMemo(
     () => ({

--- a/apps/google-analytics-4/frontend/src/locations/Sidebar.tsx
+++ b/apps/google-analytics-4/frontend/src/locations/Sidebar.tsx
@@ -2,20 +2,23 @@ import AnalyticsApp from 'components/main-app/analytics-app/AnalyticsApp';
 import { useSDK } from '@contentful/react-apps-toolkit';
 import { useApi } from 'hooks/useApi';
 
-const hardCodedSlug = '/en-US';
-
 const Sidebar = () => {
   const sdk = useSDK<any>();
 
-  const { serviceAccountKey, serviceAccountKeyId, savedPropertyId } = sdk.parameters.installation;
+  const { serviceAccountKey, serviceAccountKeyId, savedPropertyId, contentTypes } =
+    sdk.parameters.installation;
+
+  const currentContentType = sdk.contentType.sys.id;
 
   const api = useApi(serviceAccountKeyId, serviceAccountKey);
 
   return (
     <>
-      {savedPropertyId && (
-        <AnalyticsApp api={api} propertyId={savedPropertyId} reportSlug={hardCodedSlug} />
-      )}
+      <AnalyticsApp
+        api={api}
+        propertyId={savedPropertyId}
+        reportSlug={contentTypes[currentContentType].urlPrefix}
+      />
     </>
   );
 };

--- a/apps/google-analytics-4/frontend/src/locations/Sidebar.tsx
+++ b/apps/google-analytics-4/frontend/src/locations/Sidebar.tsx
@@ -1,9 +1,10 @@
 import AnalyticsApp from 'components/main-app/analytics-app/AnalyticsApp';
 import { useSDK } from '@contentful/react-apps-toolkit';
+import { SidebarExtensionSDK } from '@contentful/app-sdk';
 import { useApi } from 'hooks/useApi';
 
 const Sidebar = () => {
-  const sdk = useSDK<any>();
+  const sdk = useSDK<SidebarExtensionSDK>();
 
   const { serviceAccountKey, serviceAccountKeyId, savedPropertyId, contentTypes } =
     sdk.parameters.installation;

--- a/apps/google-analytics-4/frontend/src/locations/Sidebar.tsx
+++ b/apps/google-analytics-4/frontend/src/locations/Sidebar.tsx
@@ -1,20 +1,22 @@
 import AnalyticsApp from 'components/main-app/analytics-app/AnalyticsApp';
 import { useSDK } from '@contentful/react-apps-toolkit';
+import { useApi } from 'hooks/useApi';
 
-// TO DO: Add propertyId and reportSlug logic
+const hardCodedSlug = '/en-US';
 
 const Sidebar = () => {
   const sdk = useSDK<any>();
 
-  const { serviceAccountKey, serviceAccountKeyId } = sdk.parameters;
+  const { serviceAccountKey, serviceAccountKeyId, savedPropertyId } = sdk.parameters.installation;
+
+  const api = useApi(serviceAccountKeyId, serviceAccountKey);
 
   return (
-    <AnalyticsApp
-      serviceAccountKeyId={serviceAccountKeyId}
-      serviceAccountKey={serviceAccountKey}
-      propertyId=""
-      reportSlug=""
-    />
+    <>
+      {savedPropertyId && (
+        <AnalyticsApp api={api} propertyId={savedPropertyId} reportSlug={hardCodedSlug} />
+      )}
+    </>
   );
 };
 

--- a/apps/google-analytics-4/frontend/src/locations/Sidebar.tsx
+++ b/apps/google-analytics-4/frontend/src/locations/Sidebar.tsx
@@ -9,16 +9,13 @@ const Sidebar = () => {
     sdk.parameters.installation;
 
   const currentContentType = sdk.contentType.sys.id;
+  const contentTypeSlug = contentTypes[currentContentType].urlPrefix.trim();
 
   const api = useApi(serviceAccountKeyId, serviceAccountKey);
 
   return (
     <>
-      <AnalyticsApp
-        api={api}
-        propertyId={savedPropertyId}
-        reportSlug={contentTypes[currentContentType].urlPrefix}
-      />
+      <AnalyticsApp api={api} propertyId={savedPropertyId} reportSlug={contentTypeSlug} />
     </>
   );
 };

--- a/apps/google-analytics-4/frontend/src/locations/Sidebar.tsx
+++ b/apps/google-analytics-4/frontend/src/locations/Sidebar.tsx
@@ -9,13 +9,13 @@ const Sidebar = () => {
     sdk.parameters.installation;
 
   const currentContentType = sdk.contentType.sys.id;
-  const contentTypeSlug = contentTypes[currentContentType].urlPrefix.trim();
+  const slugFieldInfo = contentTypes[currentContentType];
 
   const api = useApi(serviceAccountKeyId, serviceAccountKey);
 
   return (
     <>
-      <AnalyticsApp api={api} propertyId={savedPropertyId} reportSlug={contentTypeSlug} />
+      <AnalyticsApp api={api} propertyId={savedPropertyId} slugFieldInfo={slugFieldInfo} />
     </>
   );
 };


### PR DESCRIPTION
## Purpose
This PR simply ties the logic of `propertyId` and `contentType` selection to the fetching of analytics chart data within the `Sidebar` itself. 

## Approach
Pleas refer to the loom video below for an overview of thoughts here. 

https://www.loom.com/share/aec61cf50f204226a53cfff94304ffeb 

You will notice the data is grabbed from the `sdk` parameters directly within the `Sidebar` component. The `Api` instance is also passed down to the `AnalyticsApp` component as per a suggestion on a previous PR by Jim. 

Additionally I re-added a test that was being flaky on Friday with some adjustments. 