### PR TITLE
Fix/integ 192

### DIFF
--- a/apps/shopify/README.md
+++ b/apps/shopify/README.md
@@ -3,15 +3,3 @@
 The app persists base64 encoded object IDs. These can be decoded by the users e.g. by using [`atob(...)`](https://developer.mozilla.org/en-US/docs/Web/API/atob). A decoded object ID looks the following: `gid://shopify/Product/1`.
 
 Before Shopify API version 2022-04, the Shopify API returned and accepted encoded object IDs. To ensure backwards compatibility, the app keeps storing object IDs in base64 encoded format even though the Shopify API doesn't accept these IDs anymore (see [here](https://shopify.dev/api/release-notes/2022-04#breaking-changes)).
-
-# How to get your storefront access token
-1. In your `~/Developer` directory run `npm init @shopify/app@latest`
-1. Name your app whatever you'd like, this will be the app's directory name
-1. Select `node`
-1. `CD` into the app's directory
-1. run `npm run dev`
-1. Set up your configuration (org, app)
-1. Give it your ngrok token from [ngrok](https://dashboard.ngrok.com/get-started/your-authtoken)
-1. Once your server is running press `p`
-1. Install your app
-1. 

--- a/apps/shopify/README.md
+++ b/apps/shopify/README.md
@@ -3,3 +3,15 @@
 The app persists base64 encoded object IDs. These can be decoded by the users e.g. by using [`atob(...)`](https://developer.mozilla.org/en-US/docs/Web/API/atob). A decoded object ID looks the following: `gid://shopify/Product/1`.
 
 Before Shopify API version 2022-04, the Shopify API returned and accepted encoded object IDs. To ensure backwards compatibility, the app keeps storing object IDs in base64 encoded format even though the Shopify API doesn't accept these IDs anymore (see [here](https://shopify.dev/api/release-notes/2022-04#breaking-changes)).
+
+# How to get your storefront access token
+1. In your `~/Developer` directory run `npm init @shopify/app@latest`
+1. Name your app whatever you'd like, this will be the app's directory name
+1. Select `node`
+1. `CD` into the app's directory
+1. run `npm run dev`
+1. Set up your configuration (org, app)
+1. Give it your ngrok token from [ngrok](https://dashboard.ngrok.com/get-started/your-authtoken)
+1. Once your server is running press `p`
+1. Install your app
+1. 

--- a/apps/shopify/package-lock.json
+++ b/apps/shopify/package-lock.json
@@ -12,7 +12,7 @@
         "core-js": "3.4.1",
         "react": "17.0.1",
         "react-dom": "17.0.1",
-        "shopify-buy": "2.15.1",
+        "shopify-buy": "2.18.0",
         "typescript": "4.2.4"
       },
       "devDependencies": {
@@ -1501,9 +1501,9 @@
       }
     },
     "node_modules/@contentful/ecommerce-app-base": {
-      "version": "3.1.38",
-      "resolved": "https://registry.npmjs.org/@contentful/ecommerce-app-base/-/ecommerce-app-base-3.1.38.tgz",
-      "integrity": "sha512-LRwSjCtVOvWf4wOTTDrb4jbWyVPw93r0XT6wi4vU/nn2wSsIrgIwK/pSlpPZAYSFPqWZ2EdytXbtB5uBhGh1BA==",
+      "version": "3.1.44",
+      "resolved": "https://registry.npmjs.org/@contentful/ecommerce-app-base/-/ecommerce-app-base-3.1.44.tgz",
+      "integrity": "sha512-EejMtRgAbC2lIAhD1EJJNYESuN/3ugWJ+mZDD0zE2QTM7i7wfOqahh0ISKzg2g1kY1RUUezmu5RTEt4ziW5URQ==",
       "dependencies": {
         "@contentful/app-sdk": "^4.13.0",
         "@contentful/f36-components": "^4.0.42",
@@ -24295,9 +24295,9 @@
       "optional": true
     },
     "node_modules/shopify-buy": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/shopify-buy/-/shopify-buy-2.15.1.tgz",
-      "integrity": "sha512-ijtQXSTlzNWJ4xEYucfvJZ80PYYEKub+sVcXr77krDagv0NM9SHzkUVk37tMDJIwzh5KM+LOmed6ZN5V1cFyBg=="
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/shopify-buy/-/shopify-buy-2.18.0.tgz",
+      "integrity": "sha512-UaK/oegLRoeAHCfuYj+fVPfsdB8g6LoFdBg9YkSULDlzgWCHVBYWp+g4/1hYS1EZe0SRXFRkksf/3ESwFS8Nig=="
     },
     "node_modules/side-channel": {
       "version": "1.0.4",
@@ -29907,9 +29907,9 @@
       "requires": {}
     },
     "@contentful/ecommerce-app-base": {
-      "version": "3.1.38",
-      "resolved": "https://registry.npmjs.org/@contentful/ecommerce-app-base/-/ecommerce-app-base-3.1.38.tgz",
-      "integrity": "sha512-LRwSjCtVOvWf4wOTTDrb4jbWyVPw93r0XT6wi4vU/nn2wSsIrgIwK/pSlpPZAYSFPqWZ2EdytXbtB5uBhGh1BA==",
+      "version": "3.1.44",
+      "resolved": "https://registry.npmjs.org/@contentful/ecommerce-app-base/-/ecommerce-app-base-3.1.44.tgz",
+      "integrity": "sha512-EejMtRgAbC2lIAhD1EJJNYESuN/3ugWJ+mZDD0zE2QTM7i7wfOqahh0ISKzg2g1kY1RUUezmu5RTEt4ziW5URQ==",
       "requires": {
         "@contentful/app-sdk": "^4.13.0",
         "@contentful/f36-components": "^4.0.42",
@@ -47925,9 +47925,9 @@
       "optional": true
     },
     "shopify-buy": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/shopify-buy/-/shopify-buy-2.15.1.tgz",
-      "integrity": "sha512-ijtQXSTlzNWJ4xEYucfvJZ80PYYEKub+sVcXr77krDagv0NM9SHzkUVk37tMDJIwzh5KM+LOmed6ZN5V1cFyBg=="
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/shopify-buy/-/shopify-buy-2.18.0.tgz",
+      "integrity": "sha512-UaK/oegLRoeAHCfuYj+fVPfsdB8g6LoFdBg9YkSULDlzgWCHVBYWp+g4/1hYS1EZe0SRXFRkksf/3ESwFS8Nig=="
     },
     "side-channel": {
       "version": "1.0.4",

--- a/apps/shopify/package.json
+++ b/apps/shopify/package.json
@@ -12,7 +12,7 @@
     "core-js": "3.4.1",
     "react": "17.0.1",
     "react-dom": "17.0.1",
-    "shopify-buy": "2.15.1",
+    "shopify-buy": "2.18.0",
     "typescript": "4.2.4"
   },
   "scripts": {

--- a/apps/shopify/src/constants.js
+++ b/apps/shopify/src/constants.js
@@ -2,7 +2,7 @@
 // returned with this unfortunate title, and there is no other way to check
 // whether the returned variant is the default one or not
 export const DEFAULT_SHOPIFY_VARIANT_TITLE = 'Default Title';
-export const SHOPIFY_API_VERSION = '2022-04';
+export const SHOPIFY_API_VERSION = '2023-01';
 
 export const SKU_TYPES = [
   {

--- a/apps/shopify/src/constants.js
+++ b/apps/shopify/src/constants.js
@@ -3,6 +3,8 @@
 // whether the returned variant is the default one or not
 export const DEFAULT_SHOPIFY_VARIANT_TITLE = 'Default Title';
 export const SHOPIFY_API_VERSION = '2023-01';
+export const SHOPIFY_ENTITY_LIMIT = 250;
+export const SHOPIFY_ENTITY_LIMIT_AS_INDEX = SHOPIFY_ENTITY_LIMIT - 1;
 
 export const SKU_TYPES = [
   {

--- a/apps/shopify/src/constants.js
+++ b/apps/shopify/src/constants.js
@@ -4,7 +4,6 @@
 export const DEFAULT_SHOPIFY_VARIANT_TITLE = 'Default Title';
 export const SHOPIFY_API_VERSION = '2023-01';
 export const SHOPIFY_ENTITY_LIMIT = 250;
-export const SHOPIFY_ENTITY_LIMIT_AS_INDEX = SHOPIFY_ENTITY_LIMIT - 1;
 
 export const SKU_TYPES = [
   {

--- a/apps/shopify/src/dataTransformer.js
+++ b/apps/shopify/src/dataTransformer.js
@@ -1,8 +1,13 @@
 import get from 'lodash/get';
-import last from 'lodash/last';
 import flatten from 'lodash/flatten';
 import { DEFAULT_SHOPIFY_VARIANT_TITLE } from './constants';
 import { convertBase64ToString, convertStringToBase64 } from './utils/base64';
+
+/**
+ * Removes the protocol and trailing slash from a URL
+ * This is a QOL for users who copy-paste the URL from the browser
+ */
+const removeHttpsAndTrailingSlash = (url) => url.replace(/^https?:\/\//, '').replace(/\/$/, '');
 
 /**
  * Transforms the API response of Shopify collections into
@@ -21,9 +26,9 @@ export const collectionDataTransformer = (collection, apiEndpoint) => {
         collectionIdDecoded && collectionIdDecoded.slice(collectionIdDecoded.lastIndexOf('/') + 1);
 
       if (apiEndpoint && collectionId) {
-        externalLink = `https://${apiEndpoint}${
-          last(apiEndpoint) === '/' ? '' : '/'
-        }admin/collections/${collectionId}`;
+        externalLink = `https://${removeHttpsAndTrailingSlash(
+          apiEndpoint
+        )}/admin/collections/${collectionId}`;
       }
     } catch {}
   }
@@ -54,9 +59,9 @@ export const productDataTransformer = (product, apiEndpoint) => {
         productIdDecoded && productIdDecoded.slice(productIdDecoded.lastIndexOf('/') + 1);
 
       if (apiEndpoint && productId) {
-        externalLink = `https://${apiEndpoint}${
-          last(apiEndpoint) === '/' ? '' : '/'
-        }admin/products/${productId}`;
+        externalLink = `https://${removeHttpsAndTrailingSlash(
+          apiEndpoint
+        )}/admin/products/${productId}`;
       }
     } catch {}
   }
@@ -125,9 +130,9 @@ export const previewsToProductVariants =
       name: title === DEFAULT_SHOPIFY_VARIANT_TITLE ? product.title : `${product.title} (${title})`,
       ...(apiEndpoint &&
         productId && {
-          externalLink: `https://${apiEndpoint}${
-            last(apiEndpoint) === '/' ? '' : '/'
-          }admin/products/${productId}`,
+          externalLink: `https://${removeHttpsAndTrailingSlash(
+            apiEndpoint
+          )}/admin/products/${productId}`,
         }),
     };
   };

--- a/apps/shopify/src/dataTransformer.js
+++ b/apps/shopify/src/dataTransformer.js
@@ -9,12 +9,8 @@ import { convertBase64ToString, convertStringToBase64 } from './utils/base64';
  * e.g. gid://shopify/Product/1234567890 -> 1234567890
  */
 export const decodeId = (sku) => {
-  try {
-    const decodedId = convertBase64ToString(sku);
-    return decodedId && decodeId.slice(decodedId.lastIndexOf('/') + 1);
-  } catch {
-    return null;
-  }
+  const decodedId = convertBase64ToString(sku);
+  return decodedId && decodedId.slice(decodedId.lastIndexOf('/') + 1);
 };
 
 /**

--- a/apps/shopify/src/dataTransformer.js
+++ b/apps/shopify/src/dataTransformer.js
@@ -4,24 +4,25 @@ import { DEFAULT_SHOPIFY_VARIANT_TITLE } from './constants';
 import { convertBase64ToString, convertStringToBase64 } from './utils/base64';
 
 /**
- * Removes the protocol and trailing slash from a URL
- * This is a QOL for users who copy-paste the URL from the browser
- */
-const removeHttpsAndTrailingSlash = (url) => url.replace(/^https?:\/\//, '').replace(/\/$/, '');
-
-/**
  * Decodes the ID of a Shopify resource
  * The ID is encoded in base64 and the actual ID is the last part of the string
  * e.g. gid://shopify/Product/1234567890 -> 1234567890
  */
-const decodeId = (id) => {
+export const decodeId = (sku) => {
   try {
-    const idDecoded = convertBase64ToString(id);
-    return idDecoded && idDecoded.slice(idDecoded.lastIndexOf('/') + 1);
+    const decodedId = convertBase64ToString(sku);
+    return decodedId && decodeId.slice(decodedId.lastIndexOf('/') + 1);
   } catch {
-    return undefined;
+    return null;
   }
 };
+
+/**
+ * Removes the protocol and trailing slash from a URL
+ * This is a QOL for users who copy-paste the URL from the browser
+ */
+export const removeHttpsAndTrailingSlash = (url) =>
+  url.replace(/^https?:\/\/(www\.)?/, '').replace(/\/$/, '');
 
 /**
  * Transforms the API response of Shopify collections into

--- a/apps/shopify/src/skuResolvers.js
+++ b/apps/shopify/src/skuResolvers.js
@@ -168,7 +168,6 @@ export const fetchProductVariantPreviews = async (skus, config) => {
       config
     );
     response.push(...currentPage.data.nodes);
-    console.log(response);
   }
 
   const nodes = response.filter(identity).map((node) => convertProductToBase64(node));

--- a/apps/shopify/src/skuResolvers.js
+++ b/apps/shopify/src/skuResolvers.js
@@ -12,11 +12,7 @@ import {
 
 import { validateParameters } from '.';
 import { previewsToProductVariants } from './dataTransformer';
-import {
-  SHOPIFY_API_VERSION,
-  SHOPIFY_ENTITY_LIMIT,
-  SHOPIFY_ENTITY_LIMIT_AS_INDEX,
-} from './constants';
+import { SHOPIFY_API_VERSION, SHOPIFY_ENTITY_LIMIT } from './constants';
 import {
   convertStringToBase64,
   convertBase64ToString,
@@ -91,7 +87,7 @@ export const fetchProductPreviews = async (skus, config) => {
   const response = [];
   for (let i = 0; i < validIds.length; i += SHOPIFY_ENTITY_LIMIT) {
     const currentPage = await shopifyClient.product.fetchMultiple(
-      validIds.slice(i, i + SHOPIFY_ENTITY_LIMIT_AS_INDEX)
+      validIds.slice(i, i + (SHOPIFY_ENTITY_LIMIT - 1))
     );
     response.push(...currentPage);
   }
@@ -168,7 +164,7 @@ export const fetchProductVariantPreviews = async (skus, config) => {
   const response = [];
   for (let i = 0; i < validIds.length; i += SHOPIFY_ENTITY_LIMIT) {
     const currentPage = await _fetchProductVariantPreviews(
-      validIds.slice(i, i + SHOPIFY_ENTITY_LIMIT_AS_INDEX),
+      validIds.slice(i, i + (SHOPIFY_ENTITY_LIMIT - 1)),
       config
     );
     response.push(...currentPage.data.nodes);

--- a/apps/shopify/src/skuResolvers.js
+++ b/apps/shopify/src/skuResolvers.js
@@ -63,7 +63,7 @@ export const fetchCollectionPreviews = async (skus, config) => {
       (collection) => collection.id === convertStringToBase64(validId)
     );
     return collection
-      ? collectionDataTransformer(collection, removeHttpsAndTrailingSlash(config.apiEndpoint))
+      ? collectionDataTransformer(collection, config.apiEndpoint)
       : {
           sku: convertStringToBase64(validId),
           isMissing: true,
@@ -97,7 +97,7 @@ export const fetchProductPreviews = async (skus, config) => {
     const product = products.find((product) => product?.id === convertStringToBase64(validId));
 
     return product
-      ? productDataTransformer(product, removeHttpsAndTrailingSlash(config.apiEndpoint))
+      ? productDataTransformer(product, config.apiEndpoint)
       : {
           sku: convertStringToBase64(validId),
           isMissing: true,

--- a/apps/shopify/src/skuResolvers.js
+++ b/apps/shopify/src/skuResolvers.js
@@ -90,7 +90,7 @@ export const fetchProductPreviews = async (skus, config) => {
       shopifyClient.product.fetchMultiple(validIds.slice(i, i + (SHOPIFY_ENTITY_LIMIT - 1)))
     );
   }
-  const response = (await Promise.all(requests)).reduce((acc, curr) => [...acc, ...curr], []);
+  const response = (await Promise.all(requests)).flat();
 
   const products = response.map((res) => convertProductToBase64(res));
 
@@ -163,14 +163,11 @@ export const fetchProductVariantPreviews = async (skus, config) => {
 
   const requests = [];
   for (let i = 0; i < validIds.length; i += SHOPIFY_ENTITY_LIMIT) {
-    response.push(
+    requests.push(
       _fetchProductVariantPreviews(validIds.slice(i, i + (SHOPIFY_ENTITY_LIMIT - 1)), config)
     );
   }
-  const response = (await Promise.all(requests)).reduce(
-    (acc, curr) => [...acc, ...curr.data.nodes],
-    []
-  );
+  const response = (await Promise.all(requests)).flatMap((res) => res.data.nodes);
 
   const nodes = response.filter(identity).map((node) => convertProductToBase64(node));
 

--- a/apps/shopify/src/skuResolvers.js
+++ b/apps/shopify/src/skuResolvers.js
@@ -89,7 +89,7 @@ export const fetchProductPreviews = async (skus, config) => {
   const shopifyClient = await makeShopifyClient(config);
 
   const response = [];
-  for (let i = 0; i < validIds.length; i += SHOPIFY_ENTITY_LIMIT_AS_INDEX) {
+  for (let i = 0; i < validIds.length; i += SHOPIFY_ENTITY_LIMIT) {
     const currentPage = await shopifyClient.product.fetchMultiple(
       validIds.slice(i, i + SHOPIFY_ENTITY_LIMIT_AS_INDEX)
     );
@@ -166,7 +166,7 @@ export const fetchProductVariantPreviews = async (skus, config) => {
   const validIds = filterAndDecodeValidIds(skus, 'ProductVariant');
 
   const response = [];
-  for (let i = 0; i < validIds.length; i += SHOPIFY_ENTITY_LIMIT_AS_INDEX) {
+  for (let i = 0; i < validIds.length; i += SHOPIFY_ENTITY_LIMIT) {
     const currentPage = await _fetchProductVariantPreviews(
       validIds.slice(i, i + SHOPIFY_ENTITY_LIMIT_AS_INDEX),
       config

--- a/apps/shopify/src/skuResolvers.js
+++ b/apps/shopify/src/skuResolvers.js
@@ -86,12 +86,11 @@ export const fetchProductPreviews = async (skus, config) => {
 
   const requests = [];
   for (let i = 0; i < validIds.length; i += SHOPIFY_ENTITY_LIMIT) {
-    requests.push(
-      shopifyClient.product.fetchMultiple(validIds.slice(i, i + (SHOPIFY_ENTITY_LIMIT - 1)))
-    );
+    const currentIdPage = validIds.slice(i, i + (SHOPIFY_ENTITY_LIMIT - 1));
+    requests.push(shopifyClient.product.fetchMultiple(currentIdPage));
   }
-  const response = (await Promise.all(requests)).flat();
 
+  const response = (await Promise.all(requests)).flat();
   const products = response.map((res) => convertProductToBase64(res));
 
   return validIds.map((validId) => {
@@ -163,12 +162,11 @@ export const fetchProductVariantPreviews = async (skus, config) => {
 
   const requests = [];
   for (let i = 0; i < validIds.length; i += SHOPIFY_ENTITY_LIMIT) {
-    requests.push(
-      _fetchProductVariantPreviews(validIds.slice(i, i + (SHOPIFY_ENTITY_LIMIT - 1)), config)
-    );
+    const currentIdPage = validIds.slice(i, i + (SHOPIFY_ENTITY_LIMIT - 1));
+    requests.push(_fetchProductVariantPreviews(currentIdPage, config));
   }
-  const response = (await Promise.all(requests)).flatMap((res) => res.data.nodes);
 
+  const response = (await Promise.all(requests)).flatMap((res) => res.data.nodes);
   const nodes = response.filter(identity).map((node) => convertProductToBase64(node));
 
   const variantPreviews = nodes.map(previewsToProductVariants(config));

--- a/apps/shopify/src/skuResolvers.js
+++ b/apps/shopify/src/skuResolvers.js
@@ -37,7 +37,7 @@ export async function makeShopifyClient(config) {
  *
  * Note: currently there is no way to fetch multiple collections by id
  * so we use fetchAll instead and then filter on the client. Besides the obvious disadvantage,
- * this could also fail if there are mo collections in the stroe than the pagination limit
+ * this could also fail if there are no collections in the store than the pagination limit
  */
 export const fetchCollectionPreviews = async (skus, config) => {
   if (!skus.length) {


### PR DESCRIPTION
## Purpose
We have hit Shopify's 250 limit for some customers using the shopify app.

## Approach
For where we can paginate using the API, we are using the shopify-buy pagination queries. When we don't have access to pagination, we loop through through the requested ID's and batch request 250 at a time.

This PR also makes the App's config insensitive to if the user has a url with an `https:` protocol or a trailing `/`
## Dependencies and/or References
INTEG-192
