### PR TITLE
fix(deps): bump forma-36-tokens and fix tests

### DIFF
--- a/apps/gatsby/package-lock.json
+++ b/apps/gatsby/package-lock.json
@@ -11,7 +11,7 @@
         "@contentful/app-sdk": "4.9.0",
         "@contentful/forma-36-fcss": "0.3.5",
         "@contentful/forma-36-react-components": "3.100.7",
-        "@contentful/forma-36-tokens": "0.11.0",
+        "@contentful/forma-36-tokens": "0.11.2",
         "@gatsby-cloud-pkg/gatsby-cms-extension-base": "0.0.50",
         "emotion": "10.0.27",
         "prop-types": "15.8.1",
@@ -1601,13 +1601,8 @@
       "resolved": "https://registry.npmjs.org/@contentful/forma-36-fcss/-/forma-36-fcss-0.3.5.tgz",
       "integrity": "sha512-bDfUIqvE94LhgefZfoMeGgxIaeOh6N12kW0P6hUKxnjkJYLWb3i14p1NOiV+dNUa3TGNYCsDar+3O31BlmtewQ==",
       "dependencies": {
-        "@contentful/forma-36-tokens": "^0.11.2"
+        "@contentful/forma-36-tokens": "0.11.2"
       }
-    },
-    "node_modules/@contentful/forma-36-fcss/node_modules/@contentful/forma-36-tokens": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.11.2.tgz",
-      "integrity": "sha512-qjhKZahSQWQl6spebKycVTZF7Cnf4DBPh6QMoyM6YFmtbFlNfVpz8eKaO/C0hiVaBCjeN7wX/Jl6fdG+IovCgw=="
     },
     "node_modules/@contentful/forma-36-react-components": {
       "version": "3.100.7",
@@ -1616,7 +1611,7 @@
       "dependencies": {
         "@babel/runtime": "^7.3.4",
         "@contentful/forma-36-fcss": "^0.3.5",
-        "@contentful/forma-36-tokens": "^0.11.2",
+        "@contentful/forma-36-tokens": "0.11.2",
         "@popperjs/core": "^2.11.5",
         "classnames": "^2.2.6",
         "csstype": "^3.0.5",
@@ -1633,20 +1628,15 @@
         "react-dom": "^16.8.6 || ^17.0.0"
       }
     },
-    "node_modules/@contentful/forma-36-react-components/node_modules/@contentful/forma-36-tokens": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.11.2.tgz",
-      "integrity": "sha512-qjhKZahSQWQl6spebKycVTZF7Cnf4DBPh6QMoyM6YFmtbFlNfVpz8eKaO/C0hiVaBCjeN7wX/Jl6fdG+IovCgw=="
-    },
     "node_modules/@contentful/forma-36-react-components/node_modules/csstype": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
       "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
     },
     "node_modules/@contentful/forma-36-tokens": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.11.0.tgz",
