### PR TITLE
prune smartling

### DIFF
--- a/apps/smartling/lambda/package-lock.json
+++ b/apps/smartling/lambda/package-lock.json
@@ -25,6 +25,7 @@
         "jest": "^27.5.1",
         "nock": "^13.1.1",
         "serverless-domain-manager": "^3.3.0",
+        "serverless-prune-plugin": "^2.0.2",
         "supertest": "^4.0.2",
         "ts-jest": "^27.1.5",
         "ts-node": "^10.9.1",
@@ -10988,6 +10989,18 @@
         "aws-serverless-express": "^3.1.3",
         "azure-aws-serverless-express": "^0.1.5",
         "express": "^4.16.2"
+      }
+    },
+    "node_modules/serverless-prune-plugin": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/serverless-prune-plugin/-/serverless-prune-plugin-2.0.2.tgz",
+      "integrity": "sha512-tW1Q8MAVmhW8KQN+e0AsSVsb9nmRWWj28xBjMwvVC3FbammmtUJT+5nRpmjxJZ6/K/j3OV1Rx8b32md71BwkYQ==",
+      "dev": true,
+      "dependencies": {
+        "bluebird": "^3.7.2"
+      },
+      "peerDependencies": {
+        "serverless": "1 || 2 || 3"
       }
     },
     "node_modules/serverless/node_modules/@serverless/cli": {
@@ -22127,6 +22140,15 @@
         "aws-serverless-express": "^3.1.3",
         "azure-aws-serverless-express": "^0.1.5",
         "express": "^4.16.2"
+      }
+    },
+    "serverless-prune-plugin": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/serverless-prune-plugin/-/serverless-prune-plugin-2.0.2.tgz",
+      "integrity": "sha512-tW1Q8MAVmhW8KQN+e0AsSVsb9nmRWWj28xBjMwvVC3FbammmtUJT+5nRpmjxJZ6/K/j3OV1Rx8b32md71BwkYQ==",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.7.2"
       }
     },
     "set-blocking": {

--- a/apps/smartling/lambda/package.json
+++ b/apps/smartling/lambda/package.json
@@ -30,6 +30,7 @@
     "jest": "^27.5.1",
     "nock": "^13.1.1",
     "serverless-domain-manager": "^3.3.0",
+    "serverless-prune-plugin": "^2.0.2",
     "supertest": "^4.0.2",
     "ts-jest": "^27.1.5",
     "ts-node": "^10.9.1",

--- a/apps/smartling/lambda/serverless.yml
+++ b/apps/smartling/lambda/serverless.yml
@@ -5,6 +5,7 @@ frameworkVersion: '>=2.0.0 <3.0.0'
 plugins:
   - serverless-domain-manager
   - serverless-express
+  - serverless-prune-plugin
 
 custom:
   myStage: ${opt:stage, self:provider.stage}

--- a/apps/smartling/lambda/serverless.yml
+++ b/apps/smartling/lambda/serverless.yml
@@ -14,6 +14,9 @@ custom:
     createRoute53Record: true
     endpointType: 'edge'
     securityPolicy: tls_1_2
+  prune:
+    automatic: true
+    number: 3
 
 provider:
   name: aws


### PR DESCRIPTION
## Purpose

Lambda storage is getting full again. Instead of manual intervention and kicking the can down the road, I'm just adding the same [pruning method that worked for GA4](https://github.com/contentful/apps/pull/3172) in smartling, which is the largest app by storage:

![image](https://user-images.githubusercontent.com/1434735/232155854-6bc29f05-6dff-403e-a47d-f1ae094ec7cb.png)

## Approach

Use the serverless prune extension, saving 3 versions to maintain the same backups as GA4.


## Deployment

We'll want to make sure we watch this post-deploy to make sure the last 3 smartling versions are still standing.
