### PR TITLE
[INTEG-477] Disable bynder build/deploy in this repo

### DIFF
--- a/apps/bynder/package.json
+++ b/apps/bynder/package.json
@@ -13,10 +13,7 @@
     "react-dom": "16.12.0"
   },
   "scripts": {
-    "start": "cross-env BROWSER=none react-scripts start",
-    "build": "react-scripts build",
-    "deploy": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEFINITIONS_ORG_ID} --definition-id 5KySdUzG7OWuCE2V3fgtIa --token ${CONTENTFUL_CMA_TOKEN}",
-    "deploy:test": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${TEST_ORG_ID} --definition-id ${TEST_APP_ID} --token ${CONTENTFUL_CMA_TOKEN}"
+    "start": "cross-env BROWSER=none react-scripts start"
   },
   "eslintConfig": {
     "extends": "react-app"


### PR DESCRIPTION
## Purpose
See [marketplace partner app change for context](https://github.com/contentful/marketplace-partner-apps/pull/31)

## Approach
Eventually we will remove the entire Bynder app, for now we are just going to disable to build flow to prod as we get a feel for the process.

## Breaking Changes
This will prevent Bynder from deploying in this app, but this is expected

## Deployment
This will be merged before the MPA change
