### PR TITLE
[INTEG-270] Fix editor interface removal on configuration save

### DIFF
--- a/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage.tsx
@@ -58,8 +58,11 @@ export default function GoogleAnalyticsConfigPage() {
 
     setIsInEditMode(false);
 
+    const currentState = await sdk.app.getCurrentState();
+
     return {
       parameters: parameters,
+      targetState: currentState,
     };
   }, [
     isAppInstalled,
@@ -69,6 +72,7 @@ export default function GoogleAnalyticsConfigPage() {
     isValidServiceAccount,
     parameters,
     sdk.notifier,
+    sdk.app,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
## Purpose
Currently when the GA4 app configuration is saved, it removes the app from all sidebar locations. This fix ensures that the current editor interface state for the app is preserved on save.

## Approach
The fix involves returning the `targetState` in the `handleConfigure` function and setting `targetState` to `currentState`. See more information [here](https://www.contentful.com/developers/docs/extensibility/app-framework/target-state/).