### PR TITLE
[INTEG-646] Shopify provider business logic

### DIFF
--- a/apps/ecommerce/providers/shopify/src/app.ts
+++ b/apps/ecommerce/providers/shopify/src/app.ts
@@ -12,7 +12,7 @@ app.use(
   })
 );
 
-app.use('/', MetadataController);
+app.use('/metadata', MetadataController);
 app.use('/resourcesTypes', ResourceTypeController);
 
 app.get('/ping', async (req, res) => {

--- a/apps/ecommerce/providers/shopify/src/controller/MetadataController.ts
+++ b/apps/ecommerce/providers/shopify/src/controller/MetadataController.ts
@@ -1,10 +1,11 @@
+import { metadata } from '../services/metadata/MetadataService';
 import { Router } from 'express';
 import { Request, Response } from 'express';
 
 const MetadataController = Router();
 
 export const getMetadata = async (req: Request, res: Response) => {
-  return res.status(200).send('getMetadata call successful');
+  return res.status(200).send(metadata);
 };
 
 MetadataController.get('/', getMetadata);

--- a/apps/ecommerce/providers/shopify/src/controller/ResourceTypeController.ts
+++ b/apps/ecommerce/providers/shopify/src/controller/ResourceTypeController.ts
@@ -1,5 +1,8 @@
+import { resourceTypeSchema } from '../services/resourceType/ResourceTypeService';
+import { extractShopifyClientConfigParams } from '../helpers/ClientHelper';
 import { Router } from 'express';
 import { Request, Response } from 'express';
+import { fetchProduct, fetchProducts } from '../handlers/ShopifyHandler';
 
 const ResourceTypeController = Router();
 
@@ -8,7 +11,7 @@ const ping = async (req: Request, res: Response) => {
 };
 
 const getResourceType = async (req: Request, res: Response) => {
-  return res.status(200).send('getResourceType call successful');
+  return res.status(200).send(resourceTypeSchema);
 };
 
 const getResourceTypeSchema = async (req: Request, res: Response) => {
@@ -16,11 +19,29 @@ const getResourceTypeSchema = async (req: Request, res: Response) => {
 };
 
 const getResources = async (req: Request, res: Response) => {
-  return res.status(200).send('getResources call successful');
+  // TODO: HANDLE PAGINATION, QUERYING, NOR PAGINATION
+  const storefrontAccessToken = JSON.parse(JSON.stringify(req.header('x-storefront-access-token')));
+  const shopName = JSON.parse(JSON.stringify(req.header('x-shop-name')));
+  const domain = extractShopifyClientConfigParams({
+    shopName,
+    storefrontAccessToken,
+  });
+
+  const products = await fetchProducts({ domain, storefrontAccessToken });
+  return res.status(200).send(products);
 };
 
 const getOneResource = async (req: Request, res: Response) => {
-  return res.status(200).send('getOneResource call successful');
+  const storefrontAccessToken = JSON.parse(JSON.stringify(req.header('x-storefront-access-token')));
+  const shopName = JSON.parse(JSON.stringify(req.header('x-shop-name')));
+  const domain = extractShopifyClientConfigParams({
+    shopName,
+    storefrontAccessToken,
+  });
+
+  const id = JSON.parse(JSON.stringify(req.params.resourceId)); // TODO: Implement error checking here
+  const product = await fetchProduct({ domain, storefrontAccessToken }, id);
+  return res.status(200).send(product);
 };
 
 ResourceTypeController.get('/', ping);

--- a/apps/ecommerce/providers/shopify/src/handlers/ShopifyHandler.ts
+++ b/apps/ecommerce/providers/shopify/src/handlers/ShopifyHandler.ts
@@ -1,0 +1,56 @@
+import { ShopifyClientConfig } from '../types/types';
+import ShopifyBuy, { Product } from 'shopify-buy';
+
+export interface ShopifyError {
+  cause: {
+    errno: number;
+    code: string;
+    syscall: string;
+    hostname: string;
+  };
+}
+
+export class ShopifyClientError implements ShopifyError {
+  cause: {
+    errno: number;
+    code: string;
+    syscall: string;
+    hostname: string;
+  };
+
+  constructor(error: ShopifyError) {
+    this.cause = error.cause;
+  }
+}
+
+const makeClient = (params: ShopifyClientConfig): ShopifyBuy => {
+  return ShopifyBuy.buildClient({
+    ...params,
+    apiVersion: '2023-04', // TODO: Fix this hardcoding
+  });
+};
+
+export const fetchProduct = async (
+  params: ShopifyClientConfig,
+  id: string
+): Promise<Product | void> => {
+  try {
+    const client = makeClient(params);
+    return await client.product.fetch(id);
+  } catch (error: unknown) {
+    if (typeof error === 'object' && !!Object.getOwnPropertyDescriptor(error, 'cause')) {
+      throw new ShopifyClientError(<ShopifyError>error);
+    }
+  }
+};
+
+export const fetchProducts = async (params: ShopifyClientConfig): Promise<Product[] | void> => {
+  try {
+    const client = makeClient(params);
+    return await client.product.fetchAll();
+  } catch (error: unknown) {
+    if (typeof error === 'object' && !!Object.getOwnPropertyDescriptor(error, 'cause')) {
+      throw new ShopifyClientError(<ShopifyError>error);
+    }
+  }
+};

--- a/apps/ecommerce/providers/shopify/src/helpers/ClientHelper.ts
+++ b/apps/ecommerce/providers/shopify/src/helpers/ClientHelper.ts
@@ -1,0 +1,17 @@
+import { ShopifyProviderParams } from '../types/types';
+
+export const extractShopifyClientConfigParams = (params: ShopifyProviderParams): string => {
+  const { shopName, storefrontAccessToken } = params;
+
+  if (!shopName || !storefrontAccessToken)
+    throw new Error(
+      'Missing required parameters. shopName and storefrontAccessToken are required.'
+    );
+
+  const domain = `${shopName}.myshopify.com`;
+  if (!!domain.match(/^[-a-z0-9]{2,256}\b([-a-z0-9]+)\.myshopify\.com$/) === false) {
+    throw new Error('Invalid Shopify shop name');
+  }
+
+  return domain;
+};

--- a/apps/ecommerce/providers/shopify/src/services/metadata/MetadataService.ts
+++ b/apps/ecommerce/providers/shopify/src/services/metadata/MetadataService.ts
@@ -1,0 +1,26 @@
+export const metadata = {
+  name: 'Shopify',
+  description:
+    'The Shopify app allows editors to select products from their Shopify account and reference them inside of Contentful entries.',
+  parameterDefinitions: [
+    {
+      id: 'storefrontAccessToken',
+      name: 'Storefront Access Token',
+      placeholder: 'a12bc3d45e678f91011ghi121314j15k',
+      description: 'The storefront access token to your Shopify store',
+      type: 'Symbol',
+      required: true,
+    },
+    {
+      id: 'shopName',
+      name: 'Shop Name',
+      placeholder: 'example-shop',
+      description: 'The shop name of your Shopify store',
+      type: 'Symbol',
+      required: true,
+    },
+  ],
+  primaryColor: '#212F3F',
+  logoUrl:
+    'https://images.ctfassets.net/juh8bvgveao4/4eTYD0rlVO5tAucQoStln/952f5ed757229c91a099e61d8463f2f9/shopify.svg',
+};

--- a/apps/ecommerce/providers/shopify/src/services/resourceType/ResourceTypeService.ts
+++ b/apps/ecommerce/providers/shopify/src/services/resourceType/ResourceTypeService.ts
@@ -1,0 +1,284 @@
+export const getShopifyResources = async () => {
+  createShopifyClientConfig();
+};
+
+const createShopifyClientConfig = (params = '{}') => {
+  const { shopName, storefrontAccessToken } = JSON.parse(params);
+
+  if (!shopName || !storefrontAccessToken)
+    throw new Error(
+      'Missing required parameters. shopName and storefrontAccessToken are required.'
+    );
+
+  const domain = `${shopName}.myshopify.com`;
+  if (!!domain.match(/^[-a-z0-9]{2,256}\b([-a-z0-9]+)\.myshopify\.com$/) === false) {
+    throw new Error('Invalid Shopify shop name');
+  }
+
+  return { domain, storefrontAccessToken };
+};
+
+export const resourceTypeSchema = {
+  resourceTypes: [
+    {
+      'Shopify:Product': {
+        managementDisplay: {
+          type: 'productCard',
+          fieldMapping: {
+            id: '$.id',
+            name: '$.title',
+            description: '$.body_html',
+            image: '$.images[0].src',
+            status: '$.status',
+          },
+        },
+        filterAttributes: [{ id: ['eq', 'neq', 'matches'] }, { description: ['eq', 'contains'] }],
+        sortFields: ['id', 'createdAt'],
+      },
+    },
+  ],
+};
+
+export const schema = {
+  $ref: '#/definitions/Product',
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  definitions: {
+    Product: {
+      properties: {
+        body_html: {
+          title: 'body_html',
+          type: 'string',
+        },
+        created_at: {
+          title: 'created_at',
+          type: 'string',
+        },
+        handle: {
+          title: 'handle',
+          type: 'string',
+        },
+        id: {
+          title: 'id',
+          type: 'number',
+        },
+        images: {
+          items: {
+            $ref: '#/definitions/ProductImage',
+          },
+          title: 'images',
+          type: 'array',
+        },
+        options: {
+          properties: {
+            id: {
+              title: 'id',
+              type: 'number',
+            },
+            name: {
+              title: 'name',
+              type: 'string',
+            },
+            position: {
+              title: 'position',
+              type: 'number',
+            },
+            product_id: {
+              title: 'product_id',
+              type: 'number',
+            },
+            values: {
+              items: {
+                type: 'string',
+              },
+              title: 'values',
+              type: 'array',
+            },
+          },
+          title: 'options',
+          type: 'object',
+        },
+        product_type: {
+          title: 'product_type',
+          type: 'string',
+        },
+        published_at: {
+          title: 'published_at',
+          type: 'string',
+        },
+        published_scope: {
+          title: 'published_scope',
+          type: 'string',
+        },
+        status: {
+          title: 'status',
+          type: 'string',
+        },
+        tags: {
+          title: 'tags',
+          type: 'string',
+        },
+        template_suffix: {
+          title: 'template_suffix',
+          type: 'string',
+        },
+        title: {
+          title: 'title',
+          type: 'string',
+        },
+        updated_at: {
+          title: 'updated_at',
+          type: 'string',
+        },
+        variants: {
+          items: {
+            $ref: '#/definitions/ProductVariant',
+          },
+          title: 'variants',
+          type: 'array',
+        },
+        vendor: {
+          title: 'vendor',
+          type: 'string',
+        },
+      },
+      title: 'Product',
+      type: 'object',
+    },
+    ProductImage: {
+      properties: {
+        created_at: {
+          title: 'created_at',
+          type: 'string',
+        },
+        height: {
+          title: 'height',
+          type: 'number',
+        },
+        id: {
+          title: 'id',
+          type: 'number',
+        },
+        position: {
+          title: 'position',
+          type: 'number',
+        },
+        product_id: {
+          title: 'product_id',
+          type: 'number',
+        },
+        src: {
+          title: 'src',
+          type: 'string',
+        },
+        updated_at: {
+          title: 'updated_at',
+          type: 'string',
+        },
+        variant_ids: {
+          items: {
+            additionalProperties: {},
+            type: 'object',
+          },
+          title: 'variant_ids',
+          type: 'array',
+        },
+        width: {
+          title: 'width',
+          type: 'number',
+        },
+      },
+      title: 'ProductImage',
+      type: 'object',
+    },
+    ProductVariant: {
+      properties: {
+        barcode: {
+          title: 'barcode',
+          type: 'string',
+        },
+        compare_at_price: {
+          title: 'compare_at_price',
+          type: 'null',
+        },
+        created_at: {
+          title: 'created_at',
+          type: 'string',
+        },
+        fulfillment_service: {
+          title: 'fulfillment_service',
+          type: 'string',
+        },
+        grams: {
+          title: 'grams',
+          type: 'number',
+        },
+        id: {
+          title: 'id',
+          type: 'number',
+        },
+        inventory_item_id: {
+          title: 'inventory_item_id',
+          type: 'number',
+        },
+        inventory_management: {
+          title: 'inventory_management',
+          type: 'string',
+        },
+        inventory_policy: {
+          title: 'inventory_policy',
+          type: 'string',
+        },
+        inventory_quantity: {
+          title: 'inventory_quantity',
+          type: 'number',
+        },
+        option1: {
+          title: 'option1',
+          type: 'string',
+        },
+        position: {
+          title: 'position',
+          type: 'number',
+        },
+        price: {
+          title: 'price',
+          type: 'number',
+        },
+        product_id: {
+          title: 'product_id',
+          type: 'number',
+        },
+        requires_shipping: {
+          title: 'requires_shipping',
+          type: 'boolean',
+        },
+        sku: {
+          title: 'sku',
+          type: 'string',
+        },
+        taxable: {
+          title: 'taxable',
+          type: 'boolean',
+        },
+        title: {
+          title: 'title',
+          type: 'string',
+        },
+        updated_at: {
+          title: 'updated_at',
+          type: 'string',
+        },
+        weight: {
+          title: 'weight',
+          type: 'number',
+        },
+        weight_unit: {
+          title: 'weight_unit',
+          type: 'string',
+        },
+      },
+      title: 'ProductVariant',
+      type: 'object',
+    },
+  },
+};

--- a/apps/ecommerce/providers/shopify/src/types/types.ts
+++ b/apps/ecommerce/providers/shopify/src/types/types.ts
@@ -1,0 +1,9 @@
+export type ShopifyClientConfig = {
+  domain: string;
+  storefrontAccessToken: string;
+};
+
+export type ShopifyProviderParams = {
+  shopName: string;
+  storefrontAccessToken: string;
+};


### PR DESCRIPTION
## Purpose
Fill out the logic to hit the Shopify API for a single products, and a list of products.

DOES NOT HANDLE PAGINATION, QUERYING, NOR PAGINATION

## Approach
This backend logic is not yet hooked into the proxy. This will be done in a separate PR where that PR will delete all the business Shopify API logic in the proxy and instead forward those requests to this Provider backend

## Testing steps
Use postman to get data back (link to postman collection: https://elements.getpostman.com/redirect?entityId=27394115-97ca61c3-8f3b-4b81-869f-0432b6914a13&entityType=collection)

SINGLE
<img width="1170" alt="Screenshot 2023-06-06 at 4 09 48 PM" src="https://github.com/contentful/apps/assets/124832189/799157d5-48a7-418e-b05f-839e7b27668c">

MULTIPLE
<img width="1232" alt="Screenshot 2023-06-06 at 4 10 08 PM" src="https://github.com/contentful/apps/assets/124832189/c789f237-8352-4145-8d6c-01d7dd05d501">

## Breaking Changes
None

## Dependencies and/or References
None
