### PR TITLE
Add date filter to GA4 external link

### DIFF
--- a/apps/google-analytics-4/frontend/src/components/main-app/AnalyticsApp/AnalyticsApp.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/AnalyticsApp/AnalyticsApp.tsx
@@ -2,7 +2,7 @@ import { useAutoResizer } from '@contentful/react-apps-toolkit';
 import { useEffect, useState, useMemo } from 'react';
 import { Api } from 'apis/api';
 import getRangeDates from 'helpers/DateRangeHelpers/DateRangeHelpers';
-import { DateRangeType, ContentTypeValue } from 'types';
+import { DateRangeType, StartEndDates, ContentTypeValue } from 'types';
 import { styles } from './AnalyticsApp.styles';
 import { Flex } from '@contentful/f36-components';
 import { RunReportData } from 'apis/apiTypes';
@@ -20,7 +20,7 @@ const AnalyticsApp = (props: Props) => {
 
   const [runReportResponse, setRunReportResponse] = useState<RunReportData>({} as RunReportData);
   const [dateRange, setDateRange] = useState<DateRangeType>('lastWeek');
-  const [startEndDates, setStartEndDates] = useState<any>(getRangeDates('lastWeek'));
+  const [startEndDates, setStartEndDates] = useState<StartEndDates>(getRangeDates('lastWeek'));
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<Error>();
 
@@ -99,6 +99,7 @@ const AnalyticsApp = (props: Props) => {
         pageViews={pageViews}
         error={error}
         propertyId={propertyId}
+        startEndDates={startEndDates}
       />
     );
   };

