### PR TITLE
Fix(deps): Dependabot/npm and yarn/contentful/default field editors 1.4.10

### DIFF
--- a/apps/ecommerce/frontend/package-lock.json
+++ b/apps/ecommerce/frontend/package-lock.json
@@ -2325,9 +2325,9 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
     "node_modules/@codemirror/autocomplete": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.6.0.tgz",
-      "integrity": "sha512-SjbgWSwNKbyQOiVXtG8DXG2z29zTbmzpGccxMqakVo+vqK8fx3Ai0Ee7is3JqX6dxJOoK0GfP3LfeUK53Ltv7w==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.9.0.tgz",
+      "integrity": "sha512-Fbwm0V/Wn3BkEJZRhr0hi5BhCo5a7eBL6LYaliPjOSwCyfOpnjXY59HruSxOUNV+1OYer0Tgx1zRNQttjXyDog==",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.0.0",
@@ -2342,9 +2342,9 @@
       }
     },
     "node_modules/@codemirror/commands": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.2.3.tgz",
-      "integrity": "sha512-9uf0g9m2wZyrIim1SavcxMdwsu8wc/y5uSw6JRUBYIGWrN+RY4vSru/BqB+MyNWqx4C2uRhQ/Kh7Pw8lAyT3qQ==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.2.4.tgz",
+      "integrity": "sha512-42lmDqVH0ttfilLShReLXsDfASKLXzfyC36bzwcqzox9PlHulMcsUOfHXNo2X2aFMVNUoQ7j+d4q5bnfseYoOA==",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.2.0",
@@ -2362,9 +2362,9 @@
       }
     },
     "node_modules/@codemirror/language": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.6.0.tgz",
-      "integrity": "sha512-cwUd6lzt3MfNYOobdjf14ZkLbJcnv4WtndYaoBkbor/vF+rCNguMPK0IRtvZJG4dsWiaWPcK8x1VijhvSxnstg==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.8.0.tgz",
+      "integrity": "sha512-r1paAyWOZkfY0RaYEZj3Kul+MiQTEbDvYqf8gPGaRvNneHXCmfSaAVFjwRUPlgxS8yflMxw2CTu6uCMp8R8A2g==",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -2375,9 +2375,9 @@
       }
     },
     "node_modules/@codemirror/lint": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.2.1.tgz",
-      "integrity": "sha512-y1muai5U/uUPAGRyHMx9mHuHLypPcHWxzlZGknp/U5Mdb5Ol8Q5ZLp67UqyTbNFJJ3unVxZ8iX3g1fMN79S1JQ==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.4.0.tgz",
+      "integrity": "sha512-6VZ44Ysh/Zn07xrGkdtNfmHCbGSHZzFBdzWi0pbd7chAQ/iUcpLGX99NYRZTa7Ugqg4kEHCqiHhcZnH0gLIgSg==",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -2385,9 +2385,9 @@
       }
     },
     "node_modules/@codemirror/search": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.4.0.tgz",
-      "integrity": "sha512-zMDgaBXah+nMLK2dHz9GdCnGbQu+oaGRXS1qviqNZkvOCv/whp5XZFyoikLp/23PM9RBcbuKUUISUmQHM1eRHw==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.0.tgz",
+      "integrity": "sha512-64/M40YeJPToKvGO6p3fijo2vwUEj4nACEAXElCaYQ50HrXSvRaK+NHEhSh73WFBGdvIdhrV+lL9PdJy2RfCYA==",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -2395,9 +2395,9 @@
       }
     },
     "node_modules/@codemirror/state": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.2.0.tgz",
-      "integrity": "sha512-69QXtcrsc3RYtOtd+GsvczJ319udtBf1PTrr2KbLWM/e2CXUPnh0Nz9AUo8WfhSQ7GeL8dPVNUmhQVgpmuaNGA=="
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.2.1.tgz",
+      "integrity": "sha512-RupHSZ8+OjNT38zU9fKH2sv+Dnlr8Eb8sl4NOnnqz95mCFTZUaiRP8Xv5MeeaG0px2b8Bnfe7YGwCV3nsBhbuw=="
     },
     "node_modules/@codemirror/theme-one-dark": {
       "version": "6.1.2",
@@ -2411,9 +2411,9 @@
       }
     },
     "node_modules/@codemirror/view": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.10.0.tgz",
-      "integrity": "sha512-Oea3rvE4JQLMmLsy2b54yxXQJgJM9xKpUQIpF/LGgKUTH2lA06GAmEtKKWn5OUnbW3jrH1hHeUd8DJEgePMOeQ==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.15.3.tgz",
+      "integrity": "sha512-chNgR8H7Ipx7AZUt0+Kknk7BCow/ron3mHd1VZdM7hQXiI79+UlWqcxpCiexTxZQ+iSkqndk3HHAclJOcjSuog==",
       "dependencies": {
         "@codemirror/state": "^6.1.4",
         "style-mod": "^4.0.0",
@@ -2475,58 +2475,50 @@
       }
     },
     "node_modules/@contentful/app-sdk": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.17.1.tgz",
