### PR TITLE
Fix MuxUploader double drop area

### DIFF
--- a/apps/mux/src/index.tsx
+++ b/apps/mux/src/index.tsx
@@ -1074,6 +1074,7 @@ export class App extends React.Component<AppProps, AppState> {
                 type="bar"
                 onSuccess={this.onUploadSuccess}
                 endpoint={this.getUploadUrl}
+                noDrop
                 //onError={this.onUploadError}
                 style={
                   {


### PR DESCRIPTION
By default `MuxUploader` will render a drop, since we made our own drop with `MuxUploaderDrop` use the `noDrop` property to prevent `MuxUploader` from rendering the default one

## Purpose

Current bug in Mux Uploader shows 2 drop areas

![Screenshot 2023-06-21 at 11 35 55 AM](https://github.com/contentful/apps/assets/764988/2dab1312-b25f-4e61-9e9f-441e94e7a323)


## Approach

There was a slight change between `beta.8` and `beta.9` that included `MuxUploader` rendering a drop area by default.

See docs: https://docs.mux.com/guides/video/mux-uploader

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

None

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
