### PR TITLE
feat: configure (local) dynamodb and docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ jobs:
       - node/install
       - vault/get-secrets:
           template-preset: 'aws-push-artifacts'
+      - setup_remote_docker
       - run:
           name: Setup circle and tools
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,12 @@ jobs:
       - vault/get-secrets:
           template-preset: 'aws-push-artifacts'
       - run:
+          name: Setup circle and tools
+          command: |
+            circleci version
+            docker version
+            docker compose version
+      - run:
           name: Install dependencies
           command: |
             npm ci

--- a/apps/microsoft-teams/msteams-bot-service/.gitignore
+++ b/apps/microsoft-teams/msteams-bot-service/.gitignore
@@ -1,0 +1,2 @@
+.notification.localstore.json
+shared-local-instance.db

--- a/apps/microsoft-teams/msteams-bot-service/Dockerfile
+++ b/apps/microsoft-teams/msteams-bot-service/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:lts-hydrogen
+
+# set working directory
+WORKDIR /msteams-bot-service
+
+# add `/usr/src/app/node_modules/.bin` to $PATH
+ENV PATH /msteams-bot-service/node_modules/.bin:$PATH
+
+# install and cache app dependencies
+COPY package*.json .
+RUN npm ci
+
+# start app
+CMD ["npm", "run", "start"]

--- a/apps/microsoft-teams/msteams-bot-service/Makefile
+++ b/apps/microsoft-teams/msteams-bot-service/Makefile
@@ -10,13 +10,17 @@ start:
 stop:
 	@docker compose down
 
+## make build: Build all the containers required by the project
+build:
+	@docker compose build
+
 ## make initialize-db: Create the dynamodb table in the local test db
-initialize-db:
-	@docker-compose run --build --rm dynamodb-initializer || true
+initialize-db: build
+	@docker-compose run --rm dynamodb-initializer || true
 
 ## make test-ci: Run ci tests and exit
 test-ci: initialize-db
-	@docker-compose run --build --rm msteams-bot-service npm run test-ci
+	@docker-compose run --rm msteams-bot-service npm run test-ci
 
 ## make test-watch: Run tests in watch mode
 test-watch:

--- a/apps/microsoft-teams/msteams-bot-service/Makefile
+++ b/apps/microsoft-teams/msteams-bot-service/Makefile
@@ -1,0 +1,42 @@
+.PHONY: all
+all: help
+
+
+## make start: Starts a docker container for msteams, dynamdob and dynamodbadmin
+start:
+	@docker compose run --build --rm msteams-bot-service
+
+## make stop: Stops all containers started by `make start`
+stop:
+	@docker compose down
+
+## make initialize-db: Create the dynamodb table in the local test db
+initialize-db:
+	@docker-compose run --build --rm dynamodb-initializer || true
+
+## make test-ci: Run ci tests and exit
+test-ci: initialize-db
+	@docker-compose run --build --rm msteams-bot-service npm run test-ci
+
+## make test-watch: Run tests in watch mode
+test-watch:
+	@docker-compose run --build --rm msteams-bot-service npm run test:watch
+
+## make shell: Start backing services and bring up a shell on the main service
+shell:
+	@docker-compose run --build --rm msteams-bot-service bash
+
+## make clean: Remove all service containers, orphans and one off containers.
+clean:
+	@docker-compose down -v --remove-orphans || true
+	@docker-compose rm -v
+	@rm shared-local-instance.db || true
+
+## help: Show help and exit.
+help: Makefile
+	@echo
+	@echo "  Choose a command:"
+	@echo
+	@sed -n 's/^##//p' $< | column -t -s ':' |  sed -e 's/^/ /'
+	@echo
+

