### PR TITLE
Proof of Concept: unit test run without building whole repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,9 +48,6 @@ jobs:
           name: Verify project configurations
           command: npm run verify-config
       - run:
-          name: Build
-          command: npm run build
-      - run:
           name: Test
           command: npm run test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,22 @@ jobs:
           name: Test
           command: npm run test
 
+  build:
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium+
+    steps:
+      - checkout
+      - node/install
+      - run:
+          name: Install dependencies
+          command: |
+            npm ci
+            npm run bootstrap:ci
+      - run:
+          name: Build
+          command: npm run build
+
   deploy-staging:
     docker:
       - image: cimg/base:stable
@@ -170,10 +186,14 @@ workflows:
       - apps-test:
           context:
             - vault
+      - build:
+          context:
+            - vault
       - deploy-staging:
           context:
             - vault
           requires:
+            - build
             - apps-test
           filters:
             branches:
@@ -184,6 +204,7 @@ workflows:
           context:
             - vault
           requires:
+            - build
             - apps-test
           filters:
             branches:

--- a/apps/smartling/lambda/package.json
+++ b/apps/smartling/lambda/package.json
@@ -7,7 +7,8 @@
     "build": "rimraf built && tsc",
     "lint": "tslint --project ./tsconfig.json",
     "test": "jest --watch",
-    "test:ci": "jest",
+    "test:ci": "npm run test:ci:build-frontend && jest",
+    "test:ci:build-frontend": "cd ../frontend && npm run build && cd ../lambda",
     "deploy": "sls deploy --stage $STAGE",
     "deploy:test": "npm run deploy"
   },


### PR DESCRIPTION
## Purpose

This is a POC which shows that it is possible to hack together a solution where the unit tests for the repo can be run without triggering a build for the entire repo.

## Approach

What I do here is simply build the Smartling frontend package as a prerequisite for running the Smartling lambda tests. This allows the tests to run properly without triggering a build for the entire codebase.

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

~This PR has stripped actual building of the code, that will need to be added as a separate build step~
This should be now addressed.
