### PR TITLE
Cleanup of account detail buttons and loading stages

### DIFF
--- a/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/DisplayServiceAccountCard.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/DisplayServiceAccountCard.tsx
@@ -7,13 +7,13 @@ import {
   Note,
   Card,
   Stack,
-  Paragraph,
   FormControl,
   Spinner,
   Button,
   Skeleton,
+  Text,
 } from '@contentful/f36-components';
-import { ExternalLinkTrimmedIcon } from '@contentful/f36-icons';
+import { ExternalLinkTrimmedIcon, CycleIcon } from '@contentful/f36-icons';
 import { useApi } from 'hooks/useApi';
 import { ServiceAccountKeyId } from 'types';
 import { ApiErrorType, ERROR_TYPE_MAP, isApiErrorType } from 'apis/apiTypes';
@@ -245,123 +245,131 @@ const DisplayServiceAccountCard = (props: Props) => {
     return <Badge variant="positive">Successfully configured</Badge>;
   };
 
+  const isLoading = isSavingPrivateKeyFile || isLoadingAdminApi || isLoadingDataApi;
+
+  const loadingSkeleton = (width = '100%') => {
+    return (
+      <Skeleton.Container svgHeight={21}>
+        <Skeleton.BodyText numberOfLines={1} lineHeight={20} width={width} />
+      </Skeleton.Container>
+    );
+  };
+
   return (
     <Card>
-      {isSavingPrivateKeyFile || isLoadingAdminApi || isLoadingDataApi ? (
-        <Flex>
-          <Skeleton.Container>
-            <Skeleton.BodyText numberOfLines={8} />
-          </Skeleton.Container>
+      <Flex justifyContent="space-between" marginBottom="spacingS">
+        <Box marginBottom="none">
+          <b>Google Service Account Details</b>
+        </Box>
+        <Flex justifyContent="space-between">
+          <Button
+            testId="editServiceAccountButton"
+            onClick={() => onInEditModeChange(true)}
+            variant="secondary"
+            size="small">
+            Replace key
+          </Button>
         </Flex>
-      ) : (
-        <>
-          <Flex justifyContent="space-between" marginBottom="none">
-            <Paragraph marginBottom="none" marginTop="spacingXs">
-              <b>Google Service Account Details</b>
-            </Paragraph>
-            <Flex justifyContent="space-between" marginBottom="spacingL">
-              <Box paddingRight="spacingXs" paddingTop="spacingXs">
+      </Flex>
+      <FormControl>
+        <FormControl.Label marginBottom="none">Service Account</FormControl.Label>
+        <Box>
+          {isLoading ? (
+            loadingSkeleton('65%')
+          ) : (
+            <Flex alignItems="center">
+              <Box paddingRight="spacingS">
                 <TextLink
-                  testId="editServiceAccountButton"
-                  as="button"
-                  variant="primary"
-                  onClick={() => onInEditModeChange(true)}>
-                  Edit
+                  icon={<ExternalLinkTrimmedIcon />}
+                  alignIcon="end"
+                  href={`https://console.cloud.google.com/iam-admin/serviceaccounts/details/${serviceAccountKeyId.clientId}?project=${serviceAccountKeyId.projectId}`}
+                  target="_blank"
+                  rel="noopener noreferrer">
+                  {serviceAccountKeyId.clientEmail}
                 </TextLink>
               </Box>
-              <Box>
-                {isSavingPrivateKeyFile || (isLoadingAdminApi && isLoadingDataApi) ? (
-                  <Spinner variant="primary" />
-                ) : (
-                  <Button variant="primary" size="small" onClick={handleApiTestClick}>
-                    Test
-                  </Button>
-                )}
-              </Box>
             </Flex>
-          </Flex>
-          <FormControl>
-            <FormControl.Label marginBottom="none">Service Account</FormControl.Label>
-            <Box>
-              <Flex alignItems="center">
-                <Box paddingRight="spacingS">
-                  <TextLink
-                    icon={<ExternalLinkTrimmedIcon />}
-                    alignIcon="end"
-                    href={`https://console.cloud.google.com/iam-admin/serviceaccounts/details/${serviceAccountKeyId.clientId}?project=${serviceAccountKeyId.projectId}`}
-                    target="_blank"
-                    rel="noopener noreferrer">
-                    {serviceAccountKeyId.clientEmail}
-                  </TextLink>
-                </Box>
-              </Flex>
-            </Box>
-          </FormControl>
-          <FormControl>
-            <FormControl.Label marginBottom="none">Key ID</FormControl.Label>
-            <Box>
-              <Box as="code">{serviceAccountKeyId.id}</Box>
-            </Box>
-          </FormControl>
-          <FormControl marginBottom="none">
-            <FormControl.Label marginBottom="none">Status</FormControl.Label>
-            <Box>
-              <Flex>
-                <Box paddingRight="spacingS">
-                  <RenderStatusInfo />
-                </Box>
-                {!unknownError && (
-                  <Box>
-                    {showChecks ? (
-                      <TextLink as="button" variant="primary" onClick={() => setShowChecks(false)}>
-                        Hide all checks
-                      </TextLink>
-                    ) : (
-                      <TextLink as="button" variant="primary" onClick={() => setShowChecks(true)}>
-                        Show all checks
-                      </TextLink>
-                    )}
-                  </Box>
-                )}
-              </Flex>
-            </Box>
-          </FormControl>
-          {!unknownError && showChecks && (
-            <ServiceAccountChecklist
-              serviceAccountCheck={{
-                ...getServiceKeyChecklistStatus(
-                  parameters,
-                  invalidServiceAccountError,
-                  missingServiceAccountError
-                ),
-              }}
-              adminApiCheck={{
-                ...getAdminApiErrorChecklistStatus(
-                  isFirstSetup,
-                  parameters,
-                  invalidServiceAccountError,
-                  adminApiError
-                ),
-              }}
-              dataApiCheck={{
-                ...getDataApiErrorChecklistStatus(
-                  isFirstSetup,
-                  parameters,
-                  invalidServiceAccountError,
-                  dataApiError
-                ),
-              }}
-              ga4PropertiesCheck={{
-                ...getGa4PropertyErrorChecklistStatus(
-                  isFirstSetup,
-                  invalidServiceAccountError,
-                  adminApiError,
-                  ga4PropertiesError
-                ),
-              }}
-            />
           )}
-        </>
+        </Box>
+      </FormControl>
+      <FormControl>
+        <FormControl.Label marginBottom="none">Key ID</FormControl.Label>
+        <Box>
+          {isLoading ? loadingSkeleton('50%') : <Box as="code">{serviceAccountKeyId.id}</Box>}
+        </Box>
+      </FormControl>
+      <FormControl marginBottom="none">
+        <FormControl.Label marginBottom="spacing2Xs">
+          <Flex alignItems="center">
+            <Text fontWeight="fontWeightDemiBold" marginRight="spacing2Xs">
+              Status
+            </Text>
+            {isLoading ? (
+              <Spinner size="small" />
+            ) : (
+              <CycleIcon size="small" style={{ cursor: 'pointer' }} onClick={handleApiTestClick} />
+            )}
+          </Flex>
+        </FormControl.Label>
+        <Box>
+          {isLoading ? (
+            loadingSkeleton('45%')
+          ) : (
+            <Flex>
+              <Box paddingRight="spacingS">
+                <RenderStatusInfo />
+              </Box>
+              {!unknownError && (
+                <Box>
+                  {showChecks ? (
+                    <TextLink as="button" variant="primary" onClick={() => setShowChecks(false)}>
+                      Hide status checks
+                    </TextLink>
+                  ) : (
+                    <TextLink as="button" variant="primary" onClick={() => setShowChecks(true)}>
+                      Show status checks
+                    </TextLink>
+                  )}
+                </Box>
+              )}
+            </Flex>
+          )}
+        </Box>
+      </FormControl>
+      {!unknownError && showChecks && !isLoading && (
+        <ServiceAccountChecklist
+          serviceAccountCheck={{
+            ...getServiceKeyChecklistStatus(
+              parameters,
+              invalidServiceAccountError,
+              missingServiceAccountError
+            ),
+          }}
+          adminApiCheck={{
+            ...getAdminApiErrorChecklistStatus(
+              isFirstSetup,
+              parameters,
+              invalidServiceAccountError,
+              adminApiError
+            ),
+          }}
+          dataApiCheck={{
+            ...getDataApiErrorChecklistStatus(
+              isFirstSetup,
+              parameters,
+              invalidServiceAccountError,
+              dataApiError
+            ),
+          }}
+          ga4PropertiesCheck={{
+            ...getGa4PropertyErrorChecklistStatus(
+              isFirstSetup,
+              invalidServiceAccountError,
+              adminApiError,
+              ga4PropertiesError
+            ),
+          }}
+        />
       )}
     </Card>
   );

--- a/apps/google-analytics-4/frontend/src/components/config-screen/map-account-property/MapAccountPropertySection.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/map-account-property/MapAccountPropertySection.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Stack, Box, Subheading, Spinner, Paragraph } from '@contentful/f36-components';
+import { Stack, Box, Subheading, Paragraph, Skeleton, Flex } from '@contentful/f36-components';
 import { AccountSummariesType } from 'types';
 import { KeyValueMap } from '@contentful/app-sdk/dist/types/entities';
 import MapAccountPropertyDropdown from 'components/config-screen/map-account-property/MapAccountPropertyDropdown';
@@ -82,8 +82,8 @@ export default function MapAccountPropertySection(props: Props) {
           website where your content appears.
         </Paragraph>
       </div>
-      <Box marginTop="none">
-        {!loadingProperties && !loadingParameters && !isApiAccessLoading ? (
+      {!loadingProperties && !loadingParameters && !isApiAccessLoading ? (
+        <Box marginTop="none">
           <MapAccountPropertyDropdown
             onSelectionChange={handleSelectionChange}
             isPropertyIdInOptions={isPropertyIdInOptions}
@@ -91,10 +91,14 @@ export default function MapAccountPropertySection(props: Props) {
             sortedAccountSummaries={sortedAccountSummaries}
             originalPropertyId={originalPropertyId}
           />
-        ) : (
-          <Spinner variant="primary" />
-        )}
-      </Box>
+        </Box>
+      ) : (
+        <Flex marginTop="none" fullWidth={true}>
+          <Skeleton.Container svgHeight={139}>
+            <Skeleton.BodyText numberOfLines={6} />
+          </Skeleton.Container>
+        </Flex>
+      )}
     </Stack>
   );
 }


### PR DESCRIPTION
## Purpose

* Button names on the service account details were confusingly located and named in a confusing way (people didn't realize you needed to click "Test" to check the status after making changes in Google
* Loading states were unnecessarily big

## Approach

* Move "Text" to a little refresh wheel next to status (closer to the action and obvious action)
* Change the "edit" link (inaccurate) to "Replace key" button
* Add line loading skeletons instead of ad hoc mix of spinners and loaders

https://www.loom.com/share/1fb1e4243a184825ba6e9080244664c8

## Screenshots

### Before

<img width="923" alt="image" src="https://user-images.githubusercontent.com/235836/229247531-cfaaf337-62cb-4966-a176-71765edbfd02.png">

### After

<img width="924" alt="image" src="https://user-images.githubusercontent.com/235836/229247423-eedfaa65-af23-484f-a1e8-fe1ac8b65914.png">


## Dependencies and/or References
<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment
<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
