### PR TITLE
Fix save error with valid key presence

### DIFF
--- a/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage.tsx
@@ -98,8 +98,6 @@ export default function GoogleAnalyticsConfigPage() {
   );
 
   const handleConfigure = useCallback(async () => {
-    // we are making assumption that serviceAccountKeyId presence means a valid key exists
-
     // if no serviceAccountKeyId (most likely when user is saving on first install without providing a key)
     if (isEmpty(parameters.serviceAccountKeyId)) {
       sdk.notifier.error('A valid service account key file is required');

--- a/apps/google-analytics-4/frontend/src/components/config-screen/api-access/setup/SetupServiceAccountCard.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/api-access/setup/SetupServiceAccountCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import {
   Stack,
   Card,
@@ -63,6 +63,16 @@ export default function SetupServiceAccountCard(props: Props) {
       mergeSdkParameters(_parameters);
     } catch (e: any) {
       onKeyFileUpdate(undefined);
+
+      // if not edit mode, so first install, merge params as undefined when error thrown.
+      // prevents the case when user pastes a valid key (saved in parameters optimistically)
+      // and then erases key but still tries to install
+      if (!isInEditMode) {
+        const _parameters = {
+          serviceAccountKeyId: undefined,
+        };
+        mergeSdkParameters(_parameters);
+      }
       // failed assertions about key file contents or could not parse as JSON
       if (e instanceof AssertionError || e instanceof SyntaxError) {
         setErrorMessage(e.message);


### PR DESCRIPTION
## Purpose
This PR resolves a bug that was occurring where a user could not return to the config page after install and save any changes to the config without a warning that 'A valid service account key file is required'. 

## Approach
This is most definitely a patch fix to this issue, but essentially the problem was that we were setting the `validKeyFile` state within the `GoogleAnalyticsConfigPage` only once on original install. This state was never set again to reference a valid key file when the user returns to the config page, because given the security enhancements, we do not reference the key file again on the frontend. Without this state being present, errors were being thrown, some warranted, and some not. 

Follow-up specs to come today!
