### PR TITLE
feat: improved handling for rate limits [INTEG-1381]

### DIFF
--- a/apps/ai-content-generator/src/components/app/dialog/common-generator/errorMessages.ts
+++ b/apps/ai-content-generator/src/components/app/dialog/common-generator/errorMessages.ts
@@ -1,0 +1,9 @@
+const errorMessages = {
+  rateLimitMessage: 'Your Chat GPT usage quota has been met. Learn about rate limits',
+  rateLimitSubstring: 'Learn about rate limits',
+  rateLimitLink: 'https://platform.openai.com/docs/guides/rate-limits/overview',
+  defaultGenerateError: 'The stream was interrupted. Please try again.',
+  defaultOriginalError: 'No results were returned. Please try again.',
+};
+
+export { errorMessages };

--- a/apps/ai-content-generator/src/components/app/dialog/common-generator/output/output-text-panels/generated-text-panel/GeneratedTextPanel.styles.ts
+++ b/apps/ai-content-generator/src/components/app/dialog/common-generator/output/output-text-panels/generated-text-panel/GeneratedTextPanel.styles.ts
@@ -1,0 +1,18 @@
+import { css } from '@emotion/react';
+import tokens from '@contentful/f36-tokens';
+
+export const styles = {
+  panel: css({
+    flexGrow: 1,
+  }),
+  button: css({
+    marginLeft: `${tokens.spacingXs}`,
+  }),
+  errorMessage: css({
+    color: tokens.red500,
+  }),
+  errorLink: css({
+    color: `${tokens.red500} !important`,
+    fontWeight: `${tokens.fontWeightNormal} !important`,
+  }),
+};

--- a/apps/ai-content-generator/src/components/app/dialog/common-generator/output/output-text-panels/original-text-panel/OriginalTextPanel.tsx
+++ b/apps/ai-content-generator/src/components/app/dialog/common-generator/output/output-text-panels/original-text-panel/OriginalTextPanel.tsx
@@ -12,6 +12,7 @@ import { useSDK } from '@contentful/react-apps-toolkit';
 import AppInstallationParameters from '@components/config/appInstallationParameters';
 import { DialogAppSDK } from '@contentful/app-sdk';
 import { gptModels } from '@configs/ai/gptModels';
