### PR TITLE
Add waiting period when updating slug field to avoid a network call on every keystroke

### DIFF
--- a/apps/google-analytics-4/frontend/src/hooks/useSidebarSlug/useSidebarSlug.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/hooks/useSidebarSlug/useSidebarSlug.spec.tsx
@@ -102,7 +102,10 @@ describe('useSidebarSlug hook', () => {
         ),
       },
     }));
-    jest.spyOn(getFieldValue, 'default').mockImplementationOnce(() => '/fieldValue');
+    jest
+      .spyOn(getFieldValue, 'default')
+      .mockImplementationOnce(() => '/fieldValue')
+      .mockImplementationOnce(() => '/differentFieldValue');
     const slugFieldInfo = { slugField: 'slugField', urlPrefix: '/en-US' };
 
     render(<TestComponent slugFieldInfo={slugFieldInfo} />);
@@ -114,7 +117,6 @@ describe('useSidebarSlug hook', () => {
     expect(getByText('slugFieldValue: /fieldValue')).toBeVisible();
     expect(getByText('isContentTypeWarning: false')).toBeVisible();
 
-    jest.spyOn(getFieldValue, 'default').mockImplementationOnce(() => '/differentFieldValue');
     const newSlugFieldValue = await findByText('slugFieldValue: /differentFieldValue');
 
     expect(newSlugFieldValue).toBeVisible();

--- a/apps/google-analytics-4/frontend/src/hooks/useSidebarSlug/useSidebarSlug.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/hooks/useSidebarSlug/useSidebarSlug.spec.tsx
@@ -36,7 +36,7 @@ const TestComponent = (props: Props) => {
   );
 };
 
-const { getByText } = screen;
+const { getByText, findByText } = screen;
 
 describe('useSidebarSlug hook', () => {
   it('returns slug info and status when content types are configured correctly', () => {
@@ -88,5 +88,36 @@ describe('useSidebarSlug hook', () => {
     expect(getByText('reportSlug: /en-US')).toBeVisible();
     expect(getByText('slugFieldValue:')).toBeVisible();
     expect(getByText('isContentTypeWarning: true')).toBeVisible();
+  });
+
+  it('returns slug info and status when field value is updated', async () => {
+    jest.spyOn(useSDK, 'useSDK').mockImplementation(() => ({
+      ...jest.requireActual('@contentful/react-apps-toolkit'),
+      entry: {
+        fields: { slugField: {} },
+        onSysChanged: jest.fn((cb) =>
+          cb({
+            publishedAt: '2020202',
+          } as unknown as ContentEntitySys)
+        ),
+      },
+    }));
+    jest.spyOn(getFieldValue, 'default').mockImplementationOnce(() => '/fieldValue');
+    const slugFieldInfo = { slugField: 'slugField', urlPrefix: '/en-US' };
+
+    render(<TestComponent slugFieldInfo={slugFieldInfo} />);
+
+    expect(getByText('slugFieldIsConfigured: true')).toBeVisible();
+    expect(getByText('contentTypeHasSlugField: true')).toBeVisible();
+    expect(getByText('isPublished: true')).toBeVisible();
+    expect(getByText('reportSlug: /en-US/fieldValue')).toBeVisible();
+    expect(getByText('slugFieldValue: /fieldValue')).toBeVisible();
+    expect(getByText('isContentTypeWarning: false')).toBeVisible();
+
+    jest.spyOn(getFieldValue, 'default').mockImplementationOnce(() => '/differentFieldValue');
+    const newSlugFieldValue = await findByText('slugFieldValue: /differentFieldValue');
+
+    expect(newSlugFieldValue).toBeVisible();
+    expect(getByText('reportSlug: /en-US/differentFieldValue')).toBeVisible();
   });
 });

--- a/apps/google-analytics-4/frontend/src/hooks/useSidebarSlug/useSidebarSlug.tsx
+++ b/apps/google-analytics-4/frontend/src/hooks/useSidebarSlug/useSidebarSlug.tsx
@@ -19,7 +19,7 @@ export const useSidebarSlug = (slugFieldInfo: ContentTypeValue) => {
   };
 
   useEffect(() => {
-    const timeout = setTimeout(() => setDebouncedSlugFieldValue(slugFieldValue), 500);
+    const timeout = setTimeout(() => setDebouncedSlugFieldValue(slugFieldValue), 700);
 
     return () => clearTimeout(timeout);
   }, [slugFieldValue]);

--- a/apps/google-analytics-4/frontend/src/hooks/useSidebarSlug/useSidebarSlug.tsx
+++ b/apps/google-analytics-4/frontend/src/hooks/useSidebarSlug/useSidebarSlug.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { ContentTypeValue } from 'types';
 import { useSDK } from '@contentful/react-apps-toolkit';
 import { ContentEntitySys, SidebarExtensionSDK } from '@contentful/app-sdk';
@@ -18,17 +18,11 @@ export const useSidebarSlug = (slugFieldInfo: ContentTypeValue) => {
     setIsPublished(Boolean(sys.publishedAt));
   };
 
-  const updateSlugFieldValue = (v: string) => {
-    setDebouncedSlugFieldValue(v);
-  };
-
-  const handleSlugFieldValue = useCallback(updateSlugFieldValue, [updateSlugFieldValue]);
-
   useEffect(() => {
-    const timeout = setTimeout(() => handleSlugFieldValue(slugFieldValue), 500);
+    const timeout = setTimeout(() => setDebouncedSlugFieldValue(slugFieldValue), 500);
 
     return () => clearTimeout(timeout);
-  }, [slugFieldValue, handleSlugFieldValue]);
+  }, [slugFieldValue]);
 
   useEffect(() => {
     // We only want this to update state on component mount.

--- a/apps/google-analytics-4/frontend/src/hooks/useSidebarSlug/useSidebarSlug.tsx
+++ b/apps/google-analytics-4/frontend/src/hooks/useSidebarSlug/useSidebarSlug.tsx
@@ -31,7 +31,12 @@ export const useSidebarSlug = (slugFieldInfo: ContentTypeValue) => {
   }, [slugFieldValue, handleSlugFieldValue]);
 
   useEffect(() => {
+    // We only want this to update state on component mount.
+    // Otherwise when slugFieldValue changes it is updated
+    // in the above useEffect
+
     setDebouncedSlugFieldValue(slugFieldValue);
+    // eslint-disable-next-line
   }, []);
 
   useEffect(() => {

--- a/apps/google-analytics-4/frontend/src/hooks/useSidebarSlug/useSidebarSlug.tsx
+++ b/apps/google-analytics-4/frontend/src/hooks/useSidebarSlug/useSidebarSlug.tsx
@@ -6,33 +6,37 @@ import { pathJoin } from 'utils/pathJoin';
 import useGetFieldValue from '../useGetFieldValue';
 
 export const useSidebarSlug = (slugFieldInfo: ContentTypeValue) => {
+  const [isPublished, setIsPublished] = useState(false);
+  const [debouncedSlugFieldValue, setDebouncedSlugFieldValue] = useState('');
+
   const sdk = useSDK<SidebarExtensionSDK>();
 
   const { slugField, urlPrefix } = slugFieldInfo;
   const slugFieldValue = useGetFieldValue(slugField);
 
-  const [isPublished, setIsPublished] = useState(false);
-  const [debouncedSlugFieldValue, setDebouncedSlugFieldValue] = useState(slugFieldValue);
-
   const handlePublishedStatus = (sys: ContentEntitySys) => {
     setIsPublished(Boolean(sys.publishedAt));
   };
-
-  useEffect(() => {
-    sdk.entry.onSysChanged((sys) => handlePublishedStatus(sys));
-  }, [sdk.entry]);
 
   const updateSlugFieldValue = (v: string) => {
     setDebouncedSlugFieldValue(v);
   };
 
-  const handleSlugField = useCallback(updateSlugFieldValue, [updateSlugFieldValue]);
+  const handleSlugFieldValue = useCallback(updateSlugFieldValue, [updateSlugFieldValue]);
 
   useEffect(() => {
-    const timeout = setTimeout(() => handleSlugField(slugFieldValue), 500);
+    const timeout = setTimeout(() => handleSlugFieldValue(slugFieldValue), 500);
 
     return () => clearTimeout(timeout);
-  }, [slugFieldValue, handleSlugField]);
+  }, [slugFieldValue, handleSlugFieldValue]);
+
+  useEffect(() => {
+    setDebouncedSlugFieldValue(slugFieldValue);
+  }, []);
+
+  useEffect(() => {
+    sdk.entry.onSysChanged((sys) => handlePublishedStatus(sys));
+  }, [sdk.entry]);
 
   const reportSlug = `/${pathJoin(urlPrefix || '', debouncedSlugFieldValue || '')}`;
   const slugFieldIsConfigured = Boolean(slugField);

--- a/apps/google-analytics-4/frontend/src/hooks/useSidebarSlug/useSidebarSlug.tsx
+++ b/apps/google-analytics-4/frontend/src/hooks/useSidebarSlug/useSidebarSlug.tsx
@@ -5,33 +5,29 @@ import { ContentEntitySys, SidebarExtensionSDK } from '@contentful/app-sdk';
 import { pathJoin } from 'utils/pathJoin';
 import useGetFieldValue from '../useGetFieldValue';
 
-export const useSidebarSlug = (slugFieldInfo: ContentTypeValue) => {
-  const [isPublished, setIsPublished] = useState(false);
-  const [debouncedSlugFieldValue, setDebouncedSlugFieldValue] = useState('');
+const SLUG_FIELD_INPUT_DELAY = 500;
 
+export const useSidebarSlug = (slugFieldInfo: ContentTypeValue) => {
   const sdk = useSDK<SidebarExtensionSDK>();
 
   const { slugField, urlPrefix } = slugFieldInfo;
   const slugFieldValue = useGetFieldValue(slugField);
+
+  const [isPublished, setIsPublished] = useState(false);
+  const [debouncedSlugFieldValue, setDebouncedSlugFieldValue] = useState(slugFieldValue);
 
   const handlePublishedStatus = (sys: ContentEntitySys) => {
     setIsPublished(Boolean(sys.publishedAt));
   };
 
   useEffect(() => {
-    const timeout = setTimeout(() => setDebouncedSlugFieldValue(slugFieldValue), 700);
+    const timeout = setTimeout(
+      () => setDebouncedSlugFieldValue(slugFieldValue),
+      SLUG_FIELD_INPUT_DELAY
+    );
 
     return () => clearTimeout(timeout);
   }, [slugFieldValue]);
-
-  useEffect(() => {
-    // This only updates state on component mount.
-    // Any other update when slugFieldValue changes occurs
-    // in the above useEffect
-
-    setDebouncedSlugFieldValue(slugFieldValue);
-    // eslint-disable-next-line
-  }, []);
 
   useEffect(() => {
     sdk.entry.onSysChanged((sys) => handlePublishedStatus(sys));

--- a/apps/google-analytics-4/frontend/src/hooks/useSidebarSlug/useSidebarSlug.tsx
+++ b/apps/google-analytics-4/frontend/src/hooks/useSidebarSlug/useSidebarSlug.tsx
@@ -25,8 +25,8 @@ export const useSidebarSlug = (slugFieldInfo: ContentTypeValue) => {
   }, [slugFieldValue]);
 
   useEffect(() => {
-    // We only want this to update state on component mount.
-    // Otherwise when slugFieldValue changes it is updated
+    // This only updates state on component mount.
+    // Any other update when slugFieldValue changes occurs
     // in the above useEffect
 
     setDebouncedSlugFieldValue(slugFieldValue);


### PR DESCRIPTION
## Purpose

When the user updates the slug field value of an entry while viewing the GA4 app in the sidebar, each keystroke was causing a network request to the `runReports` endpoint. This is because we are using the `useFieldValue` hook from the `react-apps-toolkit` to grab that slug field value, so when the hook updated, all subsequent statetful hooks and components updated. 

## Approach
This was trickier than most classic debounce fixes. We are not debouncing a user typing into an input that is rendered as part of our component tree, for example, but rather trying to debounce a hook's ever changing value and how that value is used. 

I originally began by using the `lodash` `debounce` with the `useSidebarSlug` hook, where we grab the field value, but in any approach that I took to manipulate the hook's value, I encountered one of two problems: 1. A violation of the rules of hooks i.e placing a hook in another hook to conditionally call it or 2. State updates within the `useSidebarSlug` hook or `AnalyticsApp` component would cause re-renders, so the many network requests would continue, just in a delayed fashion. 

Therefore I did some digging and solved it by what seems to be a common approach in these cases: using `setTimeout` to update state (which I know `setTimeout` sometimes seems a little 'meh' to use but actually think it can be pretty powerful). This only updates the state once, after the timeout finishes, therefore only one network call is made. 

I set the timeout to be **700ms** given that felt like it reduced the most amount of network calls without causing a significant delay when I was testing, but happy to adjust lower or higher!

## Testing steps

Make changes to the slug field value of an entry, and observe the network tab. The `runReports` endpoint should not be called on every key stroke. 
