### PR TITLE
[INTEG-331 & INTEG-352] Fix content type errors and allow config save

### DIFF
--- a/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage.tsx
@@ -125,8 +125,20 @@ export default function GoogleAnalyticsConfigPage() {
       return false;
     }
 
+    // Remove empty content type rows
+    let parametersToSave = parameters;
+
+    if (parameters.contentTypes) {
+      const filteredContentTypes = Object.fromEntries(
+        Object.entries(parameters.contentTypes).filter(([key]) => key !== '')
+      );
+
+      parametersToSave = { ...parameters, contentTypes: filteredContentTypes };
+      setParameters(parametersToSave);
+    }
+
     // Assign the app to the sidebar for saved content types
-    const contentTypeIds = Object.keys(parameters.contentTypes ?? {});
+    const contentTypeIds = Object.keys(parametersToSave.contentTypes ?? {});
     const newEditorInterfaceAssignments = generateEditorInterfaceAssignments(
       currentEditorInterface,
       contentTypeIds,
@@ -135,14 +147,14 @@ export default function GoogleAnalyticsConfigPage() {
     );
 
     setCurrentEditorInterface(newEditorInterfaceAssignments);
-    setOriginalParameters(parameters);
+    setOriginalParameters(parametersToSave);
 
     const newAppState: AppState = {
       EditorInterface: newEditorInterfaceAssignments,
     };
 
     return {
-      parameters: parameters,
+      parameters: parametersToSave,
       targetState: newAppState,
     };
   }, [

--- a/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage.tsx
@@ -125,15 +125,15 @@ export default function GoogleAnalyticsConfigPage() {
       return false;
     }
 
-    // Remove empty content type rows
     let parametersToSave = parameters;
 
+    // Filter out empty content types that came from empty rows on the form
     if (parameters.contentTypes) {
-      const filteredContentTypes = Object.fromEntries(
+      const nonEmptyContentTypes = Object.fromEntries(
         Object.entries(parameters.contentTypes).filter(([key]) => key !== '')
       );
 
-      parametersToSave = { ...parameters, contentTypes: filteredContentTypes };
+      parametersToSave = { ...parameters, contentTypes: nonEmptyContentTypes };
       setParameters(parametersToSave);
     }
 

--- a/apps/google-analytics-4/frontend/src/components/config-screen/WarningDisplay/constants/warningMessages.ts
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/WarningDisplay/constants/warningMessages.ts
@@ -1,12 +1,11 @@
 // Content type warning and error messages
-export const NO_CONTENT_TYPE_ERR_MSG = `Please select a content type or remove this row to in order to save the configuration. `;
 export const NO_SLUG_WARNING_MSG = `This content type must have a slug field selected in order for the app to render correctly in the sidebar. `;
 export const REMOVED_FROM_SIDEBAR_WARNING_MSG = `The app has been removed from the sidebar for this content type. If you would like to remove this
 content type from the app configuration, remove this row and save. If you would like the app to be added back to the sidebar 
 for this content type, just save the app configuration. `;
 
 export const getContentTypeDeletedMsg = (contentTypeId: string): string => {
-  return `The previously configured content type '${contentTypeId}' has been deleted. Please select a new content type or remove this row in order to save the configuration. `;
+  return `The previously configured content type '${contentTypeId}' has been deleted. Please select a new content type or remove this row. `;
 };
 
 export const getSlugFieldDeletedMsg = (contentTypeId: string, slugField: string): string => {

--- a/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/DisplayServiceAccountCard.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/DisplayServiceAccountCard.tsx
@@ -73,7 +73,6 @@ const DisplayServiceAccountCard = (props: Props) => {
   const api = useApi(serviceAccountKeyId);
 
   const handleApiError = (error: ApiErrorType) => {
-    console.log('errorType', error.errorType);
     switch (error.errorType) {
       case ERROR_TYPE_MAP.invalidServiceAccountKey:
         setInvalidServiceAccountError(error);

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeRow.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeRow.spec.tsx
@@ -56,7 +56,7 @@ const props = {
 };
 
 describe('Assign Content Type Card for Config Screen', () => {
-  it('shows invalid and disabled inputs when content type is empty', () => {
+  it('shows disabled inputs when content type is empty', () => {
     render(
       <AssignContentTypeRow
         contentTypeEntry={[
@@ -70,7 +70,6 @@ describe('Assign Content Type Card for Config Screen', () => {
       />
     );
 
-    expect(screen.getByTestId('contentTypeSelect')).toBeInvalid();
     expect(screen.getByTestId('slugFieldSelect')).toBeDisabled();
     expect(screen.getByTestId('urlPrefixInput')).toBeDisabled();
   });

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeRow.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeRow.tsx
@@ -141,7 +141,7 @@ const AssignContentTypeRow = (props: Props) => {
           id={`contentType-${index}`}
           name={`contentType-${index}`}
           testId="contentTypeSelect"
-          isInvalid={!contentTypeId || !isContentTypeInOptions}
+          isInvalid={!isContentTypeInOptions && contentTypeId !== ''}
           onChange={(event: React.ChangeEvent<HTMLSelectElement>) =>
             onContentTypeChange(contentTypeId, event.target.value)
           }

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.tsx
@@ -93,6 +93,7 @@ const AssignContentTypeSection = (props: Props) => {
     setContentTypes(newContentTypes);
     const _parameters = { contentTypes: newContentTypes };
     mergeSdkParameters(_parameters);
+    // We always want the user to be able to save the configuration, even if there are errors or warnings
     onIsValidContentTypeAssignment(true);
   };
 

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.tsx
@@ -93,18 +93,7 @@ const AssignContentTypeSection = (props: Props) => {
     setContentTypes(newContentTypes);
     const _parameters = { contentTypes: newContentTypes };
     mergeSdkParameters(_parameters);
-
-    // Do not allow saving an empty content type or one that was deleted
-    let hasValidContentTypes = true;
-
-    for (const contentType in newContentTypes) {
-      if (!contentType || !allContentTypeEntries.find((entry) => entry[0] === contentType)) {
-        hasValidContentTypes = false;
-        break;
-      }
-    }
-
-    onIsValidContentTypeAssignment(hasValidContentTypes);
+    onIsValidContentTypeAssignment(true);
   };
 
   const handleContentTypeChange = (prevKey: string, newKey: string) => {

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/ContentTypeWarning.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/ContentTypeWarning.spec.tsx
@@ -2,7 +2,6 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import ContentTypeWarning from 'components/config-screen/assign-content-type/ContentTypeWarning';
 import {
-  NO_CONTENT_TYPE_ERR_MSG,
   NO_SLUG_WARNING_MSG,
   REMOVED_FROM_SIDEBAR_WARNING_MSG,
   getContentTypeDeletedMsg,
@@ -23,27 +22,6 @@ describe('Content Type Warning for Config Screen', () => {
     );
 
     expect(screen.getByTestId('noStatus')).toBeVisible();
-  });
-
-  it('renders an error icon and correct tooltip content when the content type is empty', async () => {
-    const user = userEvent.setup();
-
-    render(
-      <ContentTypeWarning
-        contentTypeId={''}
-        slugField={''}
-        isSaved={false}
-        isInSidebar={true}
-        isContentTypeInOptions={false}
-        isSlugFieldInOptions={false}
-      />
-    );
-
-    expect(screen.getByTestId('errorIcon')).toBeVisible();
-
-    await user.hover(screen.getByTestId('cf-ui-icon'));
-
-    expect(screen.getByRole('tooltip').textContent).toBe(NO_CONTENT_TYPE_ERR_MSG);
   });
 
   it('renders an error icon and correct tooltip content when content type is deleted', async () => {

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/ContentTypeWarning.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/ContentTypeWarning.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react';
 import { styles } from 'components/config-screen/assign-content-type/AssignContentType.styles';
 import {
-  NO_CONTENT_TYPE_ERR_MSG,
   NO_SLUG_WARNING_MSG,
   REMOVED_FROM_SIDEBAR_WARNING_MSG,
   getContentTypeDeletedMsg,
@@ -52,12 +51,7 @@ const ContentTypeWarning = (props: Props) => {
       content += getSlugFieldDeletedMsg(contentTypeId, slugField);
     }
 
-    // Error states
-    if (!contentTypeId) {
-      setWarningType(WarningTypes.Error);
-      content += NO_CONTENT_TYPE_ERR_MSG;
-    }
-
+    // Error state
     if (contentTypeId && !isContentTypeInOptions) {
       setWarningType(WarningTypes.Error);
       content += getContentTypeDeletedMsg(contentTypeId);


### PR DESCRIPTION
## Purpose
This PR fixes some issues with the content type configuration:
- When adding a new content type row, do not show an error state before the user has taken any action
- When there are content type errors, the user should still be able to save the configuration page

## Approach
Here's a [quick video](https://www.loom.com/share/8a2221b92342447da3060b5ae89a5867) showing current state and how I've addressed these issues in this PR.
- I removed the error state when adding a new row. If there is an empty row when saving, we are now filtering this row out instead of throwing an error
- I removed the validation on save if there is a content type error (e.g. a previously saved content type that has been deleted)
- I updated relevant tests and also removed a `console.log` from another PR
