### PR TITLE
chore: update app scripts versions in js and ts templates

### DIFF
--- a/examples/javascript/package-lock.json
+++ b/examples/javascript/package-lock.json
@@ -19,7 +19,7 @@
         "react-scripts": "5.0.1"
       },
       "devDependencies": {
-        "@contentful/app-scripts": "1.7.13",
+        "@contentful/app-scripts": "1.8.1",
         "@testing-library/jest-dom": "5.16.5",
         "@testing-library/react": "12.1.5",
         "cross-env": "7.0.3"
@@ -1870,9 +1870,9 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
     "node_modules/@contentful/app-scripts": {
-      "version": "1.7.13",
-      "resolved": "https://registry.npmjs.org/@contentful/app-scripts/-/app-scripts-1.7.13.tgz",
-      "integrity": "sha512-SrCs6UVks6EICySSAP5ETKRcrpgKWrpI5VRn2bSqOPgtcvV5PnjA3rfa1gzWYHMXZJXYdtioBehOFaEthm3ipA==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@contentful/app-scripts/-/app-scripts-1.8.1.tgz",
+      "integrity": "sha512-tGx91Esz0y0qwS5owce6fp44FjRmYBsTsmSfwxq0zVacnBxwzKusM/qEWCuML1nB8qjW6AQLrG9Hrpq8eKA1sw==",
       "dev": true,
       "dependencies": {
         "adm-zip": "0.5.10",
@@ -1880,7 +1880,7 @@
         "bottleneck": "2.19.5",
         "chalk": "4.1.2",
         "commander": "10.0.0",
-        "contentful-management": "10.30.0",
+        "contentful-management": "10.32.0",
         "dotenv": "16.0.3",
         "ignore": "5.2.4",
         "inquirer": "8.2.5",
@@ -1954,23 +1954,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/@contentful/app-scripts/node_modules/contentful-management": {
-      "version": "10.30.0",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-10.30.0.tgz",
-      "integrity": "sha512-CYeZqezYP7q++EuHgCHKakemsJqCHC784uOWyYp00Rc6+iMw5glK8GjwksbgUsbnZFfCywGyZCj4Xsd4lZ0ZaQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/json-patch": "0.0.30",
-        "axios": "^0.27.1",
-        "contentful-sdk-core": "^7.0.1",
-        "fast-copy": "^3.0.0",
-        "lodash.isplainobject": "^4.0.6",
-        "type-fest": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@contentful/app-scripts/node_modules/dotenv": {
       "version": "16.0.3",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
@@ -2025,18 +2008,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@contentful/app-scripts/node_modules/type-fest": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.6.0.tgz",
-      "integrity": "sha512-RqTRtKTzvPpNdDUp1dVkKQRunlPITk4mXeqFlAZoJsS+fLRn8AdPK0TcQDumGayhU7fjlBfiBjsq3pe3rIfXZQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@contentful/app-sdk": {
@@ -19666,9 +19637,9 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
     "@contentful/app-scripts": {
-      "version": "1.7.13",
-      "resolved": "https://registry.npmjs.org/@contentful/app-scripts/-/app-scripts-1.7.13.tgz",
-      "integrity": "sha512-SrCs6UVks6EICySSAP5ETKRcrpgKWrpI5VRn2bSqOPgtcvV5PnjA3rfa1gzWYHMXZJXYdtioBehOFaEthm3ipA==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@contentful/app-scripts/-/app-scripts-1.8.1.tgz",
+      "integrity": "sha512-tGx91Esz0y0qwS5owce6fp44FjRmYBsTsmSfwxq0zVacnBxwzKusM/qEWCuML1nB8qjW6AQLrG9Hrpq8eKA1sw==",
       "dev": true,
       "requires": {
         "adm-zip": "0.5.10",
@@ -19676,7 +19647,7 @@
         "bottleneck": "2.19.5",
         "chalk": "4.1.2",
         "commander": "10.0.0",
-        "contentful-management": "10.30.0",
+        "contentful-management": "10.32.0",
         "dotenv": "16.0.3",
         "ignore": "5.2.4",
         "inquirer": "8.2.5",
@@ -19725,20 +19696,6 @@
           "integrity": "sha512-zS5PnTI22FIRM6ylNW8G4Ap0IEOyk62fhLSD0+uHRT9McRCLGpkVNvao4bjimpK/GShynyQkFFxHhwMcETmduA==",
           "dev": true
         },
-        "contentful-management": {
-          "version": "10.30.0",
-          "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-10.30.0.tgz",
-          "integrity": "sha512-CYeZqezYP7q++EuHgCHKakemsJqCHC784uOWyYp00Rc6+iMw5glK8GjwksbgUsbnZFfCywGyZCj4Xsd4lZ0ZaQ==",
-          "dev": true,
-          "requires": {
-            "@types/json-patch": "0.0.30",
-            "axios": "^0.27.1",
-            "contentful-sdk-core": "^7.0.1",
-            "fast-copy": "^3.0.0",
-            "lodash.isplainobject": "^4.0.6",
-            "type-fest": "^3.0.0"
-          }
-        },
         "dotenv": {
           "version": "16.0.3",
           "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
@@ -19776,12 +19733,6 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
-        },
-        "type-fest": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.6.0.tgz",
-          "integrity": "sha512-RqTRtKTzvPpNdDUp1dVkKQRunlPITk4mXeqFlAZoJsS+fLRn8AdPK0TcQDumGayhU7fjlBfiBjsq3pe3rIfXZQ==",
-          "dev": true
         }
       }
     },

--- a/examples/javascript/package.json
+++ b/examples/javascript/package.json
@@ -38,7 +38,7 @@
     ]
   },
   "devDependencies": {
-    "@contentful/app-scripts": "1.7.13",
+    "@contentful/app-scripts": "1.8.1",
     "@testing-library/jest-dom": "5.16.5",
     "@testing-library/react": "12.1.5",
     "cross-env": "7.0.3"

--- a/examples/typescript/package-lock.json
+++ b/examples/typescript/package-lock.json
@@ -19,7 +19,7 @@
         "react-scripts": "5.0.1"
       },
       "devDependencies": {
-        "@contentful/app-scripts": "1.7.13",
+        "@contentful/app-scripts": "1.8.1",
         "@testing-library/jest-dom": "5.16.5",
         "@testing-library/react": "12.1.5",
         "@tsconfig/create-react-app": "1.0.3",
@@ -1932,9 +1932,9 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
     "node_modules/@contentful/app-scripts": {
-      "version": "1.7.13",
-      "resolved": "https://registry.npmjs.org/@contentful/app-scripts/-/app-scripts-1.7.13.tgz",
-      "integrity": "sha512-SrCs6UVks6EICySSAP5ETKRcrpgKWrpI5VRn2bSqOPgtcvV5PnjA3rfa1gzWYHMXZJXYdtioBehOFaEthm3ipA==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@contentful/app-scripts/-/app-scripts-1.8.1.tgz",
+      "integrity": "sha512-tGx91Esz0y0qwS5owce6fp44FjRmYBsTsmSfwxq0zVacnBxwzKusM/qEWCuML1nB8qjW6AQLrG9Hrpq8eKA1sw==",
       "dev": true,
       "dependencies": {
         "adm-zip": "0.5.10",
@@ -1942,7 +1942,7 @@
         "bottleneck": "2.19.5",
         "chalk": "4.1.2",
         "commander": "10.0.0",
-        "contentful-management": "10.30.0",
+        "contentful-management": "10.32.0",
         "dotenv": "16.0.3",
         "ignore": "5.2.4",
         "inquirer": "8.2.5",
@@ -1956,23 +1956,6 @@
       "engines": {
         "node": ">=14",
         "npm": ">=6"
-      }
-    },
-    "node_modules/@contentful/app-scripts/node_modules/contentful-management": {
-      "version": "10.30.0",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-10.30.0.tgz",
-      "integrity": "sha512-CYeZqezYP7q++EuHgCHKakemsJqCHC784uOWyYp00Rc6+iMw5glK8GjwksbgUsbnZFfCywGyZCj4Xsd4lZ0ZaQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/json-patch": "0.0.30",
-        "axios": "^0.27.1",
-        "contentful-sdk-core": "^7.0.1",
-        "fast-copy": "^3.0.0",
-        "lodash.isplainobject": "^4.0.6",
-        "type-fest": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@contentful/app-scripts/node_modules/ignore": {
@@ -1996,18 +1979,6 @@
       },
       "engines": {
         "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@contentful/app-scripts/node_modules/type-fest": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.6.0.tgz",
-      "integrity": "sha512-RqTRtKTzvPpNdDUp1dVkKQRunlPITk4mXeqFlAZoJsS+fLRn8AdPK0TcQDumGayhU7fjlBfiBjsq3pe3rIfXZQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -18237,9 +18208,9 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
     "@contentful/app-scripts": {
-      "version": "1.7.13",
-      "resolved": "https://registry.npmjs.org/@contentful/app-scripts/-/app-scripts-1.7.13.tgz",
-      "integrity": "sha512-SrCs6UVks6EICySSAP5ETKRcrpgKWrpI5VRn2bSqOPgtcvV5PnjA3rfa1gzWYHMXZJXYdtioBehOFaEthm3ipA==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@contentful/app-scripts/-/app-scripts-1.8.1.tgz",
+      "integrity": "sha512-tGx91Esz0y0qwS5owce6fp44FjRmYBsTsmSfwxq0zVacnBxwzKusM/qEWCuML1nB8qjW6AQLrG9Hrpq8eKA1sw==",
       "dev": true,
       "requires": {
         "adm-zip": "0.5.10",
@@ -18247,7 +18218,7 @@
         "bottleneck": "2.19.5",
         "chalk": "4.1.2",
         "commander": "10.0.0",
-        "contentful-management": "10.30.0",
+        "contentful-management": "10.32.0",
         "dotenv": "16.0.3",
         "ignore": "5.2.4",
         "inquirer": "8.2.5",
@@ -18256,20 +18227,6 @@
         "ora": "5.4.1"
       },
       "dependencies": {
-        "contentful-management": {
-          "version": "10.30.0",
-          "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-10.30.0.tgz",
-          "integrity": "sha512-CYeZqezYP7q++EuHgCHKakemsJqCHC784uOWyYp00Rc6+iMw5glK8GjwksbgUsbnZFfCywGyZCj4Xsd4lZ0ZaQ==",
-          "dev": true,
-          "requires": {
-            "@types/json-patch": "0.0.30",
-            "axios": "^0.27.1",
-            "contentful-sdk-core": "^7.0.1",
-            "fast-copy": "^3.0.0",
-            "lodash.isplainobject": "^4.0.6",
-            "type-fest": "^3.0.0"
-          }
-        },
         "ignore": {
           "version": "5.2.4",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
@@ -18286,12 +18243,6 @@
             "is-docker": "^2.1.1",
             "is-wsl": "^2.2.0"
           }
-        },
-        "type-fest": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.6.0.tgz",
-          "integrity": "sha512-RqTRtKTzvPpNdDUp1dVkKQRunlPITk4mXeqFlAZoJsS+fLRn8AdPK0TcQDumGayhU7fjlBfiBjsq3pe3rIfXZQ==",
-          "dev": true
         }
       }
     },

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -38,7 +38,7 @@
     ]
   },
   "devDependencies": {
-    "@contentful/app-scripts": "1.7.13",
+    "@contentful/app-scripts": "1.8.1",
     "@testing-library/jest-dom": "5.16.5",
     "@testing-library/react": "12.1.5",
     "@tsconfig/create-react-app": "1.0.3",


### PR DESCRIPTION
We need the latest version of app scripts available in the ts and js templates in order to automatically create built app actions in the connected app definition.
