### PR TITLE
Extend linting to mux app

### DIFF
--- a/apps/mux/.eslintrc.js
+++ b/apps/mux/.eslintrc.js
@@ -8,5 +8,6 @@ module.exports = {
   },
   rules: {
     '@typescript-eslint/ban-types': 0,
+    '@typescript-eslint/explicit-module-boundary-types': 0,
   },
 };

--- a/apps/mux/.eslintrc.js
+++ b/apps/mux/.eslintrc.js
@@ -1,8 +1,12 @@
 module.exports = {
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint'],
   root: true,
   env: {
     node: true,
+  },
+  rules: {
+    '@typescript-eslint/ban-types': 0,
   },
 };

--- a/apps/mux/package.json
+++ b/apps/mux/package.json
@@ -36,6 +36,7 @@
     "build": "GENERATE_SOURCEMAP=false react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
+    "lint": "eslint --max-warnings=0 .",
     "create-app-definition": "contentful-app-scripts create-app-definition",
     "deploy": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEFINITIONS_ORG_ID} --definition-id 5l4WmuXdhJGcADHfCm1v4k --token ${CONTENTFUL_CMA_TOKEN}",
     "deploy:test": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${TEST_ORG_ID} --definition-id ${TEST_APP_ID} --token ${CONTENTFUL_CMA_TOKEN}"

--- a/apps/mux/src/components/playercode.tsx
+++ b/apps/mux/src/components/playercode.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Textarea, CopyButton, TextLink, Box } from '@contentful/f36-components';
 
 interface GetPlayerCodeProps {
+  // eslint-disable-next-line  @typescript-eslint/no-explicit-any
   params: any;
 }
 
