### PR TITLE
Adding Storefront Catalog to base parameters for SFCC app.

### DIFF
--- a/apps/salesforce-commerce-cloud/src/components/dialog/CategorySearchResults.tsx
+++ b/apps/salesforce-commerce-cloud/src/components/dialog/CategorySearchResults.tsx
@@ -13,7 +13,7 @@ import {
   headerHeight,
 } from './SearchPicker';
 
-const CategorySearchResults = (props:SearchResultsProps) => {
+const CategorySearchResults = (props: SearchResultsProps) => {
   const resultsWrapperStyle = css`
     max-height: ${height}px;
     padding: ${tokens.spacingL};
@@ -21,12 +21,12 @@ const CategorySearchResults = (props:SearchResultsProps) => {
     @media screen and (min-height: ${stickyHeaderBreakpoint}px;) {
       padding-top: ${tokens.spacingL + headerHeight}px;
     }
-  `
-  
+  `;
+
   return (
-    <Box as="section" css={resultsWrapperStyle} >
+    <Box as="section" css={resultsWrapperStyle}>
       {props.searchResults.map((result) => (
-        <CategorySearchResult 
+        <CategorySearchResult
           key={`${result.catalogId}:${result.id}`}
           fieldType={props.fieldType}
           onItemSelect={props.onItemSelect}
@@ -35,15 +35,15 @@ const CategorySearchResults = (props:SearchResultsProps) => {
         />
       ))}
     </Box>
-  )
-}
-  
-const CategorySearchResult = (props:SearchResultProps) => {
-  const { result, onItemSelect, selected } = props
-  
+  );
+};
+
+const CategorySearchResult = (props: SearchResultProps) => {
+  const { result, onItemSelect, selected } = props;
+
   const categoryStyle = css`
-    margin-left: ${tokens.spacingXs}
-  `
+    margin-left: ${tokens.spacingXs};
+  `;
 
   return (
     <Card
@@ -51,25 +51,32 @@ const CategorySearchResult = (props:SearchResultProps) => {
       padding="none"
       marginBottom="spacingS"
       onClick={() => onItemSelect(result.id)}
-      isSelected={selected?.includes(result.id)}
-    >
+      isSelected={selected?.includes(result.id)}>
       <Flex flexDirection="column">
         <Flex alignItems="center" padding="spacingXs">
           <TagsIcon />
           <Flex flexDirection="column" marginLeft="spacingS">
-            <Text as="div" fontWeight="fontWeightDemiBold" fontSize='fontSizeM'>
+            <Text as="div" fontWeight="fontWeightDemiBold" fontSize="fontSizeM">
               {result.name.default}
             </Text>
-            <Text as="div" fontWeight="fontWeightMedium" fontSize='fontSizeS' fontColor='gray600'>
+            <Text as="div" fontWeight="fontWeightMedium" fontSize="fontSizeS" fontColor="gray600">
               ID: {result.id}
-              <Box as="span" css={css`margin-left: ${tokens.spacingXs};`}>|</Box>
-              <Box as="span" css={categoryStyle}>Catalog: {result.name?.default ? result.name.default : result.catalogId}</Box>
+              <Box
+                as="span"
+                css={css`
+                  margin-left: ${tokens.spacingXs};
+                `}>
+                |
+              </Box>
+              <Box as="span" css={categoryStyle}>
+                Catalog: {result.name?.default ? result.name.default : result.catalogId}
+              </Box>
             </Text>
           </Flex>
         </Flex>
       </Flex>
     </Card>
-  )
-}
+  );
+};
 
-export default CategorySearchResults
+export default CategorySearchResults;

--- a/apps/salesforce-commerce-cloud/src/components/dialog/CategorySearchResults.tsx
+++ b/apps/salesforce-commerce-cloud/src/components/dialog/CategorySearchResults.tsx
@@ -13,7 +13,7 @@ import {
   headerHeight,
 } from './SearchPicker';
 
