### PR TITLE
[INTEG-260/262/263] Small UI Fixes (Remove checkmark, make loading spinner consistent, remove bottom css splitter)

### DIFF
--- a/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage.tsx
@@ -133,9 +133,9 @@ export default function GoogleAnalyticsConfigPage() {
           onInEditModeChange={handleInEditModeChange}
           onIsValidServiceAccount={handleIsValidServiceAccount}
         />
-        <Splitter />
         {isAppInstalled && !isInEditMode && (
           <>
+            <Splitter />
             <MapAccountPropertySection
               accountsSummaries={accountsSummaries}
               parameters={parameters}
@@ -148,7 +148,6 @@ export default function GoogleAnalyticsConfigPage() {
               onIsValidContentTypeAssignment={handleIsValidContentTypeAssignment}
               parameters={parameters}
             />
-            <Splitter />
           </>
         )}
       </Box>

--- a/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/DisplayServiceAccountCard.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/DisplayServiceAccountCard.tsx
@@ -229,13 +229,6 @@ const DisplayServiceAccountCard = (props: Props) => {
                 {serviceAccountKeyId.clientEmail}
               </TextLink>
             </Box>
-            {isLoading ? (
-              <Spinner variant="default" />
-            ) : adminApiError ? (
-              <ErrorCircleIcon variant="negative" />
-            ) : (
-              <CheckCircleIcon variant="positive" />
-            )}
           </Flex>
         </Paragraph>
       </FormControl>

--- a/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/DisplayServiceAccountCard.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/DisplayServiceAccountCard.tsx
@@ -12,7 +12,7 @@ import {
   Spinner,
   Button,
 } from '@contentful/f36-components';
-import { ExternalLinkTrimmedIcon, CheckCircleIcon, ErrorCircleIcon } from '@contentful/f36-icons';
+import { ExternalLinkTrimmedIcon } from '@contentful/f36-icons';
 import { useApi } from 'hooks/useApi';
 import { ServiceAccountKeyId, ServiceAccountKey } from 'types';
 import { ApiErrorType, ERROR_TYPE_MAP, isApiErrorType } from 'apis/apiTypes';
@@ -206,7 +206,7 @@ const DisplayServiceAccountCard = (props: Props) => {
           </Box>
           <Box style={{ minWidth: '60px', minHeight: '30px' }}>
             {isLoading ? (
-              <Spinner variant="default" />
+              <Spinner variant="primary" />
             ) : (
               <Button variant="primary" size="small" onClick={handleApiTestClick}>
                 Test
@@ -240,7 +240,7 @@ const DisplayServiceAccountCard = (props: Props) => {
       </FormControl>
       <FormControl marginBottom="none">
         <FormControl.Label marginBottom="none">Status</FormControl.Label>
-        <Paragraph>{isLoading ? <Spinner variant="default" /> : <RenderStatusInfo />}</Paragraph>
+        <Paragraph>{isLoading ? <Spinner variant="primary" /> : <RenderStatusInfo />}</Paragraph>
       </FormControl>
     </Card>
   );


### PR DESCRIPTION
## Purpose
1. Removes the splitter at the bottom of the config page
2. Removes the check mark in the service account in the display card 
3. Loading spinner are now consistent

Very small UI changes and fixes. Main purposes is to quickly knock out the tickets to clean up the jira board a little more.
Also made three commits (one per JIRA ticket).

## Approach
Previous discussions were held. These are very low risk changes and unlikely to cause conflicts.

<img width="833" alt="Screenshot 2023-03-16 at 1 44 55 PM" src="https://user-images.githubusercontent.com/124832189/225736626-c248fbbf-70ba-4dd9-bc3e-c4f77e4480ff.png">