### PR TITLE
[INTEG-1044] Remove hidden fields from field selectors

### DIFF
--- a/apps/ai-content-generator/src/utils/dialog/supported-fields/supportedFieldsHelpers.ts
+++ b/apps/ai-content-generator/src/utils/dialog/supported-fields/supportedFieldsHelpers.ts
@@ -66,11 +66,9 @@ const sortFieldOptionsByLanguage = (a: Field, b: Field) => {
 };
 
 /**
- * A reducer function that checks if a field is a supported type, iterates through its supported locales,
+ * A reducer function that checks if a field is a supported type and is visible, iterates through its supported locales,
  * determines whether it has content, and assigns the field to the correct column.
  *
- * TODO: Handle the case where the field is empty
- * TODO: Support storing fields for both Source and Output
  * @param entry
  * @param supportedFields
  * @param fieldLocales
@@ -87,8 +85,9 @@ const isSupported = (
 ) => {
   return (fieldAcc: SupportedFieldsOutput, field: ContentFields) => {
     const isSupportedFieldType = supportedFields.includes(field.type as SupportedFieldTypes);
+    const isFieldVisible = !field.disabled;
 
-    if (isSupportedFieldType) {
+    if (isSupportedFieldType && isFieldVisible) {
       const fieldsWithContent = [] as Field[];
       const allFields = [] as Field[];
 


### PR DESCRIPTION
## Purpose

This PR filters out fields that are marked as `Hidden when editing` so that they are not available as an option in the field selectors in the AICG modal.

## Approach

The field property is called `field.disabled`, so I filtered out fields set to true.

## Testing steps

Add a text field on a content type and mark it as `Hidden when editing`. You should not see it as an option in the modal for either source or output field.
