### PR TITLE
Select a resource in the product picker

### DIFF
--- a/apps/ecommerce/frontend/src/components/Dialog/DialogBody.tsx
+++ b/apps/ecommerce/frontend/src/components/Dialog/DialogBody.tsx
@@ -7,6 +7,8 @@ interface Props {
   externalResources: ExternalResource[];
   resourceProvider: string;
   resourceType: string;
+  onSelect: (resource: ExternalResource) => void;
+  selectedResources: ExternalResource[];
 }
 
 const DialogBody = (props: Props) => {

--- a/apps/ecommerce/frontend/src/components/Dialog/DialogHeader.tsx
+++ b/apps/ecommerce/frontend/src/components/Dialog/DialogHeader.tsx
@@ -6,12 +6,11 @@ import { useSDK, useCMA } from '@contentful/react-apps-toolkit';
 import { DialogAppSDK } from '@contentful/app-sdk';
 import fetchWithSignedRequest from 'helpers/signedRequests';
 import { config } from 'config';
-import { FieldType } from 'types';
 
 interface Props {
-  fieldType: FieldType;
-  resourceType: string;
-  total: number;
+  onSave: () => void;
+  headerText: string;
+  resourceCountText: string;
 }
 
 const DialogHeader = (props: Props) => {
@@ -20,10 +19,7 @@ const DialogHeader = (props: Props) => {
   const sdk = useSDK<DialogAppSDK>();
   const cma = useCMA();
 
-  const { fieldType, resourceType, total } = props;
-  const headerTitle =
-    fieldType === FieldType.Single ? `Select a ${resourceType}` : `Select ${resourceType}s`;
-  const resourceCountText = `${total} ${resourceType}s`;
+  const { onSave, headerText, resourceCountText } = props;
 
   useEffect(() => {
     (async () => {
@@ -51,12 +47,14 @@ const DialogHeader = (props: Props) => {
         <Box className={styles.icon} paddingRight="spacingS">
           {logoUrl && <img src={logoUrl} alt="App logo" />}
         </Box>
-        <Subheading marginBottom="none">{headerTitle}</Subheading>
+        <Subheading marginBottom="none">{headerText}</Subheading>
       </Flex>
       <Flex alignItems="center">
         <Paragraph marginBottom="none">{resourceCountText}</Paragraph>
         <Box paddingLeft="spacingS">
-          <Button variant="primary">Save</Button>
+          <Button variant="primary" onClick={onSave}>
+            Save
+          </Button>
         </Box>
         <Box>
           <IconButton

--- a/apps/ecommerce/frontend/src/components/Dialog/ResourceCard/ResourceCard.styles.ts
+++ b/apps/ecommerce/frontend/src/components/Dialog/ResourceCard/ResourceCard.styles.ts
@@ -5,6 +5,10 @@ export const styles = {
   resourceCard: css({
     marginTop: tokens.spacingXs,
     marginBottom: tokens.spacingXs,
+    '&&:hover': {
+      borderColor: tokens.colorPrimary,
+      cursor: 'pointer',
+    },
   }),
   resourceCardHeader: css({
     borderBottom: `1px solid ${tokens.gray200}`,

--- a/apps/ecommerce/frontend/src/components/Dialog/ResourceCard/ResourceCard.tsx
+++ b/apps/ecommerce/frontend/src/components/Dialog/ResourceCard/ResourceCard.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { Badge, Box, Card, Flex, Grid, Text } from '@contentful/f36-components';
 import { styles } from './ResourceCard.styles';
 import { ExternalResource } from 'types';
@@ -5,13 +6,30 @@ import { ExternalResource } from 'types';
 export interface ResourceCardProps {
   resource: ExternalResource;
   cardHeader: string;
+  onSelect: (resource: ExternalResource) => void;
+  selectedResources: ExternalResource[];
 }
 
 const ResourceCard = (props: ResourceCardProps) => {
-  const { resource, cardHeader } = props;
+  const [isSelected, setIsSelected] = useState<boolean>(false);
+  const { resource, cardHeader, onSelect, selectedResources } = props;
+
+  useEffect(() => {
+    const isSelectedResource = selectedResources.find((item) => {
+      return item.id === resource.id;
+    });
+
+    setIsSelected(!!isSelectedResource);
+  }, [selectedResources, resource.id]);
 
   return (
-    <Card padding="none" className={styles.resourceCard}>
+    <Card
+      padding="none"
+      className={styles.resourceCard}
+      isSelected={isSelected}
+      onClick={() => {
+        onSelect(resource);
+      }}>
       <Box paddingLeft="spacingM" className={styles.resourceCardHeader}>
         <Flex alignItems="center" fullWidth={true} justifyContent="space-between">
           <Text fontColor="gray600" isWordBreak={true}>

--- a/apps/ecommerce/frontend/src/components/Dialog/ResourceList.tsx
+++ b/apps/ecommerce/frontend/src/components/Dialog/ResourceList.tsx
@@ -7,10 +7,12 @@ interface Props {
   externalResources: ExternalResource[];
   resourceProvider: string;
   resourceType: string;
+  onSelect: (resource: ExternalResource) => void;
+  selectedResources: ExternalResource[];
 }
 
 const ResourceList = (props: Props) => {
-  const { externalResources, resourceProvider, resourceType } = props;
+  const { externalResources, resourceProvider, resourceType, onSelect, selectedResources } = props;
 
   return (
     <Flex className={styles.productList}>
@@ -20,6 +22,8 @@ const ResourceList = (props: Props) => {
             key={index}
             resource={item}
             cardHeader={`${resourceProvider} ${resourceType}`}
+            onSelect={onSelect}
+            selectedResources={selectedResources}
           />
         );
       })}

--- a/apps/ecommerce/frontend/src/components/Field/Wrappers/MultipleResources.tsx
+++ b/apps/ecommerce/frontend/src/components/Field/Wrappers/MultipleResources.tsx
@@ -3,6 +3,7 @@ import { FieldAppSDK } from '@contentful/app-sdk';
 import { ResourceField } from 'components/Field/ResourceField';
 import mockValue from 'helpers/mockValue';
 import ResourceFieldProvider from 'providers/ResourceFieldProvider';
+import { ExternalResource } from 'types';
 
 const MultipleResources = () => {
   const sdk = useSDK<FieldAppSDK>();
@@ -16,6 +17,25 @@ const MultipleResources = () => {
       parameters: sdk.parameters.instance,
       width: 1400,
     });
+
+    if (resources?.length) {
+      const resourceArray = sdk.field.getValue();
+      const newResources = resources.map((resource: ExternalResource) => {
+        return {
+          sys: {
+            urn: resource.id,
+            type: 'ResourceLink',
+            linkType: sdk.parameters.instance.linkType,
+          },
+        };
+      });
+
+      if (resourceArray) {
+        sdk.field.setValue([...resourceArray, ...newResources]);
+      } else {
+        sdk.field.setValue([...newResources]);
+      }
+    }
 
     return Array.isArray(resources) ? resources : [];
   };

--- a/apps/ecommerce/frontend/src/components/Field/Wrappers/SingleResource.tsx
+++ b/apps/ecommerce/frontend/src/components/Field/Wrappers/SingleResource.tsx
@@ -21,6 +21,16 @@ const SingleResource = () => {
       width: 1400,
     });
 
+    if (resources?.length) {
+      sdk.field.setValue({
+        sys: {
+          urn: resources[0].id,
+          type: 'ResourceLink',
+          linkType: sdk.parameters.instance.linkType,
+        },
+      });
+    }
+
     return Array.isArray(resources) ? resources : [];
   };
 

--- a/apps/ecommerce/frontend/src/helpers/resourceProviderUtils.ts
+++ b/apps/ecommerce/frontend/src/helpers/resourceProviderUtils.ts
@@ -11,7 +11,7 @@ const getResourceProviderAndType = (resource?: ExternalResourceLink | string) =>
 
   return {
     resourceProvider,
-    resourceType,
+    resourceType: typeof resourceType === 'string' ? resourceType.toLowerCase() : resourceType,
   };
 };
 

--- a/apps/ecommerce/frontend/src/types.ts
+++ b/apps/ecommerce/frontend/src/types.ts
@@ -50,6 +50,7 @@ export interface ExternalResource {
   image?: string;
   status?: EntityStatus;
   extras?: JSONObject;
+  id?: string;
 }
 
 type ErrorBoundaryErrored = { hasError: true; error: Error; info: ErrorInfo };

--- a/apps/ecommerce/lambda/src/helpers/shopifyAdapter.ts
+++ b/apps/ecommerce/lambda/src/helpers/shopifyAdapter.ts
@@ -8,5 +8,6 @@ export const convertResponseToResource = (product: Product): ExternalResource =>
     image: product.images[0].src,
     status: product.availableForSale ? 'Available' : 'Not Available',
     extras: {},
+    id: product.id,
   };
 };

--- a/apps/ecommerce/lambda/src/types.ts
+++ b/apps/ecommerce/lambda/src/types.ts
@@ -22,6 +22,7 @@ export interface ExternalResource {
   image?: string;
   status?: string;
   extras?: JSONObject;
+  id?: string;
 }
 
 export interface ErrorResponse {


### PR DESCRIPTION
## Purpose

Content editors needs to be able to select a product from the picker and save that selection to an entry.

## Approach

In the product picker I added:
- Hover state for the displayed resources
- Selection state for when a resource is clicked
- Header updates to reflect the number of items selected
- On save, the dialog closes and the field is then updated with the selected item

This works for the single reference field as well as a multiple reference field. For multiple reference, it works similar to the native reference field where items selected are just appended to the field.

For now, there is still the "Add content" button as well as the "Add a product" button until we have our design sync and decide on what we want for that.

Single reference field showing hover on a card:
![Screenshot 2023-06-07 at 1 49 30 PM](https://github.com/contentful/apps/assets/62958907/d9821c6b-005d-46fe-a09e-49849f98a52a)

Multiple reference field showing items selected:
![Screenshot 2023-06-07 at 1 48 54 PM](https://github.com/contentful/apps/assets/62958907/22767f5e-1865-4ce1-8119-26256dd04b85)
