### PR TITLE
Feature INTEG-540: Connect to and retrieve products from Shopify

### DIFF
--- a/apps/ecommerce/lambda/package-lock.json
+++ b/apps/ecommerce/lambda/package-lock.json
@@ -11,11 +11,14 @@
       "dependencies": {
         "@contentful/node-apps-toolkit": "^2.0.4",
         "@sentry/node": "^7.38.0",
+        "@types/shopify-buy": "^2.17.1",
         "axios": "^1.4.0",
         "cors": "^2.8.5",
         "express": "^4.18.2",
+        "graphql": "^16.6.0",
         "nock": "^13.3.1",
-        "serverless-http": "^3.1.0"
+        "serverless-http": "^3.1.0",
+        "shopify-buy": "^2.19.0"
       },
       "devDependencies": {
         "@tsconfig/node18": "^1.0.1",
@@ -2625,6 +2628,11 @@
         "@types/mime": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/shopify-buy": {
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/@types/shopify-buy/-/shopify-buy-2.17.1.tgz",
+      "integrity": "sha512-R/LzVK/Beqsex2dccSY2rfm4AFAVuqJ177LVl18bVNtxQO78WGTgsVZKDEOaugW9ap3hm+w2XvGFBFp3XeMRvw=="
     },
     "node_modules/@types/sinon": {
       "version": "10.0.14",
@@ -6271,6 +6279,14 @@
         "lodash": "^4.17.15"
       }
     },
+    "node_modules/graphql": {
+      "version": "16.6.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
+      "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -9557,6 +9573,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/shopify-buy": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/shopify-buy/-/shopify-buy-2.19.0.tgz",
+      "integrity": "sha512-XCkQDG9DokhWUiRTOh+6K9I2w3uMys+R1mCt8h3l4le/9TjVxVJ1jbWD7ioyPf1Bc+fPLR6KX62JT1K6NE/S8A=="
     },
     "node_modules/side-channel": {
       "version": "1.0.4",
@@ -13308,6 +13329,11 @@
         "@types/node": "*"
       }
     },
+    "@types/shopify-buy": {
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/@types/shopify-buy/-/shopify-buy-2.17.1.tgz",
+      "integrity": "sha512-R/LzVK/Beqsex2dccSY2rfm4AFAVuqJ177LVl18bVNtxQO78WGTgsVZKDEOaugW9ap3hm+w2XvGFBFp3XeMRvw=="
+    },
     "@types/sinon": {
       "version": "10.0.14",
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.14.tgz",
@@ -16016,6 +16042,11 @@
         "lodash": "^4.17.15"
       }
     },
+    "graphql": {
+      "version": "16.6.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
+      "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw=="
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -18466,6 +18497,11 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
+    },
+    "shopify-buy": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/shopify-buy/-/shopify-buy-2.19.0.tgz",
+      "integrity": "sha512-XCkQDG9DokhWUiRTOh+6K9I2w3uMys+R1mCt8h3l4le/9TjVxVJ1jbWD7ioyPf1Bc+fPLR6KX62JT1K6NE/S8A=="
     },
     "side-channel": {
       "version": "1.0.4",

--- a/apps/ecommerce/lambda/package.json
+++ b/apps/ecommerce/lambda/package.json
@@ -49,10 +49,12 @@
   "dependencies": {
     "@contentful/node-apps-toolkit": "^2.0.4",
     "@sentry/node": "^7.38.0",
+    "@types/shopify-buy": "^2.17.1",
     "axios": "^1.4.0",
     "cors": "^2.8.5",
     "express": "^4.18.2",
     "nock": "^13.3.1",
-    "serverless-http": "^3.1.0"
+    "serverless-http": "^3.1.0",
+    "shopify-buy": "^2.19.0"
   }
 }

