### PR TITLE
chore: upgrade node to v18

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-v16.18
+lts/hydrogen

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "@contentful/apps",
   "private": true,
   "engines": {
-    "node": ">=16.0.0 < 18.0.0",
-    "npm": ">= 8.0.0 < 9.0.0"
+    "node": ">=16.0.0 < 19.0.0",
+    "npm": ">= 8.0.0 < 10.0.0"
   },
   "devDependencies": {
     "@sentry/cli": "^2.14.4",


### PR DESCRIPTION
## Purpose

We're blocked from using the latest node-apps-toolkit in several places because it uses node18 now, and we're stuck on node v16.

EG https://github.com/contentful/apps/pull/5300

## Approach

* Upgrade node and npm, change the nvmrc

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
