### PR TITLE
feat: add error handling to modal

### DIFF
--- a/apps/ai-content-generator/src/components/app/dialog/common-generator/output/output-text-panels/OutputTextPanels.tsx
+++ b/apps/ai-content-generator/src/components/app/dialog/common-generator/output/output-text-panels/OutputTextPanels.tsx
@@ -1,6 +1,4 @@
 import { useContext } from 'react';
-import { useSDK } from '@contentful/react-apps-toolkit';
-import { DialogAppSDK } from '@contentful/app-sdk';
 import { GeneratorContext } from '@providers/generatorProvider';
 import useEntryAndContentType from '@hooks/dialog/useEntryAndContentType';
 import useAI, { GenerateMessage } from '@hooks/dialog/useAI';
@@ -33,18 +31,9 @@ const OutputTextPanels = (props: Props) => {
   const { feature, entryId, trackGeneratorEvent } = useContext(GeneratorContext);
   const { updateEntry } = useEntryAndContentType(entryId);
 
-  const sdk = useSDK<DialogAppSDK>();
-
   const handleEntryApply = async () => {
-    const successfullyUpdated = await updateEntry(outputFieldId, outputFieldLocale, ai.output);
+    await updateEntry(outputFieldId, outputFieldLocale, ai.output);
     trackGeneratorEvent(SegmentEvents.FLOW_END, SegmentAction.APPLIED);
-
-    if (successfullyUpdated) {
-      sdk.notifier.success('Content applied successfully.');
-      sdk.close();
-    } else {
-      sdk.notifier.error('Content did not apply successfully. Please try again.');
-    }
   };
 
   const generate = () => {

--- a/apps/ai-content-generator/src/components/app/dialog/common-generator/output/output-text-panels/OutputTextPanels.tsx
+++ b/apps/ai-content-generator/src/components/app/dialog/common-generator/output/output-text-panels/OutputTextPanels.tsx
@@ -7,6 +7,7 @@ import OriginalTextPanel from './original-text-panel/OriginalTextPanel';
 import featureConfig from '@configs/features/featureConfig';
 import { ContentTypeFieldValidation } from 'contentful-management';
 import { SegmentAction, SegmentEvents } from '@configs/segment/segmentEvent';
+import { useSDK } from '@contentful/react-apps-toolkit';
 
 interface Props {
   onGenerate: (generateMessage: GenerateMessage) => void;
@@ -30,10 +31,16 @@ const OutputTextPanels = (props: Props) => {
   } = props;
   const { feature, entryId, trackGeneratorEvent } = useContext(GeneratorContext);
   const { updateEntry } = useEntryAndContentType(entryId);
+  const sdk = useSDK();
 
   const handleEntryApply = async () => {
-    await updateEntry(outputFieldId, outputFieldLocale, ai.output);
-    trackGeneratorEvent(SegmentEvents.FLOW_END, SegmentAction.APPLIED);
+    const success = await updateEntry(outputFieldId, outputFieldLocale, ai.output);
+    if (success) {
+      trackGeneratorEvent(SegmentEvents.FLOW_END, SegmentAction.APPLIED);
+      sdk.notifier.success('Content applied successfully.');
+    } else {
+      sdk.notifier.error('Content did not apply successfully. Please try again.');
+    }
   };
 
   const generate = () => {
@@ -47,6 +54,7 @@ const OutputTextPanels = (props: Props) => {
       <OriginalTextPanel
         inputText={inputText}
         generate={generate}
+        isGenerating={ai.isGenerating}
         outputFieldLocale={outputFieldLocale}
         isNewText={isNewText}
         hasOutputField={Boolean(outputFieldId)}

--- a/apps/ai-content-generator/src/components/app/dialog/common-generator/output/output-text-panels/OutputTextPanels.tsx
+++ b/apps/ai-content-generator/src/components/app/dialog/common-generator/output/output-text-panels/OutputTextPanels.tsx
@@ -40,7 +40,10 @@ const OutputTextPanels = (props: Props) => {
     trackGeneratorEvent(SegmentEvents.FLOW_END, SegmentAction.APPLIED);
 
     if (successfullyUpdated) {
+      sdk.notifier.success('Content applied successfully.');
       sdk.close();
+    } else {
+      sdk.notifier.error('Content did not apply successfully. Please try again.');
     }
   };
 
@@ -58,6 +61,7 @@ const OutputTextPanels = (props: Props) => {
         outputFieldLocale={outputFieldLocale}
         isNewText={isNewText}
         hasOutputField={Boolean(outputFieldId)}
+        hasError={ai.hasError && !ai.output.length}
         dialogText={dialogText}
       />
       <GeneratedTextPanel

--- a/apps/ai-content-generator/src/components/app/dialog/common-generator/output/output-text-panels/generated-text-panel/GeneratedTextPanel.tsx
+++ b/apps/ai-content-generator/src/components/app/dialog/common-generator/output/output-text-panels/generated-text-panel/GeneratedTextPanel.tsx
@@ -25,9 +25,11 @@ interface Props {
   apply: () => void;
 }
 
+const errorMessage = 'The stream was interrupted. Please try again.';
+
 const GeneratedTextPanel = (props: Props) => {
   const { generate, ai, outputFieldValidation, apply } = props;
-  const { sendStopSignal, output, setOutput, isGenerating } = ai;
+  const { sendStopSignal, output, setOutput, isGenerating, hasError } = ai;
   const { trackGeneratorEvent } = useContext(GeneratorContext);
 
   const [canApply, setCanApply] = useState(false);
@@ -82,7 +84,9 @@ const GeneratedTextPanel = (props: Props) => {
         <TextFieldWithButtons
           inputText={output}
           sizeValidation={outputFieldValidation?.size}
-          onFieldChange={handleGeneratedTextChange}>
+          onFieldChange={handleGeneratedTextChange}
+          hasError={hasError}
+          errorMessage={errorMessage}>
           <>
             <CopyButton value={output} onClickCapture={trackCopy} />
             <Button onClick={handleRegenerate} css={styles.button}>

--- a/apps/ai-content-generator/src/components/app/dialog/common-generator/output/output-text-panels/original-text-panel/OriginalTextPanel.tsx
+++ b/apps/ai-content-generator/src/components/app/dialog/common-generator/output/output-text-panels/original-text-panel/OriginalTextPanel.tsx
@@ -21,11 +21,14 @@ interface Props {
   isNewText: boolean;
   outputFieldLocale: string;
   hasOutputField: boolean;
+  hasError: boolean;
   dialogText: DialogText;
 }
 
+const errorMessage = 'No results were returned. Please try again.';
+
 const OriginalTextPanel = (props: Props) => {
-  const { inputText, generate, isNewText, hasOutputField, dialogText } = props;
+  const { inputText, generate, isNewText, hasOutputField, dialogText, hasError } = props;
   const { dispatch, trackGeneratorEvent } = useContext(GeneratorContext);
 
   const handleGenerate = () => {
@@ -56,6 +59,8 @@ const OriginalTextPanel = (props: Props) => {
         onFieldChange={handleOriginalTextChange}
         isDisabled={isTextAreaDisabled}
         placeholder={placeholderText}
+        hasError={hasError}
+        errorMessage={errorMessage}
         {...helpTextProps}>
         <Button onClick={handleGenerate} isDisabled={isGenerateButtonDisabled}>
           Generate

--- a/apps/ai-content-generator/src/components/app/dialog/common-generator/output/output-text-panels/original-text-panel/OriginalTextPanel.tsx
+++ b/apps/ai-content-generator/src/components/app/dialog/common-generator/output/output-text-panels/original-text-panel/OriginalTextPanel.tsx
@@ -18,6 +18,7 @@ const styles = {
 interface Props {
   inputText: string;
   generate: () => void;
+  isGenerating: boolean;
   isNewText: boolean;
   outputFieldLocale: string;
   hasOutputField: boolean;
@@ -28,7 +29,8 @@ interface Props {
 const errorMessage = 'No results were returned. Please try again.';
 
 const OriginalTextPanel = (props: Props) => {
-  const { inputText, generate, isNewText, hasOutputField, dialogText, hasError } = props;
+  const { inputText, generate, isGenerating, isNewText, hasOutputField, dialogText, hasError } =
+    props;
   const { dispatch, trackGeneratorEvent } = useContext(GeneratorContext);
 
   const handleGenerate = () => {
@@ -62,7 +64,7 @@ const OriginalTextPanel = (props: Props) => {
         hasError={hasError}
         errorMessage={errorMessage}
         {...helpTextProps}>
-        <Button onClick={handleGenerate} isDisabled={isGenerateButtonDisabled}>
+        <Button onClick={handleGenerate} isDisabled={isGenerateButtonDisabled || isGenerating}>
           Generate
         </Button>
       </TextFieldWithButtons>

--- a/apps/ai-content-generator/src/components/common/text-field-with-buttons/TextFieldWIthButtons.tsx
+++ b/apps/ai-content-generator/src/components/common/text-field-with-buttons/TextFieldWIthButtons.tsx
@@ -5,7 +5,7 @@ import TextCounter from '../text-counter/TextCounter';
 import HyperLink from '../HyperLink/HyperLink';
 import { styles } from './TextFieldWithButtons.styles';
 import { TokenWarning } from '@configs/token-warning/tokenWarning';
-import { ExternalLinkIcon } from '@contentful/f36-icons';
+import { ErrorCircleOutlineIcon, ExternalLinkIcon } from '@contentful/f36-icons';
 
 interface Props {
   inputText: string;
@@ -16,6 +16,8 @@ interface Props {
   placeholder?: string;
   helpText?: string;
   warningMessage?: TokenWarning;
+  hasError?: boolean;
+  errorMessage?: string;
 }
 
 const TextFieldWithButtons = (props: Props) => {
@@ -28,6 +30,8 @@ const TextFieldWithButtons = (props: Props) => {
     placeholder,
     helpText,
     warningMessage,
+    hasError,
+    errorMessage,
   } = props;
 
   return (
@@ -49,6 +53,18 @@ const TextFieldWithButtons = (props: Props) => {
         maxLength={sizeValidation?.max}
         minLength={sizeValidation?.min}
       />
+      <Paragraph>
+        {!hasError ? (
+          <>
+            <ErrorCircleOutlineIcon
+              variant="negative"
+              marginRight="spacing2Xs"
+              data-testid="error-icon"
+            />{' '}
+            {errorMessage}
+          </>
+        ) : null}
+      </Paragraph>
 
       <Flex alignSelf="flex-end">
         {helpText && <Paragraph css={styles.helpText}>{helpText}</Paragraph>}

--- a/apps/ai-content-generator/src/hooks/dialog/useAI.tsx
+++ b/apps/ai-content-generator/src/hooks/dialog/useAI.tsx
@@ -30,6 +30,8 @@ const useAI = () => {
   const [output, setOutput] = useState<string>('');
   const [stream, setStream] = useState<ReadableStreamDefaultReader<Uint8Array> | null>(null);
   const [isGenerating, setIsGenerating] = useState<boolean>(false);
+  const [error, setError] = useState<string>('');
+  const [hasError, setHasError] = useState<boolean>(false);
 
   const createGPTPayload = (
     content: string,
@@ -46,6 +48,8 @@ const useAI = () => {
 
   const resetOutput = () => {
     setOutput('');
+    setError('');
+    setHasError(false);
   };
 
   const generateMessage = async (prompt: string, targetLocale: string) => {
@@ -77,6 +81,8 @@ const useAI = () => {
       }
     } catch (error: unknown) {
       console.error(error);
+      setError(error as string);
+      setHasError(true);
     } finally {
       setStream(null);
     }
@@ -104,6 +110,8 @@ const useAI = () => {
     setOutput,
     resetOutput,
     sendStopSignal,
+    error,
+    hasError,
   };
 };
 

--- a/apps/ai-content-generator/src/hooks/dialog/useEntryAndContentType.ts
+++ b/apps/ai-content-generator/src/hooks/dialog/useEntryAndContentType.ts
@@ -63,10 +63,8 @@ const useEntryAndContentType = (entryId: string) => {
         entry
       );
 
-      sdk.notifier.success('Content applied successfully.');
       return true;
     } catch (error) {
-      sdk.notifier.error('Content did not apply successfully. Please try again.');
       console.error(error);
       return false;
     }


### PR DESCRIPTION
## Purpose

There was no error handling outside of some try/catches in the original modal.

## Approach

Have stateful errors in the modal, as well as launch toasts as needed
