### PR TITLE
chore: upgrade Slack to node 16

### DIFF
--- a/apps/slack/lambda/serverless.yml
+++ b/apps/slack/lambda/serverless.yml
@@ -11,7 +11,7 @@ custom: ${file(./config/serverless.${opt:stage, 'dev'}.yml):variables}
 
 provider:
   name: aws
-  runtime: nodejs14.x
+  runtime: nodejs16.x
   stage: dev
   region: 'us-east-1'
   timeout: 30


### PR DESCRIPTION

## Purpose

<!-- Why are we introducing this change now? What problem does it solve? What is the story/background for it? -->

Just noticed that the Slack lambda is still on node 14. We want to have all our lambdas on a (Maintenance) LTS. Node 14 LTS ends on the 30th.

## Approach

<!-- Why did we do it the way we did? Did we consider alternatives? What other implementation details or artifacts (screenshots etc.) would help reviewers contextualize change? -->

It should only be this one-line change. The lock file is already on v2.

## Testing steps

No testing done
<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

No code change
<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
