### PR TITLE
[INTEG-475] disable AI content gen build / deploy

### DIFF
--- a/apps/ai-content-generator/package.json
+++ b/apps/ai-content-generator/package.json
@@ -17,10 +17,7 @@
     "styled-components": "^5.3.6"
   },
   "scripts": {
-    "start": "cross-env BROWSER=none PORT=3000 react-scripts start",
-    "build": "react-scripts build",
-    "deploy": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEFINITIONS_ORG_ID} --definition-id 3iszK8Gl7aaxLvxGyCOhgA --token ${CONTENTFUL_CMA_TOKEN}",
-    "deploy:test": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${TEST_ORG_ID} --definition-id ${TEST_APP_ID} --token ${CONTENTFUL_CMA_TOKEN}"
+    "start": "cross-env BROWSER=none PORT=3000 react-scripts start"
   },
   "eslintConfig": {
     "extends": "react-app"


### PR DESCRIPTION
## Purpose

See [marketplace partner app change for context](https://github.com/contentful/marketplace-partner-apps/pull/29)

## Approach

Eventually we will remove the entire AI content gen app, for now we are just going to disable to build flow to prod as we get a feel for the proces.

## Breaking Changes

This will prevent AI content gen from deploying, but that's expected.

## Deployment

This will be merged before the MPA change
