### PR TITLE
Fetch OpenAI API key from app install params

### DIFF
--- a/apps/ai-image-generator/backend/package-lock.json
+++ b/apps/ai-image-generator/backend/package-lock.json
@@ -17,9 +17,11 @@
         "@types/chai": "^4.3.5",
         "@types/mocha": "^10.0.1",
         "@types/sinon": "^10.0.16",
+        "@types/sinon-chai": "^3.2.9",
         "chai": "^4.3.7",
         "mocha": "^10.2.0",
         "sinon": "^15.2.0",
+        "sinon-chai": "^3.7.0",
         "ts-node": "^10.9.1",
         "typescript": "^5.1.6"
       }
@@ -272,6 +274,16 @@
       "dev": true,
       "dependencies": {
         "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinon-chai": {
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.9.tgz",
+      "integrity": "sha512-/19t63pFYU0ikrdbXKBWj9PCdnKyTd0Qkz0X91Ta081cYsq90OxYdcWwK/dwEoDa6dtXgj2HJfmzgq+QZTHdmQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "*",
+        "@types/sinon": "*"
       }
     },
     "node_modules/@types/sinonjs__fake-timers": {
@@ -1923,6 +1935,16 @@
         "url": "https://opencollective.com/sinon"
       }
     },
+    "node_modules/sinon-chai": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.7.0.tgz",
+      "integrity": "sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==",
+      "dev": true,
+      "peerDependencies": {
+        "chai": "^4.0.0",
+        "sinon": ">=4.0.0"
+      }
+    },
     "node_modules/sinon/node_modules/diff": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
@@ -2468,6 +2490,16 @@
       "dev": true,
       "requires": {
         "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "@types/sinon-chai": {
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.9.tgz",
+      "integrity": "sha512-/19t63pFYU0ikrdbXKBWj9PCdnKyTd0Qkz0X91Ta081cYsq90OxYdcWwK/dwEoDa6dtXgj2HJfmzgq+QZTHdmQ==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "*",
+        "@types/sinon": "*"
       }
     },
     "@types/sinonjs__fake-timers": {
@@ -3695,6 +3727,13 @@
           }
         }
       }
+    },
+    "sinon-chai": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.7.0.tgz",
+      "integrity": "sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==",
+      "dev": true,
+      "requires": {}
     },
     "string-width": {
       "version": "4.2.3",

--- a/apps/ai-image-generator/backend/package.json
+++ b/apps/ai-image-generator/backend/package.json
@@ -21,9 +21,11 @@
     "@types/chai": "^4.3.5",
     "@types/mocha": "^10.0.1",
     "@types/sinon": "^10.0.16",
+    "@types/sinon-chai": "^3.2.9",
     "chai": "^4.3.7",
     "mocha": "^10.2.0",
     "sinon": "^15.2.0",
+    "sinon-chai": "^3.7.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.1.6"
   }

--- a/apps/ai-image-generator/backend/src/actions/aiig-generate-image.spec.ts
+++ b/apps/ai-image-generator/backend/src/actions/aiig-generate-image.spec.ts
@@ -1,5 +1,4 @@
-import { expect } from 'chai';
-import { handler } from './aiig-generate-image';
+import chai, { expect } from 'chai';
 import {
   makeMockAppActionCallContext,
   makeMockOpenAiApi,
@@ -8,12 +7,32 @@ import {
 import sinon from 'sinon';
 import { OpenAiApiService } from '../services/openaiApiService';
 import OpenAI from 'openai';
+import sinonChai from 'sinon-chai';
+import { handler } from './aiig-generate-image';
+import { AppInstallationProps, SysLink } from 'contentful-management';
+
+chai.use(sinonChai);
 
 describe('aiigGenerateImage.handler', () => {
+  const cmaRequestStub = sinon.stub();
   const parameters = {
     prompt: 'My image text',
   };
-  const context = makeMockAppActionCallContext();
+  const mockAppInstallation: AppInstallationProps = {
+    sys: {
+      type: 'AppInstallation',
+      appDefinition: {} as SysLink,
+      environment: {} as SysLink,
+      space: {} as SysLink,
+      version: 1,
+      createdAt: 'createdAt',
+      updatedAt: 'updatedAt',
+    },
+    parameters: {
+      apiKey: 'openai-api-key',
+    },
+  };
+  const context = makeMockAppActionCallContext(mockAppInstallation, cmaRequestStub);
 
   let mockOpenAiApi: sinon.SinonStubbedInstance<OpenAI>;
   let openAiApiService: OpenAiApiService;
@@ -21,12 +40,21 @@ describe('aiigGenerateImage.handler', () => {
   beforeEach(() => {
     mockOpenAiApi = makeMockOpenAiApi();
     openAiApiService = new OpenAiApiService(mockOpenAiApi);
+    sinon.stub(OpenAiApiService, 'fromOpenAiApiKey').returns(openAiApiService);
   });
 
   it('returns the images result', async () => {
-    const result = await handler(parameters, context, openAiApiService);
+    const result = await handler(parameters, context);
     expect(result).to.have.property('status', 201);
     expect(result).to.have.property('prompt', parameters.prompt);
     expect(result.images).to.include(mockImagesGenerateResponse.data[0].url);
+  });
+
+  it('calls the cma to get the api key from app installation params', async () => {
+    await handler(parameters, context);
+    expect(cmaRequestStub).to.have.been.calledWithMatch({
+      entityType: 'AppInstallation',
+      action: 'get',
+    });
   });
 });

--- a/apps/ai-image-generator/backend/test/mocks.ts
+++ b/apps/ai-image-generator/backend/test/mocks.ts
@@ -3,18 +3,21 @@ import { Adapter, PlainClientAPI, createClient } from 'contentful-management';
 import OpenAI from 'openai';
 import sinon from 'sinon';
 
-export const makeMockPlainClient = (stub: sinon.SinonStub): PlainClientAPI => {
+export const makeMockPlainClient = <T>(response: T, stub: sinon.SinonStub): PlainClientAPI => {
   const apiAdapter: Adapter = {
-    makeRequest: (args) => {
-      return stub.returns(Promise.resolve())(args);
+    makeRequest: async <T>(args: T) => {
+      return stub.returns(response)(args);
     },
   };
   return createClient({ apiAdapter }, { type: 'plain' });
 };
 
-export const makeMockAppActionCallContext = (cmaStub = sinon.stub()): AppActionCallContext => {
+export const makeMockAppActionCallContext = <T>(
+  response: T,
+  cmaStub = sinon.stub()
+): AppActionCallContext => {
   return {
-    cma: makeMockPlainClient(cmaStub),
+    cma: makeMockPlainClient(response, cmaStub),
     appActionCallContext: {
       spaceId: 'space-id',
       environmentId: 'environment-id',


### PR DESCRIPTION
## Purpose

We need to fetch the actual API key that the user saved in their config during app installation, and use that when calling OpenAI.

## Approach

* Grab it from the CMA
* Throw an error if no API key
* Remove dependency injection since sinon.stub() now works as expected. 🤷 

### Out of scope / Follow ups

* Proper error handling and testing around unhappy paths (next PR)

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
