### PR TITLE
Adds backend image upload metadata for image size and dimensions

### DIFF
--- a/apps/ai-image-generator/backend/src/actions/aiig-static.ts
+++ b/apps/ai-image-generator/backend/src/actions/aiig-static.ts
@@ -1,5 +1,5 @@
 import { AppActionCallContext } from '@contentful/node-apps-toolkit';
-import { AppActionCallResponse, Upload } from '../types';
+import { AppActionCallResponse, Layouts, Upload } from '../types';
 import { ImageEditResult } from './aiig-select-edit';
 
 interface AppActionCallParameters {
@@ -41,23 +41,52 @@ export const handler = async (
       url: 'https://www.americanhumane.org/app/uploads/2021/12/Cat-8-1024x1024.png',
       imageType: 'png',
       upload,
+      size: 1386522,
+      dimensions: {
+        width: 1024,
+        height: 1024,
+        ratio: 1,
+        layout: 'square' as Layouts,
+      },
     },
     {
       url: 'https://4kwallpapers.com/images/wallpapers/cat-kitten-pet-domestic-animals-cute-cat-portrait-fur-baby-1024x1024-3528.jpg',
       imageType: 'png',
       upload,
+      size: 212992,
+      dimensions: {
+        width: 1024,
+        height: 1024,
+        ratio: 1,
+        layout: 'square' as Layouts,
+      },
     },
     {
       url: 'https://wallpaperaccess.com/full/2448381.jpg',
       imageType: 'png',
       upload,
+      size: 2448381,
+      dimensions: {
+        width: 1024,
+        height: 1024,
+        ratio: 1,
+        layout: 'square' as Layouts,
+      },
     },
     {
       url: 'https://images.infoseemedia.com/wp-content/uploads/2022/02/Black-White-Cat-Image-1024x1024.jpg',
       imageType: 'png',
       upload,
+      size: 189858,
+      dimensions: {
+        width: 1024,
+        height: 1024,
+        ratio: 1,
+        layout: 'square' as Layouts,
+      },
     },
   ];
+
   return {
     ok: true,
     data: {

--- a/apps/ai-image-generator/backend/src/helpers/process-images-after-edit.ts
+++ b/apps/ai-image-generator/backend/src/helpers/process-images-after-edit.ts
@@ -7,7 +7,7 @@ import OpenAI from 'openai';
 export class ProcessImagesAfterEdit {
   constructor(
     readonly openAiImages: OpenAI.Images.Image[],
-    readonly initialSourceDimensions: Dimensions
+    readonly targetSourceDimensions: Dimensions
   ) {}
 
   async execute(): Promise<ImageWithStream[]> {
@@ -41,8 +41,8 @@ export class ProcessImagesAfterEdit {
     // important that we _extract first_ (to clip the black bars off) and then _resize
     // second_ (to restore the original image dimensions proportionally)
     const stream = sharpImage.extract(extractRegion).resize({
-      width: this.initialSourceDimensions.width,
-      height: this.initialSourceDimensions.height,
+      width: this.targetSourceDimensions.width,
+      height: this.targetSourceDimensions.height,
       fit: 'cover',
     });
 
@@ -62,7 +62,7 @@ export class ProcessImagesAfterEdit {
       left = 0,
       width = imageWidth,
       height = imageHeight;
-    const { layout, width: targetWidth, height: targetHeight } = this.initialSourceDimensions;
+    const { layout, width: targetWidth, height: targetHeight } = this.targetSourceDimensions;
 
     // note: logic below is "intentionally" duplicated because abstracting it made it
     // much harder to reason about than it already is!

--- a/apps/ai-image-generator/backend/src/helpers/upload-images.spec.ts
+++ b/apps/ai-image-generator/backend/src/helpers/upload-images.spec.ts
@@ -50,7 +50,10 @@ describe('UploadImages', () => {
     it('returns images with correct urls', async () => {
       const result = await uploadImages.execute();
       const image = result[0];
+      const IMAGE_SIZE = 4528979;
+      const relativeImageSizeDiff = Math.abs(image.size - IMAGE_SIZE) / IMAGE_SIZE; // Doing a relative diff of 10% within range because circleCI has a different size for images than local. Basically image sizes are not deterministic
       expect(image).to.have.property('url', sourceUrl);
+      expect(relativeImageSizeDiff).to.below(0.1);
       expect(image.upload).to.have.property(
         'url',
         `https://s3.us-east-1.amazonaws.com/upload-api.contentful.com/${spaceId}!upload!${uploadId}`

--- a/apps/ai-image-generator/backend/src/types.ts
+++ b/apps/ai-image-generator/backend/src/types.ts
@@ -1,11 +1,13 @@
 import { UploadProps } from 'contentful-management';
 import sharp from 'sharp';
 
+export type Layouts = 'portrait' | 'landscape' | 'square';
+
 export interface Dimensions {
   width: number;
   height: number;
   ratio: number;
-  layout: 'portrait' | 'landscape' | 'square';
+  layout: Layouts;
 }
 
 export interface Image {
@@ -19,6 +21,8 @@ export interface ImageWithStream extends Image {
 
 export interface ImageWithUpload extends Image {
   upload: Upload;
+  size: number;
+  dimensions: Dimensions;
 }
 
 export interface Upload extends UploadProps {


### PR DESCRIPTION
## Purpose
Frontend has a Preview UI/UX experience that requires the image size and image dimensions to display to the end user

## Approach
Refactor upload image backend to create the image buffer (somewhat inefficient) to get the image metadata that is about to be uploaded to Contentful.

## Testing steps
Through User interface and experience packages.

## Breaking Changes
None

## Dependencies and/or References
None

## Deployment
Standard
