### PR TITLE
feat: handle prefixes and slug joining gracefully [INTEG-256]

### DIFF
--- a/apps/google-analytics-4/frontend/src/components/config-screen/map-account-property/MapAccountPropertySection.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/map-account-property/MapAccountPropertySection.tsx
@@ -104,7 +104,7 @@ export default function MapAccountPropertySection(props: Props) {
                 key={accountSummary.account}>
                 {accountSummary.propertySummaries.map((propertySummary) => (
                   <Select.Option key={propertySummary.property} value={propertySummary.property}>
-                    {`${propertySummary.displayName} (${getIdOnly(propertySummary.property)}))`}
+                    {`${propertySummary.displayName} (${getIdOnly(propertySummary.property)})`}
                   </Select.Option>
                 ))}
               </optgroup>

--- a/apps/google-analytics-4/frontend/src/components/main-app/ChartFooter.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/ChartFooter.spec.tsx
@@ -8,7 +8,7 @@ describe('Chart Footer for the analytics app', () => {
   it('can render the slug name', () => {
     render(<ChartFooter slugName={mockSlugName} viewUrl={mockViewUrl} />);
 
-    expect(screen.getByText('my-page')).toBeVisible();
+    expect(screen.getByText(/my-page/)).toBeVisible();
   });
 
   it('can render the link to open in Google Analytics', () => {

--- a/apps/google-analytics-4/frontend/src/components/main-app/ChartFooter.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/ChartFooter.tsx
@@ -12,7 +12,7 @@ const ChartFooter = (props: Props) => {
   return (
     <Flex flexDirection="column" alignItems="flex-start">
       <Text fontColor="gray600" fontSize="fontSizeS" marginBottom="spacingM">
-        {slugName}
+        Page path: {slugName}
       </Text>
       {viewUrl ? (
         <TextLink

--- a/apps/google-analytics-4/frontend/src/components/main-app/analytics-app/AnalyticsApp.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/analytics-app/AnalyticsApp.tsx
@@ -10,6 +10,7 @@ import { styles } from './AnalyticsApp.styles';
 import { Flex, Note } from '@contentful/f36-components';
 import { RunReportData } from 'apis/apiTypes';
 import useGetFieldValue from 'hooks/useGetFieldValue';
+import { pathJoin } from '../../../utils/pathJoin';
 
 const DEFAULT_ERR_MSG = 'Oops! Cannot display the analytics data at this time.';
 const EMPTY_DATA_MSG = 'There are no page views to show for this range';
@@ -33,7 +34,7 @@ const AnalyticsApp = (props: Props) => {
 
   useAutoResizer();
 
-  const reportSlug = `${urlPrefix || ''}${slugValue || ''}`;
+  const reportSlug = `/${pathJoin(urlPrefix || '', slugValue || '')}`;
 
   const reportRequestParams = useMemo(
     () => ({
@@ -121,7 +122,7 @@ const AnalyticsApp = (props: Props) => {
           {renderChartContent()}
 
           <ChartFooter
-            slugName={`Page path: ${urlPrefix}${slugValue}` || ''}
+            slugName={`Page path: ${reportSlug}}`}
             viewUrl="https://analytics.google.com/"
           />
         </>

--- a/apps/google-analytics-4/frontend/src/components/main-app/analytics-app/AnalyticsApp.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/analytics-app/AnalyticsApp.tsx
@@ -121,10 +121,7 @@ const AnalyticsApp = (props: Props) => {
 
           {renderChartContent()}
 
-          <ChartFooter
-            slugName={`Page path: ${reportSlug}}`}
-            viewUrl="https://analytics.google.com/"
-          />
+          <ChartFooter slugName={reportSlug} viewUrl="https://analytics.google.com/" />
         </>
       )}
     </>

--- a/apps/google-analytics-4/frontend/src/utils/pathJoin.spec.ts
+++ b/apps/google-analytics-4/frontend/src/utils/pathJoin.spec.ts
@@ -1,0 +1,23 @@
+import { pathJoin } from './pathJoin';
+
+describe('pathJoin', () => {
+  it('combines paths into a whole', () => {
+    const result = pathJoin('a', 'b/c', 'd');
+    expect(result).toEqual('a/b/c/d');
+  });
+
+  it('takes care of extra / characters in the front or back', () => {
+    const result = pathJoin('/a/', '//b/', 'c/');
+    expect(result).toEqual('a/b/c');
+  });
+
+  it('takes care of miscellaneous empty strings', () => {
+    const result = pathJoin('/a/', '//b/', '', '/', 'c/');
+    expect(result).toEqual('a/b/c');
+  });
+
+  it('takes care of miscellaneous empty strings and undefineds', () => {
+    const result = pathJoin('/a/', '//b/', '', '/', undefined, 'c/');
+    expect(result).toEqual('a/b/c');
+  });
+});

--- a/apps/google-analytics-4/frontend/src/utils/pathJoin.ts
+++ b/apps/google-analytics-4/frontend/src/utils/pathJoin.ts
@@ -1,0 +1,6 @@
+export const pathJoin = (...parts: (string | undefined)[]): string => {
+  return parts
+    .map((part) => (part || '').trim().replace(/(^[/]*|[/]*$)/g, ''))
+    .filter((part) => part.length)
+    .join('/');
+};

--- a/apps/google-analytics-4/lambda/package-lock.json
+++ b/apps/google-analytics-4/lambda/package-lock.json
@@ -2563,23 +2563,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.55.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.55.0.tgz",
-      "integrity": "sha512-OK+cIO1ZGhJYNCL//a3ROpsd83psf4dUJ4j7pdNVzd5DmIk+ffkuUIX2vcZQbEW/IR41DYsfJTB19tpCboxQuw==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.55.0",
-        "@typescript-eslint/visitor-keys": "5.55.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
     "node_modules/@typescript-eslint/type-utils": {
       "version": "5.56.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.56.0.tgz",
@@ -2662,46 +2645,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/types": {
-      "version": "5.55.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.55.0.tgz",
-      "integrity": "sha512-M4iRh4AG1ChrOL6Y+mETEKGeDnT7Sparn6fhZ5LtVJF1909D5O4uqK+C5NPbLmpfZ0XIIxCdwzKiijpZUOvOug==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.55.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.55.0.tgz",
-      "integrity": "sha512-I7X4A9ovA8gdpWMpr7b1BN9eEbvlEtWhQvpxp/yogt48fy9Lj3iE3ild/1H3jKBBIYj5YYJmS2+9ystVhC7eaQ==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.55.0",
-        "@typescript-eslint/visitor-keys": "5.55.0",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/@typescript-eslint/utils": {
@@ -2794,23 +2737,6 @@
       "dev": true,
       "dependencies": {
         "@typescript-eslint/types": "5.56.0",
-        "eslint-visitor-keys": "^3.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.55.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.55.0.tgz",
-      "integrity": "sha512-q2dlHHwWgirKh1D3acnuApXG+VNXpEY5/AwRxDVuEQpxWaB0jCDe0jFMVMALJ3ebSfuOVE8/rMS+9ZOYGg1GWw==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.55.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -13264,16 +13190,6 @@
         }
       }
     },
-    "@typescript-eslint/scope-manager": {
-      "version": "5.55.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.55.0.tgz",
-      "integrity": "sha512-OK+cIO1ZGhJYNCL//a3ROpsd83psf4dUJ4j7pdNVzd5DmIk+ffkuUIX2vcZQbEW/IR41DYsfJTB19tpCboxQuw==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "5.55.0",
-        "@typescript-eslint/visitor-keys": "5.55.0"
-      }
-    },
     "@typescript-eslint/type-utils": {
       "version": "5.56.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.56.0.tgz",
@@ -13317,27 +13233,6 @@
             "eslint-visitor-keys": "^3.3.0"
           }
         }
-      }
-    },
-    "@typescript-eslint/types": {
-      "version": "5.55.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.55.0.tgz",
-      "integrity": "sha512-M4iRh4AG1ChrOL6Y+mETEKGeDnT7Sparn6fhZ5LtVJF1909D5O4uqK+C5NPbLmpfZ0XIIxCdwzKiijpZUOvOug==",
-      "dev": true
-    },
-    "@typescript-eslint/typescript-estree": {
-      "version": "5.55.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.55.0.tgz",
-      "integrity": "sha512-I7X4A9ovA8gdpWMpr7b1BN9eEbvlEtWhQvpxp/yogt48fy9Lj3iE3ild/1H3jKBBIYj5YYJmS2+9ystVhC7eaQ==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "5.55.0",
-        "@typescript-eslint/visitor-keys": "5.55.0",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/utils": {
@@ -13397,16 +13292,6 @@
             "eslint-visitor-keys": "^3.3.0"
           }
         }
-      }
-    },
-    "@typescript-eslint/visitor-keys": {
-      "version": "5.55.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.55.0.tgz",
-      "integrity": "sha512-q2dlHHwWgirKh1D3acnuApXG+VNXpEY5/AwRxDVuEQpxWaB0jCDe0jFMVMALJ3ebSfuOVE8/rMS+9ZOYGg1GWw==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "5.55.0",
-        "eslint-visitor-keys": "^3.3.0"
       }
     },
     "2-thenable": {


### PR DESCRIPTION
## Purpose

We had a follow up task from a previous PR to make sure our joining of prefixes to URL slugs was robust (and not just naively joining).

## Approach

* Join paths irrespective of trailing or forward `/`
* Use the same output for query as for display (assumption: this works?). display matches the output of how GA4 displays page paths.

<img width="679" alt="image" src="https://user-images.githubusercontent.com/235836/226666272-6c604d25-d610-40a7-840c-848a09eccba7.png">


## Dependencies and/or References
<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment
<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
