### PR TITLE
feat: add character count and validation to aicg

### DIFF
--- a/apps/ai-content-generator/src/components/app/dialog/common-generator/CommonGenerator.tsx
+++ b/apps/ai-content-generator/src/components/app/dialog/common-generator/CommonGenerator.tsx
@@ -12,9 +12,12 @@ import NoFieldsSelectedMessage from './output/output-text-panels/no-fields-selec
 const initialParameters: GeneratorParameters = {
   isNewText: false,
   sourceField: '',
-  outputField: '',
-  outputFieldId: '',
-  outputFieldLocale: '',
+  output: {
+    field: '',
+    id: '',
+    locale: '',
+    validation: null,
+  },
   originalText: '',
   canGenerateTextFromField: false,
 };
@@ -41,8 +44,9 @@ const CommonGenerator = (props: FeatureComponentProps) => {
       </div>
       {parameters.canGenerateTextFromField ? (
         <Output
-          outputFieldId={parameters.outputFieldId}
-          outputFieldLocale={parameters.outputFieldLocale}
+          outputFieldId={parameters.output.field}
+          outputFieldLocale={parameters.output.locale}
+          outputFieldValidation={parameters.output.validation}
           inputText={parameters.originalText}
         />
       ) : (

--- a/apps/ai-content-generator/src/components/app/dialog/common-generator/field-selector/FieldSelector.tsx
+++ b/apps/ai-content-generator/src/components/app/dialog/common-generator/field-selector/FieldSelector.tsx
@@ -17,7 +17,7 @@ interface Props {
 
 const FieldSelector = (props: Props) => {
   const { parameters, fieldTypes } = props;
-  const { isNewText, sourceField, outputField } = parameters;
+  const { isNewText, sourceField, output } = parameters;
   const { entryId, dispatch, fieldLocales, localeNames, defaultLocale } =
     useContext(GeneratorContext);
 
@@ -53,13 +53,15 @@ const FieldSelector = (props: Props) => {
 
   const handleBaseDataChange = () => {
     if (supportedFieldsWithContent.length) {
-      const sourceFieldData = isNewText
-        ? { id: '', key: '', name: '', locale: '', data: '', language: '', isDefaultLocale: false }
-        : getFieldData(sourceField, supportedFieldsWithContent);
+      const sourceFieldData = getFieldData(
+        isNewText ? sourceField : '',
+        supportedFieldsWithContent
+      );
       updateSourceField(sourceFieldData, supportedFieldsWithContent[0], dispatch);
     }
+
     if (allSupportedFields.length) {
-      const outputFieldData = getFieldData(outputField, allSupportedFields);
+      const outputFieldData = getFieldData(output.field, allSupportedFields);
       updateOutputField(outputFieldData, allSupportedFields[0], dispatch);
     }
   };
@@ -79,7 +81,7 @@ const FieldSelector = (props: Props) => {
 
       <EntryFieldList
         title="Output Field"
-        selectedField={outputField}
+        selectedField={output.field}
         fields={allSupportedFields}
         onChange={handleSelectChange(GeneratorAction.UPDATE_OUTPUT_FIELD)}
       />

--- a/apps/ai-content-generator/src/components/app/dialog/common-generator/generatorReducer.tsx
+++ b/apps/ai-content-generator/src/components/app/dialog/common-generator/generatorReducer.tsx
@@ -1,10 +1,11 @@
+import { ContentTypeFieldValidation } from 'contentful-management/types';
+
 export enum GeneratorAction {
   IS_NEW_TEXT = 'isNewText',
   IS_NOT_NEW_TEXT = 'isNotNewText',
   UPDATE_SOURCE_FIELD = 'changeSourceField',
   UPDATE_OUTPUT_FIELD = 'changeOutputField',
   UPDATE_ORIGINAL_TEXT = 'changeOriginalText',
-  CAN_GENERATE_TEXT_FROM_FIELD = 'canGenerateTextFromField',
 }
 
 export type GeneratorParameters = {
@@ -12,26 +13,23 @@ export type GeneratorParameters = {
   // can generate text from field when both source and output fields are selected
   canGenerateTextFromField: boolean;
   sourceField: string;
-  outputField: string;
-  outputFieldId: string;
-  outputFieldLocale: string;
   originalText: string;
+  output: {
+    field: string;
+    id: string;
+    locale: string;
+    validation: ContentTypeFieldValidation | null;
+  };
 };
 
-type GeneratorStringActions = {
-  type: Exclude<
-    GeneratorAction,
-    | GeneratorAction.UPDATE_SOURCE_FIELD
-    | GeneratorAction.UPDATE_OUTPUT_FIELD
-    | GeneratorAction.IS_NEW_TEXT
-    | GeneratorAction.IS_NOT_NEW_TEXT
-  >;
+type GeneratorStringAction = {
+  type: GeneratorAction.UPDATE_ORIGINAL_TEXT;
   value: string;
 };
 
 type GeneratorSourceTextAction = {
   type: GeneratorAction.UPDATE_SOURCE_FIELD;
-  field: string;
+  sourceField: string;
   value: string;
 };
 
@@ -40,20 +38,18 @@ type GeneratorOutputTextAction = {
   field: string;
   id: string;
   locale: string;
+  validation: ContentTypeFieldValidation | null;
 };
 
-type GeneratorImpulseActions = {
-  type:
-    | GeneratorAction.IS_NEW_TEXT
-    | GeneratorAction.IS_NOT_NEW_TEXT
-    | GeneratorAction.CAN_GENERATE_TEXT_FROM_FIELD;
+type GeneratorImpulseAction = {
+  type: GeneratorAction.IS_NEW_TEXT | GeneratorAction.IS_NOT_NEW_TEXT;
 };
 
 export type GeneratorReducer =
-  | GeneratorStringActions
+  | GeneratorStringAction
   | GeneratorSourceTextAction
   | GeneratorOutputTextAction
-  | GeneratorImpulseActions;
+  | GeneratorImpulseAction;
 
 const {
   IS_NEW_TEXT,
@@ -63,26 +59,32 @@ const {
   UPDATE_ORIGINAL_TEXT,
 } = GeneratorAction;
 
-const generatorReducer = (state: GeneratorParameters, action: GeneratorReducer) => {
+const generatorReducer = (
+  state: GeneratorParameters,
+  action: GeneratorReducer
+): GeneratorParameters => {
   switch (action.type) {
     case IS_NEW_TEXT:
-      return { ...state, isNewText: true, originalText: '', generatedText: '' };
+      return { ...state, isNewText: true, originalText: '' };
     case IS_NOT_NEW_TEXT:
-      return { ...state, isNewText: false, originalText: '', generatedText: '' };
+      return { ...state, isNewText: false, originalText: '' };
     case UPDATE_SOURCE_FIELD:
       return {
         ...state,
-        sourceField: action.field,
-        canGenerateTextFromField: Boolean(action.field && state.outputField),
+        canGenerateTextFromField: Boolean(action.sourceField && state.output.field),
+        sourceField: action.sourceField,
         originalText: action.value,
       };
     case UPDATE_OUTPUT_FIELD:
       return {
         ...state,
-        outputField: action.field,
-        outputFieldId: action.id,
-        outputFieldLocale: action.locale,
         canGenerateTextFromField: Boolean(action.field && state.sourceField),
+        output: {
+          field: action.field,
+          id: action.id,
+          locale: action.locale,
+          validation: action.validation,
+        },
       };
     case UPDATE_ORIGINAL_TEXT:
       return { ...state, originalText: action.value };

--- a/apps/ai-content-generator/src/components/app/dialog/common-generator/output/Output.tsx
+++ b/apps/ai-content-generator/src/components/app/dialog/common-generator/output/Output.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Flex, Tabs } from '@contentful/f36-components';
 import useAI from '@hooks/dialog/useAI';
 import OutputTextPanels from './output-text-panels/OutputTextPanels';
+import { ContentTypeFieldValidation } from 'contentful-management';
 
 enum OutputTab {
   UPDATE_ORIGINAL_TEXT = 'original-text',
@@ -12,10 +13,11 @@ interface Props {
   inputText: string;
   outputFieldId: string;
   outputFieldLocale: string;
+  outputFieldValidation: ContentTypeFieldValidation | null;
 }
 
 const Output = (props: Props) => {
-  const { inputText, outputFieldId, outputFieldLocale } = props;
+  const { inputText, outputFieldId, outputFieldLocale, outputFieldValidation } = props;
   const ai = useAI();
 
   const [currentTab, setCurrentTab] = useState(OutputTab.UPDATE_ORIGINAL_TEXT);
@@ -44,6 +46,7 @@ const Output = (props: Props) => {
         <OutputTextPanels
           outputFieldId={outputFieldId}
           outputFieldLocale={outputFieldLocale}
+          outputFieldValidation={outputFieldValidation}
           inputText={inputText}
           ai={ai}
         />

--- a/apps/ai-content-generator/src/components/app/dialog/common-generator/output/output-text-panels/OutputTextPanels.tsx
+++ b/apps/ai-content-generator/src/components/app/dialog/common-generator/output/output-text-panels/OutputTextPanels.tsx
@@ -7,16 +7,18 @@ import useAI from '@hooks/dialog/useAI';
 import GeneratedTextPanel from './generated-text-panel/GeneratedTextPanel';
 import OriginalTextPanel from './original-text-panel/OriginalTextPanel';
 import featureConfig from '@configs/features/featureConfig';
+import { ContentTypeFieldValidation } from 'contentful-management';
 
 interface Props {
   ai: ReturnType<typeof useAI>;
   inputText: string;
   outputFieldId: string;
   outputFieldLocale: string;
+  outputFieldValidation: ContentTypeFieldValidation | null;
 }
 
 const OutputTextPanels = (props: Props) => {
-  const { ai, inputText, outputFieldId, outputFieldLocale } = props;
+  const { ai, inputText, outputFieldId, outputFieldLocale, outputFieldValidation } = props;
   const { feature, entryId, localeNames } = useContext(GeneratorContext);
   const { updateEntry } = useEntryAndContentType(entryId);
 
@@ -46,7 +48,7 @@ const OutputTextPanels = (props: Props) => {
       <GeneratedTextPanel
         ai={ai}
         generate={generate}
-        hasOutputField={outputFieldId === ''}
+        outputFieldValidation={outputFieldValidation}
         apply={handleEntryApply}
       />
     </>

--- a/apps/ai-content-generator/src/components/app/dialog/common-generator/output/output-text-panels/generated-text-panel/GeneratedTextPanel.tsx
+++ b/apps/ai-content-generator/src/components/app/dialog/common-generator/output/output-text-panels/generated-text-panel/GeneratedTextPanel.tsx
@@ -2,34 +2,59 @@ import { Button, CopyButton, Tabs } from '@contentful/f36-components';
 import useAI from '@hooks/dialog/useAI';
 import TextFieldWithButtons from '@components/common/text-field-with-buttons/TextFieldWIthButtons';
 import { OutputTab } from '../../Output';
+import { ContentTypeFieldValidation } from 'contentful-management';
+import { useEffect, useState } from 'react';
 
 interface Props {
   generate: () => void;
   ai: ReturnType<typeof useAI>;
-  hasOutputField: boolean;
+  outputFieldValidation: ContentTypeFieldValidation | null;
   apply: () => void;
 }
 
 const GeneratedTextPanel = (props: Props) => {
-  const { generate, ai, hasOutputField, apply } = props;
+  const { generate, ai, outputFieldValidation, apply } = props;
   const { sendStopSignal, output, setOutput, isGenerating } = ai;
+
+  const [canApply, setCanApply] = useState(false);
 
   const handleGeneratedTextChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setOutput(event.target.value);
   };
 
+  const checkIfCanApply = () => {
+    if (isGenerating) {
+      return;
+    }
+
+    const min = outputFieldValidation?.size?.min || 0;
+    const max = outputFieldValidation?.size?.max || Infinity;
+
+    const length = output.length;
+    const isLengthValid = length >= min && length <= max;
+
+    setCanApply(isLengthValid);
+  };
+
+  useEffect(checkIfCanApply, [output]);
+
   return (
     <Tabs.Panel id={OutputTab.GENERATED_TEXT}>
       {isGenerating ? (
-        <TextFieldWithButtons inputText={output}>
+        <TextFieldWithButtons
+          inputText={output}
+          sizeValidation={{ max: outputFieldValidation?.size?.max }}>
           <Button onClick={sendStopSignal}>Stop Generating</Button>
         </TextFieldWithButtons>
       ) : (
-        <TextFieldWithButtons inputText={output} onFieldChange={handleGeneratedTextChange}>
+        <TextFieldWithButtons
+          inputText={output}
+          sizeValidation={outputFieldValidation?.size}
+          onFieldChange={handleGeneratedTextChange}>
           <>
             <CopyButton value={output} />
             <Button onClick={generate}>Regenerate</Button>
-            <Button isDisabled={hasOutputField} onClick={apply}>
+            <Button isDisabled={!canApply} onClick={apply}>
               Apply
             </Button>
           </>

--- a/apps/ai-content-generator/src/components/common/text-field-with-buttons/TextCounter.styles.ts
+++ b/apps/ai-content-generator/src/components/common/text-field-with-buttons/TextCounter.styles.ts
@@ -1,0 +1,11 @@
+import { css } from '@emotion/react';
+
+export const styles = {
+  // How do I access these colors from forma36?
+  validCount: css({
+    color: '#414D63',
+  }),
+  invalidCount: css({
+    color: '#DA294A',
+  }),
+};

--- a/apps/ai-content-generator/src/components/common/text-field-with-buttons/TextCounter.tsx
+++ b/apps/ai-content-generator/src/components/common/text-field-with-buttons/TextCounter.tsx
@@ -1,0 +1,40 @@
+import { Flex, Paragraph } from '@contentful/f36-components';
+import { styles } from './TextCounter.styles';
+
+interface Props {
+  text: string;
+  minLength?: number;
+  maxLength?: number;
+}
+
+/**
+ * The Forma36 text counter requires us to restrict the length of the text
+ * forcing the user to delete characters to get below the limit. This component
+ * is an alternative that will instead not limit the length of the text but
+ * instead show a warning message if the text is too long or too short.
+ */
+const TextCounter = (props: Props) => {
+  const { text, maxLength, minLength } = props;
+
+  const isBelowMinLength = text.length < (minLength || 0);
+  const isAboveMaxLength = text.length > (maxLength || Infinity);
+
+  const isValid = !isBelowMinLength && !isAboveMaxLength;
+  const style = isValid ? styles.validCount : styles.invalidCount;
+
+  return (
+    <Flex justifyContent="space-between">
+      <Paragraph css={styles.invalidCount}>
+        {!isValid &&
+          (isBelowMinLength
+            ? `The generated text is shorter than the minimum length of ${minLength}`
+            : `The generated text is longer than the maximum length of ${maxLength}`)}
+      </Paragraph>
+      <Paragraph css={style}>
+        {text.length} {maxLength && '/ ' + maxLength}
+      </Paragraph>
+    </Flex>
+  );
+};
+
+export default TextCounter;

--- a/apps/ai-content-generator/src/components/common/text-field-with-buttons/TextFieldWIthButtons.tsx
+++ b/apps/ai-content-generator/src/components/common/text-field-with-buttons/TextFieldWIthButtons.tsx
@@ -1,22 +1,32 @@
 import { ChangeEvent, ReactNode } from 'react';
-import { Flex, Textarea } from '@contentful/f36-components';
+import { Flex, FormControl, Textarea } from '@contentful/f36-components';
+import { ContentTypeFieldValidation } from 'contentful-management';
+import TextCounter from './TextCounter';
 
 interface Props {
   inputText: string;
   onFieldChange?: (event: ChangeEvent<HTMLInputElement>) => void;
   children: ReactNode;
+  sizeValidation?: ContentTypeFieldValidation['size'] | null;
 }
 
 const TextFieldWithButtons = (props: Props) => {
-  const { inputText, onFieldChange, children } = props;
+  const { inputText, onFieldChange, children, sizeValidation } = props;
   return (
-    <Flex flexDirection="column" fullWidth>
-      <Textarea resize="none" rows={14} value={inputText} onChange={onFieldChange}></Textarea>
+    <FormControl>
+      <Flex flexDirection="column" fullWidth>
+        <Textarea resize="none" rows={14} value={inputText} onChange={onFieldChange}></Textarea>
+        <TextCounter
+          text={inputText}
+          maxLength={sizeValidation?.max}
+          minLength={sizeValidation?.min}
+        />
 
-      <Flex alignSelf="flex-end" marginTop="spacingS">
-        {children}
+        <Flex alignSelf="flex-end" marginTop="spacingS">
+          {children}
+        </Flex>
       </Flex>
-    </Flex>
+    </FormControl>
   );
 };
 

--- a/apps/ai-content-generator/src/hooks/dialog/useSupportedFields.ts
+++ b/apps/ai-content-generator/src/hooks/dialog/useSupportedFields.ts
@@ -3,6 +3,7 @@ import { isSupported } from '@utils/dialog/supported-fields/supportedFieldsHelpe
 import useEntryAndContentType from './useEntryAndContentType';
 import { FieldLocales } from '@locations/Dialog';
 import { LocaleNames } from '@providers/generatorProvider';
+import { ContentTypeFieldValidation } from 'contentful-management/types';
 
 interface Field {
   id: string;
@@ -11,6 +12,7 @@ interface Field {
   data: string;
   locale: string;
   language: string;
+  sizeValidation: ContentTypeFieldValidation | null;
   isDefaultLocale: boolean;
 }
 

--- a/apps/ai-content-generator/src/utils/dialog/common-generator/field-selector/fieldSelectorHelpers.ts
+++ b/apps/ai-content-generator/src/utils/dialog/common-generator/field-selector/fieldSelectorHelpers.ts
@@ -21,6 +21,7 @@ const getFieldData = (fieldKey: string, fields: Field[]) => {
       locale: '',
       data: '',
       language: '',
+      sizeValidation: null,
       isDefaultLocale: false,
     }
   );
@@ -39,7 +40,7 @@ const updateSourceField = (
 ) => {
   dispatch({
     type: GeneratorAction.UPDATE_SOURCE_FIELD,
-    field: sourceField.key || fallbackField.key,
+    sourceField: sourceField.key || fallbackField.key,
     value: sourceField.key ? sourceField.data : fallbackField.data,
   });
 };
@@ -60,6 +61,7 @@ const updateOutputField = (
     field: outputField.key || fallbackField.key,
     id: outputField.id,
     locale: outputField.locale,
+    validation: outputField.sizeValidation,
   });
 };
 

--- a/apps/ai-content-generator/src/utils/dialog/supported-fields/supportedFieldsHelpers.ts
+++ b/apps/ai-content-generator/src/utils/dialog/supported-fields/supportedFieldsHelpers.ts
@@ -31,6 +31,8 @@ const formatField = (
     data: entry.fields[field.id] ? entry.fields[field.id][locale] : '',
     locale: locale,
     language: localeNames[locale],
+    sizeValidation:
+      field.validations?.find((validation) => validation.hasOwnProperty('size')) || null,
     isDefaultLocale: defaultLocale === locale,
   };
 


### PR DESCRIPTION
## Purpose

A user may or may not know that that have exceeded or are under the character limits. When a user applies this may put their entry in an unpublishable state.

## Approach

Forma36's counter requires a limit on the text field. This forces the user to backspace until they get below the limit. This UX seems unintuitive for our case.

This custom counter allows the user to exceed the limit (but disable the publishing), allowing them to edit the text as they see fit until they get below the maximum limit.

We also are showing an error for when the user is below the minimum limit.

## Testing steps

Test using a field with no limit
- verify it only shows the current character count.
- verify the apply is never disabled

Test using a field with an upper and/or lower limit
- verify that if you are over the limit you cannot apply
- verify that if you are below the limit you cannot apply
- verify that if you are within the constrains you can apply
