### PR TITLE
fix: Dependabot/npm and yarn/contentful/field editor test utils 0.17.3 wistia downgrade

### DIFF
--- a/apps/graphql-playground/package-lock.json
+++ b/apps/graphql-playground/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.2.11",
       "dependencies": {
         "@contentful/field-editor-single-line": "^0.16.0",
-        "@contentful/field-editor-test-utils": "^0.8.2",
+        "@contentful/field-editor-test-utils": "^0.17.3",
         "@contentful/forma-36-fcss": "0.3.5",
         "@contentful/forma-36-react-components": "^3.100.7",
         "@contentful/forma-36-tokens": "^0.11.2",
@@ -2431,26 +2431,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
       "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
     },
-    "node_modules/@contentful/field-editor-shared": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-0.13.3.tgz",
-      "integrity": "sha512-drwP0mWd7j/anDt3vXJ1gY6ZekuvSaKfMhgvm8cXSMunc7UNi1xvBBjElQn6yGbic0TUxUp8d8OD3XMdTbKSiw==",
-      "dependencies": {
-        "@contentful/forma-36-tokens": "^0.9.2",
-        "contentful-ui-extensions-sdk": "^3.29.2",
-        "emotion": "^10.0.17",
-        "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/forma-36-tokens": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.9.4.tgz",
-      "integrity": "sha512-lCv9MGjivCUYV25g2sNeGmqJmCk3KUF7EHy4iDru8Xo2DzqciVIumOZIyx7TVWzAckK94f4rEJ8E2PlRL5gYvg=="
-    },
     "node_modules/@contentful/field-editor-single-line": {
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/@contentful/field-editor-single-line/-/field-editor-single-line-0.16.0.tgz",
@@ -3065,26 +3045,36 @@
       }
     },
     "node_modules/@contentful/field-editor-test-utils": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-test-utils/-/field-editor-test-utils-0.8.4.tgz",
-      "integrity": "sha512-c1UVNha4aSfDEvPDyJRzvJhpN8W4fbUx6uBtfX+G0H6jxL0Mvg9dAN+oC8rbELyx5Eks+EDQg8lUh1x5vH61xQ==",
+      "version": "0.17.3",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-test-utils/-/field-editor-test-utils-0.17.3.tgz",
+      "integrity": "sha512-ct9Muux5YJLIziP2NXC8qd6NQRSKwBvCTdaeibQjIzIsHF2SQiFtDu3cUdKDTGW1o+spKix85YMZrXR7NOc/Dw==",
       "dependencies": {
-        "@contentful/field-editor-shared": "^0.13.3",
-        "@contentful/forma-36-tokens": "^0.9.2",
-        "contentful-ui-extensions-sdk": "^3.29.2",
+        "@contentful/field-editor-shared": "^0.24.0",
+        "@contentful/forma-36-tokens": "^0.11.0",
         "emotion": "^10.0.17",
         "lodash": "^4.17.15",
         "lodash-es": "^4.17.15",
         "mitt": "2.1.0"
       },
       "peerDependencies": {
+        "@contentful/app-sdk": "^3.36.0",
         "react": ">=16.8.0"
       }
     },
