### PR TITLE
Enable lint checks and fix errors [INTEG-334]

### DIFF
--- a/apps/google-analytics-4/frontend/package.json
+++ b/apps/google-analytics-4/frontend/package.json
@@ -28,6 +28,7 @@
     "build": "REACT_APP_RELEASE=$(git rev-parse --short HEAD) react-scripts build",
     "test": "REACT_APP_RELEASE=$(git rev-parse --short HEAD) react-scripts test",
     "test:ci": "REACT_APP_RELEASE=$(git rev-parse --short HEAD) CI=true react-scripts test",
+    "lint": "eslint .",
     "eject": "react-scripts eject",
     "create-app-definition": "contentful-app-scripts create-app-definition",
     "deploy": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEFINITIONS_ORG_ID} --definition-id 5DlxOS0KvGS1Wk362xgvbN --token ${CONTENTFUL_CMA_TOKEN}",

--- a/apps/google-analytics-4/frontend/package.json
+++ b/apps/google-analytics-4/frontend/package.json
@@ -28,7 +28,7 @@
     "build": "REACT_APP_RELEASE=$(git rev-parse --short HEAD) react-scripts build",
     "test": "REACT_APP_RELEASE=$(git rev-parse --short HEAD) react-scripts test",
     "test:ci": "REACT_APP_RELEASE=$(git rev-parse --short HEAD) CI=true react-scripts test",
-    "lint": "eslint .",
+    "lint": "eslint --max-warnings=0 .",
     "eject": "react-scripts eject",
     "create-app-definition": "contentful-app-scripts create-app-definition",
     "deploy": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEFINITIONS_ORG_ID} --definition-id 5DlxOS0KvGS1Wk362xgvbN --token ${CONTENTFUL_CMA_TOKEN}",

--- a/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/DisplayServiceAccountCard.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/DisplayServiceAccountCard.spec.tsx
@@ -1,10 +1,5 @@
 import { act, render, screen } from '@testing-library/react';
-import {
-  mockSdk,
-  mockCma,
-  validServiceKeyFile,
-  validServiceKeyId,
-} from '../../../../../test/mocks';
+import { mockSdk, mockCma, validServiceKeyId } from '../../../../../test/mocks';
 import DisplayServiceAccountCard from 'components/config-screen/api-access/display/DisplayServiceAccountCard';
 import { config } from '../../../../../src/config';
 

--- a/apps/google-analytics-4/lambda/package.json
+++ b/apps/google-analytics-4/lambda/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "debug": "NODE_ENV=development SLS_DEBUG=* node inspect ./node_modules/serverless/bin/serverless.js offline",
     "build": "NODE_ENV=production rimraf ./build && tsc",
-    "lint": "eslint .",
+    "lint": "eslint --max-warnings=0 .",
     "start:dev": "NODE_ENV=development nodemon",
     "test": "NODE_ENV=test TS_NODE_TRANSPILE_ONLY=1 mocha --exit -r dotenv/config",
     "test:ci": "NODE_ENV=test TS_NODE_TRANSPILE_ONLY=1 CI=true mocha --exit -r dotenv/config",

--- a/apps/google-analytics-4/lambda/src/controllers/apiController.ts
+++ b/apps/google-analytics-4/lambda/src/controllers/apiController.ts
@@ -5,7 +5,6 @@ import { DynamoDBService } from '../services/dynamoDbService';
 import {
   MissingServiceAccountKeyFile,
   assertServiceAccountKey,
-  assertServiceAccountKeyId,
 } from '../middlewares/serviceAccountKeyProvider';
 
 const formatArrays = (param: string | string[]) =>

--- a/apps/google-analytics-4/lambda/src/middlewares/verifySignedRequests.spec.ts
+++ b/apps/google-analytics-4/lambda/src/middlewares/verifySignedRequests.spec.ts
@@ -9,7 +9,12 @@ import { UnableToVerifyRequest } from '../errors/unableToVerifyRequest';
 
 const sandbox = sinon.createSandbox();
 
