### PR TITLE
Resolve Salesforce app TypeError

### DIFF
--- a/apps/salesforce-commerce-cloud/src/components/dialog/ProductPreview.tsx
+++ b/apps/salesforce-commerce-cloud/src/components/dialog/ProductPreview.tsx
@@ -14,11 +14,11 @@ const ProductPreview = (props: { product: any }) => {
         : product.shortDescription.default.markup;
   }
 
+  const imageUrl = product.image?.absUrl;
+
   return (
     <>
-      {product.image.absUrl && (
-        <img src={product.image.absUrl} alt={product.image.alt.default} height="75" width="75" />
-      )}
+      {imageUrl && <img src={imageUrl} alt={product.image.alt.default} height="75" width="75" />}
       <Flex flexDirection="column" marginLeft="spacingS">
         <Text as="div" fontWeight="fontWeightDemiBold">
           {product.name.default} (ID: {product.id})

--- a/apps/salesforce-commerce-cloud/src/components/dialog/ProductSearchResults.tsx
+++ b/apps/salesforce-commerce-cloud/src/components/dialog/ProductSearchResults.tsx
@@ -146,8 +146,8 @@ const ProductSearchResult = (props: SearchResultProps) => {
               onLoad={() => setImageHasLoaded(true)}
               onError={() => setImageHasErrored(true)}
               style={{ display: imageHasLoaded ? 'block' : 'none' }}
-              src={result.image.absUrl}
-              alt={result.image.alt.default}
+              src={result.image?.absUrl}
+              alt={result.image?.alt.default}
               data-test-id="image"
             />
           </div>

--- a/apps/salesforce-commerce-cloud/src/components/dialog/SearchBar.tsx
+++ b/apps/salesforce-commerce-cloud/src/components/dialog/SearchBar.tsx
@@ -186,7 +186,7 @@ const SelectionListItem = (props: SelectionListItemProps) => {
   };
 
   const getProductPreviewImageUrl = (productInfo?: any) => {
-    return productInfo.image?.absUrl || '';
+    return productInfo?.image?.absUrl || '';
   };
 
   const selectedItemWrapperStyles = css`

--- a/apps/salesforce-commerce-cloud/src/components/dialog/SearchBar.tsx
+++ b/apps/salesforce-commerce-cloud/src/components/dialog/SearchBar.tsx
@@ -186,7 +186,7 @@ const SelectionListItem = (props: SelectionListItemProps) => {
   };
 
   const getProductPreviewImageUrl = (productInfo?: any) => {
-    return productInfo?.image.absUrl ? productInfo.image.absUrl : '';
+    return productInfo.image?.absUrl || '';
   };
 
   const selectedItemWrapperStyles = css`

--- a/apps/salesforce-commerce-cloud/src/components/field/ItemCard.tsx
+++ b/apps/salesforce-commerce-cloud/src/components/field/ItemCard.tsx
@@ -84,10 +84,12 @@ const ItemPreview = (props: ItemPreviewProps) => {
     onRemove: props.onRemove,
   };
 
+  const imageUrl = itemData.image?.absUrl;
+
   return (
     <>
-      {useImage && itemData.image.absUrl && (
-        <img src={itemData.image.absUrl} alt={itemData.image.alt.default} height="75" width="75" />
+      {useImage && imageUrl && (
+        <img src={imageUrl} alt={itemData.image.alt.default} height="75" width="75" />
       )}
       <Flex flexDirection="column" marginLeft="spacingS">
         <Text as="div" fontWeight="fontWeightDemiBold" fontSize="fontSizeM">


### PR DESCRIPTION
## Purpose

This PR fixes a TypeError that a customer encountered while using the Salesforce app. See the thread [here](https://discord.com/channels/1030176999471321129/1111352040413724712/1138094064558952478). 

## Approach

I had difficulty replicating this issue locally, and I believe it is because of variance in images being provided as part of a product object. Locally these images are provided, but I am making the assumption, in this first attempt at resolving the customer's issue, that images are not always guaranteed. This can also be further supported by the way the code was setup to conditionally render the images if they exist. Unfortunately the code did not originally account for an undefined image object, so I have added several safeguards here. 

I can also add optional chaining to the `product` objects, but felt this change would be a good first step since the `image` object itself is the one throwing the error as `undefined`.  

Salesforce app works as before, but will hopefully not throw this blocking error for the user now. 
