### PR TITLE
add a few logs to Slack app and Jira app in order to debug customer issue

### DIFF
--- a/apps/jira/jira-app/src/components/App/Config.tsx
+++ b/apps/jira/jira-app/src/components/App/Config.tsx
@@ -47,8 +47,8 @@ export default class Config extends React.Component<Props, State> {
       this.loadEditorInterfaces(),
     ]);
 
-    console.log('app sdk>>>', app);
-    console.log('app config>>>', config);
+    console.log('JIRA app sdk>>>', app);
+    console.log('JIRA app config>>>', config);
 
     app.onConfigure(this.configure);
 
@@ -59,12 +59,12 @@ export default class Config extends React.Component<Props, State> {
         (r) => r.id === resourceId
       );
       const { project } = await JiraClient.getProjectById(resourceId, this.props.token, projectId);
-      console.log('Jira project>>>', project);
+      console.log('JIRA project>>>', project);
 
       // only use the saved config if the resource exists
       // we can assume the projectId is also invalid if it doesn't exist
       if (configResourceExistsInResources) {
-        console.log('config exists>>>', configResourceExistsInResources);
+        console.log('JIRA config exists>>>', configResourceExistsInResources);
         // eslint-disable-next-line react/no-did-mount-set-state
         this.setState({
           checkedResource: resourceId,
@@ -72,10 +72,10 @@ export default class Config extends React.Component<Props, State> {
         });
       }
 
-      console.log('reached setReady functionality in if block');
+      console.log('JIRA reached setReady functionality in if block');
       app.setReady();
     } else {
-      console.log('reached setReady functionality in else block');
+      console.log('JIRA reached setReady functionality in else block');
       app.setReady();
     }
   }

--- a/apps/jira/jira-app/src/components/App/Config.tsx
+++ b/apps/jira/jira-app/src/components/App/Config.tsx
@@ -47,6 +47,9 @@ export default class Config extends React.Component<Props, State> {
       this.loadEditorInterfaces(),
     ]);
 
+    console.log('app sdk>>>', app);
+    console.log('app config>>>', config);
+
     app.onConfigure(this.configure);
 
     if (config) {
@@ -56,10 +59,12 @@ export default class Config extends React.Component<Props, State> {
         (r) => r.id === resourceId
       );
       const { project } = await JiraClient.getProjectById(resourceId, this.props.token, projectId);
+      console.log('Jira project>>>', project);
 
       // only use the saved config if the resource exists
       // we can assume the projectId is also invalid if it doesn't exist
       if (configResourceExistsInResources) {
+        console.log('config exists>>>', configResourceExistsInResources);
         // eslint-disable-next-line react/no-did-mount-set-state
         this.setState({
           checkedResource: resourceId,
@@ -67,8 +72,10 @@ export default class Config extends React.Component<Props, State> {
         });
       }
 
+      console.log('reached setReady functionality in if block');
       app.setReady();
     } else {
+      console.log('reached setReady functionality in else block');
       app.setReady();
     }
   }

--- a/apps/slack/frontend/src/components/ConfigScreen.tsx
+++ b/apps/slack/frontend/src/components/ConfigScreen.tsx
@@ -132,8 +132,8 @@ const Config = () => {
   useEffect(() => {
     (async () => {
       const currentParameters: AppInstallationParameters | null = await sdk.app.getParameters();
-      console.log('sdk app>>>', sdk.app);
-      console.log('app installation parameters>>>', currentParameters);
+      console.log('SLACK sdk app>>>', sdk.app);
+      console.log('SLACK app installation parameters>>>', currentParameters);
 
       setParameters({
         ...currentParameters,
@@ -141,7 +141,7 @@ const Config = () => {
         workspaces: Object.values(connectedWorkspaces).map((workspace) => workspace.id),
       });
 
-      console.log('connectedWorkspaces>>>', connectedWorkspaces);
+      console.log('SLACK connected workspaces>>>', connectedWorkspaces);
 
       if (currentParameters?.notifications) {
         setNotifications(currentParameters.notifications);
@@ -151,7 +151,7 @@ const Config = () => {
 
       setActive(typeof activeFlag === 'boolean' ? activeFlag : true);
 
-      console.log('reached setReady functionality');
+      console.log('SLACK reached setReady functionality');
       await sdk.app.setReady();
     })();
   }, [sdk, connectedWorkspaces, setNotifications, setActive, installationUuid]);

--- a/apps/slack/frontend/src/components/ConfigScreen.tsx
+++ b/apps/slack/frontend/src/components/ConfigScreen.tsx
@@ -132,12 +132,16 @@ const Config = () => {
   useEffect(() => {
     (async () => {
       const currentParameters: AppInstallationParameters | null = await sdk.app.getParameters();
+      console.log('sdk app>>>', sdk.app);
+      console.log('app installation parameters>>>', currentParameters);
 
       setParameters({
         ...currentParameters,
         installationUuid,
         workspaces: Object.values(connectedWorkspaces).map((workspace) => workspace.id),
       });
+
+      console.log('connectedWorkspaces>>>', connectedWorkspaces);
 
       if (currentParameters?.notifications) {
         setNotifications(currentParameters.notifications);
@@ -147,6 +151,7 @@ const Config = () => {
 
       setActive(typeof activeFlag === 'boolean' ? activeFlag : true);
 
+      console.log('reached setReady functionality');
       await sdk.app.setReady();
     })();
   }, [sdk, connectedWorkspaces, setNotifications, setActive, installationUuid]);


### PR DESCRIPTION
## Purpose

Currently there exists a customer that cannot successfully render the app config page of two apps, Slack and Jira. They recieve [this](https://p29.zdusercontent.com/attachment/284868/VDxt5gsmyGa9J7gKRY8yQtfry?token=eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4Q0JDLUhTMjU2In0..acgWQ7Ztly-1azuNPv4N5A.zZ_osPEu6v0d4ocunubHEstHM8QKEhLd6zHl3Xovrrr0y17V9sI5BYBKQs0DKYguzmkSc0_8ln_BFc7cIbyfyd4lf9ZjFwQU0QXUrXgLj_7Kjm4yfg1c6O2myFNvjVYffQ2NSrAWwzQWdPRTabnaKnjZNVtyHdasc8brbnq7MSXgxmVtS4iVHgywerP_l3glK4yG6TVnCPT8pq1FDlqCWEwb1JDsnxK9SaiJylxohdUKIvpPUstlshN1p0xDms0RJbKqBkgW92U9HzrumvbVznlkn_mE-OZh8kI8d4TSybY.sDAVMicg4pWTPgQ4FuX9Gg) warning page. 

This is an especially tricky bug because when either I or the customer support engineer impersonate the user, the bug does not appear and we can successfully render the config page. So near impossible to reproduce.

After attempting to determine browser incompatibilities, the user indicates nothing different about our settings that would render the config page differently, though I am not entirely convinced.

The step that I have determined actually triggers that failed to load warning page is the `app.setReady()`, and if this is never called, the loading timeout is reached and the warning page is rendered. Hence why I have added logs there. I plan on verifying the logs myself, and also asking the customer to report the logs that they themselves see given they are the only ones that can see the error. 

They have mentioned programmatically installing the app after their UI failed (dun dun dun), and their parameters do not reflect valid installation parameters, so I believe this is where it might be failing now - though does not explain why it failed in the first place but gets us closer. 

