### PR TITLE
Integ 354 add supplemental tests to google analytics config page

### DIFF
--- a/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage/GoogleAnalyticsConfigPage.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage/GoogleAnalyticsConfigPage.spec.tsx
@@ -65,7 +65,7 @@ describe('Google Analytics config page with errors', () => {
   });
 });
 
-describe('Config Screen component (not installed)', () => {
+xdescribe('Config Screen component (not installed)', () => {
   it('allows the app to be installed with a valid service key file', async () => {
     render(<GoogleAnalyticsConfigPage />);
     const keyFileInputBox = screen.getByLabelText(/Service Account Key/i);

--- a/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage/GoogleAnalyticsConfigPage.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage/GoogleAnalyticsConfigPage.spec.tsx
@@ -38,17 +38,12 @@ describe('Google Analytics Page', () => {
 
 describe('Google Analytics config page with errors', () => {
   it('renders error message if user tries to install app without service key', async () => {
-    const mockOnConfigure = jest.fn((cb: Function) => cb());
     const mockNotifier = jest.fn();
     mockSdk.notifier = { error: mockNotifier };
 
     render(<GoogleAnalyticsConfigPage />);
 
-    // saves input
-    mockSdk.app.onConfigure = mockOnConfigure;
-    await waitFor(() => {
-      expect(mockOnConfigure).toHaveBeenCalled();
-    });
+    await saveAppInstallation();
 
     await waitFor(() => {
       expect(mockNotifier).toHaveBeenCalledWith('A valid service account key file is required');

--- a/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage/GoogleAnalyticsConfigPage.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage/GoogleAnalyticsConfigPage.spec.tsx
@@ -17,15 +17,6 @@ jest.mock('contentful-management', () => ({
   createClient: () => mockCma,
 }));
 
-jest.mock('hooks/useApi', () => ({
-  useApi: () => ({
-    listAccountSummaries: () => [],
-    runReports: () => {},
-  }),
-}));
-
-jest.mock('helpers/signed-requests', () => jest.fn());
-
 // Helper to mock users clicking "save" -- return result of the callback passed to onConfigure()
 const saveAppInstallation = () => {
   // We manually call the LAST onConfigure() callback (this is important, as earlier calls have stale data)

--- a/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage/GoogleAnalyticsConfigPage.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage/GoogleAnalyticsConfigPage.spec.tsx
@@ -4,14 +4,19 @@ import GoogleAnalyticsConfigPage from 'components/config-screen/GoogleAnalyticsC
 import { config } from 'config';
 import { validServiceKeyFile, validServiceKeyId } from '../../../../test/mocks';
 import userEvent from '@testing-library/user-event';
+import * as useSDK from '@contentful/react-apps-toolkit';
 import { ServiceAccountKey } from 'types';
+import { NotifierAPI } from '@contentful/app-sdk';
 
 const apiRoot = config.backendApiUrl;
 
-jest.mock('@contentful/react-apps-toolkit', () => ({
-  useSDK: () => mockSdk,
-  useCMA: () => mockCma,
-}));
+jest.mock('@contentful/react-apps-toolkit', () => ({ useSDK: jest.fn(), useCMA: jest.fn() }));
+
+// jest.mock('@contentful/react-apps-toolkit', () => ({
+//   useSDK: () => mockSdk,
+//   ...jest.requireActual('@contentful/react-apps-toolkit'),
+//   useCMA: () => mockCma,
+// }));
 
 jest.mock('contentful-management', () => ({
   createClient: () => mockCma,
@@ -36,7 +41,84 @@ describe('Google Analytics Page', () => {
   });
 });
 
-xdescribe('Config Screen component (not installed)', () => {
+describe.only('Google Analytics config page with errors', () => {
+  const mockNotifier = jest.fn();
+  beforeEach(() => {
+    jest.spyOn(useSDK, 'useSDK').mockImplementation(() => ({
+      ...jest.requireActual('@contentful/react-apps-toolkit'),
+      ...mockSdk,
+      app: {
+        ...mockSdk.app,
+        onConfigure: jest.fn((cb) => cb()),
+        onConfigurationCompleted: jest.fn((cb) => cb()) as unknown,
+      },
+      notifier: {
+        error: mockNotifier,
+      } as unknown as NotifierAPI,
+    }));
+  });
+  it('renders error message if user tries to install app without service key', async () => {
+    const user = userEvent.setup();
+    await act(async () => {
+      render(<GoogleAnalyticsConfigPage />);
+    });
+
+    const keyFileInputBox = screen.getByLabelText(/Service Account Key/i);
+    await user.click(keyFileInputBox);
+
+    await waitFor(() => {
+      expect(mockNotifier).toHaveBeenCalledWith('A valid service account key file is required');
+    });
+  });
+
+  it('renders error message when user interacts with input, does not input key, but tries to install app', async () => {
+    const user = userEvent.setup();
+    await act(async () => {
+      render(<GoogleAnalyticsConfigPage />);
+    });
+    const keyFileInputBox = screen.getByLabelText(/Service Account Key/i);
+
+    await user.click(keyFileInputBox);
+
+    await waitFor(() => {
+      expect(mockNotifier).toHaveBeenCalledWith('A valid service account key file is required');
+    });
+  });
+
+  it.only('renders error message when user interacts with input, does not input key, but tries to install app', async () => {
+    mockSdk.app.getParameters.mockReturnValue({
+      serviceAccountKeyId: validServiceKeyId,
+      propertyId: 'properties/1234',
+      contentTypes: {
+        course: { slugField: 'shortDescription', urlPrefix: 'about' },
+      },
+    });
+    mockSdk.app.isInstalled.mockReturnValue(true);
+    const user = userEvent.setup();
+    await act(async () => {
+      render(<GoogleAnalyticsConfigPage />);
+    });
+
+    await user.click(screen.getByText('Edit'));
+
+    // const keyFileInputBox = screen.getByLabelText(/Service Account Key/i);
+
+    // await user.click(keyFileInputBox);
+
+    // await waitFor(() => {
+    //   expect(mockNotifier).toHaveBeenCalledWith('The original service account key will be saved unless a new valid service account key file is provided.');
+    // })
+  });
+});
+
+describe('Config Screen component (not installed)', () => {
+  beforeAll(() => {
+    jest.mock('@contentful/react-apps-toolkit', () => ({
+      useSDK: () => mockSdk,
+      ...jest.requireActual('@contentful/react-apps-toolkit'),
+      useCMA: () => mockCma,
+    }));
+  });
   it('allows the app to be installed with a valid service key file', async () => {
     render(<GoogleAnalyticsConfigPage />);
     const keyFileInputBox = screen.getByLabelText(/Service Account Key/i);

--- a/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage/GoogleAnalyticsConfigPage.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage/GoogleAnalyticsConfigPage.spec.tsx
@@ -8,7 +8,11 @@ import { ServiceAccountKey } from 'types';
 
 const apiRoot = config.backendApiUrl;
 
-jest.mock('@contentful/react-apps-toolkit', () => ({ useSDK: () => mockSdk, useCMA: jest.fn() }));
+jest.mock('@contentful/react-apps-toolkit', () => ({
+  useSDK: () => mockSdk,
+  useCMA: () => mockCma,
+}));
+
 jest.mock('contentful-management', () => ({
   createClient: () => mockCma,
 }));
@@ -41,7 +45,7 @@ describe('Google Analytics Page', () => {
   });
 });
 
-describe.only('Google Analytics config page with errors', () => {
+describe('Google Analytics config page with errors', () => {
   it('renders error message if user tries to install app without service key', async () => {
     const mockOnConfigure = jest.fn((cb: Function) => cb());
     const mockNotifier = jest.fn();
@@ -62,13 +66,6 @@ describe.only('Google Analytics config page with errors', () => {
 });
 
 describe('Config Screen component (not installed)', () => {
-  beforeAll(() => {
-    jest.mock('@contentful/react-apps-toolkit', () => ({
-      useSDK: () => mockSdk,
-      ...jest.requireActual('@contentful/react-apps-toolkit'),
-      useCMA: () => mockCma,
-    }));
-  });
   it('allows the app to be installed with a valid service key file', async () => {
     render(<GoogleAnalyticsConfigPage />);
     const keyFileInputBox = screen.getByLabelText(/Service Account Key/i);

--- a/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage/GoogleAnalyticsConfigPage.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage/GoogleAnalyticsConfigPage.spec.tsx
@@ -4,9 +4,7 @@ import GoogleAnalyticsConfigPage from 'components/config-screen/GoogleAnalyticsC
 import { config } from 'config';
 import { validServiceKeyFile, validServiceKeyId } from '../../../../test/mocks';
 import userEvent from '@testing-library/user-event';
-import * as useSDK from '@contentful/react-apps-toolkit';
 import { ServiceAccountKey } from 'types';
-import { NotifierAPI } from '@contentful/app-sdk';
 
 const apiRoot = config.backendApiUrl;
 


### PR DESCRIPTION
## Purpose

The purpose of this PR is to add supplemental tests to the `GoogleAnalyticsConfigPage` - this ticket was specifically created after fixing a bug a while back around showing the correct error message. 

I time boxed this work and found that going beyond adding this one test extended the scope of this ticket significantly. I think it is worthwhile returning to this file to add more tests, but would love to pair program on ways to effectively mock the complexities. For now, here is one more test! 😄 

