### PR TITLE
feat: bundle code after fixing node-apps-toolkit [MONET-1463]

### DIFF
--- a/examples/hosted-delivery-function-templates/javascript/build-delivery-functions.js
+++ b/examples/hosted-delivery-function-templates/javascript/build-delivery-functions.js
@@ -56,12 +56,14 @@ const main = async (watch = false) => {
 
     const config = {
       entryPoints: getEntryPoints(),
+      bundle: true,
       minify: true,
       platform: 'node',
       outdir: 'build',
       logLevel: 'info',
       format: 'esm',
       target: 'es6',
+      external: ['node:*'],
     };
 
     if (watch) {

--- a/examples/hosted-delivery-function-templates/typescript/build-delivery-functions.js
+++ b/examples/hosted-delivery-function-templates/typescript/build-delivery-functions.js
@@ -56,12 +56,14 @@ const main = async (watch = false) => {
 
     const config = {
       entryPoints: getEntryPoints(),
+      bundle: true,
       minify: true,
       platform: 'node',
       outdir: 'build',
       logLevel: 'info',
       format: 'esm',
       target: 'es6',
+      external: ['node:*'],
     };
 
     if (watch) {


### PR DESCRIPTION
## Purpose
Follow up on https://github.com/contentful/apps/pull/4759. Bundle everything now that node-apps-toolkit is "fixed"

## Approach

Back to bundling all delivery function code before upload

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
