### PR TITLE
Add aiig staging sandbox that acts like our development sandbox

### DIFF
--- a/apps/ai-image-generator/package.json
+++ b/apps/ai-image-generator/package.json
@@ -9,7 +9,8 @@
     "build-backend": "cd backend && npm ci && cd .. && npm run build-actions",
     "build-frontend": "cd frontend && npm ci --include=dev && BUILD_PATH=../build npm run build",
     "deploy": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEFINITIONS_ORG_ID} --definition-id 3RheWQRagirMFgWrhMOBxL --token ${CONTENTFUL_CMA_TOKEN}",
-    "deploy:test": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEV_TESTING_ORG_ID} --definition-id 6H2pUZdiYcmo0WY8dlYZn5 --token ${TEST_CMA_TOKEN}"
+    "deploy:test": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEV_TESTING_ORG_ID} --definition-id 6H2pUZdiYcmo0WY8dlYZn5 --token ${TEST_CMA_TOKEN}",
+    "deploy:sandbox": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEV_TESTING_ORG_ID} --definition-id 3vLfusuPgGHcydK5ET8IcG --token ${TEST_CMA_TOKEN}"
   },
   "dependencies": {
     "@contentful/app-scripts": "1.10.2",


### PR DESCRIPTION
## Purpose
We are at the point in aiig where it's important to have a stable staging so that the frontend can keep developing from a consistent backend/app action.

But we also want to ability to test backend changes and since HAA doesn't have local development abilities, having a separate app that acts like a sandbox where we can just deploy freely to that app is a decent workaround.

## Approach
Make sure app defn ids match

## Testing steps
`npm run build`
`npm run deploy:sandbox`

## Breaking Changes
None

## Dependencies and/or References
None

## Deployment
Standard