### PR TITLE
docs: Update README.md

### DIFF
--- a/packages/dam-app-base/README.md
+++ b/packages/dam-app-base/README.md
@@ -51,7 +51,7 @@ setup({
 These Contentful apps use `@contentful/dam-app-base`. Look at their source code to learn how they utilize this library:
 
 - [Brandfolder](../../apps/brandfolder)
-- [Bynder](../../apps/brandfolder)
+- [Bynder](../../apps/bynder)
 - [Cloudinary](../../apps/cloudinary)
 - [Dropbox](../../apps/dropbox)
 - [Frontify](../../apps/frontify)


### PR DESCRIPTION
The Bynder entry was pointing to the Brandfolder directory.

## Purpose
Fix in the documentation

## Approach
Just replace the link

## Dependencies and/or References
None