### PR TITLE
[INTEG-217 & INTEG-218] Content type config UI updates & syncing saved content types

### DIFF
--- a/apps/google-analytics-4/frontend/src/components/config-screen/api-access/ApiAccessSection.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/api-access/ApiAccessSection.spec.tsx
@@ -104,7 +104,7 @@ describe('Config Screen component (not installed)', () => {
         contentTypes: {},
         savedPropertyId: '',
       },
-      targetState: undefined,
+      targetState: { EditorInterface: {} },
     });
     expect(screen.getByText('Google Service Account Details')).toBeInTheDocument();
     expect(screen.getByText('Private Key File')).toBeInTheDocument();

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentType.styles.ts
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentType.styles.ts
@@ -1,0 +1,13 @@
+import { css } from 'emotion';
+
+export const styles = {
+  contentTypeItem: css({
+    flex: 4,
+  }),
+  removeItem: css({
+    flex: 1,
+  }),
+  statusItem: css({
+    flex: 0.5,
+  }),
+};

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeCard.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeCard.spec.tsx
@@ -1,52 +1,19 @@
 import { render, screen } from '@testing-library/react';
-import { AllContentTypes, AllContentTypeEntries, ContentTypes, ContentTypeEntries } from '@/types';
+import { AllContentTypeEntries, ContentTypeEntries } from 'types';
+import { mockAllContentTypesComplete, mockContentTypes } from '../../../../test/mocks';
 import AssignContentTypeCard from 'components/config-screen/assign-content-type/AssignContentTypeCard';
 
-const allContentTypes: AllContentTypes = {
-  course: {
-    name: 'Course',
-    fields: [
-      {
-        id: 'slug',
-        name: 'Slug',
-        type: 'Symbol',
-      },
-    ],
-  },
-  category: {
-    name: 'Category',
-    fields: [
-      {
-        id: 'title',
-        name: 'Title',
-        type: 'Symbol',
-      },
-    ],
-  },
-};
+const allContentTypeEntries: AllContentTypeEntries = Object.entries(mockAllContentTypesComplete);
 
