### PR TITLE
[INTEG-871]: Update filtering for source and output field selectors

### DIFF
--- a/apps/ai-content-generator/src/components/app/dialog/common-generator/field-selector/FieldSelector.tsx
+++ b/apps/ai-content-generator/src/components/app/dialog/common-generator/field-selector/FieldSelector.tsx
@@ -22,19 +22,23 @@ const FieldSelector = (props: Props) => {
   const { isNewText, sourceField, outputField, locale, targetLocale } = parameters;
   const { entryId, dispatch } = useContext(GeneratorContext);
 
-  const { supportedFields, fields } = useSupportedFields(entryId, fieldTypes, parameters.locale);
+  const { supportedFieldsWithContent, allSupportedFields } = useSupportedFields(
+    entryId,
+    fieldTypes,
+    locale
+  );
 
   const handleSelectChange = (action: GeneratorAction) => {
     if (action === GeneratorAction.UPDATE_SOURCE_FIELD) {
       return (event: ChangeEvent<HTMLSelectElement>) => {
-        const sourceFieldData = getFieldData(event.target.value, fields);
-        updateSourceField(sourceFieldData, fields[0], dispatch);
+        const sourceFieldData = getFieldData(event.target.value, supportedFieldsWithContent);
+        updateSourceField(sourceFieldData, supportedFieldsWithContent[0], dispatch);
       };
     }
 
     if (action === GeneratorAction.UPDATE_OUTPUT_FIELD) {
       return (event: ChangeEvent<HTMLSelectElement>) =>
-        updateOutputField(event.target.value, supportedFields[0], dispatch);
+        updateOutputField(event.target.value, allSupportedFields[0], dispatch);
     }
 
     return (event: ChangeEvent<HTMLSelectElement>) =>
@@ -45,16 +49,14 @@ const FieldSelector = (props: Props) => {
   };
 
   const handleBaseDataChange = () => {
-    if (fields.length) {
+    if (supportedFieldsWithContent.length) {
       const sourceFieldData = isNewText
-        ? { name: sourceField, data: '' }
-        : getFieldData(sourceField, fields);
-
-      updateSourceField(sourceFieldData, fields[0], dispatch);
+        ? { id: '', name: '', data: '' }
+        : getFieldData(sourceField, supportedFieldsWithContent);
+      updateSourceField(sourceFieldData, supportedFieldsWithContent[0], dispatch);
     }
-
-    if (supportedFields.length) {
-      updateOutputField(outputField, supportedFields[0], dispatch);
+    if (allSupportedFields.length) {
+      updateOutputField(outputField, allSupportedFields[0], dispatch);
     }
   };
 
@@ -67,7 +69,7 @@ const FieldSelector = (props: Props) => {
         <EntryFieldList
           title="Source Field"
           selectedField={sourceField}
-          fields={fields}
+          fields={supportedFieldsWithContent}
           onChange={handleSelectChange(GeneratorAction.UPDATE_SOURCE_FIELD)}
         />
       )}
@@ -75,7 +77,7 @@ const FieldSelector = (props: Props) => {
       <EntryFieldList
         title="Output Field"
         selectedField={outputField}
-        fields={supportedFields}
+        fields={allSupportedFields}
         onChange={handleSelectChange(GeneratorAction.UPDATE_OUTPUT_FIELD)}
       />
 

--- a/apps/ai-content-generator/src/components/app/dialog/common-generator/field-selector/field-list/EntryFieldList.tsx
+++ b/apps/ai-content-generator/src/components/app/dialog/common-generator/field-selector/field-list/EntryFieldList.tsx
@@ -13,7 +13,7 @@ function EntryFieldList(props: Props) {
   const { title, selectedField, fields, onChange } = props;
 
   const fieldList = fields.map((field) => (
-    <Select.Option key={field.name} value={field.name}>
+    <Select.Option key={field.id} value={field.id}>
       {field.name}
     </Select.Option>
   ));

--- a/apps/ai-content-generator/src/hooks/dialog/useSupportedFields.ts
+++ b/apps/ai-content-generator/src/hooks/dialog/useSupportedFields.ts
@@ -3,6 +3,7 @@ import { isSupported } from '@utils/dialog/supported-fields/supportedFieldsHelpe
 import useEntryAndContentType from './useEntryAndContentType';
 
 interface Field {
+  id: string;
   name: string;
   data: string;
 }
@@ -25,7 +26,10 @@ const TranslatableFields = [
   SupportedFieldTypes.TEXT,
 ];
 
-export type SupportedFieldsOutput = { supportedFields: Field[]; fields: Field[] };
+export type SupportedFieldsOutput = {
+  allSupportedFields: Field[];
+  supportedFieldsWithContent: Field[];
+};
 
 /**
  * This hook is used to get the fields of an entry that are supported by the feature.
@@ -48,15 +52,15 @@ const useSupportedFields = (
       const validatedFields: SupportedFieldsOutput = contentType.fields.reduce(
         isSupported(entry, supportedFields, targetLocale),
         {
-          supportedFields: [],
-          fields: [],
+          supportedFieldsWithContent: [],
+          allSupportedFields: [],
         }
       );
 
       return validatedFields;
     }
 
-    return { supportedFields: [], fields: [] };
+    return { supportedFieldsWithContent: [], allSupportedFields: [] };
   }, [entry, contentType, targetLocale, supportedFields]);
 
   return { ...fields };

--- a/apps/ai-content-generator/src/utils/dialog/common-generator/field-selector/fieldSelectorHelpers.ts
+++ b/apps/ai-content-generator/src/utils/dialog/common-generator/field-selector/fieldSelectorHelpers.ts
@@ -6,14 +6,16 @@ import { Field } from '@hooks/dialog/useSupportedFields';
 import { Dispatch } from 'react';
 
 /**
- * This finds a field in a list of fields and returns the field name and data.
- * @param fieldName
+ * This finds a field in a list of fields and returns the field id, name, and data.
+ * @param fieldId
  * @param fields
  * @returns
  */
-const getFieldData = (fieldName: string, fields: Field[]) => {
-  const field = fields.find((field) => field.name === fieldName);
-  return field ? { name: field.name, data: field.data || '' } : { name: '', data: '' };
+const getFieldData = (fieldId: string, fields: Field[]) => {
+  const field = fields.find((field) => field.id === fieldId);
+  return field
+    ? { id: field.id, name: field.name, data: field.data || '' }
+    : { id: '', name: '', data: '' };
 };
 
 /**
@@ -29,25 +31,25 @@ const updateSourceField = (
 ) => {
   dispatch({
     type: GeneratorAction.UPDATE_SOURCE_FIELD,
-    field: sourceField.name || fallbackField.name,
-    value: sourceField.name ? sourceField.data : fallbackField.data,
+    field: sourceField.id || fallbackField.id,
+    value: sourceField.id ? sourceField.data : fallbackField.data,
   });
 };
 
 /**
  * Dispatches an action to update the output field.
- * @param outputFieldName
+ * @param outputFieldId
  * @param fallbackField
  * @param dispatch
  */
 const updateOutputField = (
-  outputFieldName: string,
+  outputFieldId: string,
   fallbackField: Field,
   dispatch: Dispatch<GeneratorReducer>
 ) => {
   dispatch({
     type: GeneratorAction.UPDATE_OUTPUT_FIELD,
-    value: outputFieldName || fallbackField.name,
+    value: outputFieldId || fallbackField.id,
   });
 };
 

--- a/apps/ai-content-generator/src/utils/dialog/supported-fields/supportedFieldsHelpers.ts
+++ b/apps/ai-content-generator/src/utils/dialog/supported-fields/supportedFieldsHelpers.ts
@@ -15,6 +15,7 @@ import { ContentFields, EntryProps } from 'contentful-management';
  */
 const formatField = (field: ContentFields, entry: EntryProps, targetLocale: string): Field => {
   const formattedField = {
+    id: field.id,
     name: field.name,
     data: entry.fields[field.id] ? entry.fields[field.id][targetLocale] : '',
   };
@@ -27,8 +28,8 @@ const formatField = (field: ContentFields, entry: EntryProps, targetLocale: stri
 };
 
 /**
- * A reducer function that checks if a field is supported and assigns the field
- * to the correct column.
+ * A reducer function that checks if a field is supported, whether it has content,
+ * and assigns the field to the correct column.
  *
  * TODO: Handle the case where the field is empty
  * TODO: Support storing fields for both Source and Output
@@ -39,19 +40,18 @@ const formatField = (field: ContentFields, entry: EntryProps, targetLocale: stri
  */
 const isSupported = (entry: EntryProps, supportedFields: SupportedFieldTypes[], locale: string) => {
   return (fieldAcc: SupportedFieldsOutput, field: ContentFields) => {
-    const existsInEntry = entry.fields[field.id];
-    if (!existsInEntry) {
-      return fieldAcc;
-    }
-
+    const isSupported = supportedFields.includes(field.type as SupportedFieldTypes);
+    const hasContent = entry.fields[field.id]?.[locale];
     const formattedField = formatField(field, entry, locale);
 
-    const isSupported = supportedFields.includes(field.type as SupportedFieldTypes);
-    if (isSupported) {
-      fieldAcc.supportedFields.push(formattedField);
+    if (isSupported && hasContent) {
+      fieldAcc.supportedFieldsWithContent.push(formattedField);
     }
 
-    fieldAcc.fields.push(formattedField);
+    if (isSupported) {
+      fieldAcc.allSupportedFields.push(formattedField);
+    }
+
     return fieldAcc;
   };
 };


### PR DESCRIPTION
## Purpose

This PR updates the logic for which fields will be shown in the source and output fields. 

## Approach

- The source field should show: Short text, long text, and rich text fields that have content in the field
- The output field should show: All Short text, long text, and rich text fields 

Additionally, I also updated these field selectors so that field id is saved rather than field name because field name is not unique.

Note that there are some quirks regarding whether a field is localized that will be addressed in another PR.

## Testing steps

Tested with fields of supported types and ensured that fields of different types were not listed as options.
