### PR TITLE
Add SDK provider

### DIFF
--- a/apps/jira/jira-app/src/index.tsx
+++ b/apps/jira/jira-app/src/index.tsx
@@ -9,6 +9,7 @@ import '@contentful/forma-36-react-components/dist/styles.css';
 import './index.scss';
 import JiraClient from './jiraClient';
 import { InstallationParameters } from './interfaces';
+import { SDKProvider } from '@contentful/react-apps-toolkit';
 
 function renderAtRoot(component: JSX.Element) {
   render(component, document.getElementById('root'));
@@ -23,19 +24,25 @@ if (window.location.search.includes('token')) {
 } else {
   init((sdk) => {
     if (sdk.location.is(locations.LOCATION_APP_CONFIG)) {
-      renderAtRoot(<App sdk={sdk as AppExtensionSDK} />);
+      renderAtRoot(
+        <SDKProvider>
+          <App sdk={sdk as AppExtensionSDK} />
+        </SDKProvider>
+      );
     }
 
     if (sdk.location.is(locations.LOCATION_ENTRY_SIDEBAR)) {
       (sdk as SidebarExtensionSDK).window.startAutoResizer();
       renderAtRoot(
-        <Auth
-          notifyError={sdk.notifier.error}
-          parameters={sdk.parameters.installation as InstallationParameters}>
-          {(token, client: JiraClient, resetClient) => (
-            <Jira client={client} sdk={sdk as SidebarExtensionSDK} signOut={resetClient} />
-          )}
-        </Auth>
+        <SDKProvider>
+          <Auth
+            notifyError={sdk.notifier.error}
+            parameters={sdk.parameters.installation as InstallationParameters}>
+            {(token, client: JiraClient, resetClient) => (
+              <Jira client={client} sdk={sdk as SidebarExtensionSDK} signOut={resetClient} />
+            )}
+          </Auth>
+        </SDKProvider>
       );
     }
   });


### PR DESCRIPTION
## Purpose

There's a bug that's masking error messaging:

```
react-dom.production.min.js:216 Error: SDKContext not found. Make sure this hook is used inside the SDKProvider
    at t.useSDK (useSDK.js:14:15)
    at y (ContentTypeStep.tsx:28:15)
    at ca (react-dom.production.min.js:157:137)
    at Yc (react-dom.production.min.js:267:460)
    at Cs (react-dom.production.min.js:250:347)
    at Ts (react-dom.production.min.js:250:278)
    at Is (react-dom.production.min.js:250:138)
    at bs (react-dom.production.min.js:243:163)
    at react-dom.production.min.js:123:115
    at t.unstable_runWithPriority (scheduler.production.min.js:18:343)
 ```

## Approach

* Add the missing `SDKProvider`

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
