### PR TITLE
Feat/integ 1133 - Backwards compatibility with V1 config

### DIFF
--- a/apps/ai-content-generator/src/components/config/config-page/ConfigPage.tsx
+++ b/apps/ai-content-generator/src/components/config/config-page/ConfigPage.tsx
@@ -20,8 +20,9 @@ import { modelsBaseUrl } from '@configs/ai/baseUrl';
 
 const initialParameters: AppInstallationParameters = {
   model: defaultModelId,
-  apiKey: '',
-  profile: {},
+  key: '',
+  profile: '',
+  brandProfile: {},
 };
 
 const initialContentTypes: Set<string> = new Set();
@@ -71,7 +72,7 @@ const ConfigPage = () => {
       <Heading>{Sections.pageHeading}</Heading>
       <hr css={styles.splitter} />
       <ConfigSection
-        apiKey={parameters.apiKey}
+        apiKey={parameters.key}
         model={parameters.model}
         dispatch={dispatchParameters}
         isApiKeyValid={isApiKeyValid}
@@ -84,7 +85,10 @@ const ConfigPage = () => {
       <hr css={styles.splitter} />
       <DisclaimerSection />
       <hr css={styles.splitter} />
-      <BrandSection profile={parameters.profile} dispatch={dispatchParameters} />
+      <BrandSection
+        profile={{ ...parameters.brandProfile, profile: parameters.profile }}
+        dispatch={dispatchParameters}
+      />
       <hr css={styles.splitter} />
       <AddToSidebarSection
         allContentTypes={allContentTypes}

--- a/apps/ai-content-generator/src/components/config/config-page/ConfigPage.tsx
+++ b/apps/ai-content-generator/src/components/config/config-page/ConfigPage.tsx
@@ -43,7 +43,7 @@ const ConfigPage = () => {
 
   const validateParams = async (params: AppInstallationParameters): Promise<string[]> => {
     const notifierErrors = [];
-    const isApiKeyValid = await validateApiKey(params.apiKey);
+    const isApiKeyValid = await validateApiKey(params.key);
 
     if (!isApiKeyValid) {
       notifierErrors.push(`${ConfigErrors.failedToSave} ${ConfigErrors.missingApiKey}`);

--- a/apps/ai-content-generator/src/components/config/parameterReducer.ts
+++ b/apps/ai-content-generator/src/components/config/parameterReducer.ts
@@ -4,13 +4,14 @@ export enum ParameterAction {
   UPDATE_MODEL = 'updateModel',
   UPDATE_APIKEY = 'updateApiKey',
   UPDATE_PROFILE = 'updateProfile',
+  UPDATE_BRAND_PROFILE = 'updateBrandProfile',
   APPLY_CONTENTFUL_PARAMETERS = 'applyContentfulParameters',
 }
 
 type ParameterStringActions = {
   type: Exclude<
     ParameterAction,
-    ParameterAction.APPLY_CONTENTFUL_PARAMETERS | ParameterAction.UPDATE_PROFILE
+    ParameterAction.APPLY_CONTENTFUL_PARAMETERS | ParameterAction.UPDATE_BRAND_PROFILE
   >;
   value: string;
 };
@@ -21,7 +22,7 @@ type ParameterObjectActions = {
 };
 
 type ParameterProfileActions = {
-  type: ParameterAction.UPDATE_PROFILE;
+  type: ParameterAction.UPDATE_BRAND_PROFILE;
   field: string;
   value: string;
 };
@@ -31,20 +32,27 @@ export type ParameterReducer =
   | ParameterStringActions
   | ParameterProfileActions;
 
-const { UPDATE_MODEL, UPDATE_APIKEY, UPDATE_PROFILE, APPLY_CONTENTFUL_PARAMETERS } =
-  ParameterAction;
+const {
+  UPDATE_MODEL,
+  UPDATE_APIKEY,
+  UPDATE_PROFILE,
+  UPDATE_BRAND_PROFILE,
+  APPLY_CONTENTFUL_PARAMETERS,
+} = ParameterAction;
 
 const parameterReducer = (state: AppInstallationParameters, action: ParameterReducer) => {
   switch (action.type) {
     case UPDATE_MODEL:
       return { ...state, model: action.value };
     case UPDATE_APIKEY:
-      return { ...state, apiKey: action.value };
+      return { ...state, key: action.value };
     case UPDATE_PROFILE:
+      return { ...state, profile: action.value };
+    case UPDATE_BRAND_PROFILE:
       return {
         ...state,
-        profile: {
-          ...state.profile,
+        brandProfile: {
+          ...state.brandProfile,
           [action.field]: action.value,
         },
       };

--- a/apps/ai-content-generator/src/components/config/profile/ProfileTextArea.tsx
+++ b/apps/ai-content-generator/src/components/config/profile/ProfileTextArea.tsx
@@ -2,6 +2,7 @@ import { ChangeEvent, Dispatch, useEffect, useState } from 'react';
 import { Textarea } from '@contentful/f36-components';
 import { ParameterAction, ParameterReducer } from '../parameterReducer';
 import { useDebounce } from 'usehooks-ts';
+import { ProfileFields } from '../configText';
 
 interface Props {
   value: string;
@@ -23,7 +24,11 @@ const ProfileTextArea = (props: Props) => {
   }, [value]);
 
   useEffect(() => {
-    dispatch({ type: ParameterAction.UPDATE_PROFILE, value: debouncedValue, field: id });
+    if (id === ProfileFields.PROFILE) {
+      dispatch({ type: ParameterAction.UPDATE_PROFILE, value: debouncedValue });
+    } else {
+      dispatch({ type: ParameterAction.UPDATE_BRAND_PROFILE, value: debouncedValue, field: id });
+    }
   }, [debouncedValue, dispatch, id]);
 
   const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {

--- a/apps/ai-content-generator/src/components/config/profile/ProfileTextInput.tsx
+++ b/apps/ai-content-generator/src/components/config/profile/ProfileTextInput.tsx
@@ -2,6 +2,7 @@ import { ChangeEvent, Dispatch, useEffect, useState } from 'react';
 import { TextInput } from '@contentful/f36-components';
 import { ParameterAction, ParameterReducer } from '../parameterReducer';
 import { useDebounce } from 'usehooks-ts';
+import { ProfileFields } from '../configText';
 
 interface Props {
   value: string;
@@ -21,7 +22,11 @@ const ProfileTextInput = (props: Props) => {
   }, [value]);
 
   useEffect(() => {
-    dispatch({ type: ParameterAction.UPDATE_PROFILE, value: debouncedValue, field: id });
+    if (id === ProfileFields.PROFILE) {
+      dispatch({ type: ParameterAction.UPDATE_PROFILE, value: debouncedValue });
+    } else {
+      dispatch({ type: ParameterAction.UPDATE_BRAND_PROFILE, value: debouncedValue, field: id });
+    }
   }, [debouncedValue, dispatch, id]);
 
   const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {

--- a/apps/ai-content-generator/src/hooks/dialog/useAI.tsx
+++ b/apps/ai-content-generator/src/hooks/dialog/useAI.tsx
@@ -21,7 +21,7 @@ const useAI = () => {
     () =>
       new AI(
         chatCompletionsBaseUrl,
-        sdk.parameters.installation.apiKey,
+        sdk.parameters.installation.key,
         sdk.parameters.installation.model
       ),
     [sdk.parameters.installation]
@@ -52,7 +52,14 @@ const useAI = () => {
     let completeMessage = '';
 
     try {
-      const payload = createGPTPayload(prompt, sdk.parameters.installation.profile, targetLocale);
+      const payload = createGPTPayload(
+        prompt,
+        {
+          ...sdk.parameters.installation.brandProfile,
+          profile: sdk.parameters.installation.profile,
+        },
+        targetLocale
+      );
 
       const stream = await ai.streamChatCompletion(payload);
       setStream(stream);

--- a/apps/ai-content-generator/src/locations/ConfigScreen.tsx
+++ b/apps/ai-content-generator/src/locations/ConfigScreen.tsx
@@ -6,8 +6,9 @@ export type ProfileType = {
 };
 interface AppInstallationParameters {
   model: string;
-  apiKey: string;
-  profile: ProfileType;
+  key: string;
+  profile: string;
+  brandProfile: ProfileType;
 }
 
 const ConfigScreen = () => {

--- a/apps/ai-content-generator/src/locations/Sidebar.tsx
+++ b/apps/ai-content-generator/src/locations/Sidebar.tsx
@@ -13,8 +13,8 @@ import { ExternalLinkIcon } from '@contentful/f36-icons';
 const Sidebar = () => {
   useAutoResizer();
 
-  const sdk = useSDK<SidebarAppSDK>();
-  const { key, model, profile } = sdk.parameters.installation as AppInstallationParameters;
+  const sdk = useSDK<SidebarAppSDK<AppInstallationParameters>>();
+  const { key, model, profile } = sdk.parameters.installation;
 
   if (!key || !model) {
     return (

--- a/apps/ai-content-generator/src/locations/Sidebar.tsx
+++ b/apps/ai-content-generator/src/locations/Sidebar.tsx
@@ -14,9 +14,9 @@ const Sidebar = () => {
   useAutoResizer();
 
   const sdk = useSDK<SidebarAppSDK>();
-  const { apiKey, model, profile } = sdk.parameters.installation as AppInstallationParameters;
+  const { key, model, profile } = sdk.parameters.installation as AppInstallationParameters;
 
-  if (!apiKey || !model) {
+  if (!key || !model) {
     return (
       <ParametersMissingWarning
         message={warningMessages.paramsMissing}
@@ -28,7 +28,7 @@ const Sidebar = () => {
   return (
     <>
       <SidebarButtons />
-      {!profile?.profile ? (
+      {!profile ? (
         <Box css={styles.msgWrapper}>
           <ParametersMissingWarning
             message={warningMessages.profileMissing}

--- a/apps/ai-content-generator/test/mocks/sdk/parameters/happyPathParameter.ts
+++ b/apps/ai-content-generator/test/mocks/sdk/parameters/happyPathParameter.ts
@@ -2,10 +2,9 @@ import { AppInstallationParameters } from '@locations/ConfigScreen';
 
 const happyPath: AppInstallationParameters = {
   model: 'gpt-3.5-turbo',
-  apiKey: 'test-api-key',
-  profile: {
-    profile: 'test-profile',
-  },
+  key: 'test-api-key',
+  profile: 'test-profile',
+  brandProfile: {},
 };
 
 export { happyPath };

--- a/apps/ai-content-generator/test/mocks/sdk/parameters/initParameters.ts
+++ b/apps/ai-content-generator/test/mocks/sdk/parameters/initParameters.ts
@@ -2,10 +2,9 @@ import { AppInstallationParameters } from '@locations/ConfigScreen';
 
 const init: AppInstallationParameters = {
   model: '',
-  apiKey: '',
-  profile: {
-    profile: '',
-  },
+  key: '',
+  profile: '',
+  brandProfile: {},
 };
 
 export { init };

--- a/apps/ai-content-generator/test/mocks/sdk/utils/generateRandomParameters.ts
+++ b/apps/ai-content-generator/test/mocks/sdk/utils/generateRandomParameters.ts
@@ -8,10 +8,9 @@ const generateRandomParameters = (): AppInstallationParameters => {
 
   return {
     model: gptModels[randomModelIndex].id,
-    apiKey: 'sk-' + randomApiKey,
-    profile: {
-      profile: randomProfile,
-    },
+    key: 'sk-' + randomApiKey,
+    profile: randomProfile,
+    brandProfile: {},
   };
 };
 


### PR DESCRIPTION
## Purpose
We were clearing the V1 configs on update to v2

## Approach

There were two approaches, I think this one will be more implicit and lead to less developer error long term. The original versioning config plan had too many potholes and added some in-repo knowledge that a new dev wouldn't necessarily know