### PR TITLE
refactored to unified sentry release job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,6 +144,14 @@ jobs:
           name: Post Deploy
           command: npm run post-deploy
       - run:
+          name: Sentry Release
+          command: |
+            SENTRY_RELEASE=$(git rev-parse --short HEAD); \
+            sentry-cli releases --log-level=debug new -p marketplace-apps $SENTRY_RELEASE && \
+            sentry-cli releases --log-level=debug set-commits --auto --ignore-missing $SENTRY_RELEASE && \
+            sentry-cli releases --log-level=debug finalize $SENTRY_RELEASE && \
+            sentry-cli releases --log-level=debug deploys $SENTRY_RELEASE new -e production
+      - run:
           name: Invalidate Slack cloudfront distribution
           command: aws cloudfront create-invalidation --distribution-id $SLACK_PRD_CLOUDFRONT_DIST_ID --paths "/*"
 

--- a/apps/ecommerce/frontend/package-lock.json
+++ b/apps/ecommerce/frontend/package-lock.json
@@ -22,7 +22,6 @@
       },
       "devDependencies": {
         "@contentful/app-scripts": "1.7.13",
-        "@sentry/cli": "^2.17.4",
         "@testing-library/jest-dom": "5.16.5",
         "@testing-library/react": "12.1.5",
         "@tsconfig/create-react-app": "1.0.3",
@@ -4416,26 +4415,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@sentry/cli": {
-      "version": "2.17.4",
-      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.17.4.tgz",
-      "integrity": "sha512-5tLu/2U+MuEksIhvzW5LJEwhoqbdgwxE3Q5UwIJtJt3do4PFv1UVg1aLBJ3u6sGxAJpxqJYWvqfc/tXswQCJBA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "https-proxy-agent": "^5.0.0",
-        "node-fetch": "^2.6.7",
-        "progress": "^2.0.3",
-        "proxy-from-env": "^1.1.0",
-        "which": "^2.0.2"
-      },
-      "bin": {
-        "sentry-cli": "bin/sentry-cli"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
     },
     "node_modules/@sentry/core": {
       "version": "7.50.0",
@@ -13509,48 +13488,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/node-fetch": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
-      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
-      "dev": true,
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/node-fetch/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true
-    },
-    "node_modules/node-fetch/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true
-    },
-    "node_modules/node-fetch/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
     "node_modules/node-forge": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
@@ -15409,15 +15346,6 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
-    "node_modules/progress": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/promise": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/promise/-/promise-8.3.0.tgz",
@@ -15472,12 +15400,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
     },
     "node_modules/psl": {
       "version": "1.9.0",
@@ -22058,19 +21980,6 @@
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
           "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
-      }
-    },
-    "@sentry/cli": {
-      "version": "2.17.4",
-      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.17.4.tgz",
-      "integrity": "sha512-5tLu/2U+MuEksIhvzW5LJEwhoqbdgwxE3Q5UwIJtJt3do4PFv1UVg1aLBJ3u6sGxAJpxqJYWvqfc/tXswQCJBA==",
-      "dev": true,
-      "requires": {
-        "https-proxy-agent": "^5.0.0",
-        "node-fetch": "^2.6.7",
-        "progress": "^2.0.3",
-        "proxy-from-env": "^1.1.0",
-        "which": "^2.0.2"
       }
     },
     "@sentry/core": {
@@ -28932,39 +28841,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node-fetch": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
-      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
-      "dev": true,
-      "requires": {
-        "whatwg-url": "^5.0.0"
-      },
-      "dependencies": {
-        "tr46": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-          "dev": true
-        },
-        "webidl-conversions": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-          "dev": true
-        },
-        "whatwg-url": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-          "dev": true,
-          "requires": {
-            "tr46": "~0.0.3",
-            "webidl-conversions": "^3.0.0"
-          }
-        }
-      }
-    },
     "node-forge": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
@@ -30114,12 +29990,6 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
-    "progress": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true
-    },
     "promise": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/promise/-/promise-8.3.0.tgz",
@@ -30169,12 +30039,6 @@
           "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
         }
       }
