### PR TITLE
Integ 231 improve error handling within analytics app component

### DIFF
--- a/apps/google-analytics-4/frontend/src/components/common/HyperLink/HyperLink.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/common/HyperLink/HyperLink.spec.tsx
@@ -1,24 +1,24 @@
 import HyperLink from './HyperLink';
 import { render, screen } from '@testing-library/react';
 
-const body = 'Have a great day!';
-const substring = 'great';
+const BODY = 'Have a great day!';
+const SUBSTRING = 'great';
 
 const { getByTestId } = screen;
 
 describe('HyperLink component', () => {
   it('can render the TextLink component in place of substring value', () => {
-    render(<HyperLink body={body} substring={substring} />);
+    render(<HyperLink body={BODY} substring={SUBSTRING} />);
 
     const textLink = getByTestId('cf-ui-text-link');
 
     expect(textLink).toBeVisible();
-    expect(textLink.firstChild).toHaveTextContent(substring);
+    expect(textLink.firstChild).toHaveTextContent(SUBSTRING);
   });
 
   it('can handle onClick of link', () => {
     const mockOnClick = jest.fn();
-    render(<HyperLink body={body} substring={substring} onClick={mockOnClick} />);
+    render(<HyperLink body={BODY} substring={SUBSTRING} onClick={mockOnClick} />);
 
     const textLink = getByTestId('cf-ui-text-link');
     textLink.click();

--- a/apps/google-analytics-4/frontend/src/components/common/HyperLink/HyperLink.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/common/HyperLink/HyperLink.spec.tsx
@@ -1,0 +1,27 @@
+import HyperLink from './HyperLink';
+import { render, screen } from '@testing-library/react';
+
+const body = 'Have a great day!';
+const substring = 'great';
+
+const { getByTestId } = screen;
+
+describe('HyperLink component', () => {
+  it('can render the TextLink component in place of substring value', () => {
+    render(<HyperLink body={body} substring={substring} />);
+
+    const textLink = getByTestId('cf-ui-text-link');
+
+    expect(textLink).toBeVisible();
+    expect(textLink.firstChild).toHaveTextContent(substring);
+  });
+
+  it('can handle onClick of link', () => {
+    const mockOnClick = jest.fn();
+    render(<HyperLink body={body} substring={substring} onClick={mockOnClick} />);
+
+    const textLink = getByTestId('cf-ui-text-link');
+    textLink.click();
+    expect(mockOnClick).toHaveBeenCalled();
+  });
+});

--- a/apps/google-analytics-4/frontend/src/components/common/HyperLink/HyperLink.tsx
+++ b/apps/google-analytics-4/frontend/src/components/common/HyperLink/HyperLink.tsx
@@ -1,0 +1,32 @@
+import React, { MouseEventHandler } from 'react';
+import { TextLink } from '@contentful/f36-components';
+
+interface Props {
+  body: string;
+  substring: string;
+  onClick?: MouseEventHandler<HTMLAnchorElement>;
+  hyperLinkHref?: string;
+}
+
+const HyperLink = (props: Props) => {
+  const { body, substring, onClick = () => {}, hyperLinkHref } = props;
+  const link = (
+    <TextLink onClick={onClick} href={hyperLinkHref} target="_blank" rel="noopener noreferer">
+      {substring}
+    </TextLink>
+  );
+
+  const formatLink = () => {
+    const bodyWithTextLink = body.split(substring).reduce((prev: any, current, i) => {
+      if (!i) {
+        return [current];
+      }
+      return prev.concat(link, current);
+    }, []);
+    return bodyWithTextLink;
+  };
+
+  return formatLink();
+};
+
+export default HyperLink;

--- a/apps/google-analytics-4/frontend/src/components/common/HyperLink/HyperLink.tsx
+++ b/apps/google-analytics-4/frontend/src/components/common/HyperLink/HyperLink.tsx
@@ -23,7 +23,7 @@ const HyperLink = (props: Props) => {
       }
       return prev.concat(link, current);
     }, []);
-    return bodyWithTextLink;
+    return bodyWithTextLink as JSX.Element;
   };
 
   return formatLink();

--- a/apps/google-analytics-4/frontend/src/components/common/Note/Note.styles.ts
+++ b/apps/google-analytics-4/frontend/src/components/common/Note/Note.styles.ts
@@ -4,7 +4,6 @@ import tokens from '@contentful/f36-tokens';
 export const styles = {
   note: css({
     overflow: 'hidden',
-    marginBottom: tokens.spacingM,
     wordBreak: 'break-word',
   }),
   noteContent: css({

--- a/apps/google-analytics-4/frontend/src/components/common/Note/Note.styles.ts
+++ b/apps/google-analytics-4/frontend/src/components/common/Note/Note.styles.ts
@@ -1,5 +1,4 @@
 import { css } from 'emotion';
-import tokens from '@contentful/f36-tokens';
 
 export const styles = {
   note: css({

--- a/apps/google-analytics-4/frontend/src/components/common/Note/Note.styles.ts
+++ b/apps/google-analytics-4/frontend/src/components/common/Note/Note.styles.ts
@@ -4,6 +4,7 @@ export const styles = {
   note: css({
     overflow: 'hidden',
     wordBreak: 'break-word',
+    width: '100%',
   }),
   noteContent: css({
     textOverflow: 'ellipsis',

--- a/apps/google-analytics-4/frontend/src/components/common/Note/Note.styles.ts
+++ b/apps/google-analytics-4/frontend/src/components/common/Note/Note.styles.ts
@@ -5,6 +5,7 @@ export const styles = {
   note: css({
     overflow: 'hidden',
     marginBottom: tokens.spacingM,
+    wordBreak: 'break-word',
   }),
   noteContent: css({
     textOverflow: 'ellipsis',

--- a/apps/google-analytics-4/frontend/src/components/main-app/AnalyticsApp/AnalyticsApp.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/AnalyticsApp/AnalyticsApp.spec.tsx
@@ -4,7 +4,10 @@ import { Api } from 'apis/api';
 import { mockSdk, mockCma, validServiceKeyId } from '../../../../test/mocks';
 import runReportResponseHasViews from '../../../../../lambda/public/sampleData/runReportResponseHasViews.json';
 import runReportResponseNoView from '../../../../../lambda/public/sampleData/runReportResponseNoViews.json';
-import { getContentTypeSpecificMsg } from '../constants/noteMessages';
+import {
+  EMPTY_DATA_MSG,
+  getContentTypeSpecificMsg,
+} from 'components/main-app/constants/noteMessages';
 import * as useSidebarSlug from 'hooks/useSidebarSlug/useSidebarSlug';
 
 jest.mock('@contentful/react-apps-toolkit', () => ({
@@ -65,7 +68,7 @@ describe('AnalyticsApp with correct content types configured', () => {
 
     const dropdown = await findByTestId(SELECT_TEST_ID);
     const warningNote = getByTestId(NOTE_TEST_ID);
-    const noteText = getByText('There are no page views to show for this range.');
+    const noteText = getByText(EMPTY_DATA_MSG);
 
     expect(dropdown).toBeVisible();
     expect(warningNote).toBeVisible();
@@ -105,11 +108,14 @@ describe('AnalyticsApp when content types are not configured correctly', () => {
       isContentTypeWarning: true,
     }));
     mockApi.mockImplementation(() => runReportResponseHasViews);
+    const warningMessage = getContentTypeSpecificMsg('Category')
+      .noSlugContentMsg.replace('app configuration page.', '')
+      .trim();
     renderAnalyticsApp();
 
     const dropdown = queryByTestId(SELECT_TEST_ID);
     const warningNote = await findByTestId(NOTE_TEST_ID);
-    const noteText = getByText(getContentTypeSpecificMsg('Category', true).noSlugContentMsg.trim());
+    const noteText = getByText(warningMessage);
 
     expect(dropdown).toBeFalsy();
     expect(warningNote).toBeVisible();

--- a/apps/google-analytics-4/frontend/src/components/main-app/AnalyticsApp/AnalyticsApp.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/AnalyticsApp/AnalyticsApp.tsx
@@ -45,6 +45,7 @@ const AnalyticsApp = (props: Props) => {
       try {
         const reportData = await api.runReports(reportRequestParams);
         setRunReportResponse(reportData);
+        setError(undefined);
       } catch (e) {
         setError(e as Error);
       }

--- a/apps/google-analytics-4/frontend/src/components/main-app/AnalyticsApp/AnalyticsApp.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/AnalyticsApp/AnalyticsApp.tsx
@@ -46,6 +46,7 @@ const AnalyticsApp = (props: Props) => {
         const reportData = await api.runReports(reportRequestParams);
         setRunReportResponse(reportData);
       } catch (e) {
+        console.error(e);
         setError(e as Error);
       }
 

--- a/apps/google-analytics-4/frontend/src/components/main-app/AnalyticsApp/AnalyticsApp.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/AnalyticsApp/AnalyticsApp.tsx
@@ -46,7 +46,6 @@ const AnalyticsApp = (props: Props) => {
         const reportData = await api.runReports(reportRequestParams);
         setRunReportResponse(reportData);
       } catch (e) {
-        console.error(e);
         setError(e as Error);
       }
 

--- a/apps/google-analytics-4/frontend/src/components/main-app/ChartContent/ChartContent.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/ChartContent/ChartContent.spec.tsx
@@ -1,8 +1,13 @@
 import ChartContent from './ChartContent';
 import { render, screen } from '@testing-library/react';
+import { mockSdk } from '../../../../test/mocks';
 import runReportResponseHasViews from '../../../../../lambda/public/sampleData/runReportResponseHasViews.json';
 import runReportResponseNoView from '../../../../../lambda/public/sampleData/runReportResponseNoViews.json';
 import { EMPTY_DATA_MSG } from '../constants/noteMessages';
+
+jest.mock('@contentful/react-apps-toolkit', () => ({
+  useSDK: () => mockSdk,
+}));
 
 const { getByText } = screen;
 

--- a/apps/google-analytics-4/frontend/src/components/main-app/ChartContent/ChartContent.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/ChartContent/ChartContent.tsx
@@ -2,7 +2,8 @@ import { Row, RunReportResponse } from 'types';
 import Note from 'components/common/Note/Note';
 import LineChart from 'components/main-app/LineChart/LineChart';
 import { parseDayAndMonth } from 'helpers/DateHelpers/DateHelpers';
-import { DEFAULT_ERR_MSG, EMPTY_DATA_MSG } from '../constants/noteMessages';
+import ErrorDisplay from 'components/main-app/ErrorDisplay/ErrorDisplay';
+import { EMPTY_DATA_MSG } from '../constants/noteMessages';
 import { styles } from './ChartContent.styles';
 
 interface Props {
@@ -27,7 +28,7 @@ const ChartContent = (props: Props) => {
 
   const renderChartContent = () => {
     if (error) {
-      return <Note body={error?.message || DEFAULT_ERR_MSG} variant="negative" />;
+      return <ErrorDisplay error={error} />;
     }
 
     if (!pageViewData.rowCount) {

--- a/apps/google-analytics-4/frontend/src/components/main-app/ChartHeader/ChartHeader.styles.ts
+++ b/apps/google-analytics-4/frontend/src/components/main-app/ChartHeader/ChartHeader.styles.ts
@@ -1,0 +1,9 @@
+import { css } from 'emotion';
+import tokens from '@contentful/f36-tokens';
+
+export const styles = {
+  root: css({
+    marginTop: tokens.spacing2Xs,
+    marginRight: tokens.spacing2Xs,
+  }),
+};

--- a/apps/google-analytics-4/frontend/src/components/main-app/ChartHeader/ChartHeader.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/ChartHeader/ChartHeader.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Box, DisplayText, Flex, Paragraph, Select } from '@contentful/f36-components';
 import { DateRangeType } from 'types';
+import { styles } from './ChartHeader.styles';
 
 interface Props {
   metricName: string;
@@ -39,7 +40,12 @@ const ChartHeader = (props: Props) => {
         </DisplayText>
         <Paragraph marginBottom="none">{getMetricDisplayString(metricName)}</Paragraph>
       </Box>
-      <Select id="daterange" name="daterange" value={dateSelection} onChange={handleOnChange}>
+      <Select
+        className={styles.root}
+        id="daterange"
+        name="daterange"
+        value={dateSelection}
+        onChange={handleOnChange}>
         <Select.Option value="lastDay">Last 24 hours</Select.Option>
         <Select.Option value="lastWeek">Last 7 days</Select.Option>
         <Select.Option value="lastMonth">Last 28 days</Select.Option>

--- a/apps/google-analytics-4/frontend/src/components/main-app/ErrorDisplay/CommonErrorDisplays.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/ErrorDisplay/CommonErrorDisplays.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { useSDK } from '@contentful/react-apps-toolkit';
+import { SidebarExtensionSDK } from '@contentful/app-sdk';
+import { DEFAULT_ERR_MSG } from 'components/main-app/constants/noteMessages';
+import HyperLink from 'components/common/HyperLink/HyperLink';
+
+interface AppConfigPageHyperLinkProps {
+  bodyMsg: string;
+}
+
+export const AppConfigPageHyperLink = (props: AppConfigPageHyperLinkProps) => {
+  const { bodyMsg } = props;
+  const sdk = useSDK<SidebarExtensionSDK>();
+  const openConfigPage = () => sdk.navigator.openAppConfig();
+  return <HyperLink body={bodyMsg} substring="app configuration page." onClick={openConfigPage} />;
+};
+
+export const SupportHyperLink = () => (
+  <HyperLink
+    body={DEFAULT_ERR_MSG}
+    substring="contact support."
+    hyperLinkHref="https://www.contentful.com/support/?utm_source=webapp&utm_medium=help-menu&utm_campaign=in-app-help"
+  />
+);

--- a/apps/google-analytics-4/frontend/src/components/main-app/ErrorDisplay/ErrorDisplay.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/ErrorDisplay/ErrorDisplay.spec.tsx
@@ -1,7 +1,12 @@
 import ErrorDisplay from './ErrorDisplay';
 import { render, screen } from '@testing-library/react';
 import { mockSdk } from '../../../../test/mocks';
-import { INVALID_ARGUMENT_MSG, PERMISSION_DENIED_MSG } from '../constants/noteMessages';
+import {
+  DEFAULT_ERR_MSG,
+  INVALID_ARGUMENT_MSG,
+  INVALID_SERVICE_ACCOUNT,
+  PERMISSION_DENIED_MSG,
+} from '../constants/noteMessages';
 import { ApiError } from 'apis/api';
 
 jest.mock('@contentful/react-apps-toolkit', () => ({
@@ -50,6 +55,52 @@ describe('ErrorDisplay', () => {
     const warningMsg = await findByText(PERMISSION_DENIED_MSG);
 
     expect(warningMsg).toBeVisible();
+  });
+
+  it('mounts with correct msg when error is of type FailedFetch', async () => {
+    const HYPER_LINK_COPY = 'contact support.';
+    render(
+      <ErrorDisplay
+        error={
+          new ApiError({
+            details: '',
+            message: '',
+            status: 404,
+            errorType: 'FailedFetch',
+          })
+        }
+      />
+    );
+
+    const warningMsg = await findByText(DEFAULT_ERR_MSG.replace(HYPER_LINK_COPY, '').trim());
+    const hyperLink = getByTestId('cf-ui-text-link');
+
+    expect(warningMsg).toBeVisible();
+    expect(hyperLink).toBeVisible();
+  });
+
+  it('mounts with correct msg when error is of type InvalidServiceAccount', async () => {
+    const HYPER_LINK_COPY = 'app configuration page.';
+    render(
+      <ErrorDisplay
+        error={
+          new ApiError({
+            details: '',
+            message: '',
+            status: 404,
+            errorType: 'InvalidServiceAccount',
+          })
+        }
+      />
+    );
+
+    const warningMsg = await findByText(
+      INVALID_SERVICE_ACCOUNT.replace(HYPER_LINK_COPY, '').trim()
+    );
+    const hyperLink = getByTestId('cf-ui-text-link');
+
+    expect(warningMsg).toBeVisible();
+    expect(hyperLink).toBeVisible();
   });
 
   it('mounts with correct msg when error is of ApiError class but not an Error type explicitely handled', async () => {

--- a/apps/google-analytics-4/frontend/src/components/main-app/ErrorDisplay/ErrorDisplay.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/ErrorDisplay/ErrorDisplay.spec.tsx
@@ -8,18 +8,17 @@ jest.mock('@contentful/react-apps-toolkit', () => ({
   useSDK: () => mockSdk,
 }));
 
-const HYPER_LINK_MSG = 'app configuration page.';
-
 const { findByText, getByTestId } = screen;
 
 describe('ErrorDisplay', () => {
   it('mounts with correct msg and hyperlink when error is of type InvalidProperty', async () => {
+    const HYPER_LINK_COPY = 'app configuration page.';
     render(
       <ErrorDisplay
         error={
           new ApiError({
             details: '',
-            message: 'api Error',
+            message: '',
             status: 404,
             errorType: 'InvalidProperty',
           })
@@ -27,7 +26,7 @@ describe('ErrorDisplay', () => {
       />
     );
 
-    const warningMsg = await findByText(INVALID_ARGUMENT_MSG.replace(HYPER_LINK_MSG, '').trim());
+    const warningMsg = await findByText(INVALID_ARGUMENT_MSG.replace(HYPER_LINK_COPY, '').trim());
     const hyperLink = getByTestId('cf-ui-text-link');
 
     expect(warningMsg).toBeVisible();
@@ -40,7 +39,7 @@ describe('ErrorDisplay', () => {
         error={
           new ApiError({
             details: '',
-            message: 'api Error',
+            message: '',
             status: 404,
             errorType: 'DisabledDataApi',
           })
@@ -53,10 +52,31 @@ describe('ErrorDisplay', () => {
     expect(warningMsg).toBeVisible();
   });
 
-  it('mounts with correct msg when error is not a specified Api Error Type ', async () => {
-    render(<ErrorDisplay error={new Error('random error')} />);
+  it('mounts with correct msg when error is of ApiError class but not an Error type explicitely handled', async () => {
+    const INTERNAL_ERR_MSG = 'Internal Server Error';
+    render(
+      <ErrorDisplay
+        error={
+          new ApiError({
+            details: '',
+            message: INTERNAL_ERR_MSG,
+            status: 500,
+            errorType: '',
+          })
+        }
+      />
+    );
 
-    const warningMsg = await findByText('random error');
+    const warningMsg = await findByText(INTERNAL_ERR_MSG);
+
+    expect(warningMsg).toBeVisible();
+  });
+
+  it('mounts with correct msg when error is not a specified Api Error Type ', async () => {
+    const ERR_MSG = 'random error';
+    render(<ErrorDisplay error={new Error(ERR_MSG)} />);
+
+    const warningMsg = await findByText(ERR_MSG);
 
     expect(warningMsg).toBeVisible();
   });

--- a/apps/google-analytics-4/frontend/src/components/main-app/ErrorDisplay/ErrorDisplay.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/ErrorDisplay/ErrorDisplay.spec.tsx
@@ -1,0 +1,63 @@
+import ErrorDisplay from './ErrorDisplay';
+import { render, screen } from '@testing-library/react';
+import { mockSdk } from '../../../../test/mocks';
+import { INVALID_ARGUMENT_MSG, PERMISSION_DENIED_MSG } from '../constants/noteMessages';
+import { ApiError } from 'apis/api';
+
+jest.mock('@contentful/react-apps-toolkit', () => ({
+  useSDK: () => mockSdk,
+}));
+
+const HYPER_LINK_MSG = 'app configuration page.';
+
+const { findByText, getByTestId } = screen;
+
+describe('ErrorDisplay', () => {
+  it('mounts with correct msg and hyperlink when error is of type InvalidProperty', async () => {
+    render(
+      <ErrorDisplay
+        error={
+          new ApiError({
+            details: '',
+            message: 'api Error',
+            status: 404,
+            errorType: 'InvalidProperty',
+          })
+        }
+      />
+    );
+
+    const warningMsg = await findByText(INVALID_ARGUMENT_MSG.replace(HYPER_LINK_MSG, '').trim());
+    const hyperLink = getByTestId('cf-ui-text-link');
+
+    expect(warningMsg).toBeVisible();
+    expect(hyperLink).toBeVisible();
+  });
+
+  it('mounts with correct msg when error is of type DisabledDataApi', async () => {
+    render(
+      <ErrorDisplay
+        error={
+          new ApiError({
+            details: '',
+            message: 'api Error',
+            status: 404,
+            errorType: 'DisabledDataApi',
+          })
+        }
+      />
+    );
+
+    const warningMsg = await findByText(PERMISSION_DENIED_MSG);
+
+    expect(warningMsg).toBeVisible();
+  });
+
+  it('mounts with correct msg when error is not a specified Api Error Type ', async () => {
+    render(<ErrorDisplay error={new Error('random error')} />);
+
+    const warningMsg = await findByText('random error');
+
+    expect(warningMsg).toBeVisible();
+  });
+});

--- a/apps/google-analytics-4/frontend/src/components/main-app/ErrorDisplay/ErrorDisplay.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/ErrorDisplay/ErrorDisplay.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { useSDK } from '@contentful/react-apps-toolkit';
 import { SidebarExtensionSDK } from '@contentful/app-sdk';
 import Note from 'components/common/Note/Note';
@@ -17,34 +17,49 @@ interface Props {
 const ErrorDisplay = (props: Props) => {
   const { error } = props;
   const [errorDisplay, setErrorDisplay] = useState<string | JSX.Element>('');
+
   const sdk = useSDK<SidebarExtensionSDK>();
+  const appConfigPageHyperLink = useMemo(() => {
+    const openConfigPage = () => sdk.navigator.openAppConfig();
+    return (
+      <HyperLink
+        body={INVALID_ARGUMENT_MSG}
+        substring="app configuration page."
+        onClick={openConfigPage}
+      />
+    );
+  }, [sdk.navigator]);
+
+  const supportHyperLink = useMemo(
+    () => (
+      <HyperLink
+        body={DEFAULT_ERR_MSG}
+        substring="contact support."
+        hyperLinkHref="https://www.contentful.com/support/?utm_source=webapp&utm_medium=help-menu&utm_campaign=in-app-help"
+      />
+    ),
+    []
+  );
 
   useEffect(() => {
-    const openConfigPage = () => sdk.navigator.openAppConfig();
     const handleApiError = (e: ApiErrorType) => {
       switch (e.errorType) {
         case ERROR_TYPE_MAP.invalidProperty:
-          setErrorDisplay(
-            <HyperLink
-              body={INVALID_ARGUMENT_MSG}
-              substring="app configuration page."
-              onClick={openConfigPage}
-            />
-          );
+          setErrorDisplay(appConfigPageHyperLink);
           break;
         case ERROR_TYPE_MAP.disabledDataApi:
           setErrorDisplay(PERMISSION_DENIED_MSG);
           break;
         default:
-          setErrorDisplay(e.message);
+          setErrorDisplay(e.message || supportHyperLink);
       }
     };
 
     if (isApiErrorType(error)) handleApiError(error);
     else {
-      setErrorDisplay(error.message || DEFAULT_ERR_MSG);
+      setErrorDisplay(error.message || supportHyperLink);
     }
-  }, [error, sdk.navigator]);
+  }, [error, sdk.navigator, supportHyperLink, appConfigPageHyperLink]);
 
   return <Note body={errorDisplay} variant="negative" />;
 };

--- a/apps/google-analytics-4/frontend/src/components/main-app/ErrorDisplay/ErrorDisplay.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/ErrorDisplay/ErrorDisplay.tsx
@@ -16,7 +16,7 @@ interface Props {
 
 const ErrorDisplay = (props: Props) => {
   const { error } = props;
-  const [errorMessage, setErrorMessage] = useState<string | JSX.Element>('');
+  const [errorDisplay, setErrorDisplay] = useState<string | JSX.Element>('');
   const sdk = useSDK<SidebarExtensionSDK>();
 
   useEffect(() => {
@@ -24,7 +24,7 @@ const ErrorDisplay = (props: Props) => {
     const handleApiError = (e: ApiErrorType) => {
       switch (e.errorType) {
         case ERROR_TYPE_MAP.invalidProperty:
-          setErrorMessage(
+          setErrorDisplay(
             <HyperLink
               body={INVALID_ARGUMENT_MSG}
               substring="app configuration page."
@@ -33,7 +33,7 @@ const ErrorDisplay = (props: Props) => {
           );
           break;
         case ERROR_TYPE_MAP.disabledDataApi:
-          setErrorMessage(PERMISSION_DENIED_MSG);
+          setErrorDisplay(PERMISSION_DENIED_MSG);
           break;
         default:
           throw e;
@@ -42,11 +42,11 @@ const ErrorDisplay = (props: Props) => {
 
     if (isApiErrorType(error)) handleApiError(error);
     else {
-      setErrorMessage(error.message || DEFAULT_ERR_MSG);
+      setErrorDisplay(error.message || DEFAULT_ERR_MSG);
     }
   }, [error, sdk.navigator]);
 
-  return <Note body={errorMessage} variant="negative" />;
+  return <Note body={errorDisplay} variant="negative" />;
 };
 
 export default ErrorDisplay;

--- a/apps/google-analytics-4/frontend/src/components/main-app/ErrorDisplay/ErrorDisplay.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/ErrorDisplay/ErrorDisplay.tsx
@@ -44,7 +44,7 @@ const ErrorDisplay = (props: Props) => {
     else {
       setErrorMessage(error.message || DEFAULT_ERR_MSG);
     }
-  }, [error]);
+  }, [error, sdk.navigator]);
 
   return <Note body={errorMessage} variant="negative" />;
 };

--- a/apps/google-analytics-4/frontend/src/components/main-app/ErrorDisplay/ErrorDisplay.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/ErrorDisplay/ErrorDisplay.tsx
@@ -21,31 +21,31 @@ const ErrorDisplay = (props: Props) => {
 
   const openConfigPage = () => sdk.navigator.openAppConfig();
 
-  const handleApiError = (e: ApiErrorType) => {
-    switch (e.errorType) {
-      case ERROR_TYPE_MAP.invalidProperty:
-        setErrorMessage(
-          <HyperLink
-            body={INVALID_ARGUMENT_MSG}
-            substring="app configuration page."
-            onClick={openConfigPage}
-          />
-        );
-        break;
-      case ERROR_TYPE_MAP.disabledDataApi:
-        setErrorMessage(PERMISSION_DENIED_MSG);
-        break;
-      default:
-        throw e;
-    }
-  };
-
   useEffect(() => {
+    const handleApiError = (e: ApiErrorType) => {
+      switch (e.errorType) {
+        case ERROR_TYPE_MAP.invalidProperty:
+          setErrorMessage(
+            <HyperLink
+              body={INVALID_ARGUMENT_MSG}
+              substring="app configuration page."
+              onClick={openConfigPage}
+            />
+          );
+          break;
+        case ERROR_TYPE_MAP.disabledDataApi:
+          setErrorMessage(PERMISSION_DENIED_MSG);
+          break;
+        default:
+          throw e;
+      }
+    };
+
     if (isApiErrorType(error)) handleApiError(error);
     else {
       setErrorMessage(error.message || DEFAULT_ERR_MSG);
     }
-  }, [error, handleApiError]);
+  }, [error]);
 
   return <Note body={errorMessage} variant="negative" />;
 };

--- a/apps/google-analytics-4/frontend/src/components/main-app/ErrorDisplay/ErrorDisplay.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/ErrorDisplay/ErrorDisplay.tsx
@@ -1,0 +1,53 @@
+import React, { useState, useEffect } from 'react';
+import { useSDK } from '@contentful/react-apps-toolkit';
+import { SidebarExtensionSDK } from '@contentful/app-sdk';
+import Note from 'components/common/Note/Note';
+import { ApiErrorType, ERROR_TYPE_MAP, isApiErrorType } from 'apis/apiTypes';
+import {
+  DEFAULT_ERR_MSG,
+  INVALID_ARGUMENT_MSG,
+  PERMISSION_DENIED_MSG,
+} from '../constants/noteMessages';
+import HyperLink from 'components/common/HyperLink/HyperLink';
+
+interface Props {
+  error: Error;
+}
+
+const ErrorDisplay = (props: Props) => {
+  const { error } = props;
+  const [errorMessage, setErrorMessage] = useState<string | JSX.Element>('');
+  const sdk = useSDK<SidebarExtensionSDK>();
+
+  const openConfigPage = () => sdk.navigator.openAppConfig();
+
+  const handleApiError = (e: ApiErrorType) => {
+    switch (e.errorType) {
+      case ERROR_TYPE_MAP.invalidProperty:
+        setErrorMessage(
+          <HyperLink
+            body={INVALID_ARGUMENT_MSG}
+            substring="app configuration page."
+            onClick={openConfigPage}
+          />
+        );
+        break;
+      case ERROR_TYPE_MAP.disabledDataApi:
+        setErrorMessage(PERMISSION_DENIED_MSG);
+        break;
+      default:
+        throw e;
+    }
+  };
+
+  useEffect(() => {
+    if (isApiErrorType(error)) handleApiError(error);
+    else {
+      setErrorMessage(error.message || DEFAULT_ERR_MSG);
+    }
+  }, [error]);
+
+  return <Note body={errorMessage} variant="negative" />;
+};
+
+export default ErrorDisplay;

--- a/apps/google-analytics-4/frontend/src/components/main-app/ErrorDisplay/ErrorDisplay.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/ErrorDisplay/ErrorDisplay.tsx
@@ -36,7 +36,7 @@ const ErrorDisplay = (props: Props) => {
           setErrorDisplay(PERMISSION_DENIED_MSG);
           break;
         default:
-          throw e;
+          setErrorDisplay(e.message);
       }
     };
 

--- a/apps/google-analytics-4/frontend/src/components/main-app/ErrorDisplay/ErrorDisplay.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/ErrorDisplay/ErrorDisplay.tsx
@@ -4,6 +4,7 @@ import { ApiErrorType, ERROR_TYPE_MAP, isApiErrorType } from 'apis/apiTypes';
 import {
   INVALID_ARGUMENT_MSG,
   PERMISSION_DENIED_MSG,
+  INVALID_SERVICE_ACCOUNT,
 } from 'components/main-app/constants/noteMessages';
 import { AppConfigPageHyperLink, SupportHyperLink } from './CommonErrorDisplays';
 
@@ -11,7 +12,10 @@ interface Props {
   error: Error;
 }
 
-type HyperLinkErrorDisplays = 'supportHyperLink' | 'appConfigPageHyperLink';
+type HyperLinkErrorDisplays =
+  | 'supportHyperLink'
+  | 'appConfigPageHyperLink'
+  | 'invalidServiceAccount';
 
 const ErrorDisplay = (props: Props) => {
   const { error } = props;
@@ -20,6 +24,7 @@ const ErrorDisplay = (props: Props) => {
   const hyperLinkErrorDisplays = {
     supportHyperLink: <SupportHyperLink />,
     appConfigPageHyperLink: <AppConfigPageHyperLink bodyMsg={INVALID_ARGUMENT_MSG} />,
+    invalidServiceAccount: <AppConfigPageHyperLink bodyMsg={INVALID_SERVICE_ACCOUNT} />,
   };
 
   useEffect(() => {
@@ -30,6 +35,12 @@ const ErrorDisplay = (props: Props) => {
           break;
         case ERROR_TYPE_MAP.disabledDataApi:
           setErrorBody(PERMISSION_DENIED_MSG);
+          break;
+        case ERROR_TYPE_MAP.failedFetch:
+          setErrorBody('supportHyperLink');
+          break;
+        case ERROR_TYPE_MAP.invalidServiceAccount:
+          setErrorBody('invalidServiceAccount');
           break;
         default:
           setErrorBody(e.message || 'supportHyperLink');

--- a/apps/google-analytics-4/frontend/src/components/main-app/ErrorDisplay/ErrorDisplay.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/ErrorDisplay/ErrorDisplay.tsx
@@ -45,7 +45,7 @@ const ErrorDisplay = (props: Props) => {
     else {
       setErrorMessage(error.message || DEFAULT_ERR_MSG);
     }
-  }, [error]);
+  }, [error, handleApiError]);
 
   return <Note body={errorMessage} variant="negative" />;
 };

--- a/apps/google-analytics-4/frontend/src/components/main-app/ErrorDisplay/ErrorDisplay.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/ErrorDisplay/ErrorDisplay.tsx
@@ -19,9 +19,8 @@ const ErrorDisplay = (props: Props) => {
   const [errorMessage, setErrorMessage] = useState<string | JSX.Element>('');
   const sdk = useSDK<SidebarExtensionSDK>();
 
-  const openConfigPage = () => sdk.navigator.openAppConfig();
-
   useEffect(() => {
+    const openConfigPage = () => sdk.navigator.openAppConfig();
     const handleApiError = (e: ApiErrorType) => {
       switch (e.errorType) {
         case ERROR_TYPE_MAP.invalidProperty:

--- a/apps/google-analytics-4/frontend/src/components/main-app/SlugWarningDisplay/SlugWarningDisplay.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/SlugWarningDisplay/SlugWarningDisplay.spec.tsx
@@ -16,7 +16,7 @@ const useSidebarSlugMock = {
 
 const HYPER_LINK_MSG = 'app configuration page.';
 
-const { findByText, getByText, queryByText, getByTestId } = screen;
+const { findByText, queryByText, getByTestId } = screen;
 
 const { noSlugConfigMsg, noSlugContentMsg, notPublishedMsg } =
   getContentTypeSpecificMsg('Category');

--- a/apps/google-analytics-4/frontend/src/components/main-app/SlugWarningDisplay/SlugWarningDisplay.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/SlugWarningDisplay/SlugWarningDisplay.spec.tsx
@@ -16,12 +16,10 @@ const useSidebarSlugMock = {
 
 const HYPER_LINK_MSG = 'app configuration page.';
 
-const { findByText, getByText, queryByText } = screen;
+const { findByText, getByText, queryByText, getByTestId } = screen;
 
-const { noSlugConfigMsg, noSlugContentMsg, notPublishedMsg } = getContentTypeSpecificMsg(
-  'Category',
-  true
-);
+const { noSlugConfigMsg, noSlugContentMsg, notPublishedMsg } =
+  getContentTypeSpecificMsg('Category');
 
 describe('SlugWarningDisplay for the analytics app', () => {
   it('mounts with correct msg and hyperlink when error is missing content type config', async () => {
@@ -34,11 +32,11 @@ describe('SlugWarningDisplay for the analytics app', () => {
 
     render(<SlugWarningDisplay slugFieldInfo={{ slugField: '', urlPrefix: '' }} />);
 
-    const warningMsg = await findByText(noSlugConfigMsg.trim());
-    const hyperLinkMsg = getByText(HYPER_LINK_MSG);
+    const warningMsg = await findByText(noSlugConfigMsg.replace(HYPER_LINK_MSG, '').trim());
+    const hyperLink = getByTestId('cf-ui-text-link');
 
     expect(warningMsg).toBeVisible();
-    expect(hyperLinkMsg).toBeVisible();
+    expect(hyperLink).toBeVisible();
   });
 
   it('mounts with correct msg and hyperlink when error is missing slug field', async () => {
@@ -51,11 +49,11 @@ describe('SlugWarningDisplay for the analytics app', () => {
 
     render(<SlugWarningDisplay slugFieldInfo={{ slugField: 'slug', urlPrefix: '' }} />);
 
-    const warningMsg = await findByText(noSlugContentMsg.trim());
-    const hyperLinkMsg = getByText(HYPER_LINK_MSG);
+    const warningMsg = await findByText(noSlugContentMsg.replace(HYPER_LINK_MSG, '').trim());
+    const hyperLink = getByTestId('cf-ui-text-link');
 
     expect(warningMsg).toBeVisible();
-    expect(hyperLinkMsg).toBeVisible();
+    expect(hyperLink).toBeVisible();
   });
 
   it('mounts with correct msg and no hyperlink, when error is unpublished content', async () => {

--- a/apps/google-analytics-4/frontend/src/components/main-app/SlugWarningDisplay/SlugWarningDisplay.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/SlugWarningDisplay/SlugWarningDisplay.spec.tsx
@@ -1,7 +1,7 @@
 import SlugWarningDisplay from './SlugWarningDisplay';
 import { render, screen } from '@testing-library/react';
 import { mockSdk } from '../../../../test/mocks';
-import { getContentTypeSpecificMsg } from '../constants/noteMessages';
+import { getContentTypeSpecificMsg, DEFAULT_ERR_MSG } from '../constants/noteMessages';
 import * as useSidebarSlug from 'hooks/useSidebarSlug/useSidebarSlug';
 
 jest.mock('@contentful/react-apps-toolkit', () => ({
@@ -14,7 +14,7 @@ const useSidebarSlugMock = {
   isContentTypeWarning: true,
 };
 
-const HYPER_LINK_MSG = 'app configuration page.';
+const APP_CONFIG_HYPER_LINK_MSG = 'app configuration page.';
 
 const { findByText, queryByText, getByTestId } = screen;
 
@@ -32,7 +32,9 @@ describe('SlugWarningDisplay for the analytics app', () => {
 
     render(<SlugWarningDisplay slugFieldInfo={{ slugField: '', urlPrefix: '' }} />);
 
-    const warningMsg = await findByText(noSlugConfigMsg.replace(HYPER_LINK_MSG, '').trim());
+    const warningMsg = await findByText(
+      noSlugConfigMsg.replace(APP_CONFIG_HYPER_LINK_MSG, '').trim()
+    );
     const hyperLink = getByTestId('cf-ui-text-link');
 
     expect(warningMsg).toBeVisible();
@@ -49,7 +51,9 @@ describe('SlugWarningDisplay for the analytics app', () => {
 
     render(<SlugWarningDisplay slugFieldInfo={{ slugField: 'slug', urlPrefix: '' }} />);
 
-    const warningMsg = await findByText(noSlugContentMsg.replace(HYPER_LINK_MSG, '').trim());
+    const warningMsg = await findByText(
+      noSlugContentMsg.replace(APP_CONFIG_HYPER_LINK_MSG, '').trim()
+    );
     const hyperLink = getByTestId('cf-ui-text-link');
 
     expect(warningMsg).toBeVisible();
@@ -67,9 +71,27 @@ describe('SlugWarningDisplay for the analytics app', () => {
     render(<SlugWarningDisplay slugFieldInfo={{ slugField: 'slug', urlPrefix: '' }} />);
 
     const warningMsg = await findByText(notPublishedMsg);
-    const hyperLinkMsg = queryByText(HYPER_LINK_MSG);
+    const hyperLinkMsg = queryByText(APP_CONFIG_HYPER_LINK_MSG);
 
     expect(warningMsg).toBeVisible();
     expect(hyperLinkMsg).toBeFalsy();
+  });
+
+  it('mounts with correct msg and hyperlink as default message', async () => {
+    const SUPPORT_LINK_MSG = 'contact support.';
+    jest.spyOn(useSidebarSlug, 'useSidebarSlug').mockImplementation(() => ({
+      slugFieldIsConfigured: true,
+      contentTypeHasSlugField: true,
+      isPublished: true,
+      ...useSidebarSlugMock,
+    }));
+
+    render(<SlugWarningDisplay slugFieldInfo={{ slugField: 'slug', urlPrefix: '' }} />);
+
+    const warningMsg = await findByText(DEFAULT_ERR_MSG.replace(SUPPORT_LINK_MSG, '').trim());
+    const hyperLink = getByTestId('cf-ui-text-link');
+
+    expect(warningMsg).toBeVisible();
+    expect(hyperLink).toBeVisible();
   });
 });

--- a/apps/google-analytics-4/frontend/src/components/main-app/SlugWarningDisplay/SlugWarningDisplay.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/SlugWarningDisplay/SlugWarningDisplay.tsx
@@ -7,7 +7,6 @@ import { SidebarExtensionSDK } from '@contentful/app-sdk';
 import { getContentTypeSpecificMsg, DEFAULT_CONTENT_MSG } from '../constants/noteMessages';
 import HyperLink from 'components/common/HyperLink/HyperLink';
 
-const HYPER_LINK_MSG = 'app configuration page.';
 interface Props {
   slugFieldInfo: ContentTypeValue;
 }

--- a/apps/google-analytics-4/frontend/src/components/main-app/SlugWarningDisplay/SlugWarningDisplay.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/SlugWarningDisplay/SlugWarningDisplay.tsx
@@ -17,6 +17,17 @@ const SlugWarningDisplay = (props: Props) => {
   const contentTypeName = sdk.contentType.name;
 
   const openConfigPage = () => sdk.navigator.openAppConfig();
+  const appConfigPageHyperLink = (bodyMsg: string) => (
+    <HyperLink onClick={openConfigPage} body={bodyMsg} substring="app configuration page." />
+  );
+
+  const supportHyperLink = (
+    <HyperLink
+      body={DEFAULT_ERR_MSG}
+      substring="contact support."
+      hyperLinkHref="https://www.contentful.com/support/?utm_source=webapp&utm_medium=help-menu&utm_campaign=in-app-help"
+    />
+  );
 
   const { slugFieldIsConfigured, contentTypeHasSlugField, isPublished } =
     useSidebarSlug(slugFieldInfo);
@@ -25,39 +36,21 @@ const SlugWarningDisplay = (props: Props) => {
     getContentTypeSpecificMsg(contentTypeName);
 
   const renderContent = () => {
-    const content = { bodyMsg: DEFAULT_ERR_MSG, renderHyperLink: true };
+    const content: { bodyMsg: string | JSX.Element } = { bodyMsg: supportHyperLink };
     if (!slugFieldIsConfigured) {
-      content.bodyMsg = noSlugConfigMsg;
+      content.bodyMsg = appConfigPageHyperLink(noSlugConfigMsg);
     } else if (!contentTypeHasSlugField) {
-      content.bodyMsg = noSlugContentMsg;
+      content.bodyMsg = appConfigPageHyperLink(noSlugContentMsg);
     } else if (!isPublished) {
       content.bodyMsg = notPublishedMsg;
-      content.renderHyperLink = false;
     }
 
     return content;
   };
 
-  const { bodyMsg, renderHyperLink } = renderContent();
+  const { bodyMsg } = renderContent();
 
-  return (
-    <Note
-      body={
-        <>
-          {renderHyperLink ? (
-            <HyperLink
-              onClick={openConfigPage}
-              body={bodyMsg}
-              substring="app configuration page."
-            />
-          ) : (
-            bodyMsg
-          )}
-        </>
-      }
-      variant="warning"
-    />
-  );
+  return <Note body={bodyMsg} variant="warning" />;
 };
 
 export default SlugWarningDisplay;

--- a/apps/google-analytics-4/frontend/src/components/main-app/SlugWarningDisplay/SlugWarningDisplay.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/SlugWarningDisplay/SlugWarningDisplay.tsx
@@ -25,26 +25,26 @@ const SlugWarningDisplay = (props: Props) => {
     getContentTypeSpecificMsg(contentTypeName);
 
   const renderContent = () => {
-    const content = { bodyMsg: DEFAULT_CONTENT_MSG, hyperLink: true };
+    const content = { bodyMsg: DEFAULT_CONTENT_MSG, renderHyperLink: true };
     if (!slugFieldIsConfigured) {
       content.bodyMsg = noSlugConfigMsg;
     } else if (!contentTypeHasSlugField) {
       content.bodyMsg = noSlugContentMsg;
     } else if (!isPublished) {
       content.bodyMsg = notPublishedMsg;
-      content.hyperLink = false;
+      content.renderHyperLink = false;
     }
 
     return content;
   };
 
-  const { bodyMsg, hyperLink } = renderContent();
+  const { bodyMsg, renderHyperLink } = renderContent();
 
   return (
     <Note
       body={
         <>
-          {hyperLink ? (
+          {renderHyperLink ? (
             <HyperLink
               onClick={openConfigPage}
               body={bodyMsg}

--- a/apps/google-analytics-4/frontend/src/components/main-app/SlugWarningDisplay/SlugWarningDisplay.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/SlugWarningDisplay/SlugWarningDisplay.tsx
@@ -4,8 +4,11 @@ import Note from 'components/common/Note/Note';
 import { ContentTypeValue } from 'types';
 import { useSDK } from '@contentful/react-apps-toolkit';
 import { SidebarExtensionSDK } from '@contentful/app-sdk';
-import { getContentTypeSpecificMsg, DEFAULT_ERR_MSG } from '../constants/noteMessages';
-import HyperLink from 'components/common/HyperLink/HyperLink';
+import { getContentTypeSpecificMsg } from 'components/main-app/constants/noteMessages';
+import {
+  SupportHyperLink,
+  AppConfigPageHyperLink,
+} from 'components/main-app/ErrorDisplay/CommonErrorDisplays';
 
 interface Props {
   slugFieldInfo: ContentTypeValue;
@@ -16,19 +19,6 @@ const SlugWarningDisplay = (props: Props) => {
   const sdk = useSDK<SidebarExtensionSDK>();
   const contentTypeName = sdk.contentType.name;
 
-  const openConfigPage = () => sdk.navigator.openAppConfig();
-  const appConfigPageHyperLink = (bodyMsg: string) => (
-    <HyperLink onClick={openConfigPage} body={bodyMsg} substring="app configuration page." />
-  );
-
-  const supportHyperLink = (
-    <HyperLink
-      body={DEFAULT_ERR_MSG}
-      substring="contact support."
-      hyperLinkHref="https://www.contentful.com/support/?utm_source=webapp&utm_medium=help-menu&utm_campaign=in-app-help"
-    />
-  );
-
   const { slugFieldIsConfigured, contentTypeHasSlugField, isPublished } =
     useSidebarSlug(slugFieldInfo);
 
@@ -36,11 +26,11 @@ const SlugWarningDisplay = (props: Props) => {
     getContentTypeSpecificMsg(contentTypeName);
 
   const renderContent = () => {
-    const content: { bodyMsg: string | JSX.Element } = { bodyMsg: supportHyperLink };
+    const content: { bodyMsg: string | JSX.Element } = { bodyMsg: <SupportHyperLink /> };
     if (!slugFieldIsConfigured) {
-      content.bodyMsg = appConfigPageHyperLink(noSlugConfigMsg);
+      content.bodyMsg = <AppConfigPageHyperLink bodyMsg={noSlugConfigMsg} />;
     } else if (!contentTypeHasSlugField) {
-      content.bodyMsg = appConfigPageHyperLink(noSlugContentMsg);
+      content.bodyMsg = <AppConfigPageHyperLink bodyMsg={noSlugContentMsg} />;
     } else if (!isPublished) {
       content.bodyMsg = notPublishedMsg;
     }

--- a/apps/google-analytics-4/frontend/src/components/main-app/SlugWarningDisplay/SlugWarningDisplay.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/SlugWarningDisplay/SlugWarningDisplay.tsx
@@ -4,7 +4,7 @@ import Note from 'components/common/Note/Note';
 import { ContentTypeValue } from 'types';
 import { useSDK } from '@contentful/react-apps-toolkit';
 import { SidebarExtensionSDK } from '@contentful/app-sdk';
-import { getContentTypeSpecificMsg, DEFAULT_CONTENT_MSG } from '../constants/noteMessages';
+import { getContentTypeSpecificMsg, DEFAULT_ERR_MSG } from '../constants/noteMessages';
 import HyperLink from 'components/common/HyperLink/HyperLink';
 
 interface Props {
@@ -25,7 +25,7 @@ const SlugWarningDisplay = (props: Props) => {
     getContentTypeSpecificMsg(contentTypeName);
 
   const renderContent = () => {
-    const content = { bodyMsg: DEFAULT_CONTENT_MSG, renderHyperLink: true };
+    const content = { bodyMsg: DEFAULT_ERR_MSG, renderHyperLink: true };
     if (!slugFieldIsConfigured) {
       content.bodyMsg = noSlugConfigMsg;
     } else if (!contentTypeHasSlugField) {

--- a/apps/google-analytics-4/frontend/src/components/main-app/SlugWarningDisplay/SlugWarningDisplay.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/SlugWarningDisplay/SlugWarningDisplay.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { useSidebarSlug } from 'hooks/useSidebarSlug/useSidebarSlug';
-import { TextLink } from '@contentful/f36-components';
 import Note from 'components/common/Note/Note';
 import { ContentTypeValue } from 'types';
 import { useSDK } from '@contentful/react-apps-toolkit';
 import { SidebarExtensionSDK } from '@contentful/app-sdk';
 import { getContentTypeSpecificMsg, DEFAULT_CONTENT_MSG } from '../constants/noteMessages';
+import HyperLink from 'components/common/HyperLink/HyperLink';
 
 const HYPER_LINK_MSG = 'app configuration page.';
 interface Props {
@@ -18,31 +18,22 @@ const SlugWarningDisplay = (props: Props) => {
   const contentTypeName = sdk.contentType.name;
 
   const openConfigPage = () => sdk.navigator.openAppConfig();
-  const linkToOpenConfigPage = (
-    <TextLink onClick={openConfigPage} target="_blank" rel="noopener noreferer">
-      {HYPER_LINK_MSG}
-    </TextLink>
-  );
 
   const { slugFieldIsConfigured, contentTypeHasSlugField, isPublished } =
     useSidebarSlug(slugFieldInfo);
 
-  const showHyperlink = !slugFieldIsConfigured || !contentTypeHasSlugField;
-  const { noSlugConfigMsg, noSlugContentMsg, notPublishedMsg } = getContentTypeSpecificMsg(
-    contentTypeName,
-    showHyperlink
-  );
+  const { noSlugConfigMsg, noSlugContentMsg, notPublishedMsg } =
+    getContentTypeSpecificMsg(contentTypeName);
 
   const renderContent = () => {
-    const content = { bodyMsg: DEFAULT_CONTENT_MSG, hyperLink: <></> };
+    const content = { bodyMsg: DEFAULT_CONTENT_MSG, hyperLink: true };
     if (!slugFieldIsConfigured) {
       content.bodyMsg = noSlugConfigMsg;
-      content.hyperLink = linkToOpenConfigPage;
     } else if (!contentTypeHasSlugField) {
       content.bodyMsg = noSlugContentMsg;
-      content.hyperLink = linkToOpenConfigPage;
     } else if (!isPublished) {
       content.bodyMsg = notPublishedMsg;
+      content.hyperLink = false;
     }
 
     return content;
@@ -54,7 +45,15 @@ const SlugWarningDisplay = (props: Props) => {
     <Note
       body={
         <>
-          {bodyMsg} {hyperLink}
+          {hyperLink ? (
+            <HyperLink
+              onClick={openConfigPage}
+              body={bodyMsg}
+              substring="app configuration page."
+            />
+          ) : (
+            bodyMsg
+          )}
         </>
       }
       variant="warning"

--- a/apps/google-analytics-4/frontend/src/components/main-app/constants/noteMessages.ts
+++ b/apps/google-analytics-4/frontend/src/components/main-app/constants/noteMessages.ts
@@ -6,6 +6,8 @@ export const INVALID_ARGUMENT_MSG =
   'Invalid arguments provided. Please ensure you have configured your property correctly on the app configuration page.';
 export const PERMISSION_DENIED_MSG =
   'Permission denied. Please either enable your Google Analytics Data API or ensure you have valid permissions.';
+export const INVALID_SERVICE_ACCOUNT =
+  'Invalid service key. Please ensure you have configured your service account correctly on the app configuration page.';
 
 export const getContentTypeSpecificMsg = (contentTypeName: string) => ({
   noSlugConfigMsg: `The Google Analytics 4 sidebar app cannot be displayed on this entry because the ${contentTypeName} content type has not been correctly configured. Please configure this content type on the app configuration page.`,

--- a/apps/google-analytics-4/frontend/src/components/main-app/constants/noteMessages.ts
+++ b/apps/google-analytics-4/frontend/src/components/main-app/constants/noteMessages.ts
@@ -1,10 +1,11 @@
-export const DEFAULT_ERR_MSG = 'An unknown error has occurred. Please try again or contact support';
+export const DEFAULT_ERR_MSG =
+  'An unknown error has occurred. Please try again or contact support.';
 export const EMPTY_DATA_MSG =
-  'There are no page views to show for this range. If this is not expected, assure the URL prefix and slug value accurately reflect a page path within your Google Analytics account.';
+  'There are no page views to show for this range. If this is not expected, ensure the URL prefix and slug value accurately reflect a page path within your Google Analytics account.';
 export const INVALID_ARGUMENT_MSG =
-  'Invalid arguments provided. Please assure you have configured your property correctly on the app configuration page.';
+  'Invalid arguments provided. Please ensure you have configured your property correctly on the app configuration page.';
 export const PERMISSION_DENIED_MSG =
-  'Permission denied. Please either enable your Google Analytics Data API or assure you have valid permissions.';
+  'Permission denied. Please either enable your Google Analytics Data API or ensure you have valid permissions.';
 
 export const getContentTypeSpecificMsg = (contentTypeName: string) => ({
   noSlugConfigMsg: `The Google Analytics 4 sidebar app cannot be displayed on this entry because the ${contentTypeName} content type has not been correctly configured. Please configure this content type on the app configuration page.`,

--- a/apps/google-analytics-4/frontend/src/components/main-app/constants/noteMessages.ts
+++ b/apps/google-analytics-4/frontend/src/components/main-app/constants/noteMessages.ts
@@ -2,13 +2,13 @@ export const DEFAULT_ERR_MSG = 'Oops! Cannot display the analytics data at this 
 export const EMPTY_DATA_MSG =
   'There are no page views to show for this range. If this is not expected, assure your URL prefix and slug value accurately reflect a page path within your Google Analytics instance.';
 export const DEFAULT_CONTENT_MSG = 'Oops! Something went wrong with the slug field configuration.';
+export const INVALID_ARGUMENT_MSG =
+  'Invalid arguments provided. Please assure you have configured your property correctly on the app configuration page.';
+export const PERMISSION_DENIED_MSG =
+  'Permission denied. Please either enable your Google Analytics Data API or assure you have valid permissions.';
 
-export const getContentTypeSpecificMsg = (contentTypeName: string, isHyperlink?: boolean) => ({
-  noSlugConfigMsg: `The Google Analytics 4 sidebar app cannot be displayed on this entry because the ${contentTypeName} content type has not been correctly configured. Please configure this content type on the ${
-    isHyperlink ? '' : 'app configuration page.'
-  }`,
-  noSlugContentMsg: `This ${contentTypeName} entry does not have a valid slug field. Please add a field of type short text to this entry and configure it on the ${
-    isHyperlink ? '' : 'app configuration page.'
-  }`,
+export const getContentTypeSpecificMsg = (contentTypeName: string) => ({
+  noSlugConfigMsg: `The Google Analytics 4 sidebar app cannot be displayed on this entry because the ${contentTypeName} content type has not been correctly configured. Please configure this content type on the app configuration page.`,
+  noSlugContentMsg: `This ${contentTypeName} entry does not have a valid slug field. Please add a field of type short text to this entry and configure it on the app configuration page.`,
   notPublishedMsg: `This ${contentTypeName} entry has not yet been published.`,
 });

--- a/apps/google-analytics-4/frontend/src/components/main-app/constants/noteMessages.ts
+++ b/apps/google-analytics-4/frontend/src/components/main-app/constants/noteMessages.ts
@@ -10,5 +10,5 @@ export const PERMISSION_DENIED_MSG =
 export const getContentTypeSpecificMsg = (contentTypeName: string) => ({
   noSlugConfigMsg: `The Google Analytics 4 sidebar app cannot be displayed on this entry because the ${contentTypeName} content type has not been correctly configured. Please configure this content type on the app configuration page.`,
   noSlugContentMsg: `This ${contentTypeName} entry does not have a valid slug field. Please add a field of type short text to this entry and configure it on the app configuration page.`,
-  notPublishedMsg: `This ${contentTypeName} entry has not yet been published.`,
+  notPublishedMsg: `This ${contentTypeName} entry has not yet been published. Please publish the entry and refresh to view this Google Analytics 4 app.`,
 });

--- a/apps/google-analytics-4/frontend/src/components/main-app/constants/noteMessages.ts
+++ b/apps/google-analytics-4/frontend/src/components/main-app/constants/noteMessages.ts
@@ -1,5 +1,6 @@
 export const DEFAULT_ERR_MSG = 'Oops! Cannot display the analytics data at this time.';
-export const EMPTY_DATA_MSG = 'There are no page views to show for this range.';
+export const EMPTY_DATA_MSG =
+  'There are no page views to show for this range. If this is not expected, assure your URL prefix and slug value accurately reflect a page path within your Google Analytics instance.';
 export const DEFAULT_CONTENT_MSG = 'Oops! Something went wrong with the slug field configuration.';
 
 export const getContentTypeSpecificMsg = (contentTypeName: string, isHyperlink?: boolean) => ({

--- a/apps/google-analytics-4/frontend/src/components/main-app/constants/noteMessages.ts
+++ b/apps/google-analytics-4/frontend/src/components/main-app/constants/noteMessages.ts
@@ -1,7 +1,6 @@
-export const DEFAULT_ERR_MSG = 'Oops! Cannot display the analytics data at this time.';
+export const DEFAULT_ERR_MSG = 'An unknown error has occurred. Please try again or contact support';
 export const EMPTY_DATA_MSG =
   'There are no page views to show for this range. If this is not expected, assure the URL prefix and slug value accurately reflect a page path within your Google Analytics account.';
-export const DEFAULT_CONTENT_MSG = 'Oops! Something went wrong with the slug field configuration.';
 export const INVALID_ARGUMENT_MSG =
   'Invalid arguments provided. Please assure you have configured your property correctly on the app configuration page.';
 export const PERMISSION_DENIED_MSG =
@@ -10,5 +9,5 @@ export const PERMISSION_DENIED_MSG =
 export const getContentTypeSpecificMsg = (contentTypeName: string) => ({
   noSlugConfigMsg: `The Google Analytics 4 sidebar app cannot be displayed on this entry because the ${contentTypeName} content type has not been correctly configured. Please configure this content type on the app configuration page.`,
   noSlugContentMsg: `This ${contentTypeName} entry does not have a valid slug field. Please add a field of type short text to this entry and configure it on the app configuration page.`,
-  notPublishedMsg: `This ${contentTypeName} entry has not yet been published. Please publish the entry and refresh to view this Google Analytics 4 app.`,
+  notPublishedMsg: `This ${contentTypeName} entry has not yet been published. Please publish the entry and refresh to view this Google Analytics 4 sidebar app.`,
 });

--- a/apps/google-analytics-4/frontend/src/components/main-app/constants/noteMessages.ts
+++ b/apps/google-analytics-4/frontend/src/components/main-app/constants/noteMessages.ts
@@ -1,6 +1,6 @@
 export const DEFAULT_ERR_MSG = 'Oops! Cannot display the analytics data at this time.';
 export const EMPTY_DATA_MSG =
-  'There are no page views to show for this range. If this is not expected, assure your URL prefix and slug value accurately reflect a page path within your Google Analytics instance.';
+  'There are no page views to show for this range. If this is not expected, assure the URL prefix and slug value accurately reflect a page path within your Google Analytics account.';
 export const DEFAULT_CONTENT_MSG = 'Oops! Something went wrong with the slug field configuration.';
 export const INVALID_ARGUMENT_MSG =
   'Invalid arguments provided. Please assure you have configured your property correctly on the app configuration page.';

--- a/apps/google-analytics-4/lambda/src/services/googleApiUtils.ts
+++ b/apps/google-analytics-4/lambda/src/services/googleApiUtils.ts
@@ -98,7 +98,6 @@ export function handleGoogleAdminApiError(e: any): never {
 }
 
 export function handleGoogleDataApiError(e: any): never {
-  console.log('e>>>>>>>>>>>>>>', e);
   // TODO: Find a way to have tighter distinguishing conditions.
   // Example: The PERMISSION_DENIED error is overloaded by two known actions
   //          1. data api disabled

--- a/apps/google-analytics-4/lambda/src/services/googleApiUtils.ts
+++ b/apps/google-analytics-4/lambda/src/services/googleApiUtils.ts
@@ -98,6 +98,7 @@ export function handleGoogleAdminApiError(e: any): never {
 }
 
 export function handleGoogleDataApiError(e: any): never {
+  console.log('e>>>>>>>>>>>>>>', e);
   // TODO: Find a way to have tighter distinguishing conditions.
   // Example: The PERMISSION_DENIED error is overloaded by two known actions
   //          1. data api disabled


### PR DESCRIPTION
## Purpose
This PR accomplishes the following: 

1. Adds more robust **error handling** for the common errors when rendering the GA4 app in the Sidebar. ⛔ 
2. Fixes some small **UI issues**. ✨ 

## Approach

## Error handling:
I added a component here called the `ErrorDisplay` component that is rendered in place of the Chart itself when an error is thrown. This component handles the anticipated two most common errors, providing an invalid argument somehow which is unlikely (invalid `propertyId`.), or a disabled Data api error. If the error does not belong to one of these error types, then the provided error message is displayed. I added a comment on this code to perhaps adjust the logic to display an actionable default error message if the error is not properly identified by the frontend, instead of the "mystery" error message. 

### Example error message for invalid arguments:
<img width="385" alt="Screenshot 2023-03-24 at 4 35 48 PM" src="https://user-images.githubusercontent.com/58186851/227990861-3b53813b-fe0b-49e2-83c6-d91f9256b40d.png">


## Small UI fixes:

Note content not wrapping appropriately: 

### Before: 
![Screenshot 2023-03-24 at 9 03 30 AM](https://user-images.githubusercontent.com/58186851/227975729-af800aa4-1268-44f5-85f8-ffb5d064384d.png)

### After: 
![Screenshot 2023-03-24 at 9 03 15 AM](https://user-images.githubusercontent.com/58186851/227975752-4a6df09c-baac-44ba-a82f-9d0d2e445d0d.png)

Outline of Date range Select menu cut-off on right side:

### Before: 
![Screenshot 2023-03-27 at 8 27 54 AM](https://user-images.githubusercontent.com/58186851/227975970-e7cefeb3-861a-4b5b-9199-f1cc20fd3c58.png)

### After: 
![Screenshot 2023-03-27 at 8 27 35 AM](https://user-images.githubusercontent.com/58186851/227975997-cc3bb8bf-176a-4b01-b616-65edd3dd0268.png)