-const CategorySearchResults = (props: SearchResultsProps) => {
+const CategorySearchResults = (props:SearchResultsProps) => {
   const resultsWrapperStyle = css`
     max-height: ${height}px;
     padding: ${tokens.spacingL};
@@ -21,12 +21,12 @@ const CategorySearchResults = (props: SearchResultsProps) => {
     @media screen and (min-height: ${stickyHeaderBreakpoint}px;) {
       padding-top: ${tokens.spacingL + headerHeight}px;
     }
-  `;
-
+  `
+  
   return (
-    <Box as="section" css={resultsWrapperStyle}>
+    <Box as="section" css={resultsWrapperStyle} >
       {props.searchResults.map((result) => (
-        <CategorySearchResult
+        <CategorySearchResult 
           key={`${result.catalogId}:${result.id}`}
           fieldType={props.fieldType}
           onItemSelect={props.onItemSelect}
@@ -35,49 +35,41 @@ const CategorySearchResults = (props: SearchResultsProps) => {
         />
       ))}
     </Box>
-  );
-};
-
-const CategorySearchResult = (props: SearchResultProps) => {
-  const { result, fieldType, onItemSelect, selected } = props;
-  const resultId = fieldType === 'product' ? result.id : `${result.catalogId}:${result.id}`;
-
+  )
+}
+  
+const CategorySearchResult = (props:SearchResultProps) => {
+  const { result, onItemSelect, selected } = props
+  
   const categoryStyle = css`
-    margin-left: ${tokens.spacingXs};
-  `;
+    margin-left: ${tokens.spacingXs}
+  `
 
   return (
     <Card
-      id={resultId}
+      id={result.id}
       padding="none"
       marginBottom="spacingS"
-      onClick={() => onItemSelect(resultId)}
-      isSelected={selected?.includes(resultId)}>
+      onClick={() => onItemSelect(result.id)}
+      isSelected={selected?.includes(result.id)}
+    >
       <Flex flexDirection="column">
         <Flex alignItems="center" padding="spacingXs">
           <TagsIcon />
           <Flex flexDirection="column" marginLeft="spacingS">
-            <Text as="div" fontWeight="fontWeightDemiBold" fontSize="fontSizeM">
+            <Text as="div" fontWeight="fontWeightDemiBold" fontSize='fontSizeM'>
               {result.name.default}
             </Text>
-            <Text as="div" fontWeight="fontWeightMedium" fontSize="fontSizeS" fontColor="gray600">
+            <Text as="div" fontWeight="fontWeightMedium" fontSize='fontSizeS' fontColor='gray600'>
               ID: {result.id}
-              <Box
-                as="span"
-                css={css`
-                  margin-left: ${tokens.spacingXs};
-                `}>
-                |
-              </Box>
-              <Box as="span" css={categoryStyle}>
-                Catalog: {result.name?.default ? result.name.default : result.catalogId}
-              </Box>
+              <Box as="span" css={css`margin-left: ${tokens.spacingXs};`}>|</Box>
+              <Box as="span" css={categoryStyle}>Catalog: {result.name?.default ? result.name.default : result.catalogId}</Box>
             </Text>
           </Flex>
         </Flex>
       </Flex>
     </Card>
-  );
-};
+  )
+}
 
-export default CategorySearchResults;
+export default CategorySearchResults

--- a/apps/salesforce-commerce-cloud/src/components/dialog/ProductSearchResults.tsx
+++ b/apps/salesforce-commerce-cloud/src/components/dialog/ProductSearchResults.tsx
@@ -45,25 +45,26 @@ const ProductSearchResults = (props: SearchResultsProps) => {
   );
 };
 
-const ProductSearchResult = (props:SearchResultProps) => {
-  const { result, fieldType, onItemSelect, selected } = props
-  const resultId = fieldType === 'product' ? result.id : `${result.catalogId}:${result.id}`
-  const isSelected = typeof selected === 'string' ? result.id === selected : selected?.includes(resultId)
+const ProductSearchResult = (props: SearchResultProps) => {
+  const { result, fieldType, onItemSelect, selected } = props;
+  const resultId = fieldType === 'product' ? result.id : `${result.catalogId}:${result.id}`;
+  const isSelected =
+    typeof selected === 'string' ? result.id === selected : selected?.includes(resultId);
 
-  const [imageHasLoaded, setImageHasLoaded] = useState<boolean>(false)
-  const [imageHasErrored, setImageHasErrored] = useState<boolean>(false)
+  const [imageHasLoaded, setImageHasLoaded] = useState<boolean>(false);
+  const [imageHasErrored, setImageHasErrored] = useState<boolean>(false);
 
   const productWrapperStyles = css`
     flex: 0 0 calc(50% - ${parseFloat(tokens.spacingS) * 2}rem);
     padding: ${tokens.spacingS};
     position: relative;
     @media screen and (min-width: 767px) {
-      flex: 0 0 calc(33.3% - ${parseFloat(tokens.spacingS) * 2}rem)
+      flex: 0 0 calc(33.3% - ${parseFloat(tokens.spacingS) * 2}rem);
     }
     @media screen and (min-width: 992px) {
-      flex: 0 0 calc(25% - ${parseFloat(tokens.spacingS) * 2}rem)
+      flex: 0 0 calc(25% - ${parseFloat(tokens.spacingS) * 2}rem);
     }
-  `
+  `;
 
   const productStyles = css`
     border: 1px solid ${tokens.gray200};
@@ -81,7 +82,7 @@ const ProductSearchResult = (props:SearchResultProps) => {
       border-color: ${tokens.gray400};
       cursor: pointer;
     }
-  `
+  `;
 
   const selectedProductStyles = css`
     border-color: rgba(48, 114, 190, 1);
@@ -90,18 +91,18 @@ const ProductSearchResult = (props:SearchResultProps) => {
       border-color: rgba(48, 114, 190, 1);
       cursor: pointer;
     }
-  `
+  `;
 
   const skeletonImageStyles = css`
     width: 100%;
     height: 290px;
-  `
+  `;
 
   const resultNameStyles = css`
     flex: 1 0 auto;
     font-weight: ${tokens.fontWeightDemiBold};
     text-transform: capitalize;
-  `
+  `;
 
   const resultIdStyles = css`
     flex: 0 1 auto;
@@ -113,37 +114,38 @@ const ProductSearchResult = (props:SearchResultProps) => {
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;
-  `
+  `;
 
-  const productStylesCss = [productStyles]
+  const productStylesCss = [productStyles];
   if (isSelected) {
-    productStylesCss.push(selectedProductStyles)
+    productStylesCss.push(selectedProductStyles);
   }
 
   return (
-    <Flex css={productWrapperStyles} >
+    <Flex css={productWrapperStyles}>
       <div
         data-test-id={`item-preview-${resultId}`}
         role="switch"
         aria-checked={isSelected}
         tabIndex={-1}
         onClick={() => onItemSelect(resultId)}
-        css={productStylesCss}
-      >
+        css={productStylesCss}>
         {!imageHasLoaded && !imageHasErrored && (
-          <SkeletonContainer css={skeletonImageStyles} >
+          <SkeletonContainer css={skeletonImageStyles}>
             <SkeletonImage width={400} height={290} />
           </SkeletonContainer>
         )}
         {imageHasErrored && (
-          <div><AssetIcon /></div>
+          <div>
+            <AssetIcon />
+          </div>
         )}
         {!imageHasErrored && (
           <div>
             <img
               onLoad={() => setImageHasLoaded(true)}
               onError={() => setImageHasErrored(true)}
-              style={{display: imageHasLoaded ? 'block' : 'none'}}
+              style={{ display: imageHasLoaded ? 'block' : 'none' }}
               src={result.image?.absUrl}
               alt={result.image?.alt.default}
               data-test-id="image"
@@ -152,12 +154,10 @@ const ProductSearchResult = (props:SearchResultProps) => {
         )}
         <p css={resultNameStyles}>{result.name.default}</p>
         <p css={resultIdStyles}>ID: {result.id}</p>
-        {fieldType === 'category' && (
-          <p css={resultIdStyles}>Catalog ID: {result.catalogId}</p>
-        )}
+        {fieldType === 'category' && <p css={resultIdStyles}>Catalog ID: {result.catalogId}</p>}
       </div>
     </Flex>
-  )
-}
-  
-export default ProductSearchResults
+  );
+};
+
+export default ProductSearchResults;

--- a/apps/salesforce-commerce-cloud/src/components/dialog/ProductSearchResults.tsx
+++ b/apps/salesforce-commerce-cloud/src/components/dialog/ProductSearchResults.tsx
@@ -45,26 +45,25 @@ const ProductSearchResults = (props: SearchResultsProps) => {
   );
 };
 
