### PR TITLE
feat: support short text list fields in GA4 [INTEG-1344]

### DIFF
--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeCard.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeCard.tsx
@@ -68,7 +68,7 @@ const AssignContentTypeCard = (props: AssignContentTypeCardProps) => {
         />
         <HeaderLabel
           label="Slug field"
-          helpText='The field on your content type where the page path is stored. Example: This field would typically have short slug text like "a-blog-post-i-wrote" that appears in the URL for the page.'
+          helpText='The field on your content type where the page path is stored. If you select a short text list field, the elements in the array will be joined by a forward slash. Example: This field would typically have short slug text like "a-blog-post-i-wrote" that appears in the URL for the page.'
         />
         <HeaderLabel
           label="URL prefix"

--- a/apps/google-analytics-4/frontend/src/helpers/contentTypeHelpers/contentTypeHelpers.spec.ts
+++ b/apps/google-analytics-4/frontend/src/helpers/contentTypeHelpers/contentTypeHelpers.spec.ts
@@ -52,6 +52,14 @@ const mockContentTypeItems: ContentTypeProps[] = [
         localized: false,
         required: false,
       },
+      {
+        id: 'tags',
+        name: 'Tags',
+        type: 'Array',
+        localized: false,
+        required: false,
+        items: { type: 'Symbol' },
+      },
     ],
   },
 ];
@@ -68,8 +76,8 @@ describe('contentTypeHelpers', () => {
     const fields = result['layout'].fields;
 
     expect(Object.keys(result).length).toEqual(1);
-    // Fields that are not short text should be removed
-    expect(fields.length).toEqual(2);
+    // Fields that are not short text or short text list should be removed
+    expect(fields.length).toEqual(3);
     // Fields should be sorted alphabetically
     expect(fields[0].id).toEqual('slug');
   });

--- a/apps/google-analytics-4/frontend/src/helpers/contentTypeHelpers/contentTypeHelpers.ts
+++ b/apps/google-analytics-4/frontend/src/helpers/contentTypeHelpers/contentTypeHelpers.ts
@@ -1,7 +1,11 @@
-import { EditorInterface } from '@contentful/app-sdk';
+import { ContentTypeField, EditorInterface } from '@contentful/app-sdk';
 import { ContentTypeProps } from 'contentful-management';
 import { AllContentTypes, EditorInterfaceAssignment } from '../../types';
 import sortBy from 'lodash/sortBy';
