### PR TITLE
Fix dead Gatsby docs link

### DIFF
--- a/apps/gatsby/src/AppConfig/AppConfig.js
+++ b/apps/gatsby/src/AppConfig/AppConfig.js
@@ -309,7 +309,7 @@ export class AppConfig extends React.Component {
                   <span>
                     To set up Content Sync, see the{' '}
                     <TextLink
-                      href="http://gatsby.dev/contentful-preview-docs"
+                      href="https://support.gatsbyjs.com/hc/en-us/articles/17278047641876-Add-the-Gatsby-Cloud-App-to-Contentful"
                       target="_blank"
                       rel="noopener noreferrer">
                       installation instructions


### PR DESCRIPTION
## Purpose

I noticed the link for installation instructions on the Gatsby config page lead to a dead page (I think Gatsby reorganized a lot of their site). I have added the updated page link to the component link itself. 

New page link: https://support.gatsbyjs.com/hc/en-us/articles/17278047641876-Add-the-Gatsby-Cloud-App-to-Contentful 

Added to the `installation instructions` hyperlink as seen on the config page below: 


<img width="1006" alt="Screenshot 2023-08-18 at 3 08 24 PM" src="https://github.com/contentful/apps/assets/58186851/48236ed8-a2a8-421a-bbfb-1983277c7603">

