### PR TITLE
Fix/typeform localstorage issue

### DIFF
--- a/apps/typeform/frontend/src/Auth/TypeformOAuth.tsx
+++ b/apps/typeform/frontend/src/Auth/TypeformOAuth.tsx
@@ -38,11 +38,13 @@ export function TypeformOAuth({
         return;
       }
 
-      const { token, error } = data;
+      const { token, expireTime, error } = data;
 
       if (error) {
         console.error('There was an error authenticating. Please try again.');
       } else if (token) {
+        window.localStorage.setItem('token', token);
+        window.localStorage.setItem('expireTime', expireTime.toString());
         setToken(token);
         if (oauthWindow) {
           oauthWindow.close();

--- a/apps/typeform/frontend/src/constants.ts
+++ b/apps/typeform/frontend/src/constants.ts
@@ -1,5 +1,7 @@
 const SDK_WINDOW_HEIGHT = 450;
 const BASE_URL = 'https://api.typeform.com';
+
+// TODO Move to env var
 const CLIENT_ID = 'HC3UDnoiaP1UCMqJ7kCAyTFdHrDt8nLtXx4BKRJxom2M';
 
 export { SDK_WINDOW_HEIGHT, BASE_URL, CLIENT_ID };

--- a/apps/typeform/frontend/src/constants.ts
+++ b/apps/typeform/frontend/src/constants.ts
@@ -1,5 +1,5 @@
 const SDK_WINDOW_HEIGHT = 450;
 const BASE_URL = 'https://api.typeform.com';
-const CLIENT_ID = '2vyzzT2AjqrtfWKmaigvZjF8oYwUXrJABmcS5WK4MPJg';
+const CLIENT_ID = 'HC3UDnoiaP1UCMqJ7kCAyTFdHrDt8nLtXx4BKRJxom2M';
 
 export { SDK_WINDOW_HEIGHT, BASE_URL, CLIENT_ID };

--- a/apps/typeform/frontend/src/constants.ts
+++ b/apps/typeform/frontend/src/constants.ts
@@ -1,11 +1,5 @@
-
 const SDK_WINDOW_HEIGHT = 450;
 const BASE_URL = 'https://api.typeform.com';
-const CLIENT_ID = 'HC3UDnoiaP1UCMqJ7kCAyTFdHrDt8nLtXx4BKRJxom2M'
+const CLIENT_ID = '2vyzzT2AjqrtfWKmaigvZjF8oYwUXrJABmcS5WK4MPJg';
 
-export {
-  SDK_WINDOW_HEIGHT,
-  BASE_URL,
-  CLIENT_ID,
-}
-
+export { SDK_WINDOW_HEIGHT, BASE_URL, CLIENT_ID };

--- a/apps/typeform/frontend/src/processTokenCallback.ts
+++ b/apps/typeform/frontend/src/processTokenCallback.ts
@@ -17,9 +17,7 @@ const processTokenCallback = (window: Window) => {
 
     const expireTime = Date.now() + expiresIn * 1000;
 
-    window.localStorage.setItem('token', token);
-    window.localStorage.setItem('expireTime', expireTime.toString());
-    window.opener.postMessage({ token }, '*');
+    window.opener.postMessage({ token, expireTime }, '*');
 
     window.history.replaceState({}, 'oauth', '/');
   } else {

--- a/apps/typeform/lambda/fetch-workspaces.js
+++ b/apps/typeform/lambda/fetch-workspaces.js
@@ -11,6 +11,10 @@ const makeError = (response) => {
     error.details = 'Details could not be parsed';
   }
   error.code = response.status;
+  console.log('error', error);
+  console.log('error.details', error.details);
+  console.log('response.headers', response.headers);
+  console.log('response.body', response.text());
   return error;
 };
 

--- a/apps/typeform/lambda/fetch-workspaces.js
+++ b/apps/typeform/lambda/fetch-workspaces.js
@@ -11,10 +11,6 @@ const makeError = (response) => {
     error.details = 'Details could not be parsed';
   }
   error.code = response.status;
-  console.log('error', error);
-  console.log('error.details', error.details);
-  console.log('response.headers', response.headers);
-  console.log('response.body', response.text());
   return error;
 };
 


### PR DESCRIPTION
## Purpose

In browsers where cross-site tracking and/or third party storage access partitioning features were enabled, token and expire time values received from Typeform during the Oauth flow were not being saved to local storage in a way such that they were accessible from the main Typeform Contentful app.

Instead, what was observed was that those values were not present in local storage from the main app at all.

## Approach

* Since we already created an event listener on the `message` event from the popup window (https://github.com/contentful/apps/blob/master/apps/typeform/frontend/src/Auth/TypeformOAuth.tsx#L53) and were already sending token data back to main app using `postMessage` (https://github.com/contentful/apps/blob/master/apps/typeform/frontend/src/processTokenCallback.ts#L22), we simply add the `expireTime` value to the postMessage payload and move the localStorage `setItem` call into the main app, thereby ensuring that the values set their are available for getting

## Testing steps

### Chrome

* Go to chrome://flags/#third-party-storage-partitioning and ensure "Experimental third-party storage partitioning" is *Enabled*
* Go to app config and log in to Typeform
* Verify that workspaces loads correctly.
* Hit refresh and verify that token values are correctly saved

### Safari

* coming shortly

## References

* Chrome: https://developer.chrome.com/en/docs/privacy-sandbox/storage-partitioning/

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
