### PR TITLE
fix: include content-type in allowed cors headers

### DIFF
--- a/apps/google-analytics-4/lambda/src/middlewares/corsConfig.ts
+++ b/apps/google-analytics-4/lambda/src/middlewares/corsConfig.ts
@@ -3,6 +3,7 @@ export const corsConfig = {
   methods: 'GET,PUT,POST,PATCH,DELETE,OPTIONS',
   allowedHeaders: [
     'Authorization',
+    'Content-Type',
     // Contentful SDK Headers
     'X-Contentful-Timestamp',
     'X-Contentful-Signed-Headers',


### PR DESCRIPTION
## Purpose

When we introduced the `Content-Type: application/json` here on the frontend (https://github.com/contentful/apps/blob/master/apps/google-analytics-4/frontend/src/helpers/signed-requests.ts#L16-L18) we accidentally violated our CORS rules. As a result, production API requests were broken. (Local development worked fine because we share the same host)

> Access to fetch at 'https://google-analytics-4.ctfapps.net/api/account_summaries' from origin 'https://b922ef2b-607e-4411-9386-597b9fac89a7.ctfcloud.net' has been blocked by CORS policy: Request header field content-type is not allowed by Access-Control-Allow-Headers in preflight response.

## Approach

* Add the missing header to our allowed list

## Dependencies and/or References
<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment
<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
