### PR TITLE
feat: add AICG sidebar error handling [INTEG-1182]

### DIFF
--- a/apps/ai-content-generator/src/components/app/sidebar/BrandProfileMissingWarning.spec.tsx
+++ b/apps/ai-content-generator/src/components/app/sidebar/BrandProfileMissingWarning.spec.tsx
@@ -1,0 +1,25 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { mockCma, MockSdk } from '../../../../test/mocks';
+import BrandProfileMissingWarning from './BrandProfileMissingWarning';
+
+const mockSdk = new MockSdk();
+const sdk = mockSdk.sdk;
+
+vi.mock('@contentful/react-apps-toolkit', () => ({
+  useSDK: () => sdk,
+  useCMA: () => mockCma,
+}));
+
+describe('Brand Profile Missing Warning', () => {
+  it('renders and checks local storage', () => {
+    const spy = vi.spyOn(localStorage, 'getItem');
+
+    const { getByText } = render(
+      <BrandProfileMissingWarning message="Test message" linkSubstring="" />
+    );
+
+    expect(getByText('Test message')).toBeTruthy();
+    expect(spy).toBeCalledWith('cf_dismiss_brand_profile_warning');
+  });
+});

--- a/apps/ai-content-generator/src/components/app/sidebar/BrandProfileMissingWarning.tsx
+++ b/apps/ai-content-generator/src/components/app/sidebar/BrandProfileMissingWarning.tsx
@@ -1,0 +1,54 @@
+import { useState } from 'react';
+import { useSDK } from '@contentful/react-apps-toolkit';
+import { SidebarAppSDK } from '@contentful/app-sdk';
+import Note from '@components/common/Note/Note';
+import HyperLink from '@components/common/HyperLink/HyperLink';
+import { css } from '@emotion/react';
+import tokens from '@contentful/f36-tokens';
+
+interface BrandProfileMissingProps {
+  message: string;
+  linkSubstring: string;
+}
+
+const warningLinkStyles = css({
+  color: `${tokens.gray700} !important`,
+  fontWeight: `${tokens.fontWeightNormal} !important`,
+  textDecoration: 'underline',
+});
+
+const BrandProfileMissingWarning = (props: BrandProfileMissingProps) => {
+  const userHasDismissedWarning = localStorage.getItem('cf_dismiss_brand_profile_warning');
+  const [isDismissed, setIsDismissed] = useState<boolean>(Boolean(userHasDismissedWarning));
+  const { message, linkSubstring } = props;
+
+  const sdk = useSDK<SidebarAppSDK>();
+  const openConfigPage = () => sdk.navigator.openAppConfig();
+
+  const handleClose = () => {
+    setIsDismissed(true);
+    localStorage.setItem('cf_dismiss_brand_profile_warning', 'true');
+  };
+
+  return (
+    <>
+      {!isDismissed ? (
+        <Note
+          body={
+            <HyperLink
+              body={message}
+              substring={linkSubstring}
+              onClick={openConfigPage}
+              textLinkStyle={warningLinkStyles}
+            />
+          }
+          variant="warning"
+          withCloseButton={true}
+          onClose={handleClose}
+        />
+      ) : null}
+    </>
+  );
+};
+
+export default BrandProfileMissingWarning;