-    "node_modules/@contentful/field-editor-test-utils/node_modules/@contentful/forma-36-tokens": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.9.4.tgz",
-      "integrity": "sha512-lCv9MGjivCUYV25g2sNeGmqJmCk3KUF7EHy4iDru8Xo2DzqciVIumOZIyx7TVWzAckK94f4rEJ8E2PlRL5gYvg=="
+    "node_modules/@contentful/field-editor-test-utils/node_modules/@contentful/field-editor-shared": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-0.24.0.tgz",
+      "integrity": "sha512-OWNmRhOKwG5EEtS04EUhC0Y242m/suuuCX7oMq9JGo1cTuEoEAOWWzSySiZNH7NO7OheBjpIt5vcIommxQ9TCg==",
+      "dependencies": {
+        "@contentful/forma-36-tokens": "^0.11.0",
+        "emotion": "^10.0.17",
+        "lodash": "^4.17.15",
+        "lodash-es": "^4.17.15"
+      },
+      "peerDependencies": {
+        "@contentful/app-sdk": "^3.36.0",
+        "react": ">=16.8.0"
+      }
     },
     "node_modules/@contentful/forma-36-fcss": {
       "version": "0.3.5",

--- a/apps/graphql-playground/package-lock.json
+++ b/apps/graphql-playground/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.2.11",
       "dependencies": {
         "@contentful/field-editor-single-line": "^0.16.0",
-        "@contentful/field-editor-test-utils": "^0.17.3",
+        "@contentful/field-editor-test-utils": "^1.3.0",
         "@contentful/forma-36-fcss": "0.3.5",
         "@contentful/forma-36-react-components": "^3.100.7",
         "@contentful/forma-36-tokens": "^0.11.2",
@@ -1982,20 +1982,20 @@
       }
     },
     "node_modules/@contentful/app-sdk": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.17.0.tgz",
-      "integrity": "sha512-aqUx2q9AiaUB8aAWevvyNMCLZ4PCQyCOEeHj44QSC/b9E7r9754vTqc39NrjW5yUkKAQWRPT497pwCyPvbxZCw==",
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.17.1.tgz",
+      "integrity": "sha512-8vh/X+kW33412lxwi2Acr6V4W7UxNvH273cJUSJ43OaFlwAl+T4aWhIULXq+sT9ASc9QxsujiWFHbCR38kl/oQ==",
       "peer": true,
       "peerDependencies": {
         "contentful-management": ">=7.30.0"
       }
     },
     "node_modules/@contentful/f36-icon": {
-      "version": "4.34.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.34.1.tgz",
-      "integrity": "sha512-SYjflnNOlA682/PnQcJruVRHZvdl9HCTAzdrs8UCFCO8JJZ5yP/pnICcskIsp+L3ucppxCZij6IS1QMsjrUvwA==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.37.0.tgz",
+      "integrity": "sha512-cRV1A71PCFuYITIGoORE/DnnaH0/te4Glgyg4ikQjuIrzecDj20U+wIseenEA03kYAYkTmuMhc0niXm3UEyI4Q==",
       "dependencies": {
-        "@contentful/f36-core": "^4.34.1",
+        "@contentful/f36-core": "^4.37.0",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
@@ -2004,9 +2004,9 @@
       }
     },
     "node_modules/@contentful/f36-icon/node_modules/@contentful/f36-core": {
-      "version": "4.34.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.34.1.tgz",
-      "integrity": "sha512-snXql35AMmICVgE5i3MaAQ5xKmB0CPIeJXsR3JJ9C3HayqJtu4bYOHLswq8CrvMQGmq8BLuuJeujgyJ6glEO7w==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.37.0.tgz",
+      "integrity": "sha512-9w+2JYKDY2fkMiHasHztGaytuMTjfchVqufv0jsmTb/1d2YvjSOWLhO78Vwe6HCPiUoPJ7WtwVJYPeIzWa2EdA==",
       "dependencies": {
         "@contentful/f36-tokens": "^4.0.1",
         "@emotion/core": "^10.1.1",
@@ -2301,11 +2301,11 @@
       "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
     },
     "node_modules/@contentful/f36-spinner": {
-      "version": "4.34.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.34.1.tgz",
-      "integrity": "sha512-6q5W1mId+Zux6d07NDM9xAuGoT5YB2eIDi2qz70/Q5/v3TOPqB0sAAKGAGfVDzIhrcQrURINwLGVRxlXSHypcw==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.37.0.tgz",
+      "integrity": "sha512-kEdu5QihXTjL5+07enqO5P+4uwmq/Nx6ftY2wON18swqV8nahkqDIO4w8h98fo1Ec7xFUJUkzk6QXRHNZ4bZKw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.34.1",
+        "@contentful/f36-core": "^4.37.0",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
@@ -2314,9 +2314,9 @@
       }
     },
     "node_modules/@contentful/f36-spinner/node_modules/@contentful/f36-core": {
-      "version": "4.34.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.34.1.tgz",
-      "integrity": "sha512-snXql35AMmICVgE5i3MaAQ5xKmB0CPIeJXsR3JJ9C3HayqJtu4bYOHLswq8CrvMQGmq8BLuuJeujgyJ6glEO7w==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.37.0.tgz",
+      "integrity": "sha512-9w+2JYKDY2fkMiHasHztGaytuMTjfchVqufv0jsmTb/1d2YvjSOWLhO78Vwe6HCPiUoPJ7WtwVJYPeIzWa2EdA==",
       "dependencies": {
         "@contentful/f36-tokens": "^4.0.1",
         "@emotion/core": "^10.1.1",
@@ -2390,11 +2390,11 @@
       "integrity": "sha512-NTyMAQcfvhPP8kJgOK5mtjKpErg799iglEb9B45ii4N7aMdph2GNqgv7KBgpogfbTEGBrlKIoH8MUDSV9YNREg=="
     },
     "node_modules/@contentful/f36-typography": {
-      "version": "4.34.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.34.1.tgz",
-      "integrity": "sha512-Y97epBDzyQH4WlJT4fvP0dVej3XJPS+65xa51eg92oyN1LJt4iM/oAk+gciqUXdbioqSOrtDMvRS+ADOFU5Rcg==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.37.0.tgz",
+      "integrity": "sha512-WJMFsYMbHzmYCVcXAxO5dGbb2XQ2YwYV7zQV4neth0Ea3HRxStald6e2L8YfOZ/V2XLaFAuanbtjvKyUWjikzg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.34.1",
+        "@contentful/f36-core": "^4.37.0",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
@@ -2403,9 +2403,9 @@
       }
     },
     "node_modules/@contentful/f36-typography/node_modules/@contentful/f36-core": {
-      "version": "4.34.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.34.1.tgz",
-      "integrity": "sha512-snXql35AMmICVgE5i3MaAQ5xKmB0CPIeJXsR3JJ9C3HayqJtu4bYOHLswq8CrvMQGmq8BLuuJeujgyJ6glEO7w==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.37.0.tgz",
+      "integrity": "sha512-9w+2JYKDY2fkMiHasHztGaytuMTjfchVqufv0jsmTb/1d2YvjSOWLhO78Vwe6HCPiUoPJ7WtwVJYPeIzWa2EdA==",
       "dependencies": {
         "@contentful/f36-tokens": "^4.0.1",
         "@emotion/core": "^10.1.1",
@@ -2427,6 +2427,99 @@
       }
     },
     "node_modules/@contentful/f36-typography/node_modules/@emotion/memoize": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
