### PR TITLE
fix: preview and image and marker position[NONE]

### DIFF
--- a/apps/image-focal-point/src/components/FocalPointDialog/__snapshots__/FocalPointDialog.spec.js.snap
+++ b/apps/image-focal-point/src/components/FocalPointDialog/__snapshots__/FocalPointDialog.spec.js.snap
@@ -57,7 +57,7 @@ exports[`FocalPointDialog should render the focal point dialog 1`] = `
           class="css-1biw769"
         >
           <div
-            class="css-bwgqaq"
+            class="css-1njnee2"
             role="button"
             tabindex="-1"
           >

--- a/apps/image-focal-point/src/components/FocalPointDialog/__snapshots__/FocalPointDialog.spec.js.snap
+++ b/apps/image-focal-point/src/components/FocalPointDialog/__snapshots__/FocalPointDialog.spec.js.snap
@@ -57,7 +57,7 @@ exports[`FocalPointDialog should render the focal point dialog 1`] = `
           class="css-1biw769"
         >
           <div
-            class="css-1njnee2"
+            class="css-10cwavf"
             role="button"
             tabindex="-1"
           >

--- a/apps/image-focal-point/src/components/FocalPointDialog/styles.js
+++ b/apps/image-focal-point/src/components/FocalPointDialog/styles.js
@@ -21,10 +21,9 @@ export const styles = {
       cursor: 'crosshair',
       display: 'block',
       margin: '0 auto',
-      width: '100%',
-      height: '100%',
+      maxWidth: '100%',
+      maxHeight: '100%',
       outline: 0,
-      objectFit: 'contain',
     },
   }),
   focalPointDemo: css({

--- a/apps/image-focal-point/src/components/FocalPointDialog/styles.js
+++ b/apps/image-focal-point/src/components/FocalPointDialog/styles.js
@@ -25,6 +25,11 @@ export const styles = {
       maxHeight: '100%',
       outline: 0,
     },
+    '& > img[src$=".svg"]': {
+      width: '100%',
+      height: '100%',
+      objectFit: 'contain',
+    },
   }),
   focalPointDemo: css({
     display: 'flex',


### PR DESCRIPTION
## Purpose

We are trying to fix the marker and preview image position, previously marker was able to focus even om the blank area.
After this change marker will not be focused apart from image.

<img width="381" alt="Screenshot 2023-04-12 at 18 57 48" src="https://user-images.githubusercontent.com/17832070/231473876-e8d440f8-5c99-4bb2-ae0d-396054fa8393.png">

<img width="397" alt="Screenshot 2023-04-12 at 18 49 46" src="https://user-images.githubusercontent.com/17832070/231473923-11d23d35-ef8f-4b26-8f23-53b76ad96c95.png">


## Approach
We allowed max width and height for image to take as much space as needed within parent div without changing its aspect-ratio.