--- a/apps/ai-content-generator/src/components/app/sidebar/DisplaySidebarWarning.tsx
+++ b/apps/ai-content-generator/src/components/app/sidebar/DisplaySidebarWarning.tsx
@@ -1,0 +1,68 @@
+import { Box } from '@contentful/f36-components';
+import ParametersMissingWarning from '@components/app/sidebar/ParametersMissingWarning';
+import BrandProfileMissingWarning from '@components/app/sidebar/BrandProfileMissingWarning';
+import { warningMessages } from '@components/app/sidebar/sidebarText';
+import { css } from '@emotion/react';
+import tokens from '@contentful/f36-tokens';
+import { AiApiErrorType } from '@utils/aiApi/handleAiApiErrors';
+
+const styles = {
+  msgWrapper: css({
+    marginTop: tokens.spacingM,
+  }),
+};
+
+interface Props {
+  hasBrandProfile: boolean;
+  apiError: AiApiErrorType | undefined;
+}
+
+const DisplaySidebarWarning = (props: Props) => {
+  const { hasBrandProfile, apiError } = props;
+
+  if (apiError) {
+    const { status, message } = apiError;
+
+    if (status === 401 || status === 404) {
+      return (
+        <Box css={styles.msgWrapper}>
+          <ParametersMissingWarning
+            message={warningMessages.paramsMissing}
+            linkSubstring={warningMessages.linkSubstring}
+          />
+        </Box>
+      );
+    } else if (status === 500 || status === 503) {
+      return (
+        <Box css={styles.msgWrapper}>
+          <ParametersMissingWarning message={warningMessages.unavailable} />
+        </Box>
+      );
+    } else {
+      return (
+        <Box css={styles.msgWrapper}>
+          <ParametersMissingWarning
+            message={`${warningMessages.openAiErrorMessage} ${
+              message ?? warningMessages.defaultError
+            }`}
+          />
+        </Box>
+      );
+    }
+  }
+
+  if (!hasBrandProfile) {
+    return (
+      <Box css={styles.msgWrapper}>
+        <BrandProfileMissingWarning
+          message={warningMessages.profileMissing}
+          linkSubstring={warningMessages.linkSubstring}
+        />
+      </Box>
+    );
+  }
+
+  return null;
+};
+
+export default DisplaySidebarWarning;

--- a/apps/ai-content-generator/src/components/app/sidebar/ParametersMissingWarning.tsx
+++ b/apps/ai-content-generator/src/components/app/sidebar/ParametersMissingWarning.tsx
@@ -2,11 +2,19 @@ import { useSDK } from '@contentful/react-apps-toolkit';
 import { SidebarAppSDK } from '@contentful/app-sdk';
 import Note from '@components/common/Note/Note';
 import HyperLink from '@components/common/HyperLink/HyperLink';
+import { css } from '@emotion/react';
+import tokens from '@contentful/f36-tokens';
 
 interface ParametersMissingProps {
   message: string;
-  linkSubstring: string;
+  linkSubstring?: string;
 }
