### PR TITLE
DRAFT Persist service account key on config page

### DIFF
--- a/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage.spec.tsx
@@ -17,6 +17,9 @@ jest.mock('contentful-management', () => ({
   createClient: () => mockCma,
 }));
 
+const RAW_SERVICE_ACCOUNT_KEY =
+  '{"type":"service_account","project_id":"PROJECT_ID","private_key_id":"PRIVATE_KEY_ID","private_key":"----- PRIVATE_KEY-----","client_email":"example4@PROJECT_ID.iam.gserviceaccount.com","client_id":"CLIENT_ID","auth_uri":"https://accounts.google.com/o/oauth2/auth","token_uri":"https://oauth2.googleapis.com/token","auth_provider_x509_cert_url":"https://www.googleapis.com/oauth2/v1/certs","client_x509_cert_url":"https://www.googleapis.com/robot/v1/metadata/x509/example4%40PROJECT_ID.iam.gserviceaccount.com"}';
+
 // Helper to mock users clicking "save" -- return result of the callback passed to onConfigure()
 const saveAppInstallation = async () => {
   // We manually call the LAST onConfigure() callback (this is important, as earlier calls have stale data)
@@ -68,6 +71,7 @@ describe('Config Screen component (not installed)', () => {
           id: 'PRIVATE_KEY_ID',
           projectId: 'PROJECT_ID',
         },
+        rawServiceAccountKey: RAW_SERVICE_ACCOUNT_KEY,
       },
       targetState: {
         EditorInterface: {},
@@ -162,6 +166,7 @@ describe('Installed Service Account Key', () => {
           id: 'PRIVATE_KEY_ID',
           projectId: 'PROJECT_ID',
         },
+        rawServiceAccountKey: RAW_SERVICE_ACCOUNT_KEY,
         propertyId: 'properties/1234',
         contentTypes: {
           course: { slugField: 'shortDescription', urlPrefix: 'about' },

--- a/apps/google-analytics-4/frontend/src/components/config-screen/api-access/setup/SetupServiceAccountCard.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/api-access/setup/SetupServiceAccountCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   Stack,
   Card,
@@ -34,7 +34,8 @@ const placeholderText = `{
 }`;
 
 export default function SetupServiceAccountCard(props: Props) {
-  const { mergeSdkParameters, isInEditMode, onInEditModeChange, onKeyFileUpdate } = props;
+  const { mergeSdkParameters, isInEditMode, onInEditModeChange, onKeyFileUpdate, parameters } =
+    props;
 
   const [rawServiceAccountKey, setRawServiceAccountKey] = useState<string>();
   const [serviceAccountKeyId, setServiceAccountKeyId] = useState<ServiceAccountKeyId>();
@@ -58,6 +59,7 @@ export default function SetupServiceAccountCard(props: Props) {
 
       const _parameters = {
         serviceAccountKeyId: _serviceAccountKeyId,
+        rawServiceAccountKey: keyfile,
       };
 
       mergeSdkParameters(_parameters);
@@ -79,6 +81,12 @@ export default function SetupServiceAccountCard(props: Props) {
     setErrorMessage('');
     onInEditModeChange(false);
   };
+
+  useEffect(() => {
+    if (parameters.rawServiceAccountKey) {
+      setRawServiceAccountKey(parameters.rawServiceAccountKey);
+    }
+  }, [parameters.rawServiceAccountKey]);
 
   return (
     <Stack spacing="spacingL" flexDirection="column">
@@ -115,7 +123,11 @@ export default function SetupServiceAccountCard(props: Props) {
         </Box>
         <FormControl
           id="accountCredentialsFile"
-          isInvalid={rawServiceAccountKey !== undefined && !serviceAccountKeyId}
+          isInvalid={
+            !parameters.rawServiceAccountKeyId &&
+            rawServiceAccountKey !== undefined &&
+            !serviceAccountKeyId
+          }
           isRequired={true}
           marginBottom={!isInEditMode ? 'none' : 'spacingM'}>
           <FormControl.Label>Service Account Key</FormControl.Label>

--- a/apps/google-analytics-4/frontend/src/components/config-screen/api-access/setup/SetupServiceAccountCard.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/api-access/setup/SetupServiceAccountCard.tsx
@@ -124,7 +124,7 @@ export default function SetupServiceAccountCard(props: Props) {
         <FormControl
           id="accountCredentialsFile"
           isInvalid={
-            !parameters.rawServiceAccountKeyId &&
+            !parameters.rawServiceAccountKey &&
             rawServiceAccountKey !== undefined &&
             !serviceAccountKeyId
           }


### PR DESCRIPTION
## Purpose
When the user clicks on 'edit' after already applying and saving their service account key, the textbox would render 'empty' as such:

![image](https://user-images.githubusercontent.com/58186851/228648590-ffa380c2-ae57-4e21-a102-f7330bee06ba.png)

This should instead render the key that has already been saved. 

## Approach
I figured there were two options here. To stringify, with proper line breaks so it is readable, the `serviceAccountKey` we have or to just add the lightweight JSON string to the parameters object as a `rawServiceAccountKey` to render. I went with the latter option as I felt there were little to no drawbacks here since we are provided the raw key in the first place, as opposed to unnecessarily formatting it again. Open to thoughts here!

## How to test
You will most likely need to reconfigure your current key by editing and saving the change, as the object needs to be recreated with the `rawServiceAccountKey` attribute and value. You should then be able to click 'edit' on the config page and render that same key. 
