### PR TITLE
feat: update example to make use of new interface [MONET-1335]

### DIFF
--- a/examples/hosted-delivery-function-templates/javascript/example.js
+++ b/examples/hosted-delivery-function-templates/javascript/example.js
@@ -1,33 +1,27 @@
 import { DeliveryFunctionEventType as EventType } from '@contentful/node-apps-toolkit';
-import { fetch } from 'undici';
 
 const fieldMappingHandler = (event, context) => {
   const fields = event.fields.map(({ contentTypeId, field }) => {
     return {
       contentTypeId,
       fieldId: field.id,
-      graphQLOutputType: 'Starship',
-      graphQLQueryField: 'starship',
+      graphQLOutputType: 'Foo',
+      graphQLQueryField: 'bar',
       graphQLQueryArguments: { id: '' },
     };
   });
 
   return {
-    namespace: context.appInstallationParameters.namespaceOverride || 'StarWars',
+    namespace: 'MyApp',
     fields,
   };
 };
 
 const queryHandler = (event, context) => {
-  return fetch('https://swapi-graphql.netlify.app/.netlify/functions/index', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      query: event.query,
-      operationName: event.operationName,
-      variables: event.variables,
-    }),
-  }).then((response) => response.json());
+  return {
+    data: {},
+    errors: [],
+  };
 };
 
 export const handler = (event, context) => {

--- a/examples/hosted-delivery-function-templates/javascript/example.js
+++ b/examples/hosted-delivery-function-templates/javascript/example.js
@@ -1,18 +1,21 @@
-import { DeliveryFunctionRequestEventType } from '@contentful/node-apps-toolkit';
+import { DeliveryFunctionEventType as EventType } from '@contentful/node-apps-toolkit';
 import { fetch } from 'undici';
 
 const fieldMappingHandler = (event, context) => {
-  const result = event.fields.map(({ contentTypeId, field }) => {
+  const fields = event.fields.map(({ contentTypeId, field }) => {
     return {
       contentTypeId,
       fieldId: field.id,
       graphQLOutputType: 'Starship',
       graphQLQueryField: 'starship',
-      graphQLQueryArgument: 'id',
+      graphQLQueryArguments: { id: '' },
     };
   });
 
-  return result;
+  return {
+    namespace: context.appInstallationParameters.namespaceOverride || 'StarWars',
+    fields,
+  };
 };
 
 const queryHandler = (event, context) => {
@@ -28,10 +31,10 @@ const queryHandler = (event, context) => {
 };
 
 export const handler = (event, context) => {
-  if (event.type === DeliveryFunctionRequestEventType.GRAPHQL_FIELD_MAPPING) {
+  if (event.type === EventType.GRAPHQL_FIELD_MAPPING) {
     return fieldMappingHandler(event, context);
   }
-  if (event.type === DeliveryFunctionRequestEventType.GRAPHQL_QUERY) {
+  if (event.type === EventType.GRAPHQL_QUERY) {
     return queryHandler(event, context);
   }
   throw new Error('Unknown Event');

--- a/examples/hosted-delivery-function-templates/javascript/package.json
+++ b/examples/hosted-delivery-function-templates/javascript/package.json
@@ -1,6 +1,9 @@
 {
+  "dependencies": {
+    "@contentful/node-apps-toolkit": "^2.4.0",
+    "undici": "^5.23.0"
+  },
   "devDependencies": {
-    "@contentful/node-apps-toolkit": "2.2.0",
     "esbuild": "0.19.2"
   }
 }

--- a/examples/hosted-delivery-function-templates/javascript/package.json
+++ b/examples/hosted-delivery-function-templates/javascript/package.json
@@ -1,7 +1,6 @@
 {
   "dependencies": {
-    "@contentful/node-apps-toolkit": "^2.4.0",
-    "undici": "^5.23.0"
+    "@contentful/node-apps-toolkit": "^2.4.0"
   },
   "devDependencies": {
     "esbuild": "0.19.2"

--- a/examples/hosted-delivery-function-templates/typescript/example.ts
+++ b/examples/hosted-delivery-function-templates/typescript/example.ts
@@ -1,45 +1,30 @@
 import {
-  DeliveryFunctionEventContext,
   DeliveryFunctionEventHandler as EventHandler,
   DeliveryFunctionEventType as EventType,
-  GraphQLQueryResponse,
 } from '@contentful/node-apps-toolkit';
-import { fetch } from 'undici';
 
-type AppInstallationParameters = {
-  namespaceOverride?: string;
-};
-
-const fieldMappingHandler: EventHandler<EventType.GRAPHQL_FIELD_MAPPING> = (
-  event,
-  context: DeliveryFunctionEventContext<AppInstallationParameters>
-) => {
+const fieldMappingHandler: EventHandler<EventType.GRAPHQL_FIELD_MAPPING> = (event, context) => {
   const fields = event.fields.map(({ contentTypeId, field }) => {
     return {
       contentTypeId,
       fieldId: field.id,
-      graphQLOutputType: 'Starship',
-      graphQLQueryField: 'starship',
+      graphQLOutputType: 'Foo',
+      graphQLQueryField: 'bar',
       graphQLQueryArguments: { id: '' },
     };
   });
 
   return {
-    namespace: context.appInstallationParameters.namespaceOverride || 'StarWars',
+    namespace: 'MyApp',
     fields,
   };
 };
 
 const queryHandler: EventHandler<EventType.GRAPHQL_QUERY> = (event, context) => {
-  return fetch('https://swapi-graphql.netlify.app/.netlify/functions/index', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      query: event.query,
-      operationName: event.operationName,
-      variables: event.variables,
-    }),
-  }).then((response) => response.json() as GraphQLQueryResponse);
+  return {
+    data: {},
+    errors: [],
+  };
 };
 
 export const handler: EventHandler = (event, context) => {

--- a/examples/hosted-delivery-function-templates/typescript/package.json
+++ b/examples/hosted-delivery-function-templates/typescript/package.json
@@ -1,6 +1,9 @@
 {
+  "dependencies": {
+    "@contentful/node-apps-toolkit": "^2.4.0",
+    "undici": "^5.23.0"
+  },
   "devDependencies": {
-    "@contentful/node-apps-toolkit": "2.2.0",
     "esbuild": "0.19.2"
   }
 }

--- a/examples/hosted-delivery-function-templates/typescript/package.json
+++ b/examples/hosted-delivery-function-templates/typescript/package.json
@@ -1,7 +1,6 @@
 {
   "dependencies": {
-    "@contentful/node-apps-toolkit": "^2.4.0",
-    "undici": "^5.23.0"
+    "@contentful/node-apps-toolkit": "^2.4.0"
   },
   "devDependencies": {
     "esbuild": "0.19.2"


### PR DESCRIPTION
## Purpose

The interface for Delivery Functions has changed with [this PR](https://github.com/contentful/node-apps-toolkit/pull/327)

This PR updates the `hosted-delivery-function-templates` to confirm to the new interface

In addition, the example has been expanded to include a minimal setup to call a GraphQL API to better show developers how they could implement custom delivery functions for their own GraphQL API

Note that the example does call a publicly hosted Starwars GraphQL API. If this is not an appropriate API we can easily change it with a different one.