### PR TITLE
ignore spec files in nodemon to avoid uneeded lambda restarts

### DIFF
--- a/apps/ecommerce/lambda/nodemon.json
+++ b/apps/ecommerce/lambda/nodemon.json
@@ -1,6 +1,6 @@
 {
   "watch": ["src", "config"],
   "ext": ".ts,.js,.yml",
-  "ignore": [],
+  "ignore": ["**/*.spec.ts", "**/*.spec.tsx"],
   "exec": "npm run build && serverless offline"
 }


### PR DESCRIPTION
## Purpose
ignore spec files so we don't unnecessarily restart lambda in development when updating tests.