### PR TITLE
[INTEG-1040] Update supported GPT models on config page

### DIFF
--- a/apps/ai-content-generator/src/components/config/ConfigPage.tsx
+++ b/apps/ai-content-generator/src/components/config/ConfigPage.tsx
@@ -4,14 +4,14 @@ import ConfigSection from '@components/config/config-section/ConfigSection';
 import BrandSection from '@components/config/brand-section/BrandSection';
 import { styles } from './ConfigPage.styles';
 import { Sections } from '@components/config/configText';
-import gptModels from '@configs/gptModels';
+import { defaultModelId } from '@configs/gptModels';
 import useInitializeParameters from '@hooks/config/useInitializeParameters';
 import useSaveConfigHandler from '@hooks/config/useSaveConfigHandler';
 import parameterReducer from './parameterReducer';
 import { AppInstallationParameters } from '@locations/ConfigScreen';
 
 const initialParameters: AppInstallationParameters = {
-  model: gptModels[0],
+  model: defaultModelId,
   apiKey: '',
   profile: '',
 };

--- a/apps/ai-content-generator/src/components/config/model/Model.tsx
+++ b/apps/ai-content-generator/src/components/config/model/Model.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent, Dispatch } from 'react';
 import { FormControl, Select } from '@contentful/f36-components';
-import gptModels from '@configs/gptModels';
+import { gptModels, defaultModelId } from '@configs/gptModels';
 import { ModelText } from '../configText';
 import { ParameterAction, ParameterReducer } from '../parameterReducer';
 
@@ -13,10 +13,13 @@ const Model = (props: Props) => {
   const { model, dispatch } = props;
 
   const modelList = gptModels.map((model) => (
-    <Select.Option key={model} value={model}>
-      {model}
+    <Select.Option key={model.id} value={model.id}>
+      {model.name}
     </Select.Option>
   ));
+
+  const isSelectionInModelList = gptModels.some((modelOption) => modelOption.id === model);
+  const value = isSelectionInModelList ? model : defaultModelId;
 
   const handleChange = (e: ChangeEvent<HTMLSelectElement>) => {
     dispatch({ type: ParameterAction.UPDATE_MODEL, value: e.target.value });
@@ -25,7 +28,7 @@ const Model = (props: Props) => {
   return (
     <FormControl>
       <FormControl.Label>{ModelText.title}</FormControl.Label>
-      <Select value={model} onChange={handleChange}>
+      <Select value={value} onChange={handleChange}>
         {modelList}
       </Select>
 

--- a/apps/ai-content-generator/src/configs/gptModels.ts
+++ b/apps/ai-content-generator/src/configs/gptModels.ts
@@ -1,3 +1,10 @@
-const gptModels = ['gpt-3.5-turbo', 'gpt-3.5-turbo-0301', 'gpt-4', 'gpt-4-0314'];
+const gptModels = [
+  { id: 'gpt-3.5-turbo', name: 'GPT-3.5' },
+  { id: 'gpt-3.5-turbo-16k', name: 'GPT-3.5 16k' },
+  { id: 'gpt-4', name: 'GPT-4' },
+  { id: 'gpt-4-0314', name: 'GPT-4 32k' },
+];
 
-export default gptModels;
+const defaultModelId = gptModels[0].id;
+
+export { gptModels, defaultModelId };

--- a/apps/ai-content-generator/test/mocks/sdk/utils/generateRandomParameters.ts
+++ b/apps/ai-content-generator/test/mocks/sdk/utils/generateRandomParameters.ts
@@ -1,4 +1,4 @@
-import gptModels from '@configs/gptModels';
+import { gptModels } from '@configs/gptModels';
 import { AppInstallationParameters } from '@locations/ConfigScreen';
 
 const generateRandomParameters = (): AppInstallationParameters => {
@@ -7,7 +7,7 @@ const generateRandomParameters = (): AppInstallationParameters => {
   const randomProfile = Math.random().toString(36).substring(7);
 
   return {
-    model: gptModels[randomModelIndex],
+    model: gptModels[randomModelIndex].id,
     apiKey: 'sk-' + randomApiKey,
     profile: randomProfile,
   };


### PR DESCRIPTION
## Purpose

Follow up PR for updating copy on the Configuration Page, this PR updates the options listed for the models. 
![Screenshot 2023-08-10 at 1 44 30 PM](https://github.com/contentful/apps/assets/62958907/14b3e088-349e-48e7-8363-8f7154ecb833)

## Approach

We are removing any date-specific models and instead adding support for the 4x context models. The names in the dropdown are now listed as they should be according the OpenAI branding guidelines. The default selection is GPT-3.5. I added a follow up task to better handle validation on the Config Page in general, so this will cover the case where a user had previously selected a date-specific model that we have now removed.

## Testing steps
Navigate to the Config Page and you should see the new options listed.