-    },
-    "proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
     },
     "psl": {
       "version": "1.9.0",

--- a/apps/ecommerce/frontend/package.json
+++ b/apps/ecommerce/frontend/package.json
@@ -43,7 +43,6 @@
   },
   "devDependencies": {
     "@contentful/app-scripts": "1.7.13",
-    "@sentry/cli": "^2.17.4",
     "@testing-library/jest-dom": "5.16.5",
     "@testing-library/react": "12.1.5",
     "@tsconfig/create-react-app": "1.0.3",

--- a/apps/ecommerce/frontend/package.json
+++ b/apps/ecommerce/frontend/package.json
@@ -24,13 +24,7 @@
     "eject": "react-scripts eject",
     "create-app-definition": "contentful-app-scripts create-app-definition",
     "deploy": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEFINITIONS_ORG_ID} --definition-id 6wFPGvNI463EN5xF7AwIwA --token ${CONTENTFUL_CMA_TOKEN}",
-    "deploy:test": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${TEST_ORG_ID} --definition-id ${TEST_APP_ID} --token ${CONTENTFUL_CMA_TOKEN}",
-    "sentry-create-release": "REACT_APP_RELEASE=$(git rev-parse --short HEAD); sentry-cli releases --log-level=debug new -p marketplace-apps $REACT_APP_RELEASE",
-    "sentry-set-commits": "REACT_APP_RELEASE=$(git rev-parse --short HEAD); sentry-cli releases --log-level=debug set-commits --auto --ignore-missing $REACT_APP_RELEASE",
-    "sentry-upload-source-maps": "REACT_APP_RELEASE=$(git rev-parse --short HEAD); sentry-cli releases --log-level=debug files $REACT_APP_RELEASE upload-sourcemaps --ext ts --ext tsx --ext map ./src ./build",
-    "sentry-finalize-release": "REACT_APP_RELEASE=$(git rev-parse --short HEAD); sentry-cli releases --log-level=debug finalize $REACT_APP_RELEASE",
-    "sentry-deploy": "REACT_APP_RELEASE=$(git rev-parse --short HEAD); sentry-cli releases --log-level=debug deploys $REACT_APP_RELEASE new -e production",
-    "post-deploy": "npm run -s sentry-create-release && npm run -s sentry-set-commits && npm run -s sentry-upload-source-maps && npm run -s sentry-finalize-release && npm run -s sentry-deploy"
+    "deploy:test": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${TEST_ORG_ID} --definition-id ${TEST_APP_ID} --token ${CONTENTFUL_CMA_TOKEN}"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/apps/ecommerce/lambda/package-lock.json
+++ b/apps/ecommerce/lambda/package-lock.json
@@ -16,7 +16,6 @@
         "serverless-http": "^3.1.0"
       },
       "devDependencies": {
-        "@sentry/cli": "^2.14.4",
         "@tsconfig/node18": "^1.0.1",
         "@types/chai": "^4.3.4",
         "@types/chai-http": "^4.2.0",
@@ -2050,26 +2049,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/cli": {
-      "version": "2.17.4",
-      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.17.4.tgz",
-      "integrity": "sha512-5tLu/2U+MuEksIhvzW5LJEwhoqbdgwxE3Q5UwIJtJt3do4PFv1UVg1aLBJ3u6sGxAJpxqJYWvqfc/tXswQCJBA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "https-proxy-agent": "^5.0.0",
-        "node-fetch": "^2.6.7",
-        "progress": "^2.0.3",
-        "proxy-from-env": "^1.1.0",
-        "which": "^2.0.2"
-      },
-      "bin": {
-        "sentry-cli": "bin/sentry-cli"
-      },
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/@sentry/core": {
@@ -8570,15 +8549,6 @@
         "node": ">=10.0"
       }
     },
-    "node_modules/progress": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/promise-queue": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/promise-queue/-/promise-queue-2.2.5.tgz",
@@ -8599,12 +8569,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
@@ -12616,19 +12580,6 @@
         "@sentry/types": "7.50.0",
         "@sentry/utils": "7.50.0",
         "tslib": "^1.9.3"
-      }
-    },
-    "@sentry/cli": {
-      "version": "2.17.4",
-      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.17.4.tgz",
-      "integrity": "sha512-5tLu/2U+MuEksIhvzW5LJEwhoqbdgwxE3Q5UwIJtJt3do4PFv1UVg1aLBJ3u6sGxAJpxqJYWvqfc/tXswQCJBA==",
-      "dev": true,
-      "requires": {
-        "https-proxy-agent": "^5.0.0",
-        "node-fetch": "^2.6.7",
-        "progress": "^2.0.3",
-        "proxy-from-env": "^1.1.0",
-        "which": "^2.0.2"
       }
     },
     "@sentry/core": {
@@ -17596,12 +17547,6 @@
         "type": "^2.1.0"
       }
     },
