### PR TITLE
fix: downgrade prettier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "eslint": "^7.32.0",
         "husky": "^8.0.0",
         "lint-staged": "^13.0.0",
-        "prettier": "^3.0.3"
+        "prettier": "^2.8.8"
       },
       "engines": {
         "node": ">=16.0.0 < 18.0.0",
@@ -7254,15 +7254,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
-      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
       "bin": {
-        "prettier": "bin/prettier.cjs"
+        "prettier": "bin-prettier.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=10.13.0"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
@@ -14341,9 +14341,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
-      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true
     },
     "pretty-format": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "eslint": "^7.32.0",
     "husky": "^8.0.0",
     "lint-staged": "^13.0.0",
-    "prettier": "^3.0.3"
+    "prettier": "^2.8.8"
   },
   "scripts": {
     "bootstrap": "lerna bootstrap --no-ci --since master --include-dependencies",


### PR DESCRIPTION
## Purpose

We thought `prettier@3` would work with `lerna@6`, but we need to upgrade to `lerna@7` ([see here](https://github.com/lerna/lerna/releases/tag/v7.1.2))

## Approach

## Testing steps

## Breaking Changes

## Dependencies and/or References

## Deployment
