### PR TITLE
fix: save content before launching ai content generator

### DIFF
--- a/apps/ai-content-generator/src/components/app/sidebar/SidebarButtons.tsx
+++ b/apps/ai-content-generator/src/components/app/sidebar/SidebarButtons.tsx
@@ -5,13 +5,18 @@ import { useState } from 'react';
 
 const SidebarButtons = () => {
   const [isSaving, setIsSaving] = useState(false);
+
+  const handleSaving = (toggleTo: boolean) => {
+    setIsSaving(toggleTo);
+  };
+
   const featureList = Object.keys(featureConfig).map((feature) => {
     return (
       <FeatureButton
         key={feature}
         feature={feature as AIFeature}
         isSaving={isSaving}
-        setIsSaving={setIsSaving}
+        onSaving={handleSaving}
       />
     );
   });

--- a/apps/ai-content-generator/src/components/app/sidebar/SidebarButtons.tsx
+++ b/apps/ai-content-generator/src/components/app/sidebar/SidebarButtons.tsx
@@ -1,10 +1,19 @@
 import { Box } from '@contentful/f36-components';
 import featureConfig, { AIFeature } from '@configs/features/featureConfig';
 import FeatureButton from './feature-button/FeatureButton';
+import { useState } from 'react';
 
 const SidebarButtons = () => {
+  const [isSaving, setIsSaving] = useState(false);
   const featureList = Object.keys(featureConfig).map((feature) => {
-    return <FeatureButton key={feature} feature={feature as AIFeature} />;
+    return (
+      <FeatureButton
+        key={feature}
+        feature={feature as AIFeature}
+        isSaving={isSaving}
+        setIsSaving={setIsSaving}
+      />
+    );
   });
 
   return <Box>{featureList}</Box>;

--- a/apps/ai-content-generator/src/components/app/sidebar/feature-button/FeatureButton.tsx
+++ b/apps/ai-content-generator/src/components/app/sidebar/feature-button/FeatureButton.tsx
@@ -9,7 +9,7 @@ import { useState } from 'react';
 interface Props {
   feature: AIFeature;
   isSaving: boolean;
-  setIsSaving: (isSaving: boolean) => void;
+  onSaving: (isSaving: boolean) => void;
 }
 
 interface FieldLocales {
@@ -17,7 +17,7 @@ interface FieldLocales {
 }
 
 const FeatureButton = (props: Props) => {
-  const { feature, isSaving, setIsSaving } = props;
+  const { feature, isSaving, onSaving } = props;
   const buttonCopy = featureConfig[feature].buttonTitle;
   const sdk = useSDK<SidebarAppSDK>();
 
@@ -30,8 +30,8 @@ const FeatureButton = (props: Props) => {
     return acc;
   }, {} as FieldLocales);
 
-  const toggleSaving = (toggleTo: boolean) => {
-    setIsSaving(toggleTo);
+  const updateSaveState = (toggleTo: boolean) => {
+    onSaving(toggleTo);
     setIsOpeningDialog(toggleTo);
   };
 
@@ -41,12 +41,12 @@ const FeatureButton = (props: Props) => {
     }
 
     try {
-      toggleSaving(true);
+      updateSaveState(true);
       await sdk.entry.save();
     } catch (error) {
       console.error(error);
     } finally {
-      toggleSaving(false);
+      updateSaveState(false);
     }
 
     const entryId = sdk.entry.getSys().id;

--- a/apps/ai-content-generator/src/components/app/sidebar/feature-button/FeatureButton.tsx
+++ b/apps/ai-content-generator/src/components/app/sidebar/feature-button/FeatureButton.tsx
@@ -1,12 +1,15 @@
 import { useSDK } from '@contentful/react-apps-toolkit';
 import { SidebarAppSDK } from '@contentful/app-sdk';
-import { Button, Tooltip } from '@contentful/f36-components';
+import { Button, Spinner, Tooltip } from '@contentful/f36-components';
 import featureConfig, { AIFeature } from '@configs/features/featureConfig';
 import { styles } from './FeatureButton.styles';
 import { makeDialogConfig } from '@configs/dialog/dialogConfig';
+import { useState } from 'react';
 
 interface Props {
   feature: AIFeature;
+  isSaving: boolean;
+  setIsSaving: (isSaving: boolean) => void;
 }
 
 interface FieldLocales {
@@ -14,9 +17,11 @@ interface FieldLocales {
 }
 
 const FeatureButton = (props: Props) => {
-  const { feature } = props;
+  const { feature, isSaving, setIsSaving } = props;
   const buttonCopy = featureConfig[feature].buttonTitle;
   const sdk = useSDK<SidebarAppSDK>();
+
+  const [isOpeningDialog, setIsOpeningDialog] = useState(false);
 
   const fields = sdk.entry.fields;
   const fieldLocales = Object.entries(fields).reduce((acc, entryField) => {
@@ -25,7 +30,25 @@ const FeatureButton = (props: Props) => {
     return acc;
   }, {} as FieldLocales);
 
-  const handleOnClick = () => {
+  const toggleSaving = (toggleTo: boolean) => {
+    setIsSaving(toggleTo);
+    setIsOpeningDialog(toggleTo);
+  };
+
+  const handleOnClick = async () => {
+    if (isSaving) {
+      return;
+    }
+
+    try {
+      toggleSaving(true);
+      await sdk.entry.save();
+    } catch (error) {
+      console.error(error);
+    } finally {
+      toggleSaving(false);
+    }
+
     const entryId = sdk.entry.getSys().id;
 
     const dialogConfig = makeDialogConfig({ feature, entryId, fieldLocales });
@@ -36,7 +59,7 @@ const FeatureButton = (props: Props) => {
   return (
     <Tooltip placement="top" id={feature}>
       <Button css={styles.button} onClick={handleOnClick}>
-        {buttonCopy}
+        {buttonCopy} {isOpeningDialog && <Spinner size="small" />}
       </Button>
     </Tooltip>
   );


### PR DESCRIPTION
## Purpose

When a user edits a field and launches the ai content generator, if it has not auto-saved yet we are using old data

## Approach

We decided to go with the route of least resistance here and force a save before launching the modal.

Edge cases:
- We are handling if a user spams the button
- We are handling if a user clicks one button and a different one before the save completes
- We are handling if the save fails for any reason

## Testing steps

1. Edit the entry
2. Click a button
3. Verify the spinner appears and then the modal launches
___
1. Don't edit anything
2. Click a button
3. Verify it opens instantaneously 
___
1. Edit the entry
2. Spam click the button
3. Verify nothing bad happens
___
1. Edit the entry
2. Click two different features
3. Verify nothing bad happens