-      "integrity": "sha512-8vh/X+kW33412lxwi2Acr6V4W7UxNvH273cJUSJ43OaFlwAl+T4aWhIULXq+sT9ASc9QxsujiWFHbCR38kl/oQ==",
-      "peerDependencies": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.22.1.tgz",
+      "integrity": "sha512-Db8voGJ1h045P9aXSKnZSZ+GLKt6f4vN6IzBX+GbapbLKzzPFR1+uqR3DygJX1ZE07tN+OnDzCazMPudQYsd/Q==",
+      "dependencies": {
         "contentful-management": ">=7.30.0"
       }
     },
     "node_modules/@contentful/contentful-slatejs-adapter": {
-      "version": "15.16.5",
-      "resolved": "https://registry.npmjs.org/@contentful/contentful-slatejs-adapter/-/contentful-slatejs-adapter-15.16.5.tgz",
-      "integrity": "sha512-ZgI2SyYTZEwhNAcyNYHL2pMqz1yH8BBgzSlGyQuxz42YBB0yWqViG6SckXGd/96tivH1aZDGVQdKWW4ubALbYQ==",
+      "version": "15.16.6",
+      "resolved": "https://registry.npmjs.org/@contentful/contentful-slatejs-adapter/-/contentful-slatejs-adapter-15.16.6.tgz",
+      "integrity": "sha512-7/wFYKjx+QyaeigC4njXY1TnzZSR2s8Z7dZ/hSFxnKj6QhR86RsCkUl/in8M7WAmolSddeNsMhgIeyCRXWwoOQ==",
       "dependencies": {
-        "@contentful/rich-text-types": "^16.1.0"
+        "@contentful/rich-text-types": "^16.2.0"
       },
       "engines": {
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@contentful/contentful-slatejs-adapter/node_modules/@contentful/rich-text-types": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.1.0.tgz",
-      "integrity": "sha512-Pucb68FK0j9cHJ96FAewXv+bvH4XizC4KBbVqyHhPLkDIVfasj0AWU5rI1lnvysdVKu66NQkFe8xZdeFTkaLWQ==",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@contentful/default-field-editors": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@contentful/default-field-editors/-/default-field-editors-1.3.3.tgz",
-      "integrity": "sha512-NV7glfhIO0Qy+Ym4+JQW21ESvgW3iS1PT7eaka6WeXx53UeMAPbxf4g0k268Kiv23uwUWLo3dnGvhL4z+OCZiA==",
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@contentful/default-field-editors/-/default-field-editors-1.4.10.tgz",
+      "integrity": "sha512-Md2ivD0rdBVGxsjAv97Ad4MHzQs6GJqk6qNenE31Me5Hgc9cncqkHUDmYhJ9J8JrdDAT8frHW4dtLEJlaKc4XA==",
       "dependencies": {
         "@contentful/f36-components": "^4.0.27",
-        "@contentful/field-editor-boolean": "^1.2.0",
-        "@contentful/field-editor-checkbox": "^1.2.0",
-        "@contentful/field-editor-date": "^1.4.0",
-        "@contentful/field-editor-dropdown": "^1.2.0",
-        "@contentful/field-editor-json": "^3.2.0",
-        "@contentful/field-editor-list": "^1.2.0",
-        "@contentful/field-editor-location": "^1.2.3",
-        "@contentful/field-editor-markdown": "^1.2.1",
-        "@contentful/field-editor-multiple-line": "^1.2.0",
-        "@contentful/field-editor-number": "^1.2.6",
-        "@contentful/field-editor-radio": "^1.2.0",
-        "@contentful/field-editor-rating": "^1.2.0",
-        "@contentful/field-editor-reference": "^5.9.0",
-        "@contentful/field-editor-rich-text": "^3.4.22",
-        "@contentful/field-editor-shared": "^1.2.0",
-        "@contentful/field-editor-single-line": "^1.2.0",
-        "@contentful/field-editor-slug": "^1.2.0",
-        "@contentful/field-editor-tags": "^1.2.0",
-        "@contentful/field-editor-url": "^1.2.0",
-        "@contentful/field-editor-validation-errors": "^1.2.0",
+        "@contentful/field-editor-boolean": "^1.3.1",
+        "@contentful/field-editor-checkbox": "^1.3.1",
+        "@contentful/field-editor-date": "^1.5.1",
+        "@contentful/field-editor-dropdown": "^1.3.1",
+        "@contentful/field-editor-json": "^3.3.1",
+        "@contentful/field-editor-list": "^1.3.1",
+        "@contentful/field-editor-location": "^1.3.1",
+        "@contentful/field-editor-markdown": "^1.3.1",
+        "@contentful/field-editor-multiple-line": "^1.3.1",
+        "@contentful/field-editor-number": "^1.3.1",
+        "@contentful/field-editor-radio": "^1.3.1",
+        "@contentful/field-editor-rating": "^1.3.1",
+        "@contentful/field-editor-reference": "^5.13.2",
+        "@contentful/field-editor-rich-text": "^3.9.2",
+        "@contentful/field-editor-shared": "^1.3.1",
+        "@contentful/field-editor-single-line": "^1.3.1",
+        "@contentful/field-editor-slug": "^1.3.2",
+        "@contentful/field-editor-tags": "^1.3.1",
+        "@contentful/field-editor-url": "^1.3.1",
+        "@contentful/field-editor-validation-errors": "^1.3.1",
         "contentful-management": "^10.0.0",
         "emotion": "^10.0.27"
       },
@@ -2535,32 +2527,32 @@
       }
     },
     "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text": {
-      "version": "3.4.22",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-rich-text/-/field-editor-rich-text-3.4.22.tgz",
-      "integrity": "sha512-c3vUpEKz2+TlfJV3kANBrImJvw2f5DCgtRdEwgcYrS53GZR2+PiSQjTZb5BuO6DP2CWzgWFrptrrGIEBdwV/+g==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-rich-text/-/field-editor-rich-text-3.9.2.tgz",
+      "integrity": "sha512-zh/YNVuAnfo/CZ0/WJEegssFMF1wLoQhiaC4fiLHS4fSXSVtAGAfdNQ5TZoPY/rdUkwqedoaD6EURrTaxWZRjA==",
       "dependencies": {
-        "@contentful/app-sdk": "^4.6.0",
-        "@contentful/contentful-slatejs-adapter": "^15.13.1",
+        "@contentful/app-sdk": "^4.21.1",
+        "@contentful/contentful-slatejs-adapter": "^15.16.5",
         "@contentful/f36-components": "^4.20.6",
         "@contentful/f36-icons": "^4.1.1",
         "@contentful/f36-tokens": "^4.0.0",
         "@contentful/f36-utils": "^4.19.0",
-        "@contentful/field-editor-reference": "^5.9.0",
-        "@contentful/field-editor-shared": "^1.2.0",
-        "@contentful/rich-text-plain-text-renderer": "^15.12.1",
-        "@contentful/rich-text-types": "15.14.1",
+        "@contentful/field-editor-reference": "^5.13.2",
+        "@contentful/field-editor-shared": "^1.3.1",
+        "@contentful/rich-text-plain-text-renderer": "^16.0.4",
+        "@contentful/rich-text-types": "16.1.0",
         "@popperjs/core": "^2.11.5",
-        "@udecode/plate-basic-marks": "16.8.0",
-        "@udecode/plate-break": "16.8.0",
-        "@udecode/plate-core": "16.8.0",
-        "@udecode/plate-list": "16.8.0",
-        "@udecode/plate-paragraph": "16.8.0",
-        "@udecode/plate-reset-node": "16.8.0",
-        "@udecode/plate-select": "16.8.0",
-        "@udecode/plate-serializer-docx": "16.8.0",
-        "@udecode/plate-serializer-html": "16.8.0",
-        "@udecode/plate-table": "16.8.0",
-        "@udecode/plate-trailing-block": "16.8.0",
+        "@udecode/plate-basic-marks": "18.15.0",
+        "@udecode/plate-break": "18.15.0",
+        "@udecode/plate-core": "18.15.0",
+        "@udecode/plate-list": "18.15.0",
+        "@udecode/plate-paragraph": "18.15.0",
+        "@udecode/plate-reset-node": "18.15.0",
+        "@udecode/plate-select": "18.15.0",
+        "@udecode/plate-serializer-docx": "18.15.0",
+        "@udecode/plate-serializer-html": "18.15.0",
+        "@udecode/plate-table": "18.15.0",
+        "@udecode/plate-trailing-block": "18.15.0",
         "fast-deep-equal": "^3.1.3",
         "is-hotkey": "^0.2.0",
         "is-plain-obj": "^3.0.0",
@@ -2576,11 +2568,11 @@
       }
     },
     "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-basic-marks": {
-      "version": "16.8.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-basic-marks/-/plate-basic-marks-16.8.0.tgz",
-      "integrity": "sha512-yqRVR+zowfjzOK9AxDZ//hiq6+tNUFY2gGJck8ClGMr5y9pbQfCDOyL7nkgbS7mUO4vzZmDIOjl+spGvOUVuSg==",
+      "version": "18.15.0",
+      "resolved": "https://registry.npmjs.org/@udecode/plate-basic-marks/-/plate-basic-marks-18.15.0.tgz",
+      "integrity": "sha512-2jQucmY5FVVVpLnah+H9KCYtgb0UNMUqh6U5AySAnJpEpgKMnYmyqH7joxj2Ut1uN34NOvONeRvv2H3Gbk6seQ==",
       "dependencies": {
-        "@udecode/plate-core": "16.8.0"
+        "@udecode/plate-core": "18.15.0"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -2591,11 +2583,11 @@
       }
     },
     "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-break": {
-      "version": "16.8.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-break/-/plate-break-16.8.0.tgz",
-      "integrity": "sha512-48WpW9/SqngeTP6ZNRi90j89iOii7mhI6ImYd6uA4QbhrE9rtDLm+HRHmy1uNaOlJLECZ2jp4+2yWTN6rbObdg==",
+      "version": "18.15.0",
+      "resolved": "https://registry.npmjs.org/@udecode/plate-break/-/plate-break-18.15.0.tgz",
+      "integrity": "sha512-JjN9VcpmCUhfAB+V8+/4vsGQf+lH4Ue2ZsUbVXWwRqcPwOBIbTH3Sv5J+JYxJY+NrA5fzDIwB9e/OfUR9fivjA==",
       "dependencies": {
-        "@udecode/plate-core": "16.8.0"
+        "@udecode/plate-core": "18.15.0"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -2606,15 +2598,16 @@
       }
     },
     "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-core": {
-      "version": "16.8.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-core/-/plate-core-16.8.0.tgz",
-      "integrity": "sha512-zd6ZxwDOuazKWGT4DFiQxQ8z3t2xAoBzg3JC5lY+4Xj/By5zjZD/ZmQAAogRWErC4ZNL6SqA2EbHDZij6hNrWg==",
+      "version": "18.15.0",
+      "resolved": "https://registry.npmjs.org/@udecode/plate-core/-/plate-core-18.15.0.tgz",
+      "integrity": "sha512-YncMwlTC5Bn1a5F1rg1mc2eZvOBHa2swdtqmDhnNaStSPu/isIMqCRTbUcWYHtnBbQpNYC3Ul4HegbK63mgjoA==",
       "dependencies": {
-        "@radix-ui/react-slot": "^0.1.2",
+        "@radix-ui/react-slot": "^1.0.1",
         "@udecode/zustood": "^1.1.1",
         "clsx": "^1.1.1",
         "jotai": "^1.7.2",
         "lodash": "^4.17.21",
+        "nanoid": "^3.3.4",
         "react-hotkeys-hook": "^3.4.6",
         "use-deep-compare": "^1.1.0",
         "zustand": "^3.7.2"
@@ -2640,12 +2633,12 @@
       }
     },
     "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-list": {
-      "version": "16.8.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-list/-/plate-list-16.8.0.tgz",
-      "integrity": "sha512-TNEzHS0NfYAClV3rNVa7sOD0XGBK7ykwA/uEb/tLom2L0HSyITMJQuTyStLELQ15Yn8Bz4BBfo68h/dPYXKjHg==",
+      "version": "18.15.0",
+      "resolved": "https://registry.npmjs.org/@udecode/plate-list/-/plate-list-18.15.0.tgz",
+      "integrity": "sha512-f9aXfH7eMuhP084FHWrsmcMaIPyWaE0oxbBLYGYuRraTNsvekBTzmLvOC1ixJIn88jsogb4J25KuohTXxFrrXw==",
       "dependencies": {
-        "@udecode/plate-core": "16.8.0",
-        "@udecode/plate-reset-node": "16.8.0"
+        "@udecode/plate-core": "18.15.0",
+        "@udecode/plate-reset-node": "18.15.0"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -2656,11 +2649,11 @@
       }
     },
     "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-paragraph": {
-      "version": "16.8.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-paragraph/-/plate-paragraph-16.8.0.tgz",
-      "integrity": "sha512-p44WrWqIrtfJZpjslSjnqh6g9AcajlRs1BiJf6CGU9U5ITNTltUtl9+NL0Miabibgk0Hz1SguFZ7RCVOLWtL1w==",
+      "version": "18.15.0",
+      "resolved": "https://registry.npmjs.org/@udecode/plate-paragraph/-/plate-paragraph-18.15.0.tgz",
+      "integrity": "sha512-qy6RUCZiq5ktL3FwdpYsUJFPuNpiY9DepehiiDFDjLl9++y++4MqftOqcB1qy3rAKM3u4XzM4cuh5b6+OTm1Tw==",
       "dependencies": {
-        "@udecode/plate-core": "16.8.0"
+        "@udecode/plate-core": "18.15.0"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -2671,11 +2664,11 @@
       }
     },
     "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-reset-node": {
-      "version": "16.8.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-reset-node/-/plate-reset-node-16.8.0.tgz",
-      "integrity": "sha512-ex6WEAAlgMAC4iEFxP3pxmbRPA7lCfMJJQDrJlZBT9VwOdBTSZDLWcjosPI4nYg+7r01frYH75pVwfkGlW/NUA==",
+      "version": "18.15.0",
+      "resolved": "https://registry.npmjs.org/@udecode/plate-reset-node/-/plate-reset-node-18.15.0.tgz",
+      "integrity": "sha512-6p/gMCD0BkBSkd407/d2OasUjjouT9YA1po+uIEgla97ebYbzFXadrT4mqNTSUuPYBFgJM+UZEFLFvhAZn2GcQ==",
       "dependencies": {
-        "@udecode/plate-core": "16.8.0"
+        "@udecode/plate-core": "18.15.0"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -2686,11 +2679,11 @@
       }
     },
     "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-select": {
-      "version": "16.8.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-select/-/plate-select-16.8.0.tgz",
-      "integrity": "sha512-W08xMr1UcXU9Kz9rU1CELTXzV9Sw5uBOj8efm7Bfg1jreAwEnGKZUQ9Ctx9JyQ2GgRHTzi69VF2LglSkTFeVwA==",
+      "version": "18.15.0",
+      "resolved": "https://registry.npmjs.org/@udecode/plate-select/-/plate-select-18.15.0.tgz",
+      "integrity": "sha512-zKJDnxvJDDC8HvH2c+wd1T7wJXBoK08/Laj96FHJPQwFv6bTLK7sDil6iRC8uPvG7hew6n2ZdUJcTfjThymbgw==",
       "dependencies": {
-        "@udecode/plate-core": "16.8.0"
+        "@udecode/plate-core": "18.15.0"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -2701,17 +2694,17 @@
       }
     },
     "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-serializer-docx": {
-      "version": "16.8.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-serializer-docx/-/plate-serializer-docx-16.8.0.tgz",
-      "integrity": "sha512-ZGXMIBT6HQIaDcSCHEatiUW4ekJMAy64wbtCpoByDIKwAliNzIcs2btMFVZkcjN+X1j5PrAfT4WfZ/bPt3NH3Q==",
+      "version": "18.15.0",
+      "resolved": "https://registry.npmjs.org/@udecode/plate-serializer-docx/-/plate-serializer-docx-18.15.0.tgz",
+      "integrity": "sha512-PbRV1+Egk6dmcQouC9Hj1Fu9A0OSg2NB1Ojmbl1JzIjlSVEjTY0fg+dei5AozqAdGUKUKkbH7jP5+ipQcTfKKA==",
       "dependencies": {
-        "@udecode/plate-core": "16.8.0",
-        "@udecode/plate-heading": "16.8.0",
-        "@udecode/plate-indent": "16.8.0",
-        "@udecode/plate-indent-list": "16.8.0",
-        "@udecode/plate-media": "16.8.0",
-        "@udecode/plate-paragraph": "16.8.0",
-        "@udecode/plate-table": "16.8.0",
+        "@udecode/plate-core": "18.15.0",
+        "@udecode/plate-heading": "18.15.0",
+        "@udecode/plate-indent": "18.15.0",
+        "@udecode/plate-indent-list": "18.15.0",
+        "@udecode/plate-media": "18.15.0",
+        "@udecode/plate-paragraph": "18.15.0",
+        "@udecode/plate-table": "18.15.0",
         "validator": "^13.7.0"
       },
       "peerDependencies": {
@@ -2724,11 +2717,11 @@
       }
     },
     "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-serializer-docx/node_modules/@udecode/plate-heading": {
-      "version": "16.8.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-heading/-/plate-heading-16.8.0.tgz",
-      "integrity": "sha512-L6JUgeRFkDL6lrf/CpvOMHrBBDZScJPYrmXhGzdv11MU4f34sllf5C/WLCygMRERKaDZ/CO3wt6/B18nTDTOHA==",
+      "version": "18.15.0",
+      "resolved": "https://registry.npmjs.org/@udecode/plate-heading/-/plate-heading-18.15.0.tgz",
+      "integrity": "sha512-ggHr7+cOnLABrTcl/3SS4fi2AAiieTGknte6lGqlrgJj6ysfO7vG2KOUJH6DdLR+QrT84+VFgVVpLRzs/mg5Mg==",
       "dependencies": {
-        "@udecode/plate-core": "16.8.0"
+        "@udecode/plate-core": "18.15.0"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -2739,11 +2732,11 @@
       }
     },
     "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-serializer-docx/node_modules/@udecode/plate-indent": {
-      "version": "16.8.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-indent/-/plate-indent-16.8.0.tgz",
-      "integrity": "sha512-bvhWAUCS539AK4wDBXeYv1gnE6tGukiNOz+laV5urV/9hbHEgMYa5AeA9F9NY1erZtNjy6G+hwZNPh3yrkycWw==",
+      "version": "18.15.0",
+      "resolved": "https://registry.npmjs.org/@udecode/plate-indent/-/plate-indent-18.15.0.tgz",
+      "integrity": "sha512-FA5b5eWAG7KBHZY8sN1fzqTAPwFe0hYKTwNmkpzppaWcCKVythFMNaPiAAr86qXF3Wt8t2y54d/49OHP9koXDQ==",
       "dependencies": {
-        "@udecode/plate-core": "16.8.0"
+        "@udecode/plate-core": "18.15.0"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -2754,13 +2747,13 @@
       }
     },
     "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-serializer-docx/node_modules/@udecode/plate-indent-list": {
-      "version": "16.8.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-indent-list/-/plate-indent-list-16.8.0.tgz",
-      "integrity": "sha512-sfRaYiEAqO1hsGHxfDidk1DXkIJOoTiAV5SARSSVdOmLu1m4YYT2Z/tmxMRxwI6ttV+rUjbKtnF1XbliQmWdlA==",
+      "version": "18.15.0",
+      "resolved": "https://registry.npmjs.org/@udecode/plate-indent-list/-/plate-indent-list-18.15.0.tgz",
+      "integrity": "sha512-6p4smJ6KEaVGbewO8uPrejcODz1BRvBVEelFUVlo25A5KsdPdxxuAeoxXTjDskagRwLnEmUZSRQwzpMOqKsXhg==",
       "dependencies": {
-        "@udecode/plate-core": "16.8.0",
-        "@udecode/plate-indent": "16.8.0",
-        "@udecode/plate-list": "16.8.0"
+        "@udecode/plate-core": "18.15.0",
+        "@udecode/plate-indent": "18.15.0",
+        "@udecode/plate-list": "18.15.0"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -2771,11 +2764,11 @@
       }
     },
     "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-serializer-docx/node_modules/@udecode/plate-media": {
-      "version": "16.8.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-media/-/plate-media-16.8.0.tgz",
-      "integrity": "sha512-EpYA/my8d0z2cBYxlPBtBTC134AOMYV60AH8n3TjnLpFdE69WcS2FjHlueDkt0QvteRlPILlMQ0o2zd7BMPe3Q==",
+      "version": "18.15.0",
+      "resolved": "https://registry.npmjs.org/@udecode/plate-media/-/plate-media-18.15.0.tgz",
+      "integrity": "sha512-u0lNkeEA6XGrjxfVoUVFhRcTcr8Rie09ovKQKe1U1N3Z8Fm4pAjoSTkUm+7YzEnDqWhTCxWAtsrzMGoY+p813A==",
       "dependencies": {
-        "@udecode/plate-core": "16.8.0",
+        "@udecode/plate-core": "18.15.0",
         "js-video-url-parser": "^0.5.1",
         "re-resizable": "^6.9.9",
         "react-textarea-autosize": "^8.3.3",
@@ -2799,11 +2792,11 @@
       }
     },
     "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-serializer-html": {
-      "version": "16.8.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-serializer-html/-/plate-serializer-html-16.8.0.tgz",
-      "integrity": "sha512-AY2OvWLiLbuiubgV9LzagBBdwu9mEvgBH3MLIK19pw6yB01/yPqL0cbVT0HE8YKWG9KutzRcxinoFuNG/5FNAw==",
+      "version": "18.15.0",
+      "resolved": "https://registry.npmjs.org/@udecode/plate-serializer-html/-/plate-serializer-html-18.15.0.tgz",
+      "integrity": "sha512-Af40IpWrwr9ZXLXmJrLkj0TuQmzKmmNbo1Q57yP4qFsgEZgGUzX3FJhbwVTFSLtkJCUDdJ8DcSf/lehNWYazbg==",
       "dependencies": {
-        "@udecode/plate-core": "16.8.0",
+        "@udecode/plate-core": "18.15.0",
         "html-entities": "^2.3.3"
       },
       "peerDependencies": {
@@ -2816,11 +2809,11 @@
       }
     },
     "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-table": {
-      "version": "16.8.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-table/-/plate-table-16.8.0.tgz",
-      "integrity": "sha512-6GBRw0mpiYwMMnS1XyjOJ2jK7v0C+MlIsExs3P9JjHuIxy4BZKCHF9tBs2RMBJ7vK1hR9wxcwSVI1f9wG+C2nw==",
+      "version": "18.15.0",
+      "resolved": "https://registry.npmjs.org/@udecode/plate-table/-/plate-table-18.15.0.tgz",
+      "integrity": "sha512-sHrRTx5pGMamwLCRwXTDEmZJUTBX/EtXGGM8yoigo7vPY56ARNKrsp/9iNBdfVGMkWHaYYmwqpVdUJUq82b4OA==",
       "dependencies": {
-        "@udecode/plate-core": "16.8.0"
+        "@udecode/plate-core": "18.15.0"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -2831,11 +2824,11 @@
       }
     },
     "node_modules/@contentful/default-field-editors/node_modules/@contentful/field-editor-rich-text/node_modules/@udecode/plate-trailing-block": {
-      "version": "16.8.0",
-      "resolved": "https://registry.npmjs.org/@udecode/plate-trailing-block/-/plate-trailing-block-16.8.0.tgz",
-      "integrity": "sha512-eaawcb5oCyKfvPBrXmD6J+dXv7+7wypCXqAvDQwbdS/0pckc8SZKT6j6Un2vsticCTZkmtRyEc8+x2RdZLFikg==",
+      "version": "18.15.0",
+      "resolved": "https://registry.npmjs.org/@udecode/plate-trailing-block/-/plate-trailing-block-18.15.0.tgz",
+      "integrity": "sha512-BEbIckR8UgckgAlPw6j5OUrEzc/lDaeT1yjc1g2lv73bbTdmyFWqhVLCTPply6t2LQtDSmn1sbaOVc7nV7rzvw==",
       "dependencies": {
-        "@udecode/plate-core": "16.8.0"
+        "@udecode/plate-core": "18.15.0"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -2871,34 +2864,11 @@
       "integrity": "sha512-qs3NZ1INIS+H+yeo7cD9pDfwYV/jqRh1JG9S9zYrNudkoUQg7OL7ziXqRKu+InFjUIDoP2o6HIkLYMh1pcWgyQ=="
     },
     "node_modules/@contentful/default-field-editors/node_modules/@contentful/rich-text-types": {
-      "version": "15.14.1",
-      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-15.14.1.tgz",
-      "integrity": "sha512-1sPVDz7MBuCCMWGvfZXQ06SqBTtlLN5GCP5ddU4c5tfatxVXhv2h80/pDCeTZVV2oCMw02YuNmBgql60+0oL4Q==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.1.0.tgz",
+      "integrity": "sha512-Pucb68FK0j9cHJ96FAewXv+bvH4XizC4KBbVqyHhPLkDIVfasj0AWU5rI1lnvysdVKu66NQkFe8xZdeFTkaLWQ==",
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@radix-ui/react-compose-refs": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-0.1.0.tgz",
-      "integrity": "sha512-eyclbh+b77k+69Dk72q3694OHrn9B3QsoIRx7ywX341U9RK1ThgQjMFZoPtmZNQTksXHLNEiefR8hGVeFyInGg==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
-      }
-    },
-    "node_modules/@contentful/default-field-editors/node_modules/@radix-ui/react-slot": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-0.1.2.tgz",
-      "integrity": "sha512-ADkqfL+agEzEguU3yS26jfB50hRrwf7U4VTwAOZEmi/g+ITcBWe12yM46ueS/UCIMI9Py+gFUaAdxgxafFvY2Q==",
-      "dependencies": {
-        "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-compose-refs": "0.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17.0"
       }
     },
     "node_modules/@contentful/f36-accordion": {
@@ -3517,16 +3487,15 @@
       }
     },
     "node_modules/@contentful/field-editor-boolean": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-boolean/-/field-editor-boolean-1.2.0.tgz",
