### PR TITLE
Update responses to agreed upon types

### DIFF
--- a/apps/ai-image-generator/backend/src/actions/aiig-generate-image.spec.ts
+++ b/apps/ai-image-generator/backend/src/actions/aiig-generate-image.spec.ts
@@ -8,7 +8,7 @@ import sinon from 'sinon';
 import { OpenAiApiService } from '../services/openaiApiService';
 import OpenAI from 'openai';
 import sinonChai from 'sinon-chai';
-import { handler } from './aiig-generate-image';
+import { AppActionCallResponseSuccess, handler } from './aiig-generate-image';
 import { AppInstallationProps, SysLink } from 'contentful-management';
 
 chai.use(sinonChai);
@@ -44,10 +44,10 @@ describe('aiigGenerateImage.handler', () => {
   });
 
   it('returns the images result', async () => {
-    const result = await handler(parameters, context);
-    expect(result).to.have.property('status', 201);
-    expect(result).to.have.property('prompt', parameters.prompt);
-    expect(result.images).to.include(mockImagesGenerateResponse.data[0].url);
+    const result = (await handler(parameters, context)) as AppActionCallResponseSuccess;
+    expect(result).to.have.property('ok', true);
+    expect(result.data).to.have.property('type', 'ImageCreationResult');
+    expect(result.data.images).to.deep.include(mockImagesGenerateResponse.data[0]);
   });
 
   it('calls the cma to get the api key from app installation params', async () => {


### PR DESCRIPTION
## Purpose

We need to have a fairly standard yet lightweight way to differentiate between successful and unsuccessful app action calls.

## Approach

* Implement a "result type" to differentiate between error and success
* Update the generate image action to use this format

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
