### PR TITLE
[INTEG-416] Fix limits for Optimizely experiments and projects

### DIFF
--- a/apps/optimizely/src/optimizely-client.js
+++ b/apps/optimizely/src/optimizely-client.js
@@ -25,39 +25,64 @@ export default class OptimizelyClient {
     this.onReauth();
   };
 
+  _getItemsPerPage = async (item) => {
+    let items = [];
+    const PER_PAGE = 100;
+    const MAX_REQUESTS = 10;
+
+    for (let i = 1; i <= MAX_REQUESTS; i++) {
+      const results = await this.makeRequest(this._getItemsUrl(PER_PAGE, i, item));
+      items = [...items, ...results];
+      if (results.length < PER_PAGE) {
+        break;
+      }
+    }
+
+    if (item === 'experiment') {
+      items = items.filter((experiment) => {
+        return experiment.status !== 'archived';
+      });
+    }
+
+    items = items.sort((a, b) => {
+      const nameA = a.name.toUpperCase();
+      const nameB = b.name.toUpperCase();
+
+      if (nameA < nameB) {
+        return -1;
+      }
+      if (nameA > nameB) {
+        return 1;
+      }
+      return 0;
+    });
+
+    return items;
+  };
+
+  _getItemsUrl = (perPage, page, item) => {
+    switch (item) {
+      case 'project':
+        return `/projects?per_page=${perPage.toString()}&page=${page.toString()}`;
+      case 'experiment':
+        return `/experiments?project_id=${
+          this.project
+        }&per_page=${perPage.toString()}&page=${page.toString()}`;
+      default:
+        return '';
+    }
+  };
+
   getProjects() {
-    return this.makeRequest('/projects');
+    return this._getItemsPerPage('project');
   }
 
   getExperiment = (experimentId) => {
     return this.makeRequest(`/experiments/${experimentId}`);
   };
 
-  _getExperimentsPerPage = (perPage, page) => {
-    return this.makeRequest(
-      `/experiments?project_id=${
-        this.project
-      }&per_page=${perPage.toString()}&page=${page.toString()}`
-    );
-  };
-
   getExperiments = async () => {
-    let experiments = [];
-    const PER_PAGE = 100;
-    const MAX_REQUESTS = 5;
-
-    for (let i = 1; i <= MAX_REQUESTS; i++) {
-      const results = await this._getExperimentsPerPage(PER_PAGE, i);
-      experiments = [...experiments, ...results];
-      if (results.length < PER_PAGE) {
-        break;
-      }
-    }
-
-    experiments = experiments.filter((experiment) => {
-      return experiment.status !== 'archived';
-    });
-    return experiments;
+    return this._getItemsPerPage('experiment');
   };
 
   getExperimentResults = (experimentId) => {


### PR DESCRIPTION
## Purpose

A customer reported an issue with not being able to see all of their experiments in the dropdown when working on a Variation Container entry. When querying experiments, we had a limit of 500 and the customer had over 500 experiments.

## Approach

I updated the limit to 1000. I also noticed that the experiments were not sorted in any way, and especially given the number of experiments, I thought it would be helpful to sort the experiments alphabetically in the dropdown.

In addition when researching this bug, I also noticed that there was a limit on the number of projects we were querying. Since we did not explicitly set the number of items per page, it defaulted to only 25. So I was not seeing all of my Optimizely projects in the dropdown on the app configuration page. I updated this to the same limit as experiments and also implemented sorting. The app currently does not filter out archived projects so I did not change that behavior, but I could if that is a desired behavior.

## Testing steps

See [this video](https://www.loom.com/share/ced5613c3a9544eda46c60213fbb96e5) for a walkthrough of the issue and changes.

1. Log into Optimizely using the credentials in the vault, you can use my project called "Lisa Test". In this project I created over 500 experiments so we can test the app with a large number.
2. Navigate to the Optimizely (development) space and use my "lisa.white" environment. Go to a Variation Container content entry to see the experiment dropdown and go to the app configuration page to see the projects dropdown.

## Dependencies and/or References

Relevant Optimizely documentation:
- https://docs.developers.optimizely.com/web-experimentation/reference/list_experiments
- https://docs.developers.optimizely.com/full-stack-experimentation/reference/list_projects