-function buildSignedHeaders(method: any, path: string, headers: any, secret: string) {
+function buildSignedHeaders(
+  method: NodeAppsToolkit.CanonicalRequest['method'],
+  path: string,
+  headers: NodeAppsToolkit.CanonicalRequest['headers'],
+  secret: string
+) {
   const timestamp = Date.now();
   const rawRequest = { method, path, headers };
   const signatureHeaders = NodeAppsToolkit.signRequest(secret, rawRequest, timestamp);

--- a/apps/google-analytics-4/lambda/src/services/googleApi.spec.ts
+++ b/apps/google-analytics-4/lambda/src/services/googleApi.spec.ts
@@ -11,6 +11,7 @@ import {
 } from '../../test/mocks/googleApi';
 import { GoogleApiError, handleGoogleAdminApiError } from './googleApiUtils';
 import { GoogleApiService } from './googleApiService';
+import { ERROR_TYPE_MAP } from '../errors/apiError';
 
 describe('GoogleApiService', () => {
   let googleApi: GoogleApiService;
@@ -51,21 +52,6 @@ describe('GoogleApiService', () => {
 });
 
 describe('throwGoogleApiError', () => {
-  describe('when passed a regular error', () => {
-    const someError = new Error('boom!');
-
-    it('throws a GoogleApiError', async () => {
-      let error: Error | undefined = undefined;
-      try {
-        handleGoogleAdminApiError(someError);
-      } catch (e) {
-        error = e as Error;
-      }
-      expect(error).to.be.an.instanceof(GoogleApiError);
-      expect(error?.cause).to.equal(someError);
-    });
-  });
-
   describe('when passed a GoogleError server error', () => {
     const someError = {
       name: 'Error',
@@ -75,7 +61,7 @@ describe('throwGoogleApiError', () => {
     };
 
     it('throws a GoogleApiError', async () => {
-      let error: Error | undefined = undefined;
+      let error: Error;
       try {
         handleGoogleAdminApiError(someError);
       } catch (e) {
@@ -83,6 +69,7 @@ describe('throwGoogleApiError', () => {
       }
       expect(error).to.be.an.instanceof(GoogleApiError);
       expect(error).to.have.property('cause', someError);
+      expect(error).to.have.property('errorType', ERROR_TYPE_MAP.unknown);
       expect(error).to.have.property('details', someError.details);
     });
   });
@@ -99,6 +86,7 @@ describe('throwGoogleApiError', () => {
       }
       expect(error).to.be.an.instanceof(GoogleApiError);
       expect(error).to.have.property('cause', someError);
+      expect(error).to.have.property('errorType', ERROR_TYPE_MAP.invalidServiceAccount);
       expect(error).to.have.property('details', mockGoogleErrors.invalidAuthentication.message);
     });
   });

--- a/apps/google-analytics-4/lambda/src/services/googleApiService.ts
+++ b/apps/google-analytics-4/lambda/src/services/googleApiService.ts
@@ -158,7 +158,7 @@ export class GoogleApiService {
         ...response,
         ...{ rows: this.supplementDates(response.rows as ReportRowType[], dateArray) },
       };
-    } catch (e: any) {
+    } catch (e: unknown) {
       if (isGoogleError(e)) handleGoogleDataApiError(e);
       else {
         throw e;
@@ -169,7 +169,7 @@ export class GoogleApiService {
   private async fetchAccountSummaries() {
     try {
       return await this.analyticsAdminServiceClient.listAccountSummaries();
-    } catch (e: any) {
+    } catch (e: unknown) {
       if (isGoogleError(e)) handleGoogleAdminApiError(e);
       else throw e;
     }


### PR DESCRIPTION
## Purpose

* We've had a few lint warnings build up in both frontend and lambda over the last few weeks. They are silently passing our lint checks because eslint doesn't exit non-zero for warnings by default
* A few actual code logic problems snuck in as a result of misuse of `any`
* We didn't have a linter at all on the frontend

## Approach

* Add lint script to frontend
* Enable stricter checks vis `--max-warnings=0` (we tolerate 0 warnings)
* Clean up some GoogleAPI errors that were wrong

## Dependencies and/or References

* https://eslint.org/docs/latest/use/command-line-interface#--max-warnings

## Deployment
<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
