### PR TITLE
feat: add character limit to brand fields and the prompt field in aicg

### DIFF
--- a/apps/ai-content-generator/src/components/app/dialog/common-generator/generatorReducer.tsx
+++ b/apps/ai-content-generator/src/components/app/dialog/common-generator/generatorReducer.tsx
@@ -76,7 +76,10 @@ const generatorReducer = (
 ): GeneratorParameters => {
   switch (action.type) {
     case IS_NEW_TEXT:
-      return { ...state, isNewText: true };
+      return {
+        ...state,
+        isNewText: true,
+      };
     case IS_NOT_NEW_TEXT:
       return { ...state, isNewText: false };
     case UPDATE_SOURCE_FIELD:

--- a/apps/ai-content-generator/src/components/app/dialog/common-generator/output/output-text-panels/original-text-panel/OriginalTextPanel.tsx
+++ b/apps/ai-content-generator/src/components/app/dialog/common-generator/output/output-text-panels/original-text-panel/OriginalTextPanel.tsx
@@ -76,7 +76,9 @@ const OriginalTextPanel = (props: Props) => {
         errorMessage={errorMessage}
         sizeValidation={{ max: textLimit }}
         {...helpTextProps}>
-        <Button onClick={handleGenerate} isDisabled={isGenerateButtonDisabled || textaboveLimit}>
+        <Button
+          onClick={handleGenerate}
+          isDisabled={isGenerateButtonDisabled || textaboveLimit || isGenerating}>
           Generate
         </Button>
       </TextFieldWithButtons>

--- a/apps/ai-content-generator/src/components/app/dialog/common-generator/output/output-text-panels/original-text-panel/OriginalTextPanel.tsx
+++ b/apps/ai-content-generator/src/components/app/dialog/common-generator/output/output-text-panels/original-text-panel/OriginalTextPanel.tsx
@@ -8,6 +8,10 @@ import { DialogText } from '@configs/features/featureTypes';
 import { css } from '@emotion/react';
 import { tokenWarning } from '@configs/token-warning/tokenWarning';
 import { SegmentEvents } from '@configs/segment/segmentEvent';
+import { useSDK } from '@contentful/react-apps-toolkit';
+import AppInstallationParameters from '@components/config/appInstallationParameters';
+import { DialogAppSDK } from '@contentful/app-sdk';
+import { gptModels } from '@configs/ai/gptModels';
 
 const styles = {
   panel: css({
@@ -38,6 +42,10 @@ const OriginalTextPanel = (props: Props) => {
     generate();
   };
 
+  const sdk = useSDK<DialogAppSDK<AppInstallationParameters>>();
+  const model = gptModels.find((model) => model.id === sdk.parameters.installation.model);
+  const textLimit = model?.textLimit;
+
   const handleOriginalTextChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const type = isNewText
       ? GeneratorAction.UPDATE_ORIGINAL_TEXT_PROMPT
@@ -49,8 +57,11 @@ const OriginalTextPanel = (props: Props) => {
   };
 
   const isTextAreaDisabled = isNewText ? false : !inputText;
+  const textaboveLimit = inputText.length >= (textLimit || Infinity);
+
   const isGenerateButtonDisabled = !inputText || !hasOutputField;
   const placeholderText = isNewText ? dialogText.promptPlaceholder : dialogText.fieldPlaceholder;
+
   const helpText = isNewText ? dialogText.promptHelpText : dialogText.fieldHelpText;
   const helpTextProps = isGenerateButtonDisabled ? { helpText } : { warningMessage: tokenWarning };
 
@@ -63,8 +74,9 @@ const OriginalTextPanel = (props: Props) => {
         placeholder={placeholderText}
         hasError={hasError}
         errorMessage={errorMessage}
+        sizeValidation={{ max: textLimit }}
         {...helpTextProps}>
-        <Button onClick={handleGenerate} isDisabled={isGenerateButtonDisabled || isGenerating}>
+        <Button onClick={handleGenerate} isDisabled={isGenerateButtonDisabled || textaboveLimit}>
           Generate
         </Button>
       </TextFieldWithButtons>

--- a/apps/ai-content-generator/src/components/common/text-field-with-buttons/TextFieldWIthButtons.tsx
+++ b/apps/ai-content-generator/src/components/common/text-field-with-buttons/TextFieldWIthButtons.tsx
@@ -6,6 +6,7 @@ import HyperLink from '../HyperLink/HyperLink';
 import { styles } from './TextFieldWithButtons.styles';
 import { TokenWarning } from '@configs/token-warning/tokenWarning';
 import { ErrorCircleOutlineIcon, ExternalLinkIcon } from '@contentful/f36-icons';
+import tokens from '@contentful/f36-tokens';
 
 interface Props {
   inputText: string;
@@ -53,14 +54,14 @@ const TextFieldWithButtons = (props: Props) => {
         maxLength={sizeValidation?.max}
         minLength={sizeValidation?.min}
       />
-      <Paragraph>
-        {!hasError ? (
+      <Paragraph css={{ color: tokens.red500 }}>
+        {hasError ? (
           <>
             <ErrorCircleOutlineIcon
               variant="negative"
               marginRight="spacing2Xs"
               data-testid="error-icon"
-            />{' '}
+            />
             {errorMessage}
           </>
         ) : null}

--- a/apps/ai-content-generator/src/components/config/appInstallationParameters.ts
+++ b/apps/ai-content-generator/src/components/config/appInstallationParameters.ts
@@ -1,0 +1,22 @@
+interface AppInstallationParameters {
+  model: string;
+  key: string;
+  profile: string;
+  brandProfile: ProfileType;
+}
+
+export enum ProfileFields {
+  PROFILE = 'profile',
+  VALUES = 'values',
+  TONE = 'tone',
+  EXCLUDE = 'exclude',
+  INCLUDE = 'include',
+  AUDIENCE = 'audience',
+  ADDITIONAL = 'additional',
+}
+
+export type ProfileType = {
+  [K in ProfileFields]?: string;
+};
+
+export default AppInstallationParameters;

--- a/apps/ai-content-generator/src/components/config/brand-section/BrandSection.tsx
+++ b/apps/ai-content-generator/src/components/config/brand-section/BrandSection.tsx
@@ -2,16 +2,16 @@ import { Dispatch } from 'react';
 import { Box, Flex, Form, Paragraph, Subheading } from '@contentful/f36-components';
 import Profile from '../profile/Profile';
 import { Sections } from '../configText';
-import { ParameterReducer } from '../parameterReducer';
+import { ParameterReducer, Validator } from '../parameterReducer';
 import { css } from '@emotion/react';
-import { ProfileType } from '@locations/ConfigScreen';
+import { ProfileType } from '../appInstallationParameters';
 
 export const styles = css({
   width: '100%',
 });
 
 interface Props {
-  profile: ProfileType;
+  profile: Validator<ProfileType>;
   dispatch: Dispatch<ParameterReducer>;
 }
 

--- a/apps/ai-content-generator/src/components/config/config-section/ConfigSection.tsx
+++ b/apps/ai-content-generator/src/components/config/config-section/ConfigSection.tsx
@@ -10,27 +10,17 @@ interface Props {
   model: string;
   dispatch: Dispatch<ParameterReducer>;
   isApiKeyValid: boolean;
-  localApiKey: string;
-  onApiKeyChange: (key: string) => void;
-  validateApiKey: (key: string) => Promise<void>;
 }
 
 const ConfigSection = (props: Props) => {
-  const { apiKey, model, dispatch, isApiKeyValid, localApiKey, onApiKeyChange, validateApiKey } =
-    props;
+  const { apiKey, model, dispatch, isApiKeyValid } = props;
 
   return (
     <Flex flexDirection="column" alignItems="flex-start" fullWidth={true}>
       <Subheading>{Sections.configHeading}</Subheading>
       <Box>
         <Form>
-          <APIKey
-            apiKey={apiKey}
-            isInvalid={!isApiKeyValid}
-            localApiKey={localApiKey}
-            onApiKeyChange={onApiKeyChange}
-            validateApiKey={validateApiKey}
-          />
+          <APIKey apiKey={apiKey} isInvalid={!isApiKeyValid} dispatch={dispatch} />
           <Model model={model} dispatch={dispatch} />
         </Form>
       </Box>

--- a/apps/ai-content-generator/src/components/config/configText.ts
+++ b/apps/ai-content-generator/src/components/config/configText.ts
@@ -1,3 +1,5 @@
+import { ProfileFields } from './appInstallationParameters';
+
 const ModelText = {
   title: 'Machine Learning Model',
   helpText:
@@ -5,16 +7,6 @@ const ModelText = {
     'models is not significant. However, in more complex reasoning situations, GPT-4 is much more ' +
     'capable than any previous models.',
 };
-
-export enum ProfileFields {
-  PROFILE = 'profile',
-  VALUES = 'values',
-  TONE = 'tone',
-  EXCLUDE = 'exclude',
-  INCLUDE = 'include',
-  AUDIENCE = 'audience',
-  ADDITIONAL = 'additional',
-}
 
 export enum FieldTypes {
   TEXTAREA = 'textarea',
@@ -27,36 +19,42 @@ const BrandProfileFields = [
     title: 'Describe your brand or product.',
     textAreaPlaceholder: 'Example: Contentful is a headless content management system.',
     fieldType: FieldTypes.TEXTAREA,
+    textLimit: 1000,
   },
   {
     id: ProfileFields.VALUES,
     title: "What are your brand's values and attributes?",
     textAreaPlaceholder: 'Example: Bold, unique, young',
     fieldType: FieldTypes.TEXTINPUT,
+    textLimit: 200,
   },
   {
     id: ProfileFields.TONE,
     title: "Describe your brand's voice and tone.",
     textAreaPlaceholder: 'Example: Humorous, absurd, kind',
     fieldType: FieldTypes.TEXTINPUT,
+    textLimit: 200,
   },
   {
     id: ProfileFields.EXCLUDE,
     title: 'Are there any words your brand should never use?',
     textAreaPlaceholder: 'Example: Humorous, absurd, kind',
     fieldType: FieldTypes.TEXTINPUT,
+    textLimit: 200,
   },
   {
     id: ProfileFields.INCLUDE,
     title: 'Are there any words your brand should commonly use?',
     textAreaPlaceholder: 'Example: Humorous, absurd, kind',
     fieldType: FieldTypes.TEXTINPUT,
+    textLimit: 200,
   },
   {
     id: ProfileFields.AUDIENCE,
     title: "Describe your brand's target audience.",
     textAreaPlaceholder: 'Example: Men and women ages 18-24 who love fashion.',
     fieldType: FieldTypes.TEXTINPUT,
+    textLimit: 200,
   },
   {
     id: ProfileFields.ADDITIONAL,
@@ -64,6 +62,7 @@ const BrandProfileFields = [
     textAreaPlaceholder:
       'Example: Contentful is a leading composable content platform. It was a headless CMS category maker that now has company in the marketplace, but remains to be the preferred choice for medium, large and enterprise companies.',
     fieldType: FieldTypes.TEXTAREA,
+    textLimit: 1000,
   },
 ];
 
@@ -98,7 +97,7 @@ const Sections = {
 const ConfigErrors = {
   missingApiKey: 'Invalid or missing API Key',
   missingModel: 'A valid model must be selected',
-  missingProfile: 'Please enter a brand profile',
+  exceededCharacterLimit: 'One or more profile fields exceeds the character limit',
   noContentTypes:
     'There are no content types available in this environment. You can add a content type and then assign it to the app from this screen.',
   noContentTypesSubstring: 'add a content type',

--- a/apps/ai-content-generator/src/components/config/parameterReducer.ts
+++ b/apps/ai-content-generator/src/components/config/parameterReducer.ts
@@ -1,4 +1,4 @@
-import { AppInstallationParameters } from '@locations/ConfigScreen';
+import AppInstallationParameters from './appInstallationParameters';
 
 export enum ParameterAction {
   UPDATE_MODEL = 'updateModel',
@@ -9,11 +9,14 @@ export enum ParameterAction {
 }
 
 type ParameterStringActions = {
-  type: Exclude<
-    ParameterAction,
-    ParameterAction.APPLY_CONTENTFUL_PARAMETERS | ParameterAction.UPDATE_BRAND_PROFILE
-  >;
+  type: ParameterAction.UPDATE_MODEL;
   value: string;
+};
+
+type ParameterUpdateKeyAction = {
+  type: ParameterAction.UPDATE_APIKEY;
+  value: string;
+  isValid: boolean;
 };
 
 type ParameterObjectActions = {
@@ -21,16 +24,25 @@ type ParameterObjectActions = {
   value: AppInstallationParameters;
 };
 
-type ParameterProfileActions = {
+type ParameterProfileAction = {
+  type: ParameterAction.UPDATE_PROFILE;
+  value: string;
+  textLimit: number;
+};
+
+type ParameterBrandProfileActions = {
   type: ParameterAction.UPDATE_BRAND_PROFILE;
   field: string;
   value: string;
+  textLimit: number;
 };
 
 export type ParameterReducer =
   | ParameterObjectActions
+  | ParameterUpdateKeyAction
   | ParameterStringActions
-  | ParameterProfileActions;
+  | ParameterProfileAction
+  | ParameterBrandProfileActions;
 
 const {
   UPDATE_MODEL,
@@ -40,24 +52,111 @@ const {
   APPLY_CONTENTFUL_PARAMETERS,
 } = ParameterAction;
 
-const parameterReducer = (state: AppInstallationParameters, action: ParameterReducer) => {
+/**
+ * This is a recursive type that will validate the parameter
+ * It first evaluates if the current key has a value that is an object
+ * If it is an object, it will recursively call the type to validate the object
+ */
+export type Validator<Type> = {
+  [Key in keyof Type]: Type[Key] extends object
+    ? Validator<Type[Key]>
+    : {
+        isValid: boolean;
+        value: Type[Key];
+      };
+};
+
+const parameterReducer = (
+  state: Validator<AppInstallationParameters>,
+  action: ParameterReducer
+): Validator<AppInstallationParameters> => {
   switch (action.type) {
     case UPDATE_MODEL:
-      return { ...state, model: action.value };
-    case UPDATE_APIKEY:
-      return { ...state, key: action.value };
-    case UPDATE_PROFILE:
-      return { ...state, profile: action.value };
-    case UPDATE_BRAND_PROFILE:
+      return {
+        ...state,
+        model: {
+          value: action.value,
+          isValid: action.value.length > 0,
+        },
+      };
+    case UPDATE_APIKEY: {
+      return {
+        ...state,
+        key: {
+          value: action.value,
+          isValid: action.isValid,
+        },
+      };
+    }
+    case UPDATE_PROFILE: {
+      const isValid = action.value.length <= action.textLimit;
+
+      return {
+        ...state,
+        profile: {
+          value: action.value,
+          isValid,
+        },
+      };
+    }
+    case UPDATE_BRAND_PROFILE: {
+      const isValid = action.value.length <= action.textLimit;
+
       return {
         ...state,
         brandProfile: {
           ...state.brandProfile,
-          [action.field]: action.value,
+          [action.field]: {
+            value: action.value,
+            isValid,
+          },
         },
       };
-    case APPLY_CONTENTFUL_PARAMETERS:
-      return { ...state, ...action.value };
+    }
+    case APPLY_CONTENTFUL_PARAMETERS: {
+      const parameter = action.value as AppInstallationParameters;
+      return {
+        ...state,
+        model: {
+          value: parameter.model,
+          isValid: parameter.model.length > 0,
+        },
+        key: {
+          value: parameter.key,
+          isValid: true,
+        },
+        profile: {
+          value: parameter.profile,
+          isValid: true,
+        },
+        brandProfile: {
+          values: {
+            value: parameter.brandProfile?.values || '',
+            isValid: true,
+          },
+          tone: {
+            value: parameter.brandProfile?.tone || '',
+            isValid: true,
+          },
+          exclude: {
+            value: parameter.brandProfile?.exclude || '',
+            isValid: true,
+          },
+          include: {
+            value: parameter.brandProfile?.include || '',
+            isValid: true,
+          },
+          audience: {
+            value: parameter.brandProfile?.audience || '',
+            isValid: true,
+          },
+          additional: {
+            value: parameter.brandProfile?.additional || '',
+            isValid: true,
+          },
+        },
+      };
+    }
     default:
       return state;
   }

--- a/apps/ai-content-generator/src/components/config/profile/Profile.tsx
+++ b/apps/ai-content-generator/src/components/config/profile/Profile.tsx
@@ -1,13 +1,13 @@
 import { Dispatch } from 'react';
 import { FormControl } from '@contentful/f36-components';
-import { ParameterReducer } from '../parameterReducer';
-import { BrandProfileFields, FieldTypes, ProfileFields } from '../configText';
-import { ProfileType } from '@locations/ConfigScreen';
+import { ParameterReducer, Validator } from '../parameterReducer';
+import { BrandProfileFields, FieldTypes } from '../configText';
 import ProfileTextArea from './ProfileTextArea';
 import ProfileTextInput from './ProfileTextInput';
+import { ProfileType, ProfileFields } from '../appInstallationParameters';
 
 interface Props {
-  profile: ProfileType;
+  profile: Validator<ProfileType>;
   dispatch: Dispatch<ParameterReducer>;
 }
 
@@ -20,9 +20,10 @@ const Profile = (props: Props) => {
         const marginBottomStyle = field.id === ProfileFields.ADDITIONAL ? 'none' : 'spacingL';
 
         const fieldProps = {
-          value: profile[field.id] ?? '',
+          value: profile[field.id]?.value ?? '',
           name: field.title,
           id: field.id,
+          textLimit: field.textLimit,
           placeholder: field.textAreaPlaceholder,
           dispatch: dispatch,
         };

--- a/apps/ai-content-generator/src/components/config/profile/ProfileTextArea.tsx
+++ b/apps/ai-content-generator/src/components/config/profile/ProfileTextArea.tsx
@@ -2,20 +2,22 @@ import { ChangeEvent, Dispatch, useEffect, useState } from 'react';
 import { Textarea } from '@contentful/f36-components';
 import { ParameterAction, ParameterReducer } from '../parameterReducer';
 import { useDebounce } from 'usehooks-ts';
-import { ProfileFields } from '../configText';
+import TextCounter from '@components/common/text-counter/TextCounter';
+import { ProfileFields } from '../appInstallationParameters';
 
 interface Props {
   value: string;
   name: string;
   id: string;
   placeholder: string;
+  textLimit: number;
   dispatch: Dispatch<ParameterReducer>;
 }
 
 const TEXTAREA_ROWS = 5;
 
 const ProfileTextArea = (props: Props) => {
-  const { value, name, id, placeholder, dispatch } = props;
+  const { value, name, id, placeholder, textLimit, dispatch } = props;
   const [fieldValue, setFieldValue] = useState('');
   const debouncedValue = useDebounce<string>(fieldValue, 300);
 
@@ -25,25 +27,33 @@ const ProfileTextArea = (props: Props) => {
 
   useEffect(() => {
     if (id === ProfileFields.PROFILE) {
-      dispatch({ type: ParameterAction.UPDATE_PROFILE, value: debouncedValue });
+      dispatch({ type: ParameterAction.UPDATE_PROFILE, value: debouncedValue, textLimit });
     } else {
-      dispatch({ type: ParameterAction.UPDATE_BRAND_PROFILE, value: debouncedValue, field: id });
+      dispatch({
+        type: ParameterAction.UPDATE_BRAND_PROFILE,
+        value: debouncedValue,
+        field: id,
+        textLimit,
+      });
     }
-  }, [debouncedValue, dispatch, id]);
+  }, [debouncedValue, dispatch, id, textLimit]);
 
   const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
     setFieldValue(e.target.value);
   };
 
   return (
-    <Textarea
-      rows={TEXTAREA_ROWS}
-      resize="none"
-      value={fieldValue}
-      name={name}
-      placeholder={placeholder}
-      onChange={handleChange}
-    />
+    <>
+      <Textarea
+        rows={TEXTAREA_ROWS}
+        resize="none"
+        value={fieldValue}
+        name={name}
+        placeholder={placeholder}
+        onChange={handleChange}
+      />
+      <TextCounter text={fieldValue} maxLength={textLimit} />
+    </>
   );
 };
 

--- a/apps/ai-content-generator/src/components/config/profile/ProfileTextInput.tsx
+++ b/apps/ai-content-generator/src/components/config/profile/ProfileTextInput.tsx
@@ -2,18 +2,20 @@ import { ChangeEvent, Dispatch, useEffect, useState } from 'react';
 import { TextInput } from '@contentful/f36-components';
 import { ParameterAction, ParameterReducer } from '../parameterReducer';
 import { useDebounce } from 'usehooks-ts';
-import { ProfileFields } from '../configText';
+import TextCounter from '@components/common/text-counter/TextCounter';
+import { ProfileFields } from '../appInstallationParameters';
 
 interface Props {
   value: string;
   name: string;
   id: string;
   placeholder: string;
+  textLimit: number;
   dispatch: Dispatch<ParameterReducer>;
 }
 
 const ProfileTextInput = (props: Props) => {
-  const { value, name, id, placeholder, dispatch } = props;
+  const { value, name, id, placeholder, textLimit, dispatch } = props;
   const [fieldValue, setFieldValue] = useState('');
   const debouncedValue = useDebounce<string>(fieldValue, 300);
 
@@ -23,24 +25,32 @@ const ProfileTextInput = (props: Props) => {
 
   useEffect(() => {
     if (id === ProfileFields.PROFILE) {
-      dispatch({ type: ParameterAction.UPDATE_PROFILE, value: debouncedValue });
+      dispatch({ type: ParameterAction.UPDATE_PROFILE, value: debouncedValue, textLimit });
     } else {
-      dispatch({ type: ParameterAction.UPDATE_BRAND_PROFILE, value: debouncedValue, field: id });
+      dispatch({
+        type: ParameterAction.UPDATE_BRAND_PROFILE,
+        value: debouncedValue,
+        field: id,
+        textLimit,
+      });
     }
-  }, [debouncedValue, dispatch, id]);
+  }, [debouncedValue, dispatch, id, textLimit]);
 
   const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
     setFieldValue(e.target.value);
   };
 
   return (
-    <TextInput
-      type="text"
-      value={fieldValue}
-      name={name}
-      placeholder={placeholder}
-      onChange={handleChange}
-    />
+    <>
+      <TextInput
+        type="text"
+        value={fieldValue}
+        name={name}
+        placeholder={placeholder}
+        onChange={handleChange}
+      />
+      <TextCounter text={fieldValue} maxLength={textLimit}></TextCounter>
+    </>
   );
 };
 

--- a/apps/ai-content-generator/src/configs/ai/gptModels.ts
+++ b/apps/ai-content-generator/src/configs/ai/gptModels.ts
@@ -1,6 +1,6 @@
 const gptModels = [
-  { id: 'gpt-3.5-turbo', name: 'GPT-3.5' },
-  { id: 'gpt-3.5-turbo-16k', name: 'GPT-3.5 16k' },
+  { id: 'gpt-3.5-turbo', name: 'GPT-3.5', textLimit: 12000 },
+  { id: 'gpt-3.5-turbo-16k', name: 'GPT-3.5 16k', textLimit: 12000 },
   { id: 'gpt-4', name: 'GPT-4' },
   { id: 'gpt-4-32k', name: 'GPT-4 32k' },
 ];

--- a/apps/ai-content-generator/src/configs/prompts/baseSystemPrompt.ts
+++ b/apps/ai-content-generator/src/configs/prompts/baseSystemPrompt.ts
@@ -1,6 +1,5 @@
+import { ProfileFields, ProfileType } from '@components/config/appInstallationParameters';
 import { ChatCompletionRequestMessage } from 'openai';
-import { ProfileFields } from '@components/config/configText';
-import { ProfileType } from '@locations/ConfigScreen';
 
 const generateBrandProfile = (profile: ProfileType) => {
   const { PROFILE, ADDITIONAL, VALUES, TONE, AUDIENCE, EXCLUDE, INCLUDE } = ProfileFields;

--- a/apps/ai-content-generator/src/hooks/config/useInitializeParameters.ts
+++ b/apps/ai-content-generator/src/hooks/config/useInitializeParameters.ts
@@ -1,8 +1,8 @@
 import { Dispatch, useEffect, useCallback } from 'react';
 import { useSDK } from '@contentful/react-apps-toolkit';
 import type { ConfigAppSDK } from '@contentful/app-sdk';
-import { AppInstallationParameters } from '@locations/ConfigScreen';
 import { ParameterAction, ParameterReducer } from '@components/config/parameterReducer';
+import AppInstallationParameters from '@components/config/appInstallationParameters';
 
 /**
  * This hook is used to initialize the parameters of the app.

--- a/apps/ai-content-generator/src/hooks/config/useSaveConfigHandler.spec.tsx
+++ b/apps/ai-content-generator/src/hooks/config/useSaveConfigHandler.spec.tsx
@@ -8,7 +8,7 @@ import {
   mockContentTypes,
 } from '../../../test/mocks';
 import useSaveConfigHandler from './useSaveConfigHandler';
-import { AppInstallationParameters } from '@locations/ConfigScreen';
+import AppInstallationParameters from '@components/config/appInstallationParameters';
 
 const mockSdk = new MockSdk();
 const sdk = mockSdk.sdk;

--- a/apps/ai-content-generator/src/hooks/config/useSaveConfigHandler.ts
+++ b/apps/ai-content-generator/src/hooks/config/useSaveConfigHandler.ts
@@ -1,4 +1,4 @@
-import { AppInstallationParameters } from '@locations/ConfigScreen';
+import AppInstallationParameters from '@components/config/appInstallationParameters';
 import { AppState, ConfigAppSDK } from '@contentful/app-sdk';
 import { useSDK } from '@contentful/react-apps-toolkit';
 import { useEffect, useCallback, useContext } from 'react';
@@ -15,14 +15,14 @@ import { SegmentEvents } from '@configs/segment/segmentEvent';
  */
 const useSaveConfigHandler = (
   parameters: AppInstallationParameters,
-  validateParams: (params: AppInstallationParameters) => Promise<string[]>,
+  validateParams: (params: AppInstallationParameters) => string[],
   contentTypes: Set<string>
 ) => {
   const sdk = useSDK<ConfigAppSDK>();
   const { trackEvent } = useContext(SegmentAnalyticsContext);
 
   const getCurrentState = useCallback(async () => {
-    const notifierErrors = await validateParams(parameters);
+    const notifierErrors = validateParams(parameters);
 
     if (notifierErrors.length) {
       notifierErrors.forEach((error) => sdk.notifier.error(error));

--- a/apps/ai-content-generator/src/hooks/dialog/useAI.tsx
+++ b/apps/ai-content-generator/src/hooks/dialog/useAI.tsx
@@ -51,12 +51,18 @@ const useAI = () => {
   const resetOutput = () => {
     setOutput('');
     setError('');
+    if (stream) {
+      stream.cancel();
+    }
+    setStream(null);
+
     setHasError(false);
   };
 
   const generateMessage = async (prompt: string, targetLocale: string) => {
     resetOutput();
     let completeMessage = '';
+    setIsGenerating(true);
 
     try {
       const payload = createGPTPayload(
@@ -84,6 +90,7 @@ const useAI = () => {
     } catch (error: unknown) {
       console.error(error);
       setError(error as string);
+      console.log('error launched');
       setHasError(true);
     } finally {
       setStream(null);

--- a/apps/ai-content-generator/src/hooks/dialog/useAI.tsx
+++ b/apps/ai-content-generator/src/hooks/dialog/useAI.tsx
@@ -2,11 +2,13 @@ import baseSystemPrompt from '@configs/prompts/baseSystemPrompt';
 import { chatCompletionsBaseUrl } from '@configs/ai/baseUrl';
 import { DialogAppSDK } from '@contentful/app-sdk';
 import { useSDK } from '@contentful/react-apps-toolkit';
-import { AppInstallationParameters, ProfileType } from '@locations/ConfigScreen';
 import AI from '@utils/aiApi';
 import { ChatCompletionRequestMessage } from 'openai';
 import { useEffect, useMemo, useState } from 'react';
 import { defaultModelId } from '@configs/ai/gptModels';
+import AppInstallationParameters, {
+  ProfileType,
+} from '@components/config/appInstallationParameters';
 
 export type GenerateMessage = (prompt: string, targetLocale: string) => Promise<string>;
 

--- a/apps/ai-content-generator/src/hooks/dialog/useDialogParameters.ts
+++ b/apps/ai-content-generator/src/hooks/dialog/useDialogParameters.ts
@@ -1,6 +1,6 @@
+import AppInstallationParameters from '@components/config/appInstallationParameters';
 import { DialogAppSDK } from '@contentful/app-sdk';
 import { useSDK } from '@contentful/react-apps-toolkit';
-import { AppInstallationParameters } from '@locations/ConfigScreen';
 import { DialogInvocationParameters } from '@locations/Dialog';
 import { useEffect, useState } from 'react';
 

--- a/apps/ai-content-generator/src/hooks/sidebar/useSidebarParameters.ts
+++ b/apps/ai-content-generator/src/hooks/sidebar/useSidebarParameters.ts
@@ -3,8 +3,8 @@ import { useSDK } from '@contentful/react-apps-toolkit';
 import { SidebarAppSDK } from '@contentful/app-sdk';
 import AI from '@utils/aiApi';
 import { modelsBaseUrl } from '@configs/ai/baseUrl';
-import { AppInstallationParameters } from '@locations/ConfigScreen';
 import { AiApiError, AiApiErrorType } from '@utils/aiApi/handleAiApiErrors';
+import AppInstallationParameters from '@components/config/appInstallationParameters';
 
 /**
  * This hook is used to get the installation parameters from the sidebar location,

--- a/apps/ai-content-generator/src/locations/ConfigScreen.tsx
+++ b/apps/ai-content-generator/src/locations/ConfigScreen.tsx
@@ -1,21 +1,7 @@
 import ConfigPage from '@components/config/config-page/ConfigPage';
-import { ProfileFields } from '@components/config/configText';
-
-export type ProfileType = {
-  [K in ProfileFields]?: string;
-};
-interface AppInstallationParameters {
-  // Model is optional since V1 of the config page didn't save model as a param if you had the default selected.
-  model?: string;
-  key: string;
-  profile: string;
-  // Optional since we are accessing properties on this object
-  brandProfile?: ProfileType;
-}
 
 const ConfigScreen = () => {
   return <ConfigPage />;
 };
 
 export default ConfigScreen;
-export type { AppInstallationParameters };

--- a/apps/ai-content-generator/src/providers/segmentAnalyticsProvider.tsx
+++ b/apps/ai-content-generator/src/providers/segmentAnalyticsProvider.tsx
@@ -4,9 +4,9 @@ import { createContext, ReactNode } from 'react';
 import { getUserCookieConsent } from '@utils/segment/cookieConsent';
 import { SegmentEvent, SegmentEventData, SegmentIdentify } from '@configs/segment/segmentEvent';
 import getTrackedAppData from '@utils/segment/getTrackedAppData';
-import { AppInstallationParameters } from '@locations/ConfigScreen';
 import { useSDK } from '@contentful/react-apps-toolkit';
 import { SegmentEvents } from '@configs/segment/segmentEvent';
+import AppInstallationParameters from '@components/config/appInstallationParameters';
 
 interface SegmentAnalyticsContextProps {
   identify: () => void;

--- a/apps/ai-content-generator/src/utils/segment/getTrackedAppData.ts
+++ b/apps/ai-content-generator/src/utils/segment/getTrackedAppData.ts
@@ -1,6 +1,6 @@
 import { SegmentAppData } from '@configs/segment/segmentEvent';
 import { BaseAppSDK } from '@contentful/app-sdk';
-import { AppInstallationParameters } from '@locations/ConfigScreen';
+import AppInstallationParameters from '@components/config/appInstallationParameters';
 
 const getTrackedAppData = (sdk: BaseAppSDK<AppInstallationParameters>): SegmentAppData => {
   const { installation } = sdk.parameters;

--- a/apps/ai-content-generator/test/mocks/sdk/mockSdk.ts
+++ b/apps/ai-content-generator/test/mocks/sdk/mockSdk.ts
@@ -1,4 +1,3 @@
-import { AppInstallationParameters } from '@locations/ConfigScreen';
 import { mockSdkParameters } from '..';
 import { createSDK } from './utils/createSdk';
 import { vi } from 'vitest';
@@ -8,6 +7,7 @@ import {
   mockContentType,
 } from './contentTypes/mockContentType';
 import { mockEntry } from './entry/mockEntry';
+import AppInstallationParameters from '@components/config/appInstallationParameters';
 
 interface MockSdk {
   sdk: ReturnType<typeof createSDK>;

--- a/apps/ai-content-generator/test/mocks/sdk/parameters/happyPathParameter.ts
+++ b/apps/ai-content-generator/test/mocks/sdk/parameters/happyPathParameter.ts
@@ -1,4 +1,4 @@
-import { AppInstallationParameters } from '@locations/ConfigScreen';
+import AppInstallationParameters from '@components/config/appInstallationParameters';
 
 const happyPath: AppInstallationParameters = {
   model: 'gpt-3.5-turbo',

--- a/apps/ai-content-generator/test/mocks/sdk/parameters/initParameters.ts
+++ b/apps/ai-content-generator/test/mocks/sdk/parameters/initParameters.ts
@@ -1,4 +1,4 @@
-import { AppInstallationParameters } from '@locations/ConfigScreen';
+import AppInstallationParameters from '@components/config/appInstallationParameters';
 
 const init: AppInstallationParameters = {
   model: '',

--- a/apps/ai-content-generator/test/mocks/sdk/utils/createSdk.ts
+++ b/apps/ai-content-generator/test/mocks/sdk/utils/createSdk.ts
@@ -1,4 +1,3 @@
-import { AppInstallationParameters } from '@locations/ConfigScreen';
 import { vi } from 'vitest';
 import {
   mockGetManyContentType,
@@ -6,6 +5,7 @@ import {
   mockContentType,
 } from '../contentTypes/mockContentType';
 import { mockEntry } from '../entry/mockEntry';
+import AppInstallationParameters from '@components/config/appInstallationParameters';
 
 const createSDK = (parameters: AppInstallationParameters) => {
   return {

--- a/apps/ai-content-generator/test/mocks/sdk/utils/generateRandomParameters.ts
+++ b/apps/ai-content-generator/test/mocks/sdk/utils/generateRandomParameters.ts
@@ -1,5 +1,5 @@
+import AppInstallationParameters from '@components/config/appInstallationParameters';
 import { gptModels } from '@configs/ai/gptModels';
-import { AppInstallationParameters } from '@locations/ConfigScreen';
 
 const generateRandomParameters = (): AppInstallationParameters => {
   const randomModelIndex = Math.floor(Math.random() * gptModels.length);


### PR DESCRIPTION
## Purpose

ChatGPT 3 has a character limit of ~16k. Also the ai gets significantly worse when user adds too much data for it to consider

## Approach

Create a `Validator` type that takes an existing type and recursively adds `{ value: originalValue, isValid: bool }` to every field.

Then reorganized the code so the validation happens during the dispatch

## Testing steps

Verify:
- The config page still has original functionality
- You can't submit the form when exceeding the character count
- Prompt/From Source shows a character count when using gpt3 and not in gpt4
