### PR TITLE
scripts package

### DIFF
--- a/examples/vue/package.json
+++ b/examples/vue/package.json
@@ -7,13 +7,17 @@
     "preview": "vite preview --port 5050",
     "test:unit": "vitest --environment jsdom",
     "typecheck": "vue-tsc --noEmit -p tsconfig.vitest.json --composite false",
-    "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore"
+    "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore",
+    "create-app-definition": "contentful-app-scripts create-app-definition",
+    "upload": "contentful-app-scripts upload --bundle-dir ./dist",
+    "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./dist  --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN"
   },
   "dependencies": {
     "@contentful/app-sdk": "^4.17.1",
     "vue": "^3.2.31"
   },
   "devDependencies": {
+    "@contentful/app-scripts": "^1.9.0",
     "@rushstack/eslint-patch": "^1.1.0",
     "@types/jsdom": "^16.2.14",
     "@types/node": "^16.11.26",


### PR DESCRIPTION
## Purpose

The Vue template is missing @contentfu/app-scripts package and NPM scripts.

## Approach

This might have been possibly overlooked as React seems to be the favorable approach to creating apps with Contentful.
I didn't find anything relating to the missing @contentful/app-scripts needed to properly upload via CLI in the documentation in https://www.contentful.com/developers/docs/extensibility/app-framework/create-contentful-app/

## Testing steps

None

## Breaking Changes

No

## Dependencies and/or References

This was my original issue, I didn't see any documentation on where or how to add @contentful/app-scripts as a package when creating a new app using a template or other than React in https://www.contentful.com/developers/docs/extensibility/app-framework/create-contentful-app/

## Deployment

No
