### PR TITLE
[INTEG-426] Fix formatting of sidebar date range

### DIFF
--- a/apps/google-analytics-4/frontend/src/helpers/DateRangeHelpers/DateRangeHelpers.spec.ts
+++ b/apps/google-analytics-4/frontend/src/helpers/DateRangeHelpers/DateRangeHelpers.spec.ts
@@ -14,7 +14,7 @@ const getDateRangeTime = (range: DateRangeType) => {
 
 const getParsedDateRangeDate = (range: DateRangeType) => {
   const { start, end } = getRangeDates(range);
-  const getDate = (date: string) => Number(new Date(date).toLocaleDateString().split('/')[1]);
+  const getDate = (date: string) => Number(new Date(date).getDate());
   return {
     startDay: getDate(start),
     endDay: getDate(end),

--- a/apps/google-analytics-4/frontend/src/helpers/DateRangeHelpers/DateRangeHelpers.ts
+++ b/apps/google-analytics-4/frontend/src/helpers/DateRangeHelpers/DateRangeHelpers.ts
@@ -16,8 +16,12 @@ const DAY_IN_MS = 1000 * 60 * 60 * 24;
 
 // date should be local to user in format of YYYY-MM-DD
 const formatDate = (date: Date) => {
-  const localDate = date.toLocaleDateString().split('/');
-  return `${localDate[2]}-${localDate[0]}-${localDate[1]}`;
+  const year = date.getFullYear();
+  // months start at 0
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+
+  return `${year}-${month}-${day}`;
 };
 
 const getRangeDates = (dateRange: DateRangeType) => {


### PR DESCRIPTION
## Purpose

There was a reported issue for a GA4 app user in a different locale where the Sidebar app wasn't displaying data and the 'Open in Google Analytics' link was showing the wrong date range in the Google Analytics report.

## Approach

Initially we were taking the date, converting it to a locale date string, and then reformatting the date string from there. The problem with this is when the locale date format was not in the 'MM/DD/YYYY', our parsing would generate the wrong date string. To fix this, we are now using methods on the JavaScript Date object to get the year, month, and date, rather than formatting to the locale date string first.

## Testing steps

If you change your locale (changing your language and region on your device) and test the app, you should see that the startDate and endDate query parameters are properly formatted (YYYY-MM-DD) and that the linked report in Google Analytics displays the same date range as the chart.