-const ProductSearchResult = (props: SearchResultProps) => {
-  const { result, fieldType, onItemSelect, selected } = props;
-  const resultId = fieldType === 'product' ? result.id : `${result.catalogId}:${result.id}`;
-  const isSelected =
-    typeof selected === 'string' ? result.id === selected : selected?.includes(resultId);
+const ProductSearchResult = (props:SearchResultProps) => {
+  const { result, fieldType, onItemSelect, selected } = props
+  const resultId = fieldType === 'product' ? result.id : `${result.catalogId}:${result.id}`
+  const isSelected = typeof selected === 'string' ? result.id === selected : selected?.includes(resultId)
 
-  const [imageHasLoaded, setImageHasLoaded] = useState<boolean>(false);
-  const [imageHasErrored, setImageHasErrored] = useState<boolean>(false);
+  const [imageHasLoaded, setImageHasLoaded] = useState<boolean>(false)
+  const [imageHasErrored, setImageHasErrored] = useState<boolean>(false)
 
   const productWrapperStyles = css`
     flex: 0 0 calc(50% - ${parseFloat(tokens.spacingS) * 2}rem);
     padding: ${tokens.spacingS};
     position: relative;
     @media screen and (min-width: 767px) {
-      flex: 0 0 calc(33.3% - ${parseFloat(tokens.spacingS) * 2}rem);
+      flex: 0 0 calc(33.3% - ${parseFloat(tokens.spacingS) * 2}rem)
     }
     @media screen and (min-width: 992px) {
-      flex: 0 0 calc(25% - ${parseFloat(tokens.spacingS) * 2}rem);
+      flex: 0 0 calc(25% - ${parseFloat(tokens.spacingS) * 2}rem)
     }
-  `;
+  `
 
   const productStyles = css`
     border: 1px solid ${tokens.gray200};
@@ -82,7 +81,7 @@ const ProductSearchResult = (props: SearchResultProps) => {
       border-color: ${tokens.gray400};
       cursor: pointer;
     }
-  `;
+  `
 
   const selectedProductStyles = css`
     border-color: rgba(48, 114, 190, 1);
@@ -91,18 +90,18 @@ const ProductSearchResult = (props: SearchResultProps) => {
       border-color: rgba(48, 114, 190, 1);
       cursor: pointer;
     }
-  `;
+  `
 
   const skeletonImageStyles = css`
     width: 100%;
     height: 290px;
-  `;
+  `
 
   const resultNameStyles = css`
     flex: 1 0 auto;
     font-weight: ${tokens.fontWeightDemiBold};
     text-transform: capitalize;
-  `;
+  `
 
   const resultIdStyles = css`
     flex: 0 1 auto;
@@ -114,50 +113,51 @@ const ProductSearchResult = (props: SearchResultProps) => {
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;
-  `;
+  `
 
-  const productStylesCss = [productStyles];
+  const productStylesCss = [productStyles]
   if (isSelected) {
-    productStylesCss.push(selectedProductStyles);
+    productStylesCss.push(selectedProductStyles)
   }
 
   return (
-    <Flex css={productWrapperStyles}>
+    <Flex css={productWrapperStyles} >
       <div
         data-test-id={`item-preview-${resultId}`}
         role="switch"
         aria-checked={isSelected}
         tabIndex={-1}
         onClick={() => onItemSelect(resultId)}
-        css={productStylesCss}>
+        css={productStylesCss}
+      >
         {!imageHasLoaded && !imageHasErrored && (
-          <SkeletonContainer css={skeletonImageStyles}>
+          <SkeletonContainer css={skeletonImageStyles} >
             <SkeletonImage width={400} height={290} />
           </SkeletonContainer>
         )}
         {imageHasErrored && (
-          <div>
-            <AssetIcon />
-          </div>
+          <div><AssetIcon /></div>
         )}
         {!imageHasErrored && (
           <div>
             <img
               onLoad={() => setImageHasLoaded(true)}
               onError={() => setImageHasErrored(true)}
-              style={{ display: imageHasLoaded ? 'block' : 'none' }}
-              src={result.image.absUrl}
-              alt={result.image.alt.default}
+              style={{display: imageHasLoaded ? 'block' : 'none'}}
+              src={result.image?.absUrl}
+              alt={result.image?.alt.default}
               data-test-id="image"
             />
           </div>
         )}
         <p css={resultNameStyles}>{result.name.default}</p>
         <p css={resultIdStyles}>ID: {result.id}</p>
-        {fieldType === 'category' && <p css={resultIdStyles}>Catalog ID: {result.catalogId}</p>}
+        {fieldType === 'category' && (
+          <p css={resultIdStyles}>Catalog ID: {result.catalogId}</p>
+        )}
       </div>
     </Flex>
-  );
-};
-
-export default ProductSearchResults;
+  )
+}
+  
+export default ProductSearchResults