-    "progress": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true
-    },
     "promise-queue": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/promise-queue/-/promise-queue-2.2.5.tgz",
@@ -17616,12 +17561,6 @@
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
       }
-    },
-    "proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
     },
     "pstree.remy": {
       "version": "1.1.8",

--- a/apps/ecommerce/lambda/package.json
+++ b/apps/ecommerce/lambda/package.json
@@ -19,7 +19,6 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@sentry/cli": "^2.14.4",
     "@tsconfig/node18": "^1.0.1",
     "@types/chai": "^4.3.4",
     "@types/chai-http": "^4.2.0",

--- a/apps/ecommerce/lambda/package.json
+++ b/apps/ecommerce/lambda/package.json
@@ -13,13 +13,7 @@
     "test:watch": "NODE_ENV=test TS_NODE_TRANSPILE_ONLY=1 mocha --watch --watch-files src --watch-files test -r dotenv/config",
     "deploy:test": "NODE_ENV=test sls deploy --stage test",
     "deploy": "NODE_ENV=production CIRCLE_SHA1=$(git rev-parse --short HEAD) sls deploy --stage $STAGE",
-    "verify-config": "STAGE=$(test \"$CIRCLE_BRANCH\" = 'master' && echo 'prd' || echo 'test'); sls print --stage $STAGE",
-    "sentry-create-release": "sentry-cli releases --log-level=debug new -p marketplace-apps $CIRCLE_SHA1",
-    "sentry-set-commits": "sentry-cli releases --log-level=debug set-commits --auto --ignore-missing $CIRCLE_SHA1",
-    "sentry-upload-source-maps": "sentry-cli releases --log-level=debug files $CIRCLE_SHA1 upload-sourcemaps --ext ts --ext tsx --ext map ./src ./build",
-    "sentry-finalize-release": "sentry-cli releases --log-level=debug finalize $CIRCLE_SHA1",
-    "sentry-deploy": "sentry-cli releases --log-level=debug deploys $CIRCLE_SHA1 new -e production",
-    "post-deploy": "npm run -s sentry-create-release && npm run -s sentry-set-commits && npm run -s sentry-upload-source-maps && npm run -s sentry-finalize-release && npm run -s sentry-deploy"
+    "verify-config": "STAGE=$(test \"$CIRCLE_BRANCH\" = 'master' && echo 'prd' || echo 'test'); sls print --stage $STAGE"
   },
   "keywords": [],
   "author": "",

--- a/apps/google-analytics-4/frontend/package-lock.json
+++ b/apps/google-analytics-4/frontend/package-lock.json
@@ -31,7 +31,6 @@
       },
       "devDependencies": {
         "@contentful/app-scripts": "1.7.13",
-        "@sentry/cli": "^2.14.4",
         "@testing-library/jest-dom": "5.16.5",
         "@testing-library/react": "12.1.5",
         "@tsconfig/create-react-app": "1.0.3",
@@ -4602,26 +4601,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@sentry/cli": {
-      "version": "2.17.4",
-      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.17.4.tgz",
-      "integrity": "sha512-5tLu/2U+MuEksIhvzW5LJEwhoqbdgwxE3Q5UwIJtJt3do4PFv1UVg1aLBJ3u6sGxAJpxqJYWvqfc/tXswQCJBA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "https-proxy-agent": "^5.0.0",
-        "node-fetch": "^2.6.7",
-        "progress": "^2.0.3",
-        "proxy-from-env": "^1.1.0",
-        "which": "^2.0.2"
-      },
-      "bin": {
-        "sentry-cli": "bin/sentry-cli"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
     },
     "node_modules/@sentry/core": {
       "version": "7.50.0",
@@ -18651,15 +18630,6 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
-    "node_modules/progress": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/promise": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/promise/-/promise-8.3.0.tgz",
@@ -18714,12 +18684,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
     },
     "node_modules/psl": {
       "version": "1.9.0",

--- a/apps/google-analytics-4/frontend/package.json
+++ b/apps/google-analytics-4/frontend/package.json
@@ -52,7 +52,6 @@
   },
   "devDependencies": {
     "@contentful/app-scripts": "1.7.13",
-    "@sentry/cli": "^2.14.4",
     "@testing-library/jest-dom": "5.16.5",
     "@testing-library/react": "12.1.5",
     "@tsconfig/create-react-app": "1.0.3",

--- a/apps/google-analytics-4/frontend/package.json
+++ b/apps/google-analytics-4/frontend/package.json
@@ -33,13 +33,7 @@
     "eject": "react-scripts eject",
     "create-app-definition": "contentful-app-scripts create-app-definition",
     "deploy": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEFINITIONS_ORG_ID} --definition-id 5DlxOS0KvGS1Wk362xgvbN --token ${CONTENTFUL_CMA_TOKEN}",
