### PR TITLE
refactors shopify app installation parameter to be "shopName" instead of "apiEndpoint"

### DIFF
--- a/apps/ecommerce/frontend/src/components/Config/ConfigBody.tsx
+++ b/apps/ecommerce/frontend/src/components/Config/ConfigBody.tsx
@@ -67,6 +67,7 @@ const ConfigBody = (props: Props) => {
                       type={def.type === 'Symbol' ? 'text' : 'number'}
                       maxLength={255}
                       isRequired={def.required}
+                      placeholder={def.placeholder}
                       value={parameters?.[def.id] ?? ''}
                       onChange={onParameterChange.bind(this, def.id)}
                     />

--- a/apps/ecommerce/frontend/src/components/Config/ConfigPage.tsx
+++ b/apps/ecommerce/frontend/src/components/Config/ConfigPage.tsx
@@ -75,7 +75,7 @@ const ConfigPage = () => {
     const url = new URL(`${baseUrl}/healthcheck`);
     fetchWithSignedRequest(url, sdk.ids.app, cma, 'POST', {
       'X-Contentful-Data-Provider': sdk.parameters.instance.provider,
-      'x-contentful-shopify-domain': parameters.apiEndpoint,
+      'x-contentful-shopify-shop': parameters.shopName,
       'x-contentful-shopify-token': parameters.storefrontAccessToken,
     })
       .then((res) => {

--- a/apps/ecommerce/frontend/src/helpers/mockValue.ts
+++ b/apps/ecommerce/frontend/src/helpers/mockValue.ts
@@ -15,9 +15,6 @@ const mockValue = (sdk: FieldAppSDK) => {
       type: 'ResourceLink',
       linkType: sdk.parameters.instance.linkType,
     },
-    metadata: {
-      resourceType: 'Commerce:Product',
-    },
   } as ExternalResourceLink;
 };
 

--- a/apps/ecommerce/frontend/src/hooks/useExternalResource.tsx
+++ b/apps/ecommerce/frontend/src/hooks/useExternalResource.tsx
@@ -8,7 +8,7 @@ import { getResourceProviderAndType } from 'helpers/resourceProviderUtils';
 const useExternalResource = (resource?: ExternalResourceLink) => {
   const sdk = useSDK<FieldAppSDK>();
   const cma = useCMA();
-  const { storefrontAccessToken, apiEndpoint } = sdk.parameters.installation;
+  const { storefrontAccessToken, shopName } = sdk.parameters.installation;
 
   const [externalResource, setExternalResource] = useState<ExternalResource>({});
   const [isLoading, setIsLoading] = useState<boolean>(true);
@@ -30,7 +30,7 @@ const useExternalResource = (resource?: ExternalResourceLink) => {
         {
           'x-contentful-data-provider': resourceProvider.toLowerCase(),
           'X-Contentful-Data-Provider-BaseURL': sdk.parameters.instance.baseUrl,
-          'x-contentful-shopify-domain': apiEndpoint,
+          'x-contentful-shopify-shop': shopName,
           'x-contentful-shopify-token': storefrontAccessToken,
         },
         resource
@@ -38,7 +38,7 @@ const useExternalResource = (resource?: ExternalResourceLink) => {
 
       return data;
     },
-    [cma, sdk.ids.app, sdk.parameters.instance.baseUrl, apiEndpoint, storefrontAccessToken]
+    [cma, sdk.ids.app, sdk.parameters.instance.baseUrl, shopName, storefrontAccessToken]
   );
 
   useEffect(() => {

--- a/apps/ecommerce/frontend/src/types.ts
+++ b/apps/ecommerce/frontend/src/types.ts
@@ -41,9 +41,6 @@ export interface ExternalResourceLink {
     linkType: ExternalResourceLinkType;
     urn: string;
   };
-  metadata?: {
-    [key: string]: JSONValue;
-  };
 }
 
 export interface ExternalResource {
@@ -83,4 +80,5 @@ export interface ParameterDefinition {
   description: string;
   type: string;
   required: boolean;
+  placeholder?: string;
 }

--- a/apps/ecommerce/lambda/public/shopify/config.json
+++ b/apps/ecommerce/lambda/public/shopify/config.json
@@ -5,14 +5,16 @@
     {
       "id": "storefrontAccessToken",
       "name": "Storefront Access Token",
+      "placeholder": "a12bc3d45e678f91011ghi121314j15k",
       "description": "The storefront access token to your Shopify store",
       "type": "Symbol",
       "required": true
     },
     {
-      "id": "apiEndpoint",
-      "name": "API Endpoint",
-      "description": "The Shopify API endpoint",
+      "id": "shopName",
+      "name": "Shop Name",
+      "placeholder": "example-shop",
+      "description": "The shop name of your Shopify store",
       "type": "Symbol",
       "required": true
     }

--- a/apps/ecommerce/lambda/src/mocks/resourceLink.mock.ts
+++ b/apps/ecommerce/lambda/src/mocks/resourceLink.mock.ts
@@ -4,7 +4,4 @@ export const mockResourceLink = {
     linkType: 'Shopify:Product',
     urn: 'gid://shopify/Product/123456789',
   },
-  metadata: {
-    resourceType: 'Commerce:Product',
-  },
 };

--- a/apps/ecommerce/lambda/src/routers/shopifyRouter.spec.ts
+++ b/apps/ecommerce/lambda/src/routers/shopifyRouter.spec.ts
@@ -56,7 +56,7 @@ const shopifyClientStub = {
   },
 };
 
-const stubDomain = 'mytest-domain.myshopify.com';
+const shopName = 'mytest-shop';
 
 describe('Shopify Router', () => {
   beforeEach((done) => {
@@ -78,7 +78,7 @@ describe('Shopify Router', () => {
         .request(app)
         .post('/shopify/healthcheck')
         .set('X-Contentful-Data-Provider', 'shopify')
-        .set('x-contentful-shopify-domain', stubDomain)
+        .set('x-contentful-shopify-shop', shopName)
         .send({ sys: mockResourceLink.sys })
         .end((error, res) => {
           expect(res).to.have.status(200);
@@ -96,7 +96,7 @@ describe('Shopify Router', () => {
         .request(app)
         .post('/shopify/resource')
         .set('X-Contentful-Data-Provider', 'shopify')
-        .set('x-contentful-shopify-domain', stubDomain)
+        .set('x-contentful-shopify-shop', shopName)
         .send({ sys: mockResourceLink.sys })
         .end((error, res) => {
           expect(res).to.have.status(200);
@@ -119,7 +119,7 @@ describe('Shopify Router', () => {
         .request(app)
         .post('/shopify/resource')
         .set('X-Contentful-Data-Provider', 'shopify')
-        .set('x-contentful-shopify-domain', stubDomain)
+        .set('x-contentful-shopify-shop', shopName)
         .send({ sys: mockResourceLink.sys })
         .end((error, res) => {
           expect(res).to.have.status(404);

--- a/apps/ecommerce/lambda/src/types.ts
+++ b/apps/ecommerce/lambda/src/types.ts
@@ -14,9 +14,6 @@ export interface ExternalResourceLink {
     linkType: ExternalResourceLinkType;
     urn: string;
   };
-  metadata?: {
-    [key: string]: JSONValue;
-  };
 }
 
 export interface ExternalResource {


### PR DESCRIPTION
## Purpose
refactors shopify app installation parameter to be "shopName" instead of "apiEndpoint"
- also adds placeholder to `ParameterDefinition` interface

![image](https://github.com/contentful/apps/assets/492573/f4ff2e0f-c724-4a6e-af2b-1e9e50448a70)
