### PR TITLE
Fix build to match correct runtime

### DIFF
--- a/apps/ai-image-generator/backend/.nvmrc
+++ b/apps/ai-image-generator/backend/.nvmrc
@@ -1,1 +1,1 @@
-v16.18
+lts/hydrogen

--- a/apps/ai-image-generator/backend/package-lock.json
+++ b/apps/ai-image-generator/backend/package-lock.json
@@ -13,7 +13,7 @@
         "openai": "^4.0.0"
       },
       "devDependencies": {
-        "@tsconfig/node16": "^16.1.0",
+        "@tsconfig/node18": "^18.2.0",
         "@types/chai": "^4.3.5",
         "@types/mocha": "^10.0.1",
         "@types/sinon": "^10.0.16",
@@ -172,10 +172,10 @@
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
       "dev": true
     },
-    "node_modules/@tsconfig/node16": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-16.1.0.tgz",
-      "integrity": "sha512-cfwhqrdZEKS+Iqu1OPDwmKsOV/eo7q4sPhWzOXc1rU77nnPFV3+77yPg8uKQ2e8eir6mERCvrKnd+EGa4qo4bQ==",
+    "node_modules/@tsconfig/node18": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.0.tgz",
+      "integrity": "sha512-yhxwIlFVSVcMym3O31HoMnRXpoenmpIxcj4Yoes2DUpe+xCJnA7ECQP1Vw889V0jTt/2nzvpLQ/UuMYCd3JPIg==",
       "dev": true
     },
     "node_modules/@types/cacheable-request": {
@@ -2389,10 +2389,10 @@
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
       "dev": true
     },
-    "@tsconfig/node16": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-16.1.0.tgz",
-      "integrity": "sha512-cfwhqrdZEKS+Iqu1OPDwmKsOV/eo7q4sPhWzOXc1rU77nnPFV3+77yPg8uKQ2e8eir6mERCvrKnd+EGa4qo4bQ==",
+    "@tsconfig/node18": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.0.tgz",
+      "integrity": "sha512-yhxwIlFVSVcMym3O31HoMnRXpoenmpIxcj4Yoes2DUpe+xCJnA7ECQP1Vw889V0jTt/2nzvpLQ/UuMYCd3JPIg==",
       "dev": true
     },
     "@types/cacheable-request": {

--- a/apps/ai-image-generator/backend/package.json
+++ b/apps/ai-image-generator/backend/package.json
@@ -5,7 +5,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "build": "NODE_ENV=production tsc --module es6",
+    "build": "NODE_ENV=production tsc",
     "test": "NODE_ENV=test TS_NODE_TRANSPILE_ONLY=1 mocha --exit",
     "test:ci": "NODE_ENV=test TS_NODE_TRANSPILE_ONLY=1 CI=true mocha --exit",
     "test:debug": "NODE_ENV=test TS_NODE_TRANSPILE_ONLY=1 mocha -- --inspect --inspect-brk",
@@ -17,7 +17,7 @@
     "openai": "^4.0.0"
   },
   "devDependencies": {
-    "@tsconfig/node16": "^16.1.0",
+    "@tsconfig/node18": "^18.2.0",
     "@types/chai": "^4.3.5",
     "@types/mocha": "^10.0.1",
     "@types/sinon": "^10.0.16",

--- a/apps/ai-image-generator/backend/tsconfig.json
+++ b/apps/ai-image-generator/backend/tsconfig.json
@@ -1,8 +1,10 @@
 {
-  "extends": "@tsconfig/node16/tsconfig.json",
+  "extends": "@tsconfig/node18/tsconfig.json",
   "compilerOptions": {
     "outDir": "./build",
-    "sourceMap": false
+    "sourceMap": false,
+    "target": "es2022"
+
   },
   "include": ["src"],
   "exclude": ["node_modules", "**/*.spec.ts"]

--- a/apps/ai-image-generator/build-actions.js
+++ b/apps/ai-image-generator/build-actions.js
@@ -58,8 +58,8 @@ const main = async (watch = false) => {
       platform: 'node',
       outdir: 'build',
       logLevel: 'info',
-      format: 'esm',
-      target: 'es6',
+      format: 'cjs',
+      target: 'es2022',
       external: ['node:*'],
     };
 


### PR DESCRIPTION
## Purpose

Since the AIIG hosted app action is an internal org, we recently realized this will run with the Node18 runtime instead of Deno. We also fixed our development organization to be marked as "internal" to better align with this.

Doing that broke our current build settings, so we need to make some tweaks.

## Approach

* Set .nvrmc explicitly to the LTS version of Node 18 used by AWS (`lts/hydrogen`)
* Set target to `cjs` since that's what the Node18 runtime uses
* Align the `tsconfig` settings

## Dependencies and/or References

* https://aws.amazon.com/blogs/compute/node-js-18-x-runtime-now-available-in-aws-lambda/

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
