### PR TITLE
Fix (dependabot): Remove deprecated sentry tracing package

### DIFF
--- a/apps/google-analytics-4/frontend/package-lock.json
+++ b/apps/google-analytics-4/frontend/package-lock.json
@@ -14,7 +14,6 @@
         "@contentful/react-apps-toolkit": "1.2.16",
         "@segment/analytics-next": "^1.51.3",
         "@sentry/react": "^7.44.2",
-        "@sentry/tracing": "^7.44.2",
         "@testing-library/user-event": "14.4.3",
         "@types/chart.js": "^2.9.37",
         "@types/lodash": "4.14.195",
@@ -4637,17 +4636,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@sentry/tracing": {
-      "version": "7.57.0",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.57.0.tgz",
-      "integrity": "sha512-D8eKJMYN529mDP9lsOLyhe0Rf9Qiexo7Ul4+MQwDlwRr9c9tc0AdGwFlnKGvCMDh7ucITzvZkMZDHBapU3WHNQ==",
-      "dependencies": {
-        "@sentry-internal/tracing": "7.57.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@sentry/types": {

--- a/apps/google-analytics-4/frontend/package.json
+++ b/apps/google-analytics-4/frontend/package.json
@@ -9,7 +9,6 @@
     "@contentful/react-apps-toolkit": "1.2.16",
     "@segment/analytics-next": "^1.51.3",
     "@sentry/react": "^7.44.2",
-    "@sentry/tracing": "^7.44.2",
     "@testing-library/user-event": "14.4.3",
     "@types/chart.js": "^2.9.37",
     "@types/lodash": "4.14.195",

--- a/apps/google-analytics-4/frontend/src/index.tsx
+++ b/apps/google-analytics-4/frontend/src/index.tsx
@@ -1,6 +1,4 @@
 import * as Sentry from '@sentry/react';
-import { BrowserTracing } from '@sentry/tracing';
-import React from 'react';
 import { render } from 'react-dom';
 
 import { GlobalStyles } from '@contentful/f36-components';
@@ -13,7 +11,7 @@ import { SegmentAnalyticsProvider } from 'providers/SegmentAnalyticsProvider';
 
 Sentry.init({
   dsn: config.sentryDSN,
-  integrations: [new BrowserTracing()],
+  integrations: [new Sentry.BrowserTracing()],
   // Set tracesSampleRate to 1.0 to capture 100%
   // of transactions for performance monitoring.
   // We recommend adjusting this value in production


### PR DESCRIPTION
## Purpose

This PR resolves a dependabot build issue found in the GA4 app, in [this](https://github.com/contentful/apps/pull/4350) PR. The dependabot update was updating `@sentry/tracy` package, which caused a type error in the build. This package is actually deprecated and no longer necessary, as its functionality is encapsulated by the Sentry react sdk. 

## Approach

I have updated the file where the type error is being thrown by adjusting the import. Additionally have removed the `@sentry/tracing` package entirely as its antiquated now. 

Confirmed that the app still works as before. 

## Dependencies and/or References

Sentry React package: https://www.npmjs.com/package/@sentry/react 
Sentry Tracing package deprecation info: https://www.npmjs.com/package/@sentry/tracing
