### PR TITLE
Update Field.tsx on Wistia App

### DIFF
--- a/apps/wistia-videos/src/components/Field.tsx
+++ b/apps/wistia-videos/src/components/Field.tsx
@@ -160,11 +160,7 @@ const Field = (props: FieldProps) => {
                             <img src={item.thumbnail.url} alt={item.name} />
                           </StyledImageContainer>
                         </Card>
-                        <Paragraph style={{    whiteSpace: 'nowrap',
-    width: '100%',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-}}}>{item.name}</Paragraph>
+                        <Paragraph style={{ whiteSpace: 'nowrap', width: '100%', overflow: 'hidden', textOverflow: 'ellipsis'}}>{item.name}</Paragraph>
                       </GridItem>
                     ))}
                   </Grid>

--- a/apps/wistia-videos/src/components/Field.tsx
+++ b/apps/wistia-videos/src/components/Field.tsx
@@ -160,7 +160,11 @@ const Field = (props: FieldProps) => {
                             <img src={item.thumbnail.url} alt={item.name} />
                           </StyledImageContainer>
                         </Card>
-                        <Paragraph>{item.name}</Paragraph>
+                        <Paragraph style={{    whiteSpace: 'nowrap',
+    width: '100%',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+}}}>{item.name}</Paragraph>
                       </GridItem>
                     ))}
                   </Grid>


### PR DESCRIPTION
## Purpose

When the videos have a long name the text overlaps the next column, creating a bad editor experience. Applying the correct styles to the paragraph will create an ellipsis when the name is long.
<img width="731" alt="Screenshot 2023-08-07 at 15 12 01" src="https://github.com/contentful/apps/assets/54865094/96a096af-28e4-4f57-b520-7ac183a51d74">


## Approach
Apply correct styles to the Paragraph on the Card component.

## Testing steps

Connect Wistia App with a Contentful Environment. Check for videos with long names, which should be visible with a ellipsis. 