+import { errorMessages } from '@components/app/dialog/common-generator/errorMessages';
 
 const styles = {
   panel: css({
@@ -29,8 +30,6 @@ interface Props {
   hasError: boolean;
   dialogText: DialogText;
 }
-
-const errorMessage = 'No results were returned. Please try again.';
 
 const OriginalTextPanel = (props: Props) => {
   const { inputText, generate, isGenerating, isNewText, hasOutputField, dialogText, hasError } =
@@ -73,7 +72,7 @@ const OriginalTextPanel = (props: Props) => {
         isDisabled={isTextAreaDisabled}
         placeholder={placeholderText}
         hasError={hasError}
-        errorMessage={errorMessage}
+        errorMessage={errorMessages.defaultOriginalError}
         sizeValidation={{ max: textLimit }}
         {...helpTextProps}>
         <Button

--- a/apps/ai-content-generator/src/components/common/text-field-with-buttons/TextFieldWIthButtons.tsx
+++ b/apps/ai-content-generator/src/components/common/text-field-with-buttons/TextFieldWIthButtons.tsx
@@ -6,7 +6,6 @@ import HyperLink from '../HyperLink/HyperLink';
 import { styles } from './TextFieldWithButtons.styles';
 import { TokenWarning } from '@configs/token-warning/tokenWarning';
 import { ErrorCircleOutlineIcon, ExternalLinkIcon } from '@contentful/f36-icons';
-import tokens from '@contentful/f36-tokens';
 
 interface Props {
   inputText: string;
@@ -18,7 +17,7 @@ interface Props {
   helpText?: string;
   warningMessage?: TokenWarning;
   hasError?: boolean;
-  errorMessage?: string;
+  errorMessage?: string | ReactNode;
 }
 
 const TextFieldWithButtons = (props: Props) => {
@@ -54,18 +53,16 @@ const TextFieldWithButtons = (props: Props) => {
         maxLength={sizeValidation?.max}
         minLength={sizeValidation?.min}
       />
-      <Paragraph css={{ color: tokens.red500 }}>
-        {hasError ? (
-          <>
-            <ErrorCircleOutlineIcon
-              variant="negative"
-              marginRight="spacing2Xs"
-              data-testid="error-icon"
-            />
-            {errorMessage}
-          </>
-        ) : null}
-      </Paragraph>
+      {hasError ? (
+        <Flex marginBottom="spacingM">
+          <ErrorCircleOutlineIcon
+            variant="negative"
+            marginRight="spacing2Xs"
+            data-testid="error-icon"
+          />
+          {errorMessage}
+        </Flex>
+      ) : null}
 
       <Flex alignSelf="flex-end">
         {helpText && <Paragraph css={styles.helpText}>{helpText}</Paragraph>}

--- a/apps/ai-content-generator/src/components/config/configText.ts
+++ b/apps/ai-content-generator/src/components/config/configText.ts
@@ -87,6 +87,9 @@ const Sections = {
   costDescription: 'View the current pricing model at openai.com/pricing',
   costLinkSubstring: 'openai.com/pricing',
   costLink: 'https://openai.com/pricing',
+  rateLimitDescription: "Chat GPT enforces usage quotas. Learn about Chat GPT's rate limits",
+  rateLimitLinkSubstring: "Chat GPT's rate limits",
+  rateLimitLink: 'https://platform.openai.com/docs/guides/rate-limits/overview',
   disclaimerHeading: 'Disclaimer',
   disclaimerDescription:
     "This feature uses a third party AI tool. Please ensure your use of the tool and any AI-generated content complies with applicable laws, your company's policies, and all other Terms and Policies",

--- a/apps/ai-content-generator/src/components/config/cost-section/CostSection.spec.tsx
+++ b/apps/ai-content-generator/src/components/config/cost-section/CostSection.spec.tsx
@@ -4,7 +4,7 @@ import { render, screen } from '@testing-library/react';
 import { Sections } from '../configText';
 
 const { getByText } = screen;
-const { costHeading, costLinkSubstring } = Sections;
+const { costHeading, costLinkSubstring, rateLimitLinkSubstring } = Sections;
 
 describe('CostSection component', () => {
   it('Component mounts without correct content', async () => {
@@ -12,8 +12,10 @@ describe('CostSection component', () => {
 
     const title = getByText(costHeading);
     const pricingHyperlink = getByText(costLinkSubstring);
+    const rateLimitHyperlink = getByText(rateLimitLinkSubstring);
 
     expect(title).toBeTruthy();
     expect(pricingHyperlink).toBeTruthy();
+    expect(rateLimitHyperlink).toBeTruthy();
   });
 });

--- a/apps/ai-content-generator/src/components/config/cost-section/CostSection.tsx
+++ b/apps/ai-content-generator/src/components/config/cost-section/CostSection.tsx
@@ -4,7 +4,17 @@ import Hyperlink from '@components/common/HyperLink/HyperLink';
 import { ExternalLinkIcon } from '@contentful/f36-icons';
 
 const CostSection = () => {
-  const { costHeading, costSubheading, costDescription, costLink, costLinkSubstring } = Sections;
+  const {
+    costHeading,
+    costSubheading,
+    costDescription,
+    costLink,
+    costLinkSubstring,
+    rateLimitDescription,
+    rateLimitLink,
+    rateLimitLinkSubstring,
+  } = Sections;
+
   return (
     <Flex flexDirection="column">
       <Subheading>{costHeading}</Subheading>
@@ -16,6 +26,15 @@ const CostSection = () => {
           body={costDescription}
           substring={costLinkSubstring}
           hyperLinkHref={costLink}
+          icon={<ExternalLinkIcon />}
+          alignIcon="end"
+        />
+      </Paragraph>
+      <Paragraph marginBottom="none" marginTop="spacingXs">
+        <Hyperlink
+          body={rateLimitDescription}
+          substring={rateLimitLinkSubstring}
+          hyperLinkHref={rateLimitLink}
           icon={<ExternalLinkIcon />}
           alignIcon="end"
         />

--- a/apps/ai-content-generator/src/utils/aiApi/index.ts
+++ b/apps/ai-content-generator/src/utils/aiApi/index.ts
@@ -41,19 +41,19 @@ class AI {
       stream: true,
     });
 
-    const stream = (
-      await fetch(this.baseUrl, {
-        method: 'POST',
-        headers,
-        body,
-      })
-    ).body?.getReader();
+    const streamResponse = await fetch(this.baseUrl, {
+      method: 'POST',
+      headers,
+      body,
+    });
 
-    if (!stream) {
-      throw new Error('Unable to create stream');
+    if (streamResponse.status === 200) {
+      const stream = streamResponse.body?.getReader();
+      return stream;
+    } else {
+      const streamJson = await streamResponse.json();
+      validateResponseStatus(streamResponse, streamJson);
     }
-
-    return stream;
   };
 
   /**
@@ -86,7 +86,7 @@ class AI {
    * @param stream ReadableStreamDefaultReader<Uint8Array> | null
    * @returns void
    */
-  sendStopSignal = (stream: ReadableStreamDefaultReader<Uint8Array> | null) => {
+  sendStopSignal = (stream: ReadableStreamDefaultReader<Uint8Array> | null | undefined) => {
     if (stream) {
       stream.cancel();
     }


### PR DESCRIPTION
## Purpose

We wanted to improve the feedback to AICG users about rate limits for Chat GPT. This PR adds more helpful messaging to the config page and the modal.

## Approach

Added new copy to the config page:
![Screenshot 2023-09-29 at 7 50 01 AM](https://github.com/contentful/apps/assets/62958907/b87b9665-0f48-4b6c-8ce8-54dc4c3b2ebc)

For the modal, refactored the API call to the completions endpoint so that we could display different messages based on the response status. If a 429 response is returned, we have a custom message, otherwise, the default will show.

Rate limit error message:
![Screenshot 2023-09-28 at 9 09 40 PM](https://github.com/contentful/apps/assets/62958907/cbd39b52-b71f-4471-9c42-9d60d4208e16)

Default modal error message:
![Screenshot 2023-09-28 at 9 10 43 PM](https://github.com/contentful/apps/assets/62958907/4321895a-4d5f-4001-b7bb-a02368e469ad)

## Testing steps

- Ensure that all actions still work as expected for the happy path
- Trigger an error (e.g. make an invalid API key) and the error message should appear in the modal after clicking "Generate"

## Breaking Changes

None

## Dependencies and/or References

Links go to this page: https://platform.openai.com/docs/guides/rate-limits/overview
OpenAI error codes:https://platform.openai.com/docs/guides/error-codes

