### PR TITLE
AIIG: update brush color in backend

### DIFF
--- a/apps/ai-image-generator/backend/src/transform-images.ts
+++ b/apps/ai-image-generator/backend/src/transform-images.ts
@@ -2,7 +2,7 @@ import * as nodeFetch from 'node-fetch';
 import { default as sharp } from 'sharp';
 import { areEqualColors, toRGBA, toSharp } from './utils';
 
-export const ERASE_COLOR: sharp.RGBA = { r: 174, g: 193, b: 204 };
+export const ERASE_COLOR: sharp.RGBA = { r: 231, g: 235, b: 238 };
 export const MAX_SIDE = 1024;
 
 interface TransformedImages {


### PR DESCRIPTION
## Purpose

This PR updates the brush color (`ERASE_COLOR`) to match the gray200 being used on the frontend in [this](https://github.com/contentful/experience-packages/pull/2297) PR. 

