### PR TITLE
Add IAM role policy for resource deletion

### DIFF
--- a/apps/google-analytics-4/lambda/serverless.yml
+++ b/apps/google-analytics-4/lambda/serverless.yml
@@ -43,6 +43,7 @@ provider:
             - dynamodb:PutItem
             - dynamodb:UpdateItem
             - dynamodb:DeleteItem
+            - dynamodb:DeleteTable
           Resource:
             - Fn::GetAtt: [ServiceAccountKeysTable, Arn]
 

--- a/apps/google-analytics-4/lambda/serverless.yml
+++ b/apps/google-analytics-4/lambda/serverless.yml
@@ -44,7 +44,7 @@ provider:
             - dynamodb:UpdateItem
             - dynamodb:DeleteItem
           Resource:
-            - Fn::GetAtt: [service-account-keys, Arn]
+            - Fn::GetAtt: [ServiceAccountKeysTable, Arn]
 
 functions:
   api:


### PR DESCRIPTION
## Purpose
<!-- Why are we introducing this change now? What problem does it solve? What is the story/background for it? -->
- updates IAM role to allow for dynamoDB table deletion

## Approach
<!-- Why did we do it the way we did? Did we consider alternatives? What other implementation details or artifacts (screenshots etc.) would help reviewers contextualize change? -->

## Dependencies and/or References
<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment
<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
