### PR TITLE
fix: avoid relying on node-apps-toolkit on runtime [MONET-1463]

### DIFF
--- a/examples/hosted-delivery-function-templates/javascript/example.js
+++ b/examples/hosted-delivery-function-templates/javascript/example.js
@@ -1,4 +1,7 @@
-import { DeliveryFunctionEventType as EventType } from '@contentful/node-apps-toolkit';
+const EventType = {
+  GRAPHQL_FIELD_MAPPING: 'graphql.field.mapping',
+  GRAPHQL_QUERY: 'graphql.query',
+};
 
 const fieldMappingHandler = (event, context) => {
   const fields = event.fields.map(({ contentTypeId, field }) => {

--- a/examples/hosted-delivery-function-templates/javascript/package.json
+++ b/examples/hosted-delivery-function-templates/javascript/package.json
@@ -1,7 +1,4 @@
 {
-  "dependencies": {
-    "@contentful/node-apps-toolkit": "^2.5.2"
-  },
   "devDependencies": {
     "esbuild": "0.19.2"
   }

--- a/examples/hosted-delivery-function-templates/typescript/example.ts
+++ b/examples/hosted-delivery-function-templates/typescript/example.ts
@@ -1,7 +1,9 @@
-import {
-  DeliveryFunctionEventHandler as EventHandler,
-  DeliveryFunctionEventType as EventType,
-} from '@contentful/node-apps-toolkit';
+import { DeliveryFunctionEventHandler as EventHandler } from '@contentful/node-apps-toolkit';
+
+enum EventType {
+  GRAPHQL_FIELD_MAPPING = 'graphql.field.mapping',
+  GRAPHQL_QUERY = 'graphql.query',
+}
 
 const fieldMappingHandler: EventHandler<EventType.GRAPHQL_FIELD_MAPPING> = (event, context) => {
   const fields = event.fields.map(({ contentTypeId, field }) => {

--- a/examples/hosted-delivery-function-templates/typescript/package.json
+++ b/examples/hosted-delivery-function-templates/typescript/package.json
@@ -1,8 +1,6 @@
 {
-  "dependencies": {
-    "@contentful/node-apps-toolkit": "^2.5.2"
-  },
   "devDependencies": {
+    "@contentful/node-apps-toolkit": "^2.5.2",
     "esbuild": "0.19.2"
   }
 }


### PR DESCRIPTION
## Purpose

node-apps-toolkit is built into commonjs which throws errors in runtime as it's not "treeshakeable". Trying to modify the library to build into esm is too complicated to support both commonjs & esm. It's doesn't make much sense to do a major version upgrade just because of this tiny change.

## Approach

Hardcode the enum for now

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