-      "integrity": "sha512-PP+gia5E0u7H2TyfB31YHGeE2OOZtuIe9aKayH6fIwONO3XHTNN5mElnD5uVcockVQ36laAU2Iif8eVe3Zpvnw=="
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.11.2.tgz",
+      "integrity": "sha512-qjhKZahSQWQl6spebKycVTZF7Cnf4DBPh6QMoyM6YFmtbFlNfVpz8eKaO/C0hiVaBCjeN7wX/Jl6fdG+IovCgw=="
     },
     "node_modules/@csstools/convert-colors": {
       "version": "1.4.0",
@@ -29265,14 +29255,7 @@
       "resolved": "https://registry.npmjs.org/@contentful/forma-36-fcss/-/forma-36-fcss-0.3.5.tgz",
       "integrity": "sha512-bDfUIqvE94LhgefZfoMeGgxIaeOh6N12kW0P6hUKxnjkJYLWb3i14p1NOiV+dNUa3TGNYCsDar+3O31BlmtewQ==",
       "requires": {
-        "@contentful/forma-36-tokens": "^0.11.2"
-      },
-      "dependencies": {
-        "@contentful/forma-36-tokens": {
-          "version": "0.11.2",
-          "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.11.2.tgz",
-          "integrity": "sha512-qjhKZahSQWQl6spebKycVTZF7Cnf4DBPh6QMoyM6YFmtbFlNfVpz8eKaO/C0hiVaBCjeN7wX/Jl6fdG+IovCgw=="
-        }
+        "@contentful/forma-36-tokens": "0.11.2"
       }
     },
     "@contentful/forma-36-react-components": {
@@ -29282,7 +29265,7 @@
       "requires": {
         "@babel/runtime": "^7.3.4",
         "@contentful/forma-36-fcss": "^0.3.5",
-        "@contentful/forma-36-tokens": "^0.11.2",
+        "@contentful/forma-36-tokens": "0.11.2",
         "@popperjs/core": "^2.11.5",
         "classnames": "^2.2.6",
         "csstype": "^3.0.5",
@@ -29295,11 +29278,6 @@
         "truncate": "^3.0.0"
       },
       "dependencies": {
-        "@contentful/forma-36-tokens": {
-          "version": "0.11.2",
-          "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.11.2.tgz",
-          "integrity": "sha512-qjhKZahSQWQl6spebKycVTZF7Cnf4DBPh6QMoyM6YFmtbFlNfVpz8eKaO/C0hiVaBCjeN7wX/Jl6fdG+IovCgw=="
-        },
         "csstype": {
           "version": "3.0.8",
           "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
@@ -29308,9 +29286,9 @@
       }
     },
     "@contentful/forma-36-tokens": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.11.0.tgz",
-      "integrity": "sha512-PP+gia5E0u7H2TyfB31YHGeE2OOZtuIe9aKayH6fIwONO3XHTNN5mElnD5uVcockVQ36laAU2Iif8eVe3Zpvnw=="
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.11.2.tgz",
+      "integrity": "sha512-qjhKZahSQWQl6spebKycVTZF7Cnf4DBPh6QMoyM6YFmtbFlNfVpz8eKaO/C0hiVaBCjeN7wX/Jl6fdG+IovCgw=="
     },
     "@csstools/convert-colors": {
       "version": "1.4.0",

--- a/apps/gatsby/package.json
+++ b/apps/gatsby/package.json
@@ -12,7 +12,7 @@
     "@contentful/app-sdk": "4.9.0",
     "@contentful/forma-36-fcss": "0.3.5",
     "@contentful/forma-36-react-components": "3.100.7",
-    "@contentful/forma-36-tokens": "0.11.0",
+    "@contentful/forma-36-tokens": "0.11.2",
     "@gatsby-cloud-pkg/gatsby-cms-extension-base": "0.0.50",
     "emotion": "10.0.27",
     "prop-types": "15.8.1",

--- a/apps/google-analytics/package-lock.json
+++ b/apps/google-analytics/package-lock.json
@@ -11,7 +11,7 @@
         "@contentful/app-sdk": "4.9.0",
         "@contentful/forma-36-fcss": "0.3.5",
         "@contentful/forma-36-react-components": "3.100.7",
-        "@contentful/forma-36-tokens": "0.11.0",
+        "@contentful/forma-36-tokens": "0.11.2",
         "emotion": "10.0.27",
         "lodash": "4.17.21",
         "prop-types": "15.8.1",
@@ -1832,13 +1832,8 @@
       "resolved": "https://registry.npmjs.org/@contentful/forma-36-fcss/-/forma-36-fcss-0.3.5.tgz",
       "integrity": "sha512-bDfUIqvE94LhgefZfoMeGgxIaeOh6N12kW0P6hUKxnjkJYLWb3i14p1NOiV+dNUa3TGNYCsDar+3O31BlmtewQ==",
       "dependencies": {
-        "@contentful/forma-36-tokens": "^0.11.2"
+        "@contentful/forma-36-tokens": "0.11.2"
       }
-    },
-    "node_modules/@contentful/forma-36-fcss/node_modules/@contentful/forma-36-tokens": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.11.2.tgz",
-      "integrity": "sha512-qjhKZahSQWQl6spebKycVTZF7Cnf4DBPh6QMoyM6YFmtbFlNfVpz8eKaO/C0hiVaBCjeN7wX/Jl6fdG+IovCgw=="
     },
     "node_modules/@contentful/forma-36-react-components": {
       "version": "3.100.7",
@@ -1847,7 +1842,7 @@
       "dependencies": {
         "@babel/runtime": "^7.3.4",
         "@contentful/forma-36-fcss": "^0.3.5",
-        "@contentful/forma-36-tokens": "^0.11.2",
+        "@contentful/forma-36-tokens": "0.11.2",
         "@popperjs/core": "^2.11.5",
         "classnames": "^2.2.6",
         "csstype": "^3.0.5",
@@ -1864,20 +1859,15 @@
         "react-dom": "^16.8.6 || ^17.0.0"
       }
     },
-    "node_modules/@contentful/forma-36-react-components/node_modules/@contentful/forma-36-tokens": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.11.2.tgz",
-      "integrity": "sha512-qjhKZahSQWQl6spebKycVTZF7Cnf4DBPh6QMoyM6YFmtbFlNfVpz8eKaO/C0hiVaBCjeN7wX/Jl6fdG+IovCgw=="
-    },
     "node_modules/@contentful/forma-36-react-components/node_modules/csstype": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
       "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
     },
     "node_modules/@contentful/forma-36-tokens": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.11.0.tgz",