--- a/apps/microsoft-teams/msteams-bot-service/docker-compose.yml
+++ b/apps/microsoft-teams/msteams-bot-service/docker-compose.yml
@@ -1,0 +1,59 @@
+version: '3.8'
+
+services:
+  dynamodb:
+    image: amazon/dynamodb-local
+    restart: always
+    volumes:
+      - .:/home/dynamodblocal/data
+    ports:
+      - 8000:8000
+    command: '-jar DynamoDBLocal.jar -sharedDb -dbPath /home/dynamodblocal/data/'
+
+  dynamodb-admin:
+    image: aaronshaf/dynamodb-admin
+    ports:
+      - 8001:8001
+    environment:
+      DYNAMO_ENDPOINT: http://dynamodb:8000
+      AWS_REGION: us-east-1
+      AWS_ACCESS_KEY_ID: local
+      AWS_SECRET_ACCESS_KEY: local
+    depends_on:
+      - dynamodb
+
+  dynamodb-initializer:
+    image: amazon/aws-cli
+    container_name: msteams-bot-service-dynamodb-initializer
+    working_dir: /home/dynamodblocal
+    command: >
+      dynamodb create-table
+      --cli-input-json file://sls-apps-msteams-bot-service-storage.json
+      --endpoint-url http://dynamodb:8000
+      || true
+    volumes:
+      - ./schema:/home/dynamodblocal
+    environment:
+      AWS_REGION: us-east-1
+      AWS_ACCESS_KEY_ID: local
+      AWS_SECRET_ACCESS_KEY: local
+    depends_on:
+      - dynamodb
+
+  msteams-bot-service:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - '.:/msteams-bot-service'
+    ports:
+      - 3000:3000
+    environment:
+      AWS_REGION: us-east-1
+      AWS_ACCESS_KEY_ID: local
+      AWS_SECRET_ACCESS_KEY: local
+      DYNAMO_TABLE_NAME: sls-apps-msteams-bot-service-storage
+      DYNAMO_ENDPOINT: http://dynamodb:8000
+    depends_on:
+      - dynamodb
+      - dynamodb-admin

--- a/apps/microsoft-teams/msteams-bot-service/package-lock.json
+++ b/apps/microsoft-teams/msteams-bot-service/package-lock.json
@@ -26,6 +26,7 @@
         "botframework-connector": "^4.21.0",
         "chai": "^4.3.10",
         "chai-http": "^4.4.0",
+        "dotenv": "^16.3.1",
         "eslint": "^8.53.0",
         "mocha": "^10.2.0",
         "nodemon": "^3.0.1",
@@ -2614,6 +2615,18 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/eastasianwidth": {
@@ -8790,6 +8803,12 @@
         "domelementtype": "^2.2.0",
         "domhandler": "^4.2.0"
       }
+    },
+    "dotenv": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "dev": true
     },
     "eastasianwidth": {
       "version": "0.2.0",

--- a/apps/microsoft-teams/msteams-bot-service/package.json
+++ b/apps/microsoft-teams/msteams-bot-service/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint --max-warnings=0 .",
     "start": "nodemon",
     "test": "NODE_ENV=test TS_NODE_TRANSPILE_ONLY=1 mocha",
-    "test:ci": "NODE_ENV=test TS_NODE_TRANSPILE_ONLY=1 CI=true mocha",
+    "test:ci": "make test-ci",
+    "test-ci": "NODE_ENV=test TS_NODE_TRANSPILE_ONLY=1 CI=true mocha",
     "test:debug": "NODE_ENV=test TS_NODE_TRANSPILE_ONLY=1 mocha -- --inspect --inspect-brk",
     "test:watch": "NODE_ENV=test TS_NODE_TRANSPILE_ONLY=1 mocha --watch --watch-files src --watch-files test"
   },
@@ -27,6 +28,7 @@
     "botframework-connector": "^4.21.0",
     "chai": "^4.3.10",
     "chai-http": "^4.4.0",
+    "dotenv": "^16.3.1",
     "eslint": "^8.53.0",
     "mocha": "^10.2.0",
     "nodemon": "^3.0.1",

--- a/apps/microsoft-teams/msteams-bot-service/schema/sls-apps-msteams-bot-service-storage.json
+++ b/apps/microsoft-teams/msteams-bot-service/schema/sls-apps-msteams-bot-service-storage.json
@@ -1,0 +1,10 @@
+{
+  "TableName": "sls-apps-msteams-bot-service-storage",
+  "AttributeDefinitions": [{ "AttributeName": "id", "AttributeType": "S" }],
+  "KeySchema": [{ "AttributeName": "id", "KeyType": "HASH" }],
+  "ProvisionedThroughput": {
+    "ReadCapacityUnits": 10,
+    "WriteCapacityUnits": 5
+  }
+}
+


### PR DESCRIPTION
## Purpose

For the bots service, we will implement the storage backend using DynamoDB. As a precursor, it would be great to configure docker for the service and ensure that the development server and tests all run on docker, including the local dynamodb.

## Approach

* Dockerize the service itself
* Add a docker compose file to manage the service, the dynamodb as well as a dynamodb admin and initializer (which creates the table for us if it doesn't already exit)
* Add a makefile to cover the main use cases (so we can do the same things we did before when working locally with the backend, but just via docker)
* Convert the ci tests to run inside docker. This allows us to use an actual dynamodb instance in tests vs mocking.

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
