### PR TITLE
[INTEG-1186] Success and error notification on apply

### DIFF
--- a/apps/ai-content-generator/src/hooks/dialog/useEntryAndContentType.ts
+++ b/apps/ai-content-generator/src/hooks/dialog/useEntryAndContentType.ts
@@ -63,8 +63,10 @@ const useEntryAndContentType = (entryId: string) => {
         entry
       );
 
+      sdk.notifier.success('Content applied successfully.');
       return true;
     } catch (error) {
+      sdk.notifier.error('Content did not apply successfully. Please try again.');
       console.error(error);
       return false;
     }

--- a/apps/ai-content-generator/src/hooks/dialog/useEntryAndContentTypes.spec.ts
+++ b/apps/ai-content-generator/src/hooks/dialog/useEntryAndContentTypes.spec.ts
@@ -1,0 +1,30 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import useEntryAndContentType from './useEntryAndContentType';
+import {
+  mockCma,
+  MockSdk,
+  mockSdkParameters,
+  mockContentTypes,
+  mockEntry,
+} from '../../../test/mocks';
+
+const mockSdk = new MockSdk(mockSdkParameters.happyPath);
+const sdk = mockSdk.sdk;
+
+vi.mock('@contentful/react-apps-toolkit', () => ({
+  useSDK: () => sdk,
+  useCMA: () => mockCma,
+}));
+
+describe('useEntryAndContentType', () => {
+  it('should return the entry, the content type for the entry, and updateEntry function', async () => {
+    const { result } = renderHook(() => useEntryAndContentType('abc123'));
+
+    await waitFor(() => {
+      expect(result.current).toHaveProperty('entry', mockEntry);
+      expect(result.current).toHaveProperty('contentType', mockContentTypes.mockContentType);
+      expect(result.current).toHaveProperty('updateEntry');
+    });
+  });
+});

--- a/apps/ai-content-generator/test/mocks/index.ts
+++ b/apps/ai-content-generator/test/mocks/index.ts
@@ -3,3 +3,4 @@ export { MockSdk } from './sdk/mockSdk';
 export * as mockSdkParameters from './sdk/parameters';
 export { generateRandomParameters } from './sdk/utils/generateRandomParameters';
 export * as mockContentTypes from './sdk/contentTypes/mockContentType';
+export { mockEntry } from './sdk/entry/mockEntry';

--- a/apps/ai-content-generator/test/mocks/sdk/entry/mockEntry.ts
+++ b/apps/ai-content-generator/test/mocks/sdk/entry/mockEntry.ts
@@ -1,0 +1,56 @@
+const mockEntry = {
+  metadata: {
+    tags: [],
+  },
+  sys: {
+    space: {
+      sys: {
+        type: 'Link',
+        linkType: 'Space',
+        id: '123456',
+      },
+    },
+    id: 'abc123',
+    type: 'Entry',
+    createdAt: '2023-08-25T15:10:27.806Z',
+    updatedAt: '2023-09-01T00:46:53.890Z',
+    environment: {
+      sys: {
+        id: 'staging',
+        type: 'Link',
+        linkType: 'Environment',
+      },
+    },
+    createdBy: {
+      sys: {
+        type: 'Link',
+        linkType: 'User',
+        id: 'qwerty890',
+      },
+    },
+    updatedBy: {
+      sys: {
+        type: 'Link',
+        linkType: 'User',
+        id: 'qwerty890',
+      },
+    },
+    publishedCounter: 0,
+    version: 4,
+    automationTags: [],
+    contentType: {
+      sys: {
+        type: 'Link',
+        linkType: 'ContentType',
+        id: 'page',
+      },
+    },
+  },
+  fields: {
+    title: {
+      'en-US': 'Sample Title',
+    },
+  },
+};
+
+export { mockEntry };

--- a/apps/ai-content-generator/test/mocks/sdk/mockSdk.ts
+++ b/apps/ai-content-generator/test/mocks/sdk/mockSdk.ts
@@ -2,7 +2,12 @@ import { AppInstallationParameters } from '@locations/ConfigScreen';
 import { mockSdkParameters } from '..';
 import { createSDK } from './utils/createSdk';
 import { vi } from 'vitest';
-import { mockGetManyContentType, mockEditorInterface } from './contentTypes/mockContentType';
+import {
+  mockGetManyContentType,
+  mockEditorInterface,
+  mockContentType,
+} from './contentTypes/mockContentType';
+import { mockEntry } from './entry/mockEntry';
 
 interface MockSdk {
   sdk: ReturnType<typeof createSDK>;
@@ -30,6 +35,8 @@ class MockSdk {
       .mockReturnValue({ EditorInterface: mockEditorInterface });
     this.sdk.notifier.error = vi.fn();
     this.sdk.cma.contentType.getMany = vi.fn().mockReturnValue(mockGetManyContentType);
+    this.sdk.cma.contentType.get = vi.fn().mockReturnValue(mockContentType);
+    this.sdk.cma.entry.get = vi.fn().mockReturnValue(mockEntry);
   }
 }
 

--- a/apps/ai-content-generator/test/mocks/sdk/utils/createSdk.ts
+++ b/apps/ai-content-generator/test/mocks/sdk/utils/createSdk.ts
@@ -1,6 +1,11 @@
 import { AppInstallationParameters } from '@locations/ConfigScreen';
 import { vi } from 'vitest';
-import { mockGetManyContentType, mockEditorInterface } from '../contentTypes/mockContentType';
+import {
+  mockGetManyContentType,
+  mockEditorInterface,
+  mockContentType,
+} from '../contentTypes/mockContentType';
+import { mockEntry } from '../entry/mockEntry';
 
 const createSDK = (parameters: AppInstallationParameters) => {
   return {
@@ -19,6 +24,10 @@ const createSDK = (parameters: AppInstallationParameters) => {
     cma: {
       contentType: {
         getMany: vi.fn().mockReturnValueOnce(mockGetManyContentType),
+        get: vi.fn().mockReturnValueOnce(mockContentType),
+      },
+      entry: {
+        get: vi.fn().mockReturnValueOnce(mockEntry),
       },
     },
   };


### PR DESCRIPTION
## Purpose

For AI Content Generator, we want users to know whether their content from the modal has been successfully applied or not. 

## Approach

Added notifications for when content is applied successfully and when there is an error. For the error, the modal remains open so that users will not lose their work in the modal. For success, the modal closes and the notification appears. I also added a test for the `useEntryAndContentTypes` hook.

Screenshots:
![Screenshot 2023-09-01 at 8 02 17 AM](https://github.com/contentful/apps/assets/62958907/cdef99c6-9295-4a88-8cfa-49cb27ca1fd5)

![Screenshot 2023-09-01 at 8 01 12 AM](https://github.com/contentful/apps/assets/62958907/676ecb43-68c7-42ae-abb6-d62dff785f39)

## Testing steps

Success notification should appear when you click "Apply" for any action.
