### PR TITLE
Fix: Filter out deleted files in prettier check

### DIFF
--- a/.circleci/prettier-check.sh
+++ b/.circleci/prettier-check.sh
@@ -7,7 +7,7 @@
 test -n "$SKIP_PRETTIER_CHECK" && exit 0
 
 MERGE_BASE=$(git merge-base HEAD origin/master)
-CHANGED_FILES=$(git diff --name-only HEAD $MERGE_BASE | egrep --color=no "\.[jt]s(x)?$" | xargs)
+CHANGED_FILES=$(git diff --name-only --diff-filter=d $MERGE_BASE | egrep --color=no "\.[jt]s(x)?$" | xargs)
 echo $CHANGED_FILES
 
 test -z "$CHANGED_FILES" && echo "No files for prettier to check. Skipping..." && exit 0


### PR DESCRIPTION
## Purpose

Currently, any changed files (added, modified, or deleted) are being included in the prettier check. Adding a filter to exclude deleted files from the prettier check to avoid getting an error of `No files matching the pattern were found` on this check. Also removed the `HEAD` from this line since we are already getting that in the line above for `MERGE_BASE`.

Fun fact, using the lowercase `d` in the filter excludes that status whereas an uppercase `D` includes that status in the filter (https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---diff-filterACDMRTUXB82308203).
