### PR TITLE
improve loading status indication onConfigure and onConfigurationCompleted

### DIFF
--- a/apps/google-analytics-4/frontend/src/components/config-screen/api-access/ApiAccessSection.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/api-access/ApiAccessSection.spec.tsx
@@ -17,7 +17,7 @@ describe('Config Screen component (not installed)', () => {
           parameters={{}}
           mergeSdkParameters={() => {}}
           isInEditMode={false}
-          isSavingPrivateKeyFile={false}
+          isSavingConfiguration={false}
           onInEditModeChange={() => {}}
           onHasServiceCheckErrorsChange={() => {}}
           onKeyFileUpdate={() => {}}

--- a/apps/google-analytics-4/frontend/src/components/config-screen/api-access/ApiAccessSection.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/api-access/ApiAccessSection.tsx
@@ -9,7 +9,7 @@ interface Props {
   parameters: KeyValueMap;
   mergeSdkParameters: Function;
   isInEditMode: boolean;
-  isSavingPrivateKeyFile: boolean;
+  isSavingConfiguration: boolean;
   onInEditModeChange: Function;
   onHasServiceCheckErrorsChange: Function;
   onKeyFileUpdate: Function;
@@ -23,7 +23,7 @@ const ApiAccessSection = (props: Props) => {
     parameters,
     mergeSdkParameters,
     isInEditMode,
-    isSavingPrivateKeyFile,
+    isSavingConfiguration,
     onInEditModeChange,
     onHasServiceCheckErrorsChange,
     onKeyFileUpdate,
@@ -40,7 +40,7 @@ const ApiAccessSection = (props: Props) => {
       </div>
       {!isInEditMode && isAppInstalled && parameters && parameters.serviceAccountKeyId ? (
         <DisplayServiceAccountCard
-          isSavingPrivateKeyFile={isSavingPrivateKeyFile}
+          isSavingConfiguration={isSavingConfiguration}
           onInEditModeChange={onInEditModeChange}
           serviceAccountKeyId={parameters.serviceAccountKeyId}
           onAccountSummariesChange={onAccountSummariesChange}

--- a/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/DisplayServiceAccountCard.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/DisplayServiceAccountCard.spec.tsx
@@ -25,7 +25,7 @@ describe('Installed Service Account Card', () => {
     await act(async () => {
       render(
         <DisplayServiceAccountCard
-          isSavingPrivateKeyFile={false}
+          isSavingConfiguration={false}
           serviceAccountKeyId={validServiceKeyId}
           parameters={{}}
           onInEditModeChange={() => {}}

--- a/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/DisplayServiceAccountCard.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/DisplayServiceAccountCard.tsx
@@ -34,7 +34,7 @@ interface Props {
   isAppInstalled: boolean;
   parameters: KeyValueMap;
   onHasServiceCheckErrorsChange: Function;
-  isSavingPrivateKeyFile: boolean;
+  isSavingConfiguration: boolean;
   onIsApiAccessLoading: Function;
 }
 
@@ -46,7 +46,7 @@ const DisplayServiceAccountCard = (props: Props) => {
     isAppInstalled,
     parameters,
     onHasServiceCheckErrorsChange,
-    isSavingPrivateKeyFile,
+    isSavingConfiguration,
     onIsApiAccessLoading,
   } = props;
 
@@ -183,9 +183,11 @@ const DisplayServiceAccountCard = (props: Props) => {
   }, [adminApiError, dataApiError, ga4PropertiesError, invalidServiceAccountError]);
 
   useEffect(() => {
+    if (isSavingConfiguration) return;
+
     verifyAdminApi();
     verifyDataApi();
-  }, [verifyAdminApi, verifyDataApi]);
+  }, [isSavingConfiguration, verifyAdminApi, verifyDataApi]);
 
   const handleApiTestClick = () => {
     verifyAdminApi();
@@ -246,7 +248,7 @@ const DisplayServiceAccountCard = (props: Props) => {
     return <Badge variant="positive">Successfully configured</Badge>;
   };
 
-  const isLoading = isSavingPrivateKeyFile || isLoadingAdminApi || isLoadingDataApi;
+  const isLoading = isSavingConfiguration || isLoadingAdminApi || isLoadingDataApi;
 
   const loadingSkeleton = (width = '100%') => {
     return (


### PR DESCRIPTION
## Purpose
This addressed a jarring UX from the moment a user clicks "save" or "install" through the post configuration/installation step when we write their secret key to dynamodb.

## Approach
It wraps both the `onConfigure` and `onConfigurationCompleted` callbacks with a boolean loading state so we can eagerly reset from the `isInEditMode` state, but avoid making eager calls to `verifyAdminApi()` and `verifyDataApi()` which are in a useEffect in the DisplayServiceAccountCard.tsx component (see newly added guard clause)

https://user-images.githubusercontent.com/492573/230084523-7fbef44d-bc49-48c7-b852-7871d4b57cb9.mov