### PR TITLE
SAP/Remove Application Interface Key

### DIFF
--- a/apps/sap-commerce-cloud/src/index.tsx
+++ b/apps/sap-commerce-cloud/src/index.tsx
@@ -41,8 +41,8 @@ const getApplicationInterfaceKey = async (): Promise<boolean | string> => {
 
 init(async (sdk) => {
   const root = document.getElementById('root');
-  const isTestEnv = config.isTestEnv;
-  const sapApplicationInterfaceKey = !isTestEnv ? await getApplicationInterfaceKey() : '';
+  //const isTestEnv = config.isTestEnv;
+  const sapApplicationInterfaceKey = '';
   const ComponentLocationSettings = [
     {
       location: locations.LOCATION_APP_CONFIG,


### PR DESCRIPTION

## Purpose

We're having some issues with the application interface key in our prod space, SAP blocks access with the header added. In order to unblock prod we're removing this for the time being and have reached out to SAP to help diagnose. 

