### PR TITLE
Add image type to backend result

### DIFF
--- a/apps/ai-image-generator/backend/src/actions/aiig-generate-image.spec.ts
+++ b/apps/ai-image-generator/backend/src/actions/aiig-generate-image.spec.ts
@@ -47,7 +47,10 @@ describe('aiigGenerateImage.handler', () => {
     const result = (await handler(parameters, context)) as AppActionCallResponseSuccess;
     expect(result).to.have.property('ok', true);
     expect(result.data).to.have.property('type', 'ImageCreationResult');
-    expect(result.data.images).to.deep.include(mockImagesGenerateResponse.data[0]);
+    expect(result.data.images).to.deep.include({
+      url: mockImagesGenerateResponse.data[0].url,
+      imageType: 'png',
+    });
   });
 
   it('calls the cma to get the api key from app installation params', async () => {

--- a/apps/ai-image-generator/backend/src/actions/aiig-generate-image.ts
+++ b/apps/ai-image-generator/backend/src/actions/aiig-generate-image.ts
@@ -1,6 +1,7 @@
 import { AppActionCallContext } from '@contentful/node-apps-toolkit';
 import { PlainClientAPI } from 'contentful-management';
 import { OpenAiApiService } from '../services/openaiApiService';
+import OpenAI from 'openai';
 
 interface AppActionCallParameters {
   prompt: string;
@@ -8,6 +9,7 @@ interface AppActionCallParameters {
 
 interface Image {
   url: string;
+  imageType: string;
 }
 
 // TODO: Create generic versions of success and error
@@ -57,7 +59,9 @@ export const handler = async (
     numImages: 4,
     size: '1024x1024',
   });
-  const images = openAiImages.filter((image): image is Image => !!image.url);
+  const images = openAiImages
+    .map((image) => ({ url: image.url, imageType: 'png' }))
+    .filter((image): image is Image => !!image.url);
   return {
     ok: true,
     data: {

--- a/apps/ai-image-generator/backend/src/actions/aiig-generate-image.ts
+++ b/apps/ai-image-generator/backend/src/actions/aiig-generate-image.ts
@@ -1,7 +1,6 @@
 import { AppActionCallContext } from '@contentful/node-apps-toolkit';
 import { PlainClientAPI } from 'contentful-management';
 import { OpenAiApiService } from '../services/openaiApiService';
-import OpenAI from 'openai';
 
 interface AppActionCallParameters {
   prompt: string;


### PR DESCRIPTION
## Purpose

We don't want to hardcode an assumption in the front end that image types will always be a certain type (ie png) so instead we want the backend to specify the image type explicitly.

## Approach

* Add an `imageType` attribute
* Hard code to `png` for OpenAI
* Idea is it's the second half of the mime type https://www.iana.org/assignments/media-types/media-types.xhtml#image

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
