### PR TITLE
chore: add deploy scripts to MS Teams app [INTEG-1469]

### DIFF
--- a/apps/microsoft-teams/frontend/package.json
+++ b/apps/microsoft-teams/frontend/package.json
@@ -17,7 +17,9 @@
     "build": "tsc && vite build",
     "lint": "eslint . --max-warnings 0",
     "test": "vitest --logHeapUsage --coverage",
-    "test:ci": "vitest"
+    "test:ci": "vitest",
+    "deploy": "contentful-app-scripts upload --ci --bundle-dir ./dist --organization-id ${DEFINITIONS_ORG_ID} --definition-id 7lcE2IF8TiXXKiMj2UGM8k --token ${CONTENTFUL_CMA_TOKEN}",
+    "deploy:test": "contentful-app-scripts upload --ci --bundle-dir ./dist --organization-id ${DEV_TESTING_ORG_ID} --definition-id 73UaKZLqfCJTTqayKn73Rv --token ${TEST_CMA_TOKEN}"
   },
   "devDependencies": {
     "@contentful/app-scripts": "1.10.2",


### PR DESCRIPTION
## Purpose

After confirming that the newly created MS Teams app build runs correctly, this PR adds the deploy scripts for the staging and production apps.

## Approach

## Testing steps

## Breaking Changes

## Dependencies and/or References

## Deployment
