### PR TITLE
refactors to store private key file in dynamoDB via backend lambda PUT

### DIFF
--- a/apps/google-analytics-4/frontend/src/apis/api.spec.ts
+++ b/apps/google-analytics-4/frontend/src/apis/api.spec.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { rest } from 'msw';
 import { server } from '../../test/mocks/api/server';
 import { Api, ApiError } from './api';
-import { mockCma, validServiceKeyFile, validServiceKeyId } from '../../test/mocks';
+import { mockCma, validServiceKeyId } from '../../test/mocks';
 import { mockAccountSummary } from '../../test/mocks/api/mockData';
 import { ContentfulContext } from 'types';
 import { fetchFromApi } from 'apis/fetchApi';
@@ -120,7 +120,7 @@ describe('fetchFromApi()', () => {
 
 // Note: mocked http responses are set up using msw in tests/mocks/api/handler
 describe('Api', () => {
-  describe('getCredentials()', () => {
+  describe('getServiceAccountKeyFile()', () => {
     const contentfulContext = {
       app: 'appDefinitionId',
       contentType: 'contentType',
@@ -134,8 +134,8 @@ describe('Api', () => {
     };
 
     it('calls fetchApi with the correct parameters', async () => {
-      const api = new Api(contentfulContext, mockCma, validServiceKeyId, validServiceKeyFile);
-      const result = await api.getCredentials();
+      const api = new Api(contentfulContext, mockCma, validServiceKeyId);
+      const result = await api.getServiceAccountKeyFile();
       expect(result).toEqual(expect.objectContaining({ status: 'active' }));
     });
   });
@@ -155,7 +155,7 @@ describe('Api', () => {
     };
 
     it('returns a set of credentials', async () => {
-      const api = new Api(contentfulContext, mockCma, validServiceKeyId, validServiceKeyFile);
+      const api = new Api(contentfulContext, mockCma, validServiceKeyId);
       const result = await api.listAccountSummaries();
       expect(result).toEqual(expect.arrayContaining([expect.objectContaining(mockAccountSummary)]));
     });
@@ -176,7 +176,7 @@ describe('Api', () => {
     };
 
     it('returns a set of data from ga4', async () => {
-      const api = new Api(contentfulContext, mockCma, validServiceKeyId, validServiceKeyFile);
+      const api = new Api(contentfulContext, mockCma, validServiceKeyId);
       const result = await api.runReports();
       expect(result).toEqual(runReportData);
     });

--- a/apps/google-analytics-4/frontend/src/apis/api.ts
+++ b/apps/google-analytics-4/frontend/src/apis/api.ts
@@ -37,25 +37,22 @@ export class Api {
   readonly baseUrl: string;
   readonly contentfulContext: ContentfulContext;
   readonly serviceAccountKeyId: ServiceAccountKeyId;
-  readonly serviceAccountKey: ServiceAccountKey;
   readonly cma: PlainClientAPI;
 
   constructor(
     contentfulContext: ContentfulContext,
     cma: PlainClientAPI,
-    serviceAccountKeyId: ServiceAccountKeyId,
-    serviceAccountKey: ServiceAccountKey
+    serviceAccountKeyId: ServiceAccountKeyId
   ) {
     this.baseUrl = config.backendApiUrl;
     this.contentfulContext = contentfulContext;
     this.cma = cma;
     this.serviceAccountKeyId = serviceAccountKeyId;
-    this.serviceAccountKey = serviceAccountKey;
   }
 
-  async getCredentials(): Promise<Credentials> {
+  async getServiceAccountKeyFile(): Promise<Credentials> {
     return await fetchFromApi<Credentials>(
-      this.requestUrl('api/credentials'),
+      this.requestUrl('api/service_account_key_file'),
       ZCredentials,
       this.contentfulContext.app!,
       this.cma,
@@ -106,9 +103,6 @@ export class Api {
     return {
       'X-Contentful-ServiceAccountKeyId': this.encodeServiceAccountHeaderValue(
         this.serviceAccountKeyId
-      ),
-      'X-Contentful-ServiceAccountKey': this.encodeServiceAccountHeaderValue(
-        this.serviceAccountKey
       ),
     };
   }

--- a/apps/google-analytics-4/frontend/src/apis/apiTypes.ts
+++ b/apps/google-analytics-4/frontend/src/apis/apiTypes.ts
@@ -77,6 +77,7 @@ export const ERROR_TYPE_MAP = {
   noAccountsOrPropertiesFound: 'NoAccountsOrPropertiesFound',
   invalidProperty: 'InvalidProperty',
   invalidServiceAccount: 'InvalidServiceAccount',
+  missingServiceAccountKeyFile: 'MissingServiceAccountKeyFile',
 };
 
 export const ZApiError = z.object({

--- a/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage.spec.tsx
@@ -44,19 +44,35 @@ describe('Config Screen component (not installed)', () => {
     await act(async () => {
       render(<GoogleAnalyticsConfigPage />);
     });
-    const keyFileInputBox = screen.getByLabelText(/Private Key File/i);
+    const keyFileInputBox = screen.getByLabelText(/Service Account Key/i);
 
     // user.type() got confused by the JSON string chars, so we'll just click and paste -- this
     // actually better recreates likely user behavior as a bonus
     await user.click(keyFileInputBox);
     await user.paste(JSON.stringify(validServiceKeyFile));
 
+    await waitFor(() => {
+      expect(screen.getByText('Service account key file is valid')).toBeInTheDocument();
+    });
+
     let result;
     await act(async () => {
       result = await saveAppInstallation();
     });
 
-    expect(result).toEqual(false);
+    expect(result).toEqual({
+      parameters: {
+        serviceAccountKeyId: {
+          clientEmail: 'example4@PROJECT_ID.iam.gserviceaccount.com',
+          clientId: 'CLIENT_ID',
+          id: 'PRIVATE_KEY_ID',
+          projectId: 'PROJECT_ID',
+        },
+      },
+      targetState: {
+        EditorInterface: {},
+      },
+    });
     expect(screen.getByText('Google Service Account Details')).toBeInTheDocument();
   });
 
@@ -66,7 +82,7 @@ describe('Config Screen component (not installed)', () => {
       render(<GoogleAnalyticsConfigPage />);
     });
 
-    const keyFileInputBox = screen.getByLabelText(/Private Key File/i);
+    const keyFileInputBox = screen.getByLabelText(/Service Account Key/i);
 
     // user.type() got confused by the JSON string chars, so we'll just click and paste -- this
     // actually better recreates likely user behavior as a bonus
@@ -102,7 +118,6 @@ describe('Config Screen component (not installed)', () => {
 describe('Installed Service Account Key', () => {
   beforeEach(() => {
     mockSdk.app.getParameters.mockReturnValue({
-      serviceAccountKey: validServiceKeyFile,
       serviceAccountKeyId: validServiceKeyId,
       propertyId: 'properties/1234',
       contentTypes: {
@@ -121,7 +136,7 @@ describe('Installed Service Account Key', () => {
     const editServiceAccountButton = await screen.findByTestId('editServiceAccountButton');
 
     await user.click(editServiceAccountButton);
-    const keyFileInputBox = screen.getByLabelText(/Private Key File/i);
+    const keyFileInputBox = screen.getByLabelText(/Service Account Key/i);
     await waitFor(() => user.click(keyFileInputBox));
 
     const newServiceKeyFile: ServiceAccountKey = {
@@ -130,6 +145,10 @@ describe('Installed Service Account Key', () => {
     };
     await user.paste(JSON.stringify(newServiceKeyFile));
 
+    await waitFor(() => {
+      expect(screen.getByText('Service account key file is valid')).toBeInTheDocument();
+    });
+
     let result;
     await act(async () => {
       result = await saveAppInstallation();
@@ -137,9 +156,8 @@ describe('Installed Service Account Key', () => {
 
     expect(result).toEqual({
       parameters: {
-        serviceAccountKey: newServiceKeyFile,
         serviceAccountKeyId: {
-          clientEmail: 'CLIENT_ID',
+          clientEmail: 'example4@PROJECT_ID.iam.gserviceaccount.com',
           clientId: 'CLIENT_ID',
           id: 'PRIVATE_KEY_ID',
           projectId: 'PROJECT_ID',
@@ -159,10 +177,5 @@ describe('Installed Service Account Key', () => {
         },
       },
     });
-
-    expect(await screen.findByText('Google Service Account Details')).toBeInTheDocument();
-    expect(screen.getByText('Service Account')).toBeInTheDocument();
-    expect(screen.getByText('Key ID')).toBeInTheDocument();
-    expect(screen.getByText('Status')).toBeInTheDocument();
   });
 });

--- a/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage.tsx
@@ -1,24 +1,26 @@
 import { useCallback, useEffect, useState } from 'react';
-import { useSDK } from '@contentful/react-apps-toolkit';
 import { AppExtensionSDK, AppState, EditorInterface } from '@contentful/app-sdk';
+import { useCMA, useSDK } from '@contentful/react-apps-toolkit';
 import GoogleAnalyticsIcon from 'components/common/GoogleAnalyticsIcon';
 import { styles } from 'components/config-screen/GoogleAnalytics.styles';
 import Splitter from 'components/common/Splitter';
 import ApiAccessSection from 'components/config-screen/api-access/ApiAccessSection';
 import AboutSection from 'components/config-screen/header/AboutSection';
-import { AccountSummariesType } from 'types';
+import { AccountSummariesType, ServiceAccountKey } from 'types';
 import { Box } from '@contentful/f36-components';
 import AssignContentTypeSection from 'components/config-screen/assign-content-type/AssignContentTypeSection';
 import MapAccountPropertySection from 'components/config-screen/map-account-property/MapAccountPropertySection';
 import { KeyValueMap } from '@contentful/app-sdk/dist/types/entities';
 import { generateEditorInterfaceAssignments } from 'helpers/contentTypeHelpers/contentTypeHelpers';
+import fetchWithSignedRequest from '../../helpers/signed-requests';
+import { config } from '../../config';
+import { convertServiceAccountKeyToServiceAccountKeyId } from '../../utils/serviceAccountKey';
 
 export default function GoogleAnalyticsConfigPage() {
   const [accountsSummaries, setAccountsSummaries] = useState<AccountSummariesType[]>([]);
   const [isInEditMode, setIsInEditMode] = useState<boolean>(false);
   const [isAppInstalled, setIsAppInstalled] = useState<boolean>(false);
   const [parameters, setParameters] = useState<KeyValueMap>({});
-  const [isValidServiceAccount, setIsValidServiceAccount] = useState<boolean>(false);
   const [isValidAccountProperty, setIsValidAccountProperty] = useState<boolean>(true);
   const [isValidContentTypeAssignment, setIsValidContentTypeAssignment] = useState<boolean>(true);
   const [currentEditorInterface, setCurrentEditorInterface] = useState<Partial<EditorInterface>>(
@@ -26,8 +28,11 @@ export default function GoogleAnalyticsConfigPage() {
   );
   const [originalParameters, setOriginalParameters] = useState<KeyValueMap>({});
   const [hasServiceCheckErrors, setHasServiceCheckErrors] = useState<boolean>(true);
+  const [validKeyFile, setValidKeyFile] = useState<ServiceAccountKey | undefined>();
+  const [isSavingPrivateKeyFile, setIsSavingPrivateKeyFile] = useState<boolean>(false);
 
   const sdk = useSDK<AppExtensionSDK>();
+  const cma = useCMA();
 
   const handleHasServiceCheckErrorsChange = (hasErrors: boolean) => {
     setHasServiceCheckErrors(hasErrors);
@@ -61,9 +66,39 @@ export default function GoogleAnalyticsConfigPage() {
     fetchEditorInterfaceFromSdk();
   }, [sdk]);
 
+  const postServiceKeyFileToBackend = useCallback(
+    async (validKeyFile: ServiceAccountKey) => {
+      const apiCredentialsUrl = new URL(`${config.backendApiUrl}/api/service_account_key_file`);
+      const encodedServiceAccountKeyId = window.btoa(
+        JSON.stringify(convertServiceAccountKeyToServiceAccountKeyId(validKeyFile))
+      );
+
+      const res = await fetchWithSignedRequest(
+        apiCredentialsUrl,
+        sdk.ids.app,
+        cma,
+        'PUT',
+        {
+          'X-Contentful-ServiceAccountKeyId': encodedServiceAccountKeyId,
+        },
+        validKeyFile
+      );
+
+      if (!res.ok) {
+        sdk.notifier.error(
+          'Error: Failed to store Google Service Account Key. Please try again. If the problem persists, please contact support.'
+        );
+        return false;
+      }
+
+      return true;
+    },
+    [cma, sdk.ids.app, sdk.notifier]
+  );
+
   const handleConfigure = useCallback(async () => {
     // Service Account checks go here
-    if (!isValidServiceAccount) {
+    if (!validKeyFile) {
       sdk.notifier.error('A valid service account key file is required');
       return false;
     }
@@ -79,8 +114,6 @@ export default function GoogleAnalyticsConfigPage() {
       sdk.notifier.error('Invalid content types assignment');
       return false;
     }
-
-    setIsInEditMode(false);
 
     // Assign the app to the sidebar for saved content types
     const contentTypeIds = Object.keys(parameters.contentTypes ?? {});
@@ -103,14 +136,14 @@ export default function GoogleAnalyticsConfigPage() {
       targetState: newAppState,
     };
   }, [
+    validKeyFile,
+    isValidAccountProperty,
     isAppInstalled,
     isInEditMode,
-    isValidAccountProperty,
     isValidContentTypeAssignment,
-    isValidServiceAccount,
     parameters,
-    sdk.notifier,
     currentEditorInterface,
+    sdk.notifier,
   ]);
 
   useEffect(() => {
@@ -130,19 +163,26 @@ export default function GoogleAnalyticsConfigPage() {
     getIsAppInstalled();
   }, [sdk]);
 
-  const handleConfigurationCompleted = useCallback(() => {
+  const handleConfigurationCompleted = useCallback(async () => {
+    // Save valid google service account key file in backend
+    setIsSavingPrivateKeyFile(true);
+    const keyFileSaved = validKeyFile && (await postServiceKeyFileToBackend(validKeyFile));
+    setIsSavingPrivateKeyFile(false);
+    if (!keyFileSaved) {
+      sdk.notifier.error(
+        'Failed to save private key file. Please try again. Contact support if the problem persists.'
+      );
+    }
+
+    setIsInEditMode(false);
     setIsAppInstalled(true);
-  }, []);
+  }, [postServiceKeyFileToBackend, sdk.notifier, validKeyFile]);
 
   useEffect(() => {
     sdk.app.onConfigurationCompleted(() => handleConfigurationCompleted());
   }, [sdk, handleConfigurationCompleted]);
 
   /** isValid handlers for each Configuration component **/
-  const handleIsValidServiceAccount = (isValid: boolean) => {
-    setIsValidServiceAccount(isValid);
-  };
-
   const handleIsValidAccountProperty = (isValid: boolean) => {
     setIsValidAccountProperty(isValid);
   };
@@ -164,6 +204,10 @@ export default function GoogleAnalyticsConfigPage() {
     return !hasServiceCheckErrors || parameters.propertyId;
   };
 
+  const handleKeyFileUpdate = (_validKeyFile: ServiceAccountKey) => {
+    setValidKeyFile(_validKeyFile);
+  };
+
   return (
     <>
       <Box className={styles.background} />
@@ -176,9 +220,10 @@ export default function GoogleAnalyticsConfigPage() {
           mergeSdkParameters={mergeSdkParameters}
           onAccountSummariesChange={handleAccountSummariesChange}
           isInEditMode={isInEditMode}
+          isSavingPrivateKeyFile={isSavingPrivateKeyFile}
           onInEditModeChange={handleInEditModeChange}
-          onIsValidServiceAccount={handleIsValidServiceAccount}
           onHasServiceCheckErrorsChange={handleHasServiceCheckErrorsChange}
+          onKeyFileUpdate={handleKeyFileUpdate}
         />
         {isAppInstalled && showPropertyDropdownAndContentTypeSection() && (
           <>

--- a/apps/google-analytics-4/frontend/src/components/config-screen/api-access/ApiAccessSection.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/api-access/ApiAccessSection.spec.tsx
@@ -15,17 +15,18 @@ describe('Config Screen component (not installed)', () => {
           isAppInstalled={false}
           onAccountSummariesChange={() => {}}
           parameters={{}}
-          onIsValidServiceAccount={() => {}}
           mergeSdkParameters={() => {}}
           isInEditMode={false}
+          isSavingPrivateKeyFile={false}
           onInEditModeChange={() => {}}
           onHasServiceCheckErrorsChange={() => {}}
+          onKeyFileUpdate={() => {}}
         />
       );
     });
 
     expect(screen.getByText('API access')).toBeInTheDocument();
     expect(screen.getByText('Google Service Account Details')).toBeInTheDocument();
-    expect(screen.getByText('Private Key File')).toBeInTheDocument();
+    expect(screen.getByText('Service Account Key')).toBeInTheDocument();
   });
 });

--- a/apps/google-analytics-4/frontend/src/components/config-screen/api-access/ApiAccessSection.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/api-access/ApiAccessSection.tsx
@@ -9,9 +9,10 @@ interface Props {
   parameters: KeyValueMap;
   mergeSdkParameters: Function;
   isInEditMode: boolean;
+  isSavingPrivateKeyFile: boolean;
   onInEditModeChange: Function;
-  onIsValidServiceAccount: Function;
   onHasServiceCheckErrorsChange: Function;
+  onKeyFileUpdate: Function;
 }
 
 const ApiAccessSection = (props: Props) => {
@@ -21,9 +22,10 @@ const ApiAccessSection = (props: Props) => {
     parameters,
     mergeSdkParameters,
     isInEditMode,
+    isSavingPrivateKeyFile,
     onInEditModeChange,
-    onIsValidServiceAccount,
     onHasServiceCheckErrorsChange,
+    onKeyFileUpdate,
   } = props;
 
   return (
@@ -34,15 +36,11 @@ const ApiAccessSection = (props: Props) => {
           Authorize this application to access Google Analytics Admin & Data APIs
         </Paragraph>
       </div>
-      {!isInEditMode &&
-      isAppInstalled &&
-      parameters &&
-      parameters.serviceAccountKeyId &&
-      parameters.serviceAccountKey ? (
+      {!isInEditMode && isAppInstalled && parameters && parameters.serviceAccountKeyId ? (
         <DisplayServiceAccountCard
+          isSavingPrivateKeyFile={isSavingPrivateKeyFile}
           onInEditModeChange={onInEditModeChange}
           serviceAccountKeyId={parameters.serviceAccountKeyId}
-          serviceAccountKey={parameters.serviceAccountKey}
           onAccountSummariesChange={onAccountSummariesChange}
           isAppInstalled={isAppInstalled}
           parameters={parameters}
@@ -54,7 +52,7 @@ const ApiAccessSection = (props: Props) => {
           mergeSdkParameters={mergeSdkParameters}
           isInEditMode={isInEditMode}
           onInEditModeChange={onInEditModeChange}
-          onIsValidServiceAccount={onIsValidServiceAccount}
+          onKeyFileUpdate={onKeyFileUpdate}
         />
       )}
     </Stack>

--- a/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/ChecklistUtils.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/ChecklistUtils.tsx
@@ -64,6 +64,7 @@ export type ChecklistStatus = {
   ServiceKey: {
     success: ChecklistRow;
     invalid: ChecklistRow;
+    missing: ChecklistRow;
   };
   AdminApi: {
     success: ChecklistRow;
@@ -103,6 +104,14 @@ export const CHECKLIST_STATUSES: ChecklistStatus = {
       ),
       title: CHECKLIST_NAMES.serviceAccount,
       description: 'Invalid service account and service account key',
+      disabled: false,
+    },
+    missing: {
+      icon: getErrorIcon(
+        'We were unable to retrieve the private key from your service account key file. Please try reinstalling your service account key file. If the problem persists, contact support.'
+      ),
+      title: CHECKLIST_NAMES.serviceAccount,
+      description: 'Unable to retrieve service account key file.',
       disabled: false,
     },
   },
@@ -219,7 +228,7 @@ export const CHECKLIST_STATUSES: ChecklistStatus = {
 };
 
 export const getApiChecklistURLs = (parameters: KeyValueMap, apiError: boolean) => {
-  const projectId = parameters.serviceAccountKey['project_id'];
+  const projectId = parameters.serviceAccountKeyId['projectId'];
   return {
     adminApi: {
       title: apiError ? 'Enable Admin API' : 'Details',
@@ -234,7 +243,8 @@ export const getApiChecklistURLs = (parameters: KeyValueMap, apiError: boolean) 
 
 export const getServiceKeyChecklistStatus = (
   parameters: KeyValueMap,
-  invalidServiceAccountError: ApiErrorType | undefined
+  invalidServiceAccountError: ApiErrorType | undefined,
+  missingServiceAccountError: ApiErrorType | undefined
 ) => {
   const url = `https://console.cloud.google.com/iam-admin/serviceaccounts/details/${parameters.serviceAccountKeyId.clientId}?project=${parameters.serviceAccountKeyId.projectId}`;
   const title = invalidServiceAccountError ? 'Edit service account' : 'Details';
@@ -242,9 +252,13 @@ export const getServiceKeyChecklistStatus = (
     title: title,
     url: url,
   };
-  if (!invalidServiceAccountError)
+  if (invalidServiceAccountError) {
+    return { ...CHECKLIST_STATUSES.ServiceKey.invalid, checklistUrl: checklistUrl };
+  } else if (missingServiceAccountError) {
+    return { ...CHECKLIST_STATUSES.ServiceKey.missing };
+  } else {
     return { ...CHECKLIST_STATUSES.ServiceKey.success, checklistUrl: checklistUrl };
-  else return { ...CHECKLIST_STATUSES.ServiceKey.invalid, checklistUrl: checklistUrl };
+  }
 };
 
 export const getAdminApiErrorChecklistStatus = (

--- a/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/DisplayServiceAccountCard.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/DisplayServiceAccountCard.spec.tsx
@@ -22,7 +22,6 @@ export const apiPath = (path: string) => {
 describe('Installed Service Account Card', () => {
   beforeEach(() => {
     mockSdk.app.getParameters.mockReturnValue({
-      serviceAccountKey: validServiceKeyFile,
       serviceAccountKeyId: validServiceKeyId,
     });
   });
@@ -31,8 +30,8 @@ describe('Installed Service Account Card', () => {
     await act(async () => {
       render(
         <DisplayServiceAccountCard
+          isSavingPrivateKeyFile={false}
           serviceAccountKeyId={validServiceKeyId}
-          serviceAccountKey={validServiceKeyFile}
           parameters={{}}
           onInEditModeChange={() => {}}
           onAccountSummariesChange={() => {}}

--- a/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/ServiceAccountChecklist.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/ServiceAccountChecklist.spec.tsx
@@ -50,7 +50,7 @@ describe('Service Account Checklist', () => {
       render(
         <ServiceAccountChecklist
           serviceAccountCheck={{
-            ...getServiceKeyChecklistStatus(parameters, undefined),
+            ...getServiceKeyChecklistStatus(parameters, undefined, undefined),
           }}
           adminApiCheck={{
             ...getAdminApiErrorChecklistStatus(false, parameters, undefined, undefined),
@@ -77,7 +77,7 @@ describe('Service Account Checklist', () => {
       render(
         <ServiceAccountChecklist
           serviceAccountCheck={{
-            ...getServiceKeyChecklistStatus(parameters, undefined),
+            ...getServiceKeyChecklistStatus(parameters, undefined, undefined),
           }}
           adminApiCheck={{
             ...getAdminApiErrorChecklistStatus(
@@ -110,12 +110,50 @@ describe('Service Account Checklist', () => {
     await screen.findAllByText(/Awaiting a correctly configured service account installation/);
   });
 
+  it('missing service account key', async () => {
+    await act(async () => {
+      render(
+        <ServiceAccountChecklist
+          serviceAccountCheck={{
+            ...getServiceKeyChecklistStatus(parameters, undefined, {} as ApiErrorType),
+          }}
+          adminApiCheck={{
+            ...getAdminApiErrorChecklistStatus(
+              false,
+              parameters,
+              invalidServiceAccountError,
+              undefined
+            ),
+          }}
+          dataApiCheck={{
+            ...getDataApiErrorChecklistStatus(
+              false,
+              parameters,
+              invalidServiceAccountError,
+              undefined
+            ),
+          }}
+          ga4PropertiesCheck={{
+            ...getGa4PropertyErrorChecklistStatus(
+              false,
+              invalidServiceAccountError,
+              undefined,
+              undefined
+            ),
+          }}
+        />
+      );
+    });
+
+    await screen.findAllByText(/Unable to retrieve service account key file./);
+  });
+
   it('first time install with invalid service account key', async () => {
     await act(async () => {
       render(
         <ServiceAccountChecklist
           serviceAccountCheck={{
-            ...getServiceKeyChecklistStatus(parameters, undefined),
+            ...getServiceKeyChecklistStatus(parameters, undefined, undefined),
           }}
           adminApiCheck={{
             ...getAdminApiErrorChecklistStatus(
@@ -153,7 +191,7 @@ describe('Service Account Checklist', () => {
       render(
         <ServiceAccountChecklist
           serviceAccountCheck={{
-            ...getServiceKeyChecklistStatus(parameters, {} as ApiErrorType),
+            ...getServiceKeyChecklistStatus(parameters, {} as ApiErrorType, undefined),
           }}
           adminApiCheck={{
             ...getAdminApiErrorChecklistStatus(
@@ -194,7 +232,7 @@ describe('Service Account Checklist', () => {
       render(
         <ServiceAccountChecklist
           serviceAccountCheck={{
-            ...getServiceKeyChecklistStatus(parameters, undefined),
+            ...getServiceKeyChecklistStatus(parameters, undefined, undefined),
           }}
           adminApiCheck={{
             ...getAdminApiErrorChecklistStatus(true, parameters, undefined, adminApiError),
@@ -217,7 +255,7 @@ describe('Service Account Checklist', () => {
       render(
         <ServiceAccountChecklist
           serviceAccountCheck={{
-            ...getServiceKeyChecklistStatus(parameters, undefined),
+            ...getServiceKeyChecklistStatus(parameters, undefined, undefined),
           }}
           adminApiCheck={{
             ...getAdminApiErrorChecklistStatus(true, parameters, undefined, undefined),
@@ -245,7 +283,7 @@ describe('Service Account Checklist', () => {
       render(
         <ServiceAccountChecklist
           serviceAccountCheck={{
-            ...getServiceKeyChecklistStatus(parameters, undefined),
+            ...getServiceKeyChecklistStatus(parameters, undefined, undefined),
           }}
           adminApiCheck={{
             ...getAdminApiErrorChecklistStatus(true, parameters, undefined, undefined),

--- a/apps/google-analytics-4/frontend/src/components/config-screen/api-access/setup/SetupServiceAccountCard.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/api-access/setup/SetupServiceAccountCard.spec.tsx
@@ -14,17 +14,17 @@ describe('Setup Google Service Account Details page', () => {
       render(
         <SetupServiceAccountCard
           parameters={{}}
-          onIsValidServiceAccount={() => {}}
           mergeSdkParameters={() => {}}
           onInEditModeChange={() => {}}
           isInEditMode={false}
+          onKeyFileUpdate={() => {}}
         />
       );
     });
 
     expect(screen.getByText('Google Service Account Details')).toBeInTheDocument();
     expect(screen.getByText('Paste the service account key file (JSON) above')).toBeInTheDocument();
-    expect(screen.getByLabelText(/Private Key File/).getAttribute('aria-invalid')).toBeNull();
+    expect(screen.getByLabelText(/Service Account Key/).getAttribute('aria-invalid')).toBeNull();
   });
 
   it('renders an error state when invalid input', async () => {
@@ -34,15 +34,15 @@ describe('Setup Google Service Account Details page', () => {
       render(
         <SetupServiceAccountCard
           parameters={{}}
-          onIsValidServiceAccount={() => {}}
           mergeSdkParameters={() => {}}
           onInEditModeChange={() => {}}
           isInEditMode={false}
+          onKeyFileUpdate={() => {}}
         />
       );
     });
 
-    const keyFileInputBox = screen.getByLabelText(/Private Key File/i);
+    const keyFileInputBox = screen.getByLabelText(/Service Account Key/i);
 
     // user.type() got confused by the JSON string chars, so we'll just click and paste -- this
     // actually better recreates likely user behavior as a bonus
@@ -50,7 +50,7 @@ describe('Setup Google Service Account Details page', () => {
     await user.paste(JSON.stringify({ foo: 'bar' }));
 
     await waitFor(() => {
-      expect(screen.getByLabelText(/Private Key File/).getAttribute('aria-invalid')).toEqual(
+      expect(screen.getByLabelText(/Service Account Key/).getAttribute('aria-invalid')).toEqual(
         'true'
       );
       expect(screen.getByText(/Error:/)).toBeInTheDocument();
@@ -64,15 +64,15 @@ describe('Setup Google Service Account Details page', () => {
       render(
         <SetupServiceAccountCard
           parameters={{}}
-          onIsValidServiceAccount={() => {}}
           mergeSdkParameters={() => {}}
           onInEditModeChange={() => {}}
           isInEditMode={false}
+          onKeyFileUpdate={() => {}}
         />
       );
     });
 
-    const keyFileInputBox = screen.getByLabelText(/Private Key File/i);
+    const keyFileInputBox = screen.getByLabelText(/Service Account Key/i);
 
     // user.type() got confused by the JSON string chars, so we'll just click and paste -- this
     // actually better recreates likely user behavior as a bonus
@@ -80,7 +80,7 @@ describe('Setup Google Service Account Details page', () => {
     await user.paste(JSON.stringify(validServiceKeyFile));
 
     await waitFor(() => {
-      expect(screen.getByLabelText(/Private Key File/).getAttribute('aria-invalid')).toBeNull();
+      expect(screen.getByLabelText(/Service Account Key/).getAttribute('aria-invalid')).toBeNull();
       expect(screen.getByText('Service account key file is valid')).toBeInTheDocument();
     });
   });

--- a/apps/google-analytics-4/frontend/src/components/config-screen/api-access/setup/SetupServiceAccountCard.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/api-access/setup/SetupServiceAccountCard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import {
   Stack,
   Card,
@@ -12,20 +12,20 @@ import {
   Box,
 } from '@contentful/f36-components';
 import { CheckCircleIcon, ExternalLinkTrimmedIcon } from '@contentful/f36-icons';
+import { ServiceAccountKeyId } from 'types';
 import {
   AssertionError,
   convertKeyFileToServiceAccountKey,
   convertServiceAccountKeyToServiceAccountKeyId,
 } from 'utils/serviceAccountKey';
-import { debounce } from 'lodash';
 import { KeyValueMap } from '@contentful/app-sdk/dist/types/entities';
 
 interface Props {
   isInEditMode: boolean;
   mergeSdkParameters: Function;
   parameters: KeyValueMap;
-  onIsValidServiceAccount: Function;
   onInEditModeChange: Function;
+  onKeyFileUpdate: Function;
 }
 
 const placeholderText = `{
@@ -34,30 +34,16 @@ const placeholderText = `{
 }`;
 
 export default function SetupServiceAccountCard(props: Props) {
-  const {
-    mergeSdkParameters,
-    parameters,
-    isInEditMode,
-    onInEditModeChange,
-    onIsValidServiceAccount,
-  } = props;
+  const { mergeSdkParameters, isInEditMode, onInEditModeChange, onKeyFileUpdate } = props;
 
-  const [keyFile, setKeyFile] = useState<string>();
+  const [rawServiceAccountKey, setRawServiceAccountKey] = useState<string>();
+  const [serviceAccountKeyId, setServiceAccountKeyId] = useState<ServiceAccountKeyId>();
   const [errorMessage, setErrorMessage] = useState<string>('');
 
-  useEffect(() => {
-    !errorMessage && parameters.serviceAccountKey && parameters.serviceAccountKeyId
-      ? onIsValidServiceAccount(true)
-      : onIsValidServiceAccount(false);
-
-    // This is a on page load check, not whenever parameters service accounts change
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [onIsValidServiceAccount]);
-
-  const handleKeyFileChange = (e: any) => {
-    setKeyFile(e.target.value);
-    const debHandleServiceKey = debounce(() => handleKeyFileToServiceAccount(e.target.value), 150);
-    debHandleServiceKey();
+  const handleRawServiceAccountKeyChange = (e: any) => {
+    const keyfile = e.target.value;
+    setRawServiceAccountKey(keyfile);
+    handleKeyFileToServiceAccount(keyfile);
   };
 
   const handleKeyFileToServiceAccount = (keyfile: string) => {
@@ -65,17 +51,18 @@ export default function SetupServiceAccountCard(props: Props) {
       const _serviceAccountKey = convertKeyFileToServiceAccountKey(keyfile);
       const _serviceAccountKeyId =
         convertServiceAccountKeyToServiceAccountKeyId(_serviceAccountKey);
+
+      onKeyFileUpdate(_serviceAccountKey);
+      setServiceAccountKeyId(_serviceAccountKeyId);
       setErrorMessage('');
 
       const _parameters = {
-        serviceAccountKey: _serviceAccountKey,
         serviceAccountKeyId: _serviceAccountKeyId,
       };
 
       mergeSdkParameters(_parameters);
-      onIsValidServiceAccount(true);
     } catch (e: any) {
-      onIsValidServiceAccount(false);
+      onKeyFileUpdate(undefined);
       // failed assertions about key file contents or could not parse as JSON
       if (e instanceof AssertionError || e instanceof SyntaxError) {
         setErrorMessage(e.message);
@@ -87,15 +74,11 @@ export default function SetupServiceAccountCard(props: Props) {
   };
 
   const handleCancelClick = () => {
-    setKeyFile('');
+    setRawServiceAccountKey('');
+    setServiceAccountKeyId(undefined);
     setErrorMessage('');
     onInEditModeChange(false);
-    onIsValidServiceAccount(true);
   };
-
-  // consider form value invalid if they've provided at least some text but a serviceAccountKey or serivceAccountKeyId has
-  // not been able to be generated successfully
-  const isInvalid = keyFile !== '' && errorMessage !== '';
 
   return (
     <Stack spacing="spacingL" flexDirection="column">
@@ -132,19 +115,19 @@ export default function SetupServiceAccountCard(props: Props) {
         </Box>
         <FormControl
           id="accountCredentialsFile"
-          isInvalid={isInvalid}
+          isInvalid={rawServiceAccountKey !== undefined && !serviceAccountKeyId}
           isRequired={true}
           marginBottom={!isInEditMode ? 'none' : 'spacingM'}>
-          <FormControl.Label>Private Key File</FormControl.Label>
+          <FormControl.Label>Service Account Key</FormControl.Label>
           <Textarea
             spellCheck={false}
             name="accountCredentialsFile"
             placeholder={placeholderText}
             rows={10}
-            value={keyFile}
-            onChange={handleKeyFileChange}
+            value={rawServiceAccountKey}
+            onChange={handleRawServiceAccountKeyChange}
           />
-          {!keyFile ? (
+          {!rawServiceAccountKey ? (
             <FormControl.HelpText>
               Paste the service account key file (JSON) above
             </FormControl.HelpText>

--- a/apps/google-analytics-4/frontend/src/components/main-app/AnalyticsApp/AnalyticsApp.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/AnalyticsApp/AnalyticsApp.spec.tsx
@@ -1,7 +1,7 @@
 import AnalyticsApp from './AnalyticsApp';
 import { act, render, screen } from '@testing-library/react';
 import { Api } from 'apis/api';
-import { mockSdk, mockCma, validServiceKeyFile, validServiceKeyId } from '../../../../test/mocks';
+import { mockSdk, mockCma, validServiceKeyId } from '../../../../test/mocks';
 import runReportResponseHasViews from '../../../../../lambda/public/sampleData/runReportResponseHasViews.json';
 import runReportResponseNoView from '../../../../../lambda/public/sampleData/runReportResponseNoViews.json';
 import { getContentTypeSpecificMsg } from '../constants/noteMessages';
@@ -35,7 +35,6 @@ const renderAnalyticsApp = async () =>
 describe('AnalyticsApp with correct content types configured', () => {
   beforeEach(() => {
     mockSdk.app.getParameters.mockReturnValue({
-      serviceAccountKey: validServiceKeyFile,
       serviceAccountKeyId: validServiceKeyId,
     });
 

--- a/apps/google-analytics-4/frontend/src/helpers/signed-requests.ts
+++ b/apps/google-analytics-4/frontend/src/helpers/signed-requests.ts
@@ -1,3 +1,4 @@
+import { ServiceAccountKey } from '@/types';
 import { CreateAppSignedRequestProps } from 'contentful-management/dist/typings/entities/app-signed-request';
 import { PlainClientAPI } from 'contentful-management/dist/typings/plain/common-types';
 
@@ -6,12 +7,16 @@ async function fetchWithSignedRequest(
   appDefinitionId: string,
   cma: PlainClientAPI,
   method: CreateAppSignedRequestProps['method'] = 'GET',
-  unsignedHeaders: Record<string, string> = {}
+  unsignedHeaders: Record<string, string> = {},
+  body?: ServiceAccountKey
 ): Promise<Response> {
   const req = {
     url: url,
     method: method,
-    headers: {},
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: body ? JSON.stringify(body) : undefined,
   };
 
   const rootRelativePath = req.url.pathname;
@@ -25,8 +30,10 @@ async function fetchWithSignedRequest(
       method: req.method,
       headers: req.headers,
       path: rootRelativePath,
+      body: req.body,
     }
   );
+
   Object.assign(req.headers, unsignedHeaders, signedHeaders);
 
   return fetch(req.url, req);

--- a/apps/google-analytics-4/frontend/src/hooks/useApi.spec.ts
+++ b/apps/google-analytics-4/frontend/src/hooks/useApi.spec.ts
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react';
 import React, { FunctionComponent } from 'react';
-import { mockCma, mockSdk, validServiceKeyFile, validServiceKeyId } from '../../test/mocks';
+import { mockCma, mockSdk, validServiceKeyId } from '../../test/mocks';
 import { Api } from '../apis/api';
 import { useApi } from './useApi';
 
@@ -19,7 +19,7 @@ const renderTestComponent = (componentFn: FunctionComponent) => {
 describe('useApi', () => {
   it('provides an Api instance to children', () => {
     renderTestComponent(() => {
-      const api = useApi(validServiceKeyId, validServiceKeyFile);
+      const api = useApi(validServiceKeyId);
       testFn(api);
       return null;
     });
@@ -31,7 +31,6 @@ describe('useApi', () => {
 
     beforeEach(() => {
       mockSdk.parameters.installation = {
-        serviceAccountKey: validServiceKeyFile,
         serviceAccountKeyId: validServiceKeyId,
       };
     });

--- a/apps/google-analytics-4/frontend/src/hooks/useApi.ts
+++ b/apps/google-analytics-4/frontend/src/hooks/useApi.ts
@@ -1,32 +1,22 @@
 import { useCMA, useSDK } from '@contentful/react-apps-toolkit';
 import { useMemo } from 'react';
 import { Api } from '../apis/api';
-import { ServiceAccountKey, ServiceAccountKeyId } from '../types';
+import { ServiceAccountKeyId } from '../types';
 import { contentfulContext } from '../helpers/contentfulContext';
 
-export function useApi(
-  serviceAccountKeyId?: ServiceAccountKeyId,
-  serviceAccountKey?: ServiceAccountKey
-): Api {
+export function useApi(serviceAccountKeyId?: ServiceAccountKeyId): Api {
   const cma = useCMA();
   const sdk = useSDK();
 
   const accountKeyId = serviceAccountKeyId || sdk.parameters.installation.serviceAccountKeyId;
 
-  // NOTE: The service account key file here will later be removed when it's moved to secret storage
-  const accountKey = serviceAccountKey || sdk.parameters.installation.serviceAccountKey;
-
   if (!accountKeyId) {
     throw new Error('No ServiceAccountKeyId provided or found in installation parameters');
   }
 
-  if (!accountKey) {
-    throw new Error('No ServiceAccountKey provided or found in installation parameters');
-  }
-
   const api = useMemo(() => {
-    return new Api(contentfulContext(sdk), cma, accountKeyId, accountKey);
-  }, [cma, accountKeyId, accountKey, sdk]);
+    return new Api(contentfulContext(sdk), cma, accountKeyId);
+  }, [cma, accountKeyId, sdk]);
 
   return api;
 }

--- a/apps/google-analytics-4/frontend/src/locations/Sidebar.tsx
+++ b/apps/google-analytics-4/frontend/src/locations/Sidebar.tsx
@@ -7,13 +7,13 @@ import { AppInstallationParameters } from 'types';
 const Sidebar = () => {
   const sdk = useSDK<SidebarExtensionSDK>();
 
-  const { serviceAccountKey, serviceAccountKeyId, propertyId, contentTypes } = sdk.parameters
+  const { serviceAccountKeyId, propertyId, contentTypes } = sdk.parameters
     .installation as AppInstallationParameters;
 
   const currentContentType = sdk.contentType.sys.id;
   const slugFieldInfo = contentTypes[currentContentType] ?? { slugField: '', urlPrefix: '' };
 
-  const api = useApi(serviceAccountKeyId, serviceAccountKey);
+  const api = useApi(serviceAccountKeyId);
 
   return (
     <>

--- a/apps/google-analytics-4/frontend/src/types.ts
+++ b/apps/google-analytics-4/frontend/src/types.ts
@@ -1,7 +1,6 @@
 import { IdsAPI } from '@contentful/app-sdk';
 
 export interface AppInstallationParameters {
-  serviceAccountKey: ServiceAccountKey;
   serviceAccountKeyId: ServiceAccountKeyId;
   contentTypes: ContentTypes;
   propertyId: string;

--- a/apps/google-analytics-4/frontend/test/mocks/api/handlers.ts
+++ b/apps/google-analytics-4/frontend/test/mocks/api/handlers.ts
@@ -9,7 +9,7 @@ export const apiPath = (path: string) => {
 };
 
 export const handlers = [
-  rest.get(apiPath('/api/credentials'), (_req, res, ctx) => {
+  rest.get(apiPath('/api/service_account_key_file'), (_req, res, ctx) => {
     return res(ctx.json({ status: 'active' }));
   }),
 

--- a/apps/google-analytics-4/lambda/.env
+++ b/apps/google-analytics-4/lambda/.env
@@ -7,4 +7,4 @@ RELEASE_VERSION: test
 AWS_REGION: us-east-1
 DYNAMODB_ENDPOINT: http://localhost:8000
 DYNAMODB_TABLE_NAME: test
-SHARED_CREDENTIALS_SECRET_KEY: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+SERVICE_ACCOUNT_KEY_ENCRYPTION_SECRET: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/apps/google-analytics-4/lambda/config/serverless-env.dev.yml.example
+++ b/apps/google-analytics-4/lambda/config/serverless-env.dev.yml.example
@@ -1,3 +1,3 @@
 signingSecret: <APP_SIGNING_KEY_GOES_HERE>
 domainName: google-analytics-4-test.ctfapps.net
-dynamoDbSharedCredentialsSecretKey: this-is-a-32-byte-secret-key1234
+serviceAccountKeyEncryptionSecret: this-is-a-32-byte-secret-key1234

--- a/apps/google-analytics-4/lambda/config/serverless-env.prd.yml
+++ b/apps/google-analytics-4/lambda/config/serverless-env.prd.yml
@@ -1,3 +1,3 @@
 signingSecret: ${ssm:/aws/reference/secretsmanager/ci/apps/google-analytics-4-action/prd/signing-secret}
 domainName: google-analytics-4.ctfapps.net
-dynamoDbSharedCredentialsSecretKey: ${ssm:/aws/reference/secretsmanager/ci/apps/google-analytics-4-action/prd/shared-credentials-secret-key}
+serviceAccountKeyEncryptionSecret: ${ssm:/aws/reference/secretsmanager/ci/apps/google-analytics-4-action/prd/service-account-key-encryption-secret}

--- a/apps/google-analytics-4/lambda/config/serverless-env.test.yml
+++ b/apps/google-analytics-4/lambda/config/serverless-env.test.yml
@@ -1,3 +1,3 @@
 signingSecret: ${ssm:/aws/reference/secretsmanager/ci/apps/google-analytics-4-action/prd/signing-secret}
 domainName: google-analytics-4-test.ctfapps.net
-dynamoDbSharedCredentialsSecretKey: ${ssm:/aws/reference/secretsmanager/ci/apps/google-analytics-4-action/prd/shared-credentials-secret-key}
+serviceAccountKeyEncryptionSecret: ${ssm:/aws/reference/secretsmanager/ci/apps/google-analytics-4-action/test/service-account-key-encryption-secret}

--- a/apps/google-analytics-4/lambda/docker-compose.yml
+++ b/apps/google-analytics-4/lambda/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     image: amazon/aws-cli
     container_name: app-dynamodb_migrator
     working_dir: /home/dynamodblocal
-    command: dynamodb create-table --cli-input-json file://shared_credentials.json --endpoint-url http://dynamodb:8000
+    command: dynamodb create-table --cli-input-json file://service-account-keys-table.json --endpoint-url http://dynamodb:8000
     volumes:
       - ./schema:/home/dynamodblocal
     environment:
@@ -48,7 +48,7 @@ services:
       AWS_REGION: us-east-1
       AWS_ACCESS_KEY_ID: local
       AWS_SECRET_ACCESS_KEY: local
-      DYNAMO_TABLE_NAME: sls-apps-ga4-backend-dev-SharedCredentialsTable
+      DYNAMO_TABLE_NAME: sls-apps-ga4-backend-dev-service-account-keys
       DYNAMO_ENDPOINT: http://dynamodb:8000
     depends_on:
       - dynamodb

--- a/apps/google-analytics-4/lambda/schema/service-account-keys-table.json
+++ b/apps/google-analytics-4/lambda/schema/service-account-keys-table.json
@@ -1,0 +1,9 @@
+{
+  "TableName": "sls-apps-ga4-backend-dev-service-account-keys",
+  "AttributeDefinitions": [{ "AttributeName": "id", "AttributeType": "S" }],
+  "KeySchema": [{ "AttributeName": "id", "KeyType": "HASH" }],
+  "ProvisionedThroughput": {
+    "ReadCapacityUnits": 10,
+    "WriteCapacityUnits": 5
+  }
+}

--- a/apps/google-analytics-4/lambda/schema/shared_credentials.json
+++ b/apps/google-analytics-4/lambda/schema/shared_credentials.json
@@ -1,9 +1,0 @@
-{
-  "TableName": "sls-apps-ga4-backend-dev-SharedCredentialsTable",
-  "AttributeDefinitions": [{ "AttributeName": "sharedCredentialsId", "AttributeType": "S" }],
-  "KeySchema": [{ "AttributeName": "sharedCredentialsId", "KeyType": "HASH" }],
-  "ProvisionedThroughput": {
-    "ReadCapacityUnits": 10,
-    "WriteCapacityUnits": 5
-  }
-}

--- a/apps/google-analytics-4/lambda/serverless.yml
+++ b/apps/google-analytics-4/lambda/serverless.yml
@@ -20,8 +20,8 @@ custom:
     host: 0.0.0.0
   awsRegion: us-east-1
   dynamoDbEndpoint: http://dynamodb:8000
-  dynamoDbtableName: sls-apps-ga4-backend-${opt:stage, 'dev'}-SharedCredentialsTable
-  dynamoDbSharedCredentialsSecretKey: ${file(./config/serverless-env.${opt:stage, 'dev'}.yml):dynamoDbSharedCredentialsSecretKey}
+  dynamoDbTableName: sls-apps-ga4-backend-${opt:stage, 'dev'}-service-account-keys
+  serviceAccountKeyEncryptionSecret: ${file(./config/serverless-env.${opt:stage, 'dev'}.yml):serviceAccountKeyEncryptionSecret}
 
 provider:
   name: aws
@@ -44,7 +44,7 @@ provider:
             - dynamodb:UpdateItem
             - dynamodb:DeleteItem
           Resource:
-            - Fn::GetAtt: [SharedCredentialsTable, Arn]
+            - Fn::GetAtt: [service-account-keys, Arn]
 
 functions:
   api:
@@ -56,8 +56,8 @@ functions:
       NODE_ENV: ${env:NODE_ENV, 'development'}
       RELEASE_VERSION: ${env:CIRCLE_SHA1, 'undefined'}
       DYNAMODB_ENDPOINT: ${self:custom.dynamoDbEndpoint}
-      DYNAMODB_TABLE_NAME: ${self:custom.dynamoDbtableName}
-      SHARED_CREDENTIALS_SECRET_KEY: ${self:custom.dynamoDbSharedCredentialsSecretKey}
+      DYNAMODB_TABLE_NAME: ${self:custom.dynamoDbTableName}
+      SERVICE_ACCOUNT_KEY_ENCRYPTION_SECRET: ${self:custom.serviceAccountKeyEncryptionSecret}
     handler: build/src/index.handler
     events:
       - http:
@@ -66,14 +66,14 @@ functions:
 
 resources:
   Resources:
-    SharedCredentialsTable:
+    ServiceAccountKeysTable:
       Type: AWS::DynamoDB::Table
       Properties:
-        TableName: ${self:custom.dynamoDbtableName}
+        TableName: ${self:custom.dynamoDbTableName}
         AttributeDefinitions:
-          - AttributeName: sharedCredentialsId
+          - AttributeName: id
             AttributeType: S
         KeySchema:
-          - AttributeName: sharedCredentialsId
+          - AttributeName: id
             KeyType: HASH
         BillingMode: PAY_PER_REQUEST

--- a/apps/google-analytics-4/lambda/src/apiErrorMap.ts
+++ b/apps/google-analytics-4/lambda/src/apiErrorMap.ts
@@ -4,6 +4,7 @@ import { UnableToVerifyRequest } from './errors/unableToVerifyRequest';
 import { ApiErrorMap } from './middlewares/apiErrorHandler';
 import {
   InvalidServiceAccountKey,
+  MissingServiceAccountKeyFile,
   MissingServiceAccountKeyHeader,
 } from './middlewares/serviceAccountKeyProvider';
 import { GoogleApiError } from './services/googleApiUtils';
@@ -15,6 +16,8 @@ export const apiErrorMap: ApiErrorMap = {
     new ApiError(e.message, 'UnableToVerifyRequest', 422),
   MissingServiceAccountKeyHeader: (e: MissingServiceAccountKeyHeader) =>
     new ApiError(e.message, 'MissingServiceAccountKeyHeader', 400),
+  MissingServiceAccountKeyFile: (e: MissingServiceAccountKeyFile) =>
+    new ApiError(e.message, 'MissingServiceAccountKeyFile', 400),
   InvalidServiceAccountKey: (e: InvalidServiceAccountKey) =>
     new ApiError(e.message, 'InvalidServiceAccountKey', 400),
 };

--- a/apps/google-analytics-4/lambda/src/app.ts
+++ b/apps/google-analytics-4/lambda/src/app.ts
@@ -7,6 +7,7 @@ import { corsConfig } from './middlewares/corsConfig';
 import { apiErrorMap } from './apiErrorMap';
 
 const app = express();
+app.use(express.json());
 const apiRouteConstraint = ['/api/*'];
 
 // Initialize Sentry as early as possible

--- a/apps/google-analytics-4/lambda/src/config.ts
+++ b/apps/google-analytics-4/lambda/src/config.ts
@@ -12,5 +12,7 @@ export const config = {
   awsRegion: getEnvironmentVariable('AWS_REGION'),
   dynamoDbEndpoint: getEnvironmentVariable('DYNAMODB_ENDPOINT'),
   dynamoDbTableName: getEnvironmentVariable('DYNAMODB_TABLE_NAME'),
-  sharedCredentialsSecretKey: getEnvironmentVariable('SHARED_CREDENTIALS_SECRET_KEY'),
+  serviceAccountKeyEncryptionSecret: getEnvironmentVariable(
+    'SERVICE_ACCOUNT_KEY_ENCRYPTION_SECRET'
+  ),
 };

--- a/apps/google-analytics-4/lambda/src/controllers/apiController.ts
+++ b/apps/google-analytics-4/lambda/src/controllers/apiController.ts
@@ -1,47 +1,75 @@
 import { NextFunction, Request, Response } from 'express';
-import { RunReportParamsType } from '../types';
+import { RunReportParamsType, ServiceAccountKeyFile } from '../types';
 import { GoogleApiService } from '../services/googleApiService';
-// import { DynamoDBService } from '../services/dynamoDbService';
+import { DynamoDBService } from '../services/dynamoDbService';
+import {
+  MissingServiceAccountKeyFile,
+  assertServiceAccountKey,
+  assertServiceAccountKeyId,
+} from '../middlewares/serviceAccountKeyProvider';
 
 const formatArrays = (param: string | string[]) =>
   Array.isArray(param) ? param : param.split(',');
 
+const requireServiceAccountKey = (serviceAccountKey?: ServiceAccountKeyFile) => {
+  if (!serviceAccountKey) {
+    throw new MissingServiceAccountKeyFile(
+      'We were unable to retrieve the private key from your service account key file. Please try reinstalling your service account key file. If the problem persists, contact support.'
+    );
+  }
+
+  return serviceAccountKey;
+};
+
 const ApiController = {
-  credentials: (_req: Request, res: Response) => {
-    // TODO: actually verify the credentials
-    res.status(200).json({ status: 'active' });
+  credentials: async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const serviceAccountKeyFile = req.body;
+      assertServiceAccountKey(serviceAccountKeyFile);
+
+      if (!req.serviceAccountKeyId) {
+        throw new Error('Missing serviceAccountKeyId'); // set by serviceAccountKeyProvider middleware
+      }
+
+      // added to request by serviceAccountKeyProvider middleware if resolved from dynamoDB
+      // TODO: DRY this up, it's also done in serviceAccountKeyProvider
+      const spaceId = req.header('X-Contentful-Space-Id');
+      if (!spaceId) {
+        throw new Error('Missing X-Contentful-Space-Id header!');
+      }
+
+      const dynamoDB = new DynamoDBService();
+      await dynamoDB.saveServiceAccountKeyFile(
+        spaceId,
+        req.serviceAccountKeyId,
+        serviceAccountKeyFile
+      );
+
+      return res.send(200);
+    } catch (err) {
+      next(err);
+    }
   },
 
   account_summaries: async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const serviceAccountKeyFile = req.serviceAccountKey;
+      const serviceAccountKey = requireServiceAccountKey(req.serviceAccountKey);
 
-      if (serviceAccountKeyFile === undefined) {
-        // intentional runtime error because the middleware already handles this. typescript
-        // just doesn't realize
-        throw new Error('missing service account key value');
-      }
-
-      const googleApi = GoogleApiService.fromServiceAccountKeyFile(serviceAccountKeyFile);
+      const googleApi = GoogleApiService.fromServiceAccountKeyFile(serviceAccountKey);
       const result = await googleApi.listAccountSummaries();
       res.status(200).json(result);
     } catch (err) {
-      // pass to apiErrorHandler
       next(err);
     }
   },
 
   run_report: async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const serviceAccountKeyFile = req.serviceAccountKey;
+      const serviceAccountKey = requireServiceAccountKey(req.serviceAccountKey);
+
       const { propertyId, slug, startDate, endDate, dimensions, metrics } =
         req.query as unknown as RunReportParamsType;
-
-      // intentional runtime error because the middleware already handles this. typescript
-      // just doesn't realize
-      if (serviceAccountKeyFile === undefined) throw new Error('missing service account key value');
-
-      const googleApi = GoogleApiService.fromServiceAccountKeyFile(serviceAccountKeyFile);
+      const googleApi = GoogleApiService.fromServiceAccountKeyFile(serviceAccountKey);
       const result =
         dimensions && metrics
           ? await googleApi.runReport(
@@ -55,7 +83,6 @@ const ApiController = {
           : await googleApi.runReport(propertyId, slug, startDate, endDate);
       res.status(200).json(result);
     } catch (err) {
-      // pass to apiErrorHandler
       next(err);
     }
   },

--- a/apps/google-analytics-4/lambda/src/middlewares/apiErrorHandler.ts
+++ b/apps/google-analytics-4/lambda/src/middlewares/apiErrorHandler.ts
@@ -12,8 +12,10 @@ export type ApiErrorMap = Record<string, (e: any) => ApiError<Record<string, unk
 export const apiErrorHandler: ErrorRequestHandler = (error, _request, response, next) => {
   if (error) {
     if (isApiError(error)) {
+      console.error(error);
       response.status(error.status).send({ errors: error.toJSON() });
     } else {
+      console.error(error);
       response.status(500).send({
         errors: {
           errorType: 'ServerError',

--- a/apps/google-analytics-4/lambda/src/middlewares/corsConfig.ts
+++ b/apps/google-analytics-4/lambda/src/middlewares/corsConfig.ts
@@ -13,7 +13,6 @@ export const corsConfig = {
     'X-Contentful-App-ID',
     // ContentfulServiceAccountHeaders
     'X-Contentful-ServiceAccountKeyId',
-    'X-Contentful-ServiceAccountKey',
     // ContentfulContextHeaders
     'X-Contentful-App',
     'X-Contentful-ContentType',

--- a/apps/google-analytics-4/lambda/src/middlewares/serviceAccountKeyProvider.ts
+++ b/apps/google-analytics-4/lambda/src/middlewares/serviceAccountKeyProvider.ts
@@ -1,36 +1,43 @@
 import { RequestHandler } from 'express';
 import { ServiceAccountKeyFile, ServiceAccountKeyId } from '../types';
+import { DynamoDBService } from '../services/dynamoDbService';
 
 export class MissingServiceAccountKeyHeader extends Error {}
+export class MissingServiceAccountKeyFile extends Error {}
 export class InvalidServiceAccountKey extends Error {}
 
-export const serviceAccountKeyProvider: RequestHandler = (req, _res, next) => {
-  const serviceAccountKeyIdHeaderValue = req.header('X-Contentful-ServiceAccountKeyId');
-  if (!serviceAccountKeyIdHeaderValue || typeof serviceAccountKeyIdHeaderValue !== 'string') {
-    throw new MissingServiceAccountKeyHeader(
-      "missing or incorrectly formatted header 'X-Contentful-ServiceAccountKeyId'"
-    );
-  }
-  const serviceAccountKeyId = decodeServiceAccountHeader(serviceAccountKeyIdHeaderValue);
-  assertServiceAccountKeyId(serviceAccountKeyId);
-  req.serviceAccountKeyId = serviceAccountKeyId;
+export const serviceAccountKeyProvider: RequestHandler = async (req, _res, next) => {
+  try {
+    const serviceAccountKeyIdHeaderValue = req.header('X-Contentful-ServiceAccountKeyId');
+    if (!serviceAccountKeyIdHeaderValue || typeof serviceAccountKeyIdHeaderValue !== 'string') {
+      throw new MissingServiceAccountKeyHeader(
+        "missing or incorrectly formatted header 'X-Contentful-ServiceAccountKeyId'"
+      );
+    }
+    const serviceAccountKeyId = decodeServiceAccountHeader(serviceAccountKeyIdHeaderValue);
+    assertServiceAccountKeyId(serviceAccountKeyId);
+    req.serviceAccountKeyId = serviceAccountKeyId;
 
-  // Pulling the account key from the header will be removed later and replaced with fetching
-  // the code directly from secret storage!
-  const serviceAccountKeyHeaderValue = req.header('X-Contentful-ServiceAccountKey');
-  if (!serviceAccountKeyHeaderValue || typeof serviceAccountKeyHeaderValue !== 'string') {
-    throw new MissingServiceAccountKeyHeader(
-      "missing or incorrectly formatted header 'X-Contentful-ServiceAccountKey'"
-    );
-  }
-  const serviceAccountKey = decodeServiceAccountHeader(serviceAccountKeyHeaderValue);
-  assertServiceAccountKeyFile(serviceAccountKey);
-  req.serviceAccountKey = serviceAccountKey;
+    const spaceId = req.header('X-Contentful-Space-Id');
+    if (!spaceId) {
+      throw new Error('Missing X-Contentful-Space-Id header!');
+    }
 
-  next();
+    // fetch and decrypt serviceAccountKey from dynamoDB and add it to the request
+    const dynamoDB = new DynamoDBService();
+    const serviceAccountKey = await dynamoDB.getServiceAccountKeyFile(spaceId, serviceAccountKeyId);
+    if (serviceAccountKey !== null) {
+      assertServiceAccountKey(serviceAccountKey);
+      req.serviceAccountKey = serviceAccountKey;
+    }
+
+    next();
+  } catch (err) {
+    next(err);
+  }
 };
 
-const decodeServiceAccountHeader = (value: string) => {
+export const decodeServiceAccountHeader = (value: string) => {
   const asciiStr = Buffer.from(value, 'base64').toString('ascii');
   try {
     return JSON.parse(asciiStr);
@@ -39,7 +46,7 @@ const decodeServiceAccountHeader = (value: string) => {
   }
 };
 
-function assertServiceAccountKeyId(value: unknown): asserts value is ServiceAccountKeyId {
+export function assertServiceAccountKeyId(value: unknown): asserts value is ServiceAccountKeyId {
   const requiredFields = ['clientEmail', 'projectId', 'id'];
   for (const requiredField of requiredFields) {
     if (!value || typeof value !== 'object' || !(requiredField in value)) {
@@ -58,7 +65,7 @@ function assertServiceAccountKeyId(value: unknown): asserts value is ServiceAcco
 }
 
 // This function will be removed when we transition to using secret storage
-function assertServiceAccountKeyFile(value: unknown): asserts value is ServiceAccountKeyFile {
+export function assertServiceAccountKey(value: unknown): asserts value is ServiceAccountKeyFile {
   const requiredFields = ['client_email', 'project_id', 'private_key'];
   for (const requiredField of requiredFields) {
     if (!value || typeof value !== 'object' || !(requiredField in value)) {
@@ -76,7 +83,7 @@ function assertServiceAccountKeyFile(value: unknown): asserts value is ServiceAc
 
 declare module 'http' {
   interface IncomingMessage {
-    serviceAccountKey?: ServiceAccountKeyFile;
     serviceAccountKeyId?: ServiceAccountKeyId;
+    serviceAccountKey?: ServiceAccountKeyFile;
   }
 }

--- a/apps/google-analytics-4/lambda/src/middlewares/verifySignedRequests.ts
+++ b/apps/google-analytics-4/lambda/src/middlewares/verifySignedRequests.ts
@@ -42,14 +42,14 @@ const makeCanonicalReq = (req: Request) => {
   const fullPath = req.originalUrl.split('?')[0];
   const signedPath = `${pathPrefix}${fullPath}`; // note: req.originalUrl starts with a `/` and includes the full path & query string
 
-  console.log('makeCanonicalRequest#pathPrefix', pathPrefix);
-  console.log('makeCanonicalRequest#req.originalUrl', req.originalUrl);
-  console.log('makeCanonicalRequest#fullPath', fullPath);
-  console.log('makeCanonicalRequest#signedPath', signedPath);
+  // express.json() makes body always an object ({}), even if there is no body
+  // so we need to check if the body is empty and set it to undefined
+  const bodyOrUndefined = Object.keys(req.body).length === 0 ? undefined : JSON.stringify(req.body);
 
   return <CanonicalRequest>{
     method: req.method,
     path: signedPath,
     headers: headers,
+    body: bodyOrUndefined,
   };
 };

--- a/apps/google-analytics-4/lambda/src/routers/apiRouter.ts
+++ b/apps/google-analytics-4/lambda/src/routers/apiRouter.ts
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import { ApiController } from '../controllers';
 const app = Router();
 
-app.get('/credentials', ApiController.credentials);
+app.put('/service_account_key_file', ApiController.credentials);
 app.get('/account_summaries', ApiController.account_summaries);
 app.get('/run_report', ApiController.run_report);
 

--- a/apps/google-analytics-4/lambda/src/services/dynamoDbUtils.ts
+++ b/apps/google-analytics-4/lambda/src/services/dynamoDbUtils.ts
@@ -1,22 +1,17 @@
 import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto';
-import { config } from '../config';
 
-export async function encryptSharedCredentials(data: object): Promise<string> {
+export function encrypt(data: object, cipherKeyString: string): string {
   const iv = randomBytes(16);
-  const cipher = createCipheriv('aes-256-cbc', Buffer.from(config.sharedCredentialsSecretKey), iv);
+  const cipher = createCipheriv('aes-256-cbc', Buffer.from(cipherKeyString), iv);
   let encrypted = cipher.update(JSON.stringify(data), 'utf8', 'hex');
   encrypted += cipher.final('hex');
   return iv.toString('hex') + ':' + encrypted;
 }
 
-export async function decryptSharedCredentials(encrypted: string): Promise<object> {
+export function decrypt(encrypted: string, cipherKeyString: string): object {
   const [ivHex, encryptedHex] = encrypted.split(':');
   const iv = Buffer.from(ivHex, 'hex');
-  const decipher = createDecipheriv(
-    'aes-256-cbc',
-    Buffer.from(config.sharedCredentialsSecretKey),
-    iv
-  );
+  const decipher = createDecipheriv('aes-256-cbc', Buffer.from(cipherKeyString), iv);
   let decrypted = decipher.update(encryptedHex, 'hex', 'utf8');
   decrypted += decipher.final('utf8');
   return JSON.parse(decrypted);

--- a/apps/google-analytics-4/lambda/test/hooks.ts
+++ b/apps/google-analytics-4/lambda/test/hooks.ts
@@ -1,12 +1,15 @@
-// import sinon from 'sinon';
-//
+import { DynamoDBService } from '../src/services/dynamoDbService';
+import sinon from 'sinon';
+import { validServiceAccountKeyFile } from './mocks/googleApi';
 
 // uncomment these lines to suppress unwanted error output in testing
 export const mochaHooks = {
   beforeEach() {
-    // sinon.stub(console, 'error');
+    sinon
+      .stub(DynamoDBService.prototype, 'getServiceAccountKeyFile')
+      .resolves(validServiceAccountKeyFile);
   },
   afterEach() {
-    // sinon.restore();
+    sinon.restore();
   },
 };

--- a/apps/google-analytics-4/lambda/test/mocks/googleApi.ts
+++ b/apps/google-analytics-4/lambda/test/mocks/googleApi.ts
@@ -28,7 +28,6 @@ export const validServiceAccountKeyId: ServiceAccountKeyId = {
   projectId: validServiceAccountKeyFile.project_id,
 };
 
-export const validServiceAccountKeyFileBase64 = encodeObj(validServiceAccountKeyFile);
 export const validServiceAccountKeyIdBase64 = encodeObj(validServiceAccountKeyId);
 
 export const mockAccountSummary = {


### PR DESCRIPTION
onConfigurationUpdated callback (re: INTEG-228 & INTEG-229)

- adds error handling for MissingServiceAccountKeyFile
- defer updating IsInEditMode state until post installation callback processes are completed
- add state for isSavingPrivateKeyFile to handle post configurationUpdate callback operation

## Purpose
securely stores private google analytics service account key file

## Approach
store private key file in dynamoDB as encrypted hash

## Dependencies and/or References
<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment
<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
