### PR TITLE
feat: stores product url instead of only sku id

### DIFF
--- a/apps/sap-commerce-cloud/src/api/fetchProductPreviews.ts
+++ b/apps/sap-commerce-cloud/src/api/fetchProductPreviews.ts
@@ -23,7 +23,7 @@ export async function fetchProductPreviews(
         },
       };
   for (const sku of skus) {
-    skuIds.push(sku.split('/products/').pop()!);
+    skuIds.push(sku.split('/products/').pop() as string);
     const response = await fetch(
       sku +
         '?fields=code,name,summary,price(formattedValue,DEFAULT),images(galleryIndex,FULL),averageRating,stock(DEFAULT),description,availableForPickup,url,numberOfReviews,manufacturer,categories(FULL),priceRange,multidimensional,configuratorType,configurable,tags',

--- a/apps/sap-commerce-cloud/src/api/fetchProductPreviews.ts
+++ b/apps/sap-commerce-cloud/src/api/fetchProductPreviews.ts
@@ -23,14 +23,9 @@ export async function fetchProductPreviews(
         },
       };
   for (const sku of skus) {
-    const splitSku = sku.split(':');
-    const baseSite = splitSku[0];
-    const skuId = splitSku[1];
-    skuIds.push(skuId);
+    skuIds.push(sku.split('/products/').pop()!);
     const response = await fetch(
-      parameters.installation.apiEndpoint +
-        `/occ/v2/${baseSite}/products/` +
-        skuId +
+      sku +
         '?fields=code,name,summary,price(formattedValue,DEFAULT),images(galleryIndex,FULL),averageRating,stock(DEFAULT),description,availableForPickup,url,numberOfReviews,manufacturer,categories(FULL),priceRange,multidimensional,configuratorType,configurable,tags',
       headers
     );
@@ -43,7 +38,7 @@ export async function fetchProductPreviews(
   const products = totalResponse.map(productTransformer(parameters.installation));
   const foundSKUs = products.map((product: { sku: any }) => product.sku);
   const missingProducts = difference(skuIds, foundSKUs).map((sku) => ({
-    sku,
+    sku: sku.split('/products/').pop(),
     image: '',
     id: '',
     name: '',

--- a/apps/sap-commerce-cloud/src/components/Dialog.tsx
+++ b/apps/sap-commerce-cloud/src/components/Dialog.tsx
@@ -125,9 +125,7 @@ export default class Dialog extends React.Component<DialogProps, State> {
     if (event.target.checked) {
       if (!existingProducts.includes(skuId)) {
         const apiEndpoint = get(this.props.sdk.parameters.invocation, 'apiEndpoint', '');
-        existingProducts.push(
-          apiEndpoint + '/occ/v2/' + this.state.baseSite + '/products/' + skuId
-        );
+        existingProducts.push(`${apiEndpoint}/occ/v2/${this.state.baseSite}/products/${skuId}`);
         this.setState({
           selectedProducts: existingProducts,
         });

--- a/apps/sap-commerce-cloud/src/components/Dialog.tsx
+++ b/apps/sap-commerce-cloud/src/components/Dialog.tsx
@@ -18,6 +18,7 @@ import { fetchProductList } from '../api/fetchProductList';
 import { fetchBaseSites } from '../api/fetchBaseSites';
 import { Error, Product, SAPParameters } from '../interfaces';
 import get from 'lodash/get';
+import union from 'lodash/union';
 
 interface DialogProps {
   sdk: DialogExtensionSDK;
@@ -120,9 +121,13 @@ export default class Dialog extends React.Component<DialogProps, State> {
   multiProductsCheckBoxClickEvent = (event: any) => {
     let existingProducts: string[] = this.state.selectedProducts;
     const skuId: string = event.target.id;
+
     if (event.target.checked) {
       if (!existingProducts.includes(skuId)) {
-        existingProducts.push(this.state.baseSite + ':' + skuId);
+        const apiEndpoint = get(this.props.sdk.parameters.invocation, 'apiEndpoint', '');
+        existingProducts.push(
+          apiEndpoint + '/occ/v2/' + this.state.baseSite + '/products/' + skuId
+        );
         this.setState({
           selectedProducts: existingProducts,
         });
@@ -143,9 +148,10 @@ export default class Dialog extends React.Component<DialogProps, State> {
   };
 
   selectMultipleProductsClickEvent = () => {
-    let finalValue = get(this.props.sdk.parameters.invocation, 'fieldValue', [] as string[]);
-    finalValue = finalValue.concat(this.state.selectedProducts);
-    this.props.sdk.close(finalValue);
+    const currentField = get(this.props.sdk.parameters.invocation, 'fieldValue', [] as string[]);
+    const updatedField = union(currentField, this.state.selectedProducts);
+
+    this.props.sdk.close(updatedField);
   };
 
   searchButtonClickEvent() {


### PR DESCRIPTION
## Purpose
An experienced developer would want a full URL to fetch their products. This makes the developer experience a lot nicer

## Approach
Store the data as the full URL, and split on `/products/` when we need the sku ID (this avoids the issue of the sku ID containing `/`)
