### PR TITLE
[INTEG-1392] Update aiig create upload function to handle latest upload function for both spaceId and environmentId

### DIFF
--- a/apps/ai-image-generator/backend/src/actions/aiig-select-edit.ts
+++ b/apps/ai-image-generator/backend/src/actions/aiig-select-edit.ts
@@ -25,7 +25,7 @@ export const handler = async (
 ): Promise<AppActionCallResponse<ImageEditResult>> => {
   const {
     cma,
-    appActionCallContext: { appInstallationId, spaceId, uploadHost },
+    appActionCallContext: { appInstallationId, spaceId, environmentId, uploadHost },
   } = context;
 
   let images: ImageWithUpload[];
@@ -72,6 +72,7 @@ export const handler = async (
       imagesWithStreams: processedImages,
       cmaClient: cma,
       spaceId,
+      environmentId,
       uploadHost,
     });
   } catch (e) {

--- a/apps/ai-image-generator/backend/src/helpers/upload-images.spec.ts
+++ b/apps/ai-image-generator/backend/src/helpers/upload-images.spec.ts
@@ -8,6 +8,7 @@ import { expect } from 'chai';
 describe('UploadImages', () => {
   let uploadImages: UploadImages;
   const spaceId = 'spaceId';
+  const environmentId = 'environmentId';
   const uploadId = 'uploadId';
   const sourceUrl = 'http://www.example.com';
   const uploadHost = 'upload.contentful.com';
@@ -44,7 +45,13 @@ describe('UploadImages', () => {
       };
 
       const cmaClient = makeMockPlainClient([mockUploadApiResponse], cmaClientStub);
-      uploadImages = new UploadImages(imagesWithStreams, cmaClient, spaceId, uploadHost);
+      uploadImages = new UploadImages(
+        imagesWithStreams,
+        cmaClient,
+        spaceId,
+        environmentId,
+        uploadHost
+      );
     });
 
     it('returns images with correct urls', async () => {

--- a/apps/ai-image-generator/backend/src/helpers/upload-images.ts
+++ b/apps/ai-image-generator/backend/src/helpers/upload-images.ts
@@ -15,6 +15,7 @@ export class UploadImages {
     readonly imagesWithStreams: ImageWithStream[],
     readonly cmaClient: PlainClientAPI,
     readonly spaceId: string,
+    readonly environmentId: string,
     readonly uploadHost: string
   ) {}
 
@@ -53,7 +54,10 @@ export class UploadImages {
   }
 
   private async createUpload(file: sharp.Sharp): Promise<UploadProps> {
-    return await this.cmaClient.upload.create({ spaceId: this.spaceId }, { file });
+    return await this.cmaClient.upload.create(
+      { spaceId: this.spaceId, environmentId: this.environmentId },
+      { file }
+    );
   }
 
   private urlFromUpload(upload: UploadProps): string {
@@ -70,9 +74,16 @@ export const uploadImages = async (params: {
   imagesWithStreams: ImageWithStream[];
   cmaClient: PlainClientAPI;
   spaceId: string;
+  environmentId: string;
   uploadHost: string;
 }) => {
-  const { imagesWithStreams, cmaClient, spaceId, uploadHost } = params;
-  const imageUploader = new UploadImages(imagesWithStreams, cmaClient, spaceId, uploadHost);
+  const { imagesWithStreams, cmaClient, spaceId, environmentId, uploadHost } = params;
+  const imageUploader = new UploadImages(
+    imagesWithStreams,
+    cmaClient,
+    spaceId,
+    environmentId,
+    uploadHost
+  );
   return imageUploader.execute();
 };


### PR DESCRIPTION
## Purpose
The create asset upload function has been changed to take both spaceId and the environmentId, therefore we need to adjust accordingly to the new api params.

However, we should not merge this PR until the updates to contentful-management is made that take those new api param changes into account. (Basically this PR has a dependency on the contentful-management update and an package.json update in the PR respectively).

## Testing steps
Unit tests and build passes 

## Dependencies and/or References
Will require latest contentful-management.js package version or else merging this PR will break the backend
