### PR TITLE
[INTEG-356-373] Fix invalid and missing service account error handling

### DIFF
--- a/apps/google-analytics-4/frontend/src/apis/apiTypes.ts
+++ b/apps/google-analytics-4/frontend/src/apis/apiTypes.ts
@@ -67,6 +67,7 @@ export type RunReportData = z.infer<typeof ZRunReportData>;
 // TODO: more comprehensive recognization of known failures (ie. Stale/bad account data, lambda unavailable, transient, non-transient errors, timeouts)
 // NOTE: This needs to be in sync with the lambda - ie copy and pasted
 export const ERROR_TYPE_MAP = {
+  // Google errors
   unknown: 'Unknown',
   unexpected: 'Unexpected',
   failedFetch: 'FailedFetch',
@@ -76,6 +77,8 @@ export const ERROR_TYPE_MAP = {
   disabledDataApi: 'DisabledDataApi',
   noAccountsOrPropertiesFound: 'NoAccountsOrPropertiesFound',
   invalidProperty: 'InvalidProperty',
+  invalidServiceAccount: 'InvalidServiceAccount',
+  // Lambda errors
   invalidServiceAccountKey: 'InvalidServiceAccountKey',
   missingServiceAccountKeyFile: 'MissingServiceAccountKeyFile',
 };

--- a/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/ChecklistUtils.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/ChecklistUtils.tsx
@@ -291,15 +291,15 @@ export const getServiceKeyChecklistStatus = (
 export const getAdminApiErrorChecklistStatus = (
   isFirstSetup: boolean,
   parameters: KeyValueMap,
-  invalidServiceAccountError: ApiErrorType | undefined,
+  serviceAccountError: ApiErrorType | undefined,
   apiError: ApiErrorType | undefined
 ): ChecklistRow => {
   const checklistUrl = getApiChecklistURLs(parameters, apiError ? true : false).adminApi;
-  if (!invalidServiceAccountError && !apiError)
+  if (!serviceAccountError && !apiError)
     return { ...CHECKLIST_STATUSES.AdminApi.success, checklistUrl: checklistUrl };
-  if (isFirstSetup && (apiError || !invalidServiceAccountError))
+  if (isFirstSetup && (apiError || !serviceAccountError))
     return { ...CHECKLIST_STATUSES.AdminApi.firstTimeSetup, checklistUrl: checklistUrl };
-  if (invalidServiceAccountError) return CHECKLIST_STATUSES.AdminApi.invalidServiceAccount;
+  if (serviceAccountError) return CHECKLIST_STATUSES.AdminApi.invalidServiceAccount;
   if (apiError) return { ...CHECKLIST_STATUSES.AdminApi.error, checklistUrl: checklistUrl };
   return CHECKLIST_STATUSES.Other.unknown;
 };
@@ -307,32 +307,32 @@ export const getAdminApiErrorChecklistStatus = (
 export const getDataApiErrorChecklistStatus = (
   isFirstSetup: boolean,
   parameters: KeyValueMap,
-  invalidServiceAccountError: ApiErrorType | undefined,
+  serviceAccountError: ApiErrorType | undefined,
   apiError: ApiErrorType | undefined
 ): ChecklistRow => {
   const checklistUrl = getApiChecklistURLs(parameters, apiError ? true : false).dataApi;
-  if (!invalidServiceAccountError && !apiError)
+  if (!serviceAccountError && !apiError)
     return { ...CHECKLIST_STATUSES.DataApi.success, checklistUrl: checklistUrl };
-  if (isFirstSetup && (apiError || !invalidServiceAccountError))
+  if (isFirstSetup && (apiError || !serviceAccountError))
     return { ...CHECKLIST_STATUSES.DataApi.firstTimeSetup, checklistUrl: checklistUrl };
-  if (invalidServiceAccountError) return CHECKLIST_STATUSES.DataApi.invalidServiceAccount;
+  if (serviceAccountError) return CHECKLIST_STATUSES.DataApi.invalidServiceAccount;
   if (apiError) return { ...CHECKLIST_STATUSES.DataApi.error, checklistUrl: checklistUrl };
   return CHECKLIST_STATUSES.Other.unknown;
 };
 
 export const getGa4PropertyErrorChecklistStatus = (
   isFirstSetup: boolean,
-  invalidServiceAccountError: ApiErrorType | undefined,
+  serviceAccountError: ApiErrorType | undefined,
   adminApiError: ApiErrorType | undefined,
   ga4PropertiesError: ApiErrorType | undefined
 ): ChecklistRow => {
-  if (!invalidServiceAccountError && !adminApiError && !ga4PropertiesError)
+  if (!serviceAccountError && !adminApiError && !ga4PropertiesError)
     return CHECKLIST_STATUSES.GA4Properties.success;
   if (isFirstSetup && adminApiError)
     return CHECKLIST_STATUSES.GA4Properties.firstTimeSetupNotEnabled;
   if (isFirstSetup && ga4PropertiesError) return CHECKLIST_STATUSES.GA4Properties.firstTimeSetup;
   if (adminApiError) return CHECKLIST_STATUSES.GA4Properties.adminApiError;
-  if (invalidServiceAccountError) return CHECKLIST_STATUSES.GA4Properties.invalidServiceAccount;
+  if (serviceAccountError) return CHECKLIST_STATUSES.GA4Properties.invalidServiceAccount;
   if (ga4PropertiesError) return CHECKLIST_STATUSES.GA4Properties.error;
   return CHECKLIST_STATUSES.Other.unknown;
 };

--- a/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/DisplayServiceAccountCard.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/DisplayServiceAccountCard.tsx
@@ -75,6 +75,7 @@ const DisplayServiceAccountCard = (props: Props) => {
 
   const handleApiError = (error: ApiErrorType) => {
     switch (error.errorType) {
+      case ERROR_TYPE_MAP.invalidServiceAccount:
       case ERROR_TYPE_MAP.invalidServiceAccountKey:
         setInvalidServiceAccountError(error);
         break;
@@ -358,7 +359,7 @@ const DisplayServiceAccountCard = (props: Props) => {
             ...getAdminApiErrorChecklistStatus(
               isFirstSetup,
               parameters,
-              invalidServiceAccountError,
+              invalidServiceAccountError || missingServiceAccountError,
               adminApiError
             ),
           }}
@@ -366,14 +367,14 @@ const DisplayServiceAccountCard = (props: Props) => {
             ...getDataApiErrorChecklistStatus(
               isFirstSetup,
               parameters,
-              invalidServiceAccountError,
+              invalidServiceAccountError || missingServiceAccountError,
               dataApiError
             ),
           }}
           ga4PropertiesCheck={{
             ...getGa4PropertyErrorChecklistStatus(
               isFirstSetup,
-              invalidServiceAccountError,
+              invalidServiceAccountError || missingServiceAccountError,
               adminApiError,
               ga4PropertiesError
             ),

--- a/apps/google-analytics-4/frontend/src/components/main-app/ErrorDisplay/ErrorDisplay.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/ErrorDisplay/ErrorDisplay.spec.tsx
@@ -88,6 +88,30 @@ describe('ErrorDisplay', () => {
             details: '',
             message: '',
             status: 404,
+            errorType: 'InvalidServiceAccount',
+          })
+        }
+      />
+    );
+
+    const warningMsg = await findByText(
+      INVALID_SERVICE_ACCOUNT.replace(HYPER_LINK_COPY, '').trim()
+    );
+    const hyperLink = getByTestId('cf-ui-text-link');
+
+    expect(warningMsg).toBeVisible();
+    expect(hyperLink).toBeVisible();
+  });
+
+  it('mounts with correct msg when error is of type InvalidServiceAccountKey', async () => {
+    const HYPER_LINK_COPY = 'app configuration page.';
+    render(
+      <ErrorDisplay
+        error={
+          new ApiError({
+            details: '',
+            message: '',
+            status: 404,
             errorType: 'InvalidServiceAccountKey',
           })
         }

--- a/apps/google-analytics-4/frontend/src/components/main-app/ErrorDisplay/ErrorDisplay.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/ErrorDisplay/ErrorDisplay.tsx
@@ -39,6 +39,7 @@ const ErrorDisplay = (props: Props) => {
         case ERROR_TYPE_MAP.failedFetch:
           setErrorBody('supportHyperLink');
           break;
+        case ERROR_TYPE_MAP.invalidServiceAccount:
         case ERROR_TYPE_MAP.invalidServiceAccountKey:
           setErrorBody('invalidServiceAccount');
           break;


### PR DESCRIPTION
## Purpose

This PR fixes two issues with error handling related to invalid/missing service account keys for the GA4 app configuration.

## Approach

The first issue is that when there is an invalid service account, the wrong error message was showing. It was showing "unknown error" when it should be showing the service key check as "Service account key is not valid".

Incorrect
<img width="858" alt="image-20230404-144505" src="https://user-images.githubusercontent.com/62958907/229930696-27bc418e-c67a-43d2-bcbf-3938f1c9baf8.png">

Correct
![Screenshot 2023-04-04 at 9 48 07 AM](https://user-images.githubusercontent.com/62958907/229930617-c23346da-e7ff-41fc-b5d1-0773d83f90e8.png)

The second issue is when there is a missing service account key error, the API and property checks were showing as "enabled" when they should be showing as "Provide a valid service account key to run this check".

Incorrect
<img width="816" alt="image-20230330-194317" src="https://user-images.githubusercontent.com/62958907/229930713-0074e49c-33c8-4f7e-bbb6-de2d54fd5e5e.png">

Correct
![Screenshot 2023-04-04 at 2 37 15 PM](https://user-images.githubusercontent.com/62958907/229930652-c165feab-1023-47ad-8d21-fb7df4cc10bc.png)

This PR also adds handling for the "InvalidServiceAccountKey" error and fixes some of the tests in `ServiceAccountChecklist.spec.tsx`.

## Testing steps

To reproduce an invalid service account error from Google: 
- Install a valid service account key
- Remove the key in Google
- Refresh status checks

To reproduce the missing service account key/invalid service account key errors:
- Throw the error directly from the `ApiController`
