### PR TITLE
Add last-modified header to static frontend

### DIFF
--- a/apps/typeform/lambda/app.js
+++ b/apps/typeform/lambda/app.js
@@ -15,6 +15,18 @@ const app = express();
 
 const FRONTEND = path.dirname(require.resolve('@contentful/typeform-frontend'));
 
+const computeLastModifiedTime = () => {
+  const deployTime = process.env.DEPLOY_TIME_UNIX;
+  if (typeof deployTime === 'undefined') {
+    throw new Error('Missing DEPLOY_TIME_UNIX env var');
+  }
+
+  // JS uses number of _milliseconds_ since epoch, whereas unix generates number in
+  // _seconds_ since epoch. So we have to convert
+  const epochTime = Number(deployTime) * 1000;
+  return new Date(epochTime).toGMTString();
+};
+
 app.use('/forms', async (req, res) => {
   const { authorization } = req.headers;
   if (!authorization) {
@@ -51,7 +63,8 @@ app.use('/callback', async (req, res) => {
   res.redirect(`${origin}/frontend/?token=${access_token}&expiresIn=${expires_in}`);
 });
 
-app.use('/frontend', express.static(FRONTEND));
+const lastModified = computeLastModifiedTime();
+app.use('/frontend', express.static(FRONTEND, { lastModified }));
 
 app.use((_req, res) => res.status(404).send('Not found'));
 

--- a/apps/typeform/lambda/package.json
+++ b/apps/typeform/lambda/package.json
@@ -8,8 +8,8 @@
     "lint": "eslint .",
     "test": "jest",
     "test:ci": "jest",
-    "serve:local": "LOCAL_DEV=true nodemon serve.js",
-    "deploy": "sls deploy --stage $STAGE",
+    "serve:local": "DEPLOY_TIME_UNIX=$(date \"+%s\") LOCAL_DEV=true nodemon serve.js",
+    "deploy": "DEPLOY_TIME_UNIX=$(date \"+%s\") sls deploy --stage $STAGE",
     "deploy:test": "npm run deploy"
   },
   "devDependencies": {

--- a/apps/typeform/lambda/serverless.yml
+++ b/apps/typeform/lambda/serverless.yml
@@ -33,6 +33,7 @@ functions:
     environment:
       CLIENT_ID: ${env:TYPEFORM_CLIENT_ID}
       CLIENT_SECRET: ${env:TYPEFORM_CLIENT_SECRET}
+      DEPLOY_TIME: ${env:DEPLOY_TIME}
     handler: index.handler
     events:
       - http:


### PR DESCRIPTION
## Purpose

We have not been providing a `Last-Modified` header to our express static middleware used to host the Typeform frontend; as a result, the value of `Last-Modified` sent by AWS gateway has been 1980.

This has caused aggressive browser local caching, which often leads to "broken" deploys since the browser doesn't try to fetch the most recent value.

## Approach

* Capture the "current time" at deploy; pass through to as env var to serverless

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
