### PR TITLE
Bug fix - Optimizely App - variation container allows incorrect variant type to be selected on first render

### DIFF
--- a/apps/optimizely/src/EditorPage/index.js
+++ b/apps/optimizely/src/EditorPage/index.js
@@ -78,12 +78,43 @@ const getInitialValue = (sdk) => ({
   experimentsResults: {},
 });
 
+/**
+ * Get entries linked to a list of entries
+ * 
+ * @description Due to Contentful auto-saving after the entry has been created but not before the getEntries might return incorrect response and require a retry until the linked has been created by Contentful
+ * 
+ */
+const getEntriesLinkedByIds = async (space, entryIds) => {
+  const DELAY_IN_MILLISECONDS = 5000;
+  const RETRY_LIMIT = 5;
+
+  let retries = 0;
+
+  while (retries < RETRY_LIMIT) {
+    const entriesRes = await space.getEntries({
+      links_to_entry: entryIds,
+      skip: 0,
+      limit: 1000,
+    });
+
+    if (entriesRes.items.length) {
+      return entriesRes;
+    } else {
+      retries++;
+      await new Promise(resolve => setTimeout(resolve, DELAY_IN_MILLISECONDS));
+    }
+  }
+
+  throw new Error('Failed to retrieve entries after retries');
+};
+
+
 const fetchInitialData = async (sdk, client) => {
   const { space, ids, locales } = sdk;
 
   const [contentTypesRes, entriesRes, experiments] = await Promise.all([
     space.getContentTypes({ order: 'name', limit: 1000 }),
-    space.getEntries({ links_to_entry: ids.entry, skip: 0, limit: 1000 }),
+    getEntriesLinkedByIds(space, ids.entry),
     client.getExperiments(),
   ]);
 


### PR DESCRIPTION
Fixed #3790

## Purpose

<!-- Why are we introducing this change now? What problem does it solve? What is the story/background for it? -->

Fixes #3790

## Approach

<!-- Why did we do it the way we did? Did we consider alternatives? What other implementation details or artifacts (screenshots etc.) would help reviewers contextualize change? -->

## Testing steps

Ran the `npm test` from the Optimizely app

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
