### PR TITLE
[INTEG-1064] HAA adds 3 more hardcoded urls and return it as an array

### DIFF
--- a/apps/ai-image-generator/frontend/actions/aiig.ts
+++ b/apps/ai-image-generator/frontend/actions/aiig.ts
@@ -13,6 +13,11 @@ export const handler = async (payload: AppActionCallParameters, context: AppActi
   return {
     status: 201,
     prompt,
-    image: `https://weu-az-web-ca-cdn.azureedge.net/mediacontainer/medialibraries/mypetdoctor/images/blog-images/grey-kitten.webp?ext=.webp`,
+    images: [
+      `https://www.americanhumane.org/app/uploads/2021/12/Cat-8-1024x1024.png`,
+      `https://4kwallpapers.com/images/wallpapers/cat-kitten-pet-domestic-animals-cute-cat-portrait-fur-baby-1024x1024-3528.jpg`,
+      `https://wallpaperaccess.com/full/2448381.jpg`,
+      `https://images.infoseemedia.com/wp-content/uploads/2022/02/Black-White-Cat-Image-1024x1024.jpg`,
+    ],
   };
 };

--- a/apps/ai-image-generator/frontend/build-actions.js
+++ b/apps/ai-image-generator/frontend/build-actions.js
@@ -58,7 +58,7 @@ const main = async (watch = false) => {
       platform: 'node',
       outdir: 'build',
       logLevel: 'info',
-      format: 'cjs',
+      format: 'esm',
       target: 'es6',
       external: ['node:*'],
     };


### PR DESCRIPTION
## Purpose
Experience package PR relies on this change https://github.com/contentful/experience-packages/pull/2234. This is so that we can deal with an array of images and return them so we can continue developing the modal

## Approach
Hardcode urls

## Testing steps
Tested it in the user_interface override - aka local development

## Breaking Changes
None

## Dependencies and/or References
None

## Deployment
Standard