### PR TITLE
[INTEG-329] Update unknown error on config page

### DIFF
--- a/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/DisplayServiceAccountCard.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/api-access/display/DisplayServiceAccountCard.tsx
@@ -14,7 +14,7 @@ import {
   Text,
   CopyButton,
 } from '@contentful/f36-components';
-import { CycleIcon } from '@contentful/f36-icons';
+import { CycleIcon, ExternalLinkIcon } from '@contentful/f36-icons';
 import { useApi } from 'hooks/useApi';
 import { ServiceAccountKeyId } from 'types';
 import { ApiErrorType, ERROR_TYPE_MAP, isApiErrorType } from 'apis/apiTypes';
@@ -27,6 +27,7 @@ import {
 } from 'components/config-screen/api-access/display/ChecklistUtils';
 import ServiceAccountChecklist from 'components/config-screen/api-access/display/ServiceAccountChecklist';
 import { styles } from './DisplayServiceAccountCard.styles';
+import HyperLink from 'components/common/HyperLink/HyperLink';
 
 interface Props {
   serviceAccountKeyId: ServiceAccountKeyId;
@@ -204,7 +205,7 @@ const DisplayServiceAccountCard = (props: Props) => {
 
   interface BadgeNoteType {
     badgeLabel: string;
-    noteMessage?: string;
+    noteMessage?: string | JSX.Element;
   }
 
   // TODO: Update these Render functions (RenderSimpleBadgeNote, RenderStatusInfo) to have more robust error messages for the user to act upon
@@ -213,7 +214,7 @@ const DisplayServiceAccountCard = (props: Props) => {
     return (
       <Stack spacing="spacingL" marginBottom="none" alignItems="flex-start" flexDirection="column">
         <Badge variant="negative">{badgeLabel}</Badge>
-        {noteMessage && <Note variant="warning">{noteMessage}</Note>}
+        {noteMessage && <Note variant="negative">{noteMessage}</Note>}
       </Stack>
     );
   };
@@ -237,14 +238,16 @@ const DisplayServiceAccountCard = (props: Props) => {
         <Badge variant="negative">Problems with configuration</Badge>
       );
     } else if (unknownError) {
-      return (
-        <RenderSimpleBadgeNote
-          badgeLabel="Unknown Error"
-          noteMessage={
-            'An unknown error occurred. You can try the action again in a few minutes, or contact support if the error persists.'
-          }
+      const noteMessage = (
+        <HyperLink
+          body="An unknown error occurred. You can try the action again in a few minutes, or contact support if the error persists."
+          substring="contact support"
+          hyperLinkHref="https://www.contentful.com/support/?utm_source=webapp&utm_medium=help-menu&utm_campaign=in-app-help"
+          icon={<ExternalLinkIcon />}
+          alignIcon="end"
         />
       );
+      return <RenderSimpleBadgeNote badgeLabel="Unknown Error" noteMessage={noteMessage} />;
     }
 
     return <Badge variant="positive">Successfully configured</Badge>;


### PR DESCRIPTION
## Purpose

The "unknown error" state on the GA4 app config page is a bit confusing and unhelpful. 

## Approach

Make the message more actionable by adding a link to contact support. Also make the Note component "negative" variant to match the badge state.

Before
![Screenshot 2023-04-05 at 1 05 09 PM](https://user-images.githubusercontent.com/62958907/230208029-0de990b2-70af-4218-b525-7da90f53644d.png)

After
![Screenshot 2023-04-05 at 2 28 13 PM](https://user-images.githubusercontent.com/62958907/230208015-7206096d-2a0b-42fd-a42e-bb0181782588.png)

## Testing steps

Throw a random error from the lambda or stop the server to get into this state.


