### PR TITLE
chore: reduce number of images returned

### DIFF
--- a/apps/ai-image-generator/backend/src/actions/aiig-select-fill.ts
+++ b/apps/ai-image-generator/backend/src/actions/aiig-select-fill.ts
@@ -59,7 +59,7 @@ export const handler = async (
       prompt,
       image: await toFile(imageBuffer),
       mask: await toFile(maskBuffer),
-      numImages: 4,
+      numImages: 3,
       size: '1024x1024',
     });
 


### PR DESCRIPTION
## Purpose

We need to only return 3 images as part of the Select and Edit flow, as opposed to 4. Therefore i have adjusted the explicit return value. 
