### PR TITLE
[INTEG-993] Display message for min character validation

### DIFF
--- a/apps/ai-content-generator/src/components/app/dialog/common-generator/field-selector/SourceAndFieldSelectors.tsx
+++ b/apps/ai-content-generator/src/components/app/dialog/common-generator/field-selector/SourceAndFieldSelectors.tsx
@@ -61,7 +61,7 @@ const SourceAndFieldSelectors = (props: Props) => {
 
   const getFieldOptions = (fields: Field[]) => {
     const defaultOption = (
-      <Select.Option value="" isDisabled>
+      <Select.Option key="default-0" value="" isDisabled>
         Select field...
       </Select.Option>
     );

--- a/apps/ai-content-generator/src/components/app/dialog/common-generator/output/output-text-panels/generated-text-panel/GeneratedTextPanel.tsx
+++ b/apps/ai-content-generator/src/components/app/dialog/common-generator/output/output-text-panels/generated-text-panel/GeneratedTextPanel.tsx
@@ -44,14 +44,12 @@ const GeneratedTextPanel = (props: Props) => {
     setCanApply(isLengthValid);
   };
 
-  useEffect(checkIfCanApply, [output]);
+  useEffect(checkIfCanApply, [output, isGenerating]);
 
   return (
     <Tabs.Panel id={OutputTab.GENERATED_TEXT}>
       {isGenerating ? (
-        <TextFieldWithButtons
-          inputText={output}
-          sizeValidation={{ max: outputFieldValidation?.size?.max }}>
+        <TextFieldWithButtons inputText={output} sizeValidation={outputFieldValidation?.size}>
           <Button onClick={sendStopSignal}>Stop Generating</Button>
         </TextFieldWithButtons>
       ) : (

--- a/apps/ai-content-generator/src/components/common/text-counter/TextCounter.tsx
+++ b/apps/ai-content-generator/src/components/common/text-counter/TextCounter.tsx
@@ -24,17 +24,33 @@ const TextCounter = (props: Props) => {
   const style = isValid ? styles.validCount : styles.invalidCount;
   const errorMessage = isBelowMinLength ? `Please lengthen the text` : `Please shorten the text`;
 
+  const getCharLimitsToDisplay = () => {
+    let displayContent = '';
+
+    if (maxLength && minLength) {
+      displayContent = `Requires between ${minLength} and ${maxLength} characters`;
+    } else if (maxLength) {
+      displayContent = `Maximum ${maxLength} characters`;
+    } else if (minLength) {
+      displayContent = `Requires at least ${minLength} characters`;
+    }
+
+    const displayComponent = (
+      <Paragraph marginTop="spacing2Xs" css={styles.validCount}>
+        {displayContent}
+      </Paragraph>
+    );
+
+    return displayContent ? displayComponent : null;
+  };
+
   return (
     <Flex flexDirection="column">
       <Flex justifyContent="space-between">
         <Paragraph marginTop="spacing2Xs" css={style}>
           {text.length} characters
         </Paragraph>
-        {maxLength && (
-          <Paragraph marginTop="spacing2Xs" css={styles.validCount}>
-            Maximum {maxLength} characters
-          </Paragraph>
-        )}
+        {getCharLimitsToDisplay()}
       </Flex>
       <Flex
         css={{ visibility: isValid ? 'hidden' : 'visible' }}


### PR DESCRIPTION
## Purpose

We added character count validation on a [previous PR](https://github.com/contentful/apps/pull/4356). This is a quick follow up to display the correct character count, supporting maximum and minimum allowed number of characters. This PR also fixes a bug where the Apply button wasn't disabled if the character count was invalid immediately after generating content.

Below are the three states of the warning:
![Screenshot 2023-08-04 at 3 42 49 PM](https://github.com/contentful/apps/assets/62958907/bc56dacb-c961-4490-a700-eeae7f8700e4)

![Screenshot 2023-08-04 at 5 09 18 PM](https://github.com/contentful/apps/assets/62958907/782f02ef-b899-4f58-a41e-dc9d8f23bd8b)

![Screenshot 2023-08-04 at 3 43 22 PM](https://github.com/contentful/apps/assets/62958907/124395e8-5ac2-48d6-93b0-daae6968e5f1)

## Approach

We are showing different messages based on whether there is a minimum, a maximum, or both. I used the same language shown on the field editor.

## Testing steps

Set up some fields with various character limits.


