### PR TITLE
fix: set localstorage in correct place

### DIFF
--- a/apps/jira/jira-app/src/components/Auth/OAuth.tsx
+++ b/apps/jira/jira-app/src/components/Auth/OAuth.tsx
@@ -32,11 +32,13 @@ export default class OAuth extends React.Component<Props> {
         return;
       }
 
-      const { token, error } = e.data;
+      const { token, expireTime, error } = e.data;
 
       if (error) {
         this.props.notifyError('There was an error authenticating. Please refresh and try again.');
       } else if (token) {
+        window.localStorage.setItem('token', token);
+        window.localStorage.setItem('expireTime', expireTime.toString());
         this.props.setToken(token);
       }
 

--- a/apps/jira/jira-app/src/index.spec.tsx
+++ b/apps/jira/jira-app/src/index.spec.tsx
@@ -88,12 +88,13 @@ describe('The Jira App Components', () => {
 
       const oauthButton = wrapper.getByTestId('oauth-button');
       const token = '123';
+      const expireTime = Date.now() + 600000;
 
       const source: MessageEventSource = { close: jest.fn() } as any;
       (window.open as jest.Mock).mockReturnValue(source);
 
       fireEvent.click(oauthButton);
-      fireEvent(window, new MessageEvent('message', { data: { token }, source }));
+      fireEvent(window, new MessageEvent('message', { data: { token, expireTime }, source }));
 
       expect(window.open).toHaveBeenCalledWith(
         'https://auth.atlassian.com/authorize?audience=api.atlassian.com&client_id=XD9k9QU9VT4Rt26u6lbO3NM0fOqvvXan&scope=read%3Ajira-user%20read%3Ajira-work%20write%3Ajira-work&redirect_uri=https%3A%2F%2Fapi.jira.ctfapps.net%2Fauth&response_type=code&state=http%3A%2F%2Flocalhost%2F&prompt=consent',

--- a/apps/jira/jira-app/src/index.spec.tsx
+++ b/apps/jira/jira-app/src/index.spec.tsx
@@ -374,10 +374,10 @@ describe('The Jira App Components', () => {
       };
 
       standalone(mockWindow as any);
-
-      expect(mockWindow.localStorage.setItem).toHaveBeenCalledWith('token', '123');
-      expect(mockWindow.localStorage.setItem).toHaveBeenCalledWith('expireTime', '10100');
-      expect(mockWindow.opener.postMessage).toHaveBeenCalledWith({ token: '123' }, '*');
+      expect(mockWindow.opener.postMessage).toHaveBeenCalledWith(
+        { token: '123', expireTime: 10100 },
+        '*'
+      );
       expect(mockWindow.history.replaceState).toHaveBeenCalledWith({}, 'oauth', '/');
     });
 

--- a/apps/jira/jira-app/src/standalone.ts
+++ b/apps/jira/jira-app/src/standalone.ts
@@ -14,13 +14,11 @@ const standalone = (window: Window) => {
 
     const expireTime = Date.now() + expiresIn * 1000;
 
-    window.localStorage.setItem('token', token);
-    window.localStorage.setItem('expireTime', expireTime.toString());
-    window.opener.postMessage({ token }, '*');
+    window.opener.postMessage({ token, expireTime }, '*');
 
     window.history.replaceState({}, 'oauth', '/');
   } else {
     window.opener.postMessage({ error: 'No query string provided!' }, '*');
   }
 };
-export default standalone
+export default standalone;


### PR DESCRIPTION
## Purpose

In browsers where cross-site tracking and/or third party storage access partitioning features were enabled, token and expire time values received from Jira during the Oauth flow were not being saved to local storage in a way such that they were accessible from the main Jira Contentful app.

Instead, what was observed was that those values were not present in local storage from the main app at all.

Basically same as https://github.com/contentful/apps/pull/5000

## Approach

* Send data via postMessage

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
