### PR TITLE
fix: remove sdk hook from netlify so it renders

### DIFF
--- a/apps/netlify/frontend/package-lock.json
+++ b/apps/netlify/frontend/package-lock.json
@@ -13,7 +13,6 @@
         "@contentful/f36-icons": "^4.1.1",
         "@contentful/f36-tokens": "^4.0.0",
         "@contentful/forma-36-fcss": "0.3.5",
-        "@contentful/react-apps-toolkit": "^1.2.16",
         "date-fns": "2.30.0",
         "emotion": "10.0.27",
         "lodash.get": "4.4.2",
@@ -2572,18 +2571,6 @@
       "version": "0.11.2",
       "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.11.2.tgz",
       "integrity": "sha512-qjhKZahSQWQl6spebKycVTZF7Cnf4DBPh6QMoyM6YFmtbFlNfVpz8eKaO/C0hiVaBCjeN7wX/Jl6fdG+IovCgw=="
-    },
-    "node_modules/@contentful/react-apps-toolkit": {
-      "version": "1.2.16",
-      "resolved": "https://registry.npmjs.org/@contentful/react-apps-toolkit/-/react-apps-toolkit-1.2.16.tgz",
-      "integrity": "sha512-vx7+T4h+w1XBbn7OfRoXr8YUTtiyRNLaltF2ziM4xMqBryu/3Y71nBbhbxD6NIfOui3QIo3TR9Q5sPTZvGbIVw==",
-      "dependencies": {
-        "contentful-management": ">=7.30.0"
-      },
-      "peerDependencies": {
-        "@contentful/app-sdk": ">=4.0.0",
-        "react": ">=16.8.0"
-      }
     },
     "node_modules/@contentful/rich-text-types": {
       "version": "16.0.3",

--- a/apps/netlify/frontend/package.json
+++ b/apps/netlify/frontend/package.json
@@ -14,7 +14,6 @@
     "@contentful/f36-icons": "^4.1.1",
     "@contentful/f36-tokens": "^4.0.0",
     "@contentful/forma-36-fcss": "0.3.5",
-    "@contentful/react-apps-toolkit": "^1.2.16",
     "date-fns": "2.30.0",
     "emotion": "10.0.27",
     "lodash.get": "4.4.2",

--- a/apps/netlify/frontend/src/app/index.js
+++ b/apps/netlify/frontend/src/app/index.js
@@ -208,6 +208,7 @@ export default class NetlifyAppConfig extends React.Component {
               space={space}
               environment={environment}
               disabled={disabled}
+              hostnames={sdk.hostnames}
               contentTypes={this.state.contentTypes}
               enabledContentTypes={this.state.enabledContentTypes}
               onEnabledContentTypesChange={this.onEnabledContentTypesChange}

--- a/apps/netlify/frontend/src/app/netlify-content-types.js
+++ b/apps/netlify/frontend/src/app/netlify-content-types.js
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import { Note, Text, TextLink, Heading, Paragraph, Checkbox } from '@contentful/f36-components';
 import { css } from 'emotion';
 import tokens from '@contentful/f36-tokens';
-import { useSDK } from '@contentful/react-apps-toolkit';
 
 const styles = {
   selectAllCheckbox: css({
@@ -24,8 +23,8 @@ const NetlifyContentTypes = ({
   disabled,
   space,
   environment,
+  hostnames,
 }) => {
-  const sdk = useSDK();
   const allSelected = contentTypes.length === enabledContentTypes.length;
 
   const onChange = (e) => {
@@ -59,8 +58,8 @@ const NetlifyContentTypes = ({
             rel="noopener noreferrer"
             href={
               environment === 'master'
-                ? `https://${sdk.hostnames.webapp}/spaces/${space}/content_types`
-                : `https://${sdk.hostnames.webapp}/spaces/${space}/environments/${environment}/content_types`
+                ? `https://${hostnames.webapp}/spaces/${space}/content_types`
+                : `https://${hostnames.webapp}/spaces/${space}/environments/${environment}/content_types`
             }>
             content type
           </TextLink>{' '}
@@ -95,6 +94,7 @@ NetlifyContentTypes.propTypes = {
   contentTypes: PropTypes.array.isRequired,
   enabledContentTypes: PropTypes.array.isRequired,
   onEnabledContentTypesChange: PropTypes.func.isRequired,
+  hostnames: PropTypes.object.isRequired,
 };
 
 export default NetlifyContentTypes;

--- a/apps/netlify/frontend/src/index.js
+++ b/apps/netlify/frontend/src/index.js
@@ -4,7 +4,6 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 import { init, locations } from '@contentful/app-sdk';
-import { SDKProvider } from '@contentful/app-sdk';
 
 import '@contentful/forma-36-fcss/dist/styles.css';
 
@@ -15,18 +14,8 @@ init((sdk) => {
   const root = document.getElementById('root');
 
   if (sdk.location.is(locations.LOCATION_APP_CONFIG)) {
-    ReactDOM.render(
-      <SDKProvider>
-        <NetlifyAppConfig sdk={sdk} />
-      </SDKProvider>,
-      root
-    );
+    ReactDOM.render(<NetlifyAppConfig sdk={sdk} />, root);
   } else if (sdk.location.is(locations.LOCATION_ENTRY_SIDEBAR)) {
-    ReactDOM.render(
-      <SDKProvider>
-        <NeflifySidebar sdk={sdk} />
-      </SDKProvider>,
-      root
-    );
+    ReactDOM.render(<NeflifySidebar sdk={sdk} />, root);
   }
 });


### PR DESCRIPTION
## Purpose

Netlify wasn't rendering after our EU Data residency changes

## Approach

Instead of using hooks to access the SDK, we are just passing down the relevant SDK property from the parent. Probably should have done this anyways since it's consistent with the current codebase