### PR TITLE
[DRAFT] INTEG-478 Disable shopify build/deploy in this repo

### DIFF
--- a/apps/shopify/package.json
+++ b/apps/shopify/package.json
@@ -16,10 +16,7 @@
     "typescript": "4.2.4"
   },
   "scripts": {
-    "start": "cross-env BROWSER=none react-scripts start",
-    "build": "react-scripts build",
-    "deploy": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEFINITIONS_ORG_ID} --definition-id 60S8P6KWlzfazXqMjhsJ1v --token ${CONTENTFUL_CMA_TOKEN}",
-    "deploy:test": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${TEST_ORG_ID} --definition-id ${TEST_APP_ID} --token ${CONTENTFUL_CMA_TOKEN}"
+    "start": "cross-env BROWSER=none react-scripts start"
   },
   "eslintConfig": {
     "extends": "react-app"


### PR DESCRIPTION
## Purpose
See [marketplace partner app change for context](https://github.com/contentful/marketplace-partner-apps/pull/31)

## Approach
Eventually we will remove the entire Shopify app, for now we are just going to disable to build flow to prod as we get a feel for the process.

## Breaking Changes
This will prevent Shopify from deploying in this app, but this is expected

## Deployment
This will be merged before the MPA change
