### PR TITLE
Auto prune GA4 lambdas

### DIFF
--- a/apps/google-analytics-4/lambda/package-lock.json
+++ b/apps/google-analytics-4/lambda/package-lock.json
@@ -47,6 +47,7 @@
         "serverless": "^3.28.1",
         "serverless-domain-manager": "^6.4.4",
         "serverless-offline": "^12.0.4",
+        "serverless-prune-plugin": "^2.0.2",
         "sinon": "^15.0.1",
         "ts-node": "^10.9.1",
         "typescript": "^4.9.4"
@@ -10518,6 +10519,18 @@
         }
       }
     },
+    "node_modules/serverless-prune-plugin": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/serverless-prune-plugin/-/serverless-prune-plugin-2.0.2.tgz",
+      "integrity": "sha512-tW1Q8MAVmhW8KQN+e0AsSVsb9nmRWWj28xBjMwvVC3FbammmtUJT+5nRpmjxJZ6/K/j3OV1Rx8b32md71BwkYQ==",
+      "dev": true,
+      "dependencies": {
+        "bluebird": "^3.7.2"
+      },
+      "peerDependencies": {
+        "serverless": "1 || 2 || 3"
+      }
+    },
     "node_modules/serverless/node_modules/ajv": {
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
@@ -20131,6 +20144,15 @@
           "dev": true,
           "requires": {}
         }
+      }
+    },
+    "serverless-prune-plugin": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/serverless-prune-plugin/-/serverless-prune-plugin-2.0.2.tgz",
+      "integrity": "sha512-tW1Q8MAVmhW8KQN+e0AsSVsb9nmRWWj28xBjMwvVC3FbammmtUJT+5nRpmjxJZ6/K/j3OV1Rx8b32md71BwkYQ==",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.7.2"
       }
     },
     "setimmediate": {

--- a/apps/google-analytics-4/lambda/package.json
+++ b/apps/google-analytics-4/lambda/package.json
@@ -50,6 +50,7 @@
     "serverless": "^3.28.1",
     "serverless-domain-manager": "^6.4.4",
     "serverless-offline": "^12.0.4",
+    "serverless-prune-plugin": "^2.0.2",
     "sinon": "^15.0.1",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.4"

--- a/apps/google-analytics-4/lambda/serverless.yml
+++ b/apps/google-analytics-4/lambda/serverless.yml
@@ -5,6 +5,7 @@ frameworkVersion: '>=3.0.0 <4.0.0'
 plugins:
   - serverless-domain-manager
   - serverless-offline
+  - serverless-prune-plugin
 
 custom:
   sentryDSN: https://b8f524eae7c446fb8071476431426640@o2239.ingest.sentry.io/4504725335834624
@@ -22,6 +23,9 @@ custom:
   dynamoDbTableName: sls-apps-ga4-backend-${opt:stage, 'dev'}-service-account-keys
   dynamoDbEndpoint: ${file(./config/serverless-env.${opt:stage, 'dev'}.yml):dynamoDbEndpoint}
   serviceAccountKeyEncryptionSecret: ${file(./config/serverless-env.${opt:stage, 'dev'}.yml):serviceAccountKeyEncryptionSecret}
+  prune:
+    automatic: true
+    number: 3
 
 provider:
   name: aws


### PR DESCRIPTION
## Purpose

We have limited lambda deploy space. Adding this configuration will automatically delete versions 3 older from the current.

## Approach

I used the purpose-built [sls prune plugin](https://www.serverless.com/plugins/serverless-prune-plugin
)

## Testing steps

We'll need to deploy this production to test unfortunately. That said, it seems fairly straightforward.

There might be additional IAM roles needed for this to work.
