### PR TITLE
Show checks when incomplete or problems with config

### DIFF
--- a/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/DisplayServiceAccountCard.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/DisplayServiceAccountCard.tsx
@@ -222,6 +222,7 @@ const DisplayServiceAccountCard = (props: Props) => {
       dataApiError ||
       ga4PropertiesError;
     if (configError) {
+      setShowChecks(true);
       return isFirstSetup ? (
         <Badge variant="primary">Finish configuration steps below</Badge>
       ) : (

--- a/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/DisplayServiceAccountCard.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/DisplayServiceAccountCard.tsx
@@ -214,15 +214,19 @@ const DisplayServiceAccountCard = (props: Props) => {
     );
   };
 
+  const configError =
+    invalidServiceAccountError ||
+    missingServiceAccountError ||
+    adminApiError ||
+    dataApiError ||
+    ga4PropertiesError;
+
+  useEffect(() => {
+    if (configError) setShowChecks(true);
+  }, [configError]);
+
   const RenderStatusInfo = () => {
-    const configError =
-      invalidServiceAccountError ||
-      missingServiceAccountError ||
-      adminApiError ||
-      dataApiError ||
-      ga4PropertiesError;
     if (configError) {
-      setShowChecks(true);
       return isFirstSetup ? (
         <Badge variant="primary">Finish configuration steps below</Badge>
       ) : (


### PR DESCRIPTION
## Purpose
When the configuration steps are incomplete or when there exist issues within the config setup, the checklist is currently hidden and the user has to open it manually, an unnecessary extra step asked of the user. Ex:

![image](https://user-images.githubusercontent.com/58186851/229157350-17b9f5ff-d000-45c9-b28f-60ee63f339e7.png)

This checklist should instead render automatically in these cases. 

## Approach
One adjustment in state was needed for the checklist to render appropriately when the checklist is incomplete or there exist error states. 
![Screenshot 2023-03-31 at 8 27 40 AM](https://user-images.githubusercontent.com/58186851/229148390-bab34326-d5ba-44f3-93a4-96fa047d3fa0.png)
