### PR TITLE
[INTEG-336] Fix broken tests in watch mode

### DIFF
--- a/apps/google-analytics-4/lambda/src/controllers/apiController.ts
+++ b/apps/google-analytics-4/lambda/src/controllers/apiController.ts
@@ -44,7 +44,7 @@ const ApiController = {
         serviceAccountKeyFile
       );
 
-      return res.send(200);
+      return res.sendStatus(200);
     } catch (err) {
       next(err);
     }

--- a/apps/google-analytics-4/lambda/test/hooks.ts
+++ b/apps/google-analytics-4/lambda/test/hooks.ts
@@ -1,14 +1,7 @@
-import { DynamoDBService } from '../src/services/dynamoDbService';
 import sinon from 'sinon';
-import { validServiceAccountKeyFile } from './mocks/googleApi';
 
 // uncomment these lines to suppress unwanted error output in testing
 export const mochaHooks = {
-  beforeEach() {
-    sinon
-      .stub(DynamoDBService.prototype, 'getServiceAccountKeyFile')
-      .resolves(validServiceAccountKeyFile);
-  },
   afterEach() {
     sinon.restore();
   },


### PR DESCRIPTION
## Purpose
We have a few GA4 lambda tests tests that fail (incorrectly) when run in watch mode, as a result of unneeded hook stubbing.

## Approach
- Add stubbing for `getServiceAccountKeyFile` returning correctly formatted file.
- Remove stubbing for `getServiceAccountKeyFile` that happens every test to provide more granular and accurate stubbing.
- Quick deprecation fix for sendStatus
<img width="803" alt="image" src="https://user-images.githubusercontent.com/1434735/230457859-0e081297-179e-4d41-b7f8-1fb72eb82c66.png">


## Testing steps

google-analytics-/lambda > `npm run test:watch`

- Ensure all tests pass first time as well as subsequent runs

