### PR TITLE
Disable staging deploy to prevent race condition in hosted app action deploys

### DIFF
--- a/apps/aws-amplify/package.json
+++ b/apps/aws-amplify/package.json
@@ -21,7 +21,7 @@
     "eject": "react-scripts eject",
     "create-app-definition": "contentful-app-scripts create-app-definition",
     "deploy": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEFINITIONS_ORG_ID} --definition-id 1mVogDvuE0GuW4qp4dk4zQ --token ${CONTENTFUL_CMA_TOKEN}",
-    "deploy:test": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEV_TESTING_ORG_ID} --definition-id YlAVHsxexkcs5PG3INCmc --token ${TEST_CMA_TOKEN}",
+    "DISABLED_deploy:test": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEV_TESTING_ORG_ID} --definition-id YlAVHsxexkcs5PG3INCmc --token ${TEST_CMA_TOKEN}",
     "build-actions": "node build-actions.js"
   },
   "eslintConfig": {


### PR DESCRIPTION
## Purpose

There's a bug in extensibility-api right now where if the same app action id is included for two different org ids / app definition ids, the most recent deploy overwrites the app action it does not own instead of creating a new one.

## Approach

* Disable "staging" deploy so that we have only one app action deploy active

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