-      "integrity": "sha512-PP+gia5E0u7H2TyfB31YHGeE2OOZtuIe9aKayH6fIwONO3XHTNN5mElnD5uVcockVQ36laAU2Iif8eVe3Zpvnw=="
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.11.2.tgz",
+      "integrity": "sha512-qjhKZahSQWQl6spebKycVTZF7Cnf4DBPh6QMoyM6YFmtbFlNfVpz8eKaO/C0hiVaBCjeN7wX/Jl6fdG+IovCgw=="
     },
     "node_modules/@csstools/convert-colors": {
       "version": "1.4.0",
@@ -25478,14 +25468,7 @@
       "resolved": "https://registry.npmjs.org/@contentful/forma-36-fcss/-/forma-36-fcss-0.3.5.tgz",
       "integrity": "sha512-bDfUIqvE94LhgefZfoMeGgxIaeOh6N12kW0P6hUKxnjkJYLWb3i14p1NOiV+dNUa3TGNYCsDar+3O31BlmtewQ==",
       "requires": {
-        "@contentful/forma-36-tokens": "^0.11.2"
-      },
-      "dependencies": {
-        "@contentful/forma-36-tokens": {
-          "version": "0.11.2",
-          "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.11.2.tgz",
-          "integrity": "sha512-qjhKZahSQWQl6spebKycVTZF7Cnf4DBPh6QMoyM6YFmtbFlNfVpz8eKaO/C0hiVaBCjeN7wX/Jl6fdG+IovCgw=="
-        }
+        "@contentful/forma-36-tokens": "0.11.2"
       }
     },
     "@contentful/forma-36-react-components": {
@@ -25495,7 +25478,7 @@
       "requires": {
         "@babel/runtime": "^7.3.4",
         "@contentful/forma-36-fcss": "^0.3.5",
-        "@contentful/forma-36-tokens": "^0.11.2",
+        "@contentful/forma-36-tokens": "0.11.2",
         "@popperjs/core": "^2.11.5",
         "classnames": "^2.2.6",
         "csstype": "^3.0.5",
@@ -25508,11 +25491,6 @@
         "truncate": "^3.0.0"
       },
       "dependencies": {
-        "@contentful/forma-36-tokens": {
-          "version": "0.11.2",
-          "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.11.2.tgz",
-          "integrity": "sha512-qjhKZahSQWQl6spebKycVTZF7Cnf4DBPh6QMoyM6YFmtbFlNfVpz8eKaO/C0hiVaBCjeN7wX/Jl6fdG+IovCgw=="
-        },
         "csstype": {
           "version": "3.0.8",
           "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
@@ -25521,9 +25499,9 @@
       }
     },
     "@contentful/forma-36-tokens": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.11.0.tgz",
-      "integrity": "sha512-PP+gia5E0u7H2TyfB31YHGeE2OOZtuIe9aKayH6fIwONO3XHTNN5mElnD5uVcockVQ36laAU2Iif8eVe3Zpvnw=="
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.11.2.tgz",
+      "integrity": "sha512-qjhKZahSQWQl6spebKycVTZF7Cnf4DBPh6QMoyM6YFmtbFlNfVpz8eKaO/C0hiVaBCjeN7wX/Jl6fdG+IovCgw=="
     },
     "@csstools/convert-colors": {
       "version": "1.4.0",

--- a/apps/google-analytics/package.json
+++ b/apps/google-analytics/package.json
@@ -17,7 +17,7 @@
     "@contentful/app-sdk": "4.9.0",
     "@contentful/forma-36-fcss": "0.3.5",
     "@contentful/forma-36-react-components": "3.100.7",
-    "@contentful/forma-36-tokens": "0.11.0",
+    "@contentful/forma-36-tokens": "0.11.2",
     "emotion": "10.0.27",
     "lodash": "4.17.21",
     "prop-types": "15.8.1",

--- a/apps/graphql-playground/package-lock.json
+++ b/apps/graphql-playground/package-lock.json
@@ -12,7 +12,7 @@
         "@contentful/field-editor-test-utils": "^0.8.2",
         "@contentful/forma-36-fcss": "0.3.5",
         "@contentful/forma-36-react-components": "^3.100.7",
-        "@contentful/forma-36-tokens": "^0.9.2",
+        "@contentful/forma-36-tokens": "^0.11.2",
         "contentful-ui-extensions-sdk": "^3.37.0",
         "graphql-playground-react": "^1.7.27",
         "react": "^17.0.1",
@@ -2446,6 +2446,11 @@
         "react": ">=16.8.0"
       }
     },
+    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/forma-36-tokens": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.9.4.tgz",
+      "integrity": "sha512-lCv9MGjivCUYV25g2sNeGmqJmCk3KUF7EHy4iDru8Xo2DzqciVIumOZIyx7TVWzAckK94f4rEJ8E2PlRL5gYvg=="
+    },
     "node_modules/@contentful/field-editor-single-line": {
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/@contentful/field-editor-single-line/-/field-editor-single-line-0.16.0.tgz",
@@ -3076,6 +3081,11 @@
         "react": ">=16.8.0"
       }
     },
