### PR TITLE
fixes GA4 tests and cma usage

### DIFF
--- a/apps/google-analytics-4/frontend/src/apis/api.ts
+++ b/apps/google-analytics-4/frontend/src/apis/api.ts
@@ -1,5 +1,4 @@
 import { config } from '../config';
-import { PlainClientAPI } from 'contentful-management';
 import {
   ServiceAccountKeyId,
   ServiceAccountKey,
@@ -19,6 +18,7 @@ import {
   RunReportData,
 } from 'apis/apiTypes';
 import { upperFirst } from 'lodash';
+import { CMAClient } from '@contentful/app-sdk';
 
 export class ApiError extends Error {
   details: string;
@@ -37,11 +37,11 @@ export class Api {
   readonly baseUrl: string;
   readonly contentfulContext: ContentfulContext;
   readonly serviceAccountKeyId: ServiceAccountKeyId;
-  readonly cma: PlainClientAPI;
+  readonly cma: CMAClient;
 
   constructor(
     contentfulContext: ContentfulContext,
-    cma: PlainClientAPI,
+    cma: CMAClient,
     serviceAccountKeyId: ServiceAccountKeyId
   ) {
     this.baseUrl = config.backendApiUrl;

--- a/apps/google-analytics-4/frontend/src/apis/fetchApi.ts
+++ b/apps/google-analytics-4/frontend/src/apis/fetchApi.ts
@@ -1,14 +1,14 @@
 import { z } from 'zod';
 import fetchWithSignedRequest from '../helpers/signed-requests';
-import { PlainClientAPI } from 'contentful-management';
 import { ApiError } from 'apis/api';
 import { Headers, ApiErrorType, ERROR_TYPE_MAP, ZApiErrorResponse } from 'apis/apiTypes';
+import { CMAClient } from '@contentful/app-sdk';
 
 export async function fetchFromApi<T>(
   apiUrl: URL,
   schema: z.ZodTypeAny,
   appDefinitionId: string,
-  cma: PlainClientAPI,
+  cma: CMAClient,
   headers: Headers = {}
 ): Promise<T> {
   const response = await fetchResponse(apiUrl, appDefinitionId, cma, headers);
@@ -21,7 +21,7 @@ export async function fetchFromApi<T>(
 async function fetchResponse(
   url: URL,
   appDefinitionId: string,
-  cma: PlainClientAPI,
+  cma: CMAClient,
   headers: Headers
 ): Promise<Response> {
   try {

--- a/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage/GoogleAnalyticsConfigPage.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage/GoogleAnalyticsConfigPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { AppExtensionSDK, AppState, EditorInterface } from '@contentful/app-sdk';
-import { useCMA, useSDK } from '@contentful/react-apps-toolkit';
+import { useSDK } from '@contentful/react-apps-toolkit';
 import { isEmpty } from 'lodash';
 import GoogleAnalyticsIcon from 'components/common/GoogleAnalyticsIcon';
 import { styles } from 'components/config-screen/GoogleAnalyticsConfigPage/GoogleAnalyticsConfigPage.styles';
@@ -36,7 +36,7 @@ export default function GoogleAnalyticsConfigPage() {
   const [isApiAccessLoading, setIsApiAccessLoading] = useState(true);
 
   const sdk = useSDK<AppExtensionSDK>();
-  const cma = useCMA();
+  const cma = sdk.cma;
 
   const handleHasServiceCheckErrorsChange = (hasErrors: boolean) => {
     setHasServiceCheckErrors(hasErrors);

--- a/apps/google-analytics-4/frontend/src/helpers/signed-requests.ts
+++ b/apps/google-analytics-4/frontend/src/helpers/signed-requests.ts
@@ -1,11 +1,11 @@
+import { CMAClient } from '@contentful/app-sdk';
 import { ServiceAccountKey } from '../types';
 import { CreateAppSignedRequestProps } from 'contentful-management/dist/typings/entities/app-signed-request';
-import { PlainClientAPI } from 'contentful-management/dist/typings/plain/common-types';
 
 async function fetchWithSignedRequest(
   url: URL,
   appDefinitionId: string,
-  cma: PlainClientAPI,
+  cma: CMAClient,
   method: CreateAppSignedRequestProps['method'] = 'GET',
   unsignedHeaders: Record<string, string> = {},
   body?: ServiceAccountKey

--- a/apps/google-analytics-4/frontend/src/hooks/useSidebarSlug/useSidebarSlug.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/hooks/useSidebarSlug/useSidebarSlug.spec.tsx
@@ -4,7 +4,7 @@ import { render, screen } from '@testing-library/react';
 import * as useSDK from '@contentful/react-apps-toolkit';
 import { ContentTypeValue } from 'types';
 import * as getFieldValue from '../useGetFieldValue';
-import { ContentEntitySys } from '@contentful/app-sdk';
+import { ContentEntitySys, EntrySys } from '@contentful/app-sdk';
 
 jest.mock('@contentful/react-apps-toolkit', () => ({ useSDK: jest.fn() }));
 
@@ -43,11 +43,12 @@ describe('useSidebarSlug hook', () => {
     jest.spyOn(useSDK, 'useSDK').mockImplementation(() => ({
       ...jest.requireActual('@contentful/react-apps-toolkit'),
       entry: {
+        ...jest.requireActual('@contentful/react-apps-toolkit').entry,
         fields: { slugField: {} },
         onSysChanged: jest.fn((cb) =>
           cb({
             publishedAt: '2020202',
-          } as unknown as ContentEntitySys)
+          } as unknown as EntrySys)
         ),
       },
     }));
@@ -68,11 +69,12 @@ describe('useSidebarSlug hook', () => {
     jest.spyOn(useSDK, 'useSDK').mockImplementation(() => ({
       ...jest.requireActual('@contentful/react-apps-toolkit'),
       entry: {
+        ...jest.requireActual('@contentful/react-apps-toolkit').entry,
         fields: {},
         onSysChanged: jest.fn((cb) =>
           cb({
             publishedAt: '',
-          } as unknown as ContentEntitySys)
+          } as unknown as EntrySys)
         ),
       },
     }));
@@ -94,11 +96,12 @@ describe('useSidebarSlug hook', () => {
     jest.spyOn(useSDK, 'useSDK').mockImplementation(() => ({
       ...jest.requireActual('@contentful/react-apps-toolkit'),
       entry: {
+        ...jest.requireActual('@contentful/react-apps-toolkit').entry,
         fields: { slugField: {} },
         onSysChanged: jest.fn((cb) =>
           cb({
             publishedAt: '2020202',
-          } as unknown as ContentEntitySys)
+          } as unknown as EntrySys)
         ),
       },
     }));

--- a/apps/google-analytics-4/frontend/src/hooks/useSidebarSlug/useSidebarSlug.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/hooks/useSidebarSlug/useSidebarSlug.spec.tsx
@@ -4,7 +4,7 @@ import { render, screen } from '@testing-library/react';
 import * as useSDK from '@contentful/react-apps-toolkit';
 import { ContentTypeValue } from 'types';
 import * as getFieldValue from '../useGetFieldValue';
-import { ContentEntitySys, EntrySys } from '@contentful/app-sdk';
+import { EntrySys } from '@contentful/app-sdk';
 
 jest.mock('@contentful/react-apps-toolkit', () => ({ useSDK: jest.fn() }));
 

--- a/apps/google-analytics-4/frontend/test/mocks/mockSdk.ts
+++ b/apps/google-analytics-4/frontend/test/mocks/mockSdk.ts
@@ -7,6 +7,34 @@ const mockSdk: any = {
     isInstalled: jest.fn(),
     onConfigurationCompleted: jest.fn(),
   },
+  cma: {
+    appSignedRequest: {
+      create: () => ({}),
+    },
+    getSpace: () => ({
+      getEnvironment: () => ({
+        getContentTypes: () => ({
+          description:
+            'A series of lessons designed to teach sets of concepts that enable students to master Contentful.',
+          displayField: 'title',
+          name: 'Course',
+          fields: [
+            {
+              course: {
+                disabled: false,
+                id: 'title',
+                localized: true,
+                name: 'Title',
+                omitted: false,
+                required: true,
+                type: 'Symbol',
+              },
+            },
+          ],
+        }),
+      }),
+    }),
+  },
   ids: {
     app: 'test-app',
     user: 'user-id',


### PR DESCRIPTION
## Purpose

GA4 broke when I merged, this will fix it.

The tests were failing and the typing of the CMA changed when the SDK was updated