### PR TITLE
fix: input is invalid only after user types something [INTEG-293]

### DIFF
--- a/apps/google-analytics-4/frontend/src/components/config-screen/api-access/setup/SetupServiceAccountCard.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/api-access/setup/SetupServiceAccountCard.spec.tsx
@@ -1,6 +1,7 @@
-import { act, render, screen } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import SetupServiceAccountCard from 'components/config-screen/api-access/setup/SetupServiceAccountCard';
-import { mockSdk, mockCma } from '../../../../../test/mocks';
+import { mockSdk, mockCma, validServiceKeyFile } from '../../../../../test/mocks';
 
 jest.mock('@contentful/react-apps-toolkit', () => ({
   useSDK: () => mockSdk,
@@ -8,7 +9,7 @@ jest.mock('@contentful/react-apps-toolkit', () => ({
 }));
 
 describe('Setup Google Service Account Details page', () => {
-  it('can render the about section', async () => {
+  it('renders account card with no input', async () => {
     await act(async () => {
       render(
         <SetupServiceAccountCard
@@ -22,5 +23,65 @@ describe('Setup Google Service Account Details page', () => {
     });
 
     expect(screen.getByText('Google Service Account Details')).toBeInTheDocument();
+    expect(screen.getByText('Paste the service account key file (JSON) above')).toBeInTheDocument();
+    expect(screen.getByLabelText(/Private Key File/).getAttribute('aria-invalid')).toBeNull();
+  });
+
+  it('renders an error state when invalid input', async () => {
+    const user = userEvent.setup();
+
+    await act(async () => {
+      render(
+        <SetupServiceAccountCard
+          parameters={{}}
+          onIsValidServiceAccount={() => {}}
+          mergeSdkParameters={() => {}}
+          onInEditModeChange={() => {}}
+          isInEditMode={false}
+        />
+      );
+    });
+
+    const keyFileInputBox = screen.getByLabelText(/Private Key File/i);
+
+    // user.type() got confused by the JSON string chars, so we'll just click and paste -- this
+    // actually better recreates likely user behavior as a bonus
+    await user.click(keyFileInputBox);
+    await user.paste(JSON.stringify({ foo: 'bar' }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Private Key File/).getAttribute('aria-invalid')).toEqual(
+        'true'
+      );
+      expect(screen.getByText(/Error:/)).toBeInTheDocument();
+    });
+  });
+
+  it('renders a success state when valid input', async () => {
+    const user = userEvent.setup();
+
+    await act(async () => {
+      render(
+        <SetupServiceAccountCard
+          parameters={{}}
+          onIsValidServiceAccount={() => {}}
+          mergeSdkParameters={() => {}}
+          onInEditModeChange={() => {}}
+          isInEditMode={false}
+        />
+      );
+    });
+
+    const keyFileInputBox = screen.getByLabelText(/Private Key File/i);
+
+    // user.type() got confused by the JSON string chars, so we'll just click and paste -- this
+    // actually better recreates likely user behavior as a bonus
+    await user.click(keyFileInputBox);
+    await user.paste(JSON.stringify(validServiceKeyFile));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Private Key File/).getAttribute('aria-invalid')).toBeNull();
+      expect(screen.getByText('Service account key file is valid')).toBeInTheDocument();
+    });
   });
 });

--- a/apps/google-analytics-4/frontend/src/components/config-screen/api-access/setup/SetupServiceAccountCard.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/api-access/setup/SetupServiceAccountCard.tsx
@@ -12,7 +12,6 @@ import {
   Box,
 } from '@contentful/f36-components';
 import { CheckCircleIcon, ExternalLinkTrimmedIcon } from '@contentful/f36-icons';
-import { ServiceAccountKey, ServiceAccountKeyId } from 'types';
 import {
   AssertionError,
   convertKeyFileToServiceAccountKey,
@@ -44,8 +43,6 @@ export default function SetupServiceAccountCard(props: Props) {
   } = props;
 
   const [keyFile, setKeyFile] = useState<string>();
-  const [serviceAccountKey, setServiceAccountKey] = useState<ServiceAccountKey>();
-  const [serviceAccountKeyId, setServiceAccountKeyId] = useState<ServiceAccountKeyId>();
   const [errorMessage, setErrorMessage] = useState<string>('');
 
   useEffect(() => {
@@ -68,8 +65,6 @@ export default function SetupServiceAccountCard(props: Props) {
       const _serviceAccountKey = convertKeyFileToServiceAccountKey(keyfile);
       const _serviceAccountKeyId =
         convertServiceAccountKeyToServiceAccountKeyId(_serviceAccountKey);
-      setServiceAccountKey(_serviceAccountKey);
-      setServiceAccountKeyId(_serviceAccountKeyId);
       setErrorMessage('');
 
       const _parameters = {
@@ -93,12 +88,14 @@ export default function SetupServiceAccountCard(props: Props) {
 
   const handleCancelClick = () => {
     setKeyFile('');
-    setServiceAccountKey(undefined);
-    setServiceAccountKeyId(undefined);
     setErrorMessage('');
     onInEditModeChange(false);
     onIsValidServiceAccount(true);
   };
+
+  // consider form value invalid if they've provided at least some text but a serviceAccountKey or serivceAccountKeyId has
+  // not been able to be generated successfully
+  const isInvalid = keyFile !== '' && errorMessage !== '';
 
   return (
     <Stack spacing="spacingL" flexDirection="column">
@@ -135,11 +132,12 @@ export default function SetupServiceAccountCard(props: Props) {
         </Box>
         <FormControl
           id="accountCredentialsFile"
-          isInvalid={!serviceAccountKey || !serviceAccountKeyId}
+          isInvalid={isInvalid}
           isRequired={true}
           marginBottom={!isInEditMode ? 'none' : 'spacingM'}>
           <FormControl.Label>Private Key File</FormControl.Label>
           <Textarea
+            spellCheck={false}
             name="accountCredentialsFile"
             placeholder={placeholderText}
             rows={10}


### PR DESCRIPTION
## Purpose

In the current state, we show an ugly red "invalid" state on the service key entry form before the user even inputs text. 

Spellcheckers also make the input look ugly since it's just a private key.

### Current

No input:

<img width="822" alt="image" src="https://user-images.githubusercontent.com/235836/226954223-948a2336-0e95-4ffd-a081-400ec9b77493.png">

Pasting valid key:

<img width="822" alt="image" src="https://user-images.githubusercontent.com/235836/226954532-2aeb27dc-bfea-42ca-8bd0-fd0b20dbbace.png">


## Approach

* Align isinvalid state with presence of error message and text input
* Clean up unneeded state
* Add explicit tests for error behaviors

### New

No input:

<img width="819" alt="image" src="https://user-images.githubusercontent.com/235836/226954757-3d8ac4c0-a6b6-4992-874a-902a5a3ea538.png">

Pasting valid key:

<img width="836" alt="image" src="https://user-images.githubusercontent.com/235836/226954993-5acf9864-8cfc-460d-b3d7-484ac98302d4.png">


## Dependencies and/or References
<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment
<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
