### PR TITLE
[INTEG-243/280] Adds account id and property id to dropdown and tells users the app only supports GA4 Accounts and Properties

### DIFF
--- a/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage.spec.tsx
@@ -33,7 +33,7 @@ describe('Google Analytics Page', () => {
       render(<GoogleAnalyticsConfigPage />);
     });
 
-    await screen.findByText('API Access');
+    await screen.findByText('API access');
     await screen.findByText('Google Service Account Details');
   });
 });

--- a/apps/google-analytics-4/frontend/src/components/config-screen/api-access/ApiAccessSection.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/api-access/ApiAccessSection.spec.tsx
@@ -23,7 +23,7 @@ describe('Config Screen component (not installed)', () => {
       );
     });
 
-    expect(screen.getByText('API Access')).toBeInTheDocument();
+    expect(screen.getByText('API access')).toBeInTheDocument();
     expect(screen.getByText('Google Service Account Details')).toBeInTheDocument();
     expect(screen.getByText('Private Key File')).toBeInTheDocument();
   });

--- a/apps/google-analytics-4/frontend/src/components/config-screen/api-access/ApiAccessSection.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/api-access/ApiAccessSection.tsx
@@ -27,7 +27,7 @@ const ApiAccessSection = (props: Props) => {
   return (
     <Stack spacing="spacingL" flexDirection="column" alignItems="flex-start">
       <div>
-        <Subheading marginBottom="none">API Access</Subheading>
+        <Subheading marginBottom="spacingXs">API access</Subheading>
         <Paragraph marginBottom="none">
           Authorize this application to access Google Analytics Admin & Data APIs
         </Paragraph>

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.spec.tsx
@@ -20,6 +20,6 @@ describe('Assign Content Type Section for Config Screen', () => {
       />
     );
 
-    expect(screen.getByText('Assign to content types')).toBeVisible();
+    expect(screen.getByText('Content type configuration')).toBeVisible();
   });
 });

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Paragraph, Stack, Subheading, Button, Spinner } from '@contentful/f36-components';
+import { Paragraph, Stack, Subheading, Button, Spinner, Box } from '@contentful/f36-components';
 import {
   AllContentTypes,
   AllContentTypeEntries,
@@ -150,12 +150,14 @@ const AssignContentTypeSection = (props: Props) => {
 
   return (
     <Stack spacing="spacingL" flexDirection="column" alignItems="flex-start">
-      <Subheading marginBottom="none">Assign to content types</Subheading>
-      <Paragraph marginBottom="none">
-        Select which content types will show the Google Analytics functionality in the sidebar.
-        Specify the slug field that is used for URL generation in your application. Optionally,
-        specify a prefix for the slug.
-      </Paragraph>
+      <Box>
+        <Subheading marginBottom="spacingXs">Content type configuration</Subheading>
+        <Paragraph marginBottom="none">
+          Select which content types will show the Google Analytics functionality in the sidebar.
+          Specify the slug field that is used for URL generation in your application. Optionally,
+          specify a prefix for the slug.
+        </Paragraph>
+      </Box>
       {!loadingParameters && !loadingAllContentTypes ? (
         <>
           {hasContentTypes && (

--- a/apps/google-analytics-4/frontend/src/components/config-screen/map-account-property/MapAccountPropertySection.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/map-account-property/MapAccountPropertySection.spec.tsx
@@ -60,7 +60,7 @@ describe('Empty Account Properties mapping dropdown', () => {
       );
     });
 
-    expect(screen.getByText('Configuration')).toBeVisible();
+    expect(screen.getByText('Google Analytics 4 property')).toBeVisible();
     expect(screen.queryByTestId('accountPropertyDropdown')).toBeNull();
   });
 });
@@ -80,7 +80,7 @@ describe('Account Properties mapping dropdown', () => {
 
     const propertiesDropdown = screen.getByTestId('accountPropertyDropdown');
 
-    expect(screen.getByText('Configuration')).toBeVisible();
+    expect(screen.getByText('Google Analytics 4 property')).toBeVisible();
     expect(propertiesDropdown).toBeVisible();
   });
 });

--- a/apps/google-analytics-4/frontend/src/components/config-screen/map-account-property/MapAccountPropertySection.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/map-account-property/MapAccountPropertySection.tsx
@@ -1,7 +1,16 @@
 import { useState, useEffect } from 'react';
-import { Stack, Box, Subheading, Paragraph, Select, Spinner } from '@contentful/f36-components';
-import { AccountSummariesType, FlattenedPropertiesType } from 'types';
+import {
+  Stack,
+  Box,
+  Subheading,
+  Select,
+  Spinner,
+  Paragraph,
+  TextLink,
+} from '@contentful/f36-components';
+import { AccountSummariesType } from 'types';
 import { KeyValueMap } from '@contentful/app-sdk/dist/types/entities';
