### PR TITLE
chore: [] adding catalog-info and ci-alerts

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -9,4 +9,5 @@ metadata:
 
 spec:
   type: library
+  lifecycle: production
   owner: group:team-integrations

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -8,4 +8,5 @@ metadata:
     contentful.com/ci-alert-slack: prd-integrations-engineering-bots
 
 spec:
+  type: library
   owner: group:team-integrations

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,11 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: apps
+  annotations:
+    circleci.com/project-slug: github/contentful/apps
+    github.com/project-slug: contentful/apps
+    contentful.com/ci-alert-slack: prd-integrations-engineering-bots
+
+spec:
+  owner: group:team-integrations


### PR DESCRIPTION
## Purpose
<!-- Why are we introducing this change now? What problem does it solve? What is the story/background for it? -->

* We're lacking a metadata file in this repo that integrations with our internal backstage tool
* Alerts for build failures are currently going to the wrong channel

## Approach

* Add a catalog metadata file to the repo

## Dependencies and/or References
<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment
<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