+    "node_modules/@contentful/field-editor-test-utils/node_modules/@contentful/forma-36-tokens": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.9.4.tgz",
+      "integrity": "sha512-lCv9MGjivCUYV25g2sNeGmqJmCk3KUF7EHy4iDru8Xo2DzqciVIumOZIyx7TVWzAckK94f4rEJ8E2PlRL5gYvg=="
+    },
     "node_modules/@contentful/forma-36-fcss": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/@contentful/forma-36-fcss/-/forma-36-fcss-0.3.5.tgz",
@@ -3083,11 +3093,6 @@
       "dependencies": {
         "@contentful/forma-36-tokens": "^0.11.2"
       }
-    },
-    "node_modules/@contentful/forma-36-fcss/node_modules/@contentful/forma-36-tokens": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.11.2.tgz",
-      "integrity": "sha512-qjhKZahSQWQl6spebKycVTZF7Cnf4DBPh6QMoyM6YFmtbFlNfVpz8eKaO/C0hiVaBCjeN7wX/Jl6fdG+IovCgw=="
     },
     "node_modules/@contentful/forma-36-react-components": {
       "version": "3.100.7",
@@ -3113,15 +3118,10 @@
         "react-dom": "^16.8.6 || ^17.0.0"
       }
     },
-    "node_modules/@contentful/forma-36-react-components/node_modules/@contentful/forma-36-tokens": {
+    "node_modules/@contentful/forma-36-tokens": {
       "version": "0.11.2",
       "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.11.2.tgz",
       "integrity": "sha512-qjhKZahSQWQl6spebKycVTZF7Cnf4DBPh6QMoyM6YFmtbFlNfVpz8eKaO/C0hiVaBCjeN7wX/Jl6fdG+IovCgw=="
-    },
-    "node_modules/@contentful/forma-36-tokens": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.9.4.tgz",
-      "integrity": "sha512-lCv9MGjivCUYV25g2sNeGmqJmCk3KUF7EHy4iDru8Xo2DzqciVIumOZIyx7TVWzAckK94f4rEJ8E2PlRL5gYvg=="
     },
     "node_modules/@csstools/convert-colors": {
       "version": "1.4.0",

--- a/apps/graphql-playground/package.json
+++ b/apps/graphql-playground/package.json
@@ -20,7 +20,7 @@
     "@contentful/field-editor-test-utils": "^0.8.2",
     "@contentful/forma-36-fcss": "0.3.5",
     "@contentful/forma-36-react-components": "^3.100.7",
-    "@contentful/forma-36-tokens": "^0.9.2",
+    "@contentful/forma-36-tokens": "^0.11.2",
     "contentful-ui-extensions-sdk": "^3.37.0",
     "graphql-playground-react": "^1.7.27",
     "react": "^17.0.1",

--- a/apps/image-focal-point/package-lock.json
+++ b/apps/image-focal-point/package-lock.json
@@ -11,7 +11,7 @@
         "@contentful/app-sdk": "4.9.0",
         "@contentful/forma-36-fcss": "0.3.5",
         "@contentful/forma-36-react-components": "3.100.7",
-        "@contentful/forma-36-tokens": "0.11.0",
+        "@contentful/forma-36-tokens": "0.11.2",
         "emotion": "10.0.27",
         "hex-rgb": "4.3.0",
         "lodash.camelcase": "4.3.0",
@@ -1945,13 +1945,8 @@
       "resolved": "https://registry.npmjs.org/@contentful/forma-36-fcss/-/forma-36-fcss-0.3.5.tgz",
       "integrity": "sha512-bDfUIqvE94LhgefZfoMeGgxIaeOh6N12kW0P6hUKxnjkJYLWb3i14p1NOiV+dNUa3TGNYCsDar+3O31BlmtewQ==",
       "dependencies": {
-        "@contentful/forma-36-tokens": "^0.11.2"
+        "@contentful/forma-36-tokens": "0.11.2"
       }
-    },
-    "node_modules/@contentful/forma-36-fcss/node_modules/@contentful/forma-36-tokens": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.11.2.tgz",
-      "integrity": "sha512-qjhKZahSQWQl6spebKycVTZF7Cnf4DBPh6QMoyM6YFmtbFlNfVpz8eKaO/C0hiVaBCjeN7wX/Jl6fdG+IovCgw=="
     },
     "node_modules/@contentful/forma-36-react-components": {
       "version": "3.100.7",
@@ -1960,7 +1955,7 @@
       "dependencies": {
         "@babel/runtime": "^7.3.4",
         "@contentful/forma-36-fcss": "^0.3.5",
-        "@contentful/forma-36-tokens": "^0.11.2",
+        "@contentful/forma-36-tokens": "0.11.2",
         "@popperjs/core": "^2.11.5",
         "classnames": "^2.2.6",
         "csstype": "^3.0.5",
@@ -1977,20 +1972,15 @@
         "react-dom": "^16.8.6 || ^17.0.0"
       }
     },
