### PR TITLE
Add .env to SAP for environment switching

### DIFF
--- a/apps/sap-commerce-cloud/.env
+++ b/apps/sap-commerce-cloud/.env
@@ -1,1 +1,1 @@
-REACT_APP_ENV=development
+REACT_APP_ENV=production

--- a/apps/sap-commerce-cloud/.env.development.sample
+++ b/apps/sap-commerce-cloud/.env.development.sample
@@ -1,0 +1,1 @@
+REACT_APP_ENV=development

--- a/apps/sap-commerce-cloud/.gitignore
+++ b/apps/sap-commerce-cloud/.gitignore
@@ -15,6 +15,7 @@
 # misc
 .DS_Store
 .env.local
+.env.development
 .env.development.local
 .env.test.local
 .env.production.local

--- a/apps/sap-commerce-cloud/README.md
+++ b/apps/sap-commerce-cloud/README.md
@@ -4,7 +4,15 @@ This project was bootstrapped with [Create Contentful App](https://github.com/co
 
 In the project directory, you can run:
 
-#### `npm start`
+### Install packages
+
+`npm i` 
+
+### Set development ENV
+
+Copy the contents of .env.development.sample into a new file called .env.development
+
+#### `npm run start`
 
 Creates or updates your app definition in contentful, and runs the app in development mode.
 Open your app to view it in the browser.

--- a/apps/sap-commerce-cloud/README.md
+++ b/apps/sap-commerce-cloud/README.md
@@ -10,7 +10,7 @@ In the project directory, you can run:
 
 ### Set development ENV
 
-Copy the contents of .env.development.sample into a new file called .env.development
+Copy the contents of .env.development.sample into a new file called .env.development (calls to SAP will only work from localhost with this added)
 
 #### `npm run start`
 


### PR DESCRIPTION
## Purpose
Calls to the SAP server from localhost will only work if `Application Interface Key` header is unset, however we will need this sent in a production environment so SAP knows Contentful is making the requests. This PR adds an environment context between development and production. 

## Approach
I added `.env.development` that is gitignored and a `.env.development.sample` with the correct env vars for setting the Application Interface Key. On start, the app will default to production unless working in a development (i.e. localhost) context. 


## Deployment
Should monitor the deploy and make sure in the prod space that the Application Interface Key is set correctly. 