+
+const warningLinkStyles = css({
+  color: `${tokens.gray700} !important`,
+  fontWeight: `${tokens.fontWeightNormal} !important`,
+  textDecoration: 'underline',
+});
 
 const ParametersMissingWarning = (props: ParametersMissingProps) => {
   const { message, linkSubstring } = props;
@@ -16,7 +24,18 @@ const ParametersMissingWarning = (props: ParametersMissingProps) => {
 
   return (
     <Note
-      body={<HyperLink body={message} substring={linkSubstring} onClick={openConfigPage} />}
+      body={
+        linkSubstring ? (
+          <HyperLink
+            body={message}
+            substring={linkSubstring}
+            onClick={openConfigPage}
+            textLinkStyle={warningLinkStyles}
+          />
+        ) : (
+          message
+        )
+      }
       variant="warning"
     />
   );

--- a/apps/ai-content-generator/src/components/app/sidebar/SidebarButtons.tsx
+++ b/apps/ai-content-generator/src/components/app/sidebar/SidebarButtons.tsx
@@ -3,7 +3,12 @@ import featureConfig, { AIFeature } from '@configs/features/featureConfig';
 import FeatureButton from './feature-button/FeatureButton';
 import { useState } from 'react';
 
-const SidebarButtons = () => {
+interface Props {
+  shouldDisableButtons: boolean;
+}
+
+const SidebarButtons = (props: Props) => {
+  const { shouldDisableButtons } = props;
   const [isSaving, setIsSaving] = useState(false);
 
   const handleSaving = (toggleTo: boolean) => {
@@ -17,6 +22,7 @@ const SidebarButtons = () => {
         feature={feature as AIFeature}
         isSaving={isSaving}
         onSaving={handleSaving}
+        shouldDisableButtons={shouldDisableButtons}
       />
     );
   });

--- a/apps/ai-content-generator/src/components/app/sidebar/feature-button/FeatureButton.tsx
+++ b/apps/ai-content-generator/src/components/app/sidebar/feature-button/FeatureButton.tsx
@@ -10,6 +10,7 @@ interface Props {
   feature: AIFeature;
   isSaving: boolean;
   onSaving: (isSaving: boolean) => void;
+  shouldDisableButtons: boolean;
 }
 
 interface FieldLocales {
@@ -17,7 +18,7 @@ interface FieldLocales {
 }
 
 const FeatureButton = (props: Props) => {
-  const { feature, isSaving, onSaving } = props;
+  const { feature, isSaving, onSaving, shouldDisableButtons } = props;
   const buttonCopy = featureConfig[feature].buttonTitle;
   const sdk = useSDK<SidebarAppSDK>();
 
@@ -57,7 +58,7 @@ const FeatureButton = (props: Props) => {
 
   return (
     <Tooltip placement="top" id={feature}>
-      <Button css={styles.button} onClick={handleOnClick}>
+      <Button css={styles.button} onClick={handleOnClick} isDisabled={shouldDisableButtons}>
         {buttonCopy} {isOpeningDialog && <Spinner size="small" />}
       </Button>
     </Tooltip>

--- a/apps/ai-content-generator/src/components/app/sidebar/sidebarText.ts
+++ b/apps/ai-content-generator/src/components/app/sidebar/sidebarText.ts
@@ -1,7 +1,10 @@
 const warningMessages = {
-  profileMissing: `Brand profile is not configured for this app. In order to power more accurate and on-brand content for all of your prompts, please update your app configuration page.`,
-  paramsMissing: `App installation parameters are missing. Please update your app configuration page.`,
-  linkSubstring: `app configuration page.`,
+  profileMissing: `Missing brand profile. Visit the app configuration page.`,
+  paramsMissing: `Invalid or missing API Key. Visit the app configuration page.`,
+  linkSubstring: `Visit the app configuration page.`,
+  unavailable: `Chat GPT is currently unavailable.`,
+  defaultError: 'An unknown error occurred. Please try again.',
+  openAiErrorMessage: 'OpenAI API Error: ',
 };
 
 const disclaimerMessage = {

--- a/apps/ai-content-generator/src/components/common/Note/Note.styles.ts
+++ b/apps/ai-content-generator/src/components/common/Note/Note.styles.ts
@@ -1,11 +1,14 @@
 import { css } from '@emotion/react';
 
 export const styles = {
-  note: css({
+  note: css(`
+    button {
+      padding-top: 0
+    }
     overflow: 'hidden',
     wordBreak: 'break-word',
     width: '100%',
-  }),
+  `),
   noteContent: css({
     textOverflow: 'ellipsis',
     overflow: 'hidden',

--- a/apps/ai-content-generator/src/components/common/Note/Note.tsx
+++ b/apps/ai-content-generator/src/components/common/Note/Note.tsx
@@ -1,15 +1,22 @@
+import { MouseEventHandler } from 'react';
 import { styles } from './Note.styles';
 import { Note as F36Note, NoteProps } from '@contentful/f36-components';
 
 interface Props {
   body: string | JSX.Element;
   variant: NoteProps['variant'];
+  withCloseButton?: boolean;
+  onClose?: MouseEventHandler<HTMLButtonElement>;
 }
 
 const Note = (props: Props) => {
-  const { body, variant = 'negative' } = props;
+  const { body, variant = 'negative', withCloseButton = false, onClose } = props;
   return (
-    <F36Note css={styles.note} variant={variant}>
+    <F36Note
+      css={styles.note}
+      variant={variant}
+      withCloseButton={withCloseButton}
+      onClose={onClose}>
       <p css={styles.noteContent}>{body}</p>
     </F36Note>
   );

--- a/apps/ai-content-generator/src/components/config/api-key/APIKey.tsx
+++ b/apps/ai-content-generator/src/components/config/api-key/APIKey.tsx
@@ -10,7 +10,7 @@ interface Props {
   isInvalid: boolean;
   localApiKey: string;
   onApiKeyChange: (key: string) => void;
-  validateApiKey: (key: string) => Promise<boolean>;
+  validateApiKey: (key: string) => Promise<void>;
 }
 
 const APIKey = (props: Props) => {

--- a/apps/ai-content-generator/src/components/config/config-page/ConfigPage.tsx
+++ b/apps/ai-content-generator/src/components/config/config-page/ConfigPage.tsx
@@ -33,17 +33,21 @@ const ConfigPage = () => {
   const [isApiKeyValid, setIsApiKeyValid] = useState(true);
   const [localApiKey, setLocalApiKey] = useState('');
 
-  const validateApiKey = async (key: string): Promise<boolean> => {
+  const validateApiKey = async (key: string): Promise<void> => {
     const ai = new AI(modelsBaseUrl, key, '');
-    const isApiKeyValid = await ai.isApiKeyValid();
-    setIsApiKeyValid(isApiKeyValid);
 
-    return isApiKeyValid;
+    try {
+      await ai.getModels();
+      setIsApiKeyValid(true);
+    } catch (e: unknown) {
+      console.error(e);
+      setIsApiKeyValid(false);
+    }
   };
 
   const validateParams = async (params: AppInstallationParameters): Promise<string[]> => {
     const notifierErrors = [];
-    const isApiKeyValid = await validateApiKey(params.key);
+    validateApiKey(params.key);
 
     if (!isApiKeyValid) {
       notifierErrors.push(`${ConfigErrors.failedToSave} ${ConfigErrors.missingApiKey}`);
@@ -73,7 +77,7 @@ const ConfigPage = () => {
       <hr css={styles.splitter} />
       <ConfigSection
         apiKey={parameters.key}
-        model={parameters.model}
+        model={parameters.model ?? ''}
         dispatch={dispatchParameters}
         isApiKeyValid={isApiKeyValid}
         localApiKey={localApiKey}

--- a/apps/ai-content-generator/src/components/config/config-section/ConfigSection.tsx
+++ b/apps/ai-content-generator/src/components/config/config-section/ConfigSection.tsx
@@ -12,7 +12,7 @@ interface Props {
   isApiKeyValid: boolean;
   localApiKey: string;
   onApiKeyChange: (key: string) => void;
-  validateApiKey: (key: string) => Promise<boolean>;
+  validateApiKey: (key: string) => Promise<void>;
 }
 
 const ConfigSection = (props: Props) => {

--- a/apps/ai-content-generator/src/hooks/dialog/useAI.tsx
+++ b/apps/ai-content-generator/src/hooks/dialog/useAI.tsx
@@ -6,6 +6,7 @@ import { AppInstallationParameters, ProfileType } from '@locations/ConfigScreen'
 import AI from '@utils/aiApi';
 import { ChatCompletionRequestMessage } from 'openai';
 import { useEffect, useMemo, useState } from 'react';
+import { defaultModelId } from '@configs/ai/gptModels';
 
 export type GenerateMessage = (prompt: string, targetLocale: string) => Promise<string>;
 
@@ -22,7 +23,7 @@ const useAI = () => {
       new AI(
         chatCompletionsBaseUrl,
         sdk.parameters.installation.key,
-        sdk.parameters.installation.model
+        sdk.parameters.installation.model ?? defaultModelId
       ),
     [sdk.parameters.installation]
   );

--- a/apps/ai-content-generator/src/hooks/sidebar/useSidebarParameters.spec.ts
+++ b/apps/ai-content-generator/src/hooks/sidebar/useSidebarParameters.spec.ts
@@ -1,0 +1,23 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import useSidebarParameters from './useSidebarParameters';
+import { mockCma, MockSdk, mockSdkParameters } from '../../../test/mocks';
+
+const mockSdk = new MockSdk(mockSdkParameters.happyPath);
+const sdk = mockSdk.sdk;
+
+vi.mock('@contentful/react-apps-toolkit', () => ({
+  useSDK: () => sdk,
+  useCMA: () => mockCma,
+}));
+
+describe('useSidebarParameters', () => {
+  it('should return whether there is a brand profile and any errors', async () => {
+    const { result } = renderHook(() => useSidebarParameters());
+
+    await waitFor(() => {
+      expect(result.current).toHaveProperty('hasBrandProfile', true);
+      expect(result.current).toHaveProperty('apiError', undefined);
+    });
+  });
+});

--- a/apps/ai-content-generator/src/hooks/sidebar/useSidebarParameters.ts
+++ b/apps/ai-content-generator/src/hooks/sidebar/useSidebarParameters.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+import { useSDK } from '@contentful/react-apps-toolkit';
+import { SidebarAppSDK } from '@contentful/app-sdk';
+import AI from '@utils/aiApi';
+import { modelsBaseUrl } from '@configs/ai/baseUrl';
+import { AppInstallationParameters } from '@locations/ConfigScreen';
+import { AiApiError, AiApiErrorType } from '@utils/aiApi/handleAiApiErrors';
+
+/**
+ * This hook is used to get the installation parameters from the sidebar location,
+ * checks to see if there is a brand profile, validates the API Key and returns any errors
+ *
+ * @returns {hasBrandProfile, apiError}
+ */
+const useSidebarParameters = () => {
+  const [apiError, setApiError] = useState<AiApiErrorType>();
+  const [hasBrandProfile, setHasBrandProfile] = useState(true);
+
+  const sdk = useSDK<SidebarAppSDK<AppInstallationParameters>>();
+  const { key, profile } = sdk.parameters.installation;
+
+  useEffect(() => {
+    const validateApiKey = async () => {
+      const ai = new AI(modelsBaseUrl, key);
+      try {
+        await ai.getModels();
+      } catch (e: unknown) {
+        console.error(e);
+        if (e instanceof AiApiError) {
+          setApiError(e);
+        } else {
+          setApiError(new AiApiError({}));
+        }
+      }
+    };
+
+    validateApiKey();
+    setHasBrandProfile(!!profile);
+  }, [key, profile]);
+
+  return {
+    hasBrandProfile,
+    apiError,
+  };
+};
+
+export default useSidebarParameters;

--- a/apps/ai-content-generator/src/locations/ConfigScreen.tsx
+++ b/apps/ai-content-generator/src/locations/ConfigScreen.tsx
@@ -5,10 +5,12 @@ export type ProfileType = {
   [K in ProfileFields]?: string;
 };
 interface AppInstallationParameters {
-  model: string;
+  // Model is optional since V1 of the config page didn't save model as a param if you had the default selected.
+  model?: string;
   key: string;
   profile: string;
-  brandProfile: ProfileType;
+  // Optional since we are accessing properties on this object
+  brandProfile?: ProfileType;
 }
 
 const ConfigScreen = () => {

--- a/apps/ai-content-generator/src/locations/Sidebar.tsx
+++ b/apps/ai-content-generator/src/locations/Sidebar.tsx
@@ -1,49 +1,30 @@
 import { useAutoResizer } from '@contentful/react-apps-toolkit';
-import { useSDK } from '@contentful/react-apps-toolkit';
-import { SidebarAppSDK } from '@contentful/app-sdk';
+import useSidebarParameters from '@hooks/sidebar/useSidebarParameters';
 import { Box } from '@contentful/f36-components';
 import SidebarButtons from '@components/app/sidebar/SidebarButtons';
-import ParametersMissingWarning from '@components/app/sidebar/ParametersMissingWarning';
-import { AppInstallationParameters } from '@locations/ConfigScreen';
 import { styles } from './Sidebar.styles';
-import { warningMessages, disclaimerMessage } from '@components/app/sidebar/sidebarText';
+import { disclaimerMessage } from '@components/app/sidebar/sidebarText';
 import HyperLink from '@components/common/HyperLink/HyperLink';
 import { ExternalLinkIcon } from '@contentful/f36-icons';
 import { useContext, useEffect } from 'react';
 import { SegmentAnalyticsContext } from '@providers/segmentAnalyticsProvider';
 import { SegmentEvents } from '@configs/segment/segmentEvent';
+import DisplaySidebarWarning from '@components/app/sidebar/DisplaySidebarWarning';
 
 const Sidebar = () => {
+  const { hasBrandProfile, apiError } = useSidebarParameters();
   useAutoResizer();
 
-  const sdk = useSDK<SidebarAppSDK<AppInstallationParameters>>();
   const { trackEvent } = useContext(SegmentAnalyticsContext);
-  const { key, model, profile } = sdk.parameters.installation;
 
   useEffect(() => {
     trackEvent(SegmentEvents.SIDEBAR_RENDERED);
   }, [trackEvent]);
 
-  if (!key || !model) {
-    return (
-      <ParametersMissingWarning
-        message={warningMessages.paramsMissing}
-        linkSubstring={warningMessages.linkSubstring}
-      />
-    );
-  }
-
   return (
     <>
-      <SidebarButtons />
-      {!profile ? (
-        <Box css={styles.msgWrapper}>
-          <ParametersMissingWarning
-            message={warningMessages.profileMissing}
-            linkSubstring={warningMessages.linkSubstring}
-          />
-        </Box>
-      ) : null}
+      <SidebarButtons shouldDisableButtons={!!apiError} />
+      <DisplaySidebarWarning hasBrandProfile={hasBrandProfile} apiError={apiError} />
       <Box css={styles.msgWrapper}>
         <HyperLink
           body={disclaimerMessage.body}

--- a/apps/ai-content-generator/src/utils/aiApi/handleAiApiErrors.ts
+++ b/apps/ai-content-generator/src/utils/aiApi/handleAiApiErrors.ts
@@ -1,0 +1,25 @@
+export interface AiApiErrorType {
+  message?: string;
+  status?: number;
+}
+
+export class AiApiError extends Error {
+  status: number;
+
+  constructor(res: AiApiErrorType) {
+    super(res.message);
+    this.status = res.status ?? 0;
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const validateResponseStatus = (response: Response, responseJson: any) => {
+  if (response.status >= 400) {
+    const apiErrorResponse = {
+      status: response.status,
+      message: responseJson?.error?.message,
+    };
+
+    throw new AiApiError(apiErrorResponse);
+  }
+};

--- a/apps/ai-content-generator/src/utils/segment/getTrackedAppData.ts
+++ b/apps/ai-content-generator/src/utils/segment/getTrackedAppData.ts
@@ -6,7 +6,7 @@ const getTrackedAppData = (sdk: BaseAppSDK<AppInstallationParameters>): SegmentA
   const { installation } = sdk.parameters;
 
   return {
-    gpt_model: installation?.model,
+    gpt_model: installation?.model || '',
 
     config_options: {
       has_profile: !!installation?.profile,

--- a/apps/ai-content-generator/test/mocks/sdk/mockSdk.ts
+++ b/apps/ai-content-generator/test/mocks/sdk/mockSdk.ts
@@ -29,6 +29,7 @@ class MockSdk {
   reset() {
     this.sdk.app.onConfigure = vi.fn();
     this.sdk.app.getParameters = vi.fn().mockReturnValueOnce(this.originalData.parameters);
+    this.sdk.parameters.installation = this.originalData.parameters;
     this.sdk.app.setReady = vi.fn();
     this.sdk.app.getCurrentState = vi
       .fn()

--- a/apps/ai-content-generator/test/mocks/sdk/utils/createSdk.ts
+++ b/apps/ai-content-generator/test/mocks/sdk/utils/createSdk.ts
@@ -33,6 +33,9 @@ const createSDK = (parameters: AppInstallationParameters) => {
     hostnames: {
       webapp: '',
     },
+    parameters: {
+      installation: { ...parameters },
+    },
   };
 };
 


### PR DESCRIPTION
## Purpose

We want to improve the error handling in the Sidebar for AI Content Generator.

## Approach

This PR adds several things:
- Checks to see if the API key is valid by hitting the OpenAI models endpoint
- Handles when model is undefined by defaulting to a model in the AI class
- Displays appropriate warning messages and disables the sidebar buttons when there is an OpenAI error

I added different warning components and created a hook for the logic to check the sidebar parameters.

**Example of a missing brand profile (this is a dismissible warning and buttons are still enabled):**
![Screenshot 2023-09-21 at 4 01 56 PM](https://github.com/contentful/apps/assets/62958907/13bcf956-ceb6-44d4-b3d6-e459055412ae)

**Example of a missing or invalid API Key:**
![Screenshot 2023-09-21 at 4 08 36 PM](https://github.com/contentful/apps/assets/62958907/5b50d6af-22a0-4721-9f70-ec93697eb9fb)

**Example of Chat GPT not available :**
![Screenshot 2023-09-21 at 4 51 57 PM](https://github.com/contentful/apps/assets/62958907/ecf30a40-655e-4551-bce9-371a6da2e4be)

**Example of a different OpenAI API error, showing the error message from OpenAI:**
![Screenshot 2023-09-21 at 4 07 56 PM](https://github.com/contentful/apps/assets/62958907/67440e7f-9850-4cba-9cba-725ee1e9102c)

**Example of default error message (when there is no message from OpenAI):** 
![Screenshot 2023-09-21 at 4 48 54 PM](https://github.com/contentful/apps/assets/62958907/3f78a56f-a396-4064-8899-4ceb2457bd81)

## Testing steps

- If key, model, or profile are undefined, the Sidebar app should still load
- If model is undefined, the default one should be used
- If profile is missing, warning should display. User should be able to dismiss the warning and the buttons should still be enabled
- An invalid API key should display the proper warning with buttons disabled

## Breaking Changes

None

## Dependencies and/or References

Common OpenAI errors: https://platform.openai.com/docs/guides/error-codes/api-errors

## Deployment