-    "node_modules/@contentful/forma-36-react-components/node_modules/@contentful/forma-36-tokens": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.11.2.tgz",
-      "integrity": "sha512-qjhKZahSQWQl6spebKycVTZF7Cnf4DBPh6QMoyM6YFmtbFlNfVpz8eKaO/C0hiVaBCjeN7wX/Jl6fdG+IovCgw=="
-    },
     "node_modules/@contentful/forma-36-react-components/node_modules/csstype": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
       "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
     },
     "node_modules/@contentful/forma-36-tokens": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.11.0.tgz",
-      "integrity": "sha512-PP+gia5E0u7H2TyfB31YHGeE2OOZtuIe9aKayH6fIwONO3XHTNN5mElnD5uVcockVQ36laAU2Iif8eVe3Zpvnw=="
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.11.2.tgz",
+      "integrity": "sha512-qjhKZahSQWQl6spebKycVTZF7Cnf4DBPh6QMoyM6YFmtbFlNfVpz8eKaO/C0hiVaBCjeN7wX/Jl6fdG+IovCgw=="
     },
     "node_modules/@csstools/convert-colors": {
       "version": "1.4.0",
@@ -25296,14 +25286,7 @@
       "resolved": "https://registry.npmjs.org/@contentful/forma-36-fcss/-/forma-36-fcss-0.3.5.tgz",
       "integrity": "sha512-bDfUIqvE94LhgefZfoMeGgxIaeOh6N12kW0P6hUKxnjkJYLWb3i14p1NOiV+dNUa3TGNYCsDar+3O31BlmtewQ==",
       "requires": {
-        "@contentful/forma-36-tokens": "^0.11.2"
-      },
-      "dependencies": {
-        "@contentful/forma-36-tokens": {
-          "version": "0.11.2",
-          "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.11.2.tgz",
-          "integrity": "sha512-qjhKZahSQWQl6spebKycVTZF7Cnf4DBPh6QMoyM6YFmtbFlNfVpz8eKaO/C0hiVaBCjeN7wX/Jl6fdG+IovCgw=="
-        }
+        "@contentful/forma-36-tokens": "0.11.2"
       }
     },
     "@contentful/forma-36-react-components": {
@@ -25313,7 +25296,7 @@
       "requires": {
         "@babel/runtime": "^7.3.4",
         "@contentful/forma-36-fcss": "^0.3.5",
-        "@contentful/forma-36-tokens": "^0.11.2",
+        "@contentful/forma-36-tokens": "0.11.2",
         "@popperjs/core": "^2.11.5",
         "classnames": "^2.2.6",
         "csstype": "^3.0.5",
@@ -25326,11 +25309,6 @@
         "truncate": "^3.0.0"
       },
       "dependencies": {
-        "@contentful/forma-36-tokens": {
-          "version": "0.11.2",
-          "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.11.2.tgz",
-          "integrity": "sha512-qjhKZahSQWQl6spebKycVTZF7Cnf4DBPh6QMoyM6YFmtbFlNfVpz8eKaO/C0hiVaBCjeN7wX/Jl6fdG+IovCgw=="
-        },
         "csstype": {
           "version": "3.0.8",
           "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
@@ -25339,9 +25317,9 @@
       }
     },
     "@contentful/forma-36-tokens": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.11.0.tgz",
-      "integrity": "sha512-PP+gia5E0u7H2TyfB31YHGeE2OOZtuIe9aKayH6fIwONO3XHTNN5mElnD5uVcockVQ36laAU2Iif8eVe3Zpvnw=="
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.11.2.tgz",
+      "integrity": "sha512-qjhKZahSQWQl6spebKycVTZF7Cnf4DBPh6QMoyM6YFmtbFlNfVpz8eKaO/C0hiVaBCjeN7wX/Jl6fdG+IovCgw=="
     },
     "@csstools/convert-colors": {
       "version": "1.4.0",

--- a/apps/image-focal-point/package.json
+++ b/apps/image-focal-point/package.json
@@ -19,7 +19,7 @@
     "@contentful/app-sdk": "4.9.0",
     "@contentful/forma-36-fcss": "0.3.5",
     "@contentful/forma-36-react-components": "3.100.7",
-    "@contentful/forma-36-tokens": "0.11.0",
+    "@contentful/forma-36-tokens": "0.11.2",
     "emotion": "10.0.27",
     "hex-rgb": "4.3.0",
     "lodash.camelcase": "4.3.0",

--- a/apps/optimizely/package-lock.json
+++ b/apps/optimizely/package-lock.json
@@ -11,7 +11,7 @@
         "@contentful/app-sdk": "4.9.0",
         "@contentful/forma-36-fcss": "0.3.5",
         "@contentful/forma-36-react-components": "3.100.7",
-        "@contentful/forma-36-tokens": "0.11.0",
+        "@contentful/forma-36-tokens": "0.11.2",
         "@testing-library/react": "8.0.7",
         "@use-it/interval": "0.1.4",
         "emotion": "10.0.27",
@@ -1601,13 +1601,8 @@
       "resolved": "https://registry.npmjs.org/@contentful/forma-36-fcss/-/forma-36-fcss-0.3.5.tgz",
       "integrity": "sha512-bDfUIqvE94LhgefZfoMeGgxIaeOh6N12kW0P6hUKxnjkJYLWb3i14p1NOiV+dNUa3TGNYCsDar+3O31BlmtewQ==",
       "dependencies": {
-        "@contentful/forma-36-tokens": "^0.11.2"
+        "@contentful/forma-36-tokens": "0.11.2"
       }
-    },
-    "node_modules/@contentful/forma-36-fcss/node_modules/@contentful/forma-36-tokens": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.11.2.tgz",
-      "integrity": "sha512-qjhKZahSQWQl6spebKycVTZF7Cnf4DBPh6QMoyM6YFmtbFlNfVpz8eKaO/C0hiVaBCjeN7wX/Jl6fdG+IovCgw=="
     },
     "node_modules/@contentful/forma-36-react-components": {
       "version": "3.100.7",
@@ -1616,7 +1611,7 @@
       "dependencies": {
         "@babel/runtime": "^7.3.4",
         "@contentful/forma-36-fcss": "^0.3.5",
-        "@contentful/forma-36-tokens": "^0.11.2",
+        "@contentful/forma-36-tokens": "0.11.2",
         "@popperjs/core": "^2.11.5",
         "classnames": "^2.2.6",
         "csstype": "^3.0.5",
@@ -1633,20 +1628,15 @@
         "react-dom": "^16.8.6 || ^17.0.0"
       }
     },
