### PR TITLE
fix: pipeline build - specifically the Typeform app build given recent Node upgrade

### DIFF
--- a/apps/typeform/frontend/package.json
+++ b/apps/typeform/frontend/package.json
@@ -31,10 +31,10 @@
     "whatwg-fetch": "^3.0.0"
   },
   "scripts": {
-    "start": "cross-env BROWSER=none react-scripts start",
-    "build": "react-scripts build",
+    "start": "cross-env BROWSER=none react-scripts --openssl-legacy-provider start",
+    "build": "react-scripts --openssl-legacy-provider build",
     "test": "react-scripts test",
-    "test:ci": "react-scripts test"
+    "test:ci": "CI=true react-scripts test"
   },
   "eslintConfig": {
     "extends": "react-app"


### PR DESCRIPTION
## Purpose
 Same thing as [this](https://github.com/contentful/apps/pull/5304) PR but for Typeform app because of current build failure on pipeline. 

_With the upgrade to node18 in our build environment, the build for smartling (Typeform) started to break: https://app.circleci.com/pipelines/github/contentful/apps/25320/workflows/f43a3c59-b6fb-4359-bf0b-f5092d0b55bb/jobs/76824

The problem appears to be a lack of support for node 17+ in the legacy babel loader this project uses. See https://stackoverflow.com/questions/74726224/opensslerrorstack-error03000086digital-envelope-routinesinitialization-e_


