### PR TITLE
Use the config-lerna orb to use the correct GH token for package publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,14 +9,12 @@ commands:
     steps:
       - vault/get-secrets:
           template-preset: 'semantic-release-ecosystem'
+      - vault/configure-lerna
       - run:
           name: Setup NPM
           command: |
             echo $'@contentful:registry=https://registry.npmjs.org/
             //registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> ~/.npmrc
-      - run: export GH_TOKEN=${GITHUB_TOKEN}
-      - run: git config --global user.email "${GIT_AUTHOR_EMAIL}"
-      - run: git config --global user.name "${GIT_AUTHOR_NAME}"
       - run:
           name: Publish packages
           command: npm run publish-packages


### PR DESCRIPTION
## Purpose

* The `publish-packages` step in our build requires git write privileges in order to push new versions of our packages as git tags to our repo
* Our current configuration of that step missed a key configuration, which meant instead of using the predefined `GH_TOKEN` github token, which has these write permissions, the publish package command was falling back to using deploy keys (https://github.com/contentful/apps/settings/keys)
* Deploy keys were an okay workaround, since we had a read/write key defined, but the deploy step frequently broke when folks inadvertently introduced read only deply keys

## Approach

* Use the `vault/configure-lerna` orb
* The key difference is that it sets up the origin URL to use the GH_TOKEN explicitly via this command:
  ```
  git remote set-url origin "https://$GIT_AUTHOR_NAME:$GITHUB_TOKEN@github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
  ```
* This ensures the subsequent git commands lerna uses under the cover use the GH_TOKEN vs. the implicit deploy key

## Dependencies and/or References

* https://circleci.com/developer/orbs/orb/contentful/vault#commands-configure-lerna

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
