### PR TITLE
Add aiig config page info

### DIFF
--- a/apps/ai-image-generator/frontend/src/components/config/ApiKeySection/APIKeySection.stories.tsx
+++ b/apps/ai-image-generator/frontend/src/components/config/ApiKeySection/APIKeySection.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
-import ApiKeySection from './APIKey';
+import ApiKeySection from './APIKeySection';
 
 const meta = {
   title: 'config/APIKey',
@@ -13,4 +13,8 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Primary: Story = {};
+export const Default: Story = {};
+
+export const WithApiKey: Story = {
+  args: { apiKey: 'pretend-api-key'}
+}

--- a/apps/ai-image-generator/frontend/src/components/config/ApiKeySection/APIKeySection.tsx
+++ b/apps/ai-image-generator/frontend/src/components/config/ApiKeySection/APIKeySection.tsx
@@ -1,19 +1,18 @@
 import { ChangeEvent, useState } from 'react';
 import { FormControl, TextInput } from '@contentful/f36-components';
-import OpenAILink from 'components/config/OpenAILink/OpenAILink';
+import OpenAILink from 'components/config/Hyperlink/Hyperlink';
+import configPageCopies from 'constants/configPageCopies';
 
 interface Props {
   apiKey?: string;
   handleApiKey: (value: { apiKey: string }) => void;
 }
 
-export const TITLE = 'Open AI Key';
-export const BODY = 'Provide your Open AI API key. If you need to generate a key, visit openai.com';
-export const SUBSTRING = 'visit openai.com';
-
-const APIKey = (props: Props) => {
+const APIKeySection = (props: Props) => {
   const { apiKey, handleApiKey } = props;
   const [editing, setEditing] = useState(false);
+
+  const { sectionTitle, linkBody, linkSubstring, linkHref } = configPageCopies.apiKeySection
 
   const censorApiKey = (key: string) => key.replace(/.(?=.{4,}$)/g, '*');
 
@@ -28,8 +27,8 @@ const APIKey = (props: Props) => {
   const handleClick = () => setEditing(true);
 
   return (
-    <FormControl testId="api-key-section" isRequired>
-      <FormControl.Label>{TITLE}</FormControl.Label>
+    <FormControl testId='api-key-section' isRequired>
+      <FormControl.Label>{sectionTitle}</FormControl.Label>
       {editing ? (
         <TextInput
           value={apiKey}
@@ -50,10 +49,10 @@ const APIKey = (props: Props) => {
         />
       )}
       <FormControl.HelpText>
-        <OpenAILink body={BODY} substring={SUBSTRING} />
+        <OpenAILink body={linkBody} substring={linkSubstring} href={linkHref} />
       </FormControl.HelpText>
     </FormControl>
   );
 };
 
-export default APIKey;
+export default APIKeySection;

--- a/apps/ai-image-generator/frontend/src/components/config/ApiKeySection/ApiKeySection.spec.tsx
+++ b/apps/ai-image-generator/frontend/src/components/config/ApiKeySection/ApiKeySection.spec.tsx
@@ -1,15 +1,17 @@
-import APIKey, { SUBSTRING, TITLE } from './APIKey';
+import APIKey from './APIKeySection';
 import { render, screen } from '@testing-library/react';
+import configPageCopies from 'constants/configPageCopies';
 
 const { getByText, getByTestId } = screen;
+const { sectionTitle, linkSubstring } = configPageCopies.apiKeySection;
 
-describe('APIKey component', () => {
+describe('APIKeySection component', () => {
   it('Component mounts without apiKey provided', async () => {
     render(<APIKey handleApiKey={() => null} />);
 
-    const title = getByText(TITLE);
+    const title = getByText(sectionTitle);
     const input = getByTestId('cf-ui-text-input');
-    const hyperLink = getByText(SUBSTRING);
+    const hyperLink = getByText(linkSubstring);
 
     expect(title).toBeVisible();
     expect(input).toBeVisible();
@@ -17,8 +19,7 @@ describe('APIKey component', () => {
   });
 
   it('Component mounts with apiKey provided', async () => {
-    const API_KEY = 'ksdfusdfkjh';
-    render(<APIKey handleApiKey={() => null} apiKey="ksdfusdfkjh" />);
+    render(<APIKey handleApiKey={() => null} apiKey='ksdfusdfkjh' />);
 
     const input = getByTestId('cf-ui-text-input');
 

--- a/apps/ai-image-generator/frontend/src/components/config/ConfigPage/ConfigPage.spec.tsx
+++ b/apps/ai-image-generator/frontend/src/components/config/ConfigPage/ConfigPage.spec.tsx
@@ -1,14 +1,16 @@
-import ConfigPage, { PAGE_TITLE } from './ConfigPage';
+import ConfigPage from './ConfigPage';
 import { render, screen } from '@testing-library/react';
+import configPageCopies from 'constants/configPageCopies';
 
 const { getByText, getByTestId } = screen;
+const { pageTitle } = configPageCopies.configPage;
 
 describe('ConfigPage component', () => {
   it('Component mounts', async () => {
     render(<ConfigPage handleConfig={() => null} parameters={{}} />);
 
-    const title = getByText(PAGE_TITLE);
-    const apiKeySection = getByTestId('api-key-section');
+    const title = getByText(pageTitle);
+    const apiKeySection = getByTestId('api-key-section')
 
     expect(title).toBeVisible();
     expect(apiKeySection).toBeVisible();

--- a/apps/ai-image-generator/frontend/src/components/config/ConfigPage/ConfigPage.tsx
+++ b/apps/ai-image-generator/frontend/src/components/config/ConfigPage/ConfigPage.tsx
@@ -1,9 +1,10 @@
 import { Box, Heading } from '@contentful/f36-components';
 import { styles } from './ConfigPage.styles';
-import APIKey from 'components/config/ApiKey/APIKey';
+import APIKey from 'components/config/ApiKeySection/APIKeySection';
 import { AppInstallationParameters } from 'types/configPage';
-
-export const PAGE_TITLE = 'Set up AI Images powered by DALL-E';
+import configPageCopies from 'constants/configPageCopies';
+import CostSection from '../CostSection/CostSection';
+import DisclaimerSection from '../DisclaimerSection/DisclaimerSection';
 
 interface ParameterObject {
   [key: string]: string;
@@ -16,13 +17,17 @@ interface Props {
 
 const ConfigPage = (props: Props) => {
   const { handleConfig, parameters } = props;
+  const { pageTitle } = configPageCopies.configPage
 
   return (
     <Box className={styles.body}>
-      <Heading>{PAGE_TITLE}</Heading>
+      <Heading>{pageTitle}</Heading>
       <hr className={styles.splitter} />
       <APIKey apiKey={parameters.apiKey} handleApiKey={handleConfig} />
       <hr className={styles.splitter} />
+      <CostSection />
+      <hr className={styles.splitter} />
+      <DisclaimerSection />
     </Box>
   );
 };

--- a/apps/ai-image-generator/frontend/src/components/config/ConfigPage/ConfigPage.tsx
+++ b/apps/ai-image-generator/frontend/src/components/config/ConfigPage/ConfigPage.tsx
@@ -1,10 +1,10 @@
 import { Box, Heading } from '@contentful/f36-components';
-import { styles } from './ConfigPage.styles';
 import APIKey from 'components/config/ApiKeySection/APIKeySection';
 import { AppInstallationParameters } from 'types/configPage';
 import configPageCopies from 'constants/configPageCopies';
-import CostSection from '../CostSection/CostSection';
-import DisclaimerSection from '../DisclaimerSection/DisclaimerSection';
+import CostSection from 'components/config/CostSection/CostSection';
+import DisclaimerSection from 'components/config/DisclaimerSection/DisclaimerSection';
+import { styles } from './ConfigPage.styles';
 
 interface ParameterObject {
   [key: string]: string;

--- a/apps/ai-image-generator/frontend/src/components/config/CostSection/CostSection.spec.tsx
+++ b/apps/ai-image-generator/frontend/src/components/config/CostSection/CostSection.spec.tsx
@@ -1,0 +1,21 @@
+import CostSection from './CostSection';
+import { render, screen } from '@testing-library/react';
+import configPageCopies from 'constants/configPageCopies';
+
+const { getByText } = screen;
+const { sectionTitle, pricingLinkSubstring, creditLinkSubstring } = configPageCopies.costSection;
+
+describe('CostSection component', () => {
+  it('Component mounts without correct content', async () => {
+    render(<CostSection />);
+
+    const title = getByText(sectionTitle);
+    const pricingHyperlink = getByText(pricingLinkSubstring);
+    const creditHyperlink = getByText(creditLinkSubstring);
+
+    expect(title).toBeVisible();
+    expect(pricingHyperlink).toBeVisible();
+    expect(creditHyperlink).toBeVisible();
+  });
+
+});

--- a/apps/ai-image-generator/frontend/src/components/config/CostSection/CostSection.stories.tsx
+++ b/apps/ai-image-generator/frontend/src/components/config/CostSection/CostSection.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import CostSection from './CostSection';
+
+const meta = {
+  title: 'config/CostSection',
+  component: CostSection,
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta<typeof CostSection>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {};

--- a/apps/ai-image-generator/frontend/src/components/config/CostSection/CostSection.styles.ts
+++ b/apps/ai-image-generator/frontend/src/components/config/CostSection/CostSection.styles.ts
@@ -1,0 +1,7 @@
+import { css } from 'emotion';
+
+export const styles = {
+  link: css({
+    marginTop: 0
+  }),
+};

--- a/apps/ai-image-generator/frontend/src/components/config/CostSection/CostSection.styles.ts
+++ b/apps/ai-image-generator/frontend/src/components/config/CostSection/CostSection.styles.ts
@@ -1,7 +1,13 @@
+import tokens from '@contentful/f36-tokens';
 import { css } from 'emotion';
 
 export const styles = {
   link: css({
-    marginTop: 0
+    color: tokens.gray900
   }),
+  wrapper: css({
+    'p:last-child': {
+        marginTop: 0
+    }
+  })
 };

--- a/apps/ai-image-generator/frontend/src/components/config/CostSection/CostSection.tsx
+++ b/apps/ai-image-generator/frontend/src/components/config/CostSection/CostSection.tsx
@@ -6,10 +6,10 @@ import { styles } from './CostSection.styles';
 const CostSection = () => {
     const { sectionTitle, sectionSubheading, pricingLinkBody, pricingLinkSubstring, pricingLinkHref, creditLinkBody, creditLinkSubstring, creditLinkHref } = configPageCopies.costSection;
     return (
-        <Flex flexDirection='column'>
+        <Flex className={styles.wrapper} flexDirection='column'>
             <Subheading>{sectionTitle}</Subheading>
             <Text fontWeight='fontWeightMedium' fontColor='gray900'>{sectionSubheading}</Text>
-            <HelpText>
+            <HelpText className={styles.link}>
                 <Hyperlink body={pricingLinkBody} substring={pricingLinkSubstring} href={pricingLinkHref} />
             </HelpText>
             <HelpText className={styles.link}>

--- a/apps/ai-image-generator/frontend/src/components/config/CostSection/CostSection.tsx
+++ b/apps/ai-image-generator/frontend/src/components/config/CostSection/CostSection.tsx
@@ -1,0 +1,24 @@
+import { Flex, HelpText, Subheading, Text } from '@contentful/f36-components';
+import configPageCopies from 'constants/configPageCopies';
+import Hyperlink from '../Hyperlink/Hyperlink';
+import { styles } from './CostSection.styles';
+
+const CostSection = () => {
+    const { sectionTitle, sectionSubheading, pricingLinkBody, pricingLinkSubstring, pricingLinkHref, creditLinkBody, creditLinkSubstring, creditLinkHref } = configPageCopies.costSection;
+    return (
+        <Flex flexDirection='column'>
+            <Subheading>{sectionTitle}</Subheading>
+            <Text fontWeight='fontWeightMedium' fontColor='gray900'>{sectionSubheading}</Text>
+            <HelpText>
+                <Hyperlink body={pricingLinkBody} substring={pricingLinkSubstring} href={pricingLinkHref} />
+            </HelpText>
+            <HelpText className={styles.link}>
+                <Hyperlink body={creditLinkBody} substring={creditLinkSubstring} href={creditLinkHref} />
+            </HelpText>
+        </Flex>
+    )
+
+}
+
+
+export default CostSection;

--- a/apps/ai-image-generator/frontend/src/components/config/DisclaimerSection/DisclaimerSection.spec.tsx
+++ b/apps/ai-image-generator/frontend/src/components/config/DisclaimerSection/DisclaimerSection.spec.tsx
@@ -1,0 +1,19 @@
+import DisclaimerSection from './DisclaimerSection';
+import { render, screen } from '@testing-library/react';
+import configPageCopies from 'constants/configPageCopies';
+
+const { getByText, getByTestId } = screen;
+const { sectionTitle, linkSubstring } = configPageCopies.disclaimerSection;
+
+describe('DisclaimerSection component', () => {
+  it('Component mounts without correct content', async () => {
+    render(<DisclaimerSection />);
+
+    const title = getByText(sectionTitle);
+    const hyperLink = getByText(linkSubstring);
+
+    expect(title).toBeVisible();
+    expect(hyperLink).toBeVisible();
+  });
+
+});

--- a/apps/ai-image-generator/frontend/src/components/config/DisclaimerSection/DisclaimerSection.stories.tsx
+++ b/apps/ai-image-generator/frontend/src/components/config/DisclaimerSection/DisclaimerSection.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import DisclaimerSection from './DisclaimerSection';
+
+const meta = {
+  title: 'config/DisclaimerSection',
+  component: DisclaimerSection,
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta<typeof DisclaimerSection>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {};

--- a/apps/ai-image-generator/frontend/src/components/config/DisclaimerSection/DisclaimerSection.tsx
+++ b/apps/ai-image-generator/frontend/src/components/config/DisclaimerSection/DisclaimerSection.tsx
@@ -1,0 +1,19 @@
+import { Flex, Subheading, Text } from '@contentful/f36-components';
+import Hyperlink from 'components/config/Hyperlink/Hyperlink';
+import configPageCopies from 'constants/configPageCopies';
+
+const DisclaimerSection = () => {
+  const { sectionTitle, linkBody, linkSubstring, linkHref } = configPageCopies.disclaimerSection;
+  return (
+    <Flex flexDirection='column'>
+        <Subheading>
+            {sectionTitle}
+        </Subheading>
+        <Text fontSize='fontSizeM' fontWeight='fontWeightDemiBold' fontColor='gray900'>
+            <Hyperlink body={linkBody} substring={linkSubstring} href={linkHref} />
+        </Text>
+    </Flex>
+  )
+}
+
+export default DisclaimerSection;

--- a/apps/ai-image-generator/frontend/src/components/config/Hyperlink/Hyperlink.tsx
+++ b/apps/ai-image-generator/frontend/src/components/config/Hyperlink/Hyperlink.tsx
@@ -4,15 +4,16 @@ import { TextLink } from '@contentful/f36-components';
 interface Props {
   body: string;
   substring: string;
+  href: string
 }
 
 // TODO: We should use the HyperLink component from the integration-component-library
-const OpenAILink = (props: Props) => {
-  const { body, substring } = props;
+const Hyperlink = (props: Props) => {
+  const { body, substring, href } = props;
 
   const textLinkComponent = (index: number) => (
     <TextLink
-      href={'https://openai.com'}
+      href={href}
       target="_blank"
       rel="noopener noreferer"
       key={`textLink-${index}`}
@@ -38,4 +39,4 @@ const OpenAILink = (props: Props) => {
   return formatLink();
 };
 
-export default OpenAILink;
+export default Hyperlink;

--- a/apps/ai-image-generator/frontend/src/constants/configPageCopies.ts
+++ b/apps/ai-image-generator/frontend/src/constants/configPageCopies.ts
@@ -1,0 +1,29 @@
+const configPageCopies = {
+    apiKeySection: {
+        sectionTitle: 'Open AI Key',
+        linkBody: 'Provide your Open AI API key. If you need to generate a key, visit openai.com',
+        linkSubstring: 'visit openai.com',
+        linkHref: 'https://openai.com'
+    },
+    costSection: {
+        sectionTitle: 'Cost',
+        sectionSubheading: 'Generating images uses your DALL-E credits.',
+        pricingLinkBody: 'View the current pricing model at openai.com/pricing',
+        pricingLinkSubstring: 'openai.com/pricing',
+        pricingLinkHref: 'https://openai.com/pricing',
+        creditLinkBody: 'View your current credits at labs.openai.com/account',
+        creditLinkSubstring: 'labs.openai.com/account',
+        creditLinkHref: 'https://labs.openai.com/account'
+    },
+    disclaimerSection: {
+        sectionTitle: 'Disclaimer',
+        linkBody: 'This feature uses a third party AI tool. Please ensure your use of the tool and any AI-generated content complies with applicable laws, your company\'s policies, and all other Terms and Policies',
+        linkSubstring: 'Terms and Policies',
+        linkHref: 'https://openai.com/policies'
+    },
+    configPage: {
+        pageTitle: 'Set up AI Images powered by DALL-E'
+    }
+}
+
+export default configPageCopies;


### PR DESCRIPTION
## Purpose

This PR adds two more sections to the config page. The sections are not really interactive (aside from being links) so there is little logic added here. 

## Approach

I added the `CostSection` and the `DisclaimerSection` as per [these](https://www.figma.com/file/MyzNyHqDo1vjyAVGCMD852/AI-Images-powered-by-Dall-e?type=design&node-id=64-40895&mode=design&t=jzs5OwkTLjPO6LcJ-4) designs. 

I believe I have added the correct hyperlink hrefs, but also something that is easily adjustable. 

<img width="1038" alt="Screenshot 2023-08-16 at 4 23 30 PM" src="https://github.com/contentful/apps/assets/58186851/1976b909-8c80-48d6-8485-20227839e460">


## Testing steps

Pull down this branch and head to the AI Image Generator (development) app in our testing org. Notice the newly added sections on the config page. 