--- a/apps/google-analytics-4/frontend/src/components/main-app/AnalyticsMetricDisplays/AnalyticsMetricDisplay.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/AnalyticsMetricDisplays/AnalyticsMetricDisplay.spec.tsx
@@ -18,6 +18,7 @@ describe('Analytics metric display components for the analytics app', () => {
         runReportResponse={runReportResponseHasViews}
         reportSlug="/en-US"
         propertyId=""
+        startEndDates={{ start: '2023-03-26', end: '2023-03-27' }}
       />
     );
 

--- a/apps/google-analytics-4/frontend/src/components/main-app/AnalyticsMetricDisplays/AnalyticsMetricDisplay.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/AnalyticsMetricDisplays/AnalyticsMetricDisplay.tsx
@@ -29,7 +29,7 @@ const AnalyticsMetricDisplay = (props: Props) => {
   } = props;
 
   const propertyIdNumber = propertyId.split('/')[1] || '';
-  const viewUrl = getExternalUrl(propertyIdNumber, reportSlug, startEndDates);
+  const viewUrl = getExternalUrl(propertyIdNumber, { pagePath: reportSlug, startEndDates });
 
   return (
     <>

--- a/apps/google-analytics-4/frontend/src/components/main-app/AnalyticsMetricDisplays/AnalyticsMetricDisplay.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/AnalyticsMetricDisplays/AnalyticsMetricDisplay.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ChartFooter from 'components/main-app/ChartFooter/ChartFooter';
 import ChartHeader from 'components/main-app/ChartHeader/ChartHeader';
 import ChartContent from '../ChartContent/ChartContent';
-import { RunReportResponse } from 'types';
+import { RunReportResponse, StartEndDates } from 'types';
 import { getExternalUrl } from 'helpers/externalUrlHelpers/externalUrlHelpers';
 
 interface Props {
@@ -13,6 +13,7 @@ interface Props {
   metricName: string;
   error?: Error;
   propertyId: string;
+  startEndDates: StartEndDates;
 }
 
 const AnalyticsMetricDisplay = (props: Props) => {
@@ -24,10 +25,11 @@ const AnalyticsMetricDisplay = (props: Props) => {
     metricName,
     pageViews,
     propertyId,
+    startEndDates,
   } = props;
 
   const propertyIdNumber = propertyId.split('/')[1] || '';
-  const viewUrl = getExternalUrl(propertyIdNumber, reportSlug);
+  const viewUrl = getExternalUrl(propertyIdNumber, reportSlug, startEndDates);
 
   return (
     <>

--- a/apps/google-analytics-4/frontend/src/helpers/externalUrlHelpers/externalUrlHelpers.spec.ts
+++ b/apps/google-analytics-4/frontend/src/helpers/externalUrlHelpers/externalUrlHelpers.spec.ts
@@ -1,12 +1,24 @@
 import { getExternalUrl, encodeDataFiltersParameters } from './externalUrlHelpers';
 
 describe('externalUrlHelpers', () => {
-  it('generates the correct URL', () => {
-    const result = getExternalUrl('abc123', '/en-US/search');
+  it('generates the correct URL with params', () => {
+    const result = getExternalUrl('abc123', '/en-US/search', {
+      start: '2023-03-26',
+      end: '2023-03-27',
+    });
 
     expect(result).toEqual(
-      `https://analytics.google.com/analytics/web/#/pabc123/reports/explorer?params=_u..nav%3Dmaui%26_r.explorerCard..seldim%3D%5B%22unifiedPagePathScreen%22%5D%26_r..dataFilters%3D%5B%7B%22type%22:1,%22fieldName%22:%22unifiedPagePathScreen%22,%22evaluationType%22:1,%22expressionList%22:%5B%22%2Fen-US%2Fsearch%22%5D,%22complement%22:false,%22isCaseSensitive%22:true,%22expression%22:%22%22%7D%5D&r=all-pages-and-screens&ruid=all-pages-and-screens,life-cycle,engagement&collectionId=life-cycle`
+      `https://analytics.google.com/analytics/web/#/pabc123/reports/explorer?params=_u..nav%3Dmaui%26_r.explorerCard..seldim%3D%5B%22unifiedPagePathScreen%22%5D%26_r..dataFilters%3D%5B%7B%22type%22:1,%22fieldName%22:%22unifiedPagePathScreen%22,%22evaluationType%22:1,%22expressionList%22:%5B%22%2Fen-US%2Fsearch%22%5D,%22complement%22:false,%22isCaseSensitive%22:true,%22expression%22:%22%22%7D%5D%26_u.comparisonOption%3Ddisabled%26_u.date00%3D20230326%26_u.date01%3D20230327&r=all-pages-and-screens&ruid=all-pages-and-screens,life-cycle,engagement&collectionId=life-cycle`
     );
+  });
+
+  it('generates the default base URL without params', () => {
+    const result = getExternalUrl('', '', {
+      start: '',
+      end: '',
+    });
+
+    expect(result).toEqual(`https://analytics.google.com/analytics/web/#`);
   });
 
   it('encodes the correct characters', () => {

--- a/apps/google-analytics-4/frontend/src/helpers/externalUrlHelpers/externalUrlHelpers.spec.ts
+++ b/apps/google-analytics-4/frontend/src/helpers/externalUrlHelpers/externalUrlHelpers.spec.ts
@@ -1,24 +1,58 @@
-import { getExternalUrl, encodeDataFiltersParameters } from './externalUrlHelpers';
+import { BASE_URL, getExternalUrl, encodeDataFiltersParameters } from './externalUrlHelpers';
+
+const mockPropertySegment = `/pabc123/reports/explorer?params=_u..nav%3Dmaui%26_r.explorerCard..seldim%3D%5B%22unifiedPagePathScreen%22%5D`;
+const mockPagePathSegment = `%26_r..dataFilters%3D%5B%7B%22type%22:1,%22fieldName%22:%22unifiedPagePathScreen%22,%22evaluationType%22:1,%22expressionList%22:%5B%22%2Fen-US%2Fsearch%22%5D,%22complement%22:false,%22isCaseSensitive%22:true,%22expression%22:%22%22%7D%5D`;
+const mockDateSegment = `%26_u.comparisonOption%3Ddisabled%26_u.date00%3D20230326%26_u.date01%3D20230327`;
+const mockFinalSegment = `&r=all-pages-and-screens&ruid=all-pages-and-screens,life-cycle,engagement&collectionId=life-cycle`;
 
 describe('externalUrlHelpers', () => {
   it('generates the correct URL with params', () => {
-    const result = getExternalUrl('abc123', '/en-US/search', {
-      start: '2023-03-26',
-      end: '2023-03-27',
+    const result = getExternalUrl('abc123', {
+      pagePath: '/en-US/search',
+      startEndDates: {
+        start: '2023-03-26',
+        end: '2023-03-27',
+      },
     });
 
     expect(result).toEqual(
-      `https://analytics.google.com/analytics/web/#/pabc123/reports/explorer?params=_u..nav%3Dmaui%26_r.explorerCard..seldim%3D%5B%22unifiedPagePathScreen%22%5D%26_r..dataFilters%3D%5B%7B%22type%22:1,%22fieldName%22:%22unifiedPagePathScreen%22,%22evaluationType%22:1,%22expressionList%22:%5B%22%2Fen-US%2Fsearch%22%5D,%22complement%22:false,%22isCaseSensitive%22:true,%22expression%22:%22%22%7D%5D%26_u.comparisonOption%3Ddisabled%26_u.date00%3D20230326%26_u.date01%3D20230327&r=all-pages-and-screens&ruid=all-pages-and-screens,life-cycle,engagement&collectionId=life-cycle`
+      `${BASE_URL}${mockPropertySegment}${mockPagePathSegment}${mockDateSegment}${mockFinalSegment}`
     );
   });
 
   it('generates the default base URL without params', () => {
-    const result = getExternalUrl('', '', {
-      start: '',
-      end: '',
+    const result = getExternalUrl();
+
+    expect(result).toEqual(BASE_URL);
+  });
+
+  it('generates the property report URL with no additional filters', () => {
+    const result = getExternalUrl('abc123');
+
+    expect(result).toEqual(`${BASE_URL}${mockPropertySegment}${mockFinalSegment}`);
+  });
+
+  it('generates the property report URL with only a page path filter', () => {
+    const result = getExternalUrl('abc123', {
+      pagePath: '/en-US/search',
     });
 
-    expect(result).toEqual(`https://analytics.google.com/analytics/web/#`);
+    expect(result).toEqual(
+      `${BASE_URL}${mockPropertySegment}${mockPagePathSegment}${mockFinalSegment}`
+    );
+  });
+
+  it('generates the property report URL with only a date filter', () => {
+    const result = getExternalUrl('abc123', {
+      startEndDates: {
+        start: '2023-03-26',
+        end: '2023-03-27',
+      },
+    });
+
+    expect(result).toEqual(
+      `${BASE_URL}${mockPropertySegment}${mockDateSegment}${mockFinalSegment}`
+    );
   });
 
   it('encodes the correct characters', () => {

--- a/apps/google-analytics-4/frontend/src/helpers/externalUrlHelpers/externalUrlHelpers.ts
+++ b/apps/google-analytics-4/frontend/src/helpers/externalUrlHelpers/externalUrlHelpers.ts
@@ -1,46 +1,59 @@
 import { StartEndDates } from 'types';
 
-export const getExternalUrl = (
-  propertyId: string,
-  pagePath: string,
-  startEndDates: StartEndDates
-) => {
-  // Base Google Analytics URL
-  const BASE_URL = 'https://analytics.google.com/analytics/web/#';
+export const BASE_URL = 'https://analytics.google.com/analytics/web/#';
+const PAGE_PATH_VIEW = 'unifiedPagePathScreen';
 
-  if (!propertyId || !pagePath || !startEndDates.start || !startEndDates.end) {
+export const getExternalUrl = (
+  propertyId?: string,
+  reportFilterOptions?: {
+    pagePath?: string;
+    startEndDates?: StartEndDates;
+  }
+) => {
+  if (!propertyId) {
     return BASE_URL;
   }
 
   const propertyIdSegment = `/p${propertyId}/reports/explorer?params=`;
 
-  const explorerCardParams = 'unifiedPagePathScreen';
   const explorerCardSegment = encodeURIComponent(
-    `_u..nav=maui&_r.explorerCard..seldim=["${explorerCardParams}"]&`
+    `_u..nav=maui&_r.explorerCard..seldim=["${PAGE_PATH_VIEW}"]`
   );
 
-  const dataFiltersParams = {
-    type: 1,
-    fieldName: 'unifiedPagePathScreen',
-    evaluationType: 1,
-    expressionList: [`${encodeURIComponent(pagePath)}`],
-    complement: false,
-    isCaseSensitive: true,
-    expression: '',
-  };
+  let dataFiltersParams, dateParams;
 
-  // encodeURIComponent encodes too many characters for this part of the URL, so using custom encoding function
-  const dataFiltersSegment = `_r..dataFilters${encodeDataFiltersParameters(
-    `=[${JSON.stringify(dataFiltersParams)}]`
-  )}`;
+  if (reportFilterOptions) {
+    dataFiltersParams = reportFilterOptions.pagePath && {
+      type: 1,
+      fieldName: PAGE_PATH_VIEW,
+      evaluationType: 1,
+      expressionList: [`${encodeURIComponent(reportFilterOptions.pagePath)}`],
+      complement: false,
+      isCaseSensitive: true,
+      expression: '',
+    };
 
-  const dateParams = {
-    start: formatDateParams(startEndDates.start),
-    end: formatDateParams(startEndDates.end),
-  };
-  const dateSegment = encodeURIComponent(
-    `&_u.comparisonOption=disabled&_u.date00=${dateParams.start}&_u.date01=${dateParams.end}`
-  );
+    if (reportFilterOptions.startEndDates) {
+      dateParams = reportFilterOptions.startEndDates.start &&
+        reportFilterOptions.startEndDates.end && {
+          start: formatDateParams(reportFilterOptions.startEndDates.start),
+          end: formatDateParams(reportFilterOptions.startEndDates.end),
+        };
+    }
+  }
+
+  // encodeURIComponent encodes too many characters for data filters, so using custom encoding function
+  const dataFiltersSegment = dataFiltersParams
+    ? `${encodeURIComponent('&_r..dataFilters')}${encodeDataFiltersParameters(
+        `=[${JSON.stringify(dataFiltersParams)}]`
+      )}`
+    : '';
+
+  const dateSegment = dateParams
+    ? encodeURIComponent(
+        `&_u.comparisonOption=disabled&_u.date00=${dateParams.start}&_u.date01=${dateParams.end}`
+      )
+    : '';
 
   const finalSegment = `&r=all-pages-and-screens&ruid=all-pages-and-screens,life-cycle,engagement&collectionId=life-cycle`;
 
@@ -62,8 +75,8 @@ const formatDateParams = (dateString: string) => {
   // Dates need to be formatted from YYYY-MM-DD to YYYYMMDD and month must be zero-padded
   const splitDate = dateString.split('-');
   const year = splitDate[0];
-  const month = splitDate[1].length === 1 ? `0${splitDate[1]}` : splitDate[1];
-  const day = splitDate[2];
+  const month = splitDate[1] ? (splitDate[1].length === 1 ? `0${splitDate[1]}` : splitDate[1]) : '';
+  const day = splitDate[2] ?? '';
 
   return `${year}${month}${day}`;
 };

--- a/apps/google-analytics-4/frontend/src/helpers/externalUrlHelpers/externalUrlHelpers.ts
+++ b/apps/google-analytics-4/frontend/src/helpers/externalUrlHelpers/externalUrlHelpers.ts
@@ -1,36 +1,50 @@
-export const getExternalUrl = (propertyId: string, pagePath: string) => {
+import { StartEndDates } from 'types';
+
+export const getExternalUrl = (
+  propertyId: string,
+  pagePath: string,
+  startEndDates: StartEndDates
+) => {
   // Base Google Analytics URL
   const BASE_URL = 'https://analytics.google.com/analytics/web/#';
 
-  if (propertyId && pagePath) {
-    const propertyIdSegment = `/p${propertyId}/reports/explorer?params=`;
-
-    const explorerCardParams = 'unifiedPagePathScreen';
-    const explorerCardSegment = encodeURIComponent(
-      `_u..nav=maui&_r.explorerCard..seldim=["${explorerCardParams}"]&`
-    );
-
-    const dataFiltersParams = {
-      type: 1,
-      fieldName: 'unifiedPagePathScreen',
-      evaluationType: 1,
-      expressionList: [`${encodeURIComponent(pagePath)}`],
-      complement: false,
-      isCaseSensitive: true,
-      expression: '',
-    };
-
-    // encodeURIComponent encodes too many characters for this part of the URL, so using custom encoding function
-    const dataFiltersSegment = `_r..dataFilters${encodeDataFiltersParameters(
-      `=[${JSON.stringify(dataFiltersParams)}]`
-    )}`;
-
-    const finalSegment = `&r=all-pages-and-screens&ruid=all-pages-and-screens,life-cycle,engagement&collectionId=life-cycle`;
-
-    return `${BASE_URL}${propertyIdSegment}${explorerCardSegment}${dataFiltersSegment}${finalSegment}`;
+  if (!propertyId || !pagePath || !startEndDates.start || !startEndDates.end) {
+    return BASE_URL;
   }
 
-  return BASE_URL;
+  const propertyIdSegment = `/p${propertyId}/reports/explorer?params=`;
+
+  const explorerCardParams = 'unifiedPagePathScreen';
+  const explorerCardSegment = encodeURIComponent(
+    `_u..nav=maui&_r.explorerCard..seldim=["${explorerCardParams}"]&`
+  );
+
+  const dataFiltersParams = {
+    type: 1,
+    fieldName: 'unifiedPagePathScreen',
+    evaluationType: 1,
+    expressionList: [`${encodeURIComponent(pagePath)}`],
+    complement: false,
+    isCaseSensitive: true,
+    expression: '',
+  };
+
+  // encodeURIComponent encodes too many characters for this part of the URL, so using custom encoding function
+  const dataFiltersSegment = `_r..dataFilters${encodeDataFiltersParameters(
+    `=[${JSON.stringify(dataFiltersParams)}]`
+  )}`;
+
+  const dateParams = {
+    start: formatDateParams(startEndDates.start),
+    end: formatDateParams(startEndDates.end),
+  };
+  const dateSegment = encodeURIComponent(
+    `&_u.comparisonOption=disabled&_u.date00=${dateParams.start}&_u.date01=${dateParams.end}`
+  );
+
+  const finalSegment = `&r=all-pages-and-screens&ruid=all-pages-and-screens,life-cycle,engagement&collectionId=life-cycle`;
+
+  return `${BASE_URL}${propertyIdSegment}${explorerCardSegment}${dataFiltersSegment}${dateSegment}${finalSegment}`;
 };
 
 export const encodeDataFiltersParameters = (str: string) => {
@@ -42,4 +56,14 @@ export const encodeDataFiltersParameters = (str: string) => {
   );
 
   return encodedStr;
+};
+
+const formatDateParams = (dateString: string) => {
+  // Dates need to be formatted from YYYY-MM-DD to YYYYMMDD and month must be zero-padded
+  const splitDate = dateString.split('-');
+  const year = splitDate[0];
+  const month = splitDate[1].length === 1 ? `0${splitDate[1]}` : splitDate[1];
+  const day = splitDate[2];
+
+  return `${year}${month}${day}`;
 };

--- a/apps/google-analytics-4/frontend/src/types.ts
+++ b/apps/google-analytics-4/frontend/src/types.ts
@@ -87,6 +87,11 @@ export interface RunReportParamsType {
 }
 
 export type DateRangeType = 'lastWeek' | 'lastDay' | 'lastMonth';
+
+export interface StartEndDates {
+  start: string;
+  end: string;
+}
 export interface AccountSummariesType {
   displayName: string;
   name: string;


### PR DESCRIPTION
## Purpose
When a user is viewing GA4 data in the sidebar and clicks on the 'Open in Google Analytics' link, the report they are viewing in GA4 should have the same date filter as the sidebar. This PR adds date filter parameters to the external URL that matches the dates provided to the` run_report` endpoint.

## Approach
There are some default report date filters (e.g. Today, Last 7 Days, etc.). Instead of using these, I decided to create a custom date filter that exactly matches the dates provided to the `run_report` endpoint so that the dates in the sidebar and in the linked report will be the same.

Example sidebar showing March 20-27 and corresponding GA4 report (you can see the custom date filter in the top right)

![Screenshot 2023-03-27 at 4 39 00 PM](https://user-images.githubusercontent.com/62958907/228083103-428e18e2-0d79-482f-9ab7-5ca3b6ba820c.png)
![Screenshot 2023-03-27 at 4 41 09 PM](https://user-images.githubusercontent.com/62958907/228089027-55aec909-7d1b-48ec-a0a7-feeafbbad1d8.png)


