### PR TITLE
[INTEG-389] Moved userEvents creation to occur before render

### DIFF
--- a/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage/GoogleAnalyticsConfigPage.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage/GoogleAnalyticsConfigPage.spec.tsx
@@ -38,12 +38,12 @@ describe('Google Analytics Page', () => {
 
 describe('Config Screen component (not installed)', () => {
   it('allows the app to be installed with a valid service key file', async () => {
+    const user = userEvent.setup();
     render(<GoogleAnalyticsConfigPage />);
     const keyFileInputBox = screen.getByLabelText(/Service Account Key/i);
 
     // user.type() got confused by the JSON string chars, so we'll just click and paste -- this
     // actually better recreates likely user behavior as a bonus
-    const user = userEvent.setup();
     await user.click(keyFileInputBox);
     await user.paste(JSON.stringify(validServiceKeyFile));
 
@@ -68,13 +68,13 @@ describe('Config Screen component (not installed)', () => {
   });
 
   it('prevents the app from being installed with invalid service key file', async () => {
+    const user = userEvent.setup();
     render(<GoogleAnalyticsConfigPage />);
 
     const keyFileInputBox = screen.getByLabelText(/Service Account Key/i);
 
     // user.type() got confused by the JSON string chars, so we'll just click and paste -- this
     // actually better recreates likely user behavior as a bonus
-    const user = userEvent.setup();
     await user.click(keyFileInputBox);
     await user.paste('{ "foo": "bar" }');
 
@@ -109,9 +109,9 @@ describe('Installed Service Account Key', () => {
   });
 
   it('overrides the saved values if a new key file is provided', async () => {
+    const user = userEvent.setup();
     render(<GoogleAnalyticsConfigPage />);
 
-    const user = userEvent.setup();
     const editServiceAccountButton = await screen.findByTestId('editServiceAccountButton');
     await user.click(editServiceAccountButton);
     const keyFileInputBox = screen.getByLabelText(/Service Account Key/i);

--- a/apps/google-analytics-4/frontend/src/components/config-screen/WarningDisplay/WarningDisplay.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/WarningDisplay/WarningDisplay.spec.tsx
@@ -4,22 +4,22 @@ import WarningDisplay from 'components/config-screen/WarningDisplay/WarningDispl
 
 describe('WarningDisplay component', () => {
   it('renders an error icon and correct tooltip content', async () => {
+    const user = userEvent.setup();
     render(<WarningDisplay warningType="error" tooltipContent="This is an error" />);
 
     expect(screen.getByTestId('errorIcon')).toBeInTheDocument();
 
-    const user = userEvent.setup();
     await user.hover(screen.getByTestId('cf-ui-icon'));
 
     expect(screen.getByRole('tooltip').textContent).toBe('This is an error');
   });
 
   it('renders a warning icon and correct tooltip content', async () => {
+    const user = userEvent.setup();
     render(<WarningDisplay warningType="warning" tooltipContent="This is a warning" />);
 
     expect(screen.getByTestId('warningIcon')).toBeInTheDocument();
 
-    const user = userEvent.setup();
     await user.hover(screen.getByTestId('cf-ui-icon'));
 
     expect(screen.getByRole('tooltip').textContent).toBe('This is a warning');

--- a/apps/google-analytics-4/frontend/src/components/config-screen/api-access/setup/SetupServiceAccountCard.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/api-access/setup/SetupServiceAccountCard.spec.tsx
@@ -26,6 +26,7 @@ describe('Setup Google Service Account Details page', () => {
   });
 
   it('renders an error state when invalid input', async () => {
+    const user = userEvent.setup();
     render(
       <SetupServiceAccountCard
         parameters={{}}
@@ -40,7 +41,6 @@ describe('Setup Google Service Account Details page', () => {
 
     // user.type() got confused by the JSON string chars, so we'll just click and paste -- this
     // actually better recreates likely user behavior as a bonus
-    const user = userEvent.setup();
     await user.click(keyFileInputBox);
     await user.paste(JSON.stringify({ foo: 'bar' }));
 
@@ -51,6 +51,7 @@ describe('Setup Google Service Account Details page', () => {
   });
 
   it('renders a success state when valid input', async () => {
+    const user = userEvent.setup();
     render(
       <SetupServiceAccountCard
         parameters={{}}
@@ -65,7 +66,6 @@ describe('Setup Google Service Account Details page', () => {
 
     // user.type() got confused by the JSON string chars, so we'll just click and paste -- this
     // actually better recreates likely user behavior as a bonus
-    const user = userEvent.setup();
     await user.click(keyFileInputBox);
     await user.paste(JSON.stringify(validServiceKeyFile));
 

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeRow.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeRow.spec.tsx
@@ -76,6 +76,7 @@ describe('Assign Content Type Card for Config Screen', () => {
   });
 
   it('calls remove handler when remove link is clicked', async () => {
+    const user = userEvent.setup();
     render(
       <AssignContentTypeRow
         contentTypeEntry={[
@@ -89,13 +90,13 @@ describe('Assign Content Type Card for Config Screen', () => {
       />
     );
 
-    const user = userEvent.setup();
     await user.click(screen.getByText('Remove'));
 
     expect(onRemoveContentType).toHaveBeenCalled();
   });
 
   it('calls remove handler when remove link is clicked', async () => {
+    const user = userEvent.setup();
     render(
       <AssignContentTypeRow
         contentTypeEntry={[
@@ -109,13 +110,13 @@ describe('Assign Content Type Card for Config Screen', () => {
       />
     );
 
-    const user = userEvent.setup();
     await user.click(screen.getByText('Remove'));
 
     expect(onRemoveContentType).toHaveBeenCalled();
   });
 
   it('calls change handler when content type selection is changed', async () => {
+    const user = userEvent.setup();
     render(
       <AssignContentTypeRow
         contentTypeEntry={[
@@ -129,13 +130,13 @@ describe('Assign Content Type Card for Config Screen', () => {
       />
     );
 
-    const user = userEvent.setup();
     await user.selectOptions(screen.getByTestId('contentTypeSelect'), ['course']);
 
     expect(onContentTypeChange).toHaveBeenCalled();
   });
 
   it('calls field change handler when slug field selection is changed', async () => {
+    const user = userEvent.setup();
     render(
       <AssignContentTypeRow
         contentTypeEntry={[
@@ -149,13 +150,13 @@ describe('Assign Content Type Card for Config Screen', () => {
       />
     );
 
-    const user = userEvent.setup();
     await user.selectOptions(screen.getByTestId('slugFieldSelect'), ['slug']);
 
     expect(onContentTypeFieldChange).toHaveBeenCalled();
   });
 
   it('calls field change handler when url prefix input is changed', async () => {
+    const user = userEvent.setup();
     render(
       <AssignContentTypeRow
         contentTypeEntry={[
@@ -169,7 +170,6 @@ describe('Assign Content Type Card for Config Screen', () => {
       />
     );
 
-    const user = userEvent.setup();
     await user.type(screen.getByTestId('urlPrefixInput'), '/en-US');
 
     expect(onContentTypeFieldChange).toHaveBeenCalled();

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/ContentTypeWarning.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/ContentTypeWarning.spec.tsx
@@ -25,6 +25,7 @@ describe('Content Type Warning for Config Screen', () => {
   });
 
   it('renders an error icon and correct tooltip content when content type is deleted', async () => {
+    const user = userEvent.setup();
     render(
       <ContentTypeWarning
         contentTypeId={'test'}
@@ -38,13 +39,13 @@ describe('Content Type Warning for Config Screen', () => {
 
     expect(screen.getByTestId('errorIcon')).toBeInTheDocument();
 
-    const user = userEvent.setup();
     await user.hover(screen.getByTestId('cf-ui-icon'));
 
     expect(screen.getByRole('tooltip').textContent).toBe(getContentTypeDeletedMsg('test'));
   });
 
   it('renders a warning icon and correct tooltip content when slug field empty', async () => {
+    const user = userEvent.setup();
     render(
       <ContentTypeWarning
         contentTypeId={'test'}
@@ -58,13 +59,13 @@ describe('Content Type Warning for Config Screen', () => {
 
     expect(screen.getByTestId('warningIcon')).toBeInTheDocument();
 
-    const user = userEvent.setup();
     await user.hover(screen.getByTestId('cf-ui-icon'));
 
     expect(screen.getByRole('tooltip').textContent).toBe(NO_SLUG_WARNING_MSG);
   });
 
   it('renders a warning icon and correct tooltip content when slug field is deleted', async () => {
+    const user = userEvent.setup();
     render(
       <ContentTypeWarning
         contentTypeId={'test'}
@@ -78,7 +79,6 @@ describe('Content Type Warning for Config Screen', () => {
 
     expect(screen.getByTestId('warningIcon')).toBeInTheDocument();
 
-    const user = userEvent.setup();
     await user.hover(screen.getByTestId('cf-ui-icon'));
 
     expect(screen.getByRole('tooltip').textContent).toBe(getSlugFieldDeletedMsg('test', 'slug'));
@@ -87,6 +87,7 @@ describe('Content Type Warning for Config Screen', () => {
 
 describe('Content Type Warning for Config Screen Flakey', () => {
   it('renders a warning icon and correct tooltip content when app is removed from content type sidebar', async () => {
+    const user = userEvent.setup();
     render(
       <ContentTypeWarning
         contentTypeId={'test'}
@@ -99,7 +100,6 @@ describe('Content Type Warning for Config Screen Flakey', () => {
     );
 
     expect(screen.getByTestId('warningIcon')).toBeInTheDocument();
-    const user = userEvent.setup();
     await user.hover(screen.getByTestId('cf-ui-icon'));
 
     expect(screen.getByRole('tooltip').textContent).toBe(REMOVED_FROM_SIDEBAR_WARNING_MSG);

--- a/apps/google-analytics-4/frontend/src/components/config-screen/map-account-property/MapAccountPropertyDropdown.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/map-account-property/MapAccountPropertyDropdown.spec.tsx
@@ -36,6 +36,7 @@ describe('Property selection dropdown', () => {
   });
 
   it('calls change handler when property selection is changed', async () => {
+    const user = userEvent.setup();
     render(
       <MapAccountPropertyDropdown
         onSelectionChange={onSelectionChange}
@@ -46,7 +47,6 @@ describe('Property selection dropdown', () => {
       />
     );
 
-    const user = userEvent.setup();
     await user.selectOptions(screen.getByTestId('accountPropertyDropdown'), [
       'properties/354612161',
     ]);


### PR DESCRIPTION
## Purpose
Update the tests to have the `userEvent` creation to occur before the rendering of the component
`https://testing-library.com/docs/ecosystem-user-event/`

## Approach
Tests and build pass

