### PR TITLE
[INTEG-319] Update content for service account key setup

### DIFF
--- a/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage.spec.tsx
@@ -52,7 +52,7 @@ describe('Config Screen component (not installed)', () => {
     await user.paste(JSON.stringify(validServiceKeyFile));
 
     await waitFor(() => {
-      expect(screen.getByText('Service account key file is valid')).toBeInTheDocument();
+      expect(screen.getByText('Service account key file is valid JSON')).toBeInTheDocument();
     });
 
     let result;
@@ -146,7 +146,7 @@ describe('Installed Service Account Key', () => {
     await user.paste(JSON.stringify(newServiceKeyFile));
 
     await waitFor(() => {
-      expect(screen.getByText('Service account key file is valid')).toBeInTheDocument();
+      expect(screen.getByText('Service account key file is valid JSON')).toBeInTheDocument();
     });
 
     let result;

--- a/apps/google-analytics-4/frontend/src/components/config-screen/api-access/setup/SetupServiceAccountCard.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/api-access/setup/SetupServiceAccountCard.spec.tsx
@@ -81,7 +81,7 @@ describe('Setup Google Service Account Details page', () => {
 
     await waitFor(() => {
       expect(screen.getByLabelText(/Service Account Key/).getAttribute('aria-invalid')).toBeNull();
-      expect(screen.getByText('Service account key file is valid')).toBeInTheDocument();
+      expect(screen.getByText('Service account key file is valid JSON')).toBeInTheDocument();
     });
   });
 });

--- a/apps/google-analytics-4/frontend/src/components/config-screen/api-access/setup/SetupServiceAccountCard.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/api-access/setup/SetupServiceAccountCard.tsx
@@ -118,9 +118,9 @@ export default function SetupServiceAccountCard(props: Props) {
               rel="noopener noreferrer">
               these detailed instructions
             </TextLink>{' '}
-            to create a service account in Google and obtain the required service account key file.
-            When you are finished, copy and paste the entire contents of this file into the "Service
-            Account Key File" field above.
+            to create a service account in Google and obtain the required service account key file
+            (JSON). When you are finished, copy and paste the entire contents of this file into the
+            "Service Account Key" field below.
           </Note>
         </Box>
         <FormControl
@@ -148,7 +148,7 @@ export default function SetupServiceAccountCard(props: Props) {
               <Flex isInline={true} alignItems="center">
                 <CheckCircleIcon variant="positive" />
                 <Text as="p" marginLeft="spacing2Xs" fontColor="gray700">
-                  Service account key file is valid
+                  Service account key file is valid JSON
                 </Text>
               </Flex>
             </Flex>


### PR DESCRIPTION
## Purpose
When pasting in the service account key for the GA4 app configuration, the validation message `Service account key is valid` was confusing. We are only checking to see if the key is valid JSON, not if the key itself is valid. 

## Approach
Updated the validation message to `Service account key file is valid JSON` and also updated some content in the Note text. Below are examples of the messages presented to users with valid and invalid JSON service account key files.

![Screenshot 2023-04-03 at 1 20 14 PM](https://user-images.githubusercontent.com/62958907/229610426-18ad7549-51a3-44bb-abeb-e1ce65fcbd62.png)

![Screenshot 2023-04-03 at 1 20 30 PM](https://user-images.githubusercontent.com/62958907/229610432-788880d7-f2f2-40a7-9a88-498b41629a90.png)

