### PR TITLE
hot-fix-naming-adjustments

### DIFF
--- a/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage.spec.tsx
@@ -105,7 +105,7 @@ describe('Installed Service Account Key', () => {
       serviceAccountKey: validServiceKeyFile,
       serviceAccountKeyId: validServiceKeyId,
       propertyId: 'properties/1234',
-      contentTypes: {
+      savedContentTypes: {
         course: { slugField: 'shortDescription', urlPrefix: 'about' },
       },
     });
@@ -145,7 +145,7 @@ describe('Installed Service Account Key', () => {
           projectId: 'PROJECT_ID',
         },
         propertyId: 'properties/1234',
-        contentTypes: {
+        savedContentTypes: {
           course: { slugField: 'shortDescription', urlPrefix: 'about' },
         },
       },

--- a/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage.spec.tsx
@@ -104,8 +104,8 @@ describe('Installed Service Account Key', () => {
     mockSdk.app.getParameters.mockReturnValue({
       serviceAccountKey: validServiceKeyFile,
       serviceAccountKeyId: validServiceKeyId,
-      savedPropertyId: 'properties/1234',
-      savedContentTypes: {
+      propertyId: 'properties/1234',
+      contentTypes: {
         course: { slugField: 'shortDescription', urlPrefix: 'about' },
       },
     });
@@ -144,8 +144,8 @@ describe('Installed Service Account Key', () => {
           id: 'PRIVATE_KEY_ID',
           projectId: 'PROJECT_ID',
         },
-        savedPropertyId: 'properties/1234',
-        savedContentTypes: {
+        propertyId: 'properties/1234',
+        contentTypes: {
           course: { slugField: 'shortDescription', urlPrefix: 'about' },
         },
       },

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.tsx
@@ -34,8 +34,8 @@ const AssignContentTypeSection = (props: Props) => {
   const sdk = useSDK<AppExtensionSDK>();
 
   useEffect(() => {
-    if (parameters.contentTypes) onIsValidContentTypeAssignment(true);
-  }, [onIsValidContentTypeAssignment, parameters.contentTypes]);
+    if (parameters.savedContentTypes) onIsValidContentTypeAssignment(true);
+  }, [onIsValidContentTypeAssignment, parameters.savedContentTypes]);
 
   const handleContentTypeChange = (prevKey: string, newKey: string) => {
     const newContentTypes: ContentTypes = {};

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.tsx
@@ -34,8 +34,8 @@ const AssignContentTypeSection = (props: Props) => {
   const sdk = useSDK<AppExtensionSDK>();
 
   useEffect(() => {
-    if (parameters.savedContentTypes) onIsValidContentTypeAssignment(true);
-  }, [onIsValidContentTypeAssignment, parameters.savedContentTypes]);
+    if (parameters.contentTypes) onIsValidContentTypeAssignment(true);
+  }, [onIsValidContentTypeAssignment, parameters.contentTypes]);
 
   const handleContentTypeChange = (prevKey: string, newKey: string) => {
     const newContentTypes: ContentTypes = {};

--- a/apps/google-analytics-4/frontend/src/locations/Sidebar.tsx
+++ b/apps/google-analytics-4/frontend/src/locations/Sidebar.tsx
@@ -2,12 +2,13 @@ import AnalyticsApp from 'components/main-app/analytics-app/AnalyticsApp';
 import { useSDK } from '@contentful/react-apps-toolkit';
 import { SidebarExtensionSDK } from '@contentful/app-sdk';
 import { useApi } from 'hooks/useApi';
+import { AppInstallationParameters } from 'types';
 
 const Sidebar = () => {
   const sdk = useSDK<SidebarExtensionSDK>();
 
-  const { serviceAccountKey, serviceAccountKeyId, savedPropertyId, contentTypes } =
-    sdk.parameters.installation;
+  const { serviceAccountKey, serviceAccountKeyId, propertyId, contentTypes } = sdk.parameters
+    .installation as AppInstallationParameters;
 
   const currentContentType = sdk.contentType.sys.id;
   const slugFieldInfo = contentTypes[currentContentType];
@@ -16,7 +17,7 @@ const Sidebar = () => {
 
   return (
     <>
-      <AnalyticsApp api={api} propertyId={savedPropertyId} slugFieldInfo={slugFieldInfo} />
+      <AnalyticsApp api={api} propertyId={propertyId} slugFieldInfo={slugFieldInfo} />
     </>
   );
 };

--- a/apps/google-analytics-4/frontend/src/types.ts
+++ b/apps/google-analytics-4/frontend/src/types.ts
@@ -4,7 +4,7 @@ export interface AppInstallationParameters {
   serviceAccountKey: ServiceAccountKey;
   serviceAccountKeyId: ServiceAccountKeyId;
   contentTypes: ContentTypes;
-  savedPropertyId: string;
+  propertyId: string;
 }
 
 // TODO: get this exported from the SDK


### PR DESCRIPTION
## Purpose
Fix a misalignment on naming of `propertyId` vs `savedPropertyId`. 

## Approach
Made the necessary adjustments to get things working as needed. 
