### PR TITLE
fix: update @contentful/app-sdk to fix type error

### DIFF
--- a/packages/ecommerce-app-base/package-lock.json
+++ b/packages/ecommerce-app-base/package-lock.json
@@ -679,9 +679,9 @@
       "dev": true
     },
     "node_modules/@contentful/app-sdk": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.17.1.tgz",
-      "integrity": "sha512-8vh/X+kW33412lxwi2Acr6V4W7UxNvH273cJUSJ43OaFlwAl+T4aWhIULXq+sT9ASc9QxsujiWFHbCR38kl/oQ==",
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.21.1.tgz",
+      "integrity": "sha512-sRaWKa18x3EWH84qYHT3W/yXsYKqijgPJgQhGZUcdX9Y3d38ZNOikt/FopE399s/MqyyfVJcM+CFHSC0JczAEw==",
       "peerDependencies": {
         "contentful-management": ">=7.30.0"
       }
@@ -10023,9 +10023,9 @@
       "dev": true
     },
     "@contentful/app-sdk": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.17.1.tgz",
-      "integrity": "sha512-8vh/X+kW33412lxwi2Acr6V4W7UxNvH273cJUSJ43OaFlwAl+T4aWhIULXq+sT9ASc9QxsujiWFHbCR38kl/oQ==",
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.21.1.tgz",
+      "integrity": "sha512-sRaWKa18x3EWH84qYHT3W/yXsYKqijgPJgQhGZUcdX9Y3d38ZNOikt/FopE399s/MqyyfVJcM+CFHSC0JczAEw==",
       "requires": {}
     },
     "@contentful/f36-accordion": {

--- a/packages/ecommerce-app-base/package-lock.json
+++ b/packages/ecommerce-app-base/package-lock.json
@@ -14,7 +14,7 @@
         "@contentful/f36-icons": "^4.25.0",
         "@contentful/f36-tokens": "^4.0.0",
         "array-move": "^3.0.0",
-        "contentful-management": "^10.36.0",
+        "contentful-management": "^10.0.0",
         "emotion": "^10.0.0",
         "lodash": "^4.0.0",
         "react-sortable-hoc": "^2.0.0"
@@ -1302,9 +1302,9 @@
       }
     },
     "node_modules/@contentful/rich-text-types": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.0.3.tgz",
-      "integrity": "sha512-BsUtXj93jo5XUt0YeUwfCkMWRoZIzJDPUIY4vMy9SwGIO9olTsMoQKadjA2ktlmK+Gg6710WH3eFKZxj2q39Iw==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.2.0.tgz",
+      "integrity": "sha512-4BHC+mfa50JB70epzpnas4EkiuB3mGdBZ5Rp8w7R5wXvswEf8TLg5yGau2FxmZeEjrAkDrt4vzBLVQ8v3Y//Jw==",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -3782,9 +3782,9 @@
       "dev": true
     },
     "node_modules/contentful-management": {
-      "version": "10.36.0",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-10.36.0.tgz",
-      "integrity": "sha512-YcTkIpDpk4Z5mduFTdcVCH8cfwsm1yWv5sKkS1i9NXVCU1AnEU1BwyvEVwsp5cDuknaXXadkLVYFqovPHT96Qg==",
+      "version": "10.38.0",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-10.38.0.tgz",
+      "integrity": "sha512-m6WwBdrEIaBnMDqPGIi1haVTsy3pwdDk8dYcnUjFO/LdikIh+/6fBKxfBBf08Pg1F/hrd+hvH12dXceysqO7dg==",
       "dependencies": {
         "@contentful/rich-text-types": "^16.0.3",
         "@types/json-patch": "0.0.30",
@@ -10517,9 +10517,9 @@
       }
     },
     "@contentful/rich-text-types": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.0.3.tgz",