-      "integrity": "sha512-anT3NMJskP9PZLuIWmrkYMngMtJ7xvMRsaax/TlPpNTLEHC2fpwKcx8kXJIrkKG2fOLNo7Itz8DLSc6TwGsWZg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-boolean/-/field-editor-boolean-1.3.1.tgz",
+      "integrity": "sha512-vzWcEFdDG8M1NEf+UvMqLHW6FRmmw38cLO/MivglcaKrBSYxiQk1hBLq1T9lotBsYBKfc2q7Jq4NFQR0JrM/0g==",
       "dependencies": {
         "@contentful/f36-components": "^4.0.27",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/field-editor-shared": "^1.2.0",
+        "@contentful/field-editor-shared": "^1.3.1",
         "emotion": "^10.0.17",
         "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15",
         "nanoid": "^3.1.3"
       },
       "peerDependencies": {
@@ -3534,29 +3503,28 @@
       }
     },
     "node_modules/@contentful/field-editor-checkbox": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-checkbox/-/field-editor-checkbox-1.2.0.tgz",
-      "integrity": "sha512-IkTEdrOgnmo3DKhyvJjdQZUsJJnLytuYcsWMBrvFrtXhYdNASg0pEFDKin+wnsZma85bF4WHsEBylQvla3p3FQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-checkbox/-/field-editor-checkbox-1.3.1.tgz",
+      "integrity": "sha512-DpU2XXoYAjmMfud21OTAG2pB97OE+URdBEeFpUtonqcb6rUUbbkvxMunngCKcZzDkRJ5EAfitViI/5XKmuZv1g==",
       "dependencies": {
         "@contentful/f36-components": "^4.3.23",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/field-editor-shared": "^1.2.0",
+        "@contentful/field-editor-shared": "^1.3.1",
         "emotion": "^10.0.17",
-        "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15"
+        "lodash": "^4.17.15"
       },
       "peerDependencies": {
         "react": ">=16.8.0"
       }
     },
     "node_modules/@contentful/field-editor-date": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-date/-/field-editor-date-1.4.0.tgz",
-      "integrity": "sha512-jvU4mCTwoKE2DZwB4rpPHsKEzKF+zGYqGoF4VwBXR4HAIkbCe7sDUfD9PwN0MymXemeEZkaeqRlvoug9GurXdQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-date/-/field-editor-date-1.5.1.tgz",
+      "integrity": "sha512-AydATlwoyNWRy2JIohy97Cy3BN2SKhVVoSMkF8wmGgXk+PwhBmQKPJofDhNZ/qO2FQqVa5r9EXLhQfkt/VjG5Q==",
       "dependencies": {
         "@contentful/f36-components": "^4.34.1",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/field-editor-shared": "^1.2.0",
+        "@contentful/field-editor-shared": "^1.3.1",
         "emotion": "^10.0.17",
         "moment": "^2.20.0"
       },
@@ -3565,16 +3533,15 @@
       }
     },
     "node_modules/@contentful/field-editor-dropdown": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-dropdown/-/field-editor-dropdown-1.2.0.tgz",
-      "integrity": "sha512-FL00x8EoH5ZQ2M+n9fKDpyE0Hs2Ov6d4UKto3t4CLj6QZPJErpgHjufRM6MFwiZM3DKyCk0SKwY3wI0aYiJZDA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-dropdown/-/field-editor-dropdown-1.3.1.tgz",
+      "integrity": "sha512-PnD2K9p0ie+pAAwDZya188zODqTRivUXFt41mbB4iqDsDxuzUlN8J1lKgPIzOr/vOdmYkIpToOHxSIEhnOdl1g==",
       "dependencies": {
         "@contentful/f36-components": "^4.0.27",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/field-editor-shared": "^1.2.0",
+        "@contentful/field-editor-shared": "^1.3.1",
         "emotion": "^10.0.0",
         "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15",
         "nanoid": "^3.1.3"
       },
       "peerDependencies": {
@@ -3582,36 +3549,35 @@
       }
     },
     "node_modules/@contentful/field-editor-json": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-json/-/field-editor-json-3.2.0.tgz",
-      "integrity": "sha512-/762pTZM9m6wMoxaVfADbZq7MIqrLYBkZTJrKGwfcK/Lpp14vfpZZ0ChT6ZE1v4XX2TM9sALpnMaS2qqjuljEw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-json/-/field-editor-json-3.3.1.tgz",
+      "integrity": "sha512-Zr/pYVCv+QeGgtsQUs3EdGyfMEJyYkiXJd1WroY1cajz0AwXqw2sh4dABE/1QTl/+Ac2RlK0+qex9cZz53W7jg==",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.0",
         "@contentful/f36-components": "^4.0.27",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/field-editor-shared": "^1.2.0",
+        "@contentful/field-editor-shared": "^1.3.1",
         "@types/deep-equal": "1.0.1",
         "@types/react-codemirror": "1.0.3",
         "@uiw/react-codemirror": "^4.11.4",
         "deep-equal": "2.0.5",
         "emotion": "^10.0.17",
-        "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15"
+        "lodash": "^4.17.15"
       },
       "peerDependencies": {
         "react": ">=16.8.0"
       }
     },
     "node_modules/@contentful/field-editor-json/node_modules/@uiw/react-codemirror": {
-      "version": "4.19.16",
-      "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.19.16.tgz",
-      "integrity": "sha512-uElraR7Mvwz2oZKrmtF5hmIB8dAlIiU65nfg484e/V9k4PV6/5KtPUQL3JPO4clH2pcd+TQqRTQrFFkP/D25ew==",
+      "version": "4.21.8",
+      "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.21.8.tgz",
+      "integrity": "sha512-IwnWdZcBkNIHrQie/AAsBoz2Q/XpWe/Up1nGIrpWxMXEE/+RxW3CIkqcYEwVcYDJlbfP3hcIRqN/Aoz6OeXc5Q==",
       "dependencies": {
         "@babel/runtime": "^7.18.6",
         "@codemirror/commands": "^6.1.0",
         "@codemirror/state": "^6.1.1",
         "@codemirror/theme-one-dark": "^6.0.0",
-        "@uiw/codemirror-extensions-basic-setup": "4.19.16",
+        "@uiw/codemirror-extensions-basic-setup": "4.21.8",
         "codemirror": "^6.0.0"
       },
       "peerDependencies": {
@@ -3664,35 +3630,33 @@
       }
     },
     "node_modules/@contentful/field-editor-list": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-list/-/field-editor-list-1.2.0.tgz",
-      "integrity": "sha512-yGpeL8UninJeeD2iMAtr4z6LQd0ySuuVIJwpPEWwfKI148LzF1ume7m/eucGtZms6IsQD99QJgvi6XLN98CtJA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-list/-/field-editor-list-1.3.1.tgz",
+      "integrity": "sha512-2sNEdSD/QLxDVGPdrgKYLIXkpxT1r1mImVaLc4pIKcjH5UqC4/yDxlXApF2oFZPHsHF5fV/rt3ImEm7o1OXIPw==",
       "dependencies": {
         "@contentful/f36-components": "^4.0.27",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/field-editor-shared": "^1.2.0",
+        "@contentful/field-editor-shared": "^1.3.1",
         "emotion": "^10.0.17",
-        "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15"
+        "lodash": "^4.17.15"
       },
       "peerDependencies": {
         "react": ">=16.8.0"
       }
     },
     "node_modules/@contentful/field-editor-location": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-location/-/field-editor-location-1.2.3.tgz",
-      "integrity": "sha512-UVXuZnJk1o6EJ7d1h8YP8fq2+UU59A4AZwh+bs9V9tH2i8qBv/pxP8ZW9zKj3OgZg/3Y6EtZwc3/Gxk3ziuAlQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-location/-/field-editor-location-1.3.1.tgz",
+      "integrity": "sha512-0iz9Bn1KG0OXkI5ecHwmlVvT70oniPSg33smS9iRigDjeoHd5b1ZKf8LVZWtgTVHsk7lNGo4VP1TPhWSty5yQQ==",
       "dependencies": {
         "@contentful/f36-components": "^4.0.27",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/field-editor-shared": "^1.2.0",
+        "@contentful/field-editor-shared": "^1.3.1",
         "@types/google-map-react": "2.1.7",
         "deep-equal": "2.0.5",
         "emotion": "^10.0.17",
         "google-map-react": "2.2.0",
-        "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15"
+        "lodash": "^4.17.15"
       },
       "peerDependencies": {
         "react": ">=16.8.0"
@@ -3742,14 +3706,14 @@
       }
     },
     "node_modules/@contentful/field-editor-markdown": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-markdown/-/field-editor-markdown-1.2.1.tgz",
-      "integrity": "sha512-I1iPMSk/DiUrKCtUvZI6Ofjsr7KtZq41ZxrUFp+952sFfU8CCemA8hz+Qpb480eCekLkd/QLZdL5Ukd59yw8rg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-markdown/-/field-editor-markdown-1.3.1.tgz",
+      "integrity": "sha512-AZxFP5NyeP7b4w/N0N6LSdx1AOWofCQ0FvyDn3UiQNs+/568fK+9HgkOo23bCFOIoP3SrXGuTEvd7lE4wJHPgg==",
       "dependencies": {
         "@contentful/f36-components": "^4.0.27",
         "@contentful/f36-icons": "^4.1.0",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/field-editor-shared": "^1.2.0",
+        "@contentful/field-editor-shared": "^1.3.1",
         "@types/codemirror": "0.0.109",
         "@types/markdown-to-jsx": "6.11.3",
         "codemirror": "^5.65.11",
@@ -3757,7 +3721,6 @@
         "dompurify": "^2.2.9",
         "emotion": "^10.0.17",
         "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15",
         "markdown-to-jsx": "^7.1.1"
       },
       "peerDependencies": {
@@ -3766,29 +3729,28 @@
       }
     },
     "node_modules/@contentful/field-editor-multiple-line": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-multiple-line/-/field-editor-multiple-line-1.2.0.tgz",
-      "integrity": "sha512-wpMeiEZZEf5Ljc6RBELAxjrxUi7u4/yezlGRQ3Cbb3Y8fhmfaUlLvudgU1xKM8DnP4vjgzLZD4gYODBw4o8xhA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-multiple-line/-/field-editor-multiple-line-1.3.1.tgz",
+      "integrity": "sha512-RLDH0AmT5OuuhG6jM1Z/qbSY/QnOga6Z+M637Ul/zPh6C6FUd7DUAhV+aWwCOIx+HBFOtAC4uEszTORAwSIqGA==",
       "dependencies": {
         "@contentful/f36-components": "^4.0.27",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/field-editor-shared": "^1.2.0",
+        "@contentful/field-editor-shared": "^1.3.1",
         "emotion": "^10.0.17",
-        "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15"
+        "lodash": "^4.17.15"
       },
       "peerDependencies": {
         "react": ">=16.8.0"
       }
     },
     "node_modules/@contentful/field-editor-number": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-number/-/field-editor-number-1.2.6.tgz",
-      "integrity": "sha512-0cU700sep1IKLu3ne4QYpjat8LFknph2L9Q9AnjNStUW1cmmCRsSB8mOnYjjnmPsUS752cj5GeZBvUoGCuyPCg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-number/-/field-editor-number-1.3.1.tgz",
+      "integrity": "sha512-+IFJfztXfKy5MxUtxnhZns/pIDPunRlqIOKgIsurY8alYKZn5phhjDHicRhTetLk+KRFq0VYX8j4yR7ufevjYQ==",
       "dependencies": {
         "@contentful/f36-components": "^4.0.27",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/field-editor-shared": "^1.2.0",
+        "@contentful/field-editor-shared": "^1.3.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -3796,17 +3758,16 @@
       }
     },
     "node_modules/@contentful/field-editor-radio": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-radio/-/field-editor-radio-1.2.0.tgz",
-      "integrity": "sha512-Yc5iX7PdRlRtQRCXuJiH2vaJRD4ejTHWdnAjVwrKWy9fEYIH03CxBdQ4t7+DqBSTePqgQMphgsP9eZ+yuG9Ahg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-radio/-/field-editor-radio-1.3.1.tgz",
+      "integrity": "sha512-FnR7DKjGpo4n96plCmIQHSu3Om3xkHZtgGUzOow/eM5xcw67M2g2iSoUOi7yjtYXfHcX5whEoRj7Cv92Mf5gRQ==",
       "dependencies": {
         "@contentful/f36-components": "^4.0.27",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/field-editor-dropdown": "^1.2.0",
-        "@contentful/field-editor-shared": "^1.2.0",
+        "@contentful/field-editor-dropdown": "^1.3.1",
+        "@contentful/field-editor-shared": "^1.3.1",
         "emotion": "^10.0.17",
         "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15",
         "nanoid": "^3.1.3"
       },
       "peerDependencies": {
@@ -3814,30 +3775,29 @@
       }
     },
     "node_modules/@contentful/field-editor-rating": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-rating/-/field-editor-rating-1.2.0.tgz",
-      "integrity": "sha512-KFvPHwCSpoYjtaE9WEBkELY+bm1nBB9AuFvuaKh+7HxhmgLy2OhlgA965z5YsOGCY+B0Ch3U6AbfCs0kGpWIiQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-rating/-/field-editor-rating-1.3.1.tgz",
+      "integrity": "sha512-ZMFGEOLCzO2PcKiusGvpm4rlFmL8ip5WmdMxJ+pDzHZ0bfqKUnGc2Aa8h41eQoQyvqMI0bulYf/eUBPHc5f99Q==",
       "dependencies": {
         "@contentful/f36-components": "^4.0.27",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/field-editor-shared": "^1.2.0",
+        "@contentful/field-editor-shared": "^1.3.1",
         "emotion": "^10.0.17",
-        "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15"
+        "lodash": "^4.17.15"
       },
       "peerDependencies": {
         "react": ">=16.8.0"
       }
     },
     "node_modules/@contentful/field-editor-reference": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-reference/-/field-editor-reference-5.9.0.tgz",
-      "integrity": "sha512-lUjzW8qoaGBXah3hzHndq30QIxpkRuJzE/OiAa9TCIH3Eegl0RK1eCBPMwZ3y98owU9bEzsMblwg8Yc06adHMA==",
+      "version": "5.13.2",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-reference/-/field-editor-reference-5.13.2.tgz",
+      "integrity": "sha512-Kv96nVDK0vwt0t5M8pFaobBdns3A9FfyxdwSDhMjt4ldG51YzgvirwO/Pl1mIpEp+jIoOytr1Ja0nkennt9tpw==",
       "dependencies": {
         "@contentful/f36-components": "^4.0.27",
         "@contentful/f36-icons": "^4.1.0",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/field-editor-shared": "^1.2.0",
+        "@contentful/field-editor-shared": "^1.3.1",
         "@contentful/mimetype": "^1.4.0",
         "@tanstack/react-query": "^4.3.9",
         "@types/deep-equal": "^1.0.1",
@@ -3847,7 +3807,6 @@
         "deep-equal": "2.0.5",
         "emotion": "^10.0.17",
         "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15",
         "moment": "^2.20.0",
         "p-queue": "^4.0.0",
         "react-intersection-observer": "9.4.0",
@@ -3930,15 +3889,14 @@
       }
     },
     "node_modules/@contentful/field-editor-shared": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-1.2.0.tgz",
