### PR TITLE
[INTEG-292] fix categories not respecting MC url

### DIFF
--- a/apps/commercetools/src/api/categories.ts
+++ b/apps/commercetools/src/api/categories.ts
@@ -3,16 +3,20 @@ import { Pagination, Product } from '@contentful/ecommerce-app-base';
 import { ConfigurationParameters } from '../types';
 import { createClient } from './client';
 
-function categoryTransformer({ projectKey, locale }: ConfigurationParameters) {
+function categoryTransformer({ projectKey, locale, mcUrl }: ConfigurationParameters) {
   return (item: Category): Product => {
+    const merchantCenterBaseUrl =
+      mcUrl && mcUrl.length > 0 ? mcUrl : 'https://mc.europe-west1.gcp.commercetools.com';
     const id = item.id ?? '';
+    const externalLink =
+      (projectKey && id && `${merchantCenterBaseUrl}/${projectKey}/categories/${id}/general`) || '';
     return {
       id,
       sku: id,
       displaySKU: item.slug[locale ?? 'en'] ?? id,
       name: item.name?.[locale ?? 'en'] ?? '',
       image: item.assets?.[0]?.sources?.[0]?.uri ?? '',
-      externalLink: `https://mc.europe-west1.gcp.commercetools.com/${projectKey}/categories/${id}/general`,
+      externalLink,
     };
   };
 }


### PR DESCRIPTION
## Purpose
[Zendesk ticket for barkbox](https://contentful.atlassian.net/jira/software/c/projects/ZEND/boards/254?modal=detail&selectedIssue=ZEND-3359&quickFilter=1321)

CommerceTools uses "Merchant Center URL"s as region-specific storefronts. While we persist this information for an app installer, we were only using it when creating links for products, and not categories.

## Approach
I used the same approach products use and adapted it to work with categories as well.
