### PR TITLE
fix spacing in GA4 status checklist

### DIFF
--- a/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/ServiceAccountChecklist.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/ServiceAccountChecklist.tsx
@@ -1,6 +1,7 @@
 import GenericChecklistRow from 'components/config-screen/api-access/display/GenericCheckRow';
 import { ChecklistRow } from 'components/config-screen/api-access/display/ChecklistUtils';
 import tokens from '@contentful/f36-tokens';
+import { Box } from '@contentful/f36-components';
 
 interface Props {
   serviceAccountCheck: ChecklistRow;
@@ -24,7 +25,7 @@ export default function ServiceAccountChecklist(props: Props) {
   const { adminApiCheck, dataApiCheck, serviceAccountCheck, ga4PropertiesCheck } = props;
 
   return (
-    <>
+    <Box marginTop="spacingS">
       <GenericChecklistRow
         icon={serviceAccountCheck.icon}
         title={serviceAccountCheck.title}
@@ -57,6 +58,6 @@ export default function ServiceAccountChecklist(props: Props) {
         disabled={ga4PropertiesCheck.disabled}
         style={{ ...styles.defaultRowStyle, ...styles.nonTopRowStyle }}
       />
-    </>
+    </Box>
   );
 }


### PR DESCRIPTION
## Purpose
Fix spacing on service account status checklist

Before:
![Screenshot 2023-04-03 at 10 59 07 AM](https://user-images.githubusercontent.com/492573/229548835-4bb0536e-5aa9-4167-973b-8a8030b859a9.png)

After:
![Screenshot 2023-04-03 at 10 59 00 AM](https://user-images.githubusercontent.com/492573/229548833-f5032229-3dbb-49ea-991e-811c67f4b0f8.png)


## Approach
<!-- Why did we do it the way we did? Did we consider alternatives? What other implementation details or artifacts (screenshots etc.) would help reviewers contextualize change? -->

## Dependencies and/or References
<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment
<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
