### PR TITLE
refactor: implement reducer to manage installation params [INTEG-1524]

### DIFF
--- a/apps/microsoft-teams/frontend/src/components/config/AccessSection/AccessSection.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/AccessSection/AccessSection.spec.tsx
@@ -6,7 +6,7 @@ const tenantIdValue = 'abc-123';
 
 describe('AccessSection component', () => {
   it('mounts with tenantId provided', () => {
-    render(<AccessSection handleChange={vi.fn()} tenantId={tenantIdValue} />);
+    render(<AccessSection dispatch={vi.fn()} tenantId={tenantIdValue} />);
 
     expect(screen.getByDisplayValue(tenantIdValue)).toBeTruthy();
   });

--- a/apps/microsoft-teams/frontend/src/components/config/AccessSection/AccessSection.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/AccessSection/AccessSection.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent } from 'react';
+import { ChangeEvent, Dispatch } from 'react';
 import {
   Box,
   FormControl,
@@ -9,14 +9,22 @@ import {
 } from '@contentful/f36-components';
 import { headerSection, accessSection } from '@constants/configCopy';
 import { styles } from './AccessSection.styles';
+import { ParameterAction, actions } from '@components/config/parameterReducer';
 
 interface Props {
   tenantId: string;
-  handleChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  dispatch: Dispatch<ParameterAction>;
 }
 
 const AccessSection = (props: Props) => {
-  const { tenantId, handleChange } = props;
+  const { tenantId, dispatch } = props;
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    dispatch({
+      type: actions.UPDATE_TENANT_ID,
+      payload: e.target.value,
+    });
+  };
 
   return (
     <Box className={styles.box}>

--- a/apps/microsoft-teams/frontend/src/components/config/ConfigPage/ConfigPage.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ConfigPage/ConfigPage.spec.tsx
@@ -2,10 +2,15 @@ import ConfigPage from './ConfigPage';
 import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { accessSection, notificationsSection } from '@constants/configCopy';
+import { mockSdk } from '@test/mocks';
+
+vi.mock('@contentful/react-apps-toolkit', () => ({
+  useSDK: () => mockSdk,
+}));
 
 describe('ConfigPage component', () => {
   it('mounts and renders the correct sections', () => {
-    render(<ConfigPage handleConfig={vi.fn()} parameters={{}} />);
+    render(<ConfigPage />);
 
     expect(screen.getByText(accessSection.title)).toBeTruthy();
     expect(screen.getByText(notificationsSection.title)).toBeTruthy();

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.spec.tsx
@@ -1,11 +1,11 @@
 import NotificationEditMode from './NotificationEditMode';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { contentTypeSection, channelSection, actionsSection } from '@constants/configCopy';
 
 describe('NotificationEditMode component', () => {
   it('mounts with correct copy', () => {
-    render(<NotificationEditMode index={0} />);
+    render(<NotificationEditMode index={0} handleDelete={vi.fn()} />);
 
     expect(screen.getByText(contentTypeSection.title)).toBeTruthy();
     expect(screen.getByText(channelSection.title)).toBeTruthy();

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.styles.ts
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.styles.ts
@@ -14,7 +14,4 @@ export const styles = {
   main: css({
     padding: `${tokens.spacingM}`,
   }),
-  footer: css({
-    borderTop: `1px solid ${tokens.gray300}`,
-  }),
 };

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.tsx
@@ -1,29 +1,18 @@
-import {
-  Box,
-  Button,
-  ButtonGroup,
-  Checkbox,
-  Flex,
-  FormControl,
-  Text,
-} from '@contentful/f36-components';
+import { Box, Checkbox, Flex, FormControl, Text } from '@contentful/f36-components';
 import AddButton from '@components/config/AddButton/AddButton';
 import ContentfulLogo from '@components/config/ContentfulLogo/ContentfulLogo';
 import TeamsLogo from '@components/config/TeamsLogo/TeamsLogo';
+import NotificationEditModeFooter from '@components/config/NotificationEditModeFooter/NotificationEditModeFooter';
 import { styles } from './NotificationEditMode.styles';
-import {
-  actionsSection,
-  channelSection,
-  contentTypeSection,
-  editModeFooter,
-} from '@constants/configCopy';
+import { actionsSection, channelSection, contentTypeSection } from '@constants/configCopy';
 
 interface Props {
   index: number;
+  handleDelete: (index: number) => void;
 }
 
 const NotificationEditMode = (props: Props) => {
-  const { index } = props;
+  const { index, handleDelete } = props;
 
   return (
     <Box className={styles.wrapper}>
@@ -70,15 +59,7 @@ const NotificationEditMode = (props: Props) => {
           </FormControl>
         </Box>
       </Box>
-      <Box className={styles.footer}>
-        <Flex justifyContent="flex-end" margin="spacingS">
-          <ButtonGroup variant="spaced" spacing="spacingS">
-            <Button variant="transparent">{editModeFooter.test}</Button>
-            <Button variant="negative">{editModeFooter.delete}</Button>
-            <Button variant="primary">{editModeFooter.save}</Button>
-          </ButtonGroup>
-        </Flex>
-      </Box>
+      <NotificationEditModeFooter index={index} handleDelete={handleDelete} />
     </Box>
   );
 };

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationEditModeFooter/NotificationEditModeFooter.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationEditModeFooter/NotificationEditModeFooter.spec.tsx
@@ -1,0 +1,24 @@
+import NotificationEditModeFooter from './NotificationEditModeFooter';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { editModeFooter } from '@constants/configCopy';
+
+describe('NotificationEditModeFooter component', () => {
+  it('mounts with correct button copy', () => {
+    const { unmount } = render(<NotificationEditModeFooter index={0} handleDelete={vi.fn()} />);
+
+    expect(screen.getByText(editModeFooter.test)).toBeTruthy();
+    expect(screen.getByText(editModeFooter.delete)).toBeTruthy();
+    expect(screen.getByText(editModeFooter.save)).toBeTruthy();
+    unmount();
+  });
+  it('handles clicking the delete button', () => {
+    const mockHandleDelete = vi.fn();
+    render(<NotificationEditModeFooter index={0} handleDelete={mockHandleDelete} />);
+
+    const deleteButton = screen.getByText(editModeFooter.delete);
+    deleteButton.click();
+
+    expect(mockHandleDelete).toHaveBeenCalled();
+  });
+});

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationEditModeFooter/NotificationEditModeFooter.styles.ts
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationEditModeFooter/NotificationEditModeFooter.styles.ts
@@ -1,0 +1,8 @@
+import { css } from 'emotion';
+import tokens from '@contentful/f36-tokens';
+
+export const styles = {
+  footer: css({
+    borderTop: `1px solid ${tokens.gray300}`,
+  }),
+};

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationEditModeFooter/NotificationEditModeFooter.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationEditModeFooter/NotificationEditModeFooter.tsx
@@ -1,0 +1,29 @@
+import { Box, Button, ButtonGroup, Flex } from '@contentful/f36-components';
+import { styles } from './NotificationEditModeFooter.styles';
+import { editModeFooter } from '@constants/configCopy';
+
+interface Props {
+  index: number;
+  handleDelete: (index: number) => void;
+}
+
+const NotificationEditModeFooter = (props: Props) => {
+  const { index, handleDelete } = props;
+
+  return (
+    <Box className={styles.footer}>
+      <Flex justifyContent="flex-end" margin="spacingS">
+        <ButtonGroup variant="spaced" spacing="spacingS">
+          <Button variant="transparent">{editModeFooter.test}</Button>
+          {/* TODO: implement modal to confirm deletion */}
+          <Button variant="negative" onClick={() => handleDelete(index)}>
+            {editModeFooter.delete}
+          </Button>
+          <Button variant="primary">{editModeFooter.save}</Button>
+        </ButtonGroup>
+      </Flex>
+    </Box>
+  );
+};
+
+export default NotificationEditModeFooter;

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.spec.tsx
@@ -5,7 +5,7 @@ import { notificationsSection } from '@constants/configCopy';
 
 describe('NotificationsSection component', () => {
   it('mounts with title', () => {
-    render(<NotificationsSection notifications={[]} createNewNotification={vi.fn()} />);
+    render(<NotificationsSection notifications={[]} dispatch={vi.fn()} />);
 
     expect(screen.getByText(notificationsSection.title)).toBeTruthy();
   });

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.tsx
@@ -19,6 +19,11 @@ const NotificationsSection = (props: Props) => {
     dispatch({ type: actions.ADD_NOTIFICATION });
   };
 
+  const deleteNotification = (index: number) => {
+    notifications.splice(index, 1);
+    dispatch({ type: actions.UPDATE_NOTIFICATIONS, payload: notifications });
+  };
+
   return (
     <Box className={styles.box}>
       <Subheading>{notificationsSection.title}</Subheading>
@@ -27,7 +32,13 @@ const NotificationsSection = (props: Props) => {
         handleClick={createNewNotification}
       />
       {notifications.map((notification, index) => {
-        return <NotificationEditMode key={`notification-${index}`} index={index} />;
+        return (
+          <NotificationEditMode
+            key={`notification-${index}`}
+            index={index}
+            handleDelete={deleteNotification}
+          />
+        );
       })}
     </Box>
   );

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.tsx
@@ -20,8 +20,9 @@ const NotificationsSection = (props: Props) => {
   };
 
   const deleteNotification = (index: number) => {
-    notifications.splice(index, 1);
-    dispatch({ type: actions.UPDATE_NOTIFICATIONS, payload: notifications });
+    const notificationsPayload = [...notifications];
+    notificationsPayload.splice(index, 1);
+    dispatch({ type: actions.UPDATE_NOTIFICATIONS, payload: notificationsPayload });
   };
 
   return (

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.tsx
@@ -1,17 +1,23 @@
+import { Dispatch } from 'react';
 import { Box, Subheading } from '@contentful/f36-components';
 import { styles } from './NotificationsSection.styles';
 import { notificationsSection } from '@constants/configCopy';
 import AddButton from '@components/config/AddButton/AddButton';
 import NotificationEditMode from '@components/config/NotificationEditMode/NotificationEditMode';
 import { Notification } from '@customTypes/configPage';
+import { ParameterAction, actions } from '@components/config/parameterReducer';
 
 interface Props {
   notifications: Notification[];
-  createNewNotification: () => void;
+  dispatch: Dispatch<ParameterAction>;
 }
 
 const NotificationsSection = (props: Props) => {
-  const { notifications, createNewNotification } = props;
+  const { notifications, dispatch } = props;
+
+  const createNewNotification = () => {
+    dispatch({ type: actions.ADD_NOTIFICATION });
+  };
 
   return (
     <Box className={styles.box}>

--- a/apps/microsoft-teams/frontend/src/components/config/parameterReducer.ts
+++ b/apps/microsoft-teams/frontend/src/components/config/parameterReducer.ts
@@ -1,0 +1,73 @@
+import { AppInstallationParameters, Notification } from '@customTypes/configPage';
+import { defaultNotification } from '@constants/defaultParams';
+
+export enum actions {
+  UPDATE_TENANT_ID = 'updateTenantId',
+  UPDATE_NOTIFICATIONS = 'updateNotifications',
+  ADD_NOTIFICATION = 'addNotification',
+  APPLY_CONTENTFUL_PARAMETERS = 'applyContentfulParameters',
+}
+
+type TenantIdAction = {
+  type: actions.UPDATE_TENANT_ID;
+  payload: string;
+};
+
+type NotificationsAction = {
+  type: actions.UPDATE_NOTIFICATIONS;
+  payload: Notification[];
+};
+
+type AddNotificationAction = {
+  type: actions.ADD_NOTIFICATION;
+};
+
+type ApplyContentfulParametersAction = {
+  type: actions.APPLY_CONTENTFUL_PARAMETERS;
+  payload: AppInstallationParameters;
+};
+
+export type ParameterAction =
+  | TenantIdAction
+  | NotificationsAction
+  | AddNotificationAction
+  | ApplyContentfulParametersAction;
+
+const { UPDATE_TENANT_ID, UPDATE_NOTIFICATIONS, ADD_NOTIFICATION, APPLY_CONTENTFUL_PARAMETERS } =
+  actions;
+
+const parameterReducer = (
+  state: AppInstallationParameters,
+  action: ParameterAction
+): AppInstallationParameters => {
+  switch (action.type) {
+    case UPDATE_TENANT_ID:
+      return {
+        ...state,
+        tenantId: action.payload,
+      };
+    case UPDATE_NOTIFICATIONS:
+      return {
+        ...state,
+        notifications: action.payload,
+      };
+    case ADD_NOTIFICATION: {
+      return {
+        ...state,
+        notifications: [defaultNotification, ...state.notifications],
+      };
+    }
+    case APPLY_CONTENTFUL_PARAMETERS: {
+      const parameter = action.payload as AppInstallationParameters;
+      return {
+        ...state,
+        tenantId: parameter.tenantId ?? '',
+        notifications: parameter.notifications ?? [],
+      };
+    }
+    default:
+      return state;
+  }
+};
+
+export default parameterReducer;

--- a/apps/microsoft-teams/frontend/src/components/config/parameterReducer.ts
+++ b/apps/microsoft-teams/frontend/src/components/config/parameterReducer.ts
@@ -58,11 +58,11 @@ const parameterReducer = (
       };
     }
     case APPLY_CONTENTFUL_PARAMETERS: {
-      const parameter = action.payload as AppInstallationParameters;
+      const parameters = action.payload;
       return {
         ...state,
-        tenantId: parameter.tenantId ?? '',
-        notifications: parameter.notifications ?? [],
+        tenantId: parameters.tenantId ?? '',
+        notifications: parameters.notifications ?? [],
       };
     }
     default:

--- a/apps/microsoft-teams/frontend/src/constants/defaultParams.ts
+++ b/apps/microsoft-teams/frontend/src/constants/defaultParams.ts
@@ -1,0 +1,21 @@
+import { AppInstallationParameters } from '@customTypes/configPage';
+
+const initialParameters: AppInstallationParameters = {
+  tenantId: '',
+  notifications: [],
+};
+
+const defaultNotification = {
+  channelId: '',
+  contentTypeId: '',
+  isEnabled: true,
+  selectedEvents: {
+    publish: false,
+    unpublish: false,
+    create: false,
+    delete: false,
+    edit: false,
+  },
+};
+
+export { initialParameters, defaultNotification };

--- a/apps/microsoft-teams/frontend/src/customTypes/configPage.ts
+++ b/apps/microsoft-teams/frontend/src/customTypes/configPage.ts
@@ -1,6 +1,6 @@
 export interface AppInstallationParameters {
-  tenantId?: string;
-  notifications?: Notification[];
+  tenantId: string;
+  notifications: Notification[];
 }
 
 export interface Notification {

--- a/apps/microsoft-teams/frontend/src/hooks/useInitializeParameters.spec.ts
+++ b/apps/microsoft-teams/frontend/src/hooks/useInitializeParameters.spec.ts
@@ -1,0 +1,37 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import useInitializeParameters from './useInitializeParameters';
+import { mockParameters, mockSdk } from '@test/mocks';
+import { actions } from '@components/config/parameterReducer';
+
+vi.mock('@contentful/react-apps-toolkit', () => ({
+  useSDK: () => mockSdk,
+}));
+
+describe('useInitializeParameters', () => {
+  it('should dispatch Contentful parameters and call setReady', async () => {
+    const dispatchMock = vi.fn((val) => val);
+    mockSdk.app.getParameters = vi.fn().mockReturnValueOnce(mockParameters);
+
+    renderHook(() => useInitializeParameters(dispatchMock));
+    await waitFor(() => expect(dispatchMock).toBeCalled());
+
+    expect(dispatchMock).toHaveBeenCalledWith({
+      type: actions.APPLY_CONTENTFUL_PARAMETERS,
+      payload: mockParameters,
+    });
+
+    expect(mockSdk.app.setReady).toBeCalled();
+  });
+
+  it('should not dispatch anything if parameters are not present', async () => {
+    const dispatchMock = vi.fn((val) => val);
+    mockSdk.app.getParameters = vi.fn().mockReturnValueOnce(undefined);
+
+    renderHook(() => useInitializeParameters(dispatchMock));
+    await waitFor(() => expect(dispatchMock).not.toBeCalled());
+
+    expect(dispatchMock).not.toBeCalled();
+    expect(mockSdk.app.setReady).toBeCalled();
+  });
+});

--- a/apps/microsoft-teams/frontend/src/hooks/useInitializeParameters.ts
+++ b/apps/microsoft-teams/frontend/src/hooks/useInitializeParameters.ts
@@ -1,0 +1,39 @@
+import { Dispatch, useEffect, useCallback } from 'react';
+import { useSDK } from '@contentful/react-apps-toolkit';
+import type { ConfigAppSDK } from '@contentful/app-sdk';
+import { ParameterAction, actions } from '@components/config/parameterReducer';
+import { AppInstallationParameters } from '@customTypes/configPage';
+
+/**
+ * This hook is used to initialize the parameters of the app.
+ * It will get the parameters from Contentful and dispatch them to the reducer.
+ *
+ * @param dispatch a dispatch function from useReducer
+ * @returns void
+ */
+const useInitializeParameters = (dispatch: Dispatch<ParameterAction>) => {
+  const sdk = useSDK<ConfigAppSDK>();
+
+  const dispatchParameters = useCallback(async () => {
+    try {
+      const parameters = await sdk.app.getParameters<AppInstallationParameters>();
+
+      if (!parameters) return;
+
+      dispatch({
+        type: actions.APPLY_CONTENTFUL_PARAMETERS,
+        payload: parameters,
+      });
+    } catch (error) {
+      console.error(error);
+    } finally {
+      sdk.app.setReady();
+    }
+  }, [dispatch, sdk.app]);
+
+  useEffect(() => {
+    dispatchParameters();
+  }, [sdk, dispatchParameters]);
+};
+
+export default useInitializeParameters;

--- a/apps/microsoft-teams/frontend/src/locations/ConfigScreen.tsx
+++ b/apps/microsoft-teams/frontend/src/locations/ConfigScreen.tsx
@@ -1,68 +1,7 @@
-import { ConfigAppSDK } from '@contentful/app-sdk';
-import { /* useCMA, */ useSDK } from '@contentful/react-apps-toolkit';
-import { useCallback, useEffect, useState } from 'react';
 import ConfigPage from '@components/config/ConfigPage/ConfigPage';
-import { AppInstallationParameters } from '@customTypes/configPage';
 
 const ConfigScreen = () => {
-  const [parameters, setParameters] = useState<AppInstallationParameters>({ tenantId: '' });
-  const sdk = useSDK<ConfigAppSDK>();
-
-  /*
-     To use the cma, inject it as follows.
-     If it is not needed, you can remove the next line.
-  */
-  // const cma = useCMA();
-
-  const onConfigure = useCallback(async () => {
-    // This method will be called when a user clicks on "Install"
-    // or "Save" in the configuration screen.
-    // for more details see https://www.contentful.com/developers/docs/extensibility/ui-extensions/sdk-reference/#register-an-app-configuration-hook
-
-    // Get current the state of EditorInterface and other entities
-    // related to this app installation
-    const currentState = await sdk.app.getCurrentState();
-
-    return {
-      // Parameters to be persisted as the app configuration.
-      parameters,
-      // In case you don't want to submit any update to app
-      // locations, you can just pass the currentState as is
-      targetState: currentState,
-    };
-  }, [parameters, sdk]);
-
-  useEffect(() => {
-    // `onConfigure` allows to configure a callback to be
-    // invoked when a user attempts to install the app or update
-    // its configuration.
-    sdk.app.onConfigure(() => onConfigure());
-  }, [sdk, onConfigure]);
-
-  useEffect(() => {
-    (async () => {
-      // Get current parameters of the app.
-      // If the app is not installed yet, `parameters` will be `null`.
-      const currentParameters: AppInstallationParameters | null = await sdk.app.getParameters();
-
-      if (currentParameters) {
-        setParameters(currentParameters);
-      }
-
-      // Once preparation has finished, call `setReady` to hide
-      // the loading screen and present the app to a user.
-      sdk.app.setReady();
-    })();
-  }, [sdk]);
-
-  const handleConfig = (updatedParams: AppInstallationParameters) => {
-    setParameters((prevParameters) => ({
-      ...prevParameters,
-      ...updatedParams,
-    }));
-  };
-
-  return <ConfigPage handleConfig={handleConfig} parameters={parameters} />;
+  return <ConfigPage />;
 };
 
 export default ConfigScreen;

--- a/apps/microsoft-teams/frontend/test/mocks/index.ts
+++ b/apps/microsoft-teams/frontend/test/mocks/index.ts
@@ -1,2 +1,2 @@
 export { mockCma } from './mockCma';
-export { mockSdk } from './mockSdk';
+export { mockParameters, mockSdk } from './mockSdk';

--- a/apps/microsoft-teams/frontend/test/mocks/mockSdk.ts
+++ b/apps/microsoft-teams/frontend/test/mocks/mockSdk.ts
@@ -1,5 +1,10 @@
 import { vi } from 'vitest';
 
+const mockParameters = {
+  tenantId: 'abc-123',
+  notifications: [],
+};
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mockSdk: any = {
   app: {
@@ -13,4 +18,4 @@ const mockSdk: any = {
   },
 };
 
-export { mockSdk };
+export { mockSdk, mockParameters };

--- a/apps/microsoft-teams/frontend/tsconfig.json
+++ b/apps/microsoft-teams/frontend/tsconfig.json
@@ -18,6 +18,7 @@
     "paths": {
       "@components/*": ["./src/components/*"],
       "@constants/*": ["./src/constants/*"],
+      "@hooks/*": ["./src/hooks/*"],
       "@locations/*": ["./src/locations/*"],
       "@customTypes/*": ["./src/customTypes/*"],
       "@test/*": ["./test/*"]

--- a/apps/microsoft-teams/frontend/vite.config.ts
+++ b/apps/microsoft-teams/frontend/vite.config.ts
@@ -26,6 +26,7 @@ export default defineConfig(() => ({
     alias: {
       '@components': path.resolve(__dirname, './src/components'),
       '@constants': path.resolve(__dirname, './src/constants'),
+      '@hooks': path.resolve(__dirname, './src/hooks'),
       '@locations': path.resolve(__dirname, './src/locations'),
       '@customTypes': path.resolve(__dirname, './src/customTypes'),
       '@test': path.resolve(__dirname, './test'),


### PR DESCRIPTION
## Purpose

Updating the MS Teams app config page to use a reducer to manage the installation parameters and added a hook to initialize the parameters and dispatch them to the reducer. 

## Approach

Followed much of the pattern we established in the AICG app. I also implemented the ability to remove a notification, so now you can add and remove empty notifications on the config page.

## Testing steps

Run MS Teams (development) app locally. You should be able to edit the Tenant Id and add/remove notifications and save the app config page.

## Breaking Changes

## Dependencies and/or References

## Deployment