@@ -46,8 +47,7 @@ class PlayerCode extends React.Component<GetPlayerCodeProps, {}> {
           <TextLink
             href="https://docs.mux.com/guides/video/mux-player"
             target="_blank"
-            rel="noopener noreferrer"
-          >
+            rel="noopener noreferrer">
             Read more about Mux Player
           </TextLink>
         </p>

--- a/apps/mux/src/index.test.tsx
+++ b/apps/mux/src/index.test.tsx
@@ -1,20 +1,13 @@
+/* eslint-disable  @typescript-eslint/no-explicit-any */
+
 import * as React from 'react';
-import {
-  render,
-  screen,
-  queryByAttribute,
-  fireEvent,
-  getByTestId,
-  waitFor,
-} from '@testing-library/react';
+import { render, queryByAttribute } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { App } from './';
 
 /*
  * This was a valid private key, but it has since been revoked
  */
-const keyPrivate =
-  'LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFcEFJQkFBS0NBUUVBNDZmMGl2MUdZV3VCNHpCNkZjTG9KcW05S1l0eXVBdEZ4WEZ2Q0h5MWc0OVNBNnhICnI2TzJjS1IrRmd0MlZkckxWbmc1UkdtdE5qNEd2WllMT2k4RWJ6dzBMeE9UaWtvK2xKZmVGMS95SC82Ymh2dnQKd3d4L1R4Z3RoQnpUUHp3Ry9oRjVHbGZQeXRheC91emNSN3dFY1JRUUhHeENHcUJ1ZXFZUk5GRGFnVEFJTmJOVwpJK2tkV0hZVG5lSldJTXhNb0UwLzBxOUYvN1ZCY2pibHhDLzdjeXNGUjNvbUdRR1JDejZsSzJxOFlIVGtiQm1tCk1uYnRBeEtkcElqTDljOTJERmhDdDN6ZXhGY0JadDhzMlg5UUQ4N2FBWEhvVkNDRzVMWFZNMUlaQWNzWmt5N2kKVEhLcVVVbXNJekhDdGZRKzhnQ3RGbm1DNkQrT2RHTk9ieDdoMndJREFRQUJBb0lCQUFyOXBOVEEvWkRlZTlyWQpFRXpVcUJpVndVZ3NMMUdyV2FiNm52MnQ1NlYrV2R0TGlmcDAwTzRIUXY4VmRwVVdoeEtabzBvbVAvS0tkQkRiCkdaZXBoWEZKV3N1YkNsaDIxU2FmWGwyS2lFbjdKTThUZ3BzVUUyRmlMWEJmWStOOXBtakZ0eThLWmtISXM3YzMKQUR1R1hFQ0pVMjNMM0RVazRiQ1NLK3Ayck5YbndHNHA5MDlGbkZiczRpTDl6a1hWK292bkhwQnZSYXJQRGFGZApZT0M1M3ZlekVHbHNuQU9tTnUxUitDZEZMWTZDY0grenNrU3ZXSjFGUVIvUUJ3Q0Q5UmpsS085bm4xb3BLWlJnCkxwdW1tSlFRRzNCNjhvendqenhPSnBFU3hRa0w3WVVoV1V4dFlQR0lQdmI2bm1xZVA1aUxLWXd4djhGZXlYN3cKaGZRWVhLRUNnWUVBOHhDSHl2Zm9mZlRRU1pIM3dYUWg4c2dmQUNwNlhCZ1pFWXhETkJFcHppUmx6RnZqOUlPNwp1MWtWN3pFNDE0dXRMWFRrYklSVmNpRkR3aVZ1NlkwK0lYT0lYbDRscUhjZHJBWmhiQnAxeDV3MnJjbEhXNmtICjZvM2ZqSGJKVHFMMXI2b25yUUVQSXRpQkVQMUN6Q013dnZ3WG9KcnJ2NUdieXg4bW1BVkI3ZFVDZ1lFQTc4V0EKaXIrQ0hFVnpOeCtwd0JKRXNsNnVOZnZoa1dIaldrTHF4ajMzbzA5QTJCeXlqc1ZRb1UzQi8xZnhiQ05zMmhHNwpEYUpaWFdGK3VXMklCS3VsUkFXeVN1WEJkNGhvbXlpdXRIWWUzL0Z2YnlwaFVyN3BCWFBhUWxPUkNOa1hqV3pYCmI3clVDNXIrU2t6M1E5TEtjTmppRlVYaTRucXVpUEFaQ2krK2VPOENnWUVBdmRmVVo5ZjNNNkdwcVR5ajZPbisKdGZST0drQVRMNmoyczNqODZFYmJneEYwblFmTVpLY2JVcm5DNHY1cjZoWkRIWFRtRUVmUHdRTndPOHdtODYySQpzSEhmT2UySXRpcks5eGhJc1RsOWNubDFUNGtjL2Q5b3VtOHpBaStwRFkxRUhYN2wzRDh1aGtYWmtONXVkS2lyCm93K2NtS2xIcG1sZzZHWWRLN0UzakQwQ2dZRUFyK2xFLzRhMW5LeFBkWGZqZ0tsbWdUNzVyVjJaQnFLOHZMSXYKc1RZeGd6MVlJN1lhUXFqOUdQc0ZnNk12MnRpNnVkc2NVMHB6S2hHbmViK2tkVmpCTFlESWFDN2NuQ2dXSncvWAo3VXBrS0lUbjdyVTNKaEF1d2ZOWGhDWHZXSUI5eVNLN2hKdWJpdEF5RkswWEZFbUlnUForR0lGbmppWFgrMXU3CjR6OVlEVDBDZ1lCWHBGZ2hWMnpEWW9SeExFQXQ4SUxhOXh5S1RBQmhGbDl2a1Y1TzBzQUVQd0xZSkJXS2YyTTQKOVNxZ3I3Q0JMeEN6U1NMejFWZXMyUFZCUytnR2JJYUFtQWpXbGU4bTF0ejc3MWtFMDhQdGdzOWhuT09wMy9DYwozOGt3dnJoM250YkNDbjk2MldjaEs1aHdLREU4UXd6OXhPU2JSdEpDWWhDVkJzczc5Y2Q1b2c9PQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=';
 
 const SDK_MOCK = {
   state: {
@@ -36,23 +29,7 @@ const SDK_MOCK = {
     setValue: () => ({}),
   },
   window: {
-    startAutoResizer: () => {},
-  },
-};
-
-const SDK_MOCK_WITH_SIGNED_URLS = {
-  ...SDK_MOCK,
-  ...{
-    parameters: {
-      installation: {
-        muxAccessTokenId: 'abcd1234',
-        muxAccessTokenSecret: 'efgh5678',
-        muxSigningKeyId: 'signing-key-id',
-        muxSigningKeyPrivate: keyPrivate,
-        muxEnableSignedUrls: true,
-        muxDomain: 'mux.com',
-      },
-    },
+    startAutoResizer: () => null,
   },
 };
 

--- a/apps/mux/src/index.tsx
+++ b/apps/mux/src/index.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable  @typescript-eslint/no-non-null-assertion */
+
 import React from 'react';
 import { render } from 'react-dom';
 
@@ -71,6 +73,7 @@ export class App extends React.Component<AppProps, AppState> {
     };
   }
 
+  // eslint-disable-next-line  @typescript-eslint/ban-types
   detachExternalChangeHandler: Function | null = null;
 
   checkForValidAsset = async () => {
@@ -260,7 +263,7 @@ export class App extends React.Component<AppProps, AppState> {
     this.pollForAssetDetails();
   };
 
-  addByURL = async (remoteURL: String): Promise<void> => {
+  addByURL = async (remoteURL: string): Promise<void> => {
     const passthroughId = (this.props.sdk.entry.getSys() as { id: string }).id;
 
     const result = await this.apiClient.post(
@@ -429,13 +432,14 @@ export class App extends React.Component<AppProps, AppState> {
 
   responseCheck = async (res) => {
     switch (true) {
-      case res.status === 401:
+      case res.status === 401: {
         const json = await res.json();
         this.props.sdk.notifier.error(
           'Looks like something is wrong with the Mux Access Token in the config. Are you sure the token ID and secret in the extension settings match the access token you created?'
         );
         this.setAssetError(json.error.messages[0]);
         return false;
+      }
 
       case res.status === 429:
         this.props.sdk.notifier.error(
@@ -452,6 +456,7 @@ export class App extends React.Component<AppProps, AppState> {
     }
   };
 
+  // eslint-disable-next-line  @typescript-eslint/no-explicit-any
   resync = async (params?: any) => {
     return await this.pollForAssetDetails().then(() => {
       if (!params || !params.silent)
@@ -698,7 +703,7 @@ export class App extends React.Component<AppProps, AppState> {
   playerParams = () => {
     if (!this.state.value) return;
 
-    let params = [
+    const params = [
       {
         name: 'playback-id',
         value: this.state.value.playbackId || this.state.value.signedPlaybackId,
@@ -759,6 +764,7 @@ export class App extends React.Component<AppProps, AppState> {
       if ('error' in deleteRes) {
         this.props.sdk.notifier.error(deleteResJson.error.messages[0]);
       }
+      // eslint-disable-next-line no-empty
     } catch (e) {}
 
     if (this.isUsingSigned()) {

--- a/apps/mux/src/locations/config.tsx
+++ b/apps/mux/src/locations/config.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable  @typescript-eslint/no-non-null-assertion */
 import React from 'react';
 
 import { AppExtensionSDK, AppConfigAPI, SpaceAPI } from '@contentful/app-sdk';
@@ -248,8 +249,7 @@ class Config extends React.Component<ConfigProps, IState> {
               <TextLink
                 href="https://dashboard.mux.com/settings/access-tokens"
                 rel="noopener noreferrer"
-                target="_blank"
-              >
+                target="_blank">
                 settings on your dashboard
               </TextLink>
               . Note that you must be an admin in your Mux account.
@@ -313,8 +313,7 @@ class Config extends React.Component<ConfigProps, IState> {
                                 fieldId,
                                 (e.target as HTMLInputElement).checked
                               )
-                            }
-                          >
+                            }>
                             {fieldName}
                           </Checkbox>
                         );
@@ -332,8 +331,7 @@ class Config extends React.Component<ConfigProps, IState> {
                 <TextLink
                   href="https://docs.mux.com/docs/headless-cms-contentful#advanced-signed-urls"
                   rel="noopener noreferrer"
-                  target="_blank"
-                >
+                  target="_blank">
                   this guide
                 </TextLink>
                 . To use signed URLs in your application you will have to generate valid JSON web
@@ -346,8 +344,7 @@ class Config extends React.Component<ConfigProps, IState> {
               isDisabled={!this.haveApiCredentials()}
               name="mux-enable-signed-urls"
               isChecked={muxEnableSignedUrls}
-              onChange={(e) => this.toggleSignedUrls((e.target as HTMLInputElement).checked)}
-            >
+              onChange={(e) => this.toggleSignedUrls((e.target as HTMLInputElement).checked)}>
               Enable signed URLs
             </Checkbox>
             {this.state.isEnablingSignedUrls && (
@@ -370,8 +367,7 @@ class Config extends React.Component<ConfigProps, IState> {
             helpText="Adjust audio levels on videos after upload to standard audio levels."
             name="mux-enable-audio-normalize"
             isChecked={muxEnableAudioNormalize}
-            onChange={(e) => this.toggleNormalize((e.target as HTMLInputElement).checked)}
-          >
+            onChange={(e) => this.toggleNormalize((e.target as HTMLInputElement).checked)}>
             Enable Audio Normalization
           </Checkbox>
           <hr className="config-splitter" />

--- a/apps/mux/src/util/apiClient.tsx
+++ b/apps/mux/src/util/apiClient.tsx
@@ -13,7 +13,7 @@ class ApiClient {
   }
 
   requestHeaders = () => {
-    let headers = new Headers();
+    const headers = new Headers();
     headers.set('Authorization', 'Basic ' + btoa(`${this.tokenId}:${this.tokenSecret}`));
     headers.set('Content-Type', 'application/json');
     return headers;

--- a/apps/mux/src/util/types.tsx
+++ b/apps/mux/src/util/types.tsx
@@ -25,6 +25,7 @@ export interface AppState {
   storyboardToken?: string;
   captionname?: string;
   playerPlaybackId?: string;
+  // eslint-disable-next-line  @typescript-eslint/no-explicit-any
   raw?: any;
 }
 
@@ -68,7 +69,7 @@ export interface Captions {
 export interface captionListProps {
   captions: Array<Captions>;
   requestDeleteCaption: (e) => void;
-  playbackId: String | undefined;
+  playbackId: string | undefined;
   domain: string;
   token: string | undefined;
 }


### PR DESCRIPTION
## Purpose

The purpose of this PR is to follow-up the addition of an .`eslintrc.js` file to the Mux app code (see [this](https://github.com/contentful/apps/pull/3336) PR for context there.), with an extension of `eslint` itself. Therefore enforcing recommended `eslint` rules. 

## Approach

I wanted to be as minimally disruptive to active code as possible, while also providing basic `eslint` guidelines and enforcment (and not ignoring too many rules).

Therefore in files and on specific lines you will notice I disabled `eslint` rules where I felt that changing the code may cause unintended consequences.

I also ignored rules that I felt were rampant throughout the code, and could not be safely adjusted without unforeseen consequences. 

Open to any and all suggestions/opinions on the calls I made here! 

## Testing steps

Test that the Mux app still works locally with this branch. It worked locally for me. (The Mux (development) environment within the testing org is a good place for this). 