-    "node_modules/@contentful/forma-36-react-components/node_modules/@contentful/forma-36-tokens": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.11.2.tgz",
-      "integrity": "sha512-qjhKZahSQWQl6spebKycVTZF7Cnf4DBPh6QMoyM6YFmtbFlNfVpz8eKaO/C0hiVaBCjeN7wX/Jl6fdG+IovCgw=="
-    },
     "node_modules/@contentful/forma-36-react-components/node_modules/csstype": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
       "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
     },
     "node_modules/@contentful/forma-36-tokens": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.11.0.tgz",
-      "integrity": "sha512-PP+gia5E0u7H2TyfB31YHGeE2OOZtuIe9aKayH6fIwONO3XHTNN5mElnD5uVcockVQ36laAU2Iif8eVe3Zpvnw=="
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.11.2.tgz",
+      "integrity": "sha512-qjhKZahSQWQl6spebKycVTZF7Cnf4DBPh6QMoyM6YFmtbFlNfVpz8eKaO/C0hiVaBCjeN7wX/Jl6fdG+IovCgw=="
     },
     "node_modules/@csstools/convert-colors": {
       "version": "1.4.0",
@@ -28081,14 +28071,7 @@
       "resolved": "https://registry.npmjs.org/@contentful/forma-36-fcss/-/forma-36-fcss-0.3.5.tgz",
       "integrity": "sha512-bDfUIqvE94LhgefZfoMeGgxIaeOh6N12kW0P6hUKxnjkJYLWb3i14p1NOiV+dNUa3TGNYCsDar+3O31BlmtewQ==",
       "requires": {
-        "@contentful/forma-36-tokens": "^0.11.2"
-      },
-      "dependencies": {
-        "@contentful/forma-36-tokens": {
-          "version": "0.11.2",
-          "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.11.2.tgz",
-          "integrity": "sha512-qjhKZahSQWQl6spebKycVTZF7Cnf4DBPh6QMoyM6YFmtbFlNfVpz8eKaO/C0hiVaBCjeN7wX/Jl6fdG+IovCgw=="
-        }
+        "@contentful/forma-36-tokens": "0.11.2"
       }
     },
     "@contentful/forma-36-react-components": {
@@ -28098,7 +28081,7 @@
       "requires": {
         "@babel/runtime": "^7.3.4",
         "@contentful/forma-36-fcss": "^0.3.5",
-        "@contentful/forma-36-tokens": "^0.11.2",
+        "@contentful/forma-36-tokens": "0.11.2",
         "@popperjs/core": "^2.11.5",
         "classnames": "^2.2.6",
         "csstype": "^3.0.5",
@@ -28111,11 +28094,6 @@
         "truncate": "^3.0.0"
       },
       "dependencies": {
-        "@contentful/forma-36-tokens": {
-          "version": "0.11.2",
-          "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.11.2.tgz",
-          "integrity": "sha512-qjhKZahSQWQl6spebKycVTZF7Cnf4DBPh6QMoyM6YFmtbFlNfVpz8eKaO/C0hiVaBCjeN7wX/Jl6fdG+IovCgw=="
-        },
         "csstype": {
           "version": "3.0.8",
           "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
@@ -28124,9 +28102,9 @@
       }
     },
     "@contentful/forma-36-tokens": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.11.0.tgz",
-      "integrity": "sha512-PP+gia5E0u7H2TyfB31YHGeE2OOZtuIe9aKayH6fIwONO3XHTNN5mElnD5uVcockVQ36laAU2Iif8eVe3Zpvnw=="
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.11.2.tgz",
+      "integrity": "sha512-qjhKZahSQWQl6spebKycVTZF7Cnf4DBPh6QMoyM6YFmtbFlNfVpz8eKaO/C0hiVaBCjeN7wX/Jl6fdG+IovCgw=="
     },
     "@csstools/convert-colors": {
       "version": "1.4.0",

--- a/apps/optimizely/package.json
+++ b/apps/optimizely/package.json
@@ -9,7 +9,7 @@
     "@contentful/app-sdk": "4.9.0",
     "@contentful/forma-36-fcss": "0.3.5",
     "@contentful/forma-36-react-components": "3.100.7",
-    "@contentful/forma-36-tokens": "0.11.0",
+    "@contentful/forma-36-tokens": "0.11.2",
     "@testing-library/react": "8.0.7",
     "@use-it/interval": "0.1.4",
     "emotion": "10.0.27",

--- a/apps/sap-commerce-cloud/package-lock.json
+++ b/apps/sap-commerce-cloud/package-lock.json
@@ -15,7 +15,7 @@
         "@contentful/field-editor-test-utils": "^0.9.0",
         "@contentful/forma-36-fcss": "^0.3.1",
         "@contentful/forma-36-react-components": "^3.80.1",
-        "@contentful/forma-36-tokens": "^0.10.1",
+        "@contentful/forma-36-tokens": "^0.11.2",
         "@emotion/css": "^11.1.3",
         "cross-env": "^7.0.3",
         "lodash.get": "^4.4.2",
@@ -3188,6 +3188,11 @@
         "react": ">=16.8.0"
       }
     },
