### PR TITLE
Fix [INTEG-529]: Display Sidebar Note when GA4 installation params are missing

### DIFF
--- a/apps/google-analytics-4/frontend/src/components/main-app/constants/noteMessages.ts
+++ b/apps/google-analytics-4/frontend/src/components/main-app/constants/noteMessages.ts
@@ -1,3 +1,5 @@
+import { ServiceAccountKeyId } from 'types';
+
 export const DEFAULT_ERR_MSG =
   'An unknown error has occurred. Please try again or contact support.';
 export const EMPTY_DATA_MSG =
@@ -14,3 +16,20 @@ export const getContentTypeSpecificMsg = (contentTypeName: string) => ({
   noSlugContentMsg: `This ${contentTypeName} entry does not have a valid slug field. Please add a field of type short text to this entry and configure it on the app configuration page.`,
   notPublishedMsg: `This ${contentTypeName} entry has not yet been published. Please publish the entry to view this Google Analytics 4 sidebar app.`,
 });
+
+export const getAppInstallationParamsMsg = (
+  serviceAccountKeyId: ServiceAccountKeyId | undefined,
+  propertyId: string | undefined
+) => {
+  const serviceAccountMsg = 'Service Account Key';
+  const propertyMsg = 'Google Analytics 4 property';
+  let missingParams = '';
+
+  if (!serviceAccountKeyId && !propertyId)
+    missingParams = `${serviceAccountMsg} and ${propertyMsg}`;
+  else {
+    !serviceAccountKeyId ? (missingParams = serviceAccountMsg) : (missingParams = propertyMsg);
+  }
+
+  return `No ${missingParams} provided or found in app installation parameters. Please update your app configuration page. `;
+};

--- a/apps/google-analytics-4/frontend/src/components/main-app/constants/noteMessages.ts
+++ b/apps/google-analytics-4/frontend/src/components/main-app/constants/noteMessages.ts
@@ -1,5 +1,3 @@
-import { ServiceAccountKeyId } from 'types';
-
 export const DEFAULT_ERR_MSG =
   'An unknown error has occurred. Please try again or contact support.';
 export const EMPTY_DATA_MSG =
@@ -17,19 +15,18 @@ export const getContentTypeSpecificMsg = (contentTypeName: string) => ({
   notPublishedMsg: `This ${contentTypeName} entry has not yet been published. Please publish the entry to view this Google Analytics 4 sidebar app.`,
 });
 
-export const getAppInstallationParamsMsg = (
-  serviceAccountKeyId: ServiceAccountKeyId | undefined,
-  propertyId: string | undefined
+export const getMissingParamsMsg = (
+  serviceAccountKeyMissing: boolean,
+  propertyIdMissing: boolean
 ) => {
   const serviceAccountMsg = 'Service Account Key';
   const propertyMsg = 'Google Analytics 4 property';
   let missingParams = '';
 
-  if (!serviceAccountKeyId && !propertyId)
+  if (serviceAccountKeyMissing && propertyIdMissing)
     missingParams = `${serviceAccountMsg} and ${propertyMsg}`;
-  else {
-    !serviceAccountKeyId ? (missingParams = serviceAccountMsg) : (missingParams = propertyMsg);
-  }
+  else if (serviceAccountKeyMissing) missingParams = `${serviceAccountMsg}`;
+  else if (propertyIdMissing) missingParams = `${propertyMsg}`;
 
   return `No ${missingParams} provided or found in app installation parameters. Please update your app configuration page. `;
 };

--- a/apps/google-analytics-4/frontend/src/hooks/useApi.ts
+++ b/apps/google-analytics-4/frontend/src/hooks/useApi.ts
@@ -10,10 +10,6 @@ export function useApi(serviceAccountKeyId?: ServiceAccountKeyId): Api {
 
   const accountKeyId = serviceAccountKeyId || sdk.parameters.installation.serviceAccountKeyId;
 
-  if (!accountKeyId) {
-    throw new Error('No ServiceAccountKeyId provided or found in installation parameters');
-  }
-
   const api = useMemo(() => {
     return new Api(contentfulContext(sdk), cma, accountKeyId);
   }, [cma, accountKeyId, sdk]);

--- a/apps/google-analytics-4/frontend/src/locations/Sidebar.tsx
+++ b/apps/google-analytics-4/frontend/src/locations/Sidebar.tsx
@@ -4,7 +4,7 @@ import { SidebarExtensionSDK } from '@contentful/app-sdk';
 import { useApi } from 'hooks/useApi';
 import { AppInstallationParameters } from 'types';
 import Note from 'components/common/Note/Note';
-import { getAppInstallationParamsMsg } from 'components/main-app/constants/noteMessages';
+import { getMissingParamsMsg } from 'components/main-app/constants/noteMessages';
 import { AppConfigPageHyperLink } from 'components/main-app/ErrorDisplay/CommonErrorDisplays';
 
 const Sidebar = () => {
@@ -24,7 +24,7 @@ const Sidebar = () => {
   const hasInstallationParams = serviceAccountKeyId && propertyId;
 
   if (!hasInstallationParams) {
-    const bodyMsg = getAppInstallationParamsMsg(serviceAccountKeyId, propertyId);
+    const bodyMsg = getMissingParamsMsg(!serviceAccountKeyId, !propertyId);
     return <Note body={<AppConfigPageHyperLink bodyMsg={bodyMsg} />} variant="warning" />;
   }
 

--- a/apps/google-analytics-4/frontend/src/locations/Sidebar.tsx
+++ b/apps/google-analytics-4/frontend/src/locations/Sidebar.tsx
@@ -3,6 +3,9 @@ import { useSDK } from '@contentful/react-apps-toolkit';
 import { SidebarExtensionSDK } from '@contentful/app-sdk';
 import { useApi } from 'hooks/useApi';
 import { AppInstallationParameters } from 'types';
+import Note from 'components/common/Note/Note';
+import { getAppInstallationParamsMsg } from 'components/main-app/constants/noteMessages';
+import { AppConfigPageHyperLink } from 'components/main-app/ErrorDisplay/CommonErrorDisplays';
 
 const Sidebar = () => {
   const sdk = useSDK<SidebarExtensionSDK>();
@@ -17,6 +20,13 @@ const Sidebar = () => {
   };
 
   const api = useApi(serviceAccountKeyId);
+
+  const hasInstallationParams = serviceAccountKeyId && propertyId;
+
+  if (!hasInstallationParams) {
+    const bodyMsg = getAppInstallationParamsMsg(serviceAccountKeyId, propertyId);
+    return <Note body={<AppConfigPageHyperLink bodyMsg={bodyMsg} />} variant="warning" />;
+  }
 
   return (
     <>


### PR DESCRIPTION
## Purpose

When the GA4 app is programmatically installed without the necessary app installation parameters, the Sidebar app was throwing errors for a missing `serviceAccountKeyId` and/or a missing `propertyId`. 

## Approach

This PR handles checking whether these installation parameters exist, and then displaying a helpful message if they don't exist rather than throwing an error and not rendering anything in the Sidebar. The Sentry errors we are seeing should be resolved by this.

<img width="356" alt="Screenshot 2023-07-13 at 9 10 41 PM" src="https://github.com/contentful/apps/assets/62958907/e6c96a62-acba-4fa2-a224-7b7c56546ade">

## Testing steps

Change the values of the app installation parameters in the Sidebar component to undefined to see the Note in the Sidebar.