+      "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
+    },
+    "node_modules/@contentful/field-editor-shared": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-1.2.0.tgz",
+      "integrity": "sha512-eFSnuvFre91Noq2Hais4Uqh05czN+a7KV6H9eNqTWw/Q/6G/LfHExbG+Z/0Yk51hMr15k4PB3wza7oYINb981Q==",
+      "dependencies": {
+        "@contentful/f36-note": "^4.2.8",
+        "@contentful/f36-tokens": "^4.0.0",
+        "emotion": "^10.0.17",
+        "lodash": "^4.17.15",
+        "lodash-es": "^4.17.15"
+      },
+      "peerDependencies": {
+        "@contentful/app-sdk": "^4.2.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-note": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.37.0.tgz",
+      "integrity": "sha512-eVMcRHoODQpP3ZnbwTvgNg3idL7XOJxcwKEKd2AlfCt6fp3Djv4WCzKGAAGmQUZfracyBRVO9hkzYiIdlxTcQw==",
+      "dependencies": {
+        "@contentful/f36-button": "^4.37.0",
+        "@contentful/f36-core": "^4.37.0",
+        "@contentful/f36-icon": "^4.37.0",
+        "@contentful/f36-icons": "^4.23.2",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-typography": "^4.37.0",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-note/node_modules/@contentful/f36-button": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.37.0.tgz",
+      "integrity": "sha512-KBi0XNfdeaFroTxxhMlDWOICYvwf6CFS4pCZRfPHGYsU5I5CLPsmCLhfsLGsIu3tWixLO0LtlQAmfpxsxbvweA==",
+      "dependencies": {
+        "@contentful/f36-core": "^4.37.0",
+        "@contentful/f36-spinner": "^4.37.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-note/node_modules/@contentful/f36-core": {
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.37.0.tgz",
+      "integrity": "sha512-9w+2JYKDY2fkMiHasHztGaytuMTjfchVqufv0jsmTb/1d2YvjSOWLhO78Vwe6HCPiUoPJ7WtwVJYPeIzWa2EdA==",
+      "dependencies": {
+        "@contentful/f36-tokens": "^4.0.1",
+        "@emotion/core": "^10.1.1",
+        "@emotion/is-prop-valid": "^1.2.0",
+        "csstype": "^3.1.1",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-note/node_modules/@contentful/f36-icons": {
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-4.25.0.tgz",
+      "integrity": "sha512-PDEvCtoAfP3FF7K+slhOb+LP2MxlUSKQXmRUmtBPXIFz+usZC4FOGQAMWKF9kdnDEq9C/kaYiCzPkZ6BJC4hmg==",
+      "dependencies": {
+        "@contentful/f36-core": "^4.23.2",
+        "@contentful/f36-icon": "^4.23.2",
+        "@contentful/f36-tokens": "^4.0.1",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/field-editor-shared/node_modules/@emotion/is-prop-valid": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz",
+      "integrity": "sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==",
+      "dependencies": {
+        "@emotion/memoize": "^0.8.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-shared/node_modules/@emotion/memoize": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
       "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
@@ -3045,34 +3138,19 @@
       }
     },
     "node_modules/@contentful/field-editor-test-utils": {
-      "version": "0.17.3",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-test-utils/-/field-editor-test-utils-0.17.3.tgz",
-      "integrity": "sha512-ct9Muux5YJLIziP2NXC8qd6NQRSKwBvCTdaeibQjIzIsHF2SQiFtDu3cUdKDTGW1o+spKix85YMZrXR7NOc/Dw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-test-utils/-/field-editor-test-utils-1.3.0.tgz",
+      "integrity": "sha512-4uG3uA7VQnAkjKqy8qhVOadt+d3aoB8NaBL5Naoxf4rcmJKyvm2P8/znjyi/CM6OmP79fxkbmOanzCckOLGNEw==",
       "dependencies": {
-        "@contentful/field-editor-shared": "^0.24.0",
-        "@contentful/forma-36-tokens": "^0.11.0",
+        "@contentful/f36-tokens": "^4.0.0",
+        "@contentful/field-editor-shared": "^1.2.0",
         "emotion": "^10.0.17",
         "lodash": "^4.17.15",
         "lodash-es": "^4.17.15",
         "mitt": "2.1.0"
       },
       "peerDependencies": {
-        "@contentful/app-sdk": "^3.36.0",
-        "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@contentful/field-editor-test-utils/node_modules/@contentful/field-editor-shared": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-0.24.0.tgz",
-      "integrity": "sha512-OWNmRhOKwG5EEtS04EUhC0Y242m/suuuCX7oMq9JGo1cTuEoEAOWWzSySiZNH7NO7OheBjpIt5vcIommxQ9TCg==",
-      "dependencies": {
-        "@contentful/forma-36-tokens": "^0.11.0",
-        "emotion": "^10.0.17",
-        "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15"
-      },
-      "peerDependencies": {
-        "@contentful/app-sdk": "^3.36.0",
+        "@contentful/app-sdk": "^4.2.0",
         "react": ">=16.8.0"
       }
     },

--- a/apps/graphql-playground/package.json
+++ b/apps/graphql-playground/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@contentful/field-editor-single-line": "^0.16.0",
-    "@contentful/field-editor-test-utils": "^0.8.2",
+    "@contentful/field-editor-test-utils": "^0.17.3",
     "@contentful/forma-36-fcss": "0.3.5",
     "@contentful/forma-36-react-components": "^3.100.7",
     "@contentful/forma-36-tokens": "^0.11.2",

--- a/apps/graphql-playground/package.json
+++ b/apps/graphql-playground/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@contentful/field-editor-single-line": "^0.16.0",
-    "@contentful/field-editor-test-utils": "^0.17.3",
+    "@contentful/field-editor-test-utils": "^1.3.0",
     "@contentful/forma-36-fcss": "0.3.5",
     "@contentful/forma-36-react-components": "^3.100.7",
     "@contentful/forma-36-tokens": "^0.11.2",

--- a/apps/sap-commerce-cloud/package-lock.json
+++ b/apps/sap-commerce-cloud/package-lock.json
@@ -12,7 +12,7 @@
         "@contentful/app-sdk": "^3.32.1",
         "@contentful/ecommerce-app-base": "^1.0.5",
         "@contentful/field-editor-single-line": "^0.16.0",
-        "@contentful/field-editor-test-utils": "^0.9.0",
+        "@contentful/field-editor-test-utils": "^0.17.3",
         "@contentful/forma-36-fcss": "^0.3.1",
         "@contentful/forma-36-react-components": "^3.80.1",
         "@contentful/forma-36-tokens": "^0.11.2",
@@ -2547,6 +2547,21 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/@contentful/field-editor-shared": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-0.24.0.tgz",
+      "integrity": "sha512-OWNmRhOKwG5EEtS04EUhC0Y242m/suuuCX7oMq9JGo1cTuEoEAOWWzSySiZNH7NO7OheBjpIt5vcIommxQ9TCg==",
+      "dependencies": {
+        "@contentful/forma-36-tokens": "^0.11.0",
+        "emotion": "^10.0.17",
+        "lodash": "^4.17.15",
+        "lodash-es": "^4.17.15"
+      },
+      "peerDependencies": {
+        "@contentful/app-sdk": "^3.36.0",
+        "react": ">=16.8.0"
+      }
+    },
     "node_modules/@contentful/field-editor-single-line": {
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/@contentful/field-editor-single-line/-/field-editor-single-line-0.16.0.tgz",
@@ -3157,41 +3172,21 @@
       }
     },
     "node_modules/@contentful/field-editor-test-utils": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-test-utils/-/field-editor-test-utils-0.9.0.tgz",
-      "integrity": "sha512-P88gHf+7nYF0+W7GDygBOfDSuZyTV+3z9IScuU9Ky0lWr3YAwamYHo30rTGC0IDyHvILHg5TpeT/U60Oi0cp5Q==",
+      "version": "0.17.3",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-test-utils/-/field-editor-test-utils-0.17.3.tgz",
+      "integrity": "sha512-ct9Muux5YJLIziP2NXC8qd6NQRSKwBvCTdaeibQjIzIsHF2SQiFtDu3cUdKDTGW1o+spKix85YMZrXR7NOc/Dw==",
       "dependencies": {
-        "@contentful/field-editor-shared": "^0.14.0",
-        "@contentful/forma-36-tokens": "^0.10.0",
-        "contentful-ui-extensions-sdk": "^3.29.2",
+        "@contentful/field-editor-shared": "^0.24.0",
+        "@contentful/forma-36-tokens": "^0.11.0",
         "emotion": "^10.0.17",
         "lodash": "^4.17.15",
         "lodash-es": "^4.17.15",
         "mitt": "2.1.0"
       },
       "peerDependencies": {
+        "@contentful/app-sdk": "^3.36.0",
         "react": ">=16.8.0"
       }
-    },
-    "node_modules/@contentful/field-editor-test-utils/node_modules/@contentful/field-editor-shared": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-0.14.0.tgz",
-      "integrity": "sha512-z8PT7hkuUWHcgJNnxIA2VbC2DWEVu/6yhpSKIv4iaFRHsAZjyFQ1s/0QIVK8E0nm+qHZaV5RJKDm6wEkp3G+3A==",
-      "dependencies": {
-        "@contentful/forma-36-tokens": "^0.10.0",
-        "contentful-ui-extensions-sdk": "^3.29.2",
-        "emotion": "^10.0.17",
-        "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@contentful/field-editor-test-utils/node_modules/@contentful/forma-36-tokens": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.10.2.tgz",
-      "integrity": "sha512-HHLwIN8mQv41GYxcTBYJjiDwpmmWwbcIRV09ciSDxhciYJ+wQkIurQ2lmnKHebPwv35X6fHXB4OdSTK1d9mUug=="
     },
     "node_modules/@contentful/forma-36-fcss": {
       "version": "0.3.5",
@@ -7789,11 +7784,6 @@
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-2.1.7.tgz",
       "integrity": "sha512-ozrGwyuCTAy7YgFCua8rmqmytECYk/JYAMXcswOcm0qvGoE3tPb7ivBeIHTOK2DiapBhDZgacIhzhQIKU5TCfA=="
-    },
-    "node_modules/contentful-ui-extensions-sdk": {
-      "version": "3.42.0",
-      "resolved": "https://registry.npmjs.org/contentful-ui-extensions-sdk/-/contentful-ui-extensions-sdk-3.42.0.tgz",
-      "integrity": "sha512-WZwI2WajJIn4TYAl2IAxd5ae2H7dFI2K3uLa6CAyU7TCxxvMaau9+sWZs4T149hWmS6kNCjn1U2+QUFrBA3/VQ=="
     },
     "node_modules/convert-source-map": {
       "version": "1.9.0",

--- a/apps/sap-commerce-cloud/package.json
+++ b/apps/sap-commerce-cloud/package.json
@@ -8,7 +8,7 @@
     "@contentful/app-sdk": "^3.32.1",
     "@contentful/ecommerce-app-base": "^1.0.5",
     "@contentful/field-editor-single-line": "^0.16.0",
-    "@contentful/field-editor-test-utils": "^0.9.0",
+    "@contentful/field-editor-test-utils": "^0.17.3",
     "@contentful/forma-36-fcss": "^0.3.1",
     "@contentful/forma-36-react-components": "^3.80.1",
     "@contentful/forma-36-tokens": "^0.11.2",

--- a/apps/wistia-videos/package-lock.json
+++ b/apps/wistia-videos/package-lock.json
@@ -11,7 +11,7 @@
         "@contentful/app-sdk": "^4.16.0",
         "@contentful/dam-app-base": "^2.0.32",
         "@contentful/field-editor-single-line": "^0.16.0",
-        "@contentful/field-editor-test-utils": "^1.2.4",
+        "@contentful/field-editor-test-utils": "^0.17.3",
         "@contentful/forma-36-fcss": "^0.3.5",
         "@contentful/forma-36-react-components": "^3.100.7",
         "@contentful/forma-36-tokens": "^0.11.2",
@@ -2651,35 +2651,34 @@
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
     },
     "node_modules/@contentful/field-editor-test-utils": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-test-utils/-/field-editor-test-utils-1.2.7.tgz",
-      "integrity": "sha512-UBJqucJdm0e2DBgzUZSBWpNYpZ5ldII6UwkMK0pq0SXDJU8MYcc8ykldDBJ75muPa+P5AwGT+QcYbXt8DBlNBw==",
+      "version": "0.17.3",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-test-utils/-/field-editor-test-utils-0.17.3.tgz",
+      "integrity": "sha512-ct9Muux5YJLIziP2NXC8qd6NQRSKwBvCTdaeibQjIzIsHF2SQiFtDu3cUdKDTGW1o+spKix85YMZrXR7NOc/Dw==",
       "dependencies": {
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/field-editor-shared": "^1.1.8",
+        "@contentful/field-editor-shared": "^0.24.0",
+        "@contentful/forma-36-tokens": "^0.11.0",
         "emotion": "^10.0.17",
         "lodash": "^4.17.15",
         "lodash-es": "^4.17.15",
         "mitt": "2.1.0"
       },
       "peerDependencies": {
-        "@contentful/app-sdk": "^4.2.0",
+        "@contentful/app-sdk": "^3.36.0",
         "react": ">=16.8.0"
       }
     },
     "node_modules/@contentful/field-editor-test-utils/node_modules/@contentful/field-editor-shared": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-1.1.8.tgz",
-      "integrity": "sha512-Ik7Fs0GJtDrm14LXmatAfUF7ERV4VE4WQGIA670jIxj/MRM43DQMnLS6CjH6ZOJmlC5b+rrIiLph6mMG3upgSA==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-0.24.0.tgz",
+      "integrity": "sha512-OWNmRhOKwG5EEtS04EUhC0Y242m/suuuCX7oMq9JGo1cTuEoEAOWWzSySiZNH7NO7OheBjpIt5vcIommxQ9TCg==",
       "dependencies": {
-        "@contentful/f36-note": "^4.2.8",
-        "@contentful/f36-tokens": "^4.0.0",
+        "@contentful/forma-36-tokens": "^0.11.0",
         "emotion": "^10.0.17",
         "lodash": "^4.17.15",
         "lodash-es": "^4.17.15"
       },
       "peerDependencies": {
-        "@contentful/app-sdk": "^4.2.0",
+        "@contentful/app-sdk": "^3.36.0",
         "react": ">=16.8.0"
       }
     },

--- a/apps/wistia-videos/package-lock.json
+++ b/apps/wistia-videos/package-lock.json
@@ -11,7 +11,7 @@
         "@contentful/app-sdk": "^4.16.0",
         "@contentful/dam-app-base": "^2.0.32",
         "@contentful/field-editor-single-line": "^0.16.0",
-        "@contentful/field-editor-test-utils": "^0.17.3",
+        "@contentful/field-editor-test-utils": "^1.3.0",
         "@contentful/forma-36-fcss": "^0.3.5",
         "@contentful/forma-36-react-components": "^3.100.7",
         "@contentful/forma-36-tokens": "^0.11.2",
@@ -2651,34 +2651,35 @@
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
     },
     "node_modules/@contentful/field-editor-test-utils": {
-      "version": "0.17.3",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-test-utils/-/field-editor-test-utils-0.17.3.tgz",
-      "integrity": "sha512-ct9Muux5YJLIziP2NXC8qd6NQRSKwBvCTdaeibQjIzIsHF2SQiFtDu3cUdKDTGW1o+spKix85YMZrXR7NOc/Dw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-test-utils/-/field-editor-test-utils-1.3.0.tgz",
+      "integrity": "sha512-4uG3uA7VQnAkjKqy8qhVOadt+d3aoB8NaBL5Naoxf4rcmJKyvm2P8/znjyi/CM6OmP79fxkbmOanzCckOLGNEw==",
       "dependencies": {
-        "@contentful/field-editor-shared": "^0.24.0",
-        "@contentful/forma-36-tokens": "^0.11.0",
+        "@contentful/f36-tokens": "^4.0.0",
+        "@contentful/field-editor-shared": "^1.2.0",
         "emotion": "^10.0.17",
         "lodash": "^4.17.15",
         "lodash-es": "^4.17.15",
         "mitt": "2.1.0"
       },
       "peerDependencies": {
-        "@contentful/app-sdk": "^3.36.0",
+        "@contentful/app-sdk": "^4.2.0",
         "react": ">=16.8.0"
       }
     },
     "node_modules/@contentful/field-editor-test-utils/node_modules/@contentful/field-editor-shared": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-0.24.0.tgz",