+    "node_modules/@contentful/field-editor-test-utils/node_modules/@contentful/forma-36-tokens": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.10.2.tgz",
+      "integrity": "sha512-HHLwIN8mQv41GYxcTBYJjiDwpmmWwbcIRV09ciSDxhciYJ+wQkIurQ2lmnKHebPwv35X6fHXB4OdSTK1d9mUug=="
+    },
     "node_modules/@contentful/forma-36-fcss": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/@contentful/forma-36-fcss/-/forma-36-fcss-0.3.5.tgz",
@@ -3195,11 +3200,6 @@
       "dependencies": {
         "@contentful/forma-36-tokens": "^0.11.2"
       }
-    },
-    "node_modules/@contentful/forma-36-fcss/node_modules/@contentful/forma-36-tokens": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.11.2.tgz",
-      "integrity": "sha512-qjhKZahSQWQl6spebKycVTZF7Cnf4DBPh6QMoyM6YFmtbFlNfVpz8eKaO/C0hiVaBCjeN7wX/Jl6fdG+IovCgw=="
     },
     "node_modules/@contentful/forma-36-react-components": {
       "version": "3.100.7",
@@ -3225,15 +3225,10 @@
         "react-dom": "^16.8.6 || ^17.0.0"
       }
     },
-    "node_modules/@contentful/forma-36-react-components/node_modules/@contentful/forma-36-tokens": {
+    "node_modules/@contentful/forma-36-tokens": {
       "version": "0.11.2",
       "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.11.2.tgz",
       "integrity": "sha512-qjhKZahSQWQl6spebKycVTZF7Cnf4DBPh6QMoyM6YFmtbFlNfVpz8eKaO/C0hiVaBCjeN7wX/Jl6fdG+IovCgw=="
-    },
-    "node_modules/@contentful/forma-36-tokens": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.10.2.tgz",
-      "integrity": "sha512-HHLwIN8mQv41GYxcTBYJjiDwpmmWwbcIRV09ciSDxhciYJ+wQkIurQ2lmnKHebPwv35X6fHXB4OdSTK1d9mUug=="
     },
     "node_modules/@csstools/normalize.css": {
       "version": "12.0.0",

--- a/apps/sap-commerce-cloud/package.json
+++ b/apps/sap-commerce-cloud/package.json
@@ -11,7 +11,7 @@
     "@contentful/field-editor-test-utils": "^0.9.0",
     "@contentful/forma-36-fcss": "^0.3.1",
     "@contentful/forma-36-react-components": "^3.80.1",
-    "@contentful/forma-36-tokens": "^0.10.1",
+    "@contentful/forma-36-tokens": "^0.11.2",
     "@emotion/css": "^11.1.3",
     "cross-env": "^7.0.3",
     "lodash.get": "^4.4.2",

--- a/apps/sap-commerce-cloud/src/components/CategoryPreviews/__snapshots__/SortableList.spec.tsx.snap
+++ b/apps/sap-commerce-cloud/src/components/CategoryPreviews/__snapshots__/SortableList.spec.tsx.snap
@@ -21,7 +21,7 @@ exports[`SortableList should render successfully 1`] = `
             Mock Product
           </h1>
           <h2
-            class="Subheading__Subheading___2mA9j css-1b5bj2l f36-margin-bottom--m"
+            class="Subheading__Subheading___2mA9j css-ksy8vh f36-margin-bottom--m"
             data-test-id="cf-ui-subheading"
           >
             123

--- a/apps/sap-commerce-cloud/src/components/CategoryPreviews/__snapshots__/SortableListItem.spec.tsx.snap
+++ b/apps/sap-commerce-cloud/src/components/CategoryPreviews/__snapshots__/SortableListItem.spec.tsx.snap
@@ -20,7 +20,7 @@ exports[`SortableListItem should render successfully 1`] = `
           Mock Product
         </h1>
         <h2
-          class="Subheading__Subheading___2mA9j css-1b5bj2l f36-margin-bottom--m"
+          class="Subheading__Subheading___2mA9j css-ksy8vh f36-margin-bottom--m"
           data-test-id="cf-ui-subheading"
         >
           123

--- a/apps/sap-commerce-cloud/src/components/ProductPreviews/__snapshots__/SortableList.spec.tsx.snap
+++ b/apps/sap-commerce-cloud/src/components/ProductPreviews/__snapshots__/SortableList.spec.tsx.snap
@@ -108,7 +108,7 @@ exports[`SortableList should render successfully 1`] = `
             Mock Category
           </h1>
           <h2
-            class="Subheading__Subheading___2mA9j css-1b5bj2l f36-margin-bottom--m"
+            class="Subheading__Subheading___2mA9j css-ksy8vh f36-margin-bottom--m"
             data-test-id="cf-ui-subheading"
           >
             abc1234

--- a/apps/sap-commerce-cloud/src/components/ProductPreviews/__snapshots__/SortableListItem.spec.tsx.snap
+++ b/apps/sap-commerce-cloud/src/components/ProductPreviews/__snapshots__/SortableListItem.spec.tsx.snap
@@ -30,7 +30,7 @@ exports[`SortableListItem should render successfully 1`] = `
           Mock Category
         </h1>
         <h2
-          class="Subheading__Subheading___2mA9j css-1b5bj2l f36-margin-bottom--m"
+          class="Subheading__Subheading___2mA9j css-ksy8vh f36-margin-bottom--m"
           data-test-id="cf-ui-subheading"
         >
           abc1234
@@ -104,7 +104,7 @@ exports[`SortableListItem should render successfully the error variation for mis
       </span>
     </div>
     <div
-      class="css-14lnkev"
+      class="css-6t06np"
     >
       <svg
         class="Icon__Icon___38Epv Icon__Icon--small___1yGZK Icon__Icon--primary___3M4Il"
@@ -141,7 +141,7 @@ exports[`SortableListItem should render successfully the error variation for mis
           Mock Category
         </h1>
         <h2
-          class="Subheading__Subheading___2mA9j css-1b5bj2l f36-margin-bottom--m"
+          class="Subheading__Subheading___2mA9j css-ksy8vh f36-margin-bottom--m"
           data-test-id="cf-ui-subheading"
         >
           abc1234
@@ -190,7 +190,7 @@ exports[`SortableListItem should render successfully the error variation for mis
     data-test-id="cf-ui-card"
   >
     <div
-      class="css-14lnkev"
+      class="css-6t06np"
     >
       <svg
         class="Icon__Icon___38Epv Icon__Icon--small___1yGZK Icon__Icon--primary___3M4Il"
@@ -371,7 +371,7 @@ exports[`SortableListItem should render successfully the loading variation 1`] =
           Mock Category
         </h1>
         <h2
-          class="Subheading__Subheading___2mA9j css-1b5bj2l f36-margin-bottom--m"
+          class="Subheading__Subheading___2mA9j css-ksy8vh f36-margin-bottom--m"
           data-test-id="cf-ui-subheading"
         >
           abc1234
@@ -468,7 +468,7 @@ exports[`SortableListItem should render successfully the sortable variation 1`] 
           Mock Category
         </h1>
         <h2
-          class="Subheading__Subheading___2mA9j css-1b5bj2l f36-margin-bottom--m"
+          class="Subheading__Subheading___2mA9j css-ksy8vh f36-margin-bottom--m"
           data-test-id="cf-ui-subheading"
         >
           abc1234


### PR DESCRIPTION
## Purpose

Dependabot tried to update the forma-36-tokens package in [this PR](https://github.com/contentful/apps/pull/3140) and the tests failed (see failed job [here](https://app.circleci.com/pipelines/github/contentful/apps/19296/workflows/b8ed0c7c-d35a-496b-baf7-37d70a111e84/jobs/49187)). Specifically, the SAP Commerce Cloud app has snapshot tests that needed to be updated after updating the package. 
