### PR TITLE
fix(HostedActions): allow using node libs []

### DIFF
--- a/examples/hosted-app-action-templates/javascript/build-actions.js
+++ b/examples/hosted-app-action-templates/javascript/build-actions.js
@@ -60,6 +60,7 @@ const main = async (watch = false) => {
       logLevel: 'info',
       format: 'esm',
       target: 'es6',
+      external: ['node:*'],
     };
 
     if (watch) {

--- a/examples/hosted-app-action-templates/typescript/build-actions.js
+++ b/examples/hosted-app-action-templates/typescript/build-actions.js
@@ -60,6 +60,7 @@ const main = async (watch = false) => {
       logLevel: 'info',
       format: 'esm',
       target: 'es6',
+      external: ['node:*'],
     };
 
     if (watch) {


### PR DESCRIPTION
## Purpose

If you try using node builtin libraries, current setup wont work. This fixes it

## Approach

For some reason esbuild strips out `node:` in imports. E.g: `import process from 'node:process'` transforms to `import process from 'process'`. Using https://esbuild.github.io/api/#external to avoid this.

## Testing steps

Run `cca test-app --typescript --action`, edit the `actions/example.ts` file by import a built-in  and then run `npm run build-actions`. The output action file should not strip out `node:` prefix