-      "integrity": "sha512-OWNmRhOKwG5EEtS04EUhC0Y242m/suuuCX7oMq9JGo1cTuEoEAOWWzSySiZNH7NO7OheBjpIt5vcIommxQ9TCg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-1.2.0.tgz",
+      "integrity": "sha512-eFSnuvFre91Noq2Hais4Uqh05czN+a7KV6H9eNqTWw/Q/6G/LfHExbG+Z/0Yk51hMr15k4PB3wza7oYINb981Q==",
       "dependencies": {
-        "@contentful/forma-36-tokens": "^0.11.0",
+        "@contentful/f36-note": "^4.2.8",
+        "@contentful/f36-tokens": "^4.0.0",
         "emotion": "^10.0.17",
         "lodash": "^4.17.15",
         "lodash-es": "^4.17.15"
       },
       "peerDependencies": {
-        "@contentful/app-sdk": "^3.36.0",
+        "@contentful/app-sdk": "^4.2.0",
         "react": ">=16.8.0"
       }
     },
@@ -13116,7 +13117,8 @@
     },
     "node_modules/mitt": {
       "version": "2.1.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-2.1.0.tgz",
+      "integrity": "sha512-ILj2TpLiysu2wkBbWjAmww7TkZb65aiQO+DkVdUTBpBXq+MHYiETENkKFMtsJZX1Lf4pe4QOrTSjIfUwN5lRdg=="
     },
     "node_modules/mkdirp": {
       "version": "0.5.6",

--- a/apps/wistia-videos/package.json
+++ b/apps/wistia-videos/package.json
@@ -7,7 +7,7 @@
     "@contentful/app-sdk": "^4.16.0",
     "@contentful/dam-app-base": "^2.0.32",
     "@contentful/field-editor-single-line": "^0.16.0",
-    "@contentful/field-editor-test-utils": "^0.17.3",
+    "@contentful/field-editor-test-utils": "^1.3.0",
     "@contentful/forma-36-fcss": "^0.3.5",
     "@contentful/forma-36-react-components": "^3.100.7",
     "@contentful/forma-36-tokens": "^0.11.2",

--- a/apps/wistia-videos/package.json
+++ b/apps/wistia-videos/package.json
@@ -7,7 +7,7 @@
     "@contentful/app-sdk": "^4.16.0",
     "@contentful/dam-app-base": "^2.0.32",
     "@contentful/field-editor-single-line": "^0.16.0",
-    "@contentful/field-editor-test-utils": "^1.2.4",
+    "@contentful/field-editor-test-utils": "^0.17.3",
     "@contentful/forma-36-fcss": "^0.3.5",
     "@contentful/forma-36-react-components": "^3.100.7",
     "@contentful/forma-36-tokens": "^0.11.2",


### PR DESCRIPTION
## Purpose

This PR resolves two issues found [this](dependabot/npm_and_yarn/contentful/field-editor-test-utils-0.17.3) dependabot PR: 
1. This fixes the test error that occurs within the `graphql-playground` app. 
2. This reverses the dependabot incurred downgrade found in the `wistia` `package.json` with the `field-editor-test-utils` package. 

**To clarify, this PR includes the changes from the original dependabot PR, but with the appropriate changes made.**
 
## Approach

1. In order to resolve the test error found in the PR, I installed the latest version of the `field-editor-test-utils` package within the `graphql-playground` `package.json`. This update resolved the peer dependency issues. I would prefer to test that everything is as it should be locally with the `graphql-playground` app, however the local development version is fairly broken, with maintainability work that is out of scope of this update. (this has been communicated to Extensibility and Integration PMs). I am trusting that updating to the latest version of the package should cause little to no change, but am open to holding off if others feel differently. 

2. I also manually bumped the version of the `wistia` package of `field-editor-test-utils` to the latest version. Can confirm all is working is working with that app.

I limited the scope of changes to those two adjustments ^, so as not to make any extraneous adjustments for this PR. 
