### PR TITLE
feat: introduce integration context [MONET-1338]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ tags
 **/.coverage/**
 lerna-debug.log
 .eslintcache
+.tool-versions

--- a/packages/ecommerce-app-base/package-lock.json
+++ b/packages/ecommerce-app-base/package-lock.json
@@ -13,6 +13,7 @@
         "@contentful/f36-components": "^4.0.42",
         "@contentful/f36-icons": "^4.25.0",
         "@contentful/f36-tokens": "^4.0.0",
+        "@contentful/react-apps-toolkit": "^1.2.16",
         "array-move": "^3.0.0",
         "contentful-management": "^10.0.0",
         "emotion": "^10.0.0",
@@ -1299,6 +1300,18 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/react-apps-toolkit": {
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/@contentful/react-apps-toolkit/-/react-apps-toolkit-1.2.16.tgz",
+      "integrity": "sha512-vx7+T4h+w1XBbn7OfRoXr8YUTtiyRNLaltF2ziM4xMqBryu/3Y71nBbhbxD6NIfOui3QIo3TR9Q5sPTZvGbIVw==",
+      "dependencies": {
+        "contentful-management": ">=7.30.0"
+      },
+      "peerDependencies": {
+        "@contentful/app-sdk": ">=4.0.0",
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@contentful/rich-text-types": {
@@ -7110,9 +7123,9 @@
       }
     },
     "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -8002,9 +8015,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -8242,9 +8255,9 @@
       }
     },
     "node_modules/path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -8660,9 +8673,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -9062,9 +9075,9 @@
       }
     },
     "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -10537,6 +10550,14 @@
       "integrity": "sha512-jr+61KiKn7oA38WXgAJoqVNdr6gXzmJSA+MCl7Djapxxf+jsC1vsi8j8okISCm4a/ZcPncKekDYzzWu+kkI7VQ==",
       "requires": {
         "emotion": "^10.0.17"
+      }
+    },
+    "@contentful/react-apps-toolkit": {
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/@contentful/react-apps-toolkit/-/react-apps-toolkit-1.2.16.tgz",
+      "integrity": "sha512-vx7+T4h+w1XBbn7OfRoXr8YUTtiyRNLaltF2ziM4xMqBryu/3Y71nBbhbxD6NIfOui3QIo3TR9Q5sPTZvGbIVw==",
+      "requires": {
+        "contentful-management": ">=7.30.0"
       }
     },
     "@contentful/rich-text-types": {
@@ -15239,9 +15260,9 @@
           "dev": true
         },
         "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -15818,9 +15839,9 @@
       "dev": true
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -15998,9 +16019,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "path-type": {
       "version": "4.0.0",
@@ -16304,9 +16325,9 @@
       }
     },
     "semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true
     },
     "shebang-command": {
@@ -16598,9 +16619,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"

--- a/packages/ecommerce-app-base/package.json
+++ b/packages/ecommerce-app-base/package.json
@@ -38,6 +38,7 @@
     "@contentful/f36-components": "^4.0.42",
     "@contentful/f36-icons": "^4.25.0",
     "@contentful/f36-tokens": "^4.0.0",
+    "@contentful/react-apps-toolkit": "^1.2.16",
     "array-move": "^3.0.0",
     "contentful-management": "^10.0.0",
     "emotion": "^10.0.0",

--- a/packages/ecommerce-app-base/src/Editor/IntegrationContext.tsx
+++ b/packages/ecommerce-app-base/src/Editor/IntegrationContext.tsx
@@ -1,0 +1,29 @@
+import type { ComponentType, FC, PropsWithChildren } from 'react';
+import React, { createContext, useContext } from 'react';
+import { Integration } from '../interfaces';
+
+export const IntegrationContext = createContext({} as Integration);
+
+type Props = PropsWithChildren<{ integration: Integration }>;
+
+export const IntegrationProvider: FC<Props> = ({ integration, children }) => {
+  return <IntegrationContext.Provider value={integration}>{children}</IntegrationContext.Provider>;
+};
+
+export const useIntegration = (): Integration => {
+  return useContext(IntegrationContext);
+};
+
+export function withIntegrationContext<T extends Partial<Integration> = {}>(
+  WrappedComponent: ComponentType<T>
+) {
+  const displayName = WrappedComponent.displayName || WrappedComponent.name || 'Component';
+
+  const ComponentWithContext = (props: Omit<T, keyof Integration>) => {
+    const context = useIntegration();
+    return <WrappedComponent {...context} {...(props as T)} />;
+  };
+
+  ComponentWithContext.displayName = `withIntegrationContext(${displayName})`;
+  return ComponentWithContext;
+}

--- a/packages/ecommerce-app-base/src/index.tsx
+++ b/packages/ecommerce-app-base/src/index.tsx
@@ -1,39 +1,29 @@
-import {
-  AppExtensionSDK,
-  DialogExtensionSDK,
-  FieldExtensionSDK,
-  init,
-  locations,
-} from '@contentful/app-sdk';
+import { ConfigAppSDK, DialogAppSDK, init, locations } from '@contentful/app-sdk';
 import { GlobalStyles } from '@contentful/f36-components';
 import * as React from 'react';
 import { render } from 'react-dom';
 import AppConfig from './AppConfig/AppConfig';
 import Field from './Editor/Field';
 import { Integration } from './interfaces';
+import { SDKProvider } from '@contentful/react-apps-toolkit';
+import { IntegrationProvider } from './Editor/IntegrationContext';
 
 export function setup(integration: Integration) {
   init((sdk) => {
     const root = document.getElementById('root');
 
     if (sdk.location.is(locations.LOCATION_DIALOG)) {
-      integration.renderDialog(sdk as DialogExtensionSDK);
+      integration.renderDialog(sdk as DialogAppSDK);
     }
 
     if (sdk.location.is(locations.LOCATION_ENTRY_FIELD)) {
       render(
-        <>
-          <GlobalStyles />
-          <Field
-            sdk={sdk as FieldExtensionSDK}
-            makeCTA={integration.makeCTA}
-            logo={integration.logo}
-            fetchProductPreviews={integration.fetchProductPreviews}
-            openDialog={integration.openDialog}
-            isDisabled={integration.isDisabled}
-            skuTypes={integration.skuTypes}
-          />
-        </>,
+        <IntegrationProvider integration={integration}>
+          <SDKProvider>
+            <GlobalStyles />
+            <Field />
+          </SDKProvider>
+        </IntegrationProvider>,
         root
       );
     }
@@ -42,17 +32,19 @@ export function setup(integration: Integration) {
       render(
         <>
           <GlobalStyles />
-          <AppConfig
-            name={integration.name}
-            sdk={sdk as AppExtensionSDK}
-            parameterDefinitions={integration.parameterDefinitions}
-            validateParameters={integration.validateParameters}
-            logo={integration.logo}
-            color={integration.color}
-            description={integration.description}
-            skuTypes={integration.skuTypes}
-            isInOrchestrationEAP={integration.isInOrchestrationEAP}
-          />
+          <SDKProvider>
+            <AppConfig
+              name={integration.name}
+              sdk={sdk as ConfigAppSDK}
+              parameterDefinitions={integration.parameterDefinitions}
+              validateParameters={integration.validateParameters}
+              logo={integration.logo}
+              color={integration.color}
+              description={integration.description}
+              skuTypes={integration.skuTypes}
+              isInOrchestrationEAP={integration.isInOrchestrationEAP}
+            />
+          </SDKProvider>
         </>,
         root
       );


### PR DESCRIPTION
## Purpose
Prepare `ecommerce-app-base` for future changes
<!-- Why are we introducing this change now? What problem does it solve? What is the story/background for it? -->

## Approach

Introduce an Integration (React) context to avoid excessive prop drilling through the code in the future.  
Allow react hooks usage by migrating the Field component to a functional component.  

This is exclusively a cleanup up task for future work on the codebase. No changes to the public interface have been intorduced.

<!-- Why did we do it the way we did? Did we consider alternatives? What other implementation details or artefacts (screenshots etc.) would help reviewers contextualize change? -->

## Testing steps
For now this is only tested with realtive-deps on the shopify app 
<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->
