### PR TITLE
Add useAutoResizer functionality to AWS Amplify app

### DIFF
--- a/apps/aws-amplify/src/locations/Sidebar.tsx
+++ b/apps/aws-amplify/src/locations/Sidebar.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Button, Paragraph } from '@contentful/f36-components';
 import { SidebarAppSDK } from '@contentful/app-sdk';
-import { useCMA, useSDK } from '@contentful/react-apps-toolkit';
+import { useAutoResizer, useCMA, useSDK } from '@contentful/react-apps-toolkit';
 import { getItemLocalStorage, build_status_key, setItemLocalStorage } from '../lib/localStorage';
 
 const Sidebar = () => {
@@ -11,6 +11,8 @@ const Sidebar = () => {
   const [lastBuildInitiated, setLastBuildInitiated] = useState(
     getItemLocalStorage(build_status_key) || null
   );
+
+  useAutoResizer();
 
   useEffect(() => {
     if (lastBuildInitiated) {


### PR DESCRIPTION
## Purpose

This PR adds the `useAutoResizer()` functionality to the AWS Amplify so that is it not awkwardly taking up unnecessary spice in the Sidebar. This was a nit thing pointed out a while ago while on support, felt it was low-handing fruit to adjust ✅ 

#### Before
![Screenshot 2023-10-12 at 8 38 36 AM](https://github.com/contentful/apps/assets/58186851/de202c5d-49ee-4e1a-a67c-dac3dd0d84b9)

#### After
![Screenshot 2023-10-12 at 8 38 48 AM](https://github.com/contentful/apps/assets/58186851/926df35e-12f7-440d-8aa0-9bcd26118efb)

