### PR TITLE
adds copy button for service account email

### DIFF
--- a/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/DisplayServiceAccountCard.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/DisplayServiceAccountCard.tsx
@@ -12,8 +12,9 @@ import {
   Button,
   Skeleton,
   Text,
+  CopyButton,
 } from '@contentful/f36-components';
-import { ExternalLinkTrimmedIcon, CycleIcon } from '@contentful/f36-icons';
+import { CycleIcon } from '@contentful/f36-icons';
 import { useApi } from 'hooks/useApi';
 import { ServiceAccountKeyId } from 'types';
 import { ApiErrorType, ERROR_TYPE_MAP, isApiErrorType } from 'apis/apiTypes';
@@ -261,15 +262,13 @@ const DisplayServiceAccountCard = (props: Props) => {
         <Box marginBottom="none">
           <b>Google Service Account Details</b>
         </Box>
-        <Flex justifyContent="space-between">
-          <Button
-            testId="editServiceAccountButton"
-            onClick={() => onInEditModeChange(true)}
-            variant="secondary"
-            size="small">
-            Replace key
-          </Button>
-        </Flex>
+        <Button
+          testId="editServiceAccountButton"
+          onClick={() => onInEditModeChange(true)}
+          variant="secondary"
+          size="small">
+          Replace key
+        </Button>
       </Flex>
       <FormControl>
         <FormControl.Label marginBottom="none">Service Account</FormControl.Label>
@@ -277,26 +276,27 @@ const DisplayServiceAccountCard = (props: Props) => {
           {isLoading ? (
             loadingSkeleton('65%')
           ) : (
-            <Flex alignItems="center">
-              <Box paddingRight="spacingS">
-                <TextLink
-                  icon={<ExternalLinkTrimmedIcon />}
-                  alignIcon="end"
-                  href={`https://console.cloud.google.com/iam-admin/serviceaccounts/details/${serviceAccountKeyId.clientId}?project=${serviceAccountKeyId.projectId}`}
-                  target="_blank"
-                  rel="noopener noreferrer">
-                  {serviceAccountKeyId.clientEmail}
-                </TextLink>
-              </Box>
+            <Flex alignItems="center" gap="spacingXs">
+              <Box>{serviceAccountKeyId.clientEmail}</Box>
+              <CopyButton
+                value={serviceAccountKeyId.clientEmail}
+                size="small"
+                style={{
+                  display: 'block',
+                  border: 'none',
+                  padding: 0,
+                  lineHeight: '1rem',
+                  height: '1rem',
+                  width: 'auto',
+                }}
+              />
             </Flex>
           )}
         </Box>
       </FormControl>
       <FormControl>
         <FormControl.Label marginBottom="none">Key ID</FormControl.Label>
-        <Box>
-          {isLoading ? loadingSkeleton('50%') : <Box as="code">{serviceAccountKeyId.id}</Box>}
-        </Box>
+        {isLoading ? loadingSkeleton('50%') : <Box>{serviceAccountKeyId.id}</Box>}
       </FormControl>
       <FormControl marginBottom="none">
         <FormControl.Label marginBottom="spacing2Xs">


### PR DESCRIPTION
## Purpose 
Makes it easier for space admins to copy the service account email address to invite it as a viewer to their Google Analytics account property

## Approach
Uses f36 CopyButton component

https://user-images.githubusercontent.com/492573/229912071-cd9c626d-b6b5-4a4d-a5f0-64e1684762c2.mov

## Dependencies and/or References
- [x] test in staging with new clipboard-write permissions
- [ ] ensure that user_interface deploy v6893 or greater has been deployed to production which includes the @contentful/widget-renderer package update that [allows clipboard-write](https://github.com/contentful/experience-packages/pull/2027) on the app framework iframes