### PR TITLE
Feature/INTEG-393: Added deprecation notice Note to legacy analytics

### DIFF
--- a/apps/google-analytics/src/index.tsx
+++ b/apps/google-analytics/src/index.tsx
@@ -9,7 +9,7 @@ import AppConfig from './AppConfig';
 import Analytics from './Analytics';
 import { SidebarExtensionState, SidebarExtensionProps, Gapi, SavedParams } from './typings';
 import styles from './styles';
-import { Paragraph, TextLink } from '@contentful/forma-36-react-components';
+import { Paragraph, TextLink, Note } from '@contentful/forma-36-react-components';
 import { docsUrl } from './utils';
 
 export class SidebarExtension extends React.Component<
@@ -87,6 +87,36 @@ export class SidebarExtension extends React.Component<
       </Paragraph>
     );
 
+    const deprecationNotice = (
+      <Note title="Deprecation Warning" noteType="negative" className={styles.deprecationText}>
+        <>
+          <Paragraph>
+            Google is{' '}
+            <a
+              href="https://support.google.com/analytics/answer/11583528?hl=en"
+              target="_blank"
+              rel="noreferrer"
+            >
+              deprecating
+            </a>{' '}
+            Google Universal Analytics on July 1st, 2023. After that date, no further events will be
+            processed by Google Universal Analytics.
+          </Paragraph>
+          <Paragraph>
+            We recommend switching to Google Analytics 4 (GA4) as soon as possible and using
+            Contentful's{' '}
+            <a
+              href="https://app.contentful.com/deeplink?link=apps&id=5DlxOS0KvGS1Wk362xgvbN"
+              target="_blank"
+              rel="noreferrer"
+            >
+              new GA4 app.
+            </a>
+          </Paragraph>
+        </>
+      </Note>
+    );
+
     if (!isAuthorized) {
       const renderAuthButton = async (authButton: HTMLDivElement) => {
         if (!authButton) {
@@ -124,6 +154,7 @@ export class SidebarExtension extends React.Component<
 
       return (
         <>
+          {deprecationNotice}
           <div
             ref={renderAuthButton}
             className={isAuthorized ? styles.hidden : styles.signInButton}
@@ -140,32 +171,45 @@ export class SidebarExtension extends React.Component<
 
     if (!isContentTypeConfigured) {
       return (
-        <Paragraph className={styles.lightText}>
-          The {contentTypeName} content type hasn&apos;t been configured for use with this app. It
-          must have a field of type short text and must be added to the list of content types in
-          this app&apos;s configuration.
-        </Paragraph>
+        <>
+          {deprecationNotice}
+
+          <Paragraph className={styles.lightText}>
+            The {contentTypeName} content type hasn&apos;t been configured for use with this app. It
+            must have a field of type short text and must be added to the list of content types in
+            this app&apos;s configuration.
+          </Paragraph>
+        </>
       );
     }
 
     if (!hasSlug) {
       return (
-        <Paragraph className={styles.lightText}>
-          This {contentTypeName} entry doesn&apos;t have a valid slug field.
-        </Paragraph>
+        <>
+          {deprecationNotice}
+
+          <Paragraph className={styles.lightText}>
+            This {contentTypeName} entry doesn&apos;t have a valid slug field.
+          </Paragraph>
+        </>
       );
     }
 
     if (!entry.getSys().publishedAt) {
       return (
-        <Paragraph className={styles.lightText}>
-          This {contentTypeName} entry hasn&apos;t been published.
-        </Paragraph>
+        <>
+          {deprecationNotice}
+
+          <Paragraph className={styles.lightText}>
+            This {contentTypeName} entry hasn&apos;t been published.
+          </Paragraph>
+        </>
       );
     }
 
     return (
       <section>
+        {deprecationNotice}
         {helpTextNode}
         <Analytics
           sdk={this.props.sdk}

--- a/apps/google-analytics/src/styles.ts
+++ b/apps/google-analytics/src/styles.ts
@@ -96,5 +96,9 @@ const styles = {
     justifyContent: 'center',
     margin: `${tokens.spacing2Xl} 0 ${tokens.spacing4Xl}`,
   }),
+  deprecationText: css({
+    marginBottom: tokens.spacingXs,
+    fontWeight: tokens.fontWeightMedium,
+  }),
 };
 export default styles;


### PR DESCRIPTION
## Purpose

Now that we have officially launched the Google Analytics 4 app, we need to message existing users about the legacy GA app and properly warn them about the deprecation of Google Analytics UA. 

## Approach

- Added the Note component from forma36 to the Sidebar
- Made it so it persists no matter the circumstance (whether authed or not authed)
<img width="595" alt="Screenshot 2023-04-12 at 10 56 42 AM" src="https://user-images.githubusercontent.com/122041643/231535219-e3d53da6-cd44-4b45-ac5b-0f521d13c336.png">



## Testing steps

1. Log into the Google Analytics (Development) space
2. Verify the deprecation warning shows in the Sidebar area whether authed or non authed

## Breaking Changes

- No breaking changes
