### PR TITLE
fix: update segment provider in modal

### DIFF
--- a/apps/ai-content-generator/src/components/app/dialog/common-generator/CommonGenerator.tsx
+++ b/apps/ai-content-generator/src/components/app/dialog/common-generator/CommonGenerator.tsx
@@ -25,14 +25,14 @@ const initialParameters: GeneratorParameters = {
 };
 
 const CommonGenerator = () => {
-  const { setProviderData, feature, localeNames } = useContext(GeneratorContext);
+  const { setProviderData, feature, localeNames, segmentEventData } = useContext(GeneratorContext);
   const { trackEvent } = useContext(SegmentAnalyticsContext);
 
   const [parameters, dispatch] = useReducer(generatorReducer, initialParameters);
   const [headerHeight, setHeaderHeight] = useState(0);
   const headerRef = useRef<HTMLElement>(null);
 
-  const segmentEventData: SegmentEventData = useMemo(
+  const newSegmentEventData: SegmentEventData = useMemo(
     () => ({
       feature_id: feature,
       from_prompt: parameters.isNewText,
@@ -50,13 +50,21 @@ const CommonGenerator = () => {
   );
 
   const updateProviderData = () => {
-    setProviderData({
-      dispatch,
-      segmentEventData,
-    });
+    if (newSegmentEventData !== segmentEventData) {
+      setProviderData({
+        dispatch,
+        segmentEventData: newSegmentEventData,
+      });
+    }
   };
 
-  useEffect(updateProviderData, [dispatch, segmentEventData, setProviderData, trackEvent]);
+  useEffect(updateProviderData, [
+    dispatch,
+    newSegmentEventData,
+    setProviderData,
+    trackEvent,
+    segmentEventData,
+  ]);
 
   useEffect(() => {
     if (headerRef.current) {

--- a/apps/ai-content-generator/src/components/app/dialog/rewrite-generator/RewriteGenerator.tsx
+++ b/apps/ai-content-generator/src/components/app/dialog/rewrite-generator/RewriteGenerator.tsx
@@ -28,7 +28,7 @@ const initialParameters: GeneratorParameters = {
 };
 
 const RewriteGenerator = () => {
-  const { setProviderData, localeNames, feature } = useContext(GeneratorContext);
+  const { setProviderData, localeNames, feature, segmentEventData } = useContext(GeneratorContext);
   const { trackEvent } = useContext(SegmentAnalyticsContext);
 
   const [parameters, dispatch] = useReducer(generatorReducer, initialParameters);
@@ -36,7 +36,7 @@ const RewriteGenerator = () => {
   const [headerHeight, setHeaderHeight] = useState(0);
   const headerRef = useRef<HTMLElement>(null);
 
-  const segmentEventData: SegmentEventData = useMemo(
+  const newSegmentEventData: SegmentEventData = useMemo(
     () => ({
       feature_id: feature,
       from_prompt: parameters.isNewText,
@@ -54,13 +54,21 @@ const RewriteGenerator = () => {
   );
 
   const updateProviderData = () => {
-    setProviderData({
-      dispatch,
-      segmentEventData,
-    });
+    if (newSegmentEventData !== segmentEventData) {
+      setProviderData({
+        dispatch,
+        segmentEventData: newSegmentEventData,
+      });
+    }
   };
 
-  useEffect(updateProviderData, [dispatch, segmentEventData, setProviderData, trackEvent]);
+  useEffect(updateProviderData, [
+    dispatch,
+    newSegmentEventData,
+    setProviderData,
+    trackEvent,
+    segmentEventData,
+  ]);
 
   useEffect(() => {
     if (headerRef.current) {


### PR DESCRIPTION
## Purpose

Update Segment provider in `CommonGenerator` and `RewriteGenerator` to prevent re-renders.

## Approach

## Testing steps

## Breaking Changes

## Dependencies and/or References

## Deployment
