### PR TITLE
updates example tsconfigs to use NodeNext module resolution

### DIFF
--- a/examples/app-actions/tsconfig.json
+++ b/examples/app-actions/tsconfig.json
@@ -9,7 +9,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "NodeNext",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",

--- a/examples/asset-upload/tsconfig.json
+++ b/examples/asset-upload/tsconfig.json
@@ -10,7 +10,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "NodeNext",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,

--- a/examples/blog-post-metrics/tsconfig.json
+++ b/examples/blog-post-metrics/tsconfig.json
@@ -10,7 +10,7 @@
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "NodeNext",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,

--- a/examples/nextjs/tsconfig.json
+++ b/examples/nextjs/tsconfig.json
@@ -9,7 +9,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "NodeNext",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",

--- a/examples/page-location/tsconfig.json
+++ b/examples/page-location/tsconfig.json
@@ -10,7 +10,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "NodeNext",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,

--- a/examples/typescript-github-action/tsconfig.json
+++ b/examples/typescript-github-action/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "@tsconfig/create-react-app/tsconfig.json",
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"]
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "moduleResolution": "NodeNext"
   },
   "include": ["src"]
 }

--- a/examples/typescript/tsconfig.json
+++ b/examples/typescript/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "@tsconfig/create-react-app/tsconfig.json",
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"]
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "moduleResolution": "NodeNext"
   },
   "include": ["src"]
 }

--- a/examples/vite-react/tsconfig.json
+++ b/examples/vite-react/tsconfig.json
@@ -10,7 +10,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "NodeNext",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,


### PR DESCRIPTION
## Purpose
resolve typescript compiler module resolution issues (re: https://github.com/contentful/apps/issues/4172)

## Approach
update tsconfig.json in examples to have `"moduleResolution": "NodeNext"`