### PR TITLE
Fix/smartling frontend

### DIFF
--- a/apps/smartling/frontend/package.json
+++ b/apps/smartling/frontend/package.json
@@ -18,10 +18,10 @@
     "whatwg-fetch": "^3.0.0"
   },
   "scripts": {
-    "start": "cross-env BROWSER=none react-scripts start",
-    "build": "react-scripts build",
+    "start": "cross-env BROWSER=none react-scripts --openssl-legacy-provider start",
+    "build": "react-scripts --openssl-legacy-provider build",
     "test": "TZ=UTC react-scripts test",
-    "test:ci": "react-scripts test",
+    "test:ci": "CI=true react-scripts test",
     "test:dev": "TZ=UTC react-scripts test"
   },
   "dependencies": {

--- a/apps/smartling/frontend/src/index.spec.tsx
+++ b/apps/smartling/frontend/src/index.spec.tsx
@@ -75,6 +75,7 @@ describe('App', () => {
 
   afterEach(() => {
     cleanup();
+    fetchMock.restore();
   });
 
   it('should load the AppConfig page and allow for installation', async () => {
@@ -108,9 +109,12 @@ describe('App', () => {
     expect(await mockSdk.app.onConfigure.mock.calls[0][0]()).toBe(false);
   });
 
-  it('should render the sidebar app with signing and request button', () => {
+  it('should render the sidebar app with signing and request button', async () => {
     mockSdk.location.is = (location: string) => location === locations.LOCATION_ENTRY_SIDEBAR;
+    fetchMock.get('/entry?spaceId=space-123&projectId=project-id-123&entryId=entry-123', {});
+    fetchMock.get('/refresh?refresh_token=', 401);
     const wrapper = render(<App sdk={mockSdk as AppExtensionSDK} />);
+    await wait();
     expect(wrapper).toMatchSnapshot();
   });
 


### PR DESCRIPTION
## Purpose

With the upgrade to node18 in our build environment, the build for smartling started to break: https://app.circleci.com/pipelines/github/contentful/apps/25320/workflows/f43a3c59-b6fb-4359-bf0b-f5092d0b55bb/jobs/76824

The problem appears to be a lack of support for node 17+ in the legacy babel loader this project uses. See https://stackoverflow.com/questions/74726224/opensslerrorstack-error03000086digital-envelope-routinesinitialization-e

## Approach

* Fix the problem for now by specifiying to use the legacy ssl builder
* Also fix tests which weren't running properly

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
