### PR TITLE
Improve error logging in Slack app and fix bug

### DIFF
--- a/apps/slack/frontend/src/useConnect.ts
+++ b/apps/slack/frontend/src/useConnect.ts
@@ -38,7 +38,8 @@ export const useConnect = () => {
 
           // this error is a race condition that occurs when instantiating the eventsService within the lambda.
           // the error is not valid to show to the user.
-          if (JSON.parse(error?.message)?.details !== 'AppInstallation does not exist.') {
+          const errorMessage = JSON.parse(error?.message);
+          if (errorMessage && errorMessage.details !== 'AppInstallation does not exist.') {
             console.error(e);
             sdk.notifier.error(genericErrorMessage);
           }

--- a/apps/slack/frontend/src/useConnect.ts
+++ b/apps/slack/frontend/src/useConnect.ts
@@ -34,7 +34,7 @@ export const useConnect = () => {
 
           await apiClient.createAuthToken(sdk, cma, token, installationUuid);
         } catch (e) {
-          const error = e as any;
+          const error = e as Error;
 
           // this 'AppInstallation does not exist error' is a race condition that occurs when instantiating the eventsService within the lambda.
           // it is not a valid error to show to the user.

--- a/apps/slack/frontend/src/useConnect.ts
+++ b/apps/slack/frontend/src/useConnect.ts
@@ -46,7 +46,7 @@ export const useConnect = () => {
         }
       }
     },
-    [cma, sdk, temporaryRefreshToken],
+    [cma, sdk, temporaryRefreshToken]
   );
 
   const { addConnectedWorkspace, setWorkspaceState, setNotificationsLoading, setChannels } =