+import { ExternalLinkIcon } from '@contentful/f36-icons';
 
 interface Props {
   accountsSummaries: AccountSummariesType[];
@@ -10,11 +19,15 @@ interface Props {
   onIsValidAccountProperty: Function;
 }
 
+const getIdOnly = (unformattedId: string) => {
+  return unformattedId.split('/')[1];
+};
+
 export default function MapAccountPropertySection(props: Props) {
   const { accountsSummaries, parameters, mergeSdkParameters, onIsValidAccountProperty } = props;
 
   const [selectedPropertyId, setSelectedPropertyId] = useState<string>('');
-  const [flattenedProperties, setFlattenedProperties] = useState<FlattenedPropertiesType[]>([]);
+  const [sortedAccountSummaries, setSortedAccountSummaries] = useState<AccountSummariesType[]>([]);
   const [loadingProperties, setLoadingProperties] = useState<boolean>(true);
   const [loadingParameters, setLoadingParameters] = useState<boolean>(true);
 
@@ -29,18 +42,17 @@ export default function MapAccountPropertySection(props: Props) {
   }, [onIsValidAccountProperty, parameters.propertyId]);
 
   useEffect(() => {
-    const _flattenedProperties = [] as FlattenedPropertiesType[];
+    accountsSummaries.sort((a, b) => {
+      return a.displayName < b.displayName ? -1 : a.displayName > b.displayName ? 1 : 0;
+    });
+
     accountsSummaries.forEach((accountSummary) => {
-      accountSummary.propertySummaries.forEach((propertySummary) => {
-        _flattenedProperties.push({
-          propertyId: propertySummary.property,
-          propertyName: propertySummary.displayName,
-          accountName: accountSummary.displayName,
-        });
+      accountSummary.propertySummaries.sort((a, b) => {
+        return a.displayName < b.displayName ? -1 : a.displayName > b.displayName ? 1 : 0;
       });
     });
 
-    setFlattenedProperties(_flattenedProperties);
+    setSortedAccountSummaries(accountsSummaries);
     setLoadingProperties(false);
   }, [accountsSummaries]);
 
@@ -53,32 +65,52 @@ export default function MapAccountPropertySection(props: Props) {
 
   const shouldRenderDropdown = () => {
     return (
-      !loadingProperties && !loadingParameters && accountsSummaries.length && flattenedProperties
+      !loadingProperties &&
+      !loadingParameters &&
+      accountsSummaries.length &&
+      sortedAccountSummaries.length
     );
   };
 
   return (
-    <Stack spacing="spacingL" marginBottom="none" flexDirection="column" alignItems="flex-start">
+    <Stack spacing="spacingL" flexDirection="column" alignItems="flex-start">
+      <div>
+        <Subheading marginBottom="spacingXs">Google Analytics 4 property</Subheading>
+        <Paragraph marginBottom="none">
+          Note: Only <em>Google Analytics 4</em> properties are listed.{' '}
+          <em>Google Universal Analytics</em> properties are not supported. See{' '}
+          <TextLink
+            href="https://support.google.com/analytics/answer/10759417"
+            target="_blank"
+            icon={<ExternalLinkIcon />}
+            alignIcon="end">
+            "Make the switch to Google Analytics 4"
+          </TextLink>{' '}
+          for more information.
+        </Paragraph>
+      </div>
       <Box>
-        <Subheading>Configuration</Subheading>
-        <Paragraph>Choose your Account and associated Property</Paragraph>
         {shouldRenderDropdown() ? (
           <Select
             testId="accountPropertyDropdown"
             value={selectedPropertyId}
             onChange={handleSelectionChange}>
             <Select.Option key="empty option" value="" isDisabled>
-              Please select an option...
+              Select a property...
             </Select.Option>
-            {flattenedProperties.map((flattenedProperty: any) => {
-              return (
-                <Select.Option
-                  key={flattenedProperty.propertyId}
-                  value={flattenedProperty.propertyId}>
-                  {`${flattenedProperty.accountName} -> ${flattenedProperty.propertyName}`}
-                </Select.Option>
-              );
-            })}
+            {sortedAccountSummaries.map((accountSummary: AccountSummariesType) => (
+              <optgroup
+                label={`${accountSummary.displayName} (${getIdOnly(accountSummary.account)})`}
+                key={getIdOnly(accountSummary.account)}>
+                {accountSummary.propertySummaries.map((propertySummary) => (
+                  <Select.Option
+                    key={getIdOnly(propertySummary.property)}
+                    value={getIdOnly(propertySummary.property)}>
+                    {`${propertySummary.displayName} (${getIdOnly(propertySummary.property)}))`}
+                  </Select.Option>
+                ))}
+              </optgroup>
+            ))}
           </Select>
         ) : (
           <Spinner variant="primary" />

--- a/apps/google-analytics-4/frontend/src/types.ts
+++ b/apps/google-analytics-4/frontend/src/types.ts
@@ -102,12 +102,6 @@ export interface PropertySummariesType {
   parent: string;
 }
 
-export interface FlattenedPropertiesType {
-  propertyId: string;
-  propertyName: string;
-  accountName: string;
-}
-
 export interface ContentTypeValue {
   slugField: string;
   urlPrefix: string;


### PR DESCRIPTION
INTEG-243 [JIRA Link](https://contentful.atlassian.net/browse/INTEG-243) Include property number (and account number) on property selection dropdown
INTEG-280 [JIRA Link](https://contentful.atlassian.net/browse/INTEG-280) Communicates to user that only GA4 properties are listed but not UA

REVIEWERS PLEASE DO THE FOLLOWING
1. Give your ideas and suggestions to improve UI for the dropdown. I think there's definitely room for potential UI improvements which I think should be done in this PR. However, let me also know if the UI update is out of scope for the sprint/cycle goal
2. Please give feedback on the wording and how the UA/GA4 compatability message is presented

<img width="999" alt="Screenshot 2023-03-21 at 9 37 46 AM" src="https://user-images.githubusercontent.com/124832189/226659027-f592b3e6-24f4-403c-b628-b47479df2b9f.png">
<img width="958" alt="Screenshot 2023-03-21 at 9 37 43 AM" src="https://user-images.githubusercontent.com/124832189/226659032-2c0226d8-0096-45c3-8f3d-7e1de039142a.png">

## Purpose
Brings us one step closer to completing our sprint goal