-      "integrity": "sha512-eFSnuvFre91Noq2Hais4Uqh05czN+a7KV6H9eNqTWw/Q/6G/LfHExbG+Z/0Yk51hMr15k4PB3wza7oYINb981Q==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-1.3.1.tgz",
+      "integrity": "sha512-My340HzlqC/kPOuLB3SULOaQlkej81JeBgjneap5ckIDWdiFs/TOli7dif0dyiCAyFtcKnRbrG6AXKv2/7uOxw==",
       "dependencies": {
         "@contentful/f36-note": "^4.2.8",
         "@contentful/f36-tokens": "^4.0.0",
         "emotion": "^10.0.17",
-        "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15"
+        "lodash": "^4.17.15"
       },
       "peerDependencies": {
         "@contentful/app-sdk": "^4.2.0",
@@ -3946,34 +3904,32 @@
       }
     },
     "node_modules/@contentful/field-editor-single-line": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-single-line/-/field-editor-single-line-1.2.0.tgz",
-      "integrity": "sha512-6sfcuJTnLcLpQi95KVYHouB6oRYMLXXzoxXfZkBcsRfm8cj0m9ra6puNRZS6MOH33zTe36sTc3rqbB+kCZ1h/Q==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-single-line/-/field-editor-single-line-1.3.1.tgz",
+      "integrity": "sha512-cQVD0+i7BkX2Ij1yJYNzi7CZogl7/y0ThqyQOGV8qj7F5Q5maLgzH00cnhKBwqxeqx8Nl9W1iL6K4vBJnQ+iMg==",
       "dependencies": {
         "@contentful/f36-components": "^4.0.27",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/field-editor-shared": "^1.2.0",
+        "@contentful/field-editor-shared": "^1.3.1",
         "emotion": "^10.0.17",
-        "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15"
+        "lodash": "^4.17.15"
       },
       "peerDependencies": {
         "react": ">=16.8.0"
       }
     },
     "node_modules/@contentful/field-editor-slug": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-slug/-/field-editor-slug-1.2.0.tgz",
-      "integrity": "sha512-640Vm1d7LdL8ePyWvrhUTLmpetOW+WGD4SDfuA7ZVUHBOqZH5lzEz8x85yKBnk5nm6SWvg40UePu4LJ1uKGHUQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-slug/-/field-editor-slug-1.3.2.tgz",
+      "integrity": "sha512-mojJnTAU0QkuMtTmQh8HQsLgR4ZuNYoPlGuGfGiKWygyM/bxN5m9VFJw2AzxZho8lQvb5jeJmr+4c5aEvKB2og==",
       "dependencies": {
         "@contentful/f36-components": "^4.0.27",
         "@contentful/f36-icons": "^4.1.0",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/field-editor-shared": "^1.2.0",
+        "@contentful/field-editor-shared": "^1.3.1",
         "@types/speakingurl": "^13.0.2",
         "emotion": "^10.0.17",
         "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15",
         "speakingurl": "^13.0.0",
         "use-debounce": "^7.0.0"
       },
@@ -3983,18 +3939,17 @@
       }
     },
     "node_modules/@contentful/field-editor-tags": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-tags/-/field-editor-tags-1.2.0.tgz",
-      "integrity": "sha512-RuQuOecroS+J5NzjBUIfpxqMKTFygAWoqlQ9A4czd2yUKVte90YIdvcIwssxKTFxIXWCbkZgKw7RbFADCt658Q==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-tags/-/field-editor-tags-1.3.1.tgz",
+      "integrity": "sha512-KxtA4iOKGw8XNnzkCdKfQMxtyi3ZEHyRosgeBOhI6/KzLCqohxi4VwUBepiCxi88Gsxg6P+8xry4gk8XMME0Ow==",
       "dependencies": {
         "@contentful/f36-components": "^4.0.27",
         "@contentful/f36-icons": "^4.1.0",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/field-editor-shared": "^1.2.0",
+        "@contentful/field-editor-shared": "^1.3.1",
         "array-move": "^3.0.0",
         "emotion": "^10.0.0",
         "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15",
         "react-sortable-hoc": "^2.0.0"
       },
       "peerDependencies": {
@@ -4002,30 +3957,29 @@
       }
     },
     "node_modules/@contentful/field-editor-url": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-url/-/field-editor-url-1.2.0.tgz",
-      "integrity": "sha512-DVdKPDlu1luFQAx/jwQSgekgpETFxpj8PvLgoYZey5vmEbDorDKQWPKDWyM5SAlUCfmkAq58R8EW2531cvoNgQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-url/-/field-editor-url-1.3.1.tgz",
+      "integrity": "sha512-dToTVRXUEnPfwBuLjMvYKE6Rdx0vmAoHA4Yn85wH8me5xueuMZQBhFY2QNxc0UypBHuwRmYkTIUL6iKRXfUnzg==",
       "dependencies": {
         "@contentful/f36-components": "^4.0.27",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/field-editor-shared": "^1.2.0",
+        "@contentful/field-editor-shared": "^1.3.1",
         "emotion": "^10.0.17",
-        "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15"
+        "lodash": "^4.17.15"
       },
       "peerDependencies": {
         "react": ">=16.8.0"
       }
     },
     "node_modules/@contentful/field-editor-validation-errors": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-validation-errors/-/field-editor-validation-errors-1.2.0.tgz",
-      "integrity": "sha512-/ibj5CUp2M1vcqh7MrT/SU/mZcxwpIYtho5mZzK3FgrvKqPPf5AzDu6sJsvLjJB9N/FJ1L9P2CcGywCp5CF9MQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-validation-errors/-/field-editor-validation-errors-1.3.1.tgz",
+      "integrity": "sha512-8J4SuFPR9ZLuBRXP+Hqff4aru2/WdODyWF5iFaZrgvwMPO0tu6ssnL8WID+zC3ERFWwqoeaIyBy/fBf32zmSuw==",
       "dependencies": {
         "@contentful/f36-components": "^4.0.27",
         "@contentful/f36-icons": "^4.1.0",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/field-editor-shared": "^1.2.0",
+        "@contentful/field-editor-shared": "^1.3.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -4067,28 +4021,20 @@
       }
     },
     "node_modules/@contentful/rich-text-plain-text-renderer": {
-      "version": "15.15.1",
-      "resolved": "https://registry.npmjs.org/@contentful/rich-text-plain-text-renderer/-/rich-text-plain-text-renderer-15.15.1.tgz",
-      "integrity": "sha512-uk9JC3HtOrCekJSrStS+vzZiITefuaY0Tr0AMlp+0NgRh+b5i59CPq3feo1/WsvKIS360HlIhVjuyz1nMsQoTA==",
+      "version": "16.0.5",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-plain-text-renderer/-/rich-text-plain-text-renderer-16.0.5.tgz",
+      "integrity": "sha512-Ab7SCLY5H+HSlAiV5Jf3/0Dn4wEZg/P2R5f8OwKLSTT7hrThORSxOHJxfY6hIBK8J3wzthBbNN2Bbz/eIEBCqw==",
       "dependencies": {
-        "@contentful/rich-text-types": "^15.15.1"
+        "@contentful/rich-text-types": "^16.2.0"
       },
       "engines": {
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@contentful/rich-text-plain-text-renderer/node_modules/@contentful/rich-text-types": {
-      "version": "15.15.1",
-      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-15.15.1.tgz",
-      "integrity": "sha512-oheW0vkxWDuKBIIXDeJfZaRYo+NzKbC4gETMhH+MGJd4nfL9cqrOvtRxZBgnhICN4vDpH4my/zUIZGKcFqGSjQ==",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@contentful/rich-text-types": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.0.3.tgz",
-      "integrity": "sha512-BsUtXj93jo5XUt0YeUwfCkMWRoZIzJDPUIY4vMy9SwGIO9olTsMoQKadjA2ktlmK+Gg6710WH3eFKZxj2q39Iw==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.2.0.tgz",
+      "integrity": "sha512-4BHC+mfa50JB70epzpnas4EkiuB3mGdBZ5Rp8w7R5wXvswEf8TLg5yGau2FxmZeEjrAkDrt4vzBLVQ8v3Y//Jw==",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -5119,9 +5065,9 @@
       }
     },
     "node_modules/@googlemaps/js-api-loader": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-1.15.1.tgz",
-      "integrity": "sha512-AsnEgNsB7S/VdrHGEQUaUM2e5tmjFGKBAfzR/AqO8O7TPq/jQGvoRw5liPBw4EMF38RDsHmKDV89q/X+qiUREQ==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-1.16.2.tgz",
+      "integrity": "sha512-psGw5u0QM6humao48Hn4lrChOM2/rA43ZCm3tKK9qQsEj1/VzqkCqnvGfEOshDbBQflydfaRovbKwZMF4AyqbA==",
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       }
@@ -6135,31 +6081,31 @@
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
     },
     "node_modules/@lezer/common": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.0.2.tgz",
-      "integrity": "sha512-SVgiGtMnMnW3ActR8SXgsDhw7a0w0ChHSYAyAUxxrOiJ1OqYWEKk/xJd84tTSPo1mo6DXLObAJALNnd0Hrv7Ng=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.0.3.tgz",
+      "integrity": "sha512-JH4wAXCgUOcCGNekQPLhVeUtIqjH0yPBs7vvUdSjyQama9618IOKFJwkv2kcqdhF0my8hQEgCTEJU0GIgnahvA=="
     },
     "node_modules/@lezer/highlight": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.1.4.tgz",
-      "integrity": "sha512-IECkFmw2l7sFcYXrV8iT9GeY4W0fU4CxX0WMwhmhMIVjoDdD1Hr6q3G2NqVtLg/yVe5n7i4menG3tJ2r4eCrPQ==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.1.6.tgz",
+      "integrity": "sha512-cmSJYa2us+r3SePpRCjN5ymCqCPv+zyXmDl0ciWtVaNiORT/MxM7ZgOMQZADD0o51qOaOg24qc/zBViOIwAjJg==",
       "dependencies": {
         "@lezer/common": "^1.0.0"
       }
     },
     "node_modules/@lezer/json": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.0.tgz",
-      "integrity": "sha512-zbAuUY09RBzCoCA3lJ1+ypKw5WSNvLqGMtasdW6HvVOqZoCpPr8eWrsGnOVWGKGn8Rh21FnrKRVlJXrGAVUqRw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.1.tgz",
+      "integrity": "sha512-nkVC27qiEZEjySbi6gQRuMwa2sDu2PtfjSgz0A4QF81QyRGm3kb2YRzLcOPcTEtmcwvrX/cej7mlhbwViA4WJw==",
       "dependencies": {
         "@lezer/highlight": "^1.0.0",
         "@lezer/lr": "^1.0.0"
       }
     },
     "node_modules/@lezer/lr": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.3.4.tgz",
-      "integrity": "sha512-7o+e4og/QoC/6btozDPJqnzBhUaD1fMfmvnEKQO1wRRiTse1WxaJ3OMEXZJnkgT6HCcTVOctSoXK9jGJw2oe9g==",
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.3.9.tgz",
+      "integrity": "sha512-XPz6dzuTHlnsbA5M2DZgjflNQ+9Hi5Swhic0RULdp3oOs3rh6bqGZolosVqN/fQIT8uNiepzINJDnS39oweTHQ==",
       "dependencies": {
         "@lezer/common": "^1.0.0"
       }
@@ -12363,9 +12309,9 @@
       }
     },
     "node_modules/@uiw/codemirror-extensions-basic-setup": {
-      "version": "4.19.16",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.19.16.tgz",
-      "integrity": "sha512-Xm0RDpyYVZ/8hWqaBs3+wZwi4uLwZUBwp/uCt89X80FeR6mr3BFuC+a+gcDO4dBu3l+WQE3jJdhjKjB2TCY/PQ==",
+      "version": "4.21.8",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.21.8.tgz",
+      "integrity": "sha512-uOPRPxexapuvlZ+hkVun5oyhQ0AtXIapBqv56cgjkzwZ49EILUk9mTubHFBY0B5kPqme7d57hSXYRLW8EH80LA==",
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/commands": "^6.0.0",
@@ -14247,9 +14193,9 @@
       }
     },
     "node_modules/codemirror": {
-      "version": "5.65.13",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.13.tgz",
-      "integrity": "sha512-SVWEzKXmbHmTQQWaz03Shrh4nybG0wXx2MEu3FO4ezbPW8IbnZEd5iGHGEffSUaitKYa3i+pHpBsSvw8sPHtzg=="
+      "version": "5.65.14",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.14.tgz",
+      "integrity": "sha512-VSNugIBDGt0OU9gDjeVr6fNkoFQznrWEUdAApMlXQNbfE8gGO19776D6MwSqF/V/w/sDwonsQ0z7KmmI9guScg=="
     },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.1",
@@ -14598,9 +14544,9 @@
       }
     },
     "node_modules/crelt": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.5.tgz",
-      "integrity": "sha512-+BO9wPPi+DWTDcNYhr/W90myha8ptzftZT+LwcmUbbok0rcP/fequmFYCw8NMoH7pkAZQzU78b3kYrlua5a9eA=="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="
     },
     "node_modules/cross-env": {
       "version": "7.0.3",
@@ -15495,9 +15441,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.5.tgz",
-      "integrity": "sha512-jggCCd+8Iqp4Tsz0nIvpcb22InKEBrGz5dw3EQJMs8HPJDsKbFIO3STYtAvCfDx26Muevn1MHVI0XxjgFfmiSA=="
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.7.tgz",
+      "integrity": "sha512-kxxKlPEDa6Nc5WJi+qRgPbOAbgTpSULL+vI3NUXsZMlkJxTqYI9wg5ZTay2sFrdZRWHPWNi+EdAhcJf81WtoMQ=="
     },
     "node_modules/domutils": {
       "version": "2.8.0",
@@ -21221,11 +21167,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
-    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -24593,9 +24534,9 @@
       }
     },
     "node_modules/react-textarea-autosize": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.4.1.tgz",
-      "integrity": "sha512-aD2C+qK6QypknC+lCMzteOdIjoMbNlgSFmJjCV+DrfTPwp59i/it9mMNf2HDzvRjQgKAyBDPyLJhcrzElf2U4Q==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.2.tgz",
+      "integrity": "sha512-uOkyjkEl0ByEK21eCJMHDGBAAd/BoFQBawYK5XItjAmCTeSbjxghd8qnt7nzsLYzidjnoObu6M26xts0YGKsGg==",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
         "use-composed-ref": "^1.3.0",
@@ -27559,9 +27500,9 @@
       }
     },
     "node_modules/w3c-keyname": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.6.tgz",
