### PR TITLE
[INTEG-1181] Update AICG config page error handling

### DIFF
--- a/apps/ai-content-generator/src/components/config/config-page/ConfigPage.tsx
+++ b/apps/ai-content-generator/src/components/config/config-page/ConfigPage.tsx
@@ -1,4 +1,4 @@
-import { useReducer } from 'react';
+import { useReducer, useState } from 'react';
 import { Box, Heading } from '@contentful/f36-components';
 import ConfigSection from '@components/config/config-section/ConfigSection';
 import CostSection from '@components/config/cost-section/CostSection';
@@ -11,10 +11,12 @@ import { defaultModelId } from '@configs/ai/gptModels';
 import useInitializeParameters from '@hooks/config/useInitializeParameters';
 import useSaveConfigHandler from '@hooks/config/useSaveConfigHandler';
 import useGetContentTypes from '@hooks/config/useGetContentTypes';
-import parameterReducer from '@components/config/parameterReducer';
+import parameterReducer, { ParameterAction } from '@components/config/parameterReducer';
 import contentTypeReducer from '@components/config/contentTypeReducer';
 import { AppInstallationParameters } from '@locations/ConfigScreen';
 import { ConfigErrors } from '@components/config/configText';
+import AI from '@utils/aiApi';
+import { modelsBaseUrl } from '@configs/ai/baseUrl';
 
 const initialParameters: AppInstallationParameters = {
   model: defaultModelId,
@@ -27,16 +29,29 @@ const initialContentTypes: Set<string> = new Set();
 const ConfigPage = () => {
   const [parameters, dispatchParameters] = useReducer(parameterReducer, initialParameters);
   const [contentTypes, dispatchContentTypes] = useReducer(contentTypeReducer, initialContentTypes);
+  const [isApiKeyValid, setIsApiKeyValid] = useState(true);
+  const [localApiKey, setLocalApiKey] = useState('');
 
-  const validateParams = (params: AppInstallationParameters): string[] => {
+  const validateApiKey = async (key: string): Promise<boolean> => {
+    const ai = new AI(modelsBaseUrl, key, '');
+    const isApiKeyValid = await ai.isApiKeyValid();
+    setIsApiKeyValid(isApiKeyValid);
+
+    return isApiKeyValid;
+  };
+
+  const validateParams = async (params: AppInstallationParameters): Promise<string[]> => {
     const notifierErrors = [];
+    const isApiKeyValid = await validateApiKey(params.apiKey);
 
-    if (!params.apiKey) {
-      notifierErrors.push(ConfigErrors.missingApiKey);
+    if (!isApiKeyValid) {
+      notifierErrors.push(`${ConfigErrors.failedToSave} ${ConfigErrors.missingApiKey}`);
+    } else {
+      setLocalApiKey('');
     }
 
     if (!params.model) {
-      notifierErrors.push(ConfigErrors.missingModel);
+      notifierErrors.push(`${ConfigErrors.failedToSave} ${ConfigErrors.missingModel}`);
     }
 
     if (!params.profile.profile) {
@@ -44,6 +59,11 @@ const ConfigPage = () => {
     }
 
     return notifierErrors;
+  };
+
+  const handleApiKeyChange = (key: string) => {
+    setLocalApiKey(key);
+    dispatchParameters({ type: ParameterAction.UPDATE_APIKEY, value: key });
   };
 
   useSaveConfigHandler(parameters, validateParams, contentTypes);
@@ -58,6 +78,10 @@ const ConfigPage = () => {
         apiKey={parameters.apiKey}
         model={parameters.model}
         dispatch={dispatchParameters}
+        isApiKeyValid={isApiKeyValid}
+        localApiKey={localApiKey}
+        onApiKeyChange={handleApiKeyChange}
+        validateApiKey={validateApiKey}
       />
       <hr css={styles.splitter} />
       <CostSection />

--- a/apps/ai-content-generator/src/components/config/config-page/ConfigPage.tsx
+++ b/apps/ai-content-generator/src/components/config/config-page/ConfigPage.tsx
@@ -54,10 +54,6 @@ const ConfigPage = () => {
       notifierErrors.push(`${ConfigErrors.failedToSave} ${ConfigErrors.missingModel}`);
     }
 
-    if (!params.profile.profile) {
-      notifierErrors.push(ConfigErrors.missingProfile);
-    }
-
     return notifierErrors;
   };
 

--- a/apps/ai-content-generator/src/components/config/config-section/ConfigSection.tsx
+++ b/apps/ai-content-generator/src/components/config/config-section/ConfigSection.tsx
@@ -9,17 +9,28 @@ interface Props {
   apiKey: string;
   model: string;
   dispatch: Dispatch<ParameterReducer>;
+  isApiKeyValid: boolean;
+  localApiKey: string;
+  onApiKeyChange: (key: string) => void;
+  validateApiKey: (key: string) => Promise<boolean>;
 }
 
 const ConfigSection = (props: Props) => {
-  const { apiKey, model, dispatch } = props;
+  const { apiKey, model, dispatch, isApiKeyValid, localApiKey, onApiKeyChange, validateApiKey } =
+    props;
 
   return (
     <Flex flexDirection="column" alignItems="flex-start" fullWidth={true}>
       <Subheading>{Sections.configHeading}</Subheading>
       <Box>
         <Form>
-          <APIKey apiKey={apiKey} dispatch={dispatch} />
+          <APIKey
+            apiKey={apiKey}
+            isInvalid={!isApiKeyValid}
+            localApiKey={localApiKey}
+            onApiKeyChange={onApiKeyChange}
+            validateApiKey={validateApiKey}
+          />
           <Model model={model} dispatch={dispatch} />
         </Form>
       </Box>

--- a/apps/ai-content-generator/src/components/config/configText.ts
+++ b/apps/ai-content-generator/src/components/config/configText.ts
@@ -103,12 +103,13 @@ const Sections = {
 };
 
 const ConfigErrors = {
-  missingApiKey: 'A valid API key is required',
+  missingApiKey: 'Invalid or missing API Key',
   missingModel: 'A valid model must be selected',
   missingProfile: 'Please enter a brand profile',
   noContentTypes:
     'There are no content types available in this environment. You can add a content type and then assign it to the app from this screen.',
   noContentTypesSubstring: 'add a content type',
+  failedToSave: 'Failed to save:',
 };
 
 const ContentTypeText = {

--- a/apps/ai-content-generator/src/components/config/configText.ts
+++ b/apps/ai-content-generator/src/components/config/configText.ts
@@ -26,42 +26,36 @@ const BrandProfileFields = [
     id: ProfileFields.PROFILE,
     title: 'Describe your brand or product.',
     textAreaPlaceholder: 'Example: Contentful is a headless content management system.',
-    isRequired: true,
     fieldType: FieldTypes.TEXTAREA,
   },
   {
     id: ProfileFields.VALUES,
     title: "What are your brand's values and attributes?",
     textAreaPlaceholder: 'Example: Bold, unique, young',
-    isRequired: false,
     fieldType: FieldTypes.TEXTINPUT,
   },
   {
     id: ProfileFields.TONE,
     title: "Describe your brand's voice and tone.",
     textAreaPlaceholder: 'Example: Humorous, absurd, kind',
-    isRequired: false,
     fieldType: FieldTypes.TEXTINPUT,
   },
   {
     id: ProfileFields.EXCLUDE,
     title: 'Are there any words your brand should never use?',
     textAreaPlaceholder: 'Example: Humorous, absurd, kind',
-    isRequired: false,
     fieldType: FieldTypes.TEXTINPUT,
   },
   {
     id: ProfileFields.INCLUDE,
     title: 'Are there any words your brand should commonly use?',
     textAreaPlaceholder: 'Example: Humorous, absurd, kind',
-    isRequired: false,
     fieldType: FieldTypes.TEXTINPUT,
   },
   {
     id: ProfileFields.AUDIENCE,
     title: "Describe your brand's target audience.",
     textAreaPlaceholder: 'Example: Men and women ages 18-24 who love fashion.',
-    isRequired: false,
     fieldType: FieldTypes.TEXTINPUT,
   },
   {
@@ -69,7 +63,6 @@ const BrandProfileFields = [
     title: 'Is there anything else that AI should know about your brand or product?',
     textAreaPlaceholder:
       'Example: Contentful is a leading composable content platform. It was a headless CMS category maker that now has company in the marketplace, but remains to be the preferred choice for medium, large and enterprise companies.',
-    isRequired: false,
     fieldType: FieldTypes.TEXTAREA,
   },
 ];

--- a/apps/ai-content-generator/src/components/config/model/Model.tsx
+++ b/apps/ai-content-generator/src/components/config/model/Model.tsx
@@ -3,6 +3,7 @@ import { FormControl, Select } from '@contentful/f36-components';
 import { gptModels, defaultModelId } from '@configs/ai/gptModels';
 import { ModelText } from '../configText';
 import { ParameterAction, ParameterReducer } from '../parameterReducer';
+import { ConfigErrors } from '../configText';
 
 interface Props {
   model: string;
@@ -18,6 +19,7 @@ const Model = (props: Props) => {
     </Select.Option>
   ));
 
+  const isInvalid = !model;
   const isSelectionInModelList = gptModels.some((modelOption) => modelOption.id === model);
   const value = isSelectionInModelList ? model : defaultModelId;
 
@@ -26,13 +28,16 @@ const Model = (props: Props) => {
   };
 
   return (
-    <FormControl isRequired marginBottom="none">
+    <FormControl isRequired marginBottom="none" isInvalid={isInvalid}>
       <FormControl.Label>{ModelText.title}</FormControl.Label>
       <Select value={value} onChange={handleChange}>
         {modelList}
       </Select>
 
       <FormControl.HelpText>{ModelText.helpText}</FormControl.HelpText>
+      {isInvalid && (
+        <FormControl.ValidationMessage>{ConfigErrors.missingModel}</FormControl.ValidationMessage>
+      )}
     </FormControl>
   );
 };

--- a/apps/ai-content-generator/src/components/config/profile/Profile.tsx
+++ b/apps/ai-content-generator/src/components/config/profile/Profile.tsx
@@ -28,10 +28,7 @@ const Profile = (props: Props) => {
         };
 
         return (
-          <FormControl
-            isRequired={field.isRequired}
-            key={field.id}
-            marginBottom={marginBottomStyle}>
+          <FormControl key={field.id} marginBottom={marginBottomStyle}>
             <FormControl.Label>{field.title}</FormControl.Label>
             {field.fieldType === FieldTypes.TEXTAREA ? (
               <ProfileTextArea {...fieldProps} />

--- a/apps/ai-content-generator/src/components/config/profile/Profile.tsx
+++ b/apps/ai-content-generator/src/components/config/profile/Profile.tsx
@@ -3,6 +3,7 @@ import { FormControl, TextInput, Textarea } from '@contentful/f36-components';
 import { ParameterAction, ParameterReducer } from '../parameterReducer';
 import { BrandProfileFields, FieldTypes, ProfileFields } from '../configText';
 import { ProfileType } from '@locations/ConfigScreen';
+import { ConfigErrors } from '../configText';
 
 interface Props {
   profile: ProfileType;
@@ -25,11 +26,14 @@ const Profile = (props: Props) => {
           handleChange(e, field.id);
         };
 
+        const displayInvalidMessage = field.id === ProfileFields.PROFILE && !profile.profile;
+
         const fieldProps = {
           value: profile[field.id] ?? '',
           name: field.title,
           placeholder: field.textAreaPlaceholder,
           onChange: onChange,
+          isInvalid: displayInvalidMessage,
         };
 
         const marginBottomStyle = field.id === ProfileFields.ADDITIONAL ? 'none' : 'spacingL';
@@ -44,6 +48,11 @@ const Profile = (props: Props) => {
               <Textarea rows={TEXTAREA_ROWS} resize="none" {...fieldProps} />
             ) : (
               <TextInput type="text" {...fieldProps} />
+            )}
+            {displayInvalidMessage && (
+              <FormControl.ValidationMessage>
+                {ConfigErrors.missingProfile}
+              </FormControl.ValidationMessage>
             )}
           </FormControl>
         );

--- a/apps/ai-content-generator/src/components/config/profile/Profile.tsx
+++ b/apps/ai-content-generator/src/components/config/profile/Profile.tsx
@@ -1,42 +1,31 @@
-import { ChangeEvent, Dispatch } from 'react';
-import { FormControl, TextInput, Textarea } from '@contentful/f36-components';
-import { ParameterAction, ParameterReducer } from '../parameterReducer';
+import { Dispatch } from 'react';
+import { FormControl } from '@contentful/f36-components';
+import { ParameterReducer } from '../parameterReducer';
 import { BrandProfileFields, FieldTypes, ProfileFields } from '../configText';
 import { ProfileType } from '@locations/ConfigScreen';
-import { ConfigErrors } from '../configText';
+import ProfileTextArea from './ProfileTextArea';
+import ProfileTextInput from './ProfileTextInput';
 
 interface Props {
   profile: ProfileType;
   dispatch: Dispatch<ParameterReducer>;
 }
 
-const TEXTAREA_ROWS = 5;
-
 const Profile = (props: Props) => {
   const { profile, dispatch } = props;
-
-  const handleChange = (e: ChangeEvent<HTMLTextAreaElement>, field: string) => {
-    dispatch({ type: ParameterAction.UPDATE_PROFILE, value: e.target.value, field: field });
-  };
 
   return (
     <>
       {BrandProfileFields.map((field) => {
-        const onChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
-          handleChange(e, field.id);
-        };
-
-        const displayInvalidMessage = field.id === ProfileFields.PROFILE && !profile.profile;
+        const marginBottomStyle = field.id === ProfileFields.ADDITIONAL ? 'none' : 'spacingL';
 
         const fieldProps = {
           value: profile[field.id] ?? '',
           name: field.title,
+          id: field.id,
           placeholder: field.textAreaPlaceholder,
-          onChange: onChange,
-          isInvalid: displayInvalidMessage,
+          dispatch: dispatch,
         };
-
-        const marginBottomStyle = field.id === ProfileFields.ADDITIONAL ? 'none' : 'spacingL';
 
         return (
           <FormControl
@@ -45,14 +34,9 @@ const Profile = (props: Props) => {
             marginBottom={marginBottomStyle}>
             <FormControl.Label>{field.title}</FormControl.Label>
             {field.fieldType === FieldTypes.TEXTAREA ? (
-              <Textarea rows={TEXTAREA_ROWS} resize="none" {...fieldProps} />
+              <ProfileTextArea {...fieldProps} />
             ) : (
-              <TextInput type="text" {...fieldProps} />
-            )}
-            {displayInvalidMessage && (
-              <FormControl.ValidationMessage>
-                {ConfigErrors.missingProfile}
-              </FormControl.ValidationMessage>
+              <ProfileTextInput {...fieldProps} />
             )}
           </FormControl>
         );

--- a/apps/ai-content-generator/src/components/config/profile/ProfileTextArea.tsx
+++ b/apps/ai-content-generator/src/components/config/profile/ProfileTextArea.tsx
@@ -1,0 +1,54 @@
+import { ChangeEvent, Dispatch, useEffect, useState } from 'react';
+import { FormControl, Textarea } from '@contentful/f36-components';
+import { ParameterAction, ParameterReducer } from '../parameterReducer';
+import { ProfileFields } from '../configText';
+import { ConfigErrors } from '../configText';
+import { useDebounce } from 'usehooks-ts';
+
+interface Props {
+  value: string;
+  name: string;
+  id: string;
+  placeholder: string;
+  dispatch: Dispatch<ParameterReducer>;
+}
+
+const TEXTAREA_ROWS = 5;
+
+const ProfileTextArea = (props: Props) => {
+  const { value, name, id, placeholder, dispatch } = props;
+  const [fieldValue, setFieldValue] = useState('');
+  const debouncedValue = useDebounce<string>(fieldValue, 300);
+  const displayInvalidMessage = id === ProfileFields.PROFILE && !fieldValue;
+
+  useEffect(() => {
+    setFieldValue(value);
+  }, [value]);
+
+  useEffect(() => {
+    dispatch({ type: ParameterAction.UPDATE_PROFILE, value: debouncedValue, field: id });
+  }, [debouncedValue, dispatch, id]);
+
+  const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    setFieldValue(e.target.value);
+  };
+
+  return (
+    <>
+      <Textarea
+        rows={TEXTAREA_ROWS}
+        resize="none"
+        value={fieldValue}
+        name={name}
+        placeholder={placeholder}
+        onChange={handleChange}
+        isInvalid={displayInvalidMessage}
+      />
+      {displayInvalidMessage && (
+        <FormControl.ValidationMessage>{ConfigErrors.missingProfile}</FormControl.ValidationMessage>
+      )}
+    </>
+  );
+};
+
+export default ProfileTextArea;

--- a/apps/ai-content-generator/src/components/config/profile/ProfileTextArea.tsx
+++ b/apps/ai-content-generator/src/components/config/profile/ProfileTextArea.tsx
@@ -1,8 +1,6 @@
 import { ChangeEvent, Dispatch, useEffect, useState } from 'react';
-import { FormControl, Textarea } from '@contentful/f36-components';
+import { Textarea } from '@contentful/f36-components';
 import { ParameterAction, ParameterReducer } from '../parameterReducer';
-import { ProfileFields } from '../configText';
-import { ConfigErrors } from '../configText';
 import { useDebounce } from 'usehooks-ts';
 
 interface Props {
@@ -19,7 +17,6 @@ const ProfileTextArea = (props: Props) => {
   const { value, name, id, placeholder, dispatch } = props;
   const [fieldValue, setFieldValue] = useState('');
   const debouncedValue = useDebounce<string>(fieldValue, 300);
-  const displayInvalidMessage = id === ProfileFields.PROFILE && !fieldValue;
 
   useEffect(() => {
     setFieldValue(value);
@@ -34,20 +31,14 @@ const ProfileTextArea = (props: Props) => {
   };
 
   return (
-    <>
-      <Textarea
-        rows={TEXTAREA_ROWS}
-        resize="none"
-        value={fieldValue}
-        name={name}
-        placeholder={placeholder}
-        onChange={handleChange}
-        isInvalid={displayInvalidMessage}
-      />
-      {displayInvalidMessage && (
-        <FormControl.ValidationMessage>{ConfigErrors.missingProfile}</FormControl.ValidationMessage>
-      )}
-    </>
+    <Textarea
+      rows={TEXTAREA_ROWS}
+      resize="none"
+      value={fieldValue}
+      name={name}
+      placeholder={placeholder}
+      onChange={handleChange}
+    />
   );
 };
 

--- a/apps/ai-content-generator/src/components/config/profile/ProfileTextInput.tsx
+++ b/apps/ai-content-generator/src/components/config/profile/ProfileTextInput.tsx
@@ -1,0 +1,42 @@
+import { ChangeEvent, Dispatch, useEffect, useState } from 'react';
+import { TextInput } from '@contentful/f36-components';
+import { ParameterAction, ParameterReducer } from '../parameterReducer';
+import { useDebounce } from 'usehooks-ts';
+
+interface Props {
+  value: string;
+  name: string;
+  id: string;
+  placeholder: string;
+  dispatch: Dispatch<ParameterReducer>;
+}
+
+const ProfileTextInput = (props: Props) => {
+  const { value, name, id, placeholder, dispatch } = props;
+  const [fieldValue, setFieldValue] = useState('');
+  const debouncedValue = useDebounce<string>(fieldValue, 300);
+
+  useEffect(() => {
+    setFieldValue(value);
+  }, [value]);
+
+  useEffect(() => {
+    dispatch({ type: ParameterAction.UPDATE_PROFILE, value: debouncedValue, field: id });
+  }, [debouncedValue, dispatch, id]);
+
+  const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    setFieldValue(e.target.value);
+  };
+
+  return (
+    <TextInput
+      type="text"
+      value={fieldValue}
+      name={name}
+      placeholder={placeholder}
+      onChange={handleChange}
+    />
+  );
+};
+
+export default ProfileTextInput;

--- a/apps/ai-content-generator/src/configs/ai/baseUrl.ts
+++ b/apps/ai-content-generator/src/configs/ai/baseUrl.ts
@@ -1,3 +1,4 @@
-const baseUrl = 'https://api.openai.com/v1/chat/completions';
+const chatCompletionsBaseUrl = 'https://api.openai.com/v1/chat/completions';
+const modelsBaseUrl = 'https://api.openai.com/v1/models';
 
-export default baseUrl;
+export { chatCompletionsBaseUrl, modelsBaseUrl };

--- a/apps/ai-content-generator/src/configs/ai/gptModels.ts
+++ b/apps/ai-content-generator/src/configs/ai/gptModels.ts
@@ -2,7 +2,7 @@ const gptModels = [
   { id: 'gpt-3.5-turbo', name: 'GPT-3.5' },
   { id: 'gpt-3.5-turbo-16k', name: 'GPT-3.5 16k' },
   { id: 'gpt-4', name: 'GPT-4' },
-  { id: 'gpt-4-0314', name: 'GPT-4 32k' },
+  { id: 'gpt-4-32k', name: 'GPT-4 32k' },
 ];
 
 const defaultModelId = gptModels[0].id;

--- a/apps/ai-content-generator/src/hooks/config/useSaveConfigHandler.spec.tsx
+++ b/apps/ai-content-generator/src/hooks/config/useSaveConfigHandler.spec.tsx
@@ -25,7 +25,7 @@ describe('useSaveConfigHandler', () => {
 
   it('adds the on configure callback', async () => {
     const parameters = generateRandomParameters();
-    const mockValidateParams = vi.fn(() => []);
+    const mockValidateParams = vi.fn().mockReturnValue([]);
 
     renderHook(() =>
       useSaveConfigHandler(
@@ -46,7 +46,7 @@ describe('useSaveConfigHandler', () => {
       generateRandomParameters(),
       mockSdkParameters.happyPath,
     ];
-    const mockValidateParams = vi.fn(() => []);
+    const mockValidateParams = vi.fn().mockReturnValue([]);
 
     const testIfHookUpdates = async (parameterIndex: number) => {
       const parameters = testCases[parameterIndex];
@@ -79,7 +79,7 @@ describe('useSaveConfigHandler', () => {
 
   it('does not save the configuration when there are invalid parameters', async () => {
     const parameters = generateRandomParameters();
-    const mockValidateParams = vi.fn(() => ['invalid']);
+    const mockValidateParams = vi.fn().mockReturnValue(['invalid']);
 
     renderHook(() =>
       useSaveConfigHandler(

--- a/apps/ai-content-generator/src/hooks/config/useSaveConfigHandler.ts
+++ b/apps/ai-content-generator/src/hooks/config/useSaveConfigHandler.ts
@@ -13,13 +13,13 @@ import { generateEditorInterfaceAssignments } from '@utils/config/contentTypeHel
  */
 const useSaveConfigHandler = (
   parameters: AppInstallationParameters,
-  validateParams: (params: AppInstallationParameters) => string[],
+  validateParams: (params: AppInstallationParameters) => Promise<string[]>,
   contentTypes: Set<string>
 ) => {
   const sdk = useSDK<ConfigAppSDK>();
 
   const getCurrentState = useCallback(async () => {
-    const notifierErrors = validateParams(parameters);
+    const notifierErrors = await validateParams(parameters);
 
     if (notifierErrors.length) {
       notifierErrors.forEach((error) => sdk.notifier.error(error));

--- a/apps/ai-content-generator/src/hooks/dialog/useAI.tsx
+++ b/apps/ai-content-generator/src/hooks/dialog/useAI.tsx
@@ -1,5 +1,5 @@
 import baseSystemPrompt from '@configs/prompts/baseSystemPrompt';
-import baseUrl from '@configs/ai/baseUrl';
+import { chatCompletionsBaseUrl } from '@configs/ai/baseUrl';
 import { DialogAppSDK } from '@contentful/app-sdk';
 import { useSDK } from '@contentful/react-apps-toolkit';
 import { AppInstallationParameters, ProfileType } from '@locations/ConfigScreen';
@@ -18,7 +18,12 @@ export type GenerateMessage = (prompt: string, targetLocale: string) => Promise<
 const useAI = () => {
   const sdk = useSDK<DialogAppSDK<AppInstallationParameters>>();
   const ai = useMemo(
-    () => new AI(baseUrl, sdk.parameters.installation.apiKey, sdk.parameters.installation.model),
+    () =>
+      new AI(
+        chatCompletionsBaseUrl,
+        sdk.parameters.installation.apiKey,
+        sdk.parameters.installation.model
+      ),
     [sdk.parameters.installation]
   );
   const [output, setOutput] = useState<string>('');

--- a/apps/ai-content-generator/src/utils/aiApi/index.ts
+++ b/apps/ai-content-generator/src/utils/aiApi/index.ts
@@ -89,6 +89,29 @@ class AI {
       stream.cancel();
     }
   };
+
+  /**
+   * This function calls OpenAI's models endpoint in order to test whether the API Key is valid.
+   * @returns Promise<boolean>
+   */
+  isApiKeyValid = async (): Promise<boolean> => {
+    const headers = {
+      Authorization: `Bearer ${this.apiKey}`,
+      'Content-Type': 'application/json',
+    };
+
+    try {
+      const res = await fetch(this.baseUrl, {
+        method: 'GET',
+        headers,
+      });
+
+      return res.status === 200;
+    } catch (error) {
+      console.error(error);
+      return false;
+    }
+  };
 }
 
 export default AI;

--- a/apps/ai-content-generator/test/mocks/sdk/utils/createSdk.ts
+++ b/apps/ai-content-generator/test/mocks/sdk/utils/createSdk.ts
@@ -30,6 +30,9 @@ const createSDK = (parameters: AppInstallationParameters) => {
         get: vi.fn().mockReturnValueOnce(mockEntry),
       },
     },
+    hostnames: {
+      webapp: '',
+    },
   };
 };
 


### PR DESCRIPTION
## Purpose

This PR updates the error handling on the app config page for AI content generator. In addition, there are also a few small fixes this PR addresses:

- Fixes a typo in the model name for gpt-4-32k
- Fixes some failing tests from the introduction of the SDK `hostnames` property
- Fully obfuscates the API Key on save to match the pattern in V1
- Makes the brand profile section optional and adds a debounce for that section to reduce re-renders

## Approach

The API Key and Model fields are now the only two required fields on the config page. On blur, the API Key entered is validated against the [list models](https://platform.openai.com/docs/api-reference/models) OpenAI API endpoint. The user will see a "Validating" message below the API Key field while it is validating. If there is an error, then the user will see a validation error on that field.

When saving the config page if the API Key or model fields are invalid, a toast will appear notifying the user that the config page did not save and that it has errors.

![Screenshot 2023-09-08 at 11 41 05 AM](https://github.com/contentful/apps/assets/62958907/59a50a56-cc88-46fe-ab48-c9048a2ea650)

![Screenshot 2023-09-08 at 11 40 26 AM](https://github.com/contentful/apps/assets/62958907/65004f17-c145-48f9-87ed-d28305f6a1b3)

## Testing steps

Things to check on the config page:
- API Key and Model are the only two required fields
- API Key is fully obfuscated after saving
- API Key is validated on blur
- If API Key is invalid, field appears invalid with a message
- On save if there are invalid fields, you see a notification
