### PR TITLE
[Cleanup] Remove process.envs to use the function getEnvironmentVariable instead

### DIFF
--- a/apps/google-analytics-4/frontend/package.json
+++ b/apps/google-analytics-4/frontend/package.json
@@ -24,10 +24,10 @@
     "zod": "3.21.4"
   },
   "scripts": {
-    "start": "REACT_APP_RELEASE=$(git rev-parse --short HEAD) cross-env BROWSER=none react-scripts start",
+    "start": "cross-env BROWSER=none react-scripts start",
     "build": "REACT_APP_RELEASE=$(git rev-parse --short HEAD) react-scripts build",
-    "test": "REACT_APP_RELEASE=$(git rev-parse --short HEAD) react-scripts test",
-    "test:ci": "REACT_APP_RELEASE=$(git rev-parse --short HEAD) CI=true react-scripts test",
+    "test": "react-scripts test",
+    "test:ci": "CI=true react-scripts test",
     "lint": "eslint --max-warnings=0 .",
     "eject": "react-scripts eject",
     "create-app-definition": "contentful-app-scripts create-app-definition",

--- a/apps/google-analytics-4/frontend/src/config.ts
+++ b/apps/google-analytics-4/frontend/src/config.ts
@@ -1,6 +1,12 @@
-function getEnvironmentVariable(environmentVariableName: string) {
+type EnvironmentVariable = string | null | number | undefined;
+
+function getEnvironmentVariable(
+  environmentVariableName: string,
+  fallback?: EnvironmentVariable
+): string {
   const environmentVariableValue = process.env[environmentVariableName];
-  if (environmentVariableValue === undefined) {
+  if (!environmentVariableValue) {
+    if (fallback) return fallback.toString();
     throw new Error(`Missing environment variable: '${environmentVariableName}'`);
   }
   return environmentVariableValue;
@@ -8,7 +14,8 @@ function getEnvironmentVariable(environmentVariableName: string) {
 
 export const config = {
   backendApiUrl: getEnvironmentVariable('REACT_APP_BACKEND_API_URL'),
-  version: getEnvironmentVariable('REACT_APP_VERSION'),
-  release: getEnvironmentVariable('REACT_APP_RELEASE'),
+  version: getEnvironmentVariable('REACT_APP_VERSION', 'no-version-set'),
+  release: getEnvironmentVariable('REACT_APP_RELEASE', 'no-release-hash-set'),
   sentryDSN: getEnvironmentVariable('REACT_APP_SENTRY_DSN'),
+  environment: getEnvironmentVariable('NODE_ENV'),
 };

--- a/apps/google-analytics-4/frontend/src/index.tsx
+++ b/apps/google-analytics-4/frontend/src/index.tsx
@@ -17,14 +17,14 @@ Sentry.init({
   // of transactions for performance monitoring.
   // We recommend adjusting this value in production
   tracesSampleRate: 1.0,
-  environment: process.env.NODE_ENV,
+  environment: config.environment,
   // TODO: setup Sentry as part of release pipeline (see: https://docs.sentry.io/platforms/javascript/sourcemaps/?_ga=2.56533545.342806665.1676988870-873194326.1675171780#uploading-source-maps-to-sentry)
   release: config.release,
 });
 
 const root = document.getElementById('root');
 
-if (process.env.NODE_ENV === 'development' && window.self === window.top) {
+if (config.environment === 'development' && window.self === window.top) {
   // You can remove this if block before deploying your app
   render(<LocalhostWarning />, root);
 } else {

--- a/apps/google-analytics-4/lambda/.env
+++ b/apps/google-analytics-4/lambda/.env
@@ -1,6 +1,6 @@
 # Important! These values should only be used when running tests. All environment variables must be
 # specified in serverless.yml or they will not function in the real Lambda environment
-SIGNING_SECRET: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+SIGNING_SECRET: QPFQDCfipitJcFGb4f-xnP0RhZOqnStP2thYUkqg_CcWdTlFWu4KCP6pYrWPto5x
 SENTRY_DSN: https://b8f524eae7c446fb8071476431426640@o2239.ingest.sentry.io/4504725335834624
 STAGE: test
 RELEASE_VERSION: test

--- a/apps/google-analytics-4/lambda/package.json
+++ b/apps/google-analytics-4/lambda/package.json
@@ -13,7 +13,7 @@
     "test:ci": "NODE_ENV=test TS_NODE_TRANSPILE_ONLY=1 CI=true mocha --exit -r dotenv/config",
     "test:debug": "NODE_ENV=test TS_NODE_TRANSPILE_ONLY=1 mocha -- --inspect --inspect-brk -r dotenv/config",
     "test:watch": "NODE_ENV=test TS_NODE_TRANSPILE_ONLY=1 mocha --watch --watch-files src --watch-files test -r dotenv/config",
-    "deploy:test": "NODE_ENV=test CIRCLE_SHA1=$(git rev-parse --short HEAD) sls deploy --stage test",
+    "deploy:test": "NODE_ENV=test sls deploy --stage test",
     "deploy": "NODE_ENV=production CIRCLE_SHA1=$(git rev-parse --short HEAD) sls deploy --stage $STAGE",
     "verify-config": "STAGE=$(test \"$CIRCLE_BRANCH\" = 'master' && echo 'prd' || echo 'test'); sls print --stage $STAGE",
     "sentry-create-release": "sentry-cli releases --log-level=debug new -p marketplace-apps $CIRCLE_SHA1",

--- a/apps/google-analytics-4/lambda/src/app.ts
+++ b/apps/google-analytics-4/lambda/src/app.ts
@@ -5,6 +5,7 @@ import Middleware from './middlewares';
 import { ApiRouter, HealthRouter } from './routers';
 import { corsConfig } from './middlewares/corsConfig';
 import { apiErrorMap } from './apiErrorMap';
+import { config } from './config';
 
 const app = express();
 app.use(express.json());
@@ -12,9 +13,9 @@ const apiRouteConstraint = ['/api/*'];
 
 // Initialize Sentry as early as possible
 Sentry.init({
-  dsn: process.env.SENTRY_DSN,
-  environment: process.env.NODE_ENV,
-  release: process.env.RELEASE_VERSION,
+  dsn: config.sentryDSN,
+  environment: config.environment,
+  release: config.release,
 });
 
 app.use(Middleware.setSentryContext);

--- a/apps/google-analytics-4/lambda/src/config.ts
+++ b/apps/google-analytics-4/lambda/src/config.ts
@@ -1,6 +1,12 @@
-function getEnvironmentVariable(environmentVariableName: string) {
+type EnvironmentVariable = string | null | number | undefined;
+
+function getEnvironmentVariable(
+  environmentVariableName: string,
+  fallback?: EnvironmentVariable
+): string {
   const environmentVariableValue = process.env[environmentVariableName];
-  if (environmentVariableValue === undefined) {
+  if (!environmentVariableValue) {
+    if (fallback) return fallback.toString();
     throw new Error(`Missing environment variable: '${environmentVariableName}'`);
   }
   return environmentVariableValue;
@@ -15,4 +21,7 @@ export const config = {
   serviceAccountKeyEncryptionSecret: getEnvironmentVariable(
     'SERVICE_ACCOUNT_KEY_ENCRYPTION_SECRET'
   ),
+  sentryDSN: getEnvironmentVariable('SENTRY_DSN'),
+  environment: getEnvironmentVariable('NODE_ENV'),
+  release: getEnvironmentVariable('CIRCLE_SHA1', 'no-release-hash-set'),
 };

--- a/apps/google-analytics-4/lambda/src/middlewares/setSentryContext.spec.ts
+++ b/apps/google-analytics-4/lambda/src/middlewares/setSentryContext.spec.ts
@@ -3,14 +3,15 @@ import express from 'express';
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { setSentryContext } from './setSentryContext';
+import { config } from '../config';
 
 describe('setSentryContext', () => {
   chai.use(chaiHttp);
   const app = express();
 
   Sentry.init({
-    dsn: process.env.SENTRY_DSN,
-    environment: process.env.NODE_ENV,
+    dsn: config.sentryDSN,
+    environment: config.environment,
   });
 
   app.use(setSentryContext);

--- a/apps/google-analytics-4/lambda/src/middlewares/verifySignedRequests.spec.ts
+++ b/apps/google-analytics-4/lambda/src/middlewares/verifySignedRequests.spec.ts
@@ -6,6 +6,7 @@ import Express from 'express';
 import { verifySignedRequestMiddleware } from './verifySignedRequests';
 import { InvalidSignature } from '../errors/invalidSignature';
 import { UnableToVerifyRequest } from '../errors/unableToVerifyRequest';
+import { config } from '../config';
 
 const sandbox = sinon.createSandbox();
 
@@ -42,8 +43,8 @@ describe('verifySignedRequestMiddleware', () => {
   };
 
   beforeEach(() => {
-    sandbox.stub(process.env, 'STAGE').value(stage);
-    sandbox.stub(process.env, 'SIGNING_SECRET').value(signingSecret);
+    sandbox.stub(config, 'stage').value(stage);
+    sandbox.stub(config, 'signingSecret').value(signingSecret);
     const headers = buildSignedHeaders(
       method,
       clientRequestPath,

--- a/apps/google-analytics-4/lambda/src/middlewares/verifySignedRequests.ts
+++ b/apps/google-analytics-4/lambda/src/middlewares/verifySignedRequests.ts
@@ -38,7 +38,7 @@ const makeCanonicalReq = (req: Request) => {
   });
 
   // TODO: make this stage prefixing logic better? (yuck)
-  const pathPrefix = process.env.STAGE !== 'prd' ? `/${process.env.STAGE}` : '';
+  const pathPrefix = config.stage !== 'prd' ? `/${config.stage}` : '';
   const fullPath = req.originalUrl.split('?')[0];
   const signedPath = `${pathPrefix}${fullPath}`; // note: req.originalUrl starts with a `/` and includes the full path & query string
 


### PR DESCRIPTION
## Purpose
We want to use `getEnvironmentVariable` to actually access our env vars instead of `process.env` so that we have more control of when the application should error out/succeed when accessing environment variables

Also updates the `getEnvironmentVariable` function to cleanup some of the package.json commands to set some of the env vars.

## Approach
-Make sure all tests run successfully
-Clean up package.json 
-Build should pass successfully