-    "deploy:test": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${TEST_ORG_ID} --definition-id ${TEST_APP_ID} --token ${CONTENTFUL_CMA_TOKEN}",
-    "sentry-create-release": "REACT_APP_RELEASE=$(git rev-parse --short HEAD); sentry-cli releases --log-level=debug new -p marketplace-apps $REACT_APP_RELEASE",
-    "sentry-set-commits": "REACT_APP_RELEASE=$(git rev-parse --short HEAD); sentry-cli releases --log-level=debug set-commits --auto --ignore-missing $REACT_APP_RELEASE",
-    "sentry-upload-source-maps": "REACT_APP_RELEASE=$(git rev-parse --short HEAD); sentry-cli releases --log-level=debug files $REACT_APP_RELEASE upload-sourcemaps --ext ts --ext tsx --ext map ./src ./build",
-    "sentry-finalize-release": "REACT_APP_RELEASE=$(git rev-parse --short HEAD); sentry-cli releases --log-level=debug finalize $REACT_APP_RELEASE",
-    "sentry-deploy": "REACT_APP_RELEASE=$(git rev-parse --short HEAD); sentry-cli releases --log-level=debug deploys $REACT_APP_RELEASE new -e production",
-    "post-deploy": "npm run -s sentry-create-release && npm run -s sentry-set-commits && npm run -s sentry-upload-source-maps && npm run -s sentry-finalize-release && npm run -s sentry-deploy"
+    "deploy:test": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${TEST_ORG_ID} --definition-id ${TEST_APP_ID} --token ${CONTENTFUL_CMA_TOKEN}"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/apps/google-analytics-4/lambda/package-lock.json
+++ b/apps/google-analytics-4/lambda/package-lock.json
@@ -24,7 +24,6 @@
         "serverless-http": "^3.1.0"
       },
       "devDependencies": {
-        "@sentry/cli": "^2.14.4",
         "@tsconfig/node18": "^1.0.1",
         "@types/chai": "^4.3.4",
         "@types/chai-http": "^4.2.0",
@@ -2702,26 +2701,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@sentry/cli": {
-      "version": "2.17.4",
-      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.17.4.tgz",
-      "integrity": "sha512-5tLu/2U+MuEksIhvzW5LJEwhoqbdgwxE3Q5UwIJtJt3do4PFv1UVg1aLBJ3u6sGxAJpxqJYWvqfc/tXswQCJBA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "https-proxy-agent": "^5.0.0",
-        "node-fetch": "^2.6.7",
-        "progress": "^2.0.3",
-        "proxy-from-env": "^1.1.0",
-        "which": "^2.0.2"
-      },
-      "bin": {
-        "sentry-cli": "bin/sentry-cli"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
     },
     "node_modules/@sentry/core": {
       "version": "7.50.0",
@@ -9634,15 +9613,6 @@
         "node": ">=10.0"
       }
     },
-    "node_modules/progress": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/promise-queue": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/promise-queue/-/promise-queue-2.2.5.tgz",
@@ -9785,12 +9755,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
@@ -14170,19 +14134,6 @@
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
           "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
-      }
-    },
-    "@sentry/cli": {
-      "version": "2.17.4",
-      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.17.4.tgz",
-      "integrity": "sha512-5tLu/2U+MuEksIhvzW5LJEwhoqbdgwxE3Q5UwIJtJt3do4PFv1UVg1aLBJ3u6sGxAJpxqJYWvqfc/tXswQCJBA==",
-      "dev": true,
-      "requires": {
-        "https-proxy-agent": "^5.0.0",
-        "node-fetch": "^2.6.7",
-        "progress": "^2.0.3",
-        "proxy-from-env": "^1.1.0",
-        "which": "^2.0.2"
       }
     },
     "@sentry/core": {
@@ -19465,12 +19416,6 @@
         "type": "^2.1.0"
       }
     },
-    "progress": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true
-    },
     "promise-queue": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/promise-queue/-/promise-queue-2.2.5.tgz",
