### PR TITLE
feat: save tenant id on config page [INTEG-1470]

### DIFF
--- a/apps/microsoft-teams/frontend/.eslintignore
+++ b/apps/microsoft-teams/frontend/.eslintignore
@@ -1,0 +1,3 @@
+coverage
+dist
+node_modules

--- a/apps/microsoft-teams/frontend/src/components/config/ConfigPage/ConfigPage.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ConfigPage/ConfigPage.spec.tsx
@@ -1,0 +1,11 @@
+import ConfigPage from './ConfigPage';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+describe('ConfigPage component', () => {
+  it('mounts and renders input field', () => {
+    render(<ConfigPage handleConfig={vi.fn()} parameters={{}} />);
+
+    expect(screen.getByText('Tenant Id')).toBeTruthy();
+  });
+});

--- a/apps/microsoft-teams/frontend/src/components/config/ConfigPage/ConfigPage.styles.ts
+++ b/apps/microsoft-teams/frontend/src/components/config/ConfigPage/ConfigPage.styles.ts
@@ -1,0 +1,22 @@
+import { css } from 'emotion';
+import tokens from '@contentful/f36-tokens';
+
+export const styles = {
+  body: css({
+    height: 'auto',
+    margin: `${tokens.spacingXl} auto`,
+    padding: `${tokens.spacingXl} ${tokens.spacing2Xl}`,
+    maxWidth: '900px',
+    backgroundColor: tokens.colorWhite,
+    borderRadius: '6px',
+    border: `1px solid ${tokens.gray300}`,
+    zIndex: 2,
+  }),
+  splitter: css({
+    marginTop: tokens.spacingL,
+    marginBottom: tokens.spacingL,
+    border: 0,
+    height: '1px',
+    backgroundColor: tokens.gray300,
+  }),
+};

--- a/apps/microsoft-teams/frontend/src/components/config/ConfigPage/ConfigPage.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ConfigPage/ConfigPage.tsx
@@ -1,0 +1,44 @@
+import { Box, FormControl, Heading, Paragraph, TextInput } from '@contentful/f36-components';
+import { ChangeEvent } from 'react';
+import { styles } from './ConfigPage.styles';
+import { AppInstallationParameters } from '@locations/ConfigScreen';
+
+interface ParameterObject {
+  [key: string]: string;
+}
+
+interface Props {
+  handleConfig: (value: ParameterObject) => void;
+  parameters: AppInstallationParameters;
+}
+
+const ConfigPage = (props: Props) => {
+  const { handleConfig, parameters } = props;
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    handleConfig({ tenantId: e.target.value });
+  };
+
+  return (
+    <Box className={styles.body}>
+      <Heading>Set up Microsoft Teams</Heading>
+      <Paragraph>
+        The Microsoft Teams app for Contentful lets you set up automatic notifications about
+        specific Contentful events so that you can quickly notify collaborators about changes
+        throughout the content lifecycle.
+      </Paragraph>
+      <hr className={styles.splitter} />
+      <FormControl data-test-id="tenant-id-section">
+        <FormControl.Label>Tenant Id</FormControl.Label>
+        <TextInput
+          value={parameters.tenantId}
+          type="text"
+          name="tenantId"
+          onChange={handleChange}
+        />
+      </FormControl>
+    </Box>
+  );
+};
+
+export default ConfigPage;

--- a/apps/microsoft-teams/frontend/src/locations/ConfigScreen.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/locations/ConfigScreen.spec.tsx
@@ -15,6 +15,6 @@ describe('Config Screen component', () => {
     // simulate the user clicking the install button
     await mockSdk.app.onConfigure.mock.calls[0][0]();
 
-    expect(getByText('Welcome to your contentful app. This is your config page.')).toBeTruthy();
+    expect(getByText('Set up Microsoft Teams')).toBeTruthy();
   });
 });

--- a/apps/microsoft-teams/frontend/src/locations/ConfigScreen.tsx
+++ b/apps/microsoft-teams/frontend/src/locations/ConfigScreen.tsx
@@ -1,13 +1,14 @@
 import { ConfigAppSDK } from '@contentful/app-sdk';
-import { Flex, Form, Heading, Paragraph } from '@contentful/f36-components';
 import { /* useCMA, */ useSDK } from '@contentful/react-apps-toolkit';
-import { css } from 'emotion';
 import { useCallback, useEffect, useState } from 'react';
+import ConfigPage from '@components/config/ConfigPage/ConfigPage';
 
-export interface AppInstallationParameters {}
+export interface AppInstallationParameters {
+  tenantId?: string;
+}
 
 const ConfigScreen = () => {
-  const [parameters, setParameters] = useState<AppInstallationParameters>({});
+  const [parameters, setParameters] = useState<AppInstallationParameters>({ tenantId: '' });
   const sdk = useSDK<ConfigAppSDK>();
 
   /*
@@ -57,14 +58,14 @@ const ConfigScreen = () => {
     })();
   }, [sdk]);
 
-  return (
-    <Flex flexDirection="column" className={css({ margin: '80px', maxWidth: '800px' })}>
-      <Form>
-        <Heading>App Config</Heading>
-        <Paragraph>Welcome to your contentful app. This is your config page.</Paragraph>
-      </Form>
-    </Flex>
-  );
+  const handleConfig = (updatedParams: AppInstallationParameters) => {
+    setParameters((prevParameters) => ({
+      ...prevParameters,
+      ...updatedParams,
+    }));
+  };
+
+  return <ConfigPage handleConfig={handleConfig} parameters={parameters} />;
 };
 
 export default ConfigScreen;


### PR DESCRIPTION
## Purpose

Update MS Teams config page to allow user to enter and save a tenant id.

## Approach

Tenant id is saved to app installation parameters.

## Testing steps

Run the app locally, navigate to the config page, add a tenant id in the input, and save the config.

## Breaking Changes

## Dependencies and/or References

## Deployment
