### PR TITLE
fix: content generation now uses gavin's new prompt

### DIFF
--- a/apps/ai-content-generator/src/configs/prompts/contentPrompt.ts
+++ b/apps/ai-content-generator/src/configs/prompts/contentPrompt.ts
@@ -1,3 +1,4 @@
-const contentPrompt = (prompt: string) => `Write a blog post in 400 words about "${prompt}"`;
+const contentPrompt = (prompt: string) =>
+  `You have to write the content of a blog post in 400 words or less about ${prompt}. Only generate the body content for the blog post and do not include a title or header in the response. Pretend that you are just writing the article, and someone else is writing the title.`;
 
 export default contentPrompt;


### PR DESCRIPTION
## Purpose

The old content prompt would output weird extra data

## Approach

Update the prompt with a bit more constraints (courtesy of Gavin)

## Testing steps

Try generating some content from a title or an existing blog post. It should be in a normal text style now