### PR TITLE
remove query string from request signing to work around AWS gateway/serverless differences vs development

### DIFF
--- a/apps/google-analytics-4/frontend/src/helpers/signed-requests.ts
+++ b/apps/google-analytics-4/frontend/src/helpers/signed-requests.ts
@@ -14,7 +14,7 @@ async function fetchWithSignedRequest(
     headers: {},
   };
 
-  const rootRelativeUrl = req.url.pathname + req.url.search;
+  const rootRelativePath = req.url.pathname;
 
   // add request verification signing secret to request headers
   const { additionalHeaders: signedHeaders } = await cma.appSignedRequest.create(
@@ -24,7 +24,7 @@ async function fetchWithSignedRequest(
     {
       method: req.method,
       headers: req.headers,
-      path: rootRelativeUrl,
+      path: rootRelativePath,
     }
   );
   Object.assign(req.headers, unsignedHeaders, signedHeaders);

--- a/apps/google-analytics-4/lambda/src/middlewares/verifySignedRequests.ts
+++ b/apps/google-analytics-4/lambda/src/middlewares/verifySignedRequests.ts
@@ -39,10 +39,17 @@ const makeCanonicalReq = (req: Request) => {
 
   // TODO: make this stage prefixing logic better? (yuck)
   const pathPrefix = process.env.STAGE !== 'prd' ? `/${process.env.STAGE}` : '';
+  const fullPath = req.originalUrl.split('?')[0];
+  const signedPath = `${pathPrefix}${fullPath}`; // note: req.originalUrl starts with a `/` and includes the full path & query string
+
+  console.log('makeCanonicalRequest#pathPrefix', pathPrefix);
+  console.log('makeCanonicalRequest#req.originalUrl', req.originalUrl);
+  console.log('makeCanonicalRequest#fullPath', fullPath);
+  console.log('makeCanonicalRequest#signedPath', signedPath);
 
   return <CanonicalRequest>{
     method: req.method,
-    path: `${pathPrefix}${req.originalUrl}`, // note: req.originalUrl starts with a `/` and includes the full path & query string
+    path: signedPath,
     headers: headers,
   };
 };


### PR DESCRIPTION
## Purpose
remove query string from request signing verification to ensure deterministic frontend and backend comparison in production serverless environment contexts

## Approach
- omit query strings from request verification signing
- adds logging so we can revisit once we can verify what format we're receiving in production after passing through aws gateway -> events -> lambda -> node (express)

## Dependencies and/or References
<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment
<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