-      "integrity": "sha512-f+fciywl1SJEniZHD6H+kUO8gOnwIr7f4ijKA6+ZvJFjeGi1r4PDLl53Ayud9O/rk64RqgoQine0feoeOU0kXg=="
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="
     },
     "node_modules/w3c-xmlserializer": {
       "version": "2.0.0",
@@ -30084,9 +30025,9 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
     "@codemirror/autocomplete": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.6.0.tgz",
-      "integrity": "sha512-SjbgWSwNKbyQOiVXtG8DXG2z29zTbmzpGccxMqakVo+vqK8fx3Ai0Ee7is3JqX6dxJOoK0GfP3LfeUK53Ltv7w==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.9.0.tgz",
+      "integrity": "sha512-Fbwm0V/Wn3BkEJZRhr0hi5BhCo5a7eBL6LYaliPjOSwCyfOpnjXY59HruSxOUNV+1OYer0Tgx1zRNQttjXyDog==",
       "requires": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.0.0",
@@ -30095,9 +30036,9 @@
       }
     },
     "@codemirror/commands": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.2.3.tgz",
-      "integrity": "sha512-9uf0g9m2wZyrIim1SavcxMdwsu8wc/y5uSw6JRUBYIGWrN+RY4vSru/BqB+MyNWqx4C2uRhQ/Kh7Pw8lAyT3qQ==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.2.4.tgz",
+      "integrity": "sha512-42lmDqVH0ttfilLShReLXsDfASKLXzfyC36bzwcqzox9PlHulMcsUOfHXNo2X2aFMVNUoQ7j+d4q5bnfseYoOA==",
       "requires": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.2.0",
@@ -30115,9 +30056,9 @@
       }
     },
     "@codemirror/language": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.6.0.tgz",
-      "integrity": "sha512-cwUd6lzt3MfNYOobdjf14ZkLbJcnv4WtndYaoBkbor/vF+rCNguMPK0IRtvZJG4dsWiaWPcK8x1VijhvSxnstg==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.8.0.tgz",
+      "integrity": "sha512-r1paAyWOZkfY0RaYEZj3Kul+MiQTEbDvYqf8gPGaRvNneHXCmfSaAVFjwRUPlgxS8yflMxw2CTu6uCMp8R8A2g==",
       "requires": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -30128,9 +30069,9 @@
       }
     },
     "@codemirror/lint": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.2.1.tgz",
-      "integrity": "sha512-y1muai5U/uUPAGRyHMx9mHuHLypPcHWxzlZGknp/U5Mdb5Ol8Q5ZLp67UqyTbNFJJ3unVxZ8iX3g1fMN79S1JQ==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.4.0.tgz",
+      "integrity": "sha512-6VZ44Ysh/Zn07xrGkdtNfmHCbGSHZzFBdzWi0pbd7chAQ/iUcpLGX99NYRZTa7Ugqg4kEHCqiHhcZnH0gLIgSg==",
       "requires": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -30138,9 +30079,9 @@
       }
     },
     "@codemirror/search": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.4.0.tgz",
-      "integrity": "sha512-zMDgaBXah+nMLK2dHz9GdCnGbQu+oaGRXS1qviqNZkvOCv/whp5XZFyoikLp/23PM9RBcbuKUUISUmQHM1eRHw==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.0.tgz",
+      "integrity": "sha512-64/M40YeJPToKvGO6p3fijo2vwUEj4nACEAXElCaYQ50HrXSvRaK+NHEhSh73WFBGdvIdhrV+lL9PdJy2RfCYA==",
       "requires": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -30148,9 +30089,9 @@
       }
     },
     "@codemirror/state": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.2.0.tgz",
-      "integrity": "sha512-69QXtcrsc3RYtOtd+GsvczJ319udtBf1PTrr2KbLWM/e2CXUPnh0Nz9AUo8WfhSQ7GeL8dPVNUmhQVgpmuaNGA=="
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.2.1.tgz",
+      "integrity": "sha512-RupHSZ8+OjNT38zU9fKH2sv+Dnlr8Eb8sl4NOnnqz95mCFTZUaiRP8Xv5MeeaG0px2b8Bnfe7YGwCV3nsBhbuw=="
     },
     "@codemirror/theme-one-dark": {
       "version": "6.1.2",
@@ -30164,9 +30105,9 @@
       }
     },
     "@codemirror/view": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.10.0.tgz",
-      "integrity": "sha512-Oea3rvE4JQLMmLsy2b54yxXQJgJM9xKpUQIpF/LGgKUTH2lA06GAmEtKKWn5OUnbW3jrH1hHeUd8DJEgePMOeQ==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.15.3.tgz",
+      "integrity": "sha512-chNgR8H7Ipx7AZUt0+Kknk7BCow/ron3mHd1VZdM7hQXiI79+UlWqcxpCiexTxZQ+iSkqndk3HHAclJOcjSuog==",
       "requires": {
         "@codemirror/state": "^6.1.4",
         "style-mod": "^4.0.0",
@@ -30217,83 +30158,78 @@
       }
     },
     "@contentful/app-sdk": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.17.1.tgz",
-      "integrity": "sha512-8vh/X+kW33412lxwi2Acr6V4W7UxNvH273cJUSJ43OaFlwAl+T4aWhIULXq+sT9ASc9QxsujiWFHbCR38kl/oQ==",
-      "requires": {}
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.22.1.tgz",
+      "integrity": "sha512-Db8voGJ1h045P9aXSKnZSZ+GLKt6f4vN6IzBX+GbapbLKzzPFR1+uqR3DygJX1ZE07tN+OnDzCazMPudQYsd/Q==",
+      "requires": {
+        "contentful-management": ">=7.30.0"
+      }
     },
     "@contentful/contentful-slatejs-adapter": {
-      "version": "15.16.5",
-      "resolved": "https://registry.npmjs.org/@contentful/contentful-slatejs-adapter/-/contentful-slatejs-adapter-15.16.5.tgz",
-      "integrity": "sha512-ZgI2SyYTZEwhNAcyNYHL2pMqz1yH8BBgzSlGyQuxz42YBB0yWqViG6SckXGd/96tivH1aZDGVQdKWW4ubALbYQ==",
+      "version": "15.16.6",
+      "resolved": "https://registry.npmjs.org/@contentful/contentful-slatejs-adapter/-/contentful-slatejs-adapter-15.16.6.tgz",
+      "integrity": "sha512-7/wFYKjx+QyaeigC4njXY1TnzZSR2s8Z7dZ/hSFxnKj6QhR86RsCkUl/in8M7WAmolSddeNsMhgIeyCRXWwoOQ==",
       "requires": {
-        "@contentful/rich-text-types": "^16.1.0"
-      },
-      "dependencies": {
-        "@contentful/rich-text-types": {
-          "version": "16.1.0",
-          "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.1.0.tgz",
-          "integrity": "sha512-Pucb68FK0j9cHJ96FAewXv+bvH4XizC4KBbVqyHhPLkDIVfasj0AWU5rI1lnvysdVKu66NQkFe8xZdeFTkaLWQ=="
-        }
+        "@contentful/rich-text-types": "^16.2.0"
       }
     },
     "@contentful/default-field-editors": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@contentful/default-field-editors/-/default-field-editors-1.3.3.tgz",
