### PR TITLE
DRAFT: First time install throwing error when no accounts or properties found

### DIFF
--- a/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/ChecklistUtils.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/ChecklistUtils.tsx
@@ -11,7 +11,12 @@ import { Flex, Tooltip } from '@contentful/f36-components';
 const getErrorIcon = (msg: string) => (
   <Tooltip placement="top" content={msg}>
     <Flex alignItems="center">
-      <ErrorCircleIcon marginLeft="spacingXs" marginRight="spacingXs" variant="negative" />
+      <ErrorCircleIcon
+        testId="error-icon"
+        marginLeft="spacingXs"
+        marginRight="spacingXs"
+        variant="negative"
+      />
     </Flex>
   </Tooltip>
 );
@@ -34,7 +39,12 @@ const getClockIcon = (msg: string) => (
 const getArrowIcon = (msg: string) => (
   <Tooltip placement="top" content={msg}>
     <Flex alignItems="center">
-      <ArrowForwardIcon marginLeft="spacingXs" marginRight="spacingXs" variant="muted" />
+      <ArrowForwardIcon
+        testId="arrow-icon"
+        marginLeft="spacingXs"
+        marginRight="spacingXs"
+        variant="muted"
+      />
     </Flex>
   </Tooltip>
 );
@@ -84,6 +94,7 @@ export type ChecklistStatus = {
     invalidServiceAccount: ChecklistRow;
     adminApiError: ChecklistRow;
     error: ChecklistRow;
+    noAccountsOrPropertiesFound: ChecklistRow;
   };
   Other: {
     unknown: ChecklistRow;
@@ -216,6 +227,18 @@ export const CHECKLIST_STATUSES: ChecklistStatus = {
         url: 'https://analytics.google.com/analytics/web/',
       },
     },
+    noAccountsOrPropertiesFound: {
+      icon: getArrowIcon(
+        'The service account must have properties assigned to the account for this check to pass'
+      ),
+      title: CHECKLIST_NAMES.ga4Properties,
+      description: 'Service account failed to access an Analytics property',
+      disabled: false,
+      checklistUrl: {
+        title: 'Add GA4 properties',
+        url: 'https://analytics.google.com/analytics/web/',
+      },
+    },
   },
   Other: {
     unknown: {
@@ -301,7 +324,10 @@ export const getGa4PropertyErrorChecklistStatus = (
 ): ChecklistRow => {
   if (!invalidServiceAccountError && !adminApiError && !ga4PropertiesError)
     return CHECKLIST_STATUSES.GA4Properties.success;
-  if (isFirstSetup && adminApiError) return CHECKLIST_STATUSES.GA4Properties.firstTimeSetup;
+  if (isFirstSetup) {
+    if (adminApiError) return CHECKLIST_STATUSES.GA4Properties.firstTimeSetup;
+    if (ga4PropertiesError) return CHECKLIST_STATUSES.GA4Properties.noAccountsOrPropertiesFound;
+  }
   if (invalidServiceAccountError) return CHECKLIST_STATUSES.GA4Properties.invalidServiceAccount;
   if (adminApiError) return CHECKLIST_STATUSES.GA4Properties.adminApiError;
   if (ga4PropertiesError) return CHECKLIST_STATUSES.GA4Properties.error;

--- a/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/ChecklistUtils.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/ChecklistUtils.tsx
@@ -220,10 +220,10 @@ export const CHECKLIST_STATUSES: ChecklistStatus = {
         'The service account must have properties assigned to the account for this check to pass'
       ),
       title: CHECKLIST_NAMES.ga4Properties,
-      description: 'Service account failed to access an Analytics property',
+      description: "Service account doesn't have access to any GA4 properties",
       disabled: false,
       checklistUrl: {
-        title: 'Add GA4 properties',
+        title: 'Grant access',
         url: 'https://analytics.google.com/analytics/web/',
       },
     },
@@ -232,10 +232,10 @@ export const CHECKLIST_STATUSES: ChecklistStatus = {
         'The service account must have properties assigned to the account for this check to pass'
       ),
       title: CHECKLIST_NAMES.ga4Properties,
-      description: 'Service account failed to access an Analytics property',
+      description: "Service account doesn't have access to any GA4 properties",
       disabled: false,
       checklistUrl: {
-        title: 'Add GA4 properties',
+        title: 'Grant access',
         url: 'https://analytics.google.com/analytics/web/',
       },
     },

--- a/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/ServiceAccountChecklist.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/ServiceAccountChecklist.spec.tsx
@@ -298,7 +298,7 @@ describe('Service Account Checklist', () => {
       );
     });
 
-    await screen.findByText(/Service account failed to access an Analytics property/);
+    await screen.findByText(/Service account doesn't have access to any GA4 properties/);
     expect(screen.getByTestId('arrow-icon')).toBeVisible();
   });
 
@@ -322,7 +322,7 @@ describe('Service Account Checklist', () => {
       );
     });
 
-    await screen.findByText(/Service account failed to access an Analytics property/);
+    await screen.findByText(/Service account doesn't have access to any GA4 properties/);
     expect(screen.getByTestId('error-icon')).toBeVisible();
   });
 });

--- a/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/ServiceAccountChecklist.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/ServiceAccountChecklist.spec.tsx
@@ -278,7 +278,7 @@ describe('Service Account Checklist', () => {
     await screen.findByText(/Analytics Data API is not yet enabled/);
   });
 
-  it('has no found GA4 Accounts or Properties', async () => {
+  it('has no found GA4 Accounts or Properties on first time install', async () => {
     await act(async () => {
       render(
         <ServiceAccountChecklist
@@ -299,5 +299,30 @@ describe('Service Account Checklist', () => {
     });
 
     await screen.findByText(/Service account failed to access an Analytics property/);
+    expect(screen.getByTestId('arrow-icon')).toBeVisible();
+  });
+
+  it('has no found GA4 Accounts or Properties not on first time install', async () => {
+    await act(async () => {
+      render(
+        <ServiceAccountChecklist
+          serviceAccountCheck={{
+            ...getServiceKeyChecklistStatus(parameters, undefined, undefined),
+          }}
+          adminApiCheck={{
+            ...getAdminApiErrorChecklistStatus(true, parameters, undefined, undefined),
+          }}
+          dataApiCheck={{
+            ...getDataApiErrorChecklistStatus(true, parameters, undefined, undefined),
+          }}
+          ga4PropertiesCheck={{
+            ...getGa4PropertyErrorChecklistStatus(false, undefined, undefined, ga4PropertiesError),
+          }}
+        />
+      );
+    });
+
+    await screen.findByText(/Service account failed to access an Analytics property/);
+    expect(screen.getByTestId('error-icon')).toBeVisible();
   });
 });


### PR DESCRIPTION
## Purpose
This PR fixes a small issue when a user is installing the app for the first time, and their associated service account does not have any properties or accounts, we were showing an error icon but instead should be showing an arrow icon 

## Approach
The reason behind showing an arrow icon on first time install, despite the lack of accounts or properties existing, is to be a bit nicer, patient, less alarmist with a user when they are getting things working for the first time. If they are coming back to edit the configuration at a later time, and there are no accounts or properties, we want to alert them to this in case they change something with their service account in the meantime, so the error icon shows instead. 
