### PR TITLE
[Fix] Date range tests GA4

### DIFF
--- a/apps/google-analytics-4/frontend/src/helpers/DateRangeHelpers/DateRangeHelpers.spec.ts
+++ b/apps/google-analytics-4/frontend/src/helpers/DateRangeHelpers/DateRangeHelpers.spec.ts
@@ -3,9 +3,18 @@ import getRangeDates, { RANGE_OPTIONS } from './DateRangeHelpers';
 
 const DAY_IN_MS = 1000 * 3600 * 24;
 
-const calculateRangeDates = (range: DateRangeType) => {
+const getDateRangeTime = (range: DateRangeType) => {
   const { start, end } = getRangeDates(range);
   const getDate = (date: string) => new Date(date).getTime();
+  return {
+    startTime: getDate(start),
+    endTime: getDate(end),
+  };
+};
+
+const getParsedDateRangeDate = (range: DateRangeType) => {
+  const { start, end } = getRangeDates(range);
+  const getDate = (date: string) => Number(new Date(date).toLocaleDateString().split('/')[1]);
   return {
     startDay: getDate(start),
     endDay: getDate(end),
@@ -14,14 +23,26 @@ const calculateRangeDates = (range: DateRangeType) => {
 
 describe('handle date range helper', () => {
   it('formats dates correctly for week range', () => {
-    const { startDay, endDay } = calculateRangeDates('lastWeek');
+    const { startTime, endTime } = getDateRangeTime('lastWeek');
+    const { startDay, endDay } = getParsedDateRangeDate('lastWeek');
 
-    expect((endDay - startDay) / DAY_IN_MS).toBe(RANGE_OPTIONS.lastWeek.startDaysAgo);
+    expect((endTime - startTime) / DAY_IN_MS).toBe(RANGE_OPTIONS.lastWeek.startDaysAgo);
+    const today = new Date();
+    const oneWeekAgo = new Date();
+    oneWeekAgo.setDate(oneWeekAgo.getDate() - 7);
+    expect(endDay).toBe(today.getDate());
+    expect(startDay).toBe(oneWeekAgo.getDate());
   });
 
   it('formats dates correctly for day range', () => {
-    const { startDay, endDay } = calculateRangeDates('lastDay');
+    const { startTime, endTime } = getDateRangeTime('lastDay');
+    const { startDay, endDay } = getParsedDateRangeDate('lastDay');
 
-    expect((endDay - startDay) / DAY_IN_MS).toBe(RANGE_OPTIONS.lastDay.startDaysAgo);
+    expect((endTime - startTime) / DAY_IN_MS).toBe(RANGE_OPTIONS.lastDay.startDaysAgo);
+    const today = new Date();
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    expect(endDay).toBe(today.getDate());
+    expect(startDay).toBe(yesterday.getDate());
   });
 });


### PR DESCRIPTION
## Purpose
Failures in GA4 tests because we are in a new month. 

## Approach
Update the test to not compare the date diffs, but the actual date number that's extracted from the parser