### PR TITLE
[Fix] Deploy staging and prod works now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
           name: Install dependencies
           command: |
             npm ci
-            npm run bootstrap:ci
+            npm run bootstrap:ci-deploy
       - run:
           name: Install awscli
           command: |
@@ -92,7 +92,7 @@ jobs:
           command: |
             REACT_APP_BACKEND_BASE_URL=$BACKEND_BASE_URL_TEST \
             REACT_APP_SLACK_CLIENT_ID=$SLACK_CLIENT_ID_TEST \
-            npm run build
+            npm run build:deploy
       - run:
           name: Deploy apps to staging
           command: |
@@ -118,7 +118,7 @@ jobs:
           name: Install dependencies
           command: |
             npm ci
-            npm run bootstrap:ci
+            npm run bootstrap:ci-deploy
       - run:
           name: Install awscli
           command: |
@@ -130,7 +130,7 @@ jobs:
           command: |
             REACT_APP_BACKEND_BASE_URL=$APP_SLACK_BACKEND_BASE_URL_PROD \
             REACT_APP_SLACK_CLIENT_ID=$SLACK_CLIENT_ID_PROD \
-            npm run build
+            npm run build:deploy
       - publish
       - run:
           name: Deploy apps to prod

--- a/package.json
+++ b/package.json
@@ -14,10 +14,12 @@
   "scripts": {
     "bootstrap": "lerna bootstrap --no-ci --since master",
     "bootstrap:ci": "lerna bootstrap --ci --concurrency=3 --since master",
+    "bootstrap:ci-deploy": "lerna bootstrap --ci --concurrency=3",
     "clean": "lerna clean",
     "lint": "lerna run lint --concurrency=3 --since master",
     "verify-config": "lerna run verify-config --concurrency=3 --since master",
     "build": "lerna run build --concurrency=1 --stream --since master",
+    "build:deploy": "lerna run build --concurrency=1 --stream",
     "test": "lerna run test:ci --concurrency=1 --stream --since master",
     "deploy": "lerna run deploy --concurrency=3",
     "deploy:test": "lerna run deploy:test --concurrency=3",


### PR DESCRIPTION
## Purpose
Apps don't deploy to staging and production because the --since option doesn't work once the PR is merged. So a separate command is needed at the root level for the apps to deploy