@@ -19579,12 +19524,6 @@
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
       }
-    },
-    "proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
     },
     "pstree.remy": {
       "version": "1.1.8",

--- a/apps/google-analytics-4/lambda/package.json
+++ b/apps/google-analytics-4/lambda/package.json
@@ -21,7 +21,6 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@sentry/cli": "^2.14.4",
     "@tsconfig/node18": "^1.0.1",
     "@types/chai": "^4.3.4",
     "@types/chai-http": "^4.2.0",

--- a/apps/google-analytics-4/lambda/package.json
+++ b/apps/google-analytics-4/lambda/package.json
@@ -15,13 +15,7 @@
     "test:watch": "NODE_ENV=test TS_NODE_TRANSPILE_ONLY=1 mocha --watch --watch-files src --watch-files test -r dotenv/config",
     "deploy:test": "NODE_ENV=test sls deploy --stage test",
     "deploy": "NODE_ENV=production CIRCLE_SHA1=$(git rev-parse --short HEAD) sls deploy --stage $STAGE",
-    "verify-config": "STAGE=$(test \"$CIRCLE_BRANCH\" = 'master' && echo 'prd' || echo 'test'); sls print --stage $STAGE",
-    "sentry-create-release": "sentry-cli releases --log-level=debug new -p marketplace-apps $CIRCLE_SHA1",
-    "sentry-set-commits": "sentry-cli releases --log-level=debug set-commits --auto --ignore-missing $CIRCLE_SHA1",
-    "sentry-upload-source-maps": "sentry-cli releases --log-level=debug files $CIRCLE_SHA1 upload-sourcemaps --ext ts --ext tsx --ext map ./src ./build",
-    "sentry-finalize-release": "sentry-cli releases --log-level=debug finalize $CIRCLE_SHA1",
-    "sentry-deploy": "sentry-cli releases --log-level=debug deploys $CIRCLE_SHA1 new -e production",
-    "post-deploy": "npm run -s sentry-create-release && npm run -s sentry-set-commits && npm run -s sentry-upload-source-maps && npm run -s sentry-finalize-release && npm run -s sentry-deploy"
+    "verify-config": "STAGE=$(test \"$CIRCLE_BRANCH\" = 'master' && echo 'prd' || echo 'test'); sls print --stage $STAGE"
   },
   "keywords": [],
   "author": "",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
         "lerna": "5.6.2"
       },
       "devDependencies": {
+        "@sentry/cli": "^2.14.4",
         "husky": "^8.0.0",
         "lint-staged": "^13.0.0",
         "prettier": "2.8.8"
@@ -1664,6 +1665,26 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@sentry/cli": {
+      "version": "2.17.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.17.4.tgz",
+      "integrity": "sha512-5tLu/2U+MuEksIhvzW5LJEwhoqbdgwxE3Q5UwIJtJt3do4PFv1UVg1aLBJ3u6sGxAJpxqJYWvqfc/tXswQCJBA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "progress": "^2.0.3",
+        "proxy-from-env": "^1.1.0",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "sentry-cli": "bin/sentry-cli"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -5923,6 +5944,15 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/promise-all-reject-late": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-all-reject-late/-/promise-all-reject-late-1.0.1.tgz",
@@ -8607,6 +8637,19 @@
       "requires": {
         "node-addon-api": "^3.2.1",
         "node-gyp-build": "^4.3.0"
+      }
+    },
+    "@sentry/cli": {
+      "version": "2.17.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.17.4.tgz",
+      "integrity": "sha512-5tLu/2U+MuEksIhvzW5LJEwhoqbdgwxE3Q5UwIJtJt3do4PFv1UVg1aLBJ3u6sGxAJpxqJYWvqfc/tXswQCJBA==",
+      "dev": true,
+      "requires": {
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "progress": "^2.0.3",
+        "proxy-from-env": "^1.1.0",
+        "which": "^2.0.2"
       }
     },
     "@tootallnate/once": {
@@ -11739,6 +11782,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
     },
     "promise-all-reject-late": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "npm": ">= 8.0.0 < 9.0.0"
   },
   "devDependencies": {
+    "@sentry/cli": "^2.14.4",
     "husky": "^8.0.0",
     "lint-staged": "^13.0.0",
     "prettier": "2.8.8"


### PR DESCRIPTION
## Purpose
We don't want each app responsible for the shared sentry project release, so this moves it from the ad hoc post-deploy phase that lerna runs to a single job in the deploy-prod workflow