### PR TITLE
fix CSS for loading indicator in GA4 sidebar

### DIFF
--- a/apps/google-analytics-4/frontend/src/components/main-app/analytics-app/AnalyticsApp.styles.ts
+++ b/apps/google-analytics-4/frontend/src/components/main-app/analytics-app/AnalyticsApp.styles.ts
@@ -9,6 +9,7 @@ const load = keyframes`
 	}
 `;
 
+const loaderWidth = 50;
 export const styles = {
   loader: css({
     height: '100%',
@@ -16,21 +17,18 @@ export const styles = {
     ':before': {
       content: "''",
       position: 'absolute',
-      top: 0,
-      right: 'auto',
-      bottom: 0,
-      left: 'auto',
+      top: `calc(50% - ${loaderWidth / 2}px)`,
+      left: `calc(50% - ${loaderWidth / 2}px)`,
       margin: 'auto',
-      height: '50px',
-      width: '50px',
-      borderWidth: '5px',
+      height: `${loaderWidth}px`,
+      width: `${loaderWidth}px`,
+      borderWidth: `${loaderWidth / 10}px`,
       borderStyle: 'solid',
       borderTopColor: `${tokens.blue500}`,
       borderRightColor: 'rgba(0, 0, 0, 0.1)',
       borderBottomColor: 'rgba(0, 0, 0, 0.1)',
       borderLeftColor: 'rgba(0, 0, 0, 0.1)',
       borderRadius: '100%',
-
       animation: `${load} 1s linear infinite`,
     },
   }),


### PR DESCRIPTION
## Purpose
fix styling/alignment issue with loading indicator on GA4 sidebar

## Approach
use css calc to offset absolute positioning and applies 1:1 square shape on rotating element

## Dependencies and/or References
<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment
<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->

### Before:

1. Rectangular aspect ratio can cause unwanted scrollbar jitter and other unwanted side-affects on a rotating object:
![Screenshot 2023-03-16 at 10 52 31 AM](https://user-images.githubusercontent.com/492573/225656071-66c0a1a7-1549-41f3-aa80-23407aca4936.png)

2. Alignment was off center:
![Screenshot 2023-03-16 at 10 38 26 AM](https://user-images.githubusercontent.com/492573/225656041-d3503489-ea40-4799-b09a-8770c1611b53.png)


### After:

1. Square aspect ratio:
![Screenshot 2023-03-16 at 10 52 09 AM](https://user-images.githubusercontent.com/492573/225656528-6b3f02b9-22f6-4a12-baae-c51c48587865.png)

2. Centered alignment both horizontally and vertically:
![Screenshot 2023-03-16 at 10 38 12 AM](https://user-images.githubusercontent.com/492573/225656599-f3d0b1aa-ced0-47cf-a8dd-9f5d061020bc.png)