### PR TITLE
fix: remove unneeded secrets in app-test build step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,8 +29,6 @@ jobs:
     steps:
       - checkout
       - node/install
-      - vault/get-secrets:
-          template-preset: 'aws-push-artifacts'
       - run:
           name: Check for prettier violations
           command: |


### PR DESCRIPTION
## Purpose

We're unnecessarily loading vault secrets during apps-testing, which are not needed there. As a result we can't take outside PRs to this repository (like this one #2896).

## Approach

* Remove it

## Dependencies and/or References
<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment
<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
