### PR TITLE
Zend 3321 Slack config fix

### DIFF
--- a/apps/slack/Dockerfile
+++ b/apps/slack/Dockerfile
@@ -2,16 +2,14 @@ FROM node:14-alpine AS base
 
 RUN apk add --update --no-cache openssh build-base python3 bash git && rm -rf /var/cache/apk/*
 
-WORKDIR /app
+WORKDIR /app/lambda
 
-COPY package.json yarn.lock frontend/package.json lambda/package.json /app/
+COPY lambda/package.json /app/
 
 ENV NODE_ENV development
 
-RUN yarn
+RUN npm i
 
-COPY .git /app/.git
+COPY lambda /app/lambda
 
-COPY . /app
-
-CMD ["yarn", "start:lambda"]
+CMD ["npm", "run", "start"]

--- a/apps/slack/README.md
+++ b/apps/slack/README.md
@@ -89,7 +89,7 @@ This sections explains how to run the Slack app locally.
 
 ### General
 
-- Start ngrok with `ngrok https 3000 --subdomain slack-backend-dev` (the `--subdomain` flagwill not work without paid ngrok account)
+- Start ngrok with `ngrok http 3000 --subdomain slack-backend-dev` (the `--subdomain` flagwill not work without paid ngrok account)
 - Create a new Slack app [here](https://api.slack.com/apps)
   - Add the ngrok URL as redirect URL (Features -> OAuth & Permissions -> Redirect URLs)
   - Enable token rotation (Features -> OAuth & Permissions)

--- a/apps/slack/README.md
+++ b/apps/slack/README.md
@@ -13,7 +13,7 @@ Click [here](https://app.contentful.com/deeplink?link=apps&id=7ir40h24qLGSQWJ6JC
 You can send Slack messages from your own App Framework backend app. For this to work, the Slack app has to be installed to your space environment and setup for the target Slack workspace and channel.
 
 ```javascript
-import { getManagementToken } from "@contentful/node-apps-toolkit";
+import { getManagementToken } from '@contentful/node-apps-toolkit';
 import { readFileSync } from 'fs';
 
 const APP_DEF_ID = 'app-def-id';
@@ -21,17 +21,18 @@ const SPACE_ID = 'space-id';
 const ENV_ID = 'env-id';
 
 // see https://www.contentful.com/developers/docs/extensibility/app-framework/app-keys/
-const privateKey = readFileSync("key.pem", { encoding: "utf8", });
+const privateKey = readFileSync('key.pem', { encoding: 'utf8' });
 const token = await getManagementToken(privateKey, {
   appInstallationId: APP_DEF_ID,
   spaceId: SPACE_ID,
   environmentId: ENV_ID,
 });
 
-const cma = createClient({ accessToken: token, },
+const cma = createClient(
+  { accessToken: token },
   {
-    type: "plain",
-    defaults: { spaceId: SPACE_ID, environmentId: ENV_ID, },
+    type: 'plain',
+    defaults: { spaceId: SPACE_ID, environmentId: ENV_ID },
   }
 );
 await cma.appAction.call({
@@ -39,9 +40,9 @@ await cma.appAction.call({
   body: {
     workspaceId: 'slack-workspace-id',
     channelId: 'channel-id',
-    message: 'This message was sent from my custom Contentful app'
-  }
-})
+    message: 'This message was sent from my custom Contentful app',
+  },
+});
 ```
 
 ## Support and feature requests
@@ -88,7 +89,7 @@ This sections explains how to run the Slack app locally.
 
 ### General
 
-- Start ngrok with `ngrok https 3000`
+- Start ngrok with `ngrok https 3000 --subdomain slack-backend-dev` (the `--subdomain` flagwill not work without paid ngrok account)
 - Create a new Slack app [here](https://api.slack.com/apps)
   - Add the ngrok URL as redirect URL (Features -> OAuth & Permissions -> Redirect URLs)
   - Enable token rotation (Features -> OAuth & Permissions)

--- a/apps/slack/frontend/.env.development.example
+++ b/apps/slack/frontend/.env.development.example
@@ -1,2 +1,2 @@
 REACT_APP_SLACK_CLIENT_ID=<your-slack-app-client-id>
-REACT_APP_BACKEND_BASE_URL=<your-ngrok-domain>/dev/api
+REACT_APP_BACKEND_BASE_URL=slack-backend-dev.ngrok.io/dev/api

--- a/apps/slack/frontend/src/requests.ts
+++ b/apps/slack/frontend/src/requests.ts
@@ -74,6 +74,7 @@ export const apiClient = {
         path: `/tokens`,
         headers: {
           'Content-Type': 'application/json',
+          'X-Contentful-Canonical-Environment-Id': sdk.ids.environment, // IMPORTANT: we MUST provide the backend with the canonical environment id, not the environment alias ID to ensure lookup in dynamo DB due to there being only one app installation
         },
         body: JSON.stringify({
           refreshToken: temporaryRefreshToken,

--- a/apps/slack/frontend/src/requests.ts
+++ b/apps/slack/frontend/src/requests.ts
@@ -34,9 +34,7 @@ export const apiClient = {
   ): Promise<ConnectedWorkspace> => {
     const req = {
       method: 'GET' as const,
-      path: `/spaces/${sdk.ids.space}/environments/${getEnvironmentName(
-        sdk.ids
-      )}/workspaces/${workspaceId}`,
+      path: `/spaces/${sdk.ids.space}/environments/${sdk.ids.environment}/workspaces/${workspaceId}`, // do we need this?
       headers: {
         'Content-Type': 'application/json',
       },
@@ -56,9 +54,7 @@ export const apiClient = {
     return makeSignedRequest(
       {
         method: 'GET',
-        path: `/spaces/${sdk.ids.space}/environments/${getEnvironmentName(
-          sdk.ids
-        )}/workspaces/${workspaceId}/channels`,
+        path: `/spaces/${sdk.ids.space}/environments/${sdk.ids.environment}/workspaces/${workspaceId}/channels`, // do we need this?
         headers: {
           'Content-Type': 'application/json',
         },

--- a/apps/slack/frontend/src/useConnect.ts
+++ b/apps/slack/frontend/src/useConnect.ts
@@ -89,7 +89,7 @@ export const useConnect = () => {
 
   const startOAuth = () => {
     window.addEventListener('message', onMessage);
-    openPopup(makeOAuthURL(sdk.ids.space, getEnvironmentName(sdk.ids)), 700, 900);
+    openPopup(makeOAuthURL(sdk.ids.space, sdk.ids.environment), 700, 900); // do we need this?
   };
 
   return { startOAuth };

--- a/apps/slack/lambda/config/serverless.dev.yml.example
+++ b/apps/slack/lambda/config/serverless.dev.yml.example
@@ -1,7 +1,7 @@
 variables:
   myStage: 'dev'
   app:
-    id: <your-app-id>
+    id: <your-CONTENTFUL-app-id>
     privateKey: ./private-key.pem
   baseUrl: "https://api.contentful.com"
   oauthCredentials:
@@ -16,7 +16,7 @@ variables:
   serverless:
     pathPrefix: '/dev'
   customDomain:
-    domainName: <your-ngrok-domain-without-https>/dev
+    domainName: slack-backend-dev.ngrok.io/dev
     stage: dev
     createRoute53Record: true
     endpointType: 'edge'

--- a/apps/slack/lambda/lib/routes/auth-token/controller.ts
+++ b/apps/slack/lambda/lib/routes/auth-token/controller.ts
@@ -120,7 +120,9 @@ export class AuthTokenController {
    */
   post = asyncHandler(async (request, response) => {
     const spaceId = request.header('x-contentful-space-id');
-    const environmentId = request.header('x-contentful-environment-id');
+    const environmentId = request.header('x-contentful-canonical-environment-id');
+
+    // FIXME: we MUST use the canonical environment ID here, not an environment alias!
     if (!spaceId || !environmentId) {
       throw new NotFoundException();
     }


### PR DESCRIPTION
## Purpose
The slack app is experiencing an issue where it fails to find Contentful-hosted configuration information, because it uses a resolved alias environment name instead of the canonical environment name when writing configuration details to a dynamoDB instance. This information is transmitted used the default CM API headers, which do not not yet expose the canonical environment name. 

## Approach
For now, we need to append the canonical environment name and then receive and store that name when doing first-time configuration of the slack app. Eventually this information may (and should) be exposed by the SDK, which would make the front end component of this work no longer needed.

## Dependencies and/or References
[support link](https://contentful.atlassian.net/browse/ZEND-3321)
