### PR TITLE
feat: [INTEG-470] short format for page views

### DIFF
--- a/apps/google-analytics-4/frontend/src/components/main-app/AnalyticsMetricDisplays/AnalyticsMetricDisplay.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/AnalyticsMetricDisplays/AnalyticsMetricDisplay.spec.tsx
@@ -2,7 +2,8 @@ import AnalyticsMetricDisplay from './AnalyticsMetricDisplay';
 import { render, screen } from '@testing-library/react';
 import runReportResponseHasViews from '../../../../../lambda/public/sampleData/runReportResponseHasViews.json';
 
-const PAGE_VIEWS = 0;
+const PAGE_VIEWS = 2200000;
+const PAGE_VIEWS_FORMATTED = '2.2M';
 const METRIC_NAME = 'screenPageViews';
 const SLUG = '/en-US';
 
@@ -22,7 +23,7 @@ describe('Analytics metric display components for the analytics app', () => {
       />
     );
 
-    const pageViews = getByText(PAGE_VIEWS);
+    const pageViews = getByText(PAGE_VIEWS_FORMATTED);
     const metricName = getByText('Total Views');
     const slug = getByText(`Page path: ${SLUG}`);
     const chart = document.querySelector('canvas');

--- a/apps/google-analytics-4/frontend/src/components/main-app/AnalyticsMetricDisplays/AnalyticsMetricDisplay.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/AnalyticsMetricDisplays/AnalyticsMetricDisplay.tsx
@@ -36,7 +36,7 @@ const AnalyticsMetricDisplay = (props: Props) => {
     <>
       <ChartHeader
         metricName={metricName ? metricName : ''}
-        metricValue={pageViews || pageViews === 0 ? pageViews.toString() : ''}
+        metricValue={Intl.NumberFormat('en', { notation: 'compact' }).format(pageViews)}
         handleChange={handleDateRangeChange}
         selectedDateRange={selectedDateRange}
       />


### PR DESCRIPTION
## Purpose

The old google analytics app gave useful short form formatting of page view data from Google Analytics, this PR looks to replicate that behavior in the new GA4 app.

<img width="347" alt="Screenshot 2023-04-26 at 20 17 07" src="https://user-images.githubusercontent.com/109533364/234666904-cb8d860a-cc6f-43f9-9362-90f026b4564d.png">


## Approach

## Testing steps

## Breaking Changes

## Dependencies and/or References

## Deployment