--- a/apps/ecommerce/lambda/src/controllers/apiController.ts
+++ b/apps/ecommerce/lambda/src/controllers/apiController.ts
@@ -21,8 +21,9 @@ const ApiController = {
       if (!proxyBaseUrl) {
         return res.status(404).send({
           status: 'error',
-          message: `Base URL configuration for provider${resourceProvider ? `: "${resourceProvider}"` : ''
-            } not found`,
+          message: `Base URL configuration for provider${
+            resourceProvider ? `: "${resourceProvider}"` : ''
+          } not found`,
         });
       }
 

--- a/apps/ecommerce/lambda/src/controllers/apiController.ts
+++ b/apps/ecommerce/lambda/src/controllers/apiController.ts
@@ -26,9 +26,8 @@ const ApiController = {
       if (!proxyUrl) {
         return res.status(404).send({
           status: 'error',
-          message: `Provider${
-            resourceLink.sys.provider ? `: ${resourceLink.sys.provider}` : ''
-          } not found`,
+          message: `Provider${resourceLink.sys.provider ? `: ${resourceLink.sys.provider}` : ''
+            } not found`,
         });
       }
 
@@ -44,7 +43,6 @@ const ApiController = {
             .send(JSON.parse(JSON.stringify((response as AxiosResponse).data)));
         }
       } catch (error) {
-        console.log('error', error);
         res.status(500).send({
           status: 'error',
           message: 'Error fetching resource',

--- a/apps/ecommerce/lambda/src/controllers/shopifyController.ts
+++ b/apps/ecommerce/lambda/src/controllers/shopifyController.ts
@@ -38,24 +38,30 @@ const ShopifyController = {
     const client = makeShopifyClient({
       domain: req.body.domain, storefrontAccessToken: req.body.storefrontAccessToken,
     })
-    if (req.body.sys.urn.match(/\/not_found$/)) {
+    if (id.match(/\/not_found$/)) {
       return res.status(404).send({
         status: 'error',
         message: 'Not found',
       });
-    } else if (req.body.sys.urn.match(/\/bad_request$/)) {
+    } else if (id.match(/\/bad_request$/)) {
       return res.status(400).send({
         status: 'error',
         message: 'Bad request',
       });
     }
-
     try {
       const product = await client.product.fetch(id);
-      return res.send({
-        sys: req.body.sys,
-        ...convertResponseToResource(product),
-      });
+      if (product) {
+        return res.send({
+          sys: req.body.sys,
+          ...convertResponseToResource(product),
+        });
+      } else {
+        return res.status(404).send({
+          status: 'error',
+          message: `Product Not Found for id ${id}`
+        })
+      }
     } catch (error) {
       return res.status(500).send({
         status: 'error',

--- a/apps/ecommerce/lambda/src/controllers/shopifyController.ts
+++ b/apps/ecommerce/lambda/src/controllers/shopifyController.ts
@@ -1,12 +1,23 @@
+import { LATEST_API_VERSION, ConfigParams, ApiVersion } from '@shopify/shopify-api';
 import { Request, Response } from 'express';
 import { CombinedResource, ErrorResponse, ExternalResourceLink } from '../types';
-import { mockResourceData } from '../mocks/resourceData.mock';
+import Client from 'shopify-buy';
+import { convertResponseToResource } from '../helpers/shopifyAdapter'
+
+// Initializing a client to return content in the store's primary language
+const client = Client.buildClient({
+  domain: 'contentful-test-app.myshopify.com',
+  storefrontAccessToken: '',
+  apiVersion: ApiVersion.April23
+});
 
 const ShopifyController = {
-  resource: (
+  resource: async (
     req: Request<ExternalResourceLink>,
     res: Response<CombinedResource | ErrorResponse>
-  ): Response<CombinedResource> => {
+  ): Promise<Response<CombinedResource>> => {
+    const product = await client.product.fetch('gid://shopify/Product/8191006671134');
+
     if (req.body.sys.urn.match(/\/not_found$/)) {
       return res.status(404).send({
         status: 'error',
@@ -21,7 +32,7 @@ const ShopifyController = {
 
     return res.send({
       sys: req.body.sys,
-      ...mockResourceData,
+      ...convertResponseToResource(product),
     });
   },
 };

--- a/apps/ecommerce/lambda/src/controllers/shopifyController.ts
+++ b/apps/ecommerce/lambda/src/controllers/shopifyController.ts
@@ -1,43 +1,45 @@
 import { Request, Response } from 'express';
 import { ExternalResourceLink, ErrorResponse } from '../types';
 import Client from 'shopify-buy';
-import { convertResponseToResource } from '../helpers/shopifyAdapter'
+import { convertResponseToResource } from '../helpers/shopifyAdapter';
 
 interface ShopifyParams {
-  domain: string,
-  storefrontAccessToken: string,
+  domain: string;
+  storefrontAccessToken: string;
 }
 
 const makeShopifyClient = (params: ShopifyParams) => {
   return Client.buildClient({
     ...params,
-    apiVersion: "2023-04"
+    apiVersion: '2023-04',
   });
-}
+};
 
 const ShopifyController = {
   healthcheck: async (req: Request<ShopifyParams>, res: Response): Promise<Response> => {
     try {
       const client = makeShopifyClient({
-        domain: req.body.domain, storefrontAccessToken: req.body.storefrontAccessToken,
+        domain: req.body.domain,
+        storefrontAccessToken: req.body.storefrontAccessToken,
       });
       const response = await client.shop.fetchInfo();
       return res.send(response);
     } catch (error) {
       return res.status(500).send({
         status: 'error',
-        message: error
-      })
+        message: error,
+      });
     }
   },
   resource: async (
     req: Request<ExternalResourceLink>,
     res: Response<ExternalResourceLink | ErrorResponse>
   ): Promise<Response<ExternalResourceLink>> => {
-    const id = req.body.sys.urn
+    const id = req.body.sys.urn;
     const client = makeShopifyClient({
-      domain: req.body.domain, storefrontAccessToken: req.body.storefrontAccessToken,
-    })
+      domain: req.body.domain,
+      storefrontAccessToken: req.body.storefrontAccessToken,
+    });
     if (id.match(/\/not_found$/)) {
       return res.status(404).send({
         status: 'error',
@@ -59,17 +61,15 @@ const ShopifyController = {
       } else {
         return res.status(404).send({
           status: 'error',
-          message: `Product Not Found for id ${id}`
-        })
+          message: `Product Not Found for id ${id}`,
+        });
       }
     } catch (error) {
       return res.status(500).send({
         status: 'error',
-        message: error
-      })
+        message: error,
+      });
     }
-
-
   },
 };
 

--- a/apps/ecommerce/lambda/src/helpers/shopifyAdapter.ts
+++ b/apps/ecommerce/lambda/src/helpers/shopifyAdapter.ts
@@ -1,14 +1,13 @@
 import { Product } from 'shopify-buy'
-import { HydratedResourceData } from '../types'
+import { ExternalResource, JSONObject } from '../types'
 
-export const convertResponseToResource = (product: Product): HydratedResourceData => {
+export const convertResponseToResource = (product: Product): ExternalResource => {
     return {
         name: product.title,
         description: product.description,
         image: product.images[0].url,
         status: product.availableForSale ? 'Available' : 'Not Available',
         extras: {
-            ...product
         }
     }
 }

--- a/apps/ecommerce/lambda/src/helpers/shopifyAdapter.ts
+++ b/apps/ecommerce/lambda/src/helpers/shopifyAdapter.ts
@@ -1,13 +1,12 @@
-import { Product } from 'shopify-buy'
-import { ExternalResource, JSONObject } from '../types'
+import { Product } from 'shopify-buy';
+import { ExternalResource } from '../types';
 
 export const convertResponseToResource = (product: Product): ExternalResource => {
-    return {
-        name: product.title,
-        description: product.description,
-        image: product.images[0].url,
-        status: product.availableForSale ? 'Available' : 'Not Available',
-        extras: {
-        }
-    }
-}
+  return {
+    name: product.title,
+    description: product.description,
+    image: product.images[0].url,
+    status: product.availableForSale ? 'Available' : 'Not Available',
+    extras: {},
+  };
+};

--- a/apps/ecommerce/lambda/src/helpers/shopifyAdapter.ts
+++ b/apps/ecommerce/lambda/src/helpers/shopifyAdapter.ts
@@ -1,0 +1,14 @@
+import { Product } from 'shopify-buy'
+import { HydratedResourceData } from '../types'
+
+export const convertResponseToResource = (product: Product): HydratedResourceData => {
+    return {
+        name: product.title,
+        description: product.description,
+        image: product.images[0].url,
+        status: product.availableForSale ? 'Available' : 'Not Available',
+        extras: {
+            ...product
+        }
+    }
+}

--- a/apps/ecommerce/lambda/src/middlewares/verifySignedRequests.ts
+++ b/apps/ecommerce/lambda/src/middlewares/verifySignedRequests.ts
@@ -19,7 +19,7 @@ export const verifySignedRequestMiddleware = (req: Request, _res: Response, next
         isValidReq = true;
       }
     } catch (e) {
-      console.error(e)
+      console.error(e);
       throw new UnableToVerifyRequest('Unable to verify request', {
         cause: e,
       });

--- a/apps/ecommerce/lambda/src/middlewares/verifySignedRequests.ts
+++ b/apps/ecommerce/lambda/src/middlewares/verifySignedRequests.ts
@@ -19,7 +19,6 @@ export const verifySignedRequestMiddleware = (req: Request, _res: Response, next
         isValidReq = true;
       }
     } catch (e) {
-      console.error(e);
       throw new UnableToVerifyRequest('Unable to verify request', {
         cause: e,
       });
@@ -29,7 +28,7 @@ export const verifySignedRequestMiddleware = (req: Request, _res: Response, next
   if (!isValidReq) {
     throw new InvalidSignature(
       'Request does not have a valid request signature. ' +
-        'See: https://www.contentful.com/developers/docs/extensibility/app-framework/request-verification/'
+      'See: https://www.contentful.com/developers/docs/extensibility/app-framework/request-verification/'
     );
   }
 

--- a/apps/ecommerce/lambda/src/middlewares/verifySignedRequests.ts
+++ b/apps/ecommerce/lambda/src/middlewares/verifySignedRequests.ts
@@ -19,6 +19,7 @@ export const verifySignedRequestMiddleware = (req: Request, _res: Response, next
         isValidReq = true;
       }
     } catch (e) {
+      console.error(e)
       throw new UnableToVerifyRequest('Unable to verify request', {
         cause: e,
       });

--- a/apps/ecommerce/lambda/src/middlewares/verifySignedRequests.ts
+++ b/apps/ecommerce/lambda/src/middlewares/verifySignedRequests.ts
@@ -28,7 +28,7 @@ export const verifySignedRequestMiddleware = (req: Request, _res: Response, next
   if (!isValidReq) {
     throw new InvalidSignature(
       'Request does not have a valid request signature. ' +
-      'See: https://www.contentful.com/developers/docs/extensibility/app-framework/request-verification/'
+        'See: https://www.contentful.com/developers/docs/extensibility/app-framework/request-verification/'
     );
   }
 

--- a/apps/ecommerce/lambda/src/routers/shopifyRouter.spec.ts
+++ b/apps/ecommerce/lambda/src/routers/shopifyRouter.spec.ts
@@ -1,0 +1,118 @@
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import app from '../app';
+import * as NodeAppsToolkit from '@contentful/node-apps-toolkit';
+import { mockResourceLink } from '../mocks/resourceLink.mock';
+import Sinon from 'sinon';
+import Client, { CheckoutResource, CollectionResource, ImageResource, Product, ProductResource, Shop, ShopResource } from 'shopify-buy';
+
+const sandbox = Sinon.createSandbox();
+chai.use(chaiHttp);
+chai.should();
+
+const shopifyClientStub = {
+    product: {
+        fetch: () => Sinon.promise((resolve) => {
+            return resolve({
+                title: 'Some Product title',
+                description: 'Some product description',
+                images: [{ url: 'some-product-url' }]
+            } as Product)
+        }),
+        fetchAll: () => Sinon.promise(Sinon.spy()),
+        fetchMultiple: () => Sinon.promise(Sinon.spy()),
+        fetchByHandle: () => Sinon.promise(Sinon.spy()),
+        fetchQuery: () => Sinon.promise(Sinon.spy()),
+        fetchRecommendations: () => Sinon.promise(Sinon.spy()),
+        graphQLClient: null
+    } as ProductResource,
+    collection: {} as CollectionResource,
+    checkout: {} as CheckoutResource,
+    image: {} as ImageResource,
+    shop: {
+        fetchInfo: () => {
+            return Sinon.promise((resolve) => {
+                return resolve({
+                    id: 'some-shop-id',
+                    name: 'some test shop name'
+                } as Shop)
+            });
+        },
+        fetchPolicies: () => Sinon.promise(Sinon.spy()),
+        graphQLClient: null
+    } as ShopResource,
+    graphQLClient: null,
+    fetchNextPage: function <T extends Client.Node>(): Promise<T[]> {
+        throw new Error('Function not implemented.');
+    }
+}
+
+describe('Shopify Router', () => {
+    beforeEach((done) => {
+        sandbox.stub(NodeAppsToolkit, 'verifyRequest').get(() => {
+            return () => true;
+        });
+        done();
+    });
+
+    afterEach((done) => {
+        sandbox.restore();
+        done();
+    });
+
+    describe('When sending a healthcheck', () => {
+        it('should reply with store data', (done) => {
+            sandbox.stub(Client, 'buildClient')
+                .returns(shopifyClientStub)
+            chai
+                .request(app)
+                .post('/shopify/healthcheck')
+                .set('X-Contentful-Data-Provider', 'shopify')
+                .send({ sys: mockResourceLink.sys })
+                .end((error, res) => {
+                    expect(res).to.have.status(200);
+                    expect(res.body).to.have.property('id');
+                    expect(res.body).to.have.property('name');
+                    done();
+                });
+        });
+    });
+
+    describe('When sending requesting a resource', () => {
+        it('should reply with Shopify resource when id is valid', (done) => {
+            sandbox.stub(Client, 'buildClient')
+                .returns(shopifyClientStub)
+            chai
+                .request(app)
+                .post('/shopify/resource')
+                .set('X-Contentful-Data-Provider', 'shopify')
+                .send({ sys: mockResourceLink.sys })
+                .end((error, res) => {
+                    expect(res).to.have.status(200);
+                    expect(res.body).to.have.property('name');
+                    expect(res.body).to.have.property('description');
+                    done();
+                });
+        });
+        it('shows an error message when id is invalid', (done) => {
+            sandbox.stub(Client, 'buildClient')
+                .returns({
+                    ...shopifyClientStub, product: {
+                        fetch: () => Sinon.promise((resolve) => {
+                            return resolve(null)
+                        })
+                    } as unknown as ProductResource
+                })
+            chai
+                .request(app)
+                .post('/shopify/resource')
+                .set('X-Contentful-Data-Provider', 'shopify')
+                .send({ sys: mockResourceLink.sys })
+                .end((error, res) => {
+                    expect(res).to.have.status(404);
+                    expect(res.body.message).to.match(/Product Not Found/);
+                    done();
+                });
+        });
+    });
+});

--- a/apps/ecommerce/lambda/src/routers/shopifyRouter.spec.ts
+++ b/apps/ecommerce/lambda/src/routers/shopifyRouter.spec.ts
@@ -4,115 +4,123 @@ import app from '../app';
 import * as NodeAppsToolkit from '@contentful/node-apps-toolkit';
 import { mockResourceLink } from '../mocks/resourceLink.mock';
 import Sinon from 'sinon';
-import Client, { CheckoutResource, CollectionResource, ImageResource, Product, ProductResource, Shop, ShopResource } from 'shopify-buy';
+import Client, {
+  CheckoutResource,
+  CollectionResource,
+  ImageResource,
+  Product,
+  ProductResource,
+  Shop,
+  ShopResource,
+} from 'shopify-buy';
 
 const sandbox = Sinon.createSandbox();
 chai.use(chaiHttp);
 chai.should();
 
 const shopifyClientStub = {
-    product: {
-        fetch: () => Sinon.promise((resolve) => {
-            return resolve({
-                title: 'Some Product title',
-                description: 'Some product description',
-                images: [{ url: 'some-product-url' }]
-            } as Product)
-        }),
-        fetchAll: () => Sinon.promise(Sinon.spy()),
-        fetchMultiple: () => Sinon.promise(Sinon.spy()),
-        fetchByHandle: () => Sinon.promise(Sinon.spy()),
-        fetchQuery: () => Sinon.promise(Sinon.spy()),
-        fetchRecommendations: () => Sinon.promise(Sinon.spy()),
-        graphQLClient: null
-    } as ProductResource,
-    collection: {} as CollectionResource,
-    checkout: {} as CheckoutResource,
-    image: {} as ImageResource,
-    shop: {
-        fetchInfo: () => {
-            return Sinon.promise((resolve) => {
-                return resolve({
-                    id: 'some-shop-id',
-                    name: 'some test shop name'
-                } as Shop)
-            });
-        },
-        fetchPolicies: () => Sinon.promise(Sinon.spy()),
-        graphQLClient: null
-    } as ShopResource,
+  product: {
+    fetch: () =>
+      Sinon.promise((resolve) => {
+        return resolve({
+          title: 'Some Product title',
+          description: 'Some product description',
+          images: [{ url: 'some-product-url' }],
+        } as Product);
+      }),
+    fetchAll: () => Sinon.promise(Sinon.spy()),
+    fetchMultiple: () => Sinon.promise(Sinon.spy()),
+    fetchByHandle: () => Sinon.promise(Sinon.spy()),
+    fetchQuery: () => Sinon.promise(Sinon.spy()),
+    fetchRecommendations: () => Sinon.promise(Sinon.spy()),
     graphQLClient: null,
-    fetchNextPage: function <T extends Client.Node>(): Promise<T[]> {
-        throw new Error('Function not implemented.');
-    }
-}
+  } as ProductResource,
+  collection: {} as CollectionResource,
+  checkout: {} as CheckoutResource,
+  image: {} as ImageResource,
+  shop: {
+    fetchInfo: () => {
+      return Sinon.promise((resolve) => {
+        return resolve({
+          id: 'some-shop-id',
+          name: 'some test shop name',
+        } as Shop);
+      });
+    },
+    fetchPolicies: () => Sinon.promise(Sinon.spy()),
+    graphQLClient: null,
+  } as ShopResource,
+  graphQLClient: null,
+  fetchNextPage: function <T extends Client.Node>(): Promise<T[]> {
+    throw new Error('Function not implemented.');
+  },
+};
 
 describe('Shopify Router', () => {
-    beforeEach((done) => {
-        sandbox.stub(NodeAppsToolkit, 'verifyRequest').get(() => {
-            return () => true;
-        });
-        done();
+  beforeEach((done) => {
+    sandbox.stub(NodeAppsToolkit, 'verifyRequest').get(() => {
+      return () => true;
     });
+    done();
+  });
 
-    afterEach((done) => {
-        sandbox.restore();
-        done();
-    });
+  afterEach((done) => {
+    sandbox.restore();
+    done();
+  });
 
-    describe('When sending a healthcheck', () => {
-        it('should reply with store data', (done) => {
-            sandbox.stub(Client, 'buildClient')
-                .returns(shopifyClientStub)
-            chai
-                .request(app)
-                .post('/shopify/healthcheck')
-                .set('X-Contentful-Data-Provider', 'shopify')
-                .send({ sys: mockResourceLink.sys })
-                .end((error, res) => {
-                    expect(res).to.have.status(200);
-                    expect(res.body).to.have.property('id');
-                    expect(res.body).to.have.property('name');
-                    done();
-                });
+  describe('When sending a healthcheck', () => {
+    it('should reply with store data', (done) => {
+      sandbox.stub(Client, 'buildClient').returns(shopifyClientStub);
+      chai
+        .request(app)
+        .post('/shopify/healthcheck')
+        .set('X-Contentful-Data-Provider', 'shopify')
+        .send({ sys: mockResourceLink.sys })
+        .end((error, res) => {
+          expect(res).to.have.status(200);
+          expect(res.body).to.have.property('id');
+          expect(res.body).to.have.property('name');
+          done();
         });
     });
+  });
 
-    describe('When sending requesting a resource', () => {
-        it('should reply with Shopify resource when id is valid', (done) => {
-            sandbox.stub(Client, 'buildClient')
-                .returns(shopifyClientStub)
-            chai
-                .request(app)
-                .post('/shopify/resource')
-                .set('X-Contentful-Data-Provider', 'shopify')
-                .send({ sys: mockResourceLink.sys })
-                .end((error, res) => {
-                    expect(res).to.have.status(200);
-                    expect(res.body).to.have.property('name');
-                    expect(res.body).to.have.property('description');
-                    done();
-                });
-        });
-        it('shows an error message when id is invalid', (done) => {
-            sandbox.stub(Client, 'buildClient')
-                .returns({
-                    ...shopifyClientStub, product: {
-                        fetch: () => Sinon.promise((resolve) => {
-                            return resolve(null)
-                        })
-                    } as unknown as ProductResource
-                })
-            chai
-                .request(app)
-                .post('/shopify/resource')
-                .set('X-Contentful-Data-Provider', 'shopify')
-                .send({ sys: mockResourceLink.sys })
-                .end((error, res) => {
-                    expect(res).to.have.status(404);
-                    expect(res.body.message).to.match(/Product Not Found/);
-                    done();
-                });
+  describe('When sending requesting a resource', () => {
+    it('should reply with Shopify resource when id is valid', (done) => {
+      sandbox.stub(Client, 'buildClient').returns(shopifyClientStub);
+      chai
+        .request(app)
+        .post('/shopify/resource')
+        .set('X-Contentful-Data-Provider', 'shopify')
+        .send({ sys: mockResourceLink.sys })
+        .end((error, res) => {
+          expect(res).to.have.status(200);
+          expect(res.body).to.have.property('name');
+          expect(res.body).to.have.property('description');
+          done();
         });
     });
+    it('shows an error message when id is invalid', (done) => {
+      sandbox.stub(Client, 'buildClient').returns({
+        ...shopifyClientStub,
+        product: {
+          fetch: () =>
+            Sinon.promise((resolve) => {
+              return resolve(null);
+            }),
+        } as unknown as ProductResource,
+      });
+      chai
+        .request(app)
+        .post('/shopify/resource')
+        .set('X-Contentful-Data-Provider', 'shopify')
+        .send({ sys: mockResourceLink.sys })
+        .end((error, res) => {
+          expect(res).to.have.status(404);
+          expect(res.body.message).to.match(/Product Not Found/);
+          done();
+        });
+    });
+  });
 });

--- a/apps/ecommerce/lambda/src/routers/shopifyRouter.ts
+++ b/apps/ecommerce/lambda/src/routers/shopifyRouter.ts
@@ -3,6 +3,6 @@ import { ShopifyController } from '../controllers';
 const app = Router();
 
 app.post('/resource', ShopifyController.resource);
-app.post('/healthcheck', ShopifyController.healthcheck)
+app.post('/healthcheck', ShopifyController.healthcheck);
 
 export default app;

--- a/apps/ecommerce/lambda/src/routers/shopifyRouter.ts
+++ b/apps/ecommerce/lambda/src/routers/shopifyRouter.ts
@@ -3,5 +3,6 @@ import { ShopifyController } from '../controllers';
 const app = Router();
 
 app.post('/resource', ShopifyController.resource);
+app.post('/healthcheck', ShopifyController.healthcheck)
 
 export default app;

--- a/apps/ecommerce/lambda/src/types.ts
+++ b/apps/ecommerce/lambda/src/types.ts
@@ -19,5 +19,5 @@ export interface HydratedResourceData {
 export type CombinedResource = ExternalResourceLink & HydratedResourceData;
 export interface ErrorResponse {
   status: 'error';
-  message: string;
+  message: string | unknown;
 }


### PR DESCRIPTION
## Purpose

For the e-comm stack work, it's necessary to connect our lambda to a real Provider to emulate customer needs. 

This PR connects to our Partner Shopify account for testing against our test shop data. 

## Approach

- Was trying to use `shopify-api-js`, but that ended up being way too much overhead and requiring user-based authentication with OAuth, we might revisit this down the road, but it will depend on the UX for space admins adding Shopify as an integration (i.e., do we want them to authenticate the same way we do with GA4, through a dialog, or just with access token/domain)
- Switched to https://shopify.dev/docs/custom-storefronts/additional-sdks/js-buy since it's lighter weight and requires less for authentication

## Testing steps

- Can test with the following Postman collection if you comment out L30 in `app.ts`: https://grey-spaceship-425061.postman.co/workspace/New-Team-Workspace~4ca0371f-88c4-46de-b128-da67c31e4460/request/26682020-fe3c70cb-367b-4538-8f38-4a685fdac4bc


## Dependencies and/or References

- JS Buy SDK: https://shopify.dev/docs/custom-storefronts/additional-sdks/js-buy
