### PR TITLE
disable sourcemaps in ecommerce app to resolve bundle size limit exceeded issue (11.5MB sourcemap file being created exceeds the 10MB bundle size limit)

### DIFF
--- a/apps/ecommerce/frontend/package.json
+++ b/apps/ecommerce/frontend/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "start": "cross-env BROWSER=none react-scripts start",
-    "build": "REACT_APP_RELEASE=$(git rev-parse --short HEAD) react-scripts build",
+    "build": "GENERATE_SOURCEMAP=false REACT_APP_RELEASE=$(git rev-parse --short HEAD) react-scripts build",
     "test": "react-scripts test",
     "test:ci": "CI=true react-scripts test",
     "lint": "eslint --max-warnings=0 .",


### PR DESCRIPTION
## Purpose
Resolve ecommerce deployment issue due to bundle size limit being exceeded

## Approach
disables sourcemaps in ecommerce app to resolve bundle size limit exceeded issue (11.5MB sourcemap file being created exceeds the 10MB bundle size limit)