### PR TITLE
chore: fixes token name in aicg

### DIFF
--- a/apps/ai-content-generator/package.json
+++ b/apps/ai-content-generator/package.json
@@ -23,7 +23,7 @@
     "build": "tsc && vite build --mode ${NODE_ENV:='production'}",
     "test": "vitest",
     "create-app-definition": "contentful-app-scripts create-app-definition",
-    "deploy": "contentful-app-scripts upload --ci --bundle-dir ./dist --organization-id ${DEFINITIONS_ORG_ID} --definition-id 3iszK8Gl7aaxLvxGyCOhgA --token ${CONTENTFUL_ACCESS_TOKEN}",
+    "deploy": "contentful-app-scripts upload --ci --bundle-dir ./dist --organization-id ${DEFINITIONS_ORG_ID} --definition-id 3iszK8Gl7aaxLvxGyCOhgA --token ${CONTENTFUL_CMA_TOKEN}",
     "deploy:test": "contentful-app-scripts upload --ci --bundle-dir ./dist --organization-id ${DEV_TESTING_ORG_ID} --definition-id 7sjBFUzBxj1fRrI0eUBwLc --token ${TEST_CMA_TOKEN}"
   },
   "browserslist": {


### PR DESCRIPTION
This is the real deal, the crème de la crème, the one, the PR to finish it all!

## Purpose

We want to verify our code can deploy to prod with the rewrite. But we only want to show the V1 UI while we are finishing up V2 work

## Approach

After the deploy saga, we have hit our final road block: the name of our access token. Changing our token's name from `CONTENTFUL_ACCESS_TOKEN` to `CONTENTFUL_CMA_TOKEN` should be the last change needed to deploy.

_I sure hope it is..._