### PR TITLE
Integ 230 optimize date mapping for run report data

### DIFF
--- a/apps/google-analytics-4/frontend/src/components/main-app/ChartContent.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/ChartContent.tsx
@@ -1,5 +1,6 @@
 import { Row, RunReportResponse } from '@/types';
 import LineChart from './line-chart/LineChart';
+import { parseDayAndMonth } from 'helpers/DateHelpers/DateHelpers';
 
 interface Props {
   pageViewData: RunReportResponse;
@@ -14,11 +15,8 @@ const ChartContent = (props: Props) => {
 
   const parseRowDates = (): string[] => {
     return pageViewData.rows.map((r: Row) => {
-      const d = r.dimensionValues[0].value;
-      const utcDate = new Date(
-        `${d.substring(0, 4)}-${d.substring(4, 6)}-${d.substring(6, 8)}`
-      ).toUTCString();
-      const [day, month] = utcDate.substring(5, 11).split(' ');
+      const date = r.dimensionValues[0].value;
+      const { month, day } = parseDayAndMonth(date);
       return `${month} ${day}`;
     });
   };

--- a/apps/google-analytics-4/frontend/src/components/main-app/ChartContent.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/ChartContent.tsx
@@ -28,7 +28,7 @@ const ChartContent = (props: Props) => {
       <LineChart
         dataValues={parseRowViews()}
         xAxisLabels={parseRowDates()}
-        tooltipMetricLabel="Page views"
+        tooltipMetricLabel="Page views:"
         accessibilityLabel="Analytics line chart"
       />
     </>

--- a/apps/google-analytics-4/frontend/src/components/main-app/ChartContent.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/ChartContent.tsx
@@ -15,9 +15,11 @@ const ChartContent = (props: Props) => {
   const parseRowDates = (): string[] => {
     return pageViewData.rows.map((r: Row) => {
       const d = r.dimensionValues[0].value;
-      return new Date(
+      const utcDate = new Date(
         `${d.substring(0, 4)}-${d.substring(4, 6)}-${d.substring(6, 8)}`
-      ).toLocaleDateString('en-us', { month: 'short', day: 'numeric' });
+      ).toUTCString();
+      const [day, month] = utcDate.substring(5, 11).split(' ');
+      return `${month} ${day}`;
     });
   };
 

--- a/apps/google-analytics-4/frontend/src/components/main-app/line-chart/LineChart.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/line-chart/LineChart.tsx
@@ -74,7 +74,7 @@ const LineChart = (props: Props) => {
         },
         displayColors: false,
         callbacks: {
-          title: () => tooltipMetricLabel,
+          beforeBody: () => tooltipMetricLabel,
         },
       },
     },

--- a/apps/google-analytics-4/frontend/src/helpers/DateHelpers/DateHelpers.spec.ts
+++ b/apps/google-analytics-4/frontend/src/helpers/DateHelpers/DateHelpers.spec.ts
@@ -1,0 +1,10 @@
+import { parseDayAndMonth } from './DateHelpers';
+
+describe('parseDayAndMonth method', () => {
+  it('parseDayAndMonth returns month name and day', () => {
+    const { day, month } = parseDayAndMonth('20230605');
+
+    expect(day).toBe('05');
+    expect(month).toBe('Jun');
+  });
+});

--- a/apps/google-analytics-4/frontend/src/helpers/DateHelpers/DateHelpers.ts
+++ b/apps/google-analytics-4/frontend/src/helpers/DateHelpers/DateHelpers.ts
@@ -1,0 +1,21 @@
+const monthNames = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+];
+
+export const parseDayAndMonth = (date: string) => {
+  const month = date.substring(4, 6);
+  const day = date.substring(6, 8);
+
+  return { month: monthNames[Number(month) - 1], day };
+};

--- a/apps/google-analytics-4/frontend/src/helpers/DateRangeHelpers/DateRangeHelpers.spec.ts
+++ b/apps/google-analytics-4/frontend/src/helpers/DateRangeHelpers/DateRangeHelpers.spec.ts
@@ -1,32 +1,25 @@
 import { DateRangeType } from '@/types';
 import getRangeDates, { RANGE_OPTIONS } from './DateRangeHelpers';
 
-const MS_PER_DAY = 86400000;
-
 const calculateRangeDates = (range: DateRangeType) => {
   const { start, end } = getRangeDates(range);
+  const getDate = (date: string) => Number(new Date(date).toLocaleDateString().split('/')[1]);
   return {
-    startDate: new Date(start).getTime() / MS_PER_DAY,
-    endDate: new Date(end).getTime() / MS_PER_DAY,
+    startDay: getDate(start),
+    endDay: getDate(end),
   };
 };
 
 describe('handle date range helper', () => {
   it('formats dates correctly for week range', () => {
-    const { startDate, endDate } = calculateRangeDates('lastWeek');
+    const { startDay, endDay } = calculateRangeDates('lastWeek');
 
-    expect(endDate - startDate).toBe(RANGE_OPTIONS.lastWeek.startDaysAgo);
+    expect(endDay - startDay).toBe(RANGE_OPTIONS.lastWeek.startDaysAgo);
   });
 
   it('formats dates correctly for day range', () => {
-    const { startDate, endDate } = calculateRangeDates('lastDay');
+    const { startDay, endDay } = calculateRangeDates('lastDay');
 
-    expect(endDate - startDate).toBe(RANGE_OPTIONS.lastDay.startDaysAgo);
-  });
-
-  it('formats dates correctly for 28 day range', () => {
-    const { startDate, endDate } = calculateRangeDates('lastMonth');
-
-    expect(endDate - startDate).toBe(RANGE_OPTIONS.lastMonth.startDaysAgo);
+    expect(endDay - startDay).toBe(RANGE_OPTIONS.lastDay.startDaysAgo);
   });
 });

--- a/apps/google-analytics-4/frontend/src/helpers/DateRangeHelpers/DateRangeHelpers.ts
+++ b/apps/google-analytics-4/frontend/src/helpers/DateRangeHelpers/DateRangeHelpers.ts
@@ -14,8 +14,10 @@ export const RANGE_OPTIONS = {
 
 const DAY_IN_MS = 1000 * 60 * 60 * 24;
 
+// date should be local to user in format of YYYY-MM-DD
 const formatDate = (date: Date) => {
-  return date.toISOString().slice(0, 10);
+  const localDate = date.toLocaleDateString().split('/');
+  return `${localDate[2]}-${localDate[0]}-${localDate[1]}`;
 };
 
 const getRangeDates = (dateRange: DateRangeType) => {

--- a/apps/google-analytics-4/lambda/src/controllers/apiController.ts
+++ b/apps/google-analytics-4/lambda/src/controllers/apiController.ts
@@ -5,6 +5,18 @@ import { GoogleApiService } from '../services/googleApiService';
 const formatArrays = (param: string | string[]) =>
   Array.isArray(param) ? param : param.split(',');
 
+const mapDates = (startDate: string, endDate: string) => {
+  var arr = [];
+  const dt = new Date(startDate);
+
+  while (dt <= new Date(endDate)) {
+    arr.push(new Date(dt));
+    dt.setDate(dt.getDate() + 1);
+  }
+
+  return arr;
+};
+
 const ApiController = {
   credentials: (_req: Request, res: Response) => {
     // TODO: actually verify the credentials

--- a/apps/google-analytics-4/lambda/src/controllers/apiController.ts
+++ b/apps/google-analytics-4/lambda/src/controllers/apiController.ts
@@ -5,18 +5,6 @@ import { GoogleApiService } from '../services/googleApiService';
 const formatArrays = (param: string | string[]) =>
   Array.isArray(param) ? param : param.split(',');
 
-const mapDates = (startDate: string, endDate: string) => {
-  var arr = [];
-  const dt = new Date(startDate);
-
-  while (dt <= new Date(endDate)) {
-    arr.push(new Date(dt));
-    dt.setDate(dt.getDate() + 1);
-  }
-
-  return arr;
-};
-
 const ApiController = {
   credentials: (_req: Request, res: Response) => {
     // TODO: actually verify the credentials

--- a/apps/google-analytics-4/lambda/src/services/googleApiService.ts
+++ b/apps/google-analytics-4/lambda/src/services/googleApiService.ts
@@ -53,20 +53,20 @@ export class GoogleApiService {
     );
 
   mapDates = (startDate: string, endDate: string) => {
-    var arr = [];
-    const dt = new Date(new Date(startDate).setUTCHours(0, 0, 0, 0));
+    const dates = [];
+    const date = new Date(new Date(startDate).setUTCHours(0, 0, 0, 0));
     const end = new Date(new Date(endDate).setUTCHours(0, 0, 0, 0));
 
-    while (dt <= end) {
-      arr.push(new Date(dt));
-      dt.setUTCDate(dt.getUTCDate() + 1);
+    while (date <= end) {
+      dates.push(new Date(date));
+      date.setUTCDate(date.getUTCDate() + 1);
     }
 
-    return arr;
+    return dates;
   };
 
   supplementDates = (rows: ReportRowType[], _startDate?: string, _endDate?: string) => {
-    let supplementedReportRows = [] as ReportRowType[];
+    const supplementedReportRows = [] as ReportRowType[];
 
     const startDate = _startDate || this.formatDate(new Date(Date.now() - ONE_WEEK));
     const endDate = _endDate || this.formatDate(new Date(Date.now()));

--- a/apps/google-analytics-4/lambda/src/services/googleApiService.ts
+++ b/apps/google-analytics-4/lambda/src/services/googleApiService.ts
@@ -45,35 +45,39 @@ export class GoogleApiService {
     return accountSummaries;
   }
 
-  formatDate = (dateValue: Date) => dateValue.toISOString().slice(0, 10).split('-').join('');
+  standardizeDate = (date: string | Date) => new Date(new Date(date).setUTCHours(0, 0, 0, 0));
 
-  deriveDate = (dateValue: string) =>
+  // ex: 20230319
+  formatGADate = (dateValue: Date) => dateValue.toISOString().slice(0, 10).split('-').join('');
+
+  buildDateFromGADateFormat = (dateValue: string) =>
     new Date(
       `${dateValue.substring(0, 4)}-${dateValue.substring(4, 6)}-${dateValue.substring(6, 8)}`
     );
 
-  mapDates = (startDate: string, endDate: string) => {
+  buildDateArray = (_startDate?: string, _endDate?: string) => {
+    const startDate = _startDate || this.formatGADate(new Date(Date.now() - ONE_WEEK));
+    const endDate = _endDate || this.formatGADate(new Date(Date.now()));
+
     const dates = [];
-    const date = new Date(new Date(startDate).setUTCHours(0, 0, 0, 0));
-    const end = new Date(new Date(endDate).setUTCHours(0, 0, 0, 0));
+    const date = this.standardizeDate(startDate);
+    const end = this.standardizeDate(endDate);
 
     while (date <= end) {
-      dates.push(new Date(date));
+      dates.push(this.standardizeDate(date));
       date.setUTCDate(date.getUTCDate() + 1);
     }
 
     return dates;
   };
 
-  supplementDates = (rows: ReportRowType[], _startDate?: string, _endDate?: string) => {
+  supplementDates = (rows: ReportRowType[], dateArray: Date[]) => {
     const supplementedReportRows = [] as ReportRowType[];
 
-    const startDate = _startDate || this.formatDate(new Date(Date.now() - ONE_WEEK));
-    const endDate = _endDate || this.formatDate(new Date(Date.now()));
-
-    this.mapDates(startDate, endDate).forEach((date) => {
+    dateArray.forEach((date) => {
       const foundRow = rows.find(
-        (row) => this.deriveDate(row.dimensionValues[0].value).getUTCDate() == date.getUTCDate()
+        (row) =>
+          this.buildDateFromGADateFormat(row.dimensionValues[0].value).getDate() == date.getDate()
       );
 
       if (foundRow) {
@@ -84,7 +88,7 @@ export class GoogleApiService {
       } else {
         supplementedReportRows.push({
           metricValues: [{ value: '0', oneValue: 'value' }],
-          dimensionValues: [{ value: this.formatDate(date), oneValue: 'value' }],
+          dimensionValues: [{ value: this.formatGADate(date), oneValue: 'value' }],
         });
       }
     });
@@ -139,9 +143,11 @@ export class GoogleApiService {
         ],
       });
 
+      const dateArray = this.buildDateArray(startDate, endDate);
+
       return {
         ...response,
-        ...{ rows: this.supplementDates(response.rows as ReportRowType[], startDate, endDate) },
+        ...{ rows: this.supplementDates(response.rows as ReportRowType[], dateArray) },
       };
     } catch (e: any) {
       if (isGoogleError(e)) handleGoogleDataApiError(e);

--- a/apps/google-analytics-4/lambda/src/services/googleApiService.ts
+++ b/apps/google-analytics-4/lambda/src/services/googleApiService.ts
@@ -44,16 +44,6 @@ export class GoogleApiService {
     return accountSummaries;
   }
 
-  sortReportResponse = (rows: ReportRowType[]) => {
-    rows.filter(
-      (row: ReportRowType) => row.dimensionValues?.length && row.dimensionValues[0].value
-    );
-
-    rows.sort((v1: ReportRowType, v2: ReportRowType) => {
-      return Number(v1.dimensionValues[0].value) - Number(v2.dimensionValues[0].value);
-    });
-  };
-
   async runReport(
     property: string,
     slug: string,
@@ -89,9 +79,18 @@ export class GoogleApiService {
             },
           },
         },
+        keepEmptyRows: true,
+        orderBys: [
+          {
+            desc: false,
+            dimension: {
+              dimensionName: 'date',
+              orderType: 'NUMERIC',
+            },
+          },
+        ],
       });
 
-      if (response.rows) this.sortReportResponse(response.rows as unknown as ReportRowType[]);
       return response;
     } catch (e: any) {
       if (isGoogleError(e)) handleGoogleDataApiError(e);

--- a/apps/google-analytics-4/lambda/src/services/googleApiService.ts
+++ b/apps/google-analytics-4/lambda/src/services/googleApiService.ts
@@ -45,10 +45,14 @@ export class GoogleApiService {
     return accountSummaries;
   }
 
-  standardizeDate = (date: string | Date) => new Date(new Date(date).setUTCHours(0, 0, 0, 0));
+  standardizeDate = (dateValue: string | Date) =>
+    new Date(new Date(dateValue).setUTCHours(0, 0, 0, 0));
 
-  // ex: 20230319
-  formatGADate = (dateValue: Date) => dateValue.toISOString().slice(0, 10).split('-').join('');
+  // extracts YYYY-MM-DD from ISO string
+  parseDate = (dateValue: Date) => dateValue.toISOString().slice(0, 10);
+
+  // returns YYYYMMDD format
+  formatGADate = (dateValue: Date) => this.parseDate(dateValue).split('-').join('');
 
   buildDateFromGADateFormat = (dateValue: string) =>
     new Date(
@@ -56,8 +60,8 @@ export class GoogleApiService {
     );
 
   buildDateArray = (_startDate?: string, _endDate?: string) => {
-    const startDate = _startDate || this.formatGADate(new Date(Date.now() - ONE_WEEK));
-    const endDate = _endDate || this.formatGADate(new Date(Date.now()));
+    const startDate = _startDate || this.parseDate(new Date(Date.now() - ONE_WEEK));
+    const endDate = _endDate || this.parseDate(new Date(Date.now()));
 
     const dates = [];
     const date = this.standardizeDate(startDate);
@@ -106,7 +110,7 @@ export class GoogleApiService {
   ) {
     const DEFAULT_DIMENSIONS = ['date'];
     const DEFAULT_METRICS = ['screenPageViews', 'totalUsers', 'screenPageViewsPerUser'];
-    const DEFAULT_START_DATE = new Date(Date.now() - ONE_WEEK).toISOString().split('T')[0]; // extracts YYYY-MM-DD from ISO string
+    const DEFAULT_START_DATE = this.parseDate(new Date(Date.now() - ONE_WEEK));
 
     try {
       const [response] = await this.betaAnalyticsDataClient.runReport({

--- a/apps/google-analytics-4/lambda/src/services/googleApiService.ts
+++ b/apps/google-analytics-4/lambda/src/services/googleApiService.ts
@@ -54,11 +54,14 @@ export class GoogleApiService {
   // returns YYYYMMDD format
   formatGADate = (dateValue: Date) => this.parseDate(dateValue).split('-').join('');
 
+  // builds Date object from YYYYMMDD format
   buildDateFromGADateFormat = (dateValue: string) =>
     new Date(
       `${dateValue.substring(0, 4)}-${dateValue.substring(4, 6)}-${dateValue.substring(6, 8)}`
     );
 
+  // builds a standarized date array, listing all dates between start and end dates provided.
+  // localization not required here, as this date array is locale agnostic.
   buildDateArray = (_startDate?: string, _endDate?: string) => {
     const startDate = _startDate || this.parseDate(new Date(Date.now() - ONE_WEEK));
     const endDate = _endDate || this.parseDate(new Date(Date.now()));
@@ -75,6 +78,8 @@ export class GoogleApiService {
     return dates;
   };
 
+  // hydrate data with missing data points.
+  // missing data points are dates that do not have a corresponding truthy metric value i.e 0.
   supplementDates = (rows: ReportRowType[], dateArray: Date[]) => {
     const supplementedReportRows = [] as ReportRowType[];
 

--- a/apps/google-analytics-4/lambda/src/services/googleApiService.ts
+++ b/apps/google-analytics-4/lambda/src/services/googleApiService.ts
@@ -102,14 +102,14 @@ export class GoogleApiService {
   ) {
     const DEFAULT_DIMENSIONS = ['date'];
     const DEFAULT_METRICS = ['screenPageViews', 'totalUsers', 'screenPageViewsPerUser'];
-    const DEFAULT_START_DATE = new Date(Date.now() - ONE_WEEK).toISOString();
+    const DEFAULT_START_DATE = new Date(Date.now() - ONE_WEEK).toISOString().split('T')[0]; // extracts YYYY-MM-DD from ISO string
 
     try {
       const [response] = await this.betaAnalyticsDataClient.runReport({
         property,
         dateRanges: [
           {
-            startDate: startDate ?? DEFAULT_START_DATE.split('T')[0], // extracts YYYY-MM-DD from ISO string
+            startDate: startDate ?? DEFAULT_START_DATE,
             endDate: endDate ?? 'today',
           },
         ],


### PR DESCRIPTION
## Purpose
This PR fixes three primary issues: 
1. Fixes an off-by-one issue with the list of dates appearing on the x-axis of the chart.
2. Orders the dates in ascending order with a simply `orderBys` parameter straight to the google `runReports` api. 
3. Hydrates the missing data gaps returned from the `runReports` proxy. The GA4 endpoint is not including dates for which the metric data is zero (this case most often occurs on weekends). This caused strange gaps in time with how our dates were laid out in the chart. Therefore, I have implemented a way to supplement this data so that our axes are consistently spread.

## Approach
1. The dates that are provided from the GA4 app were being translated to local strings, sometimes causing the dates to be shifted one day earlier or later. There is no need to translate these dates to local time as they are direct date references to data, therefore I just formatted them to UTC time, as you can see in the `ChartContent` component. 

2. Replaced our custom sorting logic with the Google logic to order the dates appropriately using the `orderBys` parameter. 

3. Spent a while trying to figure out the best solution for the missing dates provided. The legacy embedded app and endpoint provided empty data, so I dug through lots of documentation to see if there were parameters we could provide to assure all data was provided as the default with the new GA4 endpoint, but to no avail. I felt the most viable solution was to fill the 'date' gaps with the missing dates and their corresponding '0' value. I confirmed with many examples that this supplemental data still properly reflects the data in google analytics, but will continue to validate this logic. 

### Before: 

<img width="352" alt="Screenshot 2023-03-16 at 8 25 05 AM" src="https://user-images.githubusercontent.com/58186851/225665396-046d58ac-67f3-4d7a-b66d-4f624c74a358.png">

You will notice both the strange gaps in data (Feb 18th and 19th missing) and the off-by-one with the end-date. 

### After: 
<img width="348" alt="Screenshot 2023-03-16 at 8 30 04 AM" src="https://user-images.githubusercontent.com/58186851/225666911-eba7f603-8074-4401-a0d4-bfa9d5160ec2.png">


