### PR TITLE
updates ts and vite configs with aliases

### DIFF
--- a/apps/ai-content-generator/tsconfig.json
+++ b/apps/ai-content-generator/tsconfig.json
@@ -13,6 +13,13 @@
     "moduleResolution": "Node",
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "paths": {
+      "@/*": ["./src/*"],
+      "@components/*": ["./src/components/*"],
+      "@/configs/*": ["./src/configs/*"],
+      "@hooks/*": ["./src/hooks/*"],
+      "@utils/*": ["./src/utils/*"],
+    },
     "noEmit": true,
     "jsx": "react-jsx"
   },

--- a/apps/ai-content-generator/vite.config.ts
+++ b/apps/ai-content-generator/vite.config.ts
@@ -1,4 +1,5 @@
 import react from '@vitejs/plugin-react';
+import path from 'path';
 import { defineConfig } from 'vite';
 
 export default defineConfig(() => ({
@@ -7,6 +8,15 @@ export default defineConfig(() => ({
     port: 3000,
   },
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+      '@components': path.resolve(__dirname, './src/components'),
+      '@configs': path.resolve(__dirname, './src/configs'),
+      '@hooks': path.resolve(__dirname, './src/hooks'),
+      '@utils': path.resolve(__dirname, './src/utils'),
+    },
+  },
   test: {
     environment: 'happy-dom',
   },


### PR DESCRIPTION
## Purpose

This allows us have easy-to-read imports from a variety of locations in the codebase while keeping the path descriptive

eg. `import Slider from '@components/common/slider'` vs `import Slider from '../../../common/slider'