### PR TITLE
fix: prod deploy build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,10 +112,10 @@ jobs:
           template-preset: 'aws-push-artifacts'
       - checkout
       - node/install
+      - node/install-packages
       - run:
-          name: Install dependencies
+          name: Bootstrap
           command: |
-            npm ci
             npm run bootstrap:ci-deploy
       - run:
           name: Install awscli

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   },
   "scripts": {
     "bootstrap": "lerna bootstrap --no-ci --since master",
-    "bootstrap:ci": "lerna bootstrap --ci --concurrency=3 --since master",
-    "bootstrap:ci-deploy": "lerna bootstrap --ci --concurrency=3",
+    "bootstrap:ci": "lerna bootstrap --ci --concurrency=1 --since master",
+    "bootstrap:ci-deploy": "lerna bootstrap --ci --concurrency=1",
     "clean": "lerna clean",
     "lint": "lerna run lint --concurrency=3 --since master",
     "verify-config": "lerna run verify-config --concurrency=3 --since master",


### PR DESCRIPTION
## Purpose

Fixing production deploy, currently it is breaking because of installing too many packages at once.

## Approach

Trying to reduce the concurrency.
Using cache in circle ci.





