### PR TITLE
fix: improved clarity for gatsby app helper text

### DIFF
--- a/apps/gatsby/src/AppConfig/AppConfig.js
+++ b/apps/gatsby/src/AppConfig/AppConfig.js
@@ -351,7 +351,7 @@ export class AppConfig extends React.Component {
                     value={this.state.authToken}
                     onChange={this.updateAuthToken}
                     className={styles.input}
-                    helpText="Optional authentication token for private Gatsby Cloud sites"
+                    helpText="Optional authentication token for private Gatsby Cloud sites (Cannot use with Content Sync)"
                     textInputProps={{
                       type: 'password',
                     }}


### PR DESCRIPTION
## Purpose

The Gatsby App has an optional field , authToken for private sites, but if the site is using [Content Sync](https://www.gatsbyjs.com/docs/conceptual/content-sync/), adding said token to the app's config settings will cause errors with the preview feature (which Gatsby has [acknowledged](https://support.gatsbyjs.com/hc/en-us/articles/360056047134-Add-the-Gatsby-Cloud-App-to-Contentful#:~:text=(Optional)%20Fill%20in%20the%20input%20labeled%20%E2%80%9CAuthentication%20Token%E2%80%9D%20with%20an%C2%A0authToken.%20This%20is%20necessary%20for%20Gatsby%20Preview%20instances%20that%20require%20the%20user%20to%20login%20before%20they%20can%20view%20the%20Preview.%20(Note%20that%20this%20doesn%27t%20yet%20work%20when%20using%20Content%20Sync))).

![image](https://github.com/contentful/apps/assets/84538722/7ab02f09-e5d3-4b37-a13e-ddcb596518f9)

As long as this issue remains unfixed, the helper text (located in the [`AppConfig.js`](https://github.com/contentful/apps/blob/master/apps/gatsby/src/AppConfig/AppConfig.js) file) should at least provide more clarity on the matter (my team and I spent too long trying to figure out why this feature wasn't working, and the clarity would certainly help others not waste time as well).

## Approach

Since this issue has been in place an entire year, then fixing it is likely very difficult. Adding clarity to documentation on the issue is the best Band-Aid we can add at the moment.

## Testing steps

Did not test; no functionality was updated. 

## Breaking Changes

No.

## Dependencies and/or References

[acknowledgement of issue on Gatsby's part](https://support.gatsbyjs.com/hc/en-us/articles/360056047134-Add-the-Gatsby-Cloud-App-to-Contentful#:~:text=(Optional)%20Fill%20in%20the%20input%20labeled%20%E2%80%9CAuthentication%20Token%E2%80%9D%20with%20an%C2%A0authToken.%20This%20is%20necessary%20for%20Gatsby%20Preview%20instances%20that%20require%20the%20user%20to%20login%20before%20they%20can%20view%20the%20Preview.%20(Note%20that%20this%20doesn%27t%20yet%20work%20when%20using%20Content%20Sync))

## Deployment

None.
