### PR TITLE
Add npm-read vault policy

### DIFF
--- a/.contentful/vault-secrets.yaml
+++ b/.contentful/vault-secrets.yaml
@@ -7,4 +7,5 @@ services:
     policies:
       - semantic-release-ecosystem
       - aws-push-artifacts:
-          account-id: "017078452822"
+          account-id: '017078452822'
+      - npm-read


### PR DESCRIPTION
## Purpose

<!-- Why are we introducing this change now? What problem does it solve? What is the story/background for it? -->
This adds a policy to utilize our npm vault secrets during our ci/cd pipeline.