-      "integrity": "sha512-NV7glfhIO0Qy+Ym4+JQW21ESvgW3iS1PT7eaka6WeXx53UeMAPbxf4g0k268Kiv23uwUWLo3dnGvhL4z+OCZiA==",
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@contentful/default-field-editors/-/default-field-editors-1.4.10.tgz",
+      "integrity": "sha512-Md2ivD0rdBVGxsjAv97Ad4MHzQs6GJqk6qNenE31Me5Hgc9cncqkHUDmYhJ9J8JrdDAT8frHW4dtLEJlaKc4XA==",
       "requires": {
         "@contentful/f36-components": "^4.0.27",
-        "@contentful/field-editor-boolean": "^1.2.0",
-        "@contentful/field-editor-checkbox": "^1.2.0",
-        "@contentful/field-editor-date": "^1.4.0",
-        "@contentful/field-editor-dropdown": "^1.2.0",
-        "@contentful/field-editor-json": "^3.2.0",
-        "@contentful/field-editor-list": "^1.2.0",
-        "@contentful/field-editor-location": "^1.2.3",
-        "@contentful/field-editor-markdown": "^1.2.1",
-        "@contentful/field-editor-multiple-line": "^1.2.0",
-        "@contentful/field-editor-number": "^1.2.6",
-        "@contentful/field-editor-radio": "^1.2.0",
-        "@contentful/field-editor-rating": "^1.2.0",
-        "@contentful/field-editor-reference": "^5.9.0",
-        "@contentful/field-editor-rich-text": "^3.4.22",
-        "@contentful/field-editor-shared": "^1.2.0",
-        "@contentful/field-editor-single-line": "^1.2.0",
-        "@contentful/field-editor-slug": "^1.2.0",
-        "@contentful/field-editor-tags": "^1.2.0",
-        "@contentful/field-editor-url": "^1.2.0",
-        "@contentful/field-editor-validation-errors": "^1.2.0",
+        "@contentful/field-editor-boolean": "^1.3.1",
+        "@contentful/field-editor-checkbox": "^1.3.1",
+        "@contentful/field-editor-date": "^1.5.1",
+        "@contentful/field-editor-dropdown": "^1.3.1",
+        "@contentful/field-editor-json": "^3.3.1",
+        "@contentful/field-editor-list": "^1.3.1",
+        "@contentful/field-editor-location": "^1.3.1",
+        "@contentful/field-editor-markdown": "^1.3.1",
+        "@contentful/field-editor-multiple-line": "^1.3.1",
+        "@contentful/field-editor-number": "^1.3.1",
+        "@contentful/field-editor-radio": "^1.3.1",
+        "@contentful/field-editor-rating": "^1.3.1",
+        "@contentful/field-editor-reference": "^5.13.2",
+        "@contentful/field-editor-rich-text": "^3.9.2",
+        "@contentful/field-editor-shared": "^1.3.1",
+        "@contentful/field-editor-single-line": "^1.3.1",
+        "@contentful/field-editor-slug": "^1.3.2",
+        "@contentful/field-editor-tags": "^1.3.1",
+        "@contentful/field-editor-url": "^1.3.1",
+        "@contentful/field-editor-validation-errors": "^1.3.1",
         "contentful-management": "^10.0.0",
         "emotion": "^10.0.27"
       },
       "dependencies": {
         "@contentful/field-editor-rich-text": {
-          "version": "3.4.22",
-          "resolved": "https://registry.npmjs.org/@contentful/field-editor-rich-text/-/field-editor-rich-text-3.4.22.tgz",
-          "integrity": "sha512-c3vUpEKz2+TlfJV3kANBrImJvw2f5DCgtRdEwgcYrS53GZR2+PiSQjTZb5BuO6DP2CWzgWFrptrrGIEBdwV/+g==",
+          "version": "3.9.2",
+          "resolved": "https://registry.npmjs.org/@contentful/field-editor-rich-text/-/field-editor-rich-text-3.9.2.tgz",
+          "integrity": "sha512-zh/YNVuAnfo/CZ0/WJEegssFMF1wLoQhiaC4fiLHS4fSXSVtAGAfdNQ5TZoPY/rdUkwqedoaD6EURrTaxWZRjA==",
           "requires": {
-            "@contentful/app-sdk": "^4.6.0",
-            "@contentful/contentful-slatejs-adapter": "^15.13.1",
+            "@contentful/app-sdk": "^4.21.1",
+            "@contentful/contentful-slatejs-adapter": "^15.16.5",
             "@contentful/f36-components": "^4.20.6",
             "@contentful/f36-icons": "^4.1.1",
             "@contentful/f36-tokens": "^4.0.0",
             "@contentful/f36-utils": "^4.19.0",
-            "@contentful/field-editor-reference": "^5.9.0",
-            "@contentful/field-editor-shared": "^1.2.0",
-            "@contentful/rich-text-plain-text-renderer": "^15.12.1",
-            "@contentful/rich-text-types": "15.14.1",
+            "@contentful/field-editor-reference": "^5.13.2",
+            "@contentful/field-editor-shared": "^1.3.1",
+            "@contentful/rich-text-plain-text-renderer": "^16.0.4",
+            "@contentful/rich-text-types": "16.1.0",
             "@popperjs/core": "^2.11.5",
-            "@udecode/plate-basic-marks": "16.8.0",
-            "@udecode/plate-break": "16.8.0",
-            "@udecode/plate-core": "16.8.0",
-            "@udecode/plate-list": "16.8.0",
-            "@udecode/plate-paragraph": "16.8.0",
-            "@udecode/plate-reset-node": "16.8.0",
-            "@udecode/plate-select": "16.8.0",
-            "@udecode/plate-serializer-docx": "16.8.0",
-            "@udecode/plate-serializer-html": "16.8.0",
-            "@udecode/plate-table": "16.8.0",
-            "@udecode/plate-trailing-block": "16.8.0",
+            "@udecode/plate-basic-marks": "18.15.0",
+            "@udecode/plate-break": "18.15.0",
+            "@udecode/plate-core": "18.15.0",
+            "@udecode/plate-list": "18.15.0",
+            "@udecode/plate-paragraph": "18.15.0",
+            "@udecode/plate-reset-node": "18.15.0",
+            "@udecode/plate-select": "18.15.0",
+            "@udecode/plate-serializer-docx": "18.15.0",
+            "@udecode/plate-serializer-html": "18.15.0",
+            "@udecode/plate-table": "18.15.0",
+            "@udecode/plate-trailing-block": "18.15.0",
             "fast-deep-equal": "^3.1.3",
             "is-hotkey": "^0.2.0",
             "is-plain-obj": "^3.0.0",
@@ -30305,31 +30241,32 @@
           },
           "dependencies": {
             "@udecode/plate-basic-marks": {
-              "version": "16.8.0",
-              "resolved": "https://registry.npmjs.org/@udecode/plate-basic-marks/-/plate-basic-marks-16.8.0.tgz",
-              "integrity": "sha512-yqRVR+zowfjzOK9AxDZ//hiq6+tNUFY2gGJck8ClGMr5y9pbQfCDOyL7nkgbS7mUO4vzZmDIOjl+spGvOUVuSg==",
+              "version": "18.15.0",
+              "resolved": "https://registry.npmjs.org/@udecode/plate-basic-marks/-/plate-basic-marks-18.15.0.tgz",
+              "integrity": "sha512-2jQucmY5FVVVpLnah+H9KCYtgb0UNMUqh6U5AySAnJpEpgKMnYmyqH7joxj2Ut1uN34NOvONeRvv2H3Gbk6seQ==",
               "requires": {
-                "@udecode/plate-core": "16.8.0"
+                "@udecode/plate-core": "18.15.0"
               }
             },
             "@udecode/plate-break": {
-              "version": "16.8.0",
-              "resolved": "https://registry.npmjs.org/@udecode/plate-break/-/plate-break-16.8.0.tgz",
-              "integrity": "sha512-48WpW9/SqngeTP6ZNRi90j89iOii7mhI6ImYd6uA4QbhrE9rtDLm+HRHmy1uNaOlJLECZ2jp4+2yWTN6rbObdg==",
+              "version": "18.15.0",
+              "resolved": "https://registry.npmjs.org/@udecode/plate-break/-/plate-break-18.15.0.tgz",
+              "integrity": "sha512-JjN9VcpmCUhfAB+V8+/4vsGQf+lH4Ue2ZsUbVXWwRqcPwOBIbTH3Sv5J+JYxJY+NrA5fzDIwB9e/OfUR9fivjA==",
               "requires": {
-                "@udecode/plate-core": "16.8.0"
+                "@udecode/plate-core": "18.15.0"
               }
             },
             "@udecode/plate-core": {
-              "version": "16.8.0",
-              "resolved": "https://registry.npmjs.org/@udecode/plate-core/-/plate-core-16.8.0.tgz",
-              "integrity": "sha512-zd6ZxwDOuazKWGT4DFiQxQ8z3t2xAoBzg3JC5lY+4Xj/By5zjZD/ZmQAAogRWErC4ZNL6SqA2EbHDZij6hNrWg==",
+              "version": "18.15.0",
+              "resolved": "https://registry.npmjs.org/@udecode/plate-core/-/plate-core-18.15.0.tgz",
+              "integrity": "sha512-YncMwlTC5Bn1a5F1rg1mc2eZvOBHa2swdtqmDhnNaStSPu/isIMqCRTbUcWYHtnBbQpNYC3Ul4HegbK63mgjoA==",
               "requires": {
-                "@radix-ui/react-slot": "^0.1.2",
+                "@radix-ui/react-slot": "^1.0.1",
                 "@udecode/zustood": "^1.1.1",
                 "clsx": "^1.1.1",
                 "jotai": "^1.7.2",
                 "lodash": "^4.17.21",
+                "nanoid": "^3.3.4",
                 "react-hotkeys-hook": "^3.4.6",
                 "use-deep-compare": "^1.1.0",
                 "zustand": "^3.7.2"
@@ -30346,85 +30283,85 @@
               }
             },
             "@udecode/plate-list": {
-              "version": "16.8.0",
-              "resolved": "https://registry.npmjs.org/@udecode/plate-list/-/plate-list-16.8.0.tgz",
-              "integrity": "sha512-TNEzHS0NfYAClV3rNVa7sOD0XGBK7ykwA/uEb/tLom2L0HSyITMJQuTyStLELQ15Yn8Bz4BBfo68h/dPYXKjHg==",
+              "version": "18.15.0",
+              "resolved": "https://registry.npmjs.org/@udecode/plate-list/-/plate-list-18.15.0.tgz",
+              "integrity": "sha512-f9aXfH7eMuhP084FHWrsmcMaIPyWaE0oxbBLYGYuRraTNsvekBTzmLvOC1ixJIn88jsogb4J25KuohTXxFrrXw==",
               "requires": {
-                "@udecode/plate-core": "16.8.0",
-                "@udecode/plate-reset-node": "16.8.0"
+                "@udecode/plate-core": "18.15.0",
+                "@udecode/plate-reset-node": "18.15.0"
               }
             },
             "@udecode/plate-paragraph": {
-              "version": "16.8.0",
-              "resolved": "https://registry.npmjs.org/@udecode/plate-paragraph/-/plate-paragraph-16.8.0.tgz",
-              "integrity": "sha512-p44WrWqIrtfJZpjslSjnqh6g9AcajlRs1BiJf6CGU9U5ITNTltUtl9+NL0Miabibgk0Hz1SguFZ7RCVOLWtL1w==",
+              "version": "18.15.0",
+              "resolved": "https://registry.npmjs.org/@udecode/plate-paragraph/-/plate-paragraph-18.15.0.tgz",
+              "integrity": "sha512-qy6RUCZiq5ktL3FwdpYsUJFPuNpiY9DepehiiDFDjLl9++y++4MqftOqcB1qy3rAKM3u4XzM4cuh5b6+OTm1Tw==",
               "requires": {
-                "@udecode/plate-core": "16.8.0"
+                "@udecode/plate-core": "18.15.0"
               }
             },
             "@udecode/plate-reset-node": {
-              "version": "16.8.0",
-              "resolved": "https://registry.npmjs.org/@udecode/plate-reset-node/-/plate-reset-node-16.8.0.tgz",
-              "integrity": "sha512-ex6WEAAlgMAC4iEFxP3pxmbRPA7lCfMJJQDrJlZBT9VwOdBTSZDLWcjosPI4nYg+7r01frYH75pVwfkGlW/NUA==",
+              "version": "18.15.0",
+              "resolved": "https://registry.npmjs.org/@udecode/plate-reset-node/-/plate-reset-node-18.15.0.tgz",
+              "integrity": "sha512-6p/gMCD0BkBSkd407/d2OasUjjouT9YA1po+uIEgla97ebYbzFXadrT4mqNTSUuPYBFgJM+UZEFLFvhAZn2GcQ==",
               "requires": {
-                "@udecode/plate-core": "16.8.0"
+                "@udecode/plate-core": "18.15.0"
               }
             },
             "@udecode/plate-select": {
-              "version": "16.8.0",
-              "resolved": "https://registry.npmjs.org/@udecode/plate-select/-/plate-select-16.8.0.tgz",
-              "integrity": "sha512-W08xMr1UcXU9Kz9rU1CELTXzV9Sw5uBOj8efm7Bfg1jreAwEnGKZUQ9Ctx9JyQ2GgRHTzi69VF2LglSkTFeVwA==",
+              "version": "18.15.0",
+              "resolved": "https://registry.npmjs.org/@udecode/plate-select/-/plate-select-18.15.0.tgz",
+              "integrity": "sha512-zKJDnxvJDDC8HvH2c+wd1T7wJXBoK08/Laj96FHJPQwFv6bTLK7sDil6iRC8uPvG7hew6n2ZdUJcTfjThymbgw==",
               "requires": {
-                "@udecode/plate-core": "16.8.0"
+                "@udecode/plate-core": "18.15.0"
               }
             },
             "@udecode/plate-serializer-docx": {
-              "version": "16.8.0",
-              "resolved": "https://registry.npmjs.org/@udecode/plate-serializer-docx/-/plate-serializer-docx-16.8.0.tgz",
-              "integrity": "sha512-ZGXMIBT6HQIaDcSCHEatiUW4ekJMAy64wbtCpoByDIKwAliNzIcs2btMFVZkcjN+X1j5PrAfT4WfZ/bPt3NH3Q==",
+              "version": "18.15.0",
+              "resolved": "https://registry.npmjs.org/@udecode/plate-serializer-docx/-/plate-serializer-docx-18.15.0.tgz",
+              "integrity": "sha512-PbRV1+Egk6dmcQouC9Hj1Fu9A0OSg2NB1Ojmbl1JzIjlSVEjTY0fg+dei5AozqAdGUKUKkbH7jP5+ipQcTfKKA==",
               "requires": {
-                "@udecode/plate-core": "16.8.0",
-                "@udecode/plate-heading": "16.8.0",
-                "@udecode/plate-indent": "16.8.0",
-                "@udecode/plate-indent-list": "16.8.0",
-                "@udecode/plate-media": "16.8.0",
-                "@udecode/plate-paragraph": "16.8.0",
-                "@udecode/plate-table": "16.8.0",
+                "@udecode/plate-core": "18.15.0",
+                "@udecode/plate-heading": "18.15.0",
+                "@udecode/plate-indent": "18.15.0",
+                "@udecode/plate-indent-list": "18.15.0",
+                "@udecode/plate-media": "18.15.0",
+                "@udecode/plate-paragraph": "18.15.0",
+                "@udecode/plate-table": "18.15.0",
                 "validator": "^13.7.0"
               },
               "dependencies": {
                 "@udecode/plate-heading": {
-                  "version": "16.8.0",
-                  "resolved": "https://registry.npmjs.org/@udecode/plate-heading/-/plate-heading-16.8.0.tgz",
-                  "integrity": "sha512-L6JUgeRFkDL6lrf/CpvOMHrBBDZScJPYrmXhGzdv11MU4f34sllf5C/WLCygMRERKaDZ/CO3wt6/B18nTDTOHA==",
+                  "version": "18.15.0",
+                  "resolved": "https://registry.npmjs.org/@udecode/plate-heading/-/plate-heading-18.15.0.tgz",
+                  "integrity": "sha512-ggHr7+cOnLABrTcl/3SS4fi2AAiieTGknte6lGqlrgJj6ysfO7vG2KOUJH6DdLR+QrT84+VFgVVpLRzs/mg5Mg==",
                   "requires": {
-                    "@udecode/plate-core": "16.8.0"
+                    "@udecode/plate-core": "18.15.0"
                   }
                 },
                 "@udecode/plate-indent": {
-                  "version": "16.8.0",
-                  "resolved": "https://registry.npmjs.org/@udecode/plate-indent/-/plate-indent-16.8.0.tgz",
-                  "integrity": "sha512-bvhWAUCS539AK4wDBXeYv1gnE6tGukiNOz+laV5urV/9hbHEgMYa5AeA9F9NY1erZtNjy6G+hwZNPh3yrkycWw==",
+                  "version": "18.15.0",
+                  "resolved": "https://registry.npmjs.org/@udecode/plate-indent/-/plate-indent-18.15.0.tgz",
+                  "integrity": "sha512-FA5b5eWAG7KBHZY8sN1fzqTAPwFe0hYKTwNmkpzppaWcCKVythFMNaPiAAr86qXF3Wt8t2y54d/49OHP9koXDQ==",
                   "requires": {
-                    "@udecode/plate-core": "16.8.0"
+                    "@udecode/plate-core": "18.15.0"
                   }
                 },
                 "@udecode/plate-indent-list": {
-                  "version": "16.8.0",
-                  "resolved": "https://registry.npmjs.org/@udecode/plate-indent-list/-/plate-indent-list-16.8.0.tgz",
-                  "integrity": "sha512-sfRaYiEAqO1hsGHxfDidk1DXkIJOoTiAV5SARSSVdOmLu1m4YYT2Z/tmxMRxwI6ttV+rUjbKtnF1XbliQmWdlA==",
+                  "version": "18.15.0",
+                  "resolved": "https://registry.npmjs.org/@udecode/plate-indent-list/-/plate-indent-list-18.15.0.tgz",
+                  "integrity": "sha512-6p4smJ6KEaVGbewO8uPrejcODz1BRvBVEelFUVlo25A5KsdPdxxuAeoxXTjDskagRwLnEmUZSRQwzpMOqKsXhg==",
                   "requires": {
-                    "@udecode/plate-core": "16.8.0",
-                    "@udecode/plate-indent": "16.8.0",
-                    "@udecode/plate-list": "16.8.0"
+                    "@udecode/plate-core": "18.15.0",
+                    "@udecode/plate-indent": "18.15.0",
+                    "@udecode/plate-list": "18.15.0"
                   }
                 },
                 "@udecode/plate-media": {
-                  "version": "16.8.0",
-                  "resolved": "https://registry.npmjs.org/@udecode/plate-media/-/plate-media-16.8.0.tgz",
-                  "integrity": "sha512-EpYA/my8d0z2cBYxlPBtBTC134AOMYV60AH8n3TjnLpFdE69WcS2FjHlueDkt0QvteRlPILlMQ0o2zd7BMPe3Q==",
+                  "version": "18.15.0",
+                  "resolved": "https://registry.npmjs.org/@udecode/plate-media/-/plate-media-18.15.0.tgz",
+                  "integrity": "sha512-u0lNkeEA6XGrjxfVoUVFhRcTcr8Rie09ovKQKe1U1N3Z8Fm4pAjoSTkUm+7YzEnDqWhTCxWAtsrzMGoY+p813A==",
                   "requires": {
-                    "@udecode/plate-core": "16.8.0",
+                    "@udecode/plate-core": "18.15.0",
                     "js-video-url-parser": "^0.5.1",
                     "re-resizable": "^6.9.9",
                     "react-textarea-autosize": "^8.3.3",
@@ -30442,28 +30379,28 @@
               }
             },
             "@udecode/plate-serializer-html": {
-              "version": "16.8.0",
-              "resolved": "https://registry.npmjs.org/@udecode/plate-serializer-html/-/plate-serializer-html-16.8.0.tgz",
-              "integrity": "sha512-AY2OvWLiLbuiubgV9LzagBBdwu9mEvgBH3MLIK19pw6yB01/yPqL0cbVT0HE8YKWG9KutzRcxinoFuNG/5FNAw==",
+              "version": "18.15.0",
+              "resolved": "https://registry.npmjs.org/@udecode/plate-serializer-html/-/plate-serializer-html-18.15.0.tgz",
+              "integrity": "sha512-Af40IpWrwr9ZXLXmJrLkj0TuQmzKmmNbo1Q57yP4qFsgEZgGUzX3FJhbwVTFSLtkJCUDdJ8DcSf/lehNWYazbg==",
               "requires": {
-                "@udecode/plate-core": "16.8.0",
+                "@udecode/plate-core": "18.15.0",
                 "html-entities": "^2.3.3"
               }
             },
             "@udecode/plate-table": {
-              "version": "16.8.0",
-              "resolved": "https://registry.npmjs.org/@udecode/plate-table/-/plate-table-16.8.0.tgz",
-              "integrity": "sha512-6GBRw0mpiYwMMnS1XyjOJ2jK7v0C+MlIsExs3P9JjHuIxy4BZKCHF9tBs2RMBJ7vK1hR9wxcwSVI1f9wG+C2nw==",
+              "version": "18.15.0",
+              "resolved": "https://registry.npmjs.org/@udecode/plate-table/-/plate-table-18.15.0.tgz",
+              "integrity": "sha512-sHrRTx5pGMamwLCRwXTDEmZJUTBX/EtXGGM8yoigo7vPY56ARNKrsp/9iNBdfVGMkWHaYYmwqpVdUJUq82b4OA==",
               "requires": {
-                "@udecode/plate-core": "16.8.0"
+                "@udecode/plate-core": "18.15.0"
               }
             },
             "@udecode/plate-trailing-block": {
-              "version": "16.8.0",
-              "resolved": "https://registry.npmjs.org/@udecode/plate-trailing-block/-/plate-trailing-block-16.8.0.tgz",
-              "integrity": "sha512-eaawcb5oCyKfvPBrXmD6J+dXv7+7wypCXqAvDQwbdS/0pckc8SZKT6j6Un2vsticCTZkmtRyEc8+x2RdZLFikg==",
+              "version": "18.15.0",
+              "resolved": "https://registry.npmjs.org/@udecode/plate-trailing-block/-/plate-trailing-block-18.15.0.tgz",
+              "integrity": "sha512-BEbIckR8UgckgAlPw6j5OUrEzc/lDaeT1yjc1g2lv73bbTdmyFWqhVLCTPply6t2LQtDSmn1sbaOVc7nV7rzvw==",
               "requires": {
-                "@udecode/plate-core": "16.8.0"
+                "@udecode/plate-core": "18.15.0"
               }
             },
             "slate-react": {
@@ -30491,26 +30428,9 @@
           }
         },
         "@contentful/rich-text-types": {
-          "version": "15.14.1",
-          "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-15.14.1.tgz",
-          "integrity": "sha512-1sPVDz7MBuCCMWGvfZXQ06SqBTtlLN5GCP5ddU4c5tfatxVXhv2h80/pDCeTZVV2oCMw02YuNmBgql60+0oL4Q=="
-        },
-        "@radix-ui/react-compose-refs": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-0.1.0.tgz",
-          "integrity": "sha512-eyclbh+b77k+69Dk72q3694OHrn9B3QsoIRx7ywX341U9RK1ThgQjMFZoPtmZNQTksXHLNEiefR8hGVeFyInGg==",
-          "requires": {
-            "@babel/runtime": "^7.13.10"
-          }
-        },
-        "@radix-ui/react-slot": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-0.1.2.tgz",
-          "integrity": "sha512-ADkqfL+agEzEguU3yS26jfB50hRrwf7U4VTwAOZEmi/g+ITcBWe12yM46ueS/UCIMI9Py+gFUaAdxgxafFvY2Q==",
-          "requires": {
-            "@babel/runtime": "^7.13.10",
-            "@radix-ui/react-compose-refs": "0.1.0"
-          }
+          "version": "16.1.0",
+          "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.1.0.tgz",
+          "integrity": "sha512-Pucb68FK0j9cHJ96FAewXv+bvH4XizC4KBbVqyHhPLkDIVfasj0AWU5rI1lnvysdVKu66NQkFe8xZdeFTkaLWQ=="
         }
       }
     },