--- a/apps/salesforce-commerce-cloud/src/components/dialog/SearchBar.tsx
+++ b/apps/salesforce-commerce-cloud/src/components/dialog/SearchBar.tsx
@@ -4,7 +4,7 @@ import { css } from '@emotion/react';
 import {
   Flex,
   Box,
-  /* Text, */ TextInput,
+  TextInput,
   Spinner,
   Button,
   Tooltip,
@@ -133,17 +133,12 @@ interface SelectionListProps {
   fieldType: 'product' | 'category';
 }
 
-const SelectionList = (props: SelectionListProps) => {
-  const items: string[] | undefined = typeof props.items === 'string' ? [props.items] : props.items;
-
-  // console.log(props)
-  const findItemData = (itemId: string, fieldType: 'product' | 'category', itemsInfo?: any[]) => {
+const SelectionList = (props:SelectionListProps) => {
+  const items:string[] | undefined = typeof props.items === 'string' ? [props.items] : props.items 
+  
+  const findItemData = (itemId:string, fieldType: 'product' | 'category', itemsInfo?:any[]) => {
     if (itemsInfo?.length) {
-      return itemsInfo.find((item) => {
-        return fieldType === 'product'
-          ? item.id === itemId
-          : `${item.catalogId}:${item.id}` === itemId;
-      });
+      return itemsInfo.find((item) => item.id === itemId )
     }
   };
 

--- a/apps/salesforce-commerce-cloud/src/components/dialog/SearchBar.tsx
+++ b/apps/salesforce-commerce-cloud/src/components/dialog/SearchBar.tsx
@@ -1,15 +1,7 @@
 import React, { useState } from 'react';
 import { css } from '@emotion/react';
 
-import {
-  Flex,
-  Box,
-  TextInput,
-  Spinner,
-  Button,
-  Tooltip,
-  Grid,
-} from '@contentful/f36-components';
+import { Flex, Box, TextInput, Spinner, Button, Tooltip, Grid } from '@contentful/f36-components';
 import { SearchIcon, CloseIcon, ErrorCircleIcon, AssetIcon, TagsIcon } from '@contentful/f36-icons';
 import tokens from '@contentful/f36-tokens';
 import { useSDK } from '@contentful/react-apps-toolkit';
@@ -133,12 +125,12 @@ interface SelectionListProps {
   fieldType: 'product' | 'category';
 }
 
-const SelectionList = (props:SelectionListProps) => {
-  const items:string[] | undefined = typeof props.items === 'string' ? [props.items] : props.items 
-  
-  const findItemData = (itemId:string, fieldType: 'product' | 'category', itemsInfo?:any[]) => {
+const SelectionList = (props: SelectionListProps) => {
+  const items: string[] | undefined = typeof props.items === 'string' ? [props.items] : props.items;
+
+  const findItemData = (itemId: string, fieldType: 'product' | 'category', itemsInfo?: any[]) => {
     if (itemsInfo?.length) {
-      return itemsInfo.find((item) => item.id === itemId )
+      return itemsInfo.find((item) => item.id === itemId);
     }
   };
 

--- a/apps/salesforce-commerce-cloud/src/components/dialog/SearchPicker.tsx
+++ b/apps/salesforce-commerce-cloud/src/components/dialog/SearchPicker.tsx
@@ -6,12 +6,12 @@ import { useSDK } from '@contentful/react-apps-toolkit';
 import { DialogAppSDK } from '@contentful/app-sdk';
 
 // Local Imports
-import SfccClient from '../../utils/Sfcc';
-import SearchBar from './SearchBar';
-import ProductSearchResults from './ProductSearchResults';
-import CategorySearchResults from './CategorySearchResults';
-import { AppInstallationParameters } from '../../locations/ConfigScreen';
-import { DialogInvocationParameters } from '../../locations/Dialog';
+import { SfccClient } from '../../utils/Sfcc';
+import SearchBar from './SearchBar'
+import ProductSearchResults from './ProductSearchResults'
+import CategorySearchResults from './CategorySearchResults'
+import { AppInstallationParameters } from '../../locations/ConfigScreen'
+import { DialogInvocationParameters } from '../../locations/Dialog'
 
 export const headerHeight = 114;
 export const stickyHeaderBreakpoint = 900;
@@ -37,35 +37,29 @@ const SearchPicker = () => {
     sdk.close(selected);
   };
 
-  const findSearchResultData = (id: string) => {
-    return searchResults.find((item) => {
-      return fieldType === 'product' ? item.id === id : `${item.catalogId}:${item.id}` === id;
-    });
-  };
+  const findSearchResultData = (id:string ) => {
+    return searchResults.find((item) => item.id === id)
+  }
 
-  const onItemSelect = (id: string) => {
-    if (selectMultiple) {
-      // Multivalue
-      if (!selected?.length) {
-        // Empty array, Initial Value
-        setSelected([id]);
-        setSelectedItemsInfo([findSearchResultData(id)]);
-      } else {
-        // Array exists, modify it
-
-        const updateSelected = [...selected];
-        let updateSelectedData = [];
-        const includedIndex = updateSelected.findIndex((item) => item === id);
-        if (includedIndex > -1) {
-          // Item exists in array, unset it
-          updateSelected.splice(includedIndex, 1);
-          updateSelectedData = selectedData.filter((item) => {
-            return fieldType === 'product' ? item.id === id : `${item.catalogId}:${item.id}` === id;
-          });
-        } else {
-          console.log('Item not found.');
-          updateSelected.push(id);
-          updateSelectedData = [...selectedData, findSearchResultData(id)];
+  const onItemSelect = (id:string) => {
+    if (selectMultiple) { // Multivalue
+      if (!selected?.length) { // Empty array, Initial Value
+        setSelected([id])
+        setSelectedItemsInfo([findSearchResultData(id)])
+      }
+      else { // Array exists, modify it
+        
+        const updateSelected = [...selected]
+        let updateSelectedData = []
+        const includedIndex = updateSelected.findIndex((item) => item === id)
+        if (includedIndex > -1) { // Item exists in array, unset it
+          updateSelected.splice(includedIndex, 1)
+          updateSelectedData = selectedData.filter((item) => item.id === id)
+        }
+        else {
+          console.log('Item not found.')
+          updateSelected.push(id)
+          updateSelectedData = [...selectedData, findSearchResultData(id)]
         }
 
         setSelected(updateSelected);

--- a/apps/salesforce-commerce-cloud/src/components/dialog/SearchPicker.tsx
+++ b/apps/salesforce-commerce-cloud/src/components/dialog/SearchPicker.tsx
@@ -7,11 +7,11 @@ import { DialogAppSDK } from '@contentful/app-sdk';
 
 // Local Imports
 import { SfccClient } from '../../utils/Sfcc';
-import SearchBar from './SearchBar'
-import ProductSearchResults from './ProductSearchResults'
-import CategorySearchResults from './CategorySearchResults'
-import { AppInstallationParameters } from '../../locations/ConfigScreen'
-import { DialogInvocationParameters } from '../../locations/Dialog'
+import SearchBar from './SearchBar';
+import ProductSearchResults from './ProductSearchResults';
+import CategorySearchResults from './CategorySearchResults';
+import { AppInstallationParameters } from '../../locations/ConfigScreen';
+import { DialogInvocationParameters } from '../../locations/Dialog';
 
 export const headerHeight = 114;
 export const stickyHeaderBreakpoint = 900;
@@ -37,29 +37,31 @@ const SearchPicker = () => {
     sdk.close(selected);
   };
 
-  const findSearchResultData = (id:string ) => {
-    return searchResults.find((item) => item.id === id)
-  }
+  const findSearchResultData = (id: string) => {
+    return searchResults.find((item) => item.id === id);
+  };
 
-  const onItemSelect = (id:string) => {
-    if (selectMultiple) { // Multivalue
-      if (!selected?.length) { // Empty array, Initial Value
-        setSelected([id])
-        setSelectedItemsInfo([findSearchResultData(id)])
-      }
-      else { // Array exists, modify it
-        
-        const updateSelected = [...selected]
-        let updateSelectedData = []
-        const includedIndex = updateSelected.findIndex((item) => item === id)
-        if (includedIndex > -1) { // Item exists in array, unset it
-          updateSelected.splice(includedIndex, 1)
-          updateSelectedData = selectedData.filter((item) => item.id === id)
-        }
-        else {
-          console.log('Item not found.')
-          updateSelected.push(id)
-          updateSelectedData = [...selectedData, findSearchResultData(id)]
+  const onItemSelect = (id: string) => {
+    if (selectMultiple) {
+      // Multivalue
+      if (!selected?.length) {
+        // Empty array, Initial Value
+        setSelected([id]);
+        setSelectedItemsInfo([findSearchResultData(id)]);
+      } else {
+        // Array exists, modify it
+
+        const updateSelected = [...selected];
+        let updateSelectedData = [];
+        const includedIndex = updateSelected.findIndex((item) => item === id);
+        if (includedIndex > -1) {
+          // Item exists in array, unset it
+          updateSelected.splice(includedIndex, 1);
+          updateSelectedData = selectedData.filter((item) => item.id === id);
+        } else {
+          console.log('Item not found.');
+          updateSelected.push(id);
+          updateSelectedData = [...selectedData, findSearchResultData(id)];
         }
 
         setSelected(updateSelected);

--- a/apps/salesforce-commerce-cloud/src/components/field/ItemCard.tsx
+++ b/apps/salesforce-commerce-cloud/src/components/field/ItemCard.tsx
@@ -11,7 +11,7 @@ import { FieldAppSDK } from '@contentful/app-sdk';
 
 // Local Imports
 import { AppInstallationParameters } from '../../locations/ConfigScreen';
-import SfccClient from '../../utils/Sfcc';
+import { SfccClient } from '../../utils/Sfcc';
 
 interface ItemProps {
   id: string;
@@ -32,13 +32,12 @@ const ItemCard = (props: ItemCardProps) => {
   const installParameters = sdk.parameters.installation as AppInstallationParameters;
   const client = new SfccClient(installParameters);
 
-  const [itemId, catalogId] = props.id.split(':');
-  const { isLoading, data: itemData } = useQuery({
+  // const [itemId, catalogId] = props.id.split(":")
+  const {isLoading, data: itemData } = useQuery({
     queryKey: ['itemInfo', props.id],
-    queryFn:
-      props.type === 'product'
-        ? () => client.fetchProduct(itemId)
-        : () => client.fetchCategory(itemId, catalogId),
+    queryFn: props.type === 'product' ?
+             () => client.fetchProduct(props.id) : 
+             () => client.fetchCategory(props.id)
   });
 
   return (

--- a/apps/salesforce-commerce-cloud/src/components/field/ItemCard.tsx
+++ b/apps/salesforce-commerce-cloud/src/components/field/ItemCard.tsx
@@ -33,11 +33,12 @@ const ItemCard = (props: ItemCardProps) => {
   const client = new SfccClient(installParameters);
 
   // const [itemId, catalogId] = props.id.split(":")
-  const {isLoading, data: itemData } = useQuery({
+  const { isLoading, data: itemData } = useQuery({
     queryKey: ['itemInfo', props.id],
-    queryFn: props.type === 'product' ?
-             () => client.fetchProduct(props.id) : 
-             () => client.fetchCategory(props.id)
+    queryFn:
+      props.type === 'product'
+        ? () => client.fetchProduct(props.id)
+        : () => client.fetchCategory(props.id),
   });
 
   return (

--- a/apps/salesforce-commerce-cloud/src/components/field/SelectItemAction.tsx
+++ b/apps/salesforce-commerce-cloud/src/components/field/SelectItemAction.tsx
@@ -9,8 +9,8 @@ import { Flex, Button } from '@contentful/f36-components';
 import { ShoppingCartIcon } from '@contentful/f36-icons';
 import tokens from '@contentful/f36-tokens';
 
-import { AppInstanceParameters } from '../../locations/Field'
-import logo from '../../Salesforce_Corporate_Logo_RGB.png'
+import { AppInstanceParameters } from '../../locations/Field';
+import logo from '../../Salesforce_Corporate_Logo_RGB.png';
 import { SfccClient } from '../../utils/Sfcc';
 import { AppInstallationParameters } from '../../locations/ConfigScreen';
 import { DialogInvocationParameters } from '../../locations/Dialog';
@@ -38,15 +38,14 @@ const SelectItemAction = (props: { fieldValue?: string | string[] }) => {
 
   const client = new SfccClient(installParameters);
   const currentItemQueries = useQueries({
-    queries: queryArray.map((id:string) => {
+    queries: queryArray.map((id: string) => {
       // const [itemId, catalogId] = id.split(":")
       return {
         queryKey: ['itemInfo', id],
-        queryFn: fieldType === 'product' ? 
-                 () => client.fetchProduct(id) :
-                 () => client.fetchCategory(id)
-      }
-    })
+        queryFn:
+          fieldType === 'product' ? () => client.fetchProduct(id) : () => client.fetchCategory(id),
+      };
+    }),
   });
 
   const queriesComplete = currentItemQueries.every((query) => query.isSuccess || query.isError);

--- a/apps/salesforce-commerce-cloud/src/components/field/SelectItemAction.tsx
+++ b/apps/salesforce-commerce-cloud/src/components/field/SelectItemAction.tsx
@@ -9,9 +9,9 @@ import { Flex, Button } from '@contentful/f36-components';
 import { ShoppingCartIcon } from '@contentful/f36-icons';
 import tokens from '@contentful/f36-tokens';
 
-import { AppInstanceParameters } from '../../locations/Field';
-import logo from '../../Salesforce_Corporate_Logo_RGB.png';
-import SfccClient from '../../utils/Sfcc';
+import { AppInstanceParameters } from '../../locations/Field'
+import logo from '../../Salesforce_Corporate_Logo_RGB.png'
+import { SfccClient } from '../../utils/Sfcc';
 import { AppInstallationParameters } from '../../locations/ConfigScreen';
 import { DialogInvocationParameters } from '../../locations/Dialog';
 
@@ -38,16 +38,15 @@ const SelectItemAction = (props: { fieldValue?: string | string[] }) => {
 
   const client = new SfccClient(installParameters);
   const currentItemQueries = useQueries({
-    queries: queryArray.map((id: string) => {
-      const [itemId, catalogId] = id.split(':');
+    queries: queryArray.map((id:string) => {
+      // const [itemId, catalogId] = id.split(":")
       return {
-        queryKey: ['itemInfo', itemId],
-        queryFn:
-          fieldType === 'product'
-            ? () => client.fetchProduct(itemId)
-            : () => client.fetchCategory(itemId, catalogId),
-      };
-    }),
+        queryKey: ['itemInfo', id],
+        queryFn: fieldType === 'product' ? 
+                 () => client.fetchProduct(id) :
+                 () => client.fetchCategory(id)
+      }
+    })
   });
 
   const queriesComplete = currentItemQueries.every((query) => query.isSuccess || query.isError);

--- a/apps/salesforce-commerce-cloud/src/locations/ConfigScreen.tsx
+++ b/apps/salesforce-commerce-cloud/src/locations/ConfigScreen.tsx
@@ -50,17 +50,11 @@ const ConfigScreen = () => {
     // related to this app installation
     const currentState = await sdk.app.getCurrentState();
 
-    const paramKeys = [
-      "clientId",
-      "clientSecret",
-      "organizationId",
-      "shortCode",
-      "siteId"
-    ]
+    const paramKeys = ['clientId', 'clientSecret', 'organizationId', 'shortCode', 'siteId'];
     //Ensure we have actual values for each of the parameters.
     const isValid = paramKeys.every(
-      (key:string) => parameters[key as keyof SalesforceConfig]?.length
-    )
+      (key: string) => parameters[key as keyof SalesforceConfig]?.length
+    );
     // let isValid = true
     // const validUpdate:any = {}
     // for (const key of Object.keys(valid)) {
@@ -79,12 +73,12 @@ const ConfigScreen = () => {
       return false;
     }
 
-    const client = new SfccClient(parameters)
-    const storefrontCatalog = await client.fetchStorefrontCatalog()
+    const client = new SfccClient(parameters);
+    const storefrontCatalog = await client.fetchStorefrontCatalog();
 
     return {
       // Parameters to be persisted as the app configuration.
-      parameters: {...parameters, storefrontCatalogId: storefrontCatalog.id},
+      parameters: { ...parameters, storefrontCatalogId: storefrontCatalog.id },
       // In case you don't want to submit any update to app
       // locations, you can just pass the currentState as is
       targetState: currentState,

--- a/apps/salesforce-commerce-cloud/src/utils/Sfcc.tsx
+++ b/apps/salesforce-commerce-cloud/src/utils/Sfcc.tsx
@@ -1,4 +1,4 @@
-import axios, { AxiosInstance, InternalAxiosRequestConfig } from 'axios'
+import axios, { AxiosInstance, InternalAxiosRequestConfig } from 'axios';
 // import { AppInstallationParameters } from "../locations/ConfigScreen"
 
 export interface SalesforceConfig {
@@ -26,14 +26,14 @@ interface TokenProps {
 }
 
 export class SfccClient {
-  protected client!: AxiosInstance
-  protected parameters: SalesforceConfig
-  protected accessToken: TokenProps | undefined
-  protected storefrontCatalogId: string | undefined
-  
-  constructor (parameters:SalesforceConfig) {
-    this.parameters = parameters
-    
+  protected client!: AxiosInstance;
+  protected parameters: SalesforceConfig;
+  protected accessToken: TokenProps | undefined;
+  protected storefrontCatalogId: string | undefined;
+
+  constructor(parameters: SalesforceConfig) {
+    this.parameters = parameters;
+
     this.client = axios.create({
       baseURL: proxyUrl,
       headers: {
@@ -112,33 +112,36 @@ export class SfccClient {
   };
 
   public fetchStorefrontCatalog = async () => {
-    const { organizationId, siteId } = this.parameters
+    const { organizationId, siteId } = this.parameters;
 
-    const postData:any = {
+    const postData: any = {
       query: {
         termQuery: {
           fields: ['is_storefront_catalog'],
           operator: 'is',
-          values: [ true ]
-        }
-      }
-    }
+          values: [true],
+        },
+      },
+    };
 
-    const {data: catalogSearchResults} = await this.client.post(`/product/catalogs/v1/organizations/${organizationId}/catalog-search`, postData)
+    const { data: catalogSearchResults } = await this.client.post(
+      `/product/catalogs/v1/organizations/${organizationId}/catalog-search`,
+      postData
+    );
 
-    const storefrontCatalogArray = catalogSearchResults.hits.filter((catalog:any) => {
-      return catalog.assignedSites.some((site:any) => site.id === siteId)
-    })
-    
-    return storefrontCatalogArray[0]
-  }
+    const storefrontCatalogArray = catalogSearchResults.hits.filter((catalog: any) => {
+      return catalog.assignedSites.some((site: any) => site.id === siteId);
+    });
 
-  searchProducts = async (query?:string) => {
+    return storefrontCatalogArray[0];
+  };
+
+  searchProducts = async (query?: string) => {
     if (!this.parameters.storefrontCatalogId) {
-      throw new Error('No storefront catalog id set in client.')
+      throw new Error('No storefront catalog id set in client.');
     }
 
-    const { organizationId, storefrontCatalogId } = this.parameters
+    const { organizationId, storefrontCatalogId } = this.parameters;
 
     const data: any = {
       query: {
@@ -146,20 +149,20 @@ export class SfccClient {
           must: [
             {
               termQuery: {
-                fields: ["type"],
-                operator: "is",
-                values: [ "master" ]
-              }
+                fields: ['type'],
+                operator: 'is',
+                values: ['master'],
+              },
             },
             {
               termQuery: {
-                fields: [ "catalogId"],
-                operator: "is",
-                values: [ storefrontCatalogId ]
-              }
-            }
-          ]
-        }
+                fields: ['catalogId'],
+                operator: 'is',
+                values: [storefrontCatalogId],
+              },
+            },
+          ],
+        },
       },
       sorts: [
         {
@@ -189,12 +192,12 @@ export class SfccClient {
     return searchResults.hits?.length ? searchResults.hits : [];
   };
 
-  public searchCategories = async (query?:string) => {
+  public searchCategories = async (query?: string) => {
     if (!this.parameters.storefrontCatalogId) {
-      throw new Error('No storefront catalog id set in client.')
+      throw new Error('No storefront catalog id set in client.');
     }
 
-    const { organizationId, storefrontCatalogId } = this.parameters
+    const { organizationId, storefrontCatalogId } = this.parameters;
 
     const data: any = {
       query: {
@@ -226,29 +229,31 @@ export class SfccClient {
         },
       });
     }
-    
-    const { data: searchResults } = await this.client.post(`/product/catalogs/v1/organizations/${organizationId}/catalogs/${storefrontCatalogId}/category-search`, data)
+
+    const { data: searchResults } = await this.client.post(
+      `/product/catalogs/v1/organizations/${organizationId}/catalogs/${storefrontCatalogId}/category-search`,
+      data
+    );
 
     return searchResults.hits?.length ? searchResults.hits : [];
   };
 
-  
-
-  public fetchCategory = async (categoryId:string) => {
+  public fetchCategory = async (categoryId: string) => {
     if (!this.parameters.storefrontCatalogId) {
-      throw new Error('No storefront catalog id set in client.')
+      throw new Error('No storefront catalog id set in client.');
     }
 
-    const { organizationId, storefrontCatalogId } = this.parameters
-    
-    const {data: category} = await this.client.get(`/product/catalogs/v1/organizations/${organizationId}/catalogs/${storefrontCatalogId}/categories/${categoryId}`)
-    
-    return category
-  }
+    const { organizationId, storefrontCatalogId } = this.parameters;
+
+    const { data: category } = await this.client.get(
+      `/product/catalogs/v1/organizations/${organizationId}/catalogs/${storefrontCatalogId}/categories/${categoryId}`
+    );
+
+    return category;
+  };
 
   private setStorefrontCatalogId = async () => {
-    const storefrontCatalog = await this.fetchStorefrontCatalog()
-    this.storefrontCatalogId = storefrontCatalog.id
-  }
-
+    const storefrontCatalog = await this.fetchStorefrontCatalog();
+    this.storefrontCatalogId = storefrontCatalog.id;
+  };
 }


### PR DESCRIPTION
## Purpose

When picking products/categories from SFCC, a Storefront Catalog serves as the root for products/categories that can be used on the site.

## Approach

Updated apps `onConfigure` hook to validate Salesforce config parameters, then we fetch the storefront catalog and add the corresponding id to app's installation parameters. We then use this id when searching for products or categories to make sure we're only retrieving relevant results for the given site.

## Breaking Changes

If products/categories were selected previously that were not a child of the Storefront catalog, those links will no longer be resolved. Additionally, the field value for categories has been changed from a combination of catalog and category id to just the category id, since the catalog is now consistent.

