### PR TITLE
[INTEG-1147] Add default max length to char validation

### DIFF
--- a/apps/ai-content-generator/src/utils/dialog/supported-fields/supportedFieldsHelpers.ts
+++ b/apps/ai-content-generator/src/utils/dialog/supported-fields/supportedFieldsHelpers.ts
@@ -33,9 +33,8 @@ const createSizeValidation = (
     size: { max: defaultMax },
   };
 
-  if (customSizeValidation.size) {
-    const newMax = customSizeValidation.size?.max ? customSizeValidation.size.max : defaultMax;
-    customSizeValidation.size.max = newMax;
+  if (customSizeValidation.size && !customSizeValidation.size?.max) {
+    customSizeValidation.size.max = defaultMax;
   }
 
   return customSizeValidation;


### PR DESCRIPTION
## Purpose

For AI Content Generator, we noticed an issue with applying the content to fields. We were handling fields where there was custom size validation, but if there was no custom size validation, then we were not respecting the [default field character length](https://www.contentful.com/developers/docs/technical-limits/). For example, Short Text fields have a default max length of 256 characters. If you had a Short Text field and wanted to output content there that was 500 characters, the apply button was still enabled, you could click it, but then it wouldn't apply and a useful error was not being shown to the user.

## Approach

To fix this, I leaned into our existing handling for character count validation. I added a method when formatting the field response to add in a max length if one doesn't exist. If there was a custom max length, I defaulted to that instead. I added handling for the 3 field types that we support: Short Text, Long Text, and Rich Text.

## Testing steps

Create a Short Text field with no custom validation. Try to add content from the modal that's length is more than 256 characters. It should now prevent you from doing so.