@@ -81,7 +81,7 @@ export const useConnect = () => {
         sdk.notifier.success('Connected to the Slack workspace successfully.');
       } catch (e) {
         sdk.notifier.error(
-          'Something went wrong while authenticating with Slack. Please try again.',
+          'Something went wrong while authenticating with Slack. Please try again.'
         );
       } finally {
         setNotificationsLoading(false);

--- a/apps/slack/frontend/src/useConnect.ts
+++ b/apps/slack/frontend/src/useConnect.ts
@@ -36,8 +36,8 @@ export const useConnect = () => {
         } catch (e) {
           const error = e as any;
 
-          // this error is a race condition that occurs when instantiating the eventsService within the lambda.
-          // the error is not valid to show to the user.
+          // this 'AppInstallation does not exist error' is a race condition that occurs when instantiating the eventsService within the lambda.
+          // it is not a valid error to show to the user.
           const errorMessage = JSON.parse(error?.message);
           if (errorMessage && errorMessage.details !== 'AppInstallation does not exist.') {
             console.error(e);

--- a/apps/slack/frontend/src/useConnect.ts
+++ b/apps/slack/frontend/src/useConnect.ts
@@ -38,7 +38,7 @@ export const useConnect = () => {
 
           // this 'AppInstallation does not exist error' is a race condition that occurs when instantiating the eventsService within the lambda.
           // it is not a valid error to show to the user.
-          const errorMessage = JSON.parse(error?.message);
+          const errorMessage = JSON.parse(error.message);
           if (errorMessage && errorMessage.details !== 'AppInstallation does not exist.') {
             console.error(e);
             sdk.notifier.error(genericErrorMessage);

--- a/apps/slack/lambda/lib/clients/slack.ts
+++ b/apps/slack/lambda/lib/clients/slack.ts
@@ -30,7 +30,7 @@ export class SlackClient {
    */
   async getAuthToken(
     oauthCode: string,
-    context: SpaceEnvironmentContext
+    context: SpaceEnvironmentContext,
   ): Promise<OauthV2AccessResponse> {
     const response = await this.client.oauth.v2.access({
       code: oauthCode,
@@ -59,27 +59,27 @@ export class SlackClient {
     message: {
       text?: string;
       blocks?: (Block | KnownBlock)[];
-    }
+    },
   ): Promise<ChatPostMessageResponse> {
     return SlackClient.assertSuccessResponse(
       await this.client.chat.postMessage({
         token: token,
         channel: channelId,
         ...message,
-      })
+      }),
     );
   }
 
   async getWorkspaceInformation(token: string, workspaceId: string): Promise<TeamInfoResponse> {
     return SlackClient.assertSuccessResponse(
-      await this.client.team.info({ team: workspaceId, token })
+      await this.client.team.info({ team: workspaceId, token }),
     );
   }
 
   async getChannelsList(
     token: string,
     workspaceId: string,
-    cursor?: string
+    cursor?: string,
   ): Promise<ConversationsListResponse['channels'] | undefined> {
     const { channels, response_metadata } = await this.fetchChannels(token, workspaceId, cursor);
 
@@ -95,7 +95,7 @@ export class SlackClient {
   async fetchChannels(
     token: string,
     workspaceId: string,
-    cursor = ''
+    cursor = '',
   ): Promise<ConversationsListResponse> {
     return SlackClient.assertSuccessResponse(
       await this.client.conversations.list({
@@ -104,13 +104,13 @@ export class SlackClient {
         cursor,
         limit: 1000,
         exclude_archived: true,
-      })
+      }),
     );
   }
 
   private static assertSuccessResponse(response: WebAPICallResult) {
     if (!response.ok) {
-      throw new SlackError(response.error ?? 'Unknown error');
+      throw new SlackError({ errMessage: response.error ?? 'Unknown error' });
     }
 
     return response;

--- a/apps/slack/lambda/lib/clients/slack.ts
+++ b/apps/slack/lambda/lib/clients/slack.ts
@@ -30,7 +30,7 @@ export class SlackClient {
    */
   async getAuthToken(
     oauthCode: string,
-    context: SpaceEnvironmentContext,
+    context: SpaceEnvironmentContext
   ): Promise<OauthV2AccessResponse> {
     const response = await this.client.oauth.v2.access({
       code: oauthCode,
@@ -59,27 +59,27 @@ export class SlackClient {
     message: {
       text?: string;
       blocks?: (Block | KnownBlock)[];
-    },
+    }
   ): Promise<ChatPostMessageResponse> {
     return SlackClient.assertSuccessResponse(
       await this.client.chat.postMessage({
         token: token,
         channel: channelId,
         ...message,
-      }),
+      })
     );
   }
 
   async getWorkspaceInformation(token: string, workspaceId: string): Promise<TeamInfoResponse> {
     return SlackClient.assertSuccessResponse(
-      await this.client.team.info({ team: workspaceId, token }),
+      await this.client.team.info({ team: workspaceId, token })
     );
   }
 
   async getChannelsList(
     token: string,
     workspaceId: string,
-    cursor?: string,
+    cursor?: string
   ): Promise<ConversationsListResponse['channels'] | undefined> {
     const { channels, response_metadata } = await this.fetchChannels(token, workspaceId, cursor);
 
@@ -95,7 +95,7 @@ export class SlackClient {
   async fetchChannels(
     token: string,
     workspaceId: string,
-    cursor = '',
+    cursor = ''
   ): Promise<ConversationsListResponse> {
     return SlackClient.assertSuccessResponse(
       await this.client.conversations.list({
@@ -104,7 +104,7 @@ export class SlackClient {
         cursor,
         limit: 1000,
         exclude_archived: true,
-      }),
+      })
     );
   }
 

--- a/apps/slack/lambda/lib/errors/conflict.ts
+++ b/apps/slack/lambda/lib/errors/conflict.ts
@@ -1,7 +1,7 @@
-import { Exception } from './exception';
+import { Exception, ExceptionDetails } from './exception';
 
 export class ConflictException extends Exception<string> {
-  constructor(details?: string) {
+  constructor(details?: ExceptionDetails) {
     super(409, 'Conflict', details);
   }
 }

--- a/apps/slack/lambda/lib/errors/conflict.ts
+++ b/apps/slack/lambda/lib/errors/conflict.ts
@@ -1,6 +1,6 @@
 import { Exception, ExceptionDetails } from './exception';
 
-export class ConflictException extends Exception<string> {
+export class ConflictException extends Exception<ExceptionDetails> {
   constructor(details?: ExceptionDetails) {
     super(409, 'Conflict', details);
   }

--- a/apps/slack/lambda/lib/errors/exception.ts
+++ b/apps/slack/lambda/lib/errors/exception.ts
@@ -1,10 +1,12 @@
+import { ErrorObject } from 'ajv/dist/types';
+
 export class Exception<T> extends Error {
   status: number;
   message: string;
-  details?: T;
+  details?: ExceptionDetails;
   isException: boolean;
 
-  constructor(status: number, message: string, details?: T) {
+  constructor(status: number, message: string, details?: ExceptionDetails) {
     super(message);
     this.status = status;
     this.message = message;
@@ -31,3 +33,10 @@ export class Exception<T> extends Error {
 
 export const isException = (e: unknown): e is Exception<unknown> =>
   typeof e == 'object' && !!e && 'isException' in e;
+
+export type ExceptionDetails = {
+  errMessage?: string;
+  environmentId?: string;
+  spaceId?: string;
+  error?: ErrorObject[] | ErrorObject;
+};

--- a/apps/slack/lambda/lib/errors/exception.ts
+++ b/apps/slack/lambda/lib/errors/exception.ts
@@ -1,5 +1,6 @@
 import { ErrorObject } from 'ajv/dist/types';
 
+// eslint-disable-next-line  @typescript-eslint/no-unused-vars
 export class Exception<T> extends Error {
   status: number;
   message: string;

--- a/apps/slack/lambda/lib/errors/not-found.ts
+++ b/apps/slack/lambda/lib/errors/not-found.ts
@@ -1,7 +1,7 @@
-import { Exception } from './exception';
+import { Exception, ExceptionDetails } from './exception';
 
 export class NotFoundException extends Exception<string> {
-  constructor(details?: string) {
+  constructor(details?: ExceptionDetails) {
     super(404, 'Not Found', details);
   }
 }

--- a/apps/slack/lambda/lib/errors/not-found.ts
+++ b/apps/slack/lambda/lib/errors/not-found.ts
@@ -1,6 +1,6 @@
 import { Exception, ExceptionDetails } from './exception';
 
-export class NotFoundException extends Exception<string> {
+export class NotFoundException extends Exception<ExceptionDetails> {
   constructor(details?: ExceptionDetails) {
     super(404, 'Not Found', details);
   }

--- a/apps/slack/lambda/lib/errors/slack-error.ts
+++ b/apps/slack/lambda/lib/errors/slack-error.ts
@@ -1,6 +1,6 @@
 import { Exception, ExceptionDetails } from './exception';
 
-export class SlackError extends Exception<string> {
+export class SlackError extends Exception<ExceptionDetails> {
   constructor(details?: ExceptionDetails) {
     super(409, 'Conflict', details);
   }

--- a/apps/slack/lambda/lib/errors/slack-error.ts
+++ b/apps/slack/lambda/lib/errors/slack-error.ts
@@ -1,7 +1,7 @@
-import { Exception } from './exception';
+import { Exception, ExceptionDetails } from './exception';
 
 export class SlackError extends Exception<string> {
-  constructor(slackError: string) {
-    super(409, 'Conflict', slackError);
+  constructor(details?: ExceptionDetails) {
+    super(409, 'Conflict', details);
   }
 }

--- a/apps/slack/lambda/lib/errors/unprocessable-entity.ts
+++ b/apps/slack/lambda/lib/errors/unprocessable-entity.ts
@@ -1,8 +1,8 @@
-import { Exception } from './exception';
+import { Exception, ExceptionDetails } from './exception';
 import { ErrorObject } from 'ajv/dist/types';
 
 export class UnprocessableEntityException extends Exception<ErrorObject[] | string> {
-  constructor(details?: ErrorObject[] | string) {
+  constructor(details?: ExceptionDetails) {
     super(422, 'Unprocessable Entity', details);
   }
 }

--- a/apps/slack/lambda/lib/errors/unprocessable-entity.ts
+++ b/apps/slack/lambda/lib/errors/unprocessable-entity.ts
@@ -1,7 +1,7 @@
 import { Exception, ExceptionDetails } from './exception';
 import { ErrorObject } from 'ajv/dist/types';
 
-export class UnprocessableEntityException extends Exception<ErrorObject[] | string> {
+export class UnprocessableEntityException extends Exception<ErrorObject[] | ExceptionDetails> {
   constructor(details?: ExceptionDetails) {
     super(422, 'Unprocessable Entity', details);
   }

--- a/apps/slack/lambda/lib/helpers/getWorkspaceId.ts
+++ b/apps/slack/lambda/lib/helpers/getWorkspaceId.ts
@@ -4,7 +4,7 @@ import { NotFoundException } from '../errors';
 export async function getWorkspaceId(
   spaceId: string,
   environmentId: string,
-  workspaceIdFromParameters?: string,
+  workspaceIdFromParameters?: string
 ): Promise<string> {
   if (workspaceIdFromParameters) {
     return workspaceIdFromParameters;

--- a/apps/slack/lambda/lib/helpers/getWorkspaceId.ts
+++ b/apps/slack/lambda/lib/helpers/getWorkspaceId.ts
@@ -4,7 +4,7 @@ import { NotFoundException } from '../errors';
 export async function getWorkspaceId(
   spaceId: string,
   environmentId: string,
-  workspaceIdFromParameters?: string
+  workspaceIdFromParameters?: string,
 ): Promise<string> {
   if (workspaceIdFromParameters) {
     return workspaceIdFromParameters;
@@ -17,7 +17,7 @@ export async function getWorkspaceId(
   }
 
   if (!workspaceId) {
-    throw new NotFoundException();
+    throw new NotFoundException({ errMessage: 'WorkspaceId not found', environmentId, spaceId });
   }
   return workspaceId;
 }

--- a/apps/slack/lambda/lib/middlewares/request-verification/contentful-request-verification.ts
+++ b/apps/slack/lambda/lib/middlewares/request-verification/contentful-request-verification.ts
@@ -10,7 +10,7 @@ const DEFAULT_TTL = 300; // bump TTL to 5mins to avoid any retry issues with req
 
 export function createContentfulRequestVerificationMiddleware(
   signingSecret: string,
-  verifyRequest = defaultVerifyRequest
+  verifyRequest = defaultVerifyRequest,
 ): RequestHandler {
   return (request, _res, next) => {
     const isValid = verifyRequest(
@@ -21,11 +21,11 @@ export function createContentfulRequestVerificationMiddleware(
         headers: dedupeHeaders(request.headers),
         body: (request.body as Buffer).toString('utf-8'),
       },
-      DEFAULT_TTL
+      DEFAULT_TTL,
     );
 
     if (!isValid) {
-      throw new NotFoundException();
+      throw new NotFoundException({ errMessage: 'Request verification is not valid' });
     }
 
     next();

--- a/apps/slack/lambda/lib/middlewares/request-verification/contentful-request-verification.ts
+++ b/apps/slack/lambda/lib/middlewares/request-verification/contentful-request-verification.ts
@@ -10,7 +10,7 @@ const DEFAULT_TTL = 300; // bump TTL to 5mins to avoid any retry issues with req
 
 export function createContentfulRequestVerificationMiddleware(
   signingSecret: string,
-  verifyRequest = defaultVerifyRequest,
+  verifyRequest = defaultVerifyRequest
 ): RequestHandler {
   return (request, _res, next) => {
     const isValid = verifyRequest(
@@ -21,7 +21,7 @@ export function createContentfulRequestVerificationMiddleware(
         headers: dedupeHeaders(request.headers),
         body: (request.body as Buffer).toString('utf-8'),
       },
-      DEFAULT_TTL,
+      DEFAULT_TTL
     );
 
     if (!isValid) {

--- a/apps/slack/lambda/lib/routes/auth-token/controller.ts
+++ b/apps/slack/lambda/lib/routes/auth-token/controller.ts
@@ -11,7 +11,10 @@ import { OAuthResult } from './constants';
 import { NotFoundException } from '../../errors';
 
 export class AuthTokenController {
-  constructor(private authTokenRepository: AuthTokenRepository, private frontendUrl: string) {}
+  constructor(
+    private authTokenRepository: AuthTokenRepository,
+    private frontendUrl: string,
+  ) {}
 
   /**
    * @openapi
@@ -54,7 +57,7 @@ export class AuthTokenController {
 
     const { code, spaceId, environmentId } = assertValid<GetAuthTokenParameters>(
       getAuthTokenParametersSchema,
-      request.query
+      request.query,
     );
 
     let result, slackWorkspaceId, accessToken, refreshToken, errorMessage;
@@ -125,7 +128,11 @@ export class AuthTokenController {
     const installationUuid = request.header('x-contentful-uuid');
 
     if (!spaceId || !environmentId) {
-      throw new NotFoundException();
+      throw new NotFoundException({
+        errMessage: 'EnvironmentId or spaceId not found in headers',
+        environmentId,
+        spaceId,
+      });
     }
     const { refreshToken } = assertValid<PostAuthTokenBody>(postAuthTokenBodySchema, request.body);
 
@@ -135,7 +142,7 @@ export class AuthTokenController {
         spaceId,
         environmentId,
       },
-      installationUuid
+      installationUuid,
     );
 
     response.status(201).send({ token });

--- a/apps/slack/lambda/lib/routes/auth-token/controller.ts
+++ b/apps/slack/lambda/lib/routes/auth-token/controller.ts
@@ -57,7 +57,7 @@ export class AuthTokenController {
 
     const { code, spaceId, environmentId } = assertValid<GetAuthTokenParameters>(
       getAuthTokenParametersSchema,
-      request.query,
+      request.query
     );
 
     let result, slackWorkspaceId, accessToken, refreshToken, errorMessage;
@@ -142,7 +142,7 @@ export class AuthTokenController {
         spaceId,
         environmentId,
       },
-      installationUuid,
+      installationUuid
     );
 
     response.status(201).send({ token });

--- a/apps/slack/lambda/lib/routes/auth-token/repository.test.ts
+++ b/apps/slack/lambda/lib/routes/auth-token/repository.test.ts
@@ -70,7 +70,7 @@ describe('AuthTokenRepository', () => {
           token: 'token',
           refreshToken: 'refresh-token',
           slackWorkspaceId: 'team',
-        },
+        }
       );
     });
 
@@ -130,7 +130,7 @@ describe('AuthTokenRepository', () => {
           spaceId: 'spaceId',
           environmentId: 'environmentId',
         },
-        UUID,
+        UUID
       );
 
       const expectedData: AuthToken = {
@@ -147,7 +147,7 @@ describe('AuthTokenRepository', () => {
         Entity.AuthToken,
         UUID,
         ['spaceId', UUID],
-        expectedData,
+        expectedData
       );
       assert.deepEqual(response, expectedData);
     });
@@ -170,7 +170,7 @@ describe('AuthTokenRepository', () => {
             // @ts-expect-error expected from scenario
             environmentId: null,
           },
-          UUID,
+          UUID
         );
         assert.fail('Did not reject');
       } catch (e) {
@@ -216,7 +216,7 @@ describe('AuthTokenRepository', () => {
           spaceId: 'spaceId-1',
           environmentId: 'environmentId-1',
         },
-        UUID,
+        UUID
       );
 
       assert.calledWith(
@@ -224,7 +224,7 @@ describe('AuthTokenRepository', () => {
         Entity.AuthToken,
         UUID,
         ['spaceId-1', UUID],
-        newAuthToken,
+        newAuthToken
       );
 
       assert.calledWith(singleTableClient.put, Entity.AuthToken, UUID, ['spaceId-2', UUID], {
@@ -317,7 +317,7 @@ describe('AuthTokenRepository', () => {
         Entity.AuthToken,
         `${UUID}-other`,
         ['space-other', `${UUID}-other`],
-        newOtherToken,
+        newOtherToken
       );
     });
 
@@ -350,7 +350,7 @@ describe('AuthTokenRepository', () => {
           spaceId: 'space',
           environmentId: 'env',
         }),
-        NotFoundException,
+        NotFoundException
       );
 
       assert.notCalled(singleTableClient.delete);
@@ -385,7 +385,7 @@ describe('AuthTokenRepository', () => {
           spaceId: 'space',
           environmentId: 'env',
         }),
-        NotFoundException,
+        NotFoundException
       );
 
       assert.calledTwice(singleTableClient.delete);

--- a/apps/slack/lambda/lib/routes/auth-token/repository.test.ts
+++ b/apps/slack/lambda/lib/routes/auth-token/repository.test.ts
@@ -70,7 +70,7 @@ describe('AuthTokenRepository', () => {
           token: 'token',
           refreshToken: 'refresh-token',
           slackWorkspaceId: 'team',
-        }
+        },
       );
     });
 
@@ -130,7 +130,7 @@ describe('AuthTokenRepository', () => {
           spaceId: 'spaceId',
           environmentId: 'environmentId',
         },
-        UUID
+        UUID,
       );
 
       const expectedData: AuthToken = {
@@ -147,7 +147,7 @@ describe('AuthTokenRepository', () => {
         Entity.AuthToken,
         UUID,
         ['spaceId', UUID],
-        expectedData
+        expectedData,
       );
       assert.deepEqual(response, expectedData);
     });
@@ -170,7 +170,7 @@ describe('AuthTokenRepository', () => {
             // @ts-expect-error expected from scenario
             environmentId: null,
           },
-          UUID
+          UUID,
         );
         assert.fail('Did not reject');
       } catch (e) {
@@ -216,7 +216,7 @@ describe('AuthTokenRepository', () => {
           spaceId: 'spaceId-1',
           environmentId: 'environmentId-1',
         },
-        UUID
+        UUID,
       );
 
       assert.calledWith(
@@ -224,7 +224,7 @@ describe('AuthTokenRepository', () => {
         Entity.AuthToken,
         UUID,
         ['spaceId-1', UUID],
-        newAuthToken
+        newAuthToken,
       );
 
       assert.calledWith(singleTableClient.put, Entity.AuthToken, UUID, ['spaceId-2', UUID], {
@@ -317,7 +317,7 @@ describe('AuthTokenRepository', () => {
         Entity.AuthToken,
         `${UUID}-other`,
         ['space-other', `${UUID}-other`],
-        newOtherToken
+        newOtherToken,
       );
     });
 
@@ -343,14 +343,14 @@ describe('AuthTokenRepository', () => {
 
       singleTableClient.get.resolves(oldToken);
       singleTableClient.queryByWorkspaceId.resolves([oldToken, otherToken]);
-      slackClient.refreshToken.rejects(new SlackError('unknown'));
+      slackClient.refreshToken.rejects(new SlackError({ errMessage: 'unknown' }));
 
       await assert.rejects(
         instance.get('workspace', {
           spaceId: 'space',
           environmentId: 'env',
         }),
-        NotFoundException
+        NotFoundException,
       );
 
       assert.notCalled(singleTableClient.delete);
@@ -378,14 +378,14 @@ describe('AuthTokenRepository', () => {
 
       singleTableClient.get.resolves(oldToken);
       singleTableClient.queryByWorkspaceId.resolves([oldToken, otherToken]);
-      slackClient.refreshToken.rejects(new SlackError('invalid_refresh_token'));
+      slackClient.refreshToken.rejects(new SlackError({ errMessage: 'invalid_refresh_token' }));
 
       await assert.rejects(
         instance.get('workspace', {
           spaceId: 'space',
           environmentId: 'env',
         }),
-        NotFoundException
+        NotFoundException,
       );
 
       assert.calledTwice(singleTableClient.delete);

--- a/apps/slack/lambda/lib/routes/auth-token/repository.ts
+++ b/apps/slack/lambda/lib/routes/auth-token/repository.ts
@@ -15,7 +15,7 @@ export class AuthTokenRepository {
 
   async validate(
     code: string,
-    { spaceId, environmentId }: SpaceEnvironmentContext,
+    { spaceId, environmentId }: SpaceEnvironmentContext
   ): Promise<Pick<AuthToken, 'refreshToken' | 'token' | 'slackWorkspaceId'>> {
     const accessResponse = await this.slackClient.getAuthToken(code, {
       spaceId,
@@ -49,7 +49,7 @@ export class AuthTokenRepository {
   async put(
     refreshToken: string,
     { spaceId, environmentId }: SpaceEnvironmentContext,
-    installationUuid?: string,
+    installationUuid?: string
   ): Promise<AuthToken> {
     const accessResponse = await this.slackClient.refreshToken(refreshToken);
 
@@ -57,7 +57,7 @@ export class AuthTokenRepository {
       spaceId,
       environmentId,
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      accessResponse.team!.id!,
+      accessResponse.team!.id!
     );
 
     const authToken = AuthTokenRepository.toDatabase(
@@ -66,7 +66,7 @@ export class AuthTokenRepository {
         spaceId,
         environmentId,
       },
-      installationUuid,
+      installationUuid
     );
 
     await this.updateByWorkspaceId(authToken.slackWorkspaceId, authToken);
@@ -75,7 +75,7 @@ export class AuthTokenRepository {
       Entity.AuthToken,
       installationUuid || uuid,
       [spaceId, installationUuid || environmentId],
-      authToken,
+      authToken
     );
 
     return authToken;
@@ -115,11 +115,11 @@ export class AuthTokenRepository {
 
   private async updateByWorkspaceId(
     workspaceId: string,
-    authToken: Pick<AuthToken, 'refreshToken' | 'expiresAt' | 'token'>,
+    authToken: Pick<AuthToken, 'refreshToken' | 'expiresAt' | 'token'>
   ): Promise<void> {
     const authTokens = await this.singleTableClient.queryByWorkspaceId(
       Entity.AuthToken,
-      workspaceId,
+      workspaceId
     );
 
     await Promise.all(
@@ -127,7 +127,7 @@ export class AuthTokenRepository {
         const uuid = AuthTokenRepository.uuid(
           token.spaceId,
           token.environmentId,
-          token.slackWorkspaceId,
+          token.slackWorkspaceId
         );
         const data: AuthToken = {
           ...token,
@@ -139,16 +139,16 @@ export class AuthTokenRepository {
           Entity.AuthToken,
           token?.installationUuid || uuid,
           [token.spaceId, token.installationUuid || token.environmentId],
-          data,
+          data
         );
-      }),
+      })
     );
   }
 
   async deleteByWorkspaceId(workspaceId: string, installationUuid?: string): Promise<void> {
     const authTokens = await this.singleTableClient.queryByWorkspaceId(
       Entity.AuthToken,
-      workspaceId,
+      workspaceId
     );
 
     await Promise.all(
@@ -159,10 +159,10 @@ export class AuthTokenRepository {
             AuthTokenRepository.uuid(
               authToken.spaceId,
               authToken.environmentId,
-              authToken.slackWorkspaceId,
-            ),
-        ),
-      ),
+              authToken.slackWorkspaceId
+            )
+        )
+      )
     );
   }
 
@@ -171,7 +171,7 @@ export class AuthTokenRepository {
 
     if (values.some((i) => !i)) {
       throw new UnprocessableEntityException({
-        errMessage: `Cannot create UUID for space ${spaceId}, environment ${environmentId}, workspace ${workspaceId}`,
+        errMessage: `Cannot create UUID for space ${spaceId}, environment ${environmentId}, workspace ${workspaceId}`
       });
     }
 
@@ -185,7 +185,7 @@ export class AuthTokenRepository {
   private static toDatabase(
     slackTokenResponse: OauthV2AccessResponse,
     { spaceId, environmentId }: SpaceEnvironmentContext,
-    installationUuid?: string,
+    installationUuid?: string
   ): AuthToken {
     const defaultAttributes = {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -209,7 +209,7 @@ export class AuthTokenRepository {
    */
   private static applyRefreshResponse(
     currentToken: AuthToken,
-    slackRefreshResponse: OauthV2AccessResponse,
+    slackRefreshResponse: OauthV2AccessResponse
   ): AuthToken {
     return {
       ...currentToken,

--- a/apps/slack/lambda/lib/routes/events/service.ts
+++ b/apps/slack/lambda/lib/routes/events/service.ts
@@ -13,7 +13,7 @@ export class EventsService {
     private readonly acceptedEvents: SlackAppEventKey[],
     private readonly authTokenRepository: AuthTokenRepository,
     private readonly messagesRepository: MessagesRepository,
-    private makeCmaClient: typeof makeSpaceEnvClient
+    private makeCmaClient: typeof makeSpaceEnvClient,
   ) {
     this.acceptedEvents = acceptedEvents;
   }
@@ -21,7 +21,7 @@ export class EventsService {
   private getEntryName = async (
     cmaClient: PlainClientAPI,
     entry: EntryProps,
-    contentType: ContentTypeProps
+    contentType: ContentTypeProps,
   ): Promise<string | undefined> => {
     try {
       const locales = await cmaClient.locale.getMany({});
@@ -41,7 +41,7 @@ export class EventsService {
 
   convertToEventKey(topic?: string): SlackAppEventKey | undefined {
     if (!topic) {
-      throw new NotFoundException();
+      throw new NotFoundException({ errMessage: 'Event topic not found' });
     }
     const eventArr = topic.split('.');
     if (eventArr.length > 0) {
@@ -62,7 +62,11 @@ export class EventsService {
 
     if (!installationParameters.workspaces || installationParameters.workspaces.length < 1) {
       // no workspace connected
-      throw new NotFoundException();
+      throw new NotFoundException({
+        errMessage: 'Workspaces not found in installation parameters',
+        environmentId,
+        spaceId,
+      });
     }
     return installationParameters;
   }
@@ -71,7 +75,7 @@ export class EventsService {
     notifications: SlackNotification[],
     eventKey: SlackAppEventKey,
     workspaceId: string,
-    eventBody: EventEntity
+    eventBody: EventEntity,
   ) {
     const spaceId = eventBody.sys.space.sys.id;
     const environmentId = eventBody.sys.environment.sys.id;
@@ -96,7 +100,7 @@ export class EventsService {
         acc.push(
           this.messagesRepository.create(token, selectedChannel, {
             blocks: this.createMessageBlocks(eventKey, eventBody, resolvedEntity),
-          })
+          }),
         );
       }
       return acc;
@@ -109,7 +113,7 @@ export class EventsService {
     spaceId: string,
     environmentId: string,
     event: SlackAppEventKey,
-    eventBody: EventEntity
+    eventBody: EventEntity,
   ): Promise<ResolvedEntity | undefined> {
     let actorId: undefined | string;
     let date: undefined | string;

--- a/apps/slack/lambda/lib/routes/events/service.ts
+++ b/apps/slack/lambda/lib/routes/events/service.ts
@@ -13,7 +13,7 @@ export class EventsService {
     private readonly acceptedEvents: SlackAppEventKey[],
     private readonly authTokenRepository: AuthTokenRepository,
     private readonly messagesRepository: MessagesRepository,
-    private makeCmaClient: typeof makeSpaceEnvClient,
+    private makeCmaClient: typeof makeSpaceEnvClient
   ) {
     this.acceptedEvents = acceptedEvents;
   }
@@ -21,7 +21,7 @@ export class EventsService {
   private getEntryName = async (
     cmaClient: PlainClientAPI,
     entry: EntryProps,
-    contentType: ContentTypeProps,
+    contentType: ContentTypeProps
   ): Promise<string | undefined> => {
     try {
       const locales = await cmaClient.locale.getMany({});
@@ -75,7 +75,7 @@ export class EventsService {
     notifications: SlackNotification[],
     eventKey: SlackAppEventKey,
     workspaceId: string,
-    eventBody: EventEntity,
+    eventBody: EventEntity
   ) {
     const spaceId = eventBody.sys.space.sys.id;
     const environmentId = eventBody.sys.environment.sys.id;
@@ -100,7 +100,7 @@ export class EventsService {
         acc.push(
           this.messagesRepository.create(token, selectedChannel, {
             blocks: this.createMessageBlocks(eventKey, eventBody, resolvedEntity),
-          }),
+          })
         );
       }
       return acc;
@@ -113,7 +113,7 @@ export class EventsService {
     spaceId: string,
     environmentId: string,
     event: SlackAppEventKey,
-    eventBody: EventEntity,
+    eventBody: EventEntity
   ): Promise<ResolvedEntity | undefined> {
     let actorId: undefined | string;
     let date: undefined | string;

--- a/apps/slack/lambda/lib/routes/messages/controller.ts
+++ b/apps/slack/lambda/lib/routes/messages/controller.ts
@@ -11,7 +11,11 @@ const extractFromSignedHeaders = (request: Request) => {
   const environmentId = request.header('x-contentful-environment-id');
 
   if (!spaceId || !environmentId) {
-    throw new ConflictException();
+    throw new ConflictException({
+      errMessage: 'EnvironmentId or spaceId not found in headers',
+      spaceId,
+      environmentId,
+    });
   }
 
   return { environmentId, spaceId };
@@ -20,7 +24,7 @@ const extractFromSignedHeaders = (request: Request) => {
 export class MessagesController {
   constructor(
     private readonly authTokenRepository: AuthTokenRepository,
-    private readonly messagesRepository: MessagesRepository
+    private readonly messagesRepository: MessagesRepository,
   ) {}
 
   post = asyncHandler(async (request, response) => {

--- a/apps/slack/lambda/lib/routes/messages/controller.ts
+++ b/apps/slack/lambda/lib/routes/messages/controller.ts
@@ -24,7 +24,7 @@ const extractFromSignedHeaders = (request: Request) => {
 export class MessagesController {
   constructor(
     private readonly authTokenRepository: AuthTokenRepository,
-    private readonly messagesRepository: MessagesRepository,
+    private readonly messagesRepository: MessagesRepository
   ) {}
 
   post = asyncHandler(async (request, response) => {

--- a/apps/slack/lambda/lib/routes/workspaces/repository.ts
+++ b/apps/slack/lambda/lib/routes/workspaces/repository.ts
@@ -10,7 +10,7 @@ export class WorkspacesRepository {
     const info = await this.slackClient.getWorkspaceInformation(token, workspaceId);
 
     if (!info?.team) {
-      throw new NotFoundException(notFoundMessage(workspaceId));
+      throw new NotFoundException({ errMessage: notFoundMessage(workspaceId) });
     }
 
     return WorkspacesRepository.toAPI(info.team);

--- a/apps/slack/lambda/lib/utils.ts
+++ b/apps/slack/lambda/lib/utils.ts
@@ -15,7 +15,7 @@ const ajv = new Ajv({
 // This allows any handler to be async
 export const asyncHandler =
   (
-    handler: (...params: Parameters<RequestHandler>) => Promise<ReturnType<RequestHandler>>
+    handler: (...params: Parameters<RequestHandler>) => Promise<ReturnType<RequestHandler>>,
   ): RequestHandler =>
   (request, response, next) => {
     return handler(request, response, next).catch(next);
@@ -30,11 +30,12 @@ export const assertValid = <T>(schema: { [key: string]: any }, data: unknown): T
       // https://json-schema.org/understanding-json-schema/reference/schema.html
       $schema: 'http://json-schema.org/draft-07/schema#',
     },
-    data
+    data,
   );
 
   if (!valid) {
-    throw new UnprocessableEntityException(ajv.errors ?? `Invalid Entity`);
+    if (ajv.errors) throw new UnprocessableEntityException({ error: ajv.errors });
+    throw new UnprocessableEntityException({ errMessage: 'Invalid entity' });
   }
 
   return data as T;

--- a/apps/slack/lambda/lib/utils.ts
+++ b/apps/slack/lambda/lib/utils.ts
@@ -15,7 +15,7 @@ const ajv = new Ajv({
 // This allows any handler to be async
 export const asyncHandler =
   (
-    handler: (...params: Parameters<RequestHandler>) => Promise<ReturnType<RequestHandler>>,
+    handler: (...params: Parameters<RequestHandler>) => Promise<ReturnType<RequestHandler>>
   ): RequestHandler =>
   (request, response, next) => {
     return handler(request, response, next).catch(next);
@@ -30,7 +30,7 @@ export const assertValid = <T>(schema: { [key: string]: any }, data: unknown): T
       // https://json-schema.org/understanding-json-schema/reference/schema.html
       $schema: 'http://json-schema.org/draft-07/schema#',
     },
-    data,
+    data
   );
 
   if (!valid) {


### PR DESCRIPTION
## Purpose

This PR adjusts the following: 

1. Adds more meaningful messages and identifiers to errors thrown within the Slack app lambda. 
2. Fixes [this](https://contentful.atlassian.net/browse/INTEG-652) issue. 

Also as you will notice, lots of trailing commas are added as per the prettier commit hook. I am not sure if this is standard, but I have trouble reverting the changes locally given the commit hook does them, though I could via github if they are an issue. Please let me know your thoughts!

## Approach

1. This PR adjusts the `Exception` class within the API to handle the addition of identifying information like `environmentId` and `spaceId`. Additionally, more meaningful error messages are provided when the errors are manually thrown. 
2. This was a small issue where a snackbar was rendering and indicating to the user that an error occurred, despite successful installation. This snackbar is being initialized from the `useConnect` component which is the popup that renders when connecting to Slack via the auth flow. The error being thrown that is causing this snackbar is simply a race condition of the API grabbing installation parameters via the `CMA` just a little before the app is actually labeled as "installed". I believe the only reason this is occurring is because the `EventsService` class, that fetches these installation parameters on subsequent requests, is being instantiated when the auth token is created (`POST` call to `/api/tokens`) in the `useConnect` popup auth flow. The error is not meaningful and would require a bit of an overhaul to completely prevent it from being thrown (as far as I understand, but please let me know if you believe otherwise!), so for now to improve user experience, this PR just renders an error snackbar if the error is anything other than this specific race condition error. 

## Testing steps

Uninstall and install the Slack app in your local environment, and confirm that all works correctly and no extraneous error messages appear. 

