### PR TITLE
[INTEG-300] Update sidebar link to navigate to GA4 page

### DIFF
--- a/apps/google-analytics-4/frontend/src/components/main-app/AnalyticsApp/AnalyticsApp.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/AnalyticsApp/AnalyticsApp.tsx
@@ -97,6 +97,7 @@ const AnalyticsApp = (props: Props) => {
         reportSlug={reportSlug}
         pageViews={pageViews}
         error={error}
+        propertyId={propertyId}
       />
     );
   };

--- a/apps/google-analytics-4/frontend/src/components/main-app/AnalyticsMetricDisplays/AnalyticsMetricDisplay.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/AnalyticsMetricDisplays/AnalyticsMetricDisplay.spec.tsx
@@ -17,6 +17,7 @@ describe('Analytics metric display components for the analytics app', () => {
         metricName={METRIC_NAME}
         runReportResponse={runReportResponseHasViews}
         reportSlug="/en-US"
+        propertyId=""
       />
     );
 

--- a/apps/google-analytics-4/frontend/src/components/main-app/AnalyticsMetricDisplays/AnalyticsMetricDisplay.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/AnalyticsMetricDisplays/AnalyticsMetricDisplay.tsx
@@ -3,6 +3,7 @@ import ChartFooter from 'components/main-app/ChartFooter/ChartFooter';
 import ChartHeader from 'components/main-app/ChartHeader/ChartHeader';
 import ChartContent from '../ChartContent/ChartContent';
 import { RunReportResponse } from 'types';
+import { getExternalUrl } from 'helpers/externalUrlHelpers/externalUrlHelpers';
 
 interface Props {
   handleDateRangeChange: Function;
@@ -11,11 +12,23 @@ interface Props {
   pageViews: number;
   metricName: string;
   error?: Error;
+  propertyId: string;
 }
 
 const AnalyticsMetricDisplay = (props: Props) => {
-  const { handleDateRangeChange, runReportResponse, reportSlug, error, metricName, pageViews } =
-    props;
+  const {
+    handleDateRangeChange,
+    runReportResponse,
+    reportSlug,
+    error,
+    metricName,
+    pageViews,
+    propertyId,
+  } = props;
+
+  const propertyIdNumber = propertyId.split('/')[1] || '';
+  const viewUrl = getExternalUrl(propertyIdNumber, reportSlug);
+
   return (
     <>
       <ChartHeader
@@ -26,7 +39,7 @@ const AnalyticsMetricDisplay = (props: Props) => {
 
       <ChartContent error={error} pageViewData={runReportResponse} />
 
-      <ChartFooter slugName={reportSlug} viewUrl="https://analytics.google.com/" />
+      <ChartFooter slugName={reportSlug} viewUrl={viewUrl} />
     </>
   );
 };

--- a/apps/google-analytics-4/frontend/src/helpers/externalUrlHelpers/externalUrlHelpers.spec.ts
+++ b/apps/google-analytics-4/frontend/src/helpers/externalUrlHelpers/externalUrlHelpers.spec.ts
@@ -1,0 +1,17 @@
+import { getExternalUrl, encodeDataFiltersParameters } from './externalUrlHelpers';
+
+describe('externalUrlHelpers', () => {
+  it('generates the correct URL', () => {
+    const result = getExternalUrl('abc123', '/en-US/search');
+
+    expect(result).toEqual(
+      `https://analytics.google.com/analytics/web/#/pabc123/reports/explorer?params=_u..nav%3Dmaui%26_r.explorerCard..seldim%3D%5B%22unifiedPagePathScreen%22%5D%26_r..dataFilters%3D%5B%7B%22type%22:1,%22fieldName%22:%22unifiedPagePathScreen%22,%22evaluationType%22:1,%22expressionList%22:%5B%22%2Fen-US%2Fsearch%22%5D,%22complement%22:false,%22isCaseSensitive%22:true,%22expression%22:%22%22%7D%5D&r=all-pages-and-screens&ruid=all-pages-and-screens,life-cycle,engagement&collectionId=life-cycle`
+    );
+  });
+
+  it('encodes the correct characters', () => {
+    const result = encodeDataFiltersParameters('{}[]""=');
+
+    expect(result).toEqual('%7B%7D%5B%5D%22%22%3D');
+  });
+});

--- a/apps/google-analytics-4/frontend/src/helpers/externalUrlHelpers/externalUrlHelpers.ts
+++ b/apps/google-analytics-4/frontend/src/helpers/externalUrlHelpers/externalUrlHelpers.ts
@@ -1,0 +1,45 @@
+export const getExternalUrl = (propertyId: string, pagePath: string) => {
+  // Base Google Analytics URL
+  const BASE_URL = 'https://analytics.google.com/analytics/web/#';
+
+  if (propertyId && pagePath) {
+    const propertyIdSegment = `/p${propertyId}/reports/explorer?params=`;
+
+    const explorerCardParams = 'unifiedPagePathScreen';
+    const explorerCardSegment = encodeURIComponent(
+      `_u..nav=maui&_r.explorerCard..seldim=["${explorerCardParams}"]&`
+    );
+
+    const dataFiltersParams = {
+      type: 1,
+      fieldName: 'unifiedPagePathScreen',
+      evaluationType: 1,
+      expressionList: [`${encodeURIComponent(pagePath)}`],
+      complement: false,
+      isCaseSensitive: true,
+      expression: '',
+    };
+
+    // encodeURIComponent encodes too many characters for this part of the URL, so using custom encoding function
+    const dataFiltersSegment = `_r..dataFilters${encodeDataFiltersParameters(
+      `=[${JSON.stringify(dataFiltersParams)}]`
+    )}`;
+
+    const finalSegment = `&r=all-pages-and-screens&ruid=all-pages-and-screens,life-cycle,engagement&collectionId=life-cycle`;
+
+    return `${BASE_URL}${propertyIdSegment}${explorerCardSegment}${dataFiltersSegment}${finalSegment}`;
+  }
+
+  return BASE_URL;
+};
+
+export const encodeDataFiltersParameters = (str: string) => {
+  // Encodes these characters: {}[]"=
+  // Manually encodes specified characters by getting the unicode value, converting to hexadecimal string, then converting to uppercase
+  const encodedStr = str.replace(
+    /[{}[\]"=]/g,
+    (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`
+  );
+
+  return encodedStr;
+};


### PR DESCRIPTION
## Purpose
The 'Open in Google Analytics' link in the sidebar app should direct a user to Google Analytics where they can drill into the data for the specific page path.

## Approach
Google Analytics 4 doesn't have an easy way of seeing the data for a specific page path. Our solution is to direct the user to the 'Page and Screens' report section with a pre-populated filter based on the page path. Using the sharable link on this page as a guide, I reconstructed the URL with the proper parameters and encoding. Note that certain aspects of the URL are encoded differently, which is why I abstracted this as a helper function and in some cases, am using a custom encoder function.

This is an example of where the link will take you in Google Analytics
![Screenshot 2023-03-23 at 12 18 56 PM](https://user-images.githubusercontent.com/62958907/227324818-7562fd6a-9d0c-479b-bd48-958814b6c820.png)