@@ -31003,86 +30923,82 @@
       }
     },
     "@contentful/field-editor-boolean": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-boolean/-/field-editor-boolean-1.2.0.tgz",
-      "integrity": "sha512-anT3NMJskP9PZLuIWmrkYMngMtJ7xvMRsaax/TlPpNTLEHC2fpwKcx8kXJIrkKG2fOLNo7Itz8DLSc6TwGsWZg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-boolean/-/field-editor-boolean-1.3.1.tgz",
+      "integrity": "sha512-vzWcEFdDG8M1NEf+UvMqLHW6FRmmw38cLO/MivglcaKrBSYxiQk1hBLq1T9lotBsYBKfc2q7Jq4NFQR0JrM/0g==",
       "requires": {
         "@contentful/f36-components": "^4.0.27",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/field-editor-shared": "^1.2.0",
+        "@contentful/field-editor-shared": "^1.3.1",
         "emotion": "^10.0.17",
         "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15",
         "nanoid": "^3.1.3"
       }
     },
     "@contentful/field-editor-checkbox": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-checkbox/-/field-editor-checkbox-1.2.0.tgz",
-      "integrity": "sha512-IkTEdrOgnmo3DKhyvJjdQZUsJJnLytuYcsWMBrvFrtXhYdNASg0pEFDKin+wnsZma85bF4WHsEBylQvla3p3FQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-checkbox/-/field-editor-checkbox-1.3.1.tgz",
+      "integrity": "sha512-DpU2XXoYAjmMfud21OTAG2pB97OE+URdBEeFpUtonqcb6rUUbbkvxMunngCKcZzDkRJ5EAfitViI/5XKmuZv1g==",
       "requires": {
         "@contentful/f36-components": "^4.3.23",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/field-editor-shared": "^1.2.0",
+        "@contentful/field-editor-shared": "^1.3.1",
         "emotion": "^10.0.17",
-        "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15"
+        "lodash": "^4.17.15"
       }
     },
     "@contentful/field-editor-date": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-date/-/field-editor-date-1.4.0.tgz",
-      "integrity": "sha512-jvU4mCTwoKE2DZwB4rpPHsKEzKF+zGYqGoF4VwBXR4HAIkbCe7sDUfD9PwN0MymXemeEZkaeqRlvoug9GurXdQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-date/-/field-editor-date-1.5.1.tgz",
+      "integrity": "sha512-AydATlwoyNWRy2JIohy97Cy3BN2SKhVVoSMkF8wmGgXk+PwhBmQKPJofDhNZ/qO2FQqVa5r9EXLhQfkt/VjG5Q==",
       "requires": {
         "@contentful/f36-components": "^4.34.1",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/field-editor-shared": "^1.2.0",
+        "@contentful/field-editor-shared": "^1.3.1",
         "emotion": "^10.0.17",
         "moment": "^2.20.0"
       }
     },
     "@contentful/field-editor-dropdown": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-dropdown/-/field-editor-dropdown-1.2.0.tgz",
-      "integrity": "sha512-FL00x8EoH5ZQ2M+n9fKDpyE0Hs2Ov6d4UKto3t4CLj6QZPJErpgHjufRM6MFwiZM3DKyCk0SKwY3wI0aYiJZDA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-dropdown/-/field-editor-dropdown-1.3.1.tgz",
+      "integrity": "sha512-PnD2K9p0ie+pAAwDZya188zODqTRivUXFt41mbB4iqDsDxuzUlN8J1lKgPIzOr/vOdmYkIpToOHxSIEhnOdl1g==",
       "requires": {
         "@contentful/f36-components": "^4.0.27",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/field-editor-shared": "^1.2.0",
+        "@contentful/field-editor-shared": "^1.3.1",
         "emotion": "^10.0.0",
         "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15",
         "nanoid": "^3.1.3"
       }
     },
     "@contentful/field-editor-json": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-json/-/field-editor-json-3.2.0.tgz",
-      "integrity": "sha512-/762pTZM9m6wMoxaVfADbZq7MIqrLYBkZTJrKGwfcK/Lpp14vfpZZ0ChT6ZE1v4XX2TM9sALpnMaS2qqjuljEw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-json/-/field-editor-json-3.3.1.tgz",
+      "integrity": "sha512-Zr/pYVCv+QeGgtsQUs3EdGyfMEJyYkiXJd1WroY1cajz0AwXqw2sh4dABE/1QTl/+Ac2RlK0+qex9cZz53W7jg==",
       "requires": {
         "@codemirror/lang-json": "^6.0.0",
         "@contentful/f36-components": "^4.0.27",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/field-editor-shared": "^1.2.0",
+        "@contentful/field-editor-shared": "^1.3.1",
         "@types/deep-equal": "1.0.1",
         "@types/react-codemirror": "1.0.3",
         "@uiw/react-codemirror": "^4.11.4",
         "deep-equal": "2.0.5",
         "emotion": "^10.0.17",
-        "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15"
+        "lodash": "^4.17.15"
       },
       "dependencies": {
         "@uiw/react-codemirror": {
-          "version": "4.19.16",
-          "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.19.16.tgz",
-          "integrity": "sha512-uElraR7Mvwz2oZKrmtF5hmIB8dAlIiU65nfg484e/V9k4PV6/5KtPUQL3JPO4clH2pcd+TQqRTQrFFkP/D25ew==",
+          "version": "4.21.8",
+          "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.21.8.tgz",
+          "integrity": "sha512-IwnWdZcBkNIHrQie/AAsBoz2Q/XpWe/Up1nGIrpWxMXEE/+RxW3CIkqcYEwVcYDJlbfP3hcIRqN/Aoz6OeXc5Q==",
           "requires": {
             "@babel/runtime": "^7.18.6",
             "@codemirror/commands": "^6.1.0",
             "@codemirror/state": "^6.1.1",
             "@codemirror/theme-one-dark": "^6.0.0",
-            "@uiw/codemirror-extensions-basic-setup": "4.19.16",
+            "@uiw/codemirror-extensions-basic-setup": "4.21.8",
             "codemirror": "^6.0.0"
           }
         },
@@ -31125,32 +31041,30 @@
       }
     },
     "@contentful/field-editor-list": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-list/-/field-editor-list-1.2.0.tgz",
-      "integrity": "sha512-yGpeL8UninJeeD2iMAtr4z6LQd0ySuuVIJwpPEWwfKI148LzF1ume7m/eucGtZms6IsQD99QJgvi6XLN98CtJA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-list/-/field-editor-list-1.3.1.tgz",
+      "integrity": "sha512-2sNEdSD/QLxDVGPdrgKYLIXkpxT1r1mImVaLc4pIKcjH5UqC4/yDxlXApF2oFZPHsHF5fV/rt3ImEm7o1OXIPw==",
       "requires": {
         "@contentful/f36-components": "^4.0.27",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/field-editor-shared": "^1.2.0",
+        "@contentful/field-editor-shared": "^1.3.1",
         "emotion": "^10.0.17",
-        "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15"
+        "lodash": "^4.17.15"
       }
     },
     "@contentful/field-editor-location": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-location/-/field-editor-location-1.2.3.tgz",
-      "integrity": "sha512-UVXuZnJk1o6EJ7d1h8YP8fq2+UU59A4AZwh+bs9V9tH2i8qBv/pxP8ZW9zKj3OgZg/3Y6EtZwc3/Gxk3ziuAlQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-location/-/field-editor-location-1.3.1.tgz",
+      "integrity": "sha512-0iz9Bn1KG0OXkI5ecHwmlVvT70oniPSg33smS9iRigDjeoHd5b1ZKf8LVZWtgTVHsk7lNGo4VP1TPhWSty5yQQ==",
       "requires": {
         "@contentful/f36-components": "^4.0.27",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/field-editor-shared": "^1.2.0",
+        "@contentful/field-editor-shared": "^1.3.1",
         "@types/google-map-react": "2.1.7",
         "deep-equal": "2.0.5",
         "emotion": "^10.0.17",
         "google-map-react": "2.2.0",
-        "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15"
+        "lodash": "^4.17.15"
       },
       "dependencies": {
         "deep-equal": {
@@ -31189,14 +31103,14 @@
       }
     },
     "@contentful/field-editor-markdown": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-markdown/-/field-editor-markdown-1.2.1.tgz",
-      "integrity": "sha512-I1iPMSk/DiUrKCtUvZI6Ofjsr7KtZq41ZxrUFp+952sFfU8CCemA8hz+Qpb480eCekLkd/QLZdL5Ukd59yw8rg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-markdown/-/field-editor-markdown-1.3.1.tgz",
+      "integrity": "sha512-AZxFP5NyeP7b4w/N0N6LSdx1AOWofCQ0FvyDn3UiQNs+/568fK+9HgkOo23bCFOIoP3SrXGuTEvd7lE4wJHPgg==",
       "requires": {
         "@contentful/f36-components": "^4.0.27",
         "@contentful/f36-icons": "^4.1.0",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/field-editor-shared": "^1.2.0",
+        "@contentful/field-editor-shared": "^1.3.1",
         "@types/codemirror": "0.0.109",
         "@types/markdown-to-jsx": "6.11.3",
         "codemirror": "^5.65.11",
@@ -31204,71 +31118,67 @@
         "dompurify": "^2.2.9",
         "emotion": "^10.0.17",
         "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15",
         "markdown-to-jsx": "^7.1.1"
       }
     },
     "@contentful/field-editor-multiple-line": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-multiple-line/-/field-editor-multiple-line-1.2.0.tgz",
-      "integrity": "sha512-wpMeiEZZEf5Ljc6RBELAxjrxUi7u4/yezlGRQ3Cbb3Y8fhmfaUlLvudgU1xKM8DnP4vjgzLZD4gYODBw4o8xhA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-multiple-line/-/field-editor-multiple-line-1.3.1.tgz",
+      "integrity": "sha512-RLDH0AmT5OuuhG6jM1Z/qbSY/QnOga6Z+M637Ul/zPh6C6FUd7DUAhV+aWwCOIx+HBFOtAC4uEszTORAwSIqGA==",
       "requires": {
         "@contentful/f36-components": "^4.0.27",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/field-editor-shared": "^1.2.0",
+        "@contentful/field-editor-shared": "^1.3.1",
         "emotion": "^10.0.17",
-        "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15"
+        "lodash": "^4.17.15"
       }
     },
     "@contentful/field-editor-number": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-number/-/field-editor-number-1.2.6.tgz",
-      "integrity": "sha512-0cU700sep1IKLu3ne4QYpjat8LFknph2L9Q9AnjNStUW1cmmCRsSB8mOnYjjnmPsUS752cj5GeZBvUoGCuyPCg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-number/-/field-editor-number-1.3.1.tgz",
+      "integrity": "sha512-+IFJfztXfKy5MxUtxnhZns/pIDPunRlqIOKgIsurY8alYKZn5phhjDHicRhTetLk+KRFq0VYX8j4yR7ufevjYQ==",
       "requires": {
         "@contentful/f36-components": "^4.0.27",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/field-editor-shared": "^1.2.0",
+        "@contentful/field-editor-shared": "^1.3.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/field-editor-radio": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-radio/-/field-editor-radio-1.2.0.tgz",
-      "integrity": "sha512-Yc5iX7PdRlRtQRCXuJiH2vaJRD4ejTHWdnAjVwrKWy9fEYIH03CxBdQ4t7+DqBSTePqgQMphgsP9eZ+yuG9Ahg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-radio/-/field-editor-radio-1.3.1.tgz",
+      "integrity": "sha512-FnR7DKjGpo4n96plCmIQHSu3Om3xkHZtgGUzOow/eM5xcw67M2g2iSoUOi7yjtYXfHcX5whEoRj7Cv92Mf5gRQ==",
       "requires": {
         "@contentful/f36-components": "^4.0.27",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/field-editor-dropdown": "^1.2.0",
-        "@contentful/field-editor-shared": "^1.2.0",
+        "@contentful/field-editor-dropdown": "^1.3.1",
+        "@contentful/field-editor-shared": "^1.3.1",
         "emotion": "^10.0.17",
         "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15",
         "nanoid": "^3.1.3"
       }
     },
     "@contentful/field-editor-rating": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-rating/-/field-editor-rating-1.2.0.tgz",
-      "integrity": "sha512-KFvPHwCSpoYjtaE9WEBkELY+bm1nBB9AuFvuaKh+7HxhmgLy2OhlgA965z5YsOGCY+B0Ch3U6AbfCs0kGpWIiQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-rating/-/field-editor-rating-1.3.1.tgz",
+      "integrity": "sha512-ZMFGEOLCzO2PcKiusGvpm4rlFmL8ip5WmdMxJ+pDzHZ0bfqKUnGc2Aa8h41eQoQyvqMI0bulYf/eUBPHc5f99Q==",
       "requires": {
         "@contentful/f36-components": "^4.0.27",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/field-editor-shared": "^1.2.0",
+        "@contentful/field-editor-shared": "^1.3.1",
         "emotion": "^10.0.17",
-        "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15"
+        "lodash": "^4.17.15"
       }
     },
     "@contentful/field-editor-reference": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-reference/-/field-editor-reference-5.9.0.tgz",
-      "integrity": "sha512-lUjzW8qoaGBXah3hzHndq30QIxpkRuJzE/OiAa9TCIH3Eegl0RK1eCBPMwZ3y98owU9bEzsMblwg8Yc06adHMA==",
+      "version": "5.13.2",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-reference/-/field-editor-reference-5.13.2.tgz",
+      "integrity": "sha512-Kv96nVDK0vwt0t5M8pFaobBdns3A9FfyxdwSDhMjt4ldG51YzgvirwO/Pl1mIpEp+jIoOytr1Ja0nkennt9tpw==",
       "requires": {
         "@contentful/f36-components": "^4.0.27",
         "@contentful/f36-icons": "^4.1.0",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/field-editor-shared": "^1.2.0",
+        "@contentful/field-editor-shared": "^1.3.1",
         "@contentful/mimetype": "^1.4.0",
         "@tanstack/react-query": "^4.3.9",
         "@types/deep-equal": "^1.0.1",
@@ -31278,7 +31188,6 @@
         "deep-equal": "2.0.5",
         "emotion": "^10.0.17",
         "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15",
         "moment": "^2.20.0",
         "p-queue": "^4.0.0",
         "react-intersection-observer": "9.4.0",
@@ -31331,85 +31240,80 @@
       }
     },
     "@contentful/field-editor-shared": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-1.2.0.tgz",
-      "integrity": "sha512-eFSnuvFre91Noq2Hais4Uqh05czN+a7KV6H9eNqTWw/Q/6G/LfHExbG+Z/0Yk51hMr15k4PB3wza7oYINb981Q==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-1.3.1.tgz",
+      "integrity": "sha512-My340HzlqC/kPOuLB3SULOaQlkej81JeBgjneap5ckIDWdiFs/TOli7dif0dyiCAyFtcKnRbrG6AXKv2/7uOxw==",
       "requires": {
         "@contentful/f36-note": "^4.2.8",
         "@contentful/f36-tokens": "^4.0.0",
         "emotion": "^10.0.17",
-        "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15"
+        "lodash": "^4.17.15"
       }
     },
     "@contentful/field-editor-single-line": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-single-line/-/field-editor-single-line-1.2.0.tgz",
