### PR TITLE
[INTEG-259] No more flashing statuses on Service Account Card

### DIFF
--- a/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/DisplayServiceAccountCard.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/DisplayServiceAccountCard.tsx
@@ -34,7 +34,9 @@ const DisplayServiceAccountCard = (props: Props) => {
     isAppInstalled,
   } = props;
 
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoadingAdminApi, setIsLoadingAdminApi] = useState(true);
+  const [isLoadingDataApi, setIsLoadingDataApi] = useState(true);
+
   const [adminApiError, setAdminApiError] = useState<ApiErrorType>();
   const [dataApiError, setDataApiError] = useState<ApiErrorType>();
   const [invalidServiceAccountError, setInvalidServiceAccountError] = useState<ApiErrorType>();
@@ -68,7 +70,7 @@ const DisplayServiceAccountCard = (props: Props) => {
 
   const verifyAdminApi = useCallback(async () => {
     try {
-      setIsLoading(true);
+      setIsLoadingAdminApi(true);
       const fetchedAccountSummaries = await api.listAccountSummaries();
       onAccountSummariesChange(fetchedAccountSummaries);
       setAdminApiError(undefined);
@@ -79,12 +81,12 @@ const DisplayServiceAccountCard = (props: Props) => {
         throw e;
       }
     } finally {
-      setIsLoading(false);
+      setIsLoadingAdminApi(false);
     }
 
     return () => {
       setAdminApiError(undefined);
-      setIsLoading(false);
+      setIsLoadingAdminApi(false);
     };
 
     // It wants to add onAccountSummariesChange as a dependency but this will cause an infinite re-render
@@ -94,7 +96,7 @@ const DisplayServiceAccountCard = (props: Props) => {
 
   const verifyDataApi = useCallback(async () => {
     try {
-      setIsLoading(true);
+      setIsLoadingDataApi(true);
       await api.runReports();
       setDataApiError(undefined);
     } catch (e: any) {
@@ -104,12 +106,12 @@ const DisplayServiceAccountCard = (props: Props) => {
         throw e;
       }
     } finally {
-      setIsLoading(false);
+      setIsLoadingDataApi(false);
     }
 
     return () => {
       setDataApiError(undefined);
-      setIsLoading(false);
+      setIsLoadingDataApi(false);
     };
 
     // isAppInstalled is needed as a dependency to trigger this called once the app is installed succesffully
@@ -205,7 +207,7 @@ const DisplayServiceAccountCard = (props: Props) => {
             </TextLink>
           </Box>
           <Box style={{ minWidth: '60px', minHeight: '30px' }}>
-            {isLoading ? (
+            {isLoadingAdminApi && isLoadingDataApi ? (
               <Spinner variant="primary" />
             ) : (
               <Button variant="primary" size="small" onClick={handleApiTestClick}>
@@ -240,7 +242,13 @@ const DisplayServiceAccountCard = (props: Props) => {
       </FormControl>
       <FormControl marginBottom="none">
         <FormControl.Label marginBottom="none">Status</FormControl.Label>
-        <Paragraph>{isLoading ? <Spinner variant="primary" /> : <RenderStatusInfo />}</Paragraph>
+        <Paragraph>
+          {isLoadingAdminApi && isLoadingDataApi ? (
+            <Spinner variant="primary" />
+          ) : (
+            <RenderStatusInfo />
+          )}
+        </Paragraph>
       </FormControl>
     </Card>
   );


### PR DESCRIPTION
## Purpose
[JIRA Ticket](https://contentful.atlassian.net/browse/INTEG-259)
Fixes bug where statuses flash before loading the Configuration Page finishes

https://user-images.githubusercontent.com/124832189/225998498-22fb4bda-9ee9-421d-b5cd-bf1d81725d6a.mov

