### PR TITLE
Fix pollution of package and package lock during sharp build

### DIFF
--- a/apps/ai-image-generator/package.json
+++ b/apps/ai-image-generator/package.json
@@ -14,7 +14,7 @@
     "deploy:test": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEV_TESTING_ORG_ID} --definition-id 6H2pUZdiYcmo0WY8dlYZn5 --token ${TEST_CMA_TOKEN}",
     "deploy:sandbox": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEV_TESTING_ORG_ID} --definition-id 3vLfusuPgGHcydK5ET8IcG --token ${TEST_CMA_TOKEN}",
     "replace-installed-sharp": "rimraf ./node_modules/sharp && npm run install-linux-sharp",
-    "install-linux-sharp": "SHARP_IGNORE_GLOBAL_LIBVIPS=1 npm install --arch=x64 --platform=linux --libc=glibc sharp"
+    "install-linux-sharp": "SHARP_IGNORE_GLOBAL_LIBVIPS=1 npm ci --arch=x64 --platform=linux --libc=glibc sharp"
   },
   "dependencies": {
     "@contentful/app-scripts": "1.10.2",


### PR DESCRIPTION
## Purpose

We started seeing build failures during the `publish-package` step of the deploy-prod workflow. Example: https://app.circleci.com/pipelines/github/contentful/apps/24206/workflows/72689d12-eadd-4067-aaaa-81f2abe09c02/jobs/71745

Further investigation uncovered the problem was in the `build-sharp` script of the `ai-image-generator` app. This step (used to build an version of sharp that can run in an AWS lambda) was using `npm install`, which was polluting the git working space. This was causing a failure down the road when lerna tried to do it's git magic during `lerna version --conventional-commits --no-private --force-git-tag --create-release github --yes && lerna publish from-git --yes`

## Approach

* Use `npm ci` instead of `npm install`: https://docs.npmjs.com/cli/v7/commands/npm-ci . "It will never write to package.json or any of the package-locks: installs are essentially frozen."

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
