### PR TITLE
Support EU region in upload URLs

### DIFF
--- a/apps/ai-image-generator/backend/package-lock.json
+++ b/apps/ai-image-generator/backend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@contentful/ai-image-generator-backend",
       "version": "0.1.0",
       "dependencies": {
-        "@contentful/node-apps-toolkit": "^2.2.0",
+        "@contentful/node-apps-toolkit": "^2.6.0",
         "contentful-management": "^10.44.0",
         "openai": "^4.0.0",
         "sharp": "^0.32.5"

--- a/apps/ai-image-generator/backend/package.json
+++ b/apps/ai-image-generator/backend/package.json
@@ -13,7 +13,7 @@
     "call-hosted-app-action": "npx ts-node test/scripts/call-hosted-app-action.ts"
   },
   "dependencies": {
-    "@contentful/node-apps-toolkit": "^2.2.0",
+    "@contentful/node-apps-toolkit": "^2.6.0",
     "contentful-management": "^10.44.0",
     "openai": "^4.0.0",
     "sharp": "^0.32.5"

--- a/apps/ai-image-generator/backend/src/actions/aiig-select-edit.ts
+++ b/apps/ai-image-generator/backend/src/actions/aiig-select-edit.ts
@@ -25,7 +25,7 @@ export const handler = async (
 ): Promise<AppActionCallResponse<ImageEditResult>> => {
   const {
     cma,
-    appActionCallContext: { appInstallationId, spaceId, cmaHost },
+    appActionCallContext: { appInstallationId, spaceId, uploadHost },
   } = context;
 
   let images: ImageWithUpload[];
@@ -72,7 +72,7 @@ export const handler = async (
       imagesWithStreams: processedImages,
       cmaClient: cma,
       spaceId,
-      cmaHost,
+      uploadHost,
     });
   } catch (e) {
     if (!(e instanceof Error)) {

--- a/apps/ai-image-generator/backend/src/actions/aiig-select-edit.ts
+++ b/apps/ai-image-generator/backend/src/actions/aiig-select-edit.ts
@@ -25,7 +25,7 @@ export const handler = async (
 ): Promise<AppActionCallResponse<ImageEditResult>> => {
   const {
     cma,
-    appActionCallContext: { appInstallationId, spaceId },
+    appActionCallContext: { appInstallationId, spaceId, cmaHost },
   } = context;
 
   let images: ImageWithUpload[];
@@ -72,6 +72,7 @@ export const handler = async (
       imagesWithStreams: processedImages,
       cmaClient: cma,
       spaceId,
+      cmaHost,
     });
   } catch (e) {
     if (!(e instanceof Error)) {

--- a/apps/ai-image-generator/backend/src/helpers/upload-images.spec.ts
+++ b/apps/ai-image-generator/backend/src/helpers/upload-images.spec.ts
@@ -10,6 +10,7 @@ describe('UploadImages', () => {
   const spaceId = 'spaceId';
   const uploadId = 'uploadId';
   const sourceUrl = 'http://www.example.com';
+  const cmaHost = 'api.contentful.com';
   const cmaClientStub = sinon.stub();
 
   describe('execute', () => {
@@ -43,7 +44,7 @@ describe('UploadImages', () => {
       };
 
       const cmaClient = makeMockPlainClient([mockUploadApiResponse], cmaClientStub);
-      uploadImages = new UploadImages(imagesWithStreams, cmaClient, spaceId);
+      uploadImages = new UploadImages(imagesWithStreams, cmaClient, spaceId, cmaHost);
     });
 
     it('returns images with correct urls', async () => {

--- a/apps/ai-image-generator/backend/src/helpers/upload-images.spec.ts
+++ b/apps/ai-image-generator/backend/src/helpers/upload-images.spec.ts
@@ -10,7 +10,7 @@ describe('UploadImages', () => {
   const spaceId = 'spaceId';
   const uploadId = 'uploadId';
   const sourceUrl = 'http://www.example.com';
-  const cmaHost = 'api.contentful.com';
+  const uploadHost = 'upload.contentful.com';
   const cmaClientStub = sinon.stub();
 
   describe('execute', () => {
@@ -44,7 +44,7 @@ describe('UploadImages', () => {
       };
 
       const cmaClient = makeMockPlainClient([mockUploadApiResponse], cmaClientStub);
-      uploadImages = new UploadImages(imagesWithStreams, cmaClient, spaceId, cmaHost);
+      uploadImages = new UploadImages(imagesWithStreams, cmaClient, spaceId, uploadHost);
     });
 
     it('returns images with correct urls', async () => {

--- a/apps/ai-image-generator/backend/src/helpers/upload-images.ts
+++ b/apps/ai-image-generator/backend/src/helpers/upload-images.ts
@@ -2,15 +2,18 @@ import { PlainClientAPI, UploadProps } from 'contentful-management';
 import { ImageWithStream, ImageWithUpload } from '../types';
 
 const UPLOAD_DOMAIN: Record<string, URL> = {
-  us: new URL('https://s3.us-east-1.amazonaws.com/upload-api.contentful.com'),
-  eu: new URL('https://s3.us-east-1.amazonaws.com/upload-api.contentful.com'),
+  'api.contentful.com': new URL('https://s3.us-east-1.amazonaws.com/upload-api.contentful.com'),
+  'api.eu.contentful.com': new URL(
+    'https://s3.eu-central-1.amazonaws.com/upload-api.eu.contentful.com'
+  ),
 };
 
 export class UploadImages {
   constructor(
     readonly imagesWithStreams: ImageWithStream[],
     readonly cmaClient: PlainClientAPI,
-    readonly spaceId: string
+    readonly spaceId: string,
+    readonly cmaHost: string
   ) {}
 
   async execute(): Promise<ImageWithUpload[]> {
@@ -35,11 +38,13 @@ export class UploadImages {
     return await this.cmaClient.upload.create({ spaceId: this.spaceId }, { file });
   }
 
-  // TODO Handle eu!
   private urlFromUpload(upload: UploadProps): string {
     const uploadId = upload.sys.id;
     const uploadPath = `${this.spaceId}!upload!${uploadId}`;
-    return [UPLOAD_DOMAIN.us.toString(), uploadPath].join('/');
+    const uploadDomain = UPLOAD_DOMAIN[this.cmaHost];
+    if (!uploadDomain)
+      throw new Error(`Invalid cmaHost '${this.cmaHost}' -- could not find upload bucket`);
+    return [uploadDomain, uploadPath].join('/');
   }
 }
 
@@ -47,8 +52,9 @@ export const uploadImages = async (params: {
   imagesWithStreams: ImageWithStream[];
   cmaClient: PlainClientAPI;
   spaceId: string;
+  cmaHost: string;
 }) => {
-  const { imagesWithStreams, cmaClient, spaceId } = params;
-  const imageUploader = new UploadImages(imagesWithStreams, cmaClient, spaceId);
+  const { imagesWithStreams, cmaClient, spaceId, cmaHost } = params;
+  const imageUploader = new UploadImages(imagesWithStreams, cmaClient, spaceId, cmaHost);
   return imageUploader.execute();
 };

--- a/apps/ai-image-generator/backend/src/helpers/upload-images.ts
+++ b/apps/ai-image-generator/backend/src/helpers/upload-images.ts
@@ -4,7 +4,7 @@ import { ImageWithStream, ImageWithUpload } from '../types';
 const UPLOAD_DOMAIN: Record<string, URL> = {
   'upload.contentful.com': new URL('https://s3.us-east-1.amazonaws.com/upload-api.contentful.com'),
   'upload.eu.contentful.com': new URL(
-    'https://s3.eu-central-1.amazonaws.com/upload-api.eu.contentful.com'
+    'https://s3.eu-west-1.amazonaws.com/upload-api.eu.contentful.com'
   ),
 };
 

--- a/apps/ai-image-generator/backend/src/helpers/upload-images.ts
+++ b/apps/ai-image-generator/backend/src/helpers/upload-images.ts
@@ -2,8 +2,8 @@ import { PlainClientAPI, UploadProps } from 'contentful-management';
 import { ImageWithStream, ImageWithUpload } from '../types';
 
 const UPLOAD_DOMAIN: Record<string, URL> = {
-  'api.contentful.com': new URL('https://s3.us-east-1.amazonaws.com/upload-api.contentful.com'),
-  'api.eu.contentful.com': new URL(
+  'upload.contentful.com': new URL('https://s3.us-east-1.amazonaws.com/upload-api.contentful.com'),
+  'upload.eu.contentful.com': new URL(
     'https://s3.eu-central-1.amazonaws.com/upload-api.eu.contentful.com'
   ),
 };
@@ -13,7 +13,7 @@ export class UploadImages {
     readonly imagesWithStreams: ImageWithStream[],
     readonly cmaClient: PlainClientAPI,
     readonly spaceId: string,
-    readonly cmaHost: string
+    readonly uploadHost: string
   ) {}
 
   async execute(): Promise<ImageWithUpload[]> {
@@ -41,9 +41,9 @@ export class UploadImages {
   private urlFromUpload(upload: UploadProps): string {
     const uploadId = upload.sys.id;
     const uploadPath = `${this.spaceId}!upload!${uploadId}`;
-    const uploadDomain = UPLOAD_DOMAIN[this.cmaHost];
+    const uploadDomain = UPLOAD_DOMAIN[this.uploadHost];
     if (!uploadDomain)
-      throw new Error(`Invalid cmaHost '${this.cmaHost}' -- could not find upload bucket`);
+      throw new Error(`Invalid cmaHost '${this.uploadHost}' -- could not find upload bucket`);
     return [uploadDomain, uploadPath].join('/');
   }
 }
@@ -52,9 +52,9 @@ export const uploadImages = async (params: {
   imagesWithStreams: ImageWithStream[];
   cmaClient: PlainClientAPI;
   spaceId: string;
-  cmaHost: string;
+  uploadHost: string;
 }) => {
-  const { imagesWithStreams, cmaClient, spaceId, cmaHost } = params;
-  const imageUploader = new UploadImages(imagesWithStreams, cmaClient, spaceId, cmaHost);
+  const { imagesWithStreams, cmaClient, spaceId, uploadHost } = params;
+  const imageUploader = new UploadImages(imagesWithStreams, cmaClient, spaceId, uploadHost);
   return imageUploader.execute();
 };

--- a/apps/ai-image-generator/backend/src/helpers/upload-images.ts
+++ b/apps/ai-image-generator/backend/src/helpers/upload-images.ts
@@ -43,7 +43,7 @@ export class UploadImages {
     const uploadPath = `${this.spaceId}!upload!${uploadId}`;
     const uploadDomain = UPLOAD_DOMAIN[this.uploadHost];
     if (!uploadDomain)
-      throw new Error(`Invalid cmaHost '${this.uploadHost}' -- could not find upload bucket`);
+      throw new Error(`Invalid uploadHost '${this.uploadHost}' -- could not find upload bucket`);
     return [uploadDomain, uploadPath].join('/');
   }
 }

--- a/apps/ai-image-generator/backend/test/mocks.ts
+++ b/apps/ai-image-generator/backend/test/mocks.ts
@@ -28,6 +28,7 @@ export const makeMockAppActionCallContext = (
       appInstallationId: 'app-installation-id',
       userId: 'user-id',
       cmaHost: 'api.contentful.com',
+      uploadHost: 'upload.contentful.com',
     },
   };
 };

--- a/apps/ai-image-generator/backend/test/mocks.ts
+++ b/apps/ai-image-generator/backend/test/mocks.ts
@@ -27,6 +27,7 @@ export const makeMockAppActionCallContext = (
       environmentId: 'environment-id',
       appInstallationId: 'app-installation-id',
       userId: 'user-id',
+      cmaHost: 'api.contentful.com',
     },
   };
 };

--- a/apps/ai-image-generator/backend/test/scripts/call-hosted-app-action.ts
+++ b/apps/ai-image-generator/backend/test/scripts/call-hosted-app-action.ts
@@ -16,6 +16,7 @@ class AppActionRunner {
     this.client = createClient(
       {
         accessToken: this.accessToken,
+        host: 'api.eu.contentful.com',
       },
       { type: 'plain' }
     );


### PR DESCRIPTION
## Purpose

Right now, we upload all images to the US region (hard coded). We also report back in our `url` field that the image was uploaded to the US bucket.

Going forward, images might be uploaded to the EU region, depending on how the cma client was instantiated. We need to ensure that the URL points to the correct bucket, no matter where the image is uploaded.

## Approach

* We have no way of knowing which host or upload host the cmaClient was initialized with. However we can use the `cmaHost` value to deduce which region was used and build a correct url computation.
* We don't have support for flinkly or other environments. This current implementation is pretty brittle as a result. Better to build the upload url at the API level then hardcode this stuff in apps though.

## Testing steps

* Go to the EU region, to a space where this app is installed
* Do a select and fill
* See that the result images display correctly from the eu bucket

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
