### PR TITLE
[INTEG-361] Fix sidebar error when there are no content types

### DIFF
--- a/apps/google-analytics-4/frontend/src/components/common/HyperLink/HyperLink.tsx
+++ b/apps/google-analytics-4/frontend/src/components/common/HyperLink/HyperLink.tsx
@@ -10,8 +10,13 @@ interface Props {
 
 const HyperLink = (props: Props) => {
   const { body, substring, onClick = () => {}, hyperLinkHref } = props;
-  const link = (
-    <TextLink onClick={onClick} href={hyperLinkHref} target="_blank" rel="noopener noreferer">
+  const textLinkComponent = (index: number) => (
+    <TextLink
+      onClick={onClick}
+      href={hyperLinkHref}
+      target="_blank"
+      rel="noopener noreferer"
+      key={`textLink-${index}`}>
       {substring}
     </TextLink>
   );
@@ -21,7 +26,7 @@ const HyperLink = (props: Props) => {
       if (!i) {
         return [current];
       }
-      return prev.concat(link, current);
+      return prev.concat(textLinkComponent(i), current);
     }, []);
     return bodyWithTextLink as JSX.Element;
   };

--- a/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/DisplayServiceAccountCard.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/DisplayServiceAccountCard.tsx
@@ -282,7 +282,7 @@ const DisplayServiceAccountCard = (props: Props) => {
           </Flex>
           <FormControl>
             <FormControl.Label marginBottom="none">Service Account</FormControl.Label>
-            <Paragraph>
+            <Box>
               <Flex alignItems="center">
                 <Box paddingRight="spacingS">
                   <TextLink
@@ -295,17 +295,17 @@ const DisplayServiceAccountCard = (props: Props) => {
                   </TextLink>
                 </Box>
               </Flex>
-            </Paragraph>
+            </Box>
           </FormControl>
           <FormControl>
             <FormControl.Label marginBottom="none">Key ID</FormControl.Label>
-            <Paragraph>
+            <Box>
               <Box as="code">{serviceAccountKeyId.id}</Box>
-            </Paragraph>
+            </Box>
           </FormControl>
           <FormControl marginBottom="none">
             <FormControl.Label marginBottom="none">Status</FormControl.Label>
-            <Paragraph>
+            <Box>
               <Flex>
                 <Box paddingRight="spacingS">
                   <RenderStatusInfo />
@@ -324,7 +324,7 @@ const DisplayServiceAccountCard = (props: Props) => {
                   </Box>
                 )}
               </Flex>
-            </Paragraph>
+            </Box>
           </FormControl>
           {!unknownError && showChecks && (
             <ServiceAccountChecklist

--- a/apps/google-analytics-4/frontend/src/locations/Sidebar.tsx
+++ b/apps/google-analytics-4/frontend/src/locations/Sidebar.tsx
@@ -11,7 +11,10 @@ const Sidebar = () => {
     .installation as AppInstallationParameters;
 
   const currentContentType = sdk.contentType.sys.id;
-  const slugFieldInfo = contentTypes[currentContentType] ?? { slugField: '', urlPrefix: '' };
+  const slugFieldInfo = (contentTypes && contentTypes[currentContentType]) ?? {
+    slugField: '',
+    urlPrefix: '',
+  };
 
   const api = useApi(serviceAccountKeyId);
 


### PR DESCRIPTION
## Purpose
This PR fixes an error in the `Sidebar` component when there are no configured content types. Additionally, I fixed two warnings in the `HyperLink` and `DisplayServiceAccountCard` components.

## Approach
Reproduction steps for `Sidebar` error:
- Install the app but do not configure any content types
- Add the app manually to the sidebar of a content type
- Navigate to an entry of that content type. You should see the error: "Cannot read properties of undefined (reading 'content type id')"

In the `HyperLink` component, there was a warning for "Each child in a list should have a unique 'key' prop"

In the `DisplayServiceAccountCard` component, there was a warning for "div cannot appear as a descendant of p"