-      "integrity": "sha512-6sfcuJTnLcLpQi95KVYHouB6oRYMLXXzoxXfZkBcsRfm8cj0m9ra6puNRZS6MOH33zTe36sTc3rqbB+kCZ1h/Q==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-single-line/-/field-editor-single-line-1.3.1.tgz",
+      "integrity": "sha512-cQVD0+i7BkX2Ij1yJYNzi7CZogl7/y0ThqyQOGV8qj7F5Q5maLgzH00cnhKBwqxeqx8Nl9W1iL6K4vBJnQ+iMg==",
       "requires": {
         "@contentful/f36-components": "^4.0.27",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/field-editor-shared": "^1.2.0",
+        "@contentful/field-editor-shared": "^1.3.1",
         "emotion": "^10.0.17",
-        "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15"
+        "lodash": "^4.17.15"
       }
     },
     "@contentful/field-editor-slug": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-slug/-/field-editor-slug-1.2.0.tgz",
-      "integrity": "sha512-640Vm1d7LdL8ePyWvrhUTLmpetOW+WGD4SDfuA7ZVUHBOqZH5lzEz8x85yKBnk5nm6SWvg40UePu4LJ1uKGHUQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-slug/-/field-editor-slug-1.3.2.tgz",
+      "integrity": "sha512-mojJnTAU0QkuMtTmQh8HQsLgR4ZuNYoPlGuGfGiKWygyM/bxN5m9VFJw2AzxZho8lQvb5jeJmr+4c5aEvKB2og==",
       "requires": {
         "@contentful/f36-components": "^4.0.27",
         "@contentful/f36-icons": "^4.1.0",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/field-editor-shared": "^1.2.0",
+        "@contentful/field-editor-shared": "^1.3.1",
         "@types/speakingurl": "^13.0.2",
         "emotion": "^10.0.17",
         "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15",
         "speakingurl": "^13.0.0",
         "use-debounce": "^7.0.0"
       }
     },
     "@contentful/field-editor-tags": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-tags/-/field-editor-tags-1.2.0.tgz",
-      "integrity": "sha512-RuQuOecroS+J5NzjBUIfpxqMKTFygAWoqlQ9A4czd2yUKVte90YIdvcIwssxKTFxIXWCbkZgKw7RbFADCt658Q==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-tags/-/field-editor-tags-1.3.1.tgz",
+      "integrity": "sha512-KxtA4iOKGw8XNnzkCdKfQMxtyi3ZEHyRosgeBOhI6/KzLCqohxi4VwUBepiCxi88Gsxg6P+8xry4gk8XMME0Ow==",
       "requires": {
         "@contentful/f36-components": "^4.0.27",
         "@contentful/f36-icons": "^4.1.0",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/field-editor-shared": "^1.2.0",
+        "@contentful/field-editor-shared": "^1.3.1",
         "array-move": "^3.0.0",
         "emotion": "^10.0.0",
         "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15",
         "react-sortable-hoc": "^2.0.0"
       }
     },
     "@contentful/field-editor-url": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-url/-/field-editor-url-1.2.0.tgz",
-      "integrity": "sha512-DVdKPDlu1luFQAx/jwQSgekgpETFxpj8PvLgoYZey5vmEbDorDKQWPKDWyM5SAlUCfmkAq58R8EW2531cvoNgQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-url/-/field-editor-url-1.3.1.tgz",
+      "integrity": "sha512-dToTVRXUEnPfwBuLjMvYKE6Rdx0vmAoHA4Yn85wH8me5xueuMZQBhFY2QNxc0UypBHuwRmYkTIUL6iKRXfUnzg==",
       "requires": {
         "@contentful/f36-components": "^4.0.27",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/field-editor-shared": "^1.2.0",
+        "@contentful/field-editor-shared": "^1.3.1",
         "emotion": "^10.0.17",
-        "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15"
+        "lodash": "^4.17.15"
       }
     },
     "@contentful/field-editor-validation-errors": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-validation-errors/-/field-editor-validation-errors-1.2.0.tgz",
-      "integrity": "sha512-/ibj5CUp2M1vcqh7MrT/SU/mZcxwpIYtho5mZzK3FgrvKqPPf5AzDu6sJsvLjJB9N/FJ1L9P2CcGywCp5CF9MQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-validation-errors/-/field-editor-validation-errors-1.3.1.tgz",
+      "integrity": "sha512-8J4SuFPR9ZLuBRXP+Hqff4aru2/WdODyWF5iFaZrgvwMPO0tu6ssnL8WID+zC3ERFWwqoeaIyBy/fBf32zmSuw==",
       "requires": {
         "@contentful/f36-components": "^4.0.27",
         "@contentful/f36-icons": "^4.1.0",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/field-editor-shared": "^1.2.0",
+        "@contentful/field-editor-shared": "^1.3.1",
         "emotion": "^10.0.17"
       }
     },
@@ -31436,24 +31340,17 @@
       }
     },
     "@contentful/rich-text-plain-text-renderer": {
-      "version": "15.15.1",
-      "resolved": "https://registry.npmjs.org/@contentful/rich-text-plain-text-renderer/-/rich-text-plain-text-renderer-15.15.1.tgz",
-      "integrity": "sha512-uk9JC3HtOrCekJSrStS+vzZiITefuaY0Tr0AMlp+0NgRh+b5i59CPq3feo1/WsvKIS360HlIhVjuyz1nMsQoTA==",
+      "version": "16.0.5",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-plain-text-renderer/-/rich-text-plain-text-renderer-16.0.5.tgz",
+      "integrity": "sha512-Ab7SCLY5H+HSlAiV5Jf3/0Dn4wEZg/P2R5f8OwKLSTT7hrThORSxOHJxfY6hIBK8J3wzthBbNN2Bbz/eIEBCqw==",
       "requires": {
-        "@contentful/rich-text-types": "^15.15.1"
-      },
-      "dependencies": {
-        "@contentful/rich-text-types": {
-          "version": "15.15.1",
-          "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-15.15.1.tgz",
-          "integrity": "sha512-oheW0vkxWDuKBIIXDeJfZaRYo+NzKbC4gETMhH+MGJd4nfL9cqrOvtRxZBgnhICN4vDpH4my/zUIZGKcFqGSjQ=="
-        }
+        "@contentful/rich-text-types": "^16.2.0"
       }
     },
     "@contentful/rich-text-types": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.0.3.tgz",
-      "integrity": "sha512-BsUtXj93jo5XUt0YeUwfCkMWRoZIzJDPUIY4vMy9SwGIO9olTsMoQKadjA2ktlmK+Gg6710WH3eFKZxj2q39Iw=="
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.2.0.tgz",
+      "integrity": "sha512-4BHC+mfa50JB70epzpnas4EkiuB3mGdBZ5Rp8w7R5wXvswEf8TLg5yGau2FxmZeEjrAkDrt4vzBLVQ8v3Y//Jw=="
     },
     "@csstools/normalize.css": {
       "version": "12.0.0",
@@ -32092,9 +31989,9 @@
       }
     },
     "@googlemaps/js-api-loader": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-1.15.1.tgz",
-      "integrity": "sha512-AsnEgNsB7S/VdrHGEQUaUM2e5tmjFGKBAfzR/AqO8O7TPq/jQGvoRw5liPBw4EMF38RDsHmKDV89q/X+qiUREQ==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-1.16.2.tgz",
+      "integrity": "sha512-psGw5u0QM6humao48Hn4lrChOM2/rA43ZCm3tKK9qQsEj1/VzqkCqnvGfEOshDbBQflydfaRovbKwZMF4AyqbA==",
       "requires": {
         "fast-deep-equal": "^3.1.3"
       }
@@ -32909,31 +32806,31 @@
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
     },
     "@lezer/common": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.0.2.tgz",
-      "integrity": "sha512-SVgiGtMnMnW3ActR8SXgsDhw7a0w0ChHSYAyAUxxrOiJ1OqYWEKk/xJd84tTSPo1mo6DXLObAJALNnd0Hrv7Ng=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.0.3.tgz",
+      "integrity": "sha512-JH4wAXCgUOcCGNekQPLhVeUtIqjH0yPBs7vvUdSjyQama9618IOKFJwkv2kcqdhF0my8hQEgCTEJU0GIgnahvA=="
     },
     "@lezer/highlight": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.1.4.tgz",
-      "integrity": "sha512-IECkFmw2l7sFcYXrV8iT9GeY4W0fU4CxX0WMwhmhMIVjoDdD1Hr6q3G2NqVtLg/yVe5n7i4menG3tJ2r4eCrPQ==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.1.6.tgz",
+      "integrity": "sha512-cmSJYa2us+r3SePpRCjN5ymCqCPv+zyXmDl0ciWtVaNiORT/MxM7ZgOMQZADD0o51qOaOg24qc/zBViOIwAjJg==",
       "requires": {
         "@lezer/common": "^1.0.0"
       }
     },
     "@lezer/json": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.0.tgz",
-      "integrity": "sha512-zbAuUY09RBzCoCA3lJ1+ypKw5WSNvLqGMtasdW6HvVOqZoCpPr8eWrsGnOVWGKGn8Rh21FnrKRVlJXrGAVUqRw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.1.tgz",
+      "integrity": "sha512-nkVC27qiEZEjySbi6gQRuMwa2sDu2PtfjSgz0A4QF81QyRGm3kb2YRzLcOPcTEtmcwvrX/cej7mlhbwViA4WJw==",
       "requires": {
         "@lezer/highlight": "^1.0.0",
         "@lezer/lr": "^1.0.0"
       }
     },
     "@lezer/lr": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.3.4.tgz",
-      "integrity": "sha512-7o+e4og/QoC/6btozDPJqnzBhUaD1fMfmvnEKQO1wRRiTse1WxaJ3OMEXZJnkgT6HCcTVOctSoXK9jGJw2oe9g==",
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.3.9.tgz",
+      "integrity": "sha512-XPz6dzuTHlnsbA5M2DZgjflNQ+9Hi5Swhic0RULdp3oOs3rh6bqGZolosVqN/fQIT8uNiepzINJDnS39oweTHQ==",
       "requires": {
         "@lezer/common": "^1.0.0"
       }
@@ -37461,9 +37358,9 @@
       }
     },
     "@uiw/codemirror-extensions-basic-setup": {
-      "version": "4.19.16",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.19.16.tgz",
-      "integrity": "sha512-Xm0RDpyYVZ/8hWqaBs3+wZwi4uLwZUBwp/uCt89X80FeR6mr3BFuC+a+gcDO4dBu3l+WQE3jJdhjKjB2TCY/PQ==",
+      "version": "4.21.8",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.21.8.tgz",
+      "integrity": "sha512-uOPRPxexapuvlZ+hkVun5oyhQ0AtXIapBqv56cgjkzwZ49EILUk9mTubHFBY0B5kPqme7d57hSXYRLW8EH80LA==",
       "requires": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/commands": "^6.0.0",
@@ -38901,9 +38798,9 @@
       }
     },
     "codemirror": {
-      "version": "5.65.13",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.13.tgz",
-      "integrity": "sha512-SVWEzKXmbHmTQQWaz03Shrh4nybG0wXx2MEu3FO4ezbPW8IbnZEd5iGHGEffSUaitKYa3i+pHpBsSvw8sPHtzg=="
+      "version": "5.65.14",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.14.tgz",
+      "integrity": "sha512-VSNugIBDGt0OU9gDjeVr6fNkoFQznrWEUdAApMlXQNbfE8gGO19776D6MwSqF/V/w/sDwonsQ0z7KmmI9guScg=="
     },
     "collect-v8-coverage": {
       "version": "1.0.1",
@@ -39200,9 +39097,9 @@
       }
     },
     "crelt": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.5.tgz",
-      "integrity": "sha512-+BO9wPPi+DWTDcNYhr/W90myha8ptzftZT+LwcmUbbok0rcP/fequmFYCw8NMoH7pkAZQzU78b3kYrlua5a9eA=="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="
     },
     "cross-env": {
       "version": "7.0.3",
@@ -39829,9 +39726,9 @@
       }
     },
     "dompurify": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.5.tgz",
-      "integrity": "sha512-jggCCd+8Iqp4Tsz0nIvpcb22InKEBrGz5dw3EQJMs8HPJDsKbFIO3STYtAvCfDx26Muevn1MHVI0XxjgFfmiSA=="
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.7.tgz",
+      "integrity": "sha512-kxxKlPEDa6Nc5WJi+qRgPbOAbgTpSULL+vI3NUXsZMlkJxTqYI9wg5ZTay2sFrdZRWHPWNi+EdAhcJf81WtoMQ=="
     },
     "domutils": {
       "version": "2.8.0",
@@ -44173,11 +44070,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
-    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -46491,9 +46383,9 @@
       }
     },
     "react-textarea-autosize": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.4.1.tgz",
-      "integrity": "sha512-aD2C+qK6QypknC+lCMzteOdIjoMbNlgSFmJjCV+DrfTPwp59i/it9mMNf2HDzvRjQgKAyBDPyLJhcrzElf2U4Q==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.2.tgz",
+      "integrity": "sha512-uOkyjkEl0ByEK21eCJMHDGBAAd/BoFQBawYK5XItjAmCTeSbjxghd8qnt7nzsLYzidjnoObu6M26xts0YGKsGg==",
       "requires": {
         "@babel/runtime": "^7.20.13",
         "use-composed-ref": "^1.3.0",
@@ -48700,9 +48592,9 @@
       }
     },
     "w3c-keyname": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.6.tgz",
-      "integrity": "sha512-f+fciywl1SJEniZHD6H+kUO8gOnwIr7f4ijKA6+ZvJFjeGi1r4PDLl53Ayud9O/rk64RqgoQine0feoeOU0kXg=="
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="
     },
     "w3c-xmlserializer": {
       "version": "2.0.0",

--- a/apps/ecommerce/frontend/src/components/Config/ConfigPage/ConfigPage.tsx
+++ b/apps/ecommerce/frontend/src/components/Config/ConfigPage/ConfigPage.tsx
@@ -88,6 +88,8 @@ const ConfigPage = () => {
     setParameters({ ...parameters, [key]: value });
   };
 
+  const { baseUrl } = sdk.parameters.instance;
+
   return (
     <>
       <Box
@@ -95,7 +97,7 @@ const ConfigPage = () => {
         testId="configPageBackground"
       />
       <ConfigBody
-        baseUrl={sdk.parameters.instance.baseUrl}
+        baseUrl={baseUrl}
         error={error}
         isLoading={isLoading}
         onCredentialCheck={checkCredentials}


### PR DESCRIPTION
## Purpose

This PR fixes an [error](https://app.circleci.com/pipelines/github/contentful/apps/22390/workflows/5bd63496-c0aa-44bd-a542-8326c0764b5c/jobs/63503) thrown with the accompanying dependabot update within ecomm. The new update caused a type error, and frankly because of the deprecation of ecomm, I made adjustments that passed the build, but nothing beyond that. The app still renders locally. 

This fixes this PR: https://github.com/contentful/apps/pull/4300