-const allContentTypeEntries: AllContentTypeEntries = Object.entries(allContentTypes);
-
-const contentTypes: ContentTypes = {
-  course: {
-    slugField: 'slug',
-    urlPrefix: '/about',
-  },
-  category: {
-    slugField: 'title',
-    urlPrefix: '',
-  },
-};
-
-const contentTypeEntries: ContentTypeEntries = Object.entries(contentTypes);
+const contentTypeEntries: ContentTypeEntries = Object.entries(mockContentTypes);
 
 describe('Assign Content Type Card for Config Screen', () => {
   it('can render the field labels when there is a saved content type entry', () => {
     render(
       <AssignContentTypeCard
-        allContentTypes={allContentTypes}
+        allContentTypes={mockAllContentTypesComplete}
         allContentTypeEntries={allContentTypeEntries}
-        contentTypes={contentTypes}
+        contentTypes={mockContentTypes}
         contentTypeEntries={contentTypeEntries}
         onContentTypeChange={() => {}}
         onContentTypeFieldChange={() => {}}
@@ -62,9 +29,9 @@ describe('Assign Content Type Card for Config Screen', () => {
   it('can render the correct number of saved content types', () => {
     render(
       <AssignContentTypeCard
-        allContentTypes={allContentTypes}
+        allContentTypes={mockAllContentTypesComplete}
         allContentTypeEntries={allContentTypeEntries}
-        contentTypes={contentTypes}
+        contentTypes={mockContentTypes}
         contentTypeEntries={contentTypeEntries}
         onContentTypeChange={() => {}}
         onContentTypeFieldChange={() => {}}
@@ -72,6 +39,6 @@ describe('Assign Content Type Card for Config Screen', () => {
       />
     );
 
-    expect(screen.getAllByTestId('contentTypeRow').length).toBe(2);
+    expect(screen.getAllByTestId('contentTypeRow').length).toBe(3);
   });
 });

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeCard.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeCard.tsx
@@ -1,133 +1,21 @@
-import {
-  Box,
-  Button,
-  Card,
-  FormControl,
-  Select,
-  Stack,
-  TextInput,
-  TextLink,
-} from '@contentful/f36-components';
-import { css } from 'emotion';
+import { Box, Card, FormControl, Stack } from '@contentful/f36-components';
+import { styles } from 'components/config-screen/assign-content-type/AssignContentType.styles';
 import { AllContentTypes, AllContentTypeEntries, ContentTypes, ContentTypeEntries } from 'types';
+import AssignContentTypeRow from 'components/config-screen/assign-content-type/AssignContentTypeRow';
 
 interface AssignContentTypeCardProps {
   allContentTypes: AllContentTypes;
   allContentTypeEntries: AllContentTypeEntries;
   contentTypes: ContentTypes;
-  hasContentTypes: boolean;
   contentTypeEntries: ContentTypeEntries;
   onContentTypeChange: (prevKey: string, newKey: string) => void;
   onContentTypeFieldChange: (key: string, field: string, value: string) => void;
-  onAddContentType: () => void;
   onRemoveContentType: (key: string) => void;
 }
 
 interface HeaderLabelProps {
   label: string;
 }
-
-const styles = {
-  contentTypeItem: css({
-    flex: 4,
-  }),
-  removeItem: css({
-    flex: 1,
-  }),
-};
-
-const AssignContentTypeCard = (props: AssignContentTypeCardProps) => {
-  const {
-    allContentTypes,
-    allContentTypeEntries,
-    contentTypes,
-    hasContentTypes,
-    contentTypeEntries,
-    onContentTypeChange,
-    onContentTypeFieldChange,
-    onAddContentType,
-    onRemoveContentType,
-  } = props;
-
-  return (
-    <Card>
-      {hasContentTypes ? (
-        <Stack marginBottom="none" spacing="spacingXs">
-          <HeaderLabel label="Content type" />
-          <HeaderLabel label="Slug field" />
-          <HeaderLabel label="URL prefix" />
-          <Box className={styles.removeItem}></Box>
-        </Stack>
-      ) : null}
-      {contentTypeEntries.map(([key, { slugField, urlPrefix }], index) => {
-        return (
-          <Stack spacing="spacingXs" paddingBottom="spacingS" key={key}>
-            <Box className={styles.contentTypeItem}>
-              <Select
-                id={`contentType-${index}`}
-                name={`contentType-${index}`}
-                onChange={(event: React.ChangeEvent<HTMLSelectElement>) =>
-                  onContentTypeChange(key, event.target.value)
-                }
-                value={key}>
-                <Select.Option value="" isDisabled>
-                  Select content type
-                </Select.Option>
-                {allContentTypeEntries
-                  .filter(([type]) => type === key || !contentTypes[type])
-                  .map(([type, { name: typeName }]) => {
-                    return (
-                      <Select.Option value={type} key={`type-${type}`}>
-                        {typeName}
-                      </Select.Option>
-                    );
-                  })}
-              </Select>
-            </Box>
-            <Box className={styles.contentTypeItem}>
-              <Select
-                id={`slugField-${index}`}
-                name={`slugField-${index}`}
-                isDisabled={!key}
-                isInvalid={key ? !slugField : false}
-                onChange={(event: React.ChangeEvent<HTMLSelectElement>) =>
-                  onContentTypeFieldChange(key, 'slugField', event.target.value)
-                }
-                value={slugField}>
-                <Select.Option value="" isDisabled>
-                  Select slug field
-                </Select.Option>
-                {key &&
-                  allContentTypes[key]?.fields?.map((field) => (
-                    <Select.Option key={`${key}.${field.id}`} value={field.id}>
-                      {field.name}
-                    </Select.Option>
-                  ))}
-              </Select>
-            </Box>
-            <Box className={styles.contentTypeItem}>
-              <TextInput
-                id={`urlPrefix-${index}`}
-                name={`urlPrefix-${index}`}
-                isDisabled={!key}
-                onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
-                  onContentTypeFieldChange(key, 'urlPrefix', event.target.value)
-                }
-                value={urlPrefix}
-              />
-            </Box>
-            <Box className={styles.removeItem}>
-              <TextLink onClick={() => onRemoveContentType(key)}>Remove</TextLink>
-            </Box>
-          </Stack>
-        );
-      })}
-      <Button onClick={onAddContentType}>
-        {hasContentTypes ? 'Add another content type' : 'Add a content type'}
-      </Button>
-    </Card>
-  );
-};
 
 const HeaderLabel = (props: HeaderLabelProps) => {
   const { label } = props;
@@ -138,6 +26,45 @@ const HeaderLabel = (props: HeaderLabelProps) => {
         <FormControl.Label>{label}</FormControl.Label>
       </FormControl>
     </Box>
+  );
+};
+
+const AssignContentTypeCard = (props: AssignContentTypeCardProps) => {
+  const {
+    allContentTypes,
+    allContentTypeEntries,
+    contentTypes,
+    contentTypeEntries,
+    onContentTypeChange,
+    onContentTypeFieldChange,
+    onRemoveContentType,
+  } = props;
+
+  return (
+    <Card>
+      <Stack marginBottom="none" spacing="spacingXs">
+        <Box className={styles.statusItem}></Box>
+        <HeaderLabel label="Content type" />
+        <HeaderLabel label="Slug field" />
+        <HeaderLabel label="URL prefix" />
+        <Box className={styles.removeItem}></Box>
+      </Stack>
+      {contentTypeEntries.map((contentTypeEntry, index) => {
+        return (
+          <AssignContentTypeRow
+            key={contentTypeEntry[0]}
+            contentTypeEntry={contentTypeEntry}
+            index={index}
+            allContentTypes={allContentTypes}
+            allContentTypeEntries={allContentTypeEntries}
+            contentTypes={contentTypes}
+            onContentTypeChange={onContentTypeChange}
+            onContentTypeFieldChange={onContentTypeFieldChange}
+            onRemoveContentType={onRemoveContentType}
+          />
+        );
+      })}
+    </Card>
   );
 };
 

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeRow.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeRow.spec.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
-import { AllContentTypes, AllContentTypeEntries, ContentTypes, ContentTypeEntries } from '@/types';
-import AssignContentTypeCard from 'components/config-screen/assign-content-type/AssignContentTypeCard';
+import { AllContentTypes, AllContentTypeEntries, ContentTypes } from 'types';
+import AssignContentTypeRow from 'components/config-screen/assign-content-type/AssignContentTypeRow';
 
 const allContentTypes: AllContentTypes = {
   course: {
@@ -38,40 +38,53 @@ const contentTypes: ContentTypes = {
   },
 };
 
-const contentTypeEntries: ContentTypeEntries = Object.entries(contentTypes);
-
 describe('Assign Content Type Card for Config Screen', () => {
-  it('can render the field labels when there is a saved content type entry', () => {
+  it('shows invalid and disabled inputs when content type is empty', () => {
     render(
-      <AssignContentTypeCard
+      <AssignContentTypeRow
+        contentTypeEntry={[
+          '',
+          {
+            slugField: '',
+            urlPrefix: '',
+          },
+        ]}
+        index={0}
         allContentTypes={allContentTypes}
         allContentTypeEntries={allContentTypeEntries}
         contentTypes={contentTypes}
-        contentTypeEntries={contentTypeEntries}
         onContentTypeChange={() => {}}
         onContentTypeFieldChange={() => {}}
         onRemoveContentType={() => {}}
       />
     );
 
-    expect(screen.getByText('Content type')).toBeVisible();
-    expect(screen.getByText('Slug field')).toBeVisible();
-    expect(screen.getByText('URL prefix')).toBeVisible();
+    expect(screen.getByTestId('noStatus')).toBeVisible();
+    expect(screen.getByTestId('contentTypeSelect')).toBeInvalid();
+    expect(screen.getByTestId('slugFieldSelect')).toBeDisabled();
+    expect(screen.getByTestId('urlPrefixInput')).toBeDisabled();
   });
 
-  it('can render the correct number of saved content types', () => {
+  it('can render a warning icon when slug field is not selected', () => {
     render(
-      <AssignContentTypeCard
+      <AssignContentTypeRow
+        contentTypeEntry={[
+          'category',
+          {
+            slugField: '',
+            urlPrefix: '',
+          },
+        ]}
+        index={0}
         allContentTypes={allContentTypes}
         allContentTypeEntries={allContentTypeEntries}
         contentTypes={contentTypes}
-        contentTypeEntries={contentTypeEntries}
         onContentTypeChange={() => {}}
         onContentTypeFieldChange={() => {}}
         onRemoveContentType={() => {}}
       />
     );
 
-    expect(screen.getAllByTestId('contentTypeRow').length).toBe(2);
+    expect(screen.getByTestId('warningIcon')).toBeVisible();
   });
 });

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeRow.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeRow.tsx
@@ -1,0 +1,128 @@
+import { Box, Select, Stack, TextInput, TextLink, Tooltip } from '@contentful/f36-components';
+import { WarningIcon } from '@contentful/f36-icons';
+import { styles } from 'components/config-screen/assign-content-type/AssignContentType.styles';
+import { AllContentTypes, AllContentTypeEntries, ContentTypes, ContentTypeValue } from 'types';
+
+interface Props {
+  contentTypeEntry: [string, ContentTypeValue];
+  index: number;
+  allContentTypes: AllContentTypes;
+  allContentTypeEntries: AllContentTypeEntries;
+  contentTypes: ContentTypes;
+  onContentTypeChange: (prevKey: string, newKey: string) => void;
+  onContentTypeFieldChange: (key: string, field: string, value: string) => void;
+  onRemoveContentType: (key: string) => void;
+}
+
+const AssignContentTypeRow = (props: Props) => {
+  const {
+    contentTypeEntry,
+    index,
+    allContentTypes,
+    allContentTypeEntries,
+    contentTypes,
+    onContentTypeChange,
+    onContentTypeFieldChange,
+    onRemoveContentType,
+  } = props;
+
+  const [contentTypeId, { slugField, urlPrefix }] = contentTypeEntry;
+
+  const renderStatusItem = (key: string, slugField: string) => {
+    if (key && !slugField) {
+      return (
+        <Box className={styles.statusItem} testId="warningIcon">
+          <Tooltip content="This content type must have a slug field selected in order for the app to render correctly in the sidebar">
+            <WarningIcon variant="warning" />
+          </Tooltip>
+        </Box>
+      );
+    } else {
+      return <Box className={styles.statusItem} testId="noStatus" />;
+    }
+  };
+
+  const getContentTypeOptions = () => {
+    return (
+      <>
+        <Select.Option value="" isDisabled>
+          Select content type
+        </Select.Option>
+        {allContentTypeEntries
+          .filter(([type]) => type === contentTypeId || !contentTypes[type])
+          .map(([type, { name: typeName }]) => {
+            return (
+              <Select.Option value={type} key={`type-${type}`}>
+                {typeName}
+              </Select.Option>
+            );
+          })}
+      </>
+    );
+  };
+
+  const getSlugFieldOptions = () => {
+    return (
+      <>
+        <Select.Option value="" isDisabled>
+          Select slug field
+        </Select.Option>
+        {contentTypeId &&
+          allContentTypes[contentTypeId]?.fields?.map((field) => (
+            <Select.Option key={`${contentTypeId}.${field.id}`} value={field.id}>
+              {field.name}
+            </Select.Option>
+          ))}
+      </>
+    );
+  };
+
+  return (
+    <Stack spacing="spacingXs" paddingBottom="spacingS" key={contentTypeId} testId="contentTypeRow">
+      {renderStatusItem(contentTypeId, slugField)}
+      <Box className={styles.contentTypeItem}>
+        <Select
+          id={`contentType-${index}`}
+          name={`contentType-${index}`}
+          testId="contentTypeSelect"
+          isInvalid={!contentTypeId}
+          onChange={(event: React.ChangeEvent<HTMLSelectElement>) =>
+            onContentTypeChange(contentTypeId, event.target.value)
+          }
+          value={contentTypeId}>
+          {getContentTypeOptions()}
+        </Select>
+      </Box>
+      <Box className={styles.contentTypeItem}>
+        <Select
+          id={`slugField-${index}`}
+          name={`slugField-${index}`}
+          testId="slugFieldSelect"
+          isDisabled={!contentTypeId}
+          onChange={(event: React.ChangeEvent<HTMLSelectElement>) =>
+            onContentTypeFieldChange(contentTypeId, 'slugField', event.target.value)
+          }
+          value={slugField}>
+          {getSlugFieldOptions()}
+        </Select>
+      </Box>
+      <Box className={styles.contentTypeItem}>
+        <TextInput
+          id={`urlPrefix-${index}`}
+          name={`urlPrefix-${index}`}
+          testId="urlPrefixInput"
+          isDisabled={!contentTypeId}
+          onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+            onContentTypeFieldChange(contentTypeId, 'urlPrefix', event.target.value)
+          }
+          value={urlPrefix}
+        />
+      </Box>
+      <Box className={styles.removeItem}>
+        <TextLink onClick={() => onRemoveContentType(contentTypeId)}>Remove</TextLink>
+      </Box>
+    </Stack>
+  );
+};
+
+export default AssignContentTypeRow;

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.spec.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import { mockSdk } from '../../../../test/mocks';
+import AssignContentTypeSection from 'components/config-screen/assign-content-type/AssignContentTypeSection';
+
+jest.mock('@contentful/react-apps-toolkit', () => ({
+  useSDK: () => mockSdk,
+}));
+
+describe('Assign Content Type Section for Config Screen', () => {
+  it('can render the section heading', () => {
+    render(<AssignContentTypeSection />);
+
+    expect(screen.getByText('Assign to content types')).toBeVisible();
+  });
+});

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Paragraph, Stack, Subheading } from '@contentful/f36-components';
+import { Paragraph, Stack, Subheading, Button, Spinner } from '@contentful/f36-components';
 import { AllContentTypes, AllContentTypeEntries, ContentTypeEntries } from 'types';
 import AssignContentTypeCard from 'components/config-screen/assign-content-type/AssignContentTypeCard';
 import sortBy from 'lodash/sortBy';
@@ -11,6 +11,7 @@ import useKeyService from 'hooks/useKeyService';
 const AssignContentTypeSection = () => {
   const {
     contentTypes,
+    loadingParameters,
     handleContentTypeChange,
     handleContentTypeFieldChange,
     handleAddContentType,
@@ -25,6 +26,8 @@ const AssignContentTypeSection = () => {
   const [contentTypeEntries, setHasContentTypeEntries] = useState<ContentTypeEntries>(
     [] as ContentTypeEntries
   );
+  const [hasIncompleteContentTypes, setHasIncompleteContentTypes] = useState<boolean>(false);
+  const [loadingAllContentTypes, setLoadingAllContentTypes] = useState<boolean>(true);
 
   const sdk = useSDK<AppExtensionSDK>();
 
@@ -60,6 +63,7 @@ const AssignContentTypeSection = () => {
 
       setAllContentTypes(formattedContentTypes);
       setAllContentTypeEntries(Object.entries(formattedContentTypes));
+      setLoadingAllContentTypes(false);
     };
 
     getContentTypes();
@@ -68,6 +72,9 @@ const AssignContentTypeSection = () => {
   useEffect(() => {
     setHasContentTypes(Object.keys(contentTypes).length ? true : false);
     setHasContentTypeEntries(Object.entries(contentTypes));
+    setHasIncompleteContentTypes(
+      Object.entries(contentTypes).some(([contentTypeId]) => !contentTypeId)
+    );
   }, [contentTypes]);
 
   return (
@@ -78,17 +85,26 @@ const AssignContentTypeSection = () => {
         Specify the slug field that is used for URL generation in your application. Optionally,
         specify a prefix for the slug.
       </Paragraph>
-      <AssignContentTypeCard
-        allContentTypes={allContentTypes}
-        allContentTypeEntries={allContentTypeEntries}
-        contentTypes={contentTypes}
-        hasContentTypes={hasContentTypes}
-        contentTypeEntries={contentTypeEntries}
-        onContentTypeChange={handleContentTypeChange}
-        onContentTypeFieldChange={handleContentTypeFieldChange}
-        onAddContentType={handleAddContentType}
-        onRemoveContentType={handleRemoveContentType}
-      />
+      {!loadingParameters && !loadingAllContentTypes ? (
+        <>
+          {hasContentTypes && (
+            <AssignContentTypeCard
+              allContentTypes={allContentTypes}
+              allContentTypeEntries={allContentTypeEntries}
+              contentTypes={contentTypes}
+              contentTypeEntries={contentTypeEntries}
+              onContentTypeChange={handleContentTypeChange}
+              onContentTypeFieldChange={handleContentTypeFieldChange}
+              onRemoveContentType={handleRemoveContentType}
+            />
+          )}
+          <Button onClick={handleAddContentType} isDisabled={hasIncompleteContentTypes}>
+            {hasContentTypes ? 'Add another content type' : 'Add a content type'}
+          </Button>
+        </>
+      ) : (
+        <Spinner variant="primary" />
+      )}
     </Stack>
   );
 };

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.tsx
@@ -1,73 +1,27 @@
 import { useEffect, useState } from 'react';
 import { Paragraph, Stack, Subheading, Button, Spinner } from '@contentful/f36-components';
-import { AllContentTypes, AllContentTypeEntries, ContentTypeEntries } from 'types';
+import { ContentTypeEntries } from 'types';
 import AssignContentTypeCard from 'components/config-screen/assign-content-type/AssignContentTypeCard';
-import sortBy from 'lodash/sortBy';
-import { useSDK } from '@contentful/react-apps-toolkit';
-import { AppExtensionSDK } from '@contentful/app-sdk';
-import { ContentTypeProps, createClient } from 'contentful-management';
 import useKeyService from 'hooks/useKeyService';
 
 const AssignContentTypeSection = () => {
   const {
     contentTypes,
     loadingParameters,
+    allContentTypes,
+    allContentTypeEntries,
+    loadingAllContentTypes,
     handleContentTypeChange,
     handleContentTypeFieldChange,
     handleAddContentType,
     handleRemoveContentType,
   } = useKeyService({});
 
-  const [allContentTypes, setAllContentTypes] = useState<AllContentTypes>({} as AllContentTypes);
-  const [allContentTypeEntries, setAllContentTypeEntries] = useState<AllContentTypeEntries>(
-    [] as AllContentTypeEntries
-  );
   const [hasContentTypes, setHasContentTypes] = useState<boolean>(false);
   const [contentTypeEntries, setHasContentTypeEntries] = useState<ContentTypeEntries>(
     [] as ContentTypeEntries
   );
   const [hasIncompleteContentTypes, setHasIncompleteContentTypes] = useState<boolean>(false);
-  const [loadingAllContentTypes, setLoadingAllContentTypes] = useState<boolean>(true);
-
-  const sdk = useSDK<AppExtensionSDK>();
-
-  useEffect(() => {
-    const getContentTypes = async () => {
-      const cma = createClient({ apiAdapter: sdk.cmaAdapter });
-      const space = await cma.getSpace(sdk.ids.space);
-      const environment = await space.getEnvironment(sdk.ids.environment);
-      const contentTypes = await environment.getContentTypes();
-      const contentTypeItems = contentTypes.items as ContentTypeProps[];
-
-      const sortedContentTypes = sortBy(contentTypeItems, ['name']);
-
-      const formattedContentTypes = sortedContentTypes.reduce(
-        (acc: AllContentTypes, contentType) => {
-          // only include short text fields in the slug field dropdown
-          const fields = sortBy(
-            contentType.fields.filter((field) => field.type === 'Symbol'),
-            ['name']
-          );
-
-          if (fields.length) {
-            acc[contentType.sys.id] = {
-              ...contentType,
-              fields,
-            };
-          }
-
-          return acc;
-        },
-        {}
-      );
-
-      setAllContentTypes(formattedContentTypes);
-      setAllContentTypeEntries(Object.entries(formattedContentTypes));
-      setLoadingAllContentTypes(false);
-    };
-
-    getContentTypes();
-  }, [sdk]);
 
   useEffect(() => {
     setHasContentTypes(Object.keys(contentTypes).length ? true : false);

--- a/apps/google-analytics-4/frontend/src/hooks/useKeyService.tsx
+++ b/apps/google-analytics-4/frontend/src/hooks/useKeyService.tsx
@@ -21,6 +21,7 @@ interface KeyServiceInfoType {
   serviceAccountKeyFileIsValid: boolean;
   serviceAccountKeyFileIsRequired: boolean;
   contentTypes: ContentTypes;
+  loadingParameters: boolean;
   handleKeyFileChange: Function;
   handleContentTypeChange: (prevKey: string, newKey: string) => void;
   handleContentTypeFieldChange: (key: string, field: string, value: string) => void;
@@ -50,11 +51,13 @@ export default function useKeyService(props: Props): KeyServiceInfoType {
   const [savedPropertyId, setSavedPropertyId] = useState<string>('');
 
   const [contentTypes, setContentTypes] = useState<ContentTypes>({} as ContentTypes);
+  const [loadingParameters, setLoadingParameters] = useState<boolean>(true);
 
   const sdk = useSDK<AppExtensionSDK>();
 
   const onConfigure = useCallback(async () => {
     const currentState = await sdk.app.getCurrentState();
+    const contentTypeKeys = Object.keys(contentTypes);
 
     if (!serviceAccountKeyFileIsValid) {
       sdk.notifier.error('Invalid service account key file. See field error for details');
@@ -63,6 +66,11 @@ export default function useKeyService(props: Props): KeyServiceInfoType {
 
     if (serviceAccountKeyFileIsRequired && !newServiceAccountKeyId) {
       sdk.notifier.error('A valid service account key file is required');
+      return false;
+    }
+
+    if (contentTypeKeys.some((key) => !key)) {
+      sdk.notifier.error('Please complete or remove the incomplete content type rows');
       return false;
     }
 
@@ -117,6 +125,7 @@ export default function useKeyService(props: Props): KeyServiceInfoType {
         setServiceAccountKeyFileIsRequired(true);
       }
 
+      setLoadingParameters(false);
       sdk.app.setReady();
     };
 
@@ -218,6 +227,7 @@ export default function useKeyService(props: Props): KeyServiceInfoType {
     serviceAccountKeyFileIsValid,
     serviceAccountKeyFileIsRequired,
     contentTypes,
+    loadingParameters,
     handleKeyFileChange,
     handleContentTypeChange,
     handleContentTypeFieldChange,

--- a/apps/google-analytics-4/frontend/src/types.ts
+++ b/apps/google-analytics-4/frontend/src/types.ts
@@ -133,3 +133,7 @@ export interface AllContentTypes {
 }
 
 export type AllContentTypeEntries = [string, AllContentTypeValue][];
+
+export interface EditorInterfaceAssignment {
+  [key: string]: { sidebar: { position: number } };
+}

--- a/apps/google-analytics-4/frontend/src/utils/contentTypes.spec.ts
+++ b/apps/google-analytics-4/frontend/src/utils/contentTypes.spec.ts
@@ -1,0 +1,55 @@
+import {
+  mockContentTypeItems,
+  mockAllContentTypesIncomplete,
+  mockAllContentTypesComplete,
+  mockContentTypes,
+  mockEditorInterfaceComplete,
+  mockEditorInterfaceIncomplete,
+} from '../../test/mocks';
+import {
+  assignAppToContentTypeSidebar,
+  syncContentTypes,
+  sortAndFormatContentTypes,
+} from './contentTypes';
+
+describe('contentTypes utils', () => {
+  it('assigns the app to the content type sidebar', () => {
+    const result = assignAppToContentTypeSidebar(['course'], 2);
+
+    expect(result).toEqual(expect.objectContaining({ course: { sidebar: { position: 2 } } }));
+  });
+
+  it('removes content types when the app has been removed from the sidebar a content type', () => {
+    const result = syncContentTypes(
+      mockContentTypes,
+      mockAllContentTypesComplete,
+      mockEditorInterfaceIncomplete
+    );
+    const contentTypeIds = Object.keys(result);
+
+    expect(contentTypeIds.length).toEqual(2);
+    expect(result.layout).toBeUndefined();
+  });
+
+  it('removes content types when the content type or its fields have been deleted', () => {
+    const result = syncContentTypes(
+      mockContentTypes,
+      mockAllContentTypesIncomplete,
+      mockEditorInterfaceComplete
+    );
+    const contentTypeIds = Object.keys(result);
+
+    expect(contentTypeIds.length).toEqual(1);
+    expect(result.course).toBeUndefined();
+    expect(result.category).toBeUndefined();
+  });
+
+  it('sorts and formats content types', () => {
+    const result = sortAndFormatContentTypes(mockContentTypeItems);
+    const fields = result['layout'].fields;
+
+    expect(Object.keys(result).length).toEqual(1);
+    expect(fields.length).toEqual(2);
+    expect(fields[0].id).toEqual('slug');
+  });
+});

--- a/apps/google-analytics-4/frontend/src/utils/contentTypes.ts
+++ b/apps/google-analytics-4/frontend/src/utils/contentTypes.ts
@@ -1,0 +1,80 @@
+import { EditorInterface } from '@contentful/app-sdk';
+import { ContentTypeProps } from 'contentful-management';
+import { ContentTypes, AllContentTypes, EditorInterfaceAssignment } from '../types';
+import sortBy from 'lodash/sortBy';
+
+export const assignAppToContentTypeSidebar = (
+  contentTypeIds: string[],
+  position: number
+): EditorInterfaceAssignment => {
+  const sidebarAssignments = contentTypeIds.reduce(
+    (acc: EditorInterfaceAssignment, contentTypeId) => {
+      const sidebarPosition = {
+        sidebar: { position },
+      };
+      acc[contentTypeId] = sidebarPosition;
+      return acc;
+    },
+    {}
+  );
+
+  return sidebarAssignments;
+};
+
+export const syncContentTypes = (
+  contentTypes: ContentTypes,
+  allContentTypes: AllContentTypes,
+  editorInterface: Partial<EditorInterface>
+): ContentTypes => {
+  // Remove content types for which the app has been removed from the sidebar
+  const selectedContentTypes = Object.keys(editorInterface);
+
+  const acc = {} as ContentTypes;
+
+  const updatedContentTypes: ContentTypes = selectedContentTypes.reduce((acc, key: string) => {
+    const saved = contentTypes[key];
+
+    if (key && saved) {
+      acc[key] = saved;
+    }
+
+    return acc;
+  }, acc);
+
+  // Remove content types and fields that are no longer available
+  for (const [type, { slugField }] of Object.entries(updatedContentTypes)) {
+    if (
+      !(type in allContentTypes) ||
+      !allContentTypes[type].fields.some((f) => f.id === slugField)
+    ) {
+      delete updatedContentTypes[type];
+    }
+  }
+
+  return updatedContentTypes;
+};
+
+export const sortAndFormatContentTypes = (
+  contentTypeItems: ContentTypeProps[]
+): AllContentTypes => {
+  const sortedContentTypes = sortBy(contentTypeItems, ['name']);
+
+  const formattedContentTypes = sortedContentTypes.reduce((acc: AllContentTypes, contentType) => {
+    // Only include short text fields
+    const fields = sortBy(
+      contentType.fields.filter((field) => field.type === 'Symbol'),
+      ['name']
+    );
+
+    if (fields.length) {
+      acc[contentType.sys.id] = {
+        ...contentType,
+        fields,
+      };
+    }
+
+    return acc;
+  }, {});
+
+  return formattedContentTypes;
+};

--- a/apps/google-analytics-4/frontend/test/mocks/index.ts
+++ b/apps/google-analytics-4/frontend/test/mocks/index.ts
@@ -1,4 +1,11 @@
-import { ServiceAccountKey, ServiceAccountKeyId } from '../../src/types';
+import { ContentTypeProps } from 'contentful-management';
+import {
+  ServiceAccountKey,
+  ServiceAccountKeyId,
+  AllContentTypes,
+  ContentTypes,
+  EditorInterfaceAssignment,
+} from 'types';
 
 export { mockCma } from './mockCma';
 export { mockSdk } from './mockSdk';
@@ -23,3 +30,177 @@ export const validServiceKeyId: ServiceAccountKeyId = {
   clientEmail: validServiceKeyFile.client_id,
   projectId: validServiceKeyFile.project_id,
 };
+
+export const mockContentTypes: ContentTypes = {
+  course: {
+    slugField: 'slug',
+    urlPrefix: '/about',
+  },
+  category: {
+    slugField: 'title',
+    urlPrefix: '',
+  },
+  layout: {
+    slugField: 'title',
+    urlPrefix: '',
+  },
+};
+
+export const mockAllContentTypesIncomplete: AllContentTypes = {
+  layout: {
+    name: 'Layout',
+    fields: [
+      {
+        id: 'title',
+        name: 'Title',
+        type: 'Symbol',
+      },
+      {
+        id: 'slug',
+        name: 'Slug',
+        type: 'Symbol',
+      },
+    ],
+  },
+  category: {
+    name: 'Category',
+    fields: [
+      {
+        id: 'slug',
+        name: 'Slug',
+        type: 'Symbol',
+      },
+    ],
+  },
+};
+
+export const mockAllContentTypesComplete: AllContentTypes = {
+  layout: {
+    name: 'Layout',
+    fields: [
+      {
+        id: 'title',
+        name: 'Title',
+        type: 'Symbol',
+      },
+      {
+        id: 'slug',
+        name: 'Slug',
+        type: 'Symbol',
+      },
+    ],
+  },
+  category: {
+    name: 'Category',
+    fields: [
+      {
+        id: 'title',
+        name: 'Title',
+        type: 'Symbol',
+      },
+      {
+        id: 'slug',
+        name: 'Slug',
+        type: 'Symbol',
+      },
+    ],
+  },
+  course: {
+    name: 'Course',
+    fields: [
+      {
+        id: 'title',
+        name: 'Title',
+        type: 'Symbol',
+      },
+      {
+        id: 'slug',
+        name: 'Slug',
+        type: 'Symbol',
+      },
+    ],
+  },
+};
+
+export const mockEditorInterfaceIncomplete: EditorInterfaceAssignment = {
+  category: {
+    sidebar: {
+      position: 1,
+    },
+  },
+  course: {
+    sidebar: {
+      position: 1,
+    },
+  },
+};
+
+export const mockEditorInterfaceComplete: EditorInterfaceAssignment = {
+  ...mockEditorInterfaceIncomplete,
+  layout: {
+    sidebar: {
+      position: 1,
+    },
+  },
+};
+
+export const mockContentTypeItems: ContentTypeProps[] = [
+  {
+    sys: {
+      space: {
+        sys: {
+          type: 'Link',
+          linkType: 'Space',
+          id: 'abc123',
+        },
+      },
+      id: 'layout',
+      type: 'ContentType',
+      createdAt: '2023-01-18T01:12:58.781Z',
+      updatedAt: '2023-03-14T21:34:26.800Z',
+      environment: {
+        sys: {
+          id: 'abc123',
+          type: 'Link',
+          linkType: 'Environment',
+        },
+      },
+      version: 4,
+    },
+    displayField: 'title',
+    name: 'Layout',
+    description: '',
+    fields: [
+      {
+        id: 'title',
+        name: 'Title',
+        type: 'Symbol',
+        localized: false,
+        required: true,
+        validations: [],
+        disabled: false,
+        omitted: false,
+      },
+      {
+        id: 'slug',
+        name: 'Slug',
+        type: 'Symbol',
+        localized: false,
+        required: true,
+        validations: [],
+        disabled: false,
+        omitted: false,
+      },
+      {
+        disabled: false,
+        id: 'duration',
+        localized: false,
+        name: 'Duration',
+        omitted: false,
+        required: false,
+        type: 'Integer',
+        validations: [],
+      },
+    ],
+  },
+];


### PR DESCRIPTION
## Purpose
This PR contains updates to the Assign Content Type Section of the App Configuration Page. This includes some general UI enhancements, ensuring that saved content type data is synced with changes to content types, and some general refactoring.

## Approach
UI enhancements
- Add a loading state to the section
- Add a warning status icon with a tooltip if the user attempts to save a content type without a slug
- Prevent saving the app configuration if there is an empty content type
- Move the 'add new content type' button outside of the card

Syncing saved content types with changes to the content type
- If the app is manually removed from the sidebar for a saved content type, remove that content type from the app installation parameters
- If a saved content type is deleted or a saved slug field is deleted, remove that content type from the app installation parameters

Refactoring work
- Created a new Row component
- Added and updated some tests and consolidated mock test data
- Created content type util methods

Screen shot of loading state
![Screenshot 2023-03-14 at 7 28 43 PM](https://user-images.githubusercontent.com/62958907/225330867-bca3069f-9f8e-4ca5-b0e0-6638a8e8d89b.png)

Screen shot of warning state for incomplete content type and error if trying to save an empty content type
![Screenshot 2023-03-14 at 7 24 22 PM](https://user-images.githubusercontent.com/62958907/225331010-e52d16ec-7dbd-452d-8d17-5c6427682608.png)