+
+interface FieldItem {
+  type: string;
+}
 
 export const generateEditorInterfaceAssignments = (
   currentEditorInterface: Partial<EditorInterface>,
@@ -37,17 +41,19 @@ export const generateEditorInterfaceAssignments = (
   return { ...newAssignments, ...assignmentsToAdd };
 };
 
+// only include short text and short text list fields in the slug field dropdown
+const isCompatibleFieldType = (field: ContentTypeField): boolean => {
+  const isArray = field.type === 'Array';
+  return field.type === 'Symbol' || (isArray && (field.items as FieldItem).type === 'Symbol');
+};
+
 export const sortAndFormatAllContentTypes = (
   contentTypeItems: ContentTypeProps[]
 ): AllContentTypes => {
   const sortedContentTypes = sortBy(contentTypeItems, ['name']);
 
   const formattedContentTypes = sortedContentTypes.reduce((acc: AllContentTypes, contentType) => {
-    // only include short text fields in the slug field dropdown
-    const fields = sortBy(
-      contentType.fields.filter((field) => field.type === 'Symbol'),
-      ['name']
-    );
+    const fields = sortBy(contentType.fields.filter(isCompatibleFieldType), ['name']);
 
     if (fields.length) {
       acc[contentType.sys.id] = {

--- a/apps/google-analytics-4/frontend/src/hooks/useGetFieldValue.tsx
+++ b/apps/google-analytics-4/frontend/src/hooks/useGetFieldValue.tsx
@@ -1,6 +1,6 @@
 import { useFieldValue } from '@contentful/react-apps-toolkit';
 
-const useGetFieldValue = (fieldId: string) => {
+const useGetFieldValue = (fieldId: string): string | object => {
   let fieldValue = '';
 
   try {

--- a/apps/google-analytics-4/frontend/src/hooks/useSidebarSlug/useSidebarSlug.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/hooks/useSidebarSlug/useSidebarSlug.spec.tsx
@@ -30,7 +30,7 @@ const TestComponent = (props: Props) => {
       <div>contentTypeHasSlugField: {contentTypeHasSlugField.toString()}</div>
       <div>isPublished: {isPublished.toString()}</div>
       <div>reportSlug: {reportSlug}</div>
-      <div>slugFieldValue: {slugFieldValue}</div>
+      <div>slugFieldValue: {slugFieldValue.toString()}</div>
       <div>isContentTypeWarning: {isContentTypeWarning.toString()}</div>
     </>
   );
@@ -135,6 +135,33 @@ describe('useSidebarSlug hook', () => {
 
     expect(newSlugFieldValue).toBeVisible();
     expect(getByText('reportSlug: /en-US/differentFieldValue')).toBeVisible();
+  });
+
+  it('returns slug info and status when a short text list field is selected and no URL prefix', async () => {
+    jest.spyOn(useSDK, 'useSDK').mockImplementation(() => ({
+      ...mockInstallationParams,
+      ...jest.requireActual('@contentful/react-apps-toolkit'),
+      entry: {
+        ...jest.requireActual('@contentful/react-apps-toolkit').entry,
+        fields: { slugField: {} },
+        onSysChanged: jest.fn((cb) =>
+          cb({
+            publishedAt: '2020202',
+          } as unknown as EntrySys)
+        ),
+      },
+    }));
+    jest.spyOn(getFieldValue, 'default').mockImplementation(() => ['category', 'pants', 'jeans']);
+    const slugFieldInfo = { slugField: 'slugField', urlPrefix: '' };
+
+    render(<TestComponent slugFieldInfo={slugFieldInfo} />);
+
+    expect(getByText('slugFieldIsConfigured: true')).toBeVisible();
+    expect(getByText('contentTypeHasSlugField: true')).toBeVisible();
+    expect(getByText('isPublished: true')).toBeVisible();
+    expect(getByText('reportSlug: /category/pants/jeans')).toBeVisible();
+    expect(getByText('slugFieldValue: category,pants,jeans')).toBeVisible();
+    expect(getByText('isContentTypeWarning: false')).toBeVisible();
   });
 
   it('returns slug info and status with trailing slash', async () => {

--- a/apps/google-analytics-4/frontend/src/utils/pathJoin.spec.ts
+++ b/apps/google-analytics-4/frontend/src/utils/pathJoin.spec.ts
@@ -20,4 +20,14 @@ describe('pathJoin', () => {
     const result = pathJoin('/a/', '//b/', '', '/', undefined, 'c/');
     expect(result).toEqual('a/b/c');
   });
+
+  it('handles arrays as inputs', () => {
+    const result = pathJoin(['a', 'b'], ['c', 'd']);
+    expect(result).toEqual('a/b/c/d');
+  });
+
+  it('handles mix of stings and arrays', () => {
+    const result = pathJoin('/a/', ['/b/', '/c/']);
+    expect(result).toEqual('a/b/c');
+  });
 });

--- a/apps/google-analytics-4/frontend/src/utils/pathJoin.ts
+++ b/apps/google-analytics-4/frontend/src/utils/pathJoin.ts
@@ -1,6 +1,24 @@
-export const pathJoin = (...parts: (string | undefined)[]): string => {
+const trimAndRemoveSlashes = (item: string) => {
+  return item.trim().replace(/(^[/]*|[/]*$)/g, '');
+};
+
+const handlePartsByType = (part: string | object | undefined) => {
+  let result = '';
+
+  if (typeof part === 'string') {
+    result = trimAndRemoveSlashes(part);
+  }
+
+  if (Array.isArray(part)) {
+    result = part.map(trimAndRemoveSlashes).join('/');
+  }
+
+  return result;
+};
+
+export const pathJoin = (...parts: (string | object | undefined)[]): string => {
   return parts
-    .map((part) => (part || '').trim().replace(/(^[/]*|[/]*$)/g, ''))
+    .map(handlePartsByType)
     .filter((part) => part.length)
     .join('/');
 };


### PR DESCRIPTION
## Purpose

We received customer feedback that they want to use short text list fields as the "slug" field when configuring the GA4 app. Currently, the app only supports short text fields.

## Approach

In order to support short text list fields, I made the following changes:

1. Config page: Updated the help text displayed when selecting a slug field and updated the filtering so that both short text and short text list fields are displayed as options.
2. Sidebar app: Updated how we are creating the page path to handle an array of strings. The elements of the array will be joined by a forward slash

**Updated config page:**
![Screenshot 2023-09-22 at 2 35 39 PM](https://github.com/contentful/apps/assets/62958907/5c9ee238-6c1d-4d21-b5c0-e3b480a49af1)

**Example field on an entry and what appears in the sidebar:**
![Screenshot 2023-09-22 at 2 37 21 PM](https://github.com/contentful/apps/assets/62958907/841c7f91-a30e-4769-9513-950e57926707)

## Testing steps

1. Create a short text list field on a content type
2. Select that field as the slug field on the app config
4. Navigate to an entry and enter values in the field. See the page path update in the sidebar app

## Breaking Changes

This change is not breaking, it will just display additional fields to select on the app config page.

## Dependencies and/or References

## Deployment
