### PR TITLE
[INTEG-1031] Fix: AICG modal height

### DIFF
--- a/apps/ai-content-generator/src/components/app/dialog/common-generator/CommonGenerator.tsx
+++ b/apps/ai-content-generator/src/components/app/dialog/common-generator/CommonGenerator.tsx
@@ -1,5 +1,5 @@
-import { useContext, useEffect, useReducer } from 'react';
-import { Flex } from '@contentful/f36-components';
+import { useContext, useEffect, useReducer, useRef, useState } from 'react';
+import { Box, Flex } from '@contentful/f36-components';
 import { GeneratorContext } from '@providers/generatorProvider';
 import SourceAndFieldSelectors from '@components/app/dialog/common-generator/field-selector/SourceAndFieldSelectors';
 import Header from '@components/app/dialog/common-generator/header/Header';
@@ -26,6 +26,8 @@ const CommonGenerator = () => {
   const { setProviderData, feature, localeNames } = useContext(GeneratorContext);
 
   const [parameters, dispatch] = useReducer(generatorReducer, initialParameters);
+  const [headerHeight, setHeaderHeight] = useState(0);
+  const headerRef = useRef<HTMLElement>(null);
 
   const updateProviderData = () => {
     setProviderData({
@@ -33,7 +35,14 @@ const CommonGenerator = () => {
     });
   };
 
-  useEffect(updateProviderData, [dispatch, setProviderData]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(updateProviderData, [dispatch]);
+
+  useEffect(() => {
+    if (headerRef.current) {
+      setHeaderHeight(headerRef.current.clientHeight);
+    }
+  }, []);
 
   const inputText = parameters.isNewText
     ? parameters.originalText.prompt
@@ -51,8 +60,10 @@ const CommonGenerator = () => {
 
   return (
     <Flex flexDirection="column">
-      <Header />
-      <SourceAndFieldSelectors parameters={parameters} fieldTypes={TextFields} />
+      <Box ref={headerRef}>
+        <Header />
+        <SourceAndFieldSelectors parameters={parameters} fieldTypes={TextFields} />
+      </Box>
       <Output
         onGenerate={handleGenerate}
         outputFieldId={parameters.output.fieldId}
@@ -60,6 +71,7 @@ const CommonGenerator = () => {
         outputFieldValidation={parameters.output.validation}
         inputText={inputText}
         isNewText={parameters.isNewText}
+        headerHeight={headerHeight}
       />
     </Flex>
   );

--- a/apps/ai-content-generator/src/components/app/dialog/common-generator/output/Output.styles.ts
+++ b/apps/ai-content-generator/src/components/app/dialog/common-generator/output/Output.styles.ts
@@ -2,14 +2,13 @@ import { css } from '@emotion/react';
 import tokens from '@contentful/f36-tokens';
 
 const TAB_WIDTH = 145;
-const HEADER_HEIGHT = 160;
-const MODAL_MIN_HEIGHT = 600;
+const MODAL_MIN_HEIGHT = 620;
 
-function makeOutputStyle() {
+export function makeOutputStyle(headerHeight: number) {
   // Output section height dynamically calculated in pixels
   const twentyFivePerc = window.outerHeight * 0.25;
-  const height = window.outerHeight - twentyFivePerc - HEADER_HEIGHT;
-  const minHeight = MODAL_MIN_HEIGHT - HEADER_HEIGHT;
+  const height = window.outerHeight - twentyFivePerc - headerHeight;
+  const minHeight = MODAL_MIN_HEIGHT - headerHeight;
 
   return css({
     minHeight: minHeight,
@@ -20,7 +19,6 @@ function makeOutputStyle() {
 }
 
 export const styles = {
-  output: makeOutputStyle(),
   tabsContainer: css({
     width: '100%',
     display: 'flex',

--- a/apps/ai-content-generator/src/components/app/dialog/common-generator/output/Output.styles.ts
+++ b/apps/ai-content-generator/src/components/app/dialog/common-generator/output/Output.styles.ts
@@ -2,13 +2,30 @@ import { css } from '@emotion/react';
 import tokens from '@contentful/f36-tokens';
 
 const TAB_WIDTH = 145;
+const HEADER_HEIGHT = 160;
+const MODAL_MIN_HEIGHT = 600;
+
+function makeOutputStyle() {
+  // Output section height dynamically calculated in pixels
+  const twentyFivePerc = window.outerHeight * 0.25;
+  const height = window.outerHeight - twentyFivePerc - HEADER_HEIGHT;
+  const minHeight = MODAL_MIN_HEIGHT - HEADER_HEIGHT;
+
+  return css({
+    minHeight: minHeight,
+    height,
+    overflow: 'auto',
+    margin: `0 ${tokens.spacingL}`,
+  });
+}
 
 export const styles = {
-  wrapper: css({
-    margin: `0 ${tokens.spacingL}`,
-  }),
+  output: makeOutputStyle(),
   tabsContainer: css({
     width: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    paddingBottom: `${tokens.spacingL}`,
   }),
   tabsList: css({
     justifyContent: 'flex-end',

--- a/apps/ai-content-generator/src/components/app/dialog/common-generator/output/Output.tsx
+++ b/apps/ai-content-generator/src/components/app/dialog/common-generator/output/Output.tsx
@@ -39,7 +39,7 @@ const Output = (props: Props) => {
   }, [ai.isGenerating]);
 
   return (
-    <Flex css={styles.wrapper}>
+    <Flex css={styles.output}>
       <Tabs
         currentTab={currentTab}
         onTabChange={(tab) => setCurrentTab(tab as OutputTab)}

--- a/apps/ai-content-generator/src/components/app/dialog/common-generator/output/Output.tsx
+++ b/apps/ai-content-generator/src/components/app/dialog/common-generator/output/Output.tsx
@@ -3,7 +3,7 @@ import { Flex, Tabs } from '@contentful/f36-components';
 import useAI, { GenerateMessage } from '@hooks/dialog/useAI';
 import OutputTextPanels from './output-text-panels/OutputTextPanels';
 import { ContentTypeFieldValidation } from 'contentful-management';
-import { styles } from './Output.styles';
+import { styles, makeOutputStyle } from './Output.styles';
 
 enum OutputTab {
   UPDATE_ORIGINAL_TEXT = 'original-text',
@@ -17,6 +17,7 @@ interface Props {
   outputFieldLocale: string;
   outputFieldValidation: ContentTypeFieldValidation | null;
   isNewText: boolean;
+  headerHeight: number;
 }
 
 const Output = (props: Props) => {
@@ -27,6 +28,7 @@ const Output = (props: Props) => {
     outputFieldLocale,
     outputFieldValidation,
     isNewText,
+    headerHeight,
   } = props;
   const ai = useAI();
 
@@ -38,8 +40,10 @@ const Output = (props: Props) => {
     }
   }, [ai.isGenerating]);
 
+  const outputStyle = makeOutputStyle(headerHeight);
+
   return (
-    <Flex css={styles.output}>
+    <Flex css={outputStyle}>
       <Tabs
         currentTab={currentTab}
         onTabChange={(tab) => setCurrentTab(tab as OutputTab)}

--- a/apps/ai-content-generator/src/components/app/dialog/common-generator/output/output-text-panels/generated-text-panel/GeneratedTextPanel.tsx
+++ b/apps/ai-content-generator/src/components/app/dialog/common-generator/output/output-text-panels/generated-text-panel/GeneratedTextPanel.tsx
@@ -8,6 +8,9 @@ import { css } from '@emotion/react';
 import tokens from '@contentful/f36-tokens';
 
 const styles = {
+  panel: css({
+    flexGrow: 1,
+  }),
   button: css({
     marginLeft: `${tokens.spacingXs}`,
   }),
@@ -52,7 +55,7 @@ const GeneratedTextPanel = (props: Props) => {
   ]);
 
   return (
-    <Tabs.Panel id={OutputTab.GENERATED_TEXT}>
+    <Tabs.Panel id={OutputTab.GENERATED_TEXT} css={styles.panel}>
       {isGenerating ? (
         <TextFieldWithButtons inputText={output} sizeValidation={outputFieldValidation?.size}>
           <Button onClick={sendStopSignal}>Stop Generating</Button>

--- a/apps/ai-content-generator/src/components/app/dialog/common-generator/output/output-text-panels/original-text-panel/OriginalTextPanel.tsx
+++ b/apps/ai-content-generator/src/components/app/dialog/common-generator/output/output-text-panels/original-text-panel/OriginalTextPanel.tsx
@@ -5,6 +5,13 @@ import TextFieldWithButtons from '@components/common/text-field-with-buttons/Tex
 import { GeneratorAction } from '@components/app/dialog/common-generator/generatorReducer';
 import { OutputTab } from '../../Output';
 import { DialogText } from '@configs/features/featureTypes';
+import { css } from '@emotion/react';
+
+const styles = {
+  panel: css({
+    flexGrow: 1,
+  }),
+};
 
 interface Props {
   inputText: string;
@@ -34,7 +41,7 @@ const OriginalTextPanel = (props: Props) => {
   const helpText = isNewText ? dialogText.promptHelpText : dialogText.fieldHelpText;
 
   return (
-    <Tabs.Panel id={OutputTab.UPDATE_ORIGINAL_TEXT}>
+    <Tabs.Panel id={OutputTab.UPDATE_ORIGINAL_TEXT} css={styles.panel}>
       <TextFieldWithButtons
         inputText={inputText}
         onFieldChange={handleOriginalTextChange}

--- a/apps/ai-content-generator/src/components/app/dialog/rewrite-generator/RewriteGenerator.tsx
+++ b/apps/ai-content-generator/src/components/app/dialog/rewrite-generator/RewriteGenerator.tsx
@@ -1,5 +1,5 @@
-import { useContext, useEffect, useReducer, useState } from 'react';
-import { Flex } from '@contentful/f36-components';
+import { useContext, useEffect, useReducer, useRef, useState } from 'react';
+import { Box, Flex } from '@contentful/f36-components';
 import { GeneratorContext } from '@providers/generatorProvider';
 import SourceAndFieldSelectors from '@components/app/dialog/common-generator/field-selector/SourceAndFieldSelectors';
 import Header from '@components/app/dialog/common-generator/header/Header';
@@ -30,6 +30,8 @@ const RewriteGenerator = () => {
 
   const [parameters, dispatch] = useReducer(generatorReducer, initialParameters);
   const [rewritePromptData, setRewritePromptData] = useState('');
+  const [headerHeight, setHeaderHeight] = useState(0);
+  const headerRef = useRef<HTMLElement>(null);
 
   const updateProviderData = () => {
     setProviderData({
@@ -37,7 +39,14 @@ const RewriteGenerator = () => {
     });
   };
 
-  useEffect(updateProviderData, [dispatch, setProviderData]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(updateProviderData, [dispatch]);
+
+  useEffect(() => {
+    if (headerRef.current) {
+      setHeaderHeight(headerRef.current.clientHeight);
+    }
+  }, []);
 
   const inputText = parameters.isNewText
     ? parameters.originalText.prompt
@@ -55,9 +64,11 @@ const RewriteGenerator = () => {
 
   return (
     <Flex flexDirection="column">
-      <Header />
-      <SourceAndFieldSelectors parameters={parameters} fieldTypes={TextFields} />
-      <ButtonTextField inputValue={rewritePromptData} handleInputChange={setRewritePromptData} />
+      <Box ref={headerRef}>
+        <Header />
+        <SourceAndFieldSelectors parameters={parameters} fieldTypes={TextFields} />
+        <ButtonTextField inputValue={rewritePromptData} handleInputChange={setRewritePromptData} />
+      </Box>
       <Output
         onGenerate={handleGenerate}
         outputFieldId={parameters.output.fieldId}
@@ -65,6 +76,7 @@ const RewriteGenerator = () => {
         outputFieldValidation={parameters.output.validation}
         inputText={inputText}
         isNewText={parameters.isNewText}
+        headerHeight={headerHeight}
       />
     </Flex>
   );

--- a/apps/ai-content-generator/src/components/app/dialog/rewrite-generator/button-text-field/ButtonTextField.styles.tsx
+++ b/apps/ai-content-generator/src/components/app/dialog/rewrite-generator/button-text-field/ButtonTextField.styles.tsx
@@ -4,7 +4,7 @@ import { css } from '@emotion/react';
 export const styles = {
   wrapper: css({
     margin: `0 ${tokens.spacingL}`,
-    padding: `${tokens.spacingL} ${tokens.spacing2Xl} 0 ${tokens.spacing2Xl}`,
+    padding: `${tokens.spacingS} ${tokens.spacing2Xl} 0 ${tokens.spacing2Xl}`,
   }),
   button: css({
     marginRight: tokens.spacingXs,

--- a/apps/ai-content-generator/src/components/common/text-field-with-buttons/TextFieldWIthButtons.tsx
+++ b/apps/ai-content-generator/src/components/common/text-field-with-buttons/TextFieldWIthButtons.tsx
@@ -1,20 +1,8 @@
 import { ChangeEvent, ReactNode } from 'react';
-import { Flex, FormControl, Textarea, Paragraph } from '@contentful/f36-components';
+import { Flex, Textarea, Paragraph } from '@contentful/f36-components';
 import { ContentTypeFieldValidation } from 'contentful-management';
 import TextCounter from '../text-counter/TextCounter';
-import { css } from '@emotion/react';
-import tokens from '@contentful/f36-tokens';
-
-const TEXTAREA_ROWS = 26;
-
-const styles = {
-  helpText: css({
-    display: 'flex',
-    alignItems: 'center',
-    color: `${tokens.gray500}`,
-    margin: `0 ${tokens.spacingS}`,
-  }),
-};
+import { styles } from './TextFieldWithButtons.styles';
 
 interface Props {
   inputText: string;
@@ -30,27 +18,30 @@ const TextFieldWithButtons = (props: Props) => {
   const { inputText, onFieldChange, children, sizeValidation, isDisabled, placeholder, helpText } =
     props;
   return (
-    <FormControl>
-      <Flex flexDirection="column" fullWidth paddingLeft="spacing2Xl" paddingRight="spacing2Xl">
-        <Textarea
-          resize="none"
-          rows={TEXTAREA_ROWS}
-          value={inputText}
-          onChange={onFieldChange}
-          isDisabled={isDisabled}
-          placeholder={placeholder}></Textarea>
-        <TextCounter
-          text={inputText}
-          maxLength={sizeValidation?.max}
-          minLength={sizeValidation?.min}
-        />
+    <Flex
+      flexDirection="column"
+      fullWidth
+      paddingLeft="spacing2Xl"
+      paddingRight="spacing2Xl"
+      css={styles.container}>
+      <Textarea
+        resize="none"
+        css={styles.textarea}
+        value={inputText}
+        onChange={onFieldChange}
+        isDisabled={isDisabled}
+        placeholder={placeholder}></Textarea>
+      <TextCounter
+        text={inputText}
+        maxLength={sizeValidation?.max}
+        minLength={sizeValidation?.min}
+      />
 
-        <Flex alignSelf="flex-end">
-          <Paragraph css={styles.helpText}>{helpText}</Paragraph>
-          {children}
-        </Flex>
+      <Flex alignSelf="flex-end">
+        <Paragraph css={styles.helpText}>{helpText}</Paragraph>
+        {children}
       </Flex>
-    </FormControl>
+    </Flex>
   );
 };
 

--- a/apps/ai-content-generator/src/components/common/text-field-with-buttons/TextFieldWithButtons.styles.ts
+++ b/apps/ai-content-generator/src/components/common/text-field-with-buttons/TextFieldWithButtons.styles.ts
@@ -1,0 +1,17 @@
+import { css } from '@emotion/react';
+import tokens from '@contentful/f36-tokens';
+
+export const styles = {
+  container: css({
+    height: '100%',
+  }),
+  textarea: css({
+    flexGrow: 1,
+  }),
+  helpText: css({
+    display: 'flex',
+    alignItems: 'center',
+    color: `${tokens.gray500}`,
+    margin: `0 ${tokens.spacingS}`,
+  }),
+};

--- a/apps/ai-content-generator/src/configs/dialog/dialogConfig.ts
+++ b/apps/ai-content-generator/src/configs/dialog/dialogConfig.ts
@@ -1,7 +1,6 @@
 import { DialogInvocationParameters } from '@locations/Dialog';
 import { OpenCustomWidgetOptions } from '@contentful/app-sdk';
 
-const DIALOG_MIN_HEIGHT = 880;
 const DIALOG_WIDTH = 820;
 
 type openDialogOptions = OpenCustomWidgetOptions & { parameters: DialogInvocationParameters };
@@ -10,7 +9,6 @@ export const makeDialogConfig = (parameters: DialogInvocationParameters): openDi
   return {
     position: 'center',
     width: DIALOG_WIDTH,
-    minHeight: DIALOG_MIN_HEIGHT,
     allowHeightOverflow: true,
     parameters,
   };

--- a/apps/ai-content-generator/src/locations/Dialog.tsx
+++ b/apps/ai-content-generator/src/locations/Dialog.tsx
@@ -2,7 +2,7 @@ import useDialogParameters from '@hooks/dialog/useDialogParameters';
 import { AIFeature } from '@configs/features/featureConfig';
 import CommonGenerator from '@components/app/dialog/common-generator/CommonGenerator';
 import GeneratorProvider from '@providers/generatorProvider';
-import { useSDK } from '@contentful/react-apps-toolkit';
+import { useSDK, useAutoResizer } from '@contentful/react-apps-toolkit';
 import { DialogAppSDK } from '@contentful/app-sdk';
 import RewriteGenerator from '@components/app/dialog/rewrite-generator/RewriteGenerator';
 
@@ -19,6 +19,7 @@ type DialogInvocationParameters = {
 const Dialog = () => {
   const { feature, entryId, isLoading, fieldLocales } = useDialogParameters();
   const sdk = useSDK<DialogAppSDK>();
+  useAutoResizer();
 
   if (isLoading) {
     return null;


### PR DESCRIPTION
## Purpose

The new vertical modal design was not very useable on small screens. This PR changes the output textarea to be responsive to screen size. There is also a fix in here to reduce re-renders in the Dialog that are being caused by an addition to the dependency array of a `useEffect` for the generator components.

Examples of the modal on a small browser window:
![Screenshot 2023-08-14 at 3 50 30 PM](https://github.com/contentful/apps/assets/62958907/436328db-0fd8-4532-a51d-4e249c63e215)
![Screenshot 2023-08-14 at 3 51 14 PM](https://github.com/contentful/apps/assets/62958907/a4d7896e-b4ef-4335-bd1d-07938f46f5b0)


## Approach

In order to fix the modal size, I removed the `minHeight` prop from the `dialogConfig` and added the `useAutoResizer` hook to the `Dialog` component. I then updated the `Output` component to calculate its height based on the heights of the other elements in the modal. Note that the Rewrite action has a different layout than the other actions, so I accounted for this by passing in the height of of the other components as a prop to `Output`.

## Testing steps

Resize your browser and try opening all of the different actions. You should be able to see all of the content in the modal (including the generate button) on a variety of sizes. I did add a minimum modal height of 620 pixels, as anything smaller on the rewrite action made the textarea too small.