-      "integrity": "sha512-BsUtXj93jo5XUt0YeUwfCkMWRoZIzJDPUIY4vMy9SwGIO9olTsMoQKadjA2ktlmK+Gg6710WH3eFKZxj2q39Iw=="
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.2.0.tgz",
+      "integrity": "sha512-4BHC+mfa50JB70epzpnas4EkiuB3mGdBZ5Rp8w7R5wXvswEf8TLg5yGau2FxmZeEjrAkDrt4vzBLVQ8v3Y//Jw=="
     },
     "@emotion/cache": {
       "version": "10.0.29",
@@ -12530,9 +12530,9 @@
       "dev": true
     },
     "contentful-management": {
-      "version": "10.36.0",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-10.36.0.tgz",
-      "integrity": "sha512-YcTkIpDpk4Z5mduFTdcVCH8cfwsm1yWv5sKkS1i9NXVCU1AnEU1BwyvEVwsp5cDuknaXXadkLVYFqovPHT96Qg==",
+      "version": "10.38.0",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-10.38.0.tgz",
+      "integrity": "sha512-m6WwBdrEIaBnMDqPGIi1haVTsy3pwdDk8dYcnUjFO/LdikIh+/6fBKxfBBf08Pg1F/hrd+hvH12dXceysqO7dg==",
       "requires": {
         "@contentful/rich-text-types": "^16.0.3",
         "@types/json-patch": "0.0.30",

--- a/packages/ecommerce-app-base/package-lock.json
+++ b/packages/ecommerce-app-base/package-lock.json
@@ -14,7 +14,7 @@
         "@contentful/f36-icons": "^4.25.0",
         "@contentful/f36-tokens": "^4.0.0",
         "array-move": "^3.0.0",
-        "contentful-management": "^10.0.0",
+        "contentful-management": "^10.36.0",
         "emotion": "^10.0.0",
         "lodash": "^4.0.0",
         "react-sortable-hoc": "^2.0.0"
@@ -3782,9 +3782,9 @@
       "dev": true
     },
     "node_modules/contentful-management": {
-      "version": "10.31.4",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-10.31.4.tgz",
-      "integrity": "sha512-KztSCsOUH+0/YUXV711cJyCXaFsnsPc+2nVCfmphFTUmcbo72xau25b8OA6uA+7UFOxiKZ07ayLBohpsCm1CoA==",
+      "version": "10.36.0",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-10.36.0.tgz",
+      "integrity": "sha512-YcTkIpDpk4Z5mduFTdcVCH8cfwsm1yWv5sKkS1i9NXVCU1AnEU1BwyvEVwsp5cDuknaXXadkLVYFqovPHT96Qg==",
       "dependencies": {
         "@contentful/rich-text-types": "^16.0.3",
         "@types/json-patch": "0.0.30",
@@ -12530,9 +12530,9 @@
       "dev": true
     },
     "contentful-management": {
-      "version": "10.31.4",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-10.31.4.tgz",
-      "integrity": "sha512-KztSCsOUH+0/YUXV711cJyCXaFsnsPc+2nVCfmphFTUmcbo72xau25b8OA6uA+7UFOxiKZ07ayLBohpsCm1CoA==",
+      "version": "10.36.0",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-10.36.0.tgz",
+      "integrity": "sha512-YcTkIpDpk4Z5mduFTdcVCH8cfwsm1yWv5sKkS1i9NXVCU1AnEU1BwyvEVwsp5cDuknaXXadkLVYFqovPHT96Qg==",
       "requires": {
         "@contentful/rich-text-types": "^16.0.3",
         "@types/json-patch": "0.0.30",

--- a/packages/ecommerce-app-base/package.json
+++ b/packages/ecommerce-app-base/package.json
@@ -39,7 +39,7 @@
     "@contentful/f36-icons": "^4.25.0",
     "@contentful/f36-tokens": "^4.0.0",
     "array-move": "^3.0.0",
-    "contentful-management": "^10.36.0",
+    "contentful-management": "^10.0.0",
     "emotion": "^10.0.0",
     "lodash": "^4.0.0",
     "react-sortable-hoc": "^2.0.0"

--- a/packages/ecommerce-app-base/package.json
+++ b/packages/ecommerce-app-base/package.json
@@ -39,7 +39,7 @@
     "@contentful/f36-icons": "^4.25.0",
     "@contentful/f36-tokens": "^4.0.0",
     "array-move": "^3.0.0",
-    "contentful-management": "^10.0.0",
+    "contentful-management": "^10.36.0",
     "emotion": "^10.0.0",
     "lodash": "^4.0.0",
     "react-sortable-hoc": "^2.0.0"


### PR DESCRIPTION
## Purpose

Older version of @contentful/app-sdk had a type error that was fixed in version 4.21.1. **This is breaking the master build.**

## Approach

* Upgrade to 4.21.1 app-sdk
* Upgrade contentful-management and @contentful/rich-text-types to latest

## Dependencies and/or References

* https://github.com/contentful/ui-extensions-sdk/pull/1549

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
