### PR TITLE
feat: add content type and event selection for notifications [INTEG-1543-1551]

### DIFF
--- a/apps/microsoft-teams/frontend/src/components/config/ChannelSelection/ChannelSelection.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ChannelSelection/ChannelSelection.spec.tsx
@@ -15,7 +15,7 @@ describe('ChannelSelection component', () => {
     unmount();
   });
   it('mounts and renders an input when a channel is selected', () => {
-    render(
+    const { unmount } = render(
       <ChannelSelection
         notification={{ ...defaultNotification, channelId: 'abc-123' }}
         handleNotificationEdit={vi.fn()}
@@ -23,5 +23,6 @@ describe('ChannelSelection component', () => {
     );
 
     expect(screen.getByRole('textbox')).toBeTruthy();
+    unmount();
   });
 });

--- a/apps/microsoft-teams/frontend/src/components/config/ChannelSelection/ChannelSelection.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ChannelSelection/ChannelSelection.tsx
@@ -33,7 +33,9 @@ const ChannelSelection = (props: Props) => {
   // TODO: update this when we start fetching channel installations
   const getChannelName = (channelId: string) => {
     const channel = mockChannels.find((channel) => channelId === channel.id);
-    const displayName = channel ? `${channel.name}, ${channel.teamName}` : '';
+    const displayName = channel
+      ? `${channel.name}, ${channel.teamName}`
+      : channelSelection.notFound;
     return displayName;
   };
 

--- a/apps/microsoft-teams/frontend/src/components/config/ChannelSelectionModal/ChannelSelectionModal.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ChannelSelectionModal/ChannelSelectionModal.tsx
@@ -12,7 +12,7 @@ import { channelSelection } from '@constants/configCopy';
 import { styles } from './ChannelSelectionModal.styles';
 import { Notification } from '@customTypes/configPage';
 import ModalHeader from '@components/config/ModalHeader/ModalHeader';
-import TeamsLogo from '../TeamsLogo/TeamsLogo';
+import TeamsLogo from '@components/config/TeamsLogo/TeamsLogo';
 // TODO: update this when we start fetching channel installations
 import mockChannels from '@test/mocks/mockChannels.json';
 
@@ -29,7 +29,7 @@ const ChannelSelectionModal = (props: Props) => {
   const [selectedChannelId, setSelectedChannelId] = useState(savedChannelId ?? '');
 
   return (
-    <Modal onClose={onClose} isShown={isShown} allowHeightOverflow size="large">
+    <Modal onClose={onClose} isShown={isShown} size="large">
       {() => (
         <>
           <ModalHeader

--- a/apps/microsoft-teams/frontend/src/components/config/ChannelSelectionModal/ChannelSelectionModal.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ChannelSelectionModal/ChannelSelectionModal.tsx
@@ -12,6 +12,7 @@ import { channelSelection } from '@constants/configCopy';
 import { styles } from './ChannelSelectionModal.styles';
 import { Notification } from '@customTypes/configPage';
 import ModalHeader from '@components/config/ModalHeader/ModalHeader';
+import TeamsLogo from '../TeamsLogo/TeamsLogo';
 // TODO: update this when we start fetching channel installations
 import mockChannels from '@test/mocks/mockChannels.json';
 
@@ -31,7 +32,11 @@ const ChannelSelectionModal = (props: Props) => {
     <Modal onClose={onClose} isShown={isShown} allowHeightOverflow size="large">
       {() => (
         <>
-          <ModalHeader title={channelSelection.modal.title} onClose={onClose} />
+          <ModalHeader
+            title={channelSelection.modal.title}
+            onClose={onClose}
+            icon={<TeamsLogo />}
+          />
           <Modal.Content>
             <Paragraph>
               {/* TODO: add link to MS Teams App */}

--- a/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelection/ContentTypeSelection.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelection/ContentTypeSelection.spec.tsx
@@ -1,0 +1,32 @@
+import ContentTypeSelection from './ContentTypeSelection';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { contentTypeSelection } from '@constants/configCopy';
+import { defaultNotification } from '@constants/defaultParams';
+
+describe('ContentTypeSelection component', () => {
+  it('mounts and renders the correct title and button copy when no content type is selected', () => {
+    const { unmount } = render(
+      <ContentTypeSelection
+        notification={defaultNotification}
+        handleNotificationEdit={vi.fn()}
+        contentTypes={[]}
+      />
+    );
+
+    expect(screen.getByText(contentTypeSelection.title)).toBeTruthy();
+    expect(screen.getByText(contentTypeSelection.addButton)).toBeTruthy();
+    unmount();
+  });
+  it('mounts and renders an input when a content type is selected', () => {
+    render(
+      <ContentTypeSelection
+        notification={{ ...defaultNotification, contentTypeId: 'blogPost' }}
+        handleNotificationEdit={vi.fn()}
+        contentTypes={[]}
+      />
+    );
+
+    expect(screen.getByRole('textbox')).toBeTruthy();
+  });
+});

--- a/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelection/ContentTypeSelection.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelection/ContentTypeSelection.spec.tsx
@@ -19,7 +19,7 @@ describe('ContentTypeSelection component', () => {
     unmount();
   });
   it('mounts and renders an input when a content type is selected', () => {
-    render(
+    const { unmount } = render(
       <ContentTypeSelection
         notification={{ ...defaultNotification, contentTypeId: 'blogPost' }}
         handleNotificationEdit={vi.fn()}
@@ -28,5 +28,6 @@ describe('ContentTypeSelection component', () => {
     );
 
     expect(screen.getByRole('textbox')).toBeTruthy();
+    unmount();
   });
 });

--- a/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelection/ContentTypeSelection.styles.ts
+++ b/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelection/ContentTypeSelection.styles.ts
@@ -1,0 +1,7 @@
+import { css } from 'emotion';
+
+export const styles = {
+  input: css({
+    width: '250px',
+  }),
+};

--- a/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelection/ContentTypeSelection.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelection/ContentTypeSelection.tsx
@@ -1,0 +1,72 @@
+import { Box, Flex, IconButton, ModalLauncher, Text, TextInput } from '@contentful/f36-components';
+import AddButton from '@components/config/AddButton/AddButton';
+import ContentTypeSelectionModal from '@components/config/ContentTypeSelectionModal/ContentTypeSelectionModal';
+import ContentfulLogo from '@components/config/ContentfulLogo/ContentfulLogo';
+import { contentTypeSelection } from '@constants/configCopy';
+import { Notification } from '@customTypes/configPage';
+import { EditIcon } from '@contentful/f36-icons';
+import { styles } from './ContentTypeSelection.styles';
+import { ContentTypeProps } from 'contentful-management';
+
+interface Props {
+  notification: Notification;
+  handleNotificationEdit: (notificationEdit: Partial<Notification>) => void;
+  contentTypes: ContentTypeProps[];
+}
+
+const ContentTypeSelection = (props: Props) => {
+  const { notification, handleNotificationEdit, contentTypes } = props;
+
+  const openContentTypeSelectionModal = () => {
+    return ModalLauncher.open(({ isShown, onClose }) => (
+      <ContentTypeSelectionModal
+        isShown={isShown}
+        onClose={() => {
+          onClose(true);
+        }}
+        handleNotificationEdit={handleNotificationEdit}
+        savedContentTypeId={notification.contentTypeId}
+        contentTypes={contentTypes}
+      />
+    ));
+  };
+
+  const getContentTypeName = (contentTypeId: string) => {
+    const contentType = contentTypes.find((contentType) => contentType.sys.id === contentTypeId);
+    return contentType ? contentType.name : '';
+  };
+
+  return (
+    <Box marginBottom="spacingL">
+      <Flex marginBottom="spacingS" alignItems="center">
+        <ContentfulLogo />
+        <Text marginLeft="spacingXs" marginBottom="none" fontWeight="fontWeightMedium">
+          {contentTypeSelection.title}
+        </Text>
+      </Flex>
+      {notification.contentTypeId ? (
+        <TextInput.Group>
+          <TextInput
+            id="selected-content-type"
+            isDisabled={true}
+            value={getContentTypeName(notification.contentTypeId)}
+            className={styles.input}
+          />
+          <IconButton
+            variant="secondary"
+            icon={<EditIcon />}
+            onClick={openContentTypeSelectionModal}
+            aria-label="Change selected content type"
+          />
+        </TextInput.Group>
+      ) : (
+        <AddButton
+          buttonCopy={contentTypeSelection.addButton}
+          handleClick={openContentTypeSelectionModal}
+        />
+      )}
+    </Box>
+  );
+};
+
+export default ContentTypeSelection;

--- a/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelection/ContentTypeSelection.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelection/ContentTypeSelection.tsx
@@ -33,7 +33,7 @@ const ContentTypeSelection = (props: Props) => {
 
   const getContentTypeName = (contentTypeId: string) => {
     const contentType = contentTypes.find((contentType) => contentType.sys.id === contentTypeId);
-    return contentType ? contentType.name : '';
+    return contentType ? contentType.name : contentTypeSelection.notFound;
   };
 
   return (

--- a/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelectionModal/ContentTypeSelectionModal.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelectionModal/ContentTypeSelectionModal.spec.tsx
@@ -1,0 +1,20 @@
+import ContentTypeSelectionModal from './ContentTypeSelectionModal';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { channelSelection } from '@constants/configCopy';
+
+describe('ContentTypeSelectionModal component', () => {
+  it('mounts and renders the correct content', () => {
+    render(
+      <ContentTypeSelectionModal
+        isShown={true}
+        onClose={vi.fn()}
+        savedContentTypeId=""
+        handleNotificationEdit={vi.fn()}
+        contentTypes={[]}
+      />
+    );
+
+    expect(screen.getByText(channelSelection.modal.button)).toBeTruthy();
+  });
+});

--- a/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelectionModal/ContentTypeSelectionModal.styles.ts
+++ b/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelectionModal/ContentTypeSelectionModal.styles.ts
@@ -1,0 +1,10 @@
+import { css } from 'emotion';
+import tokens from '@contentful/f36-tokens';
+
+export const styles = {
+  table: css({
+    borderRadius: 'none !important',
+    boxShadow: 'none !important',
+    borderBottom: `1px solid ${tokens.gray200}`,
+  }),
+};

--- a/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelectionModal/ContentTypeSelectionModal.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelectionModal/ContentTypeSelectionModal.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+import { Button, FormControl, Modal, Radio, Table } from '@contentful/f36-components';
+import { contentTypeSelection } from '@constants/configCopy';
+import { styles } from './ContentTypeSelectionModal.styles';
+import { Notification } from '@customTypes/configPage';
+import ModalHeader from '@components/config/ModalHeader/ModalHeader';
+import { ContentTypeProps } from 'contentful-management';
+
+interface Props {
+  isShown: boolean;
+  onClose: () => void;
+  savedContentTypeId: string;
+  handleNotificationEdit: (notificationEdit: Partial<Notification>) => void;
+  contentTypes: ContentTypeProps[];
+}
+
+const ContentTypeSelectionModal = (props: Props) => {
+  const { isShown, onClose, savedContentTypeId, handleNotificationEdit, contentTypes } = props;
+
+  const [selectedContentTypeId, setSelectedContentTypeId] = useState(savedContentTypeId ?? '');
+
+  return (
+    <Modal onClose={onClose} isShown={isShown} allowHeightOverflow size="large">
+      {() => (
+        <>
+          <ModalHeader title={contentTypeSelection.modal.title} onClose={onClose} />
+          <Modal.Content>
+            <FormControl as="fieldset" marginBottom="none">
+              <Table className={styles.table}>
+                <Table.Body>
+                  {contentTypes.map((contentType) => (
+                    <Table.Row key={contentType.sys.id}>
+                      <Table.Cell>
+                        <Radio
+                          id={contentType.sys.id}
+                          isChecked={selectedContentTypeId === contentType.sys.id}
+                          onChange={() => setSelectedContentTypeId(contentType.sys.id)}>
+                          {contentType.name}
+                        </Radio>
+                      </Table.Cell>
+                    </Table.Row>
+                  ))}
+                </Table.Body>
+              </Table>
+            </FormControl>
+          </Modal.Content>
+          <Modal.Controls>
+            <Button
+              size="small"
+              variant="primary"
+              onClick={() => {
+                handleNotificationEdit({ contentTypeId: selectedContentTypeId });
+                onClose();
+              }}
+              isDisabled={!selectedContentTypeId}>
+              {contentTypeSelection.modal.button}
+            </Button>
+          </Modal.Controls>
+        </>
+      )}
+    </Modal>
+  );
+};
+
+export default ContentTypeSelectionModal;

--- a/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelectionModal/ContentTypeSelectionModal.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelectionModal/ContentTypeSelectionModal.tsx
@@ -20,7 +20,7 @@ const ContentTypeSelectionModal = (props: Props) => {
   const [selectedContentTypeId, setSelectedContentTypeId] = useState(savedContentTypeId ?? '');
 
   return (
-    <Modal onClose={onClose} isShown={isShown} allowHeightOverflow size="large">
+    <Modal onClose={onClose} isShown={isShown} size="large">
       {() => (
         <>
           <ModalHeader title={contentTypeSelection.modal.title} onClose={onClose} />

--- a/apps/microsoft-teams/frontend/src/components/config/EventsSelection/EventsSelection.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/EventsSelection/EventsSelection.spec.tsx
@@ -1,0 +1,15 @@
+import EventsSelection from './EventsSelection';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { eventsSelection } from '@constants/configCopy';
+import { defaultNotification } from '@constants/defaultParams';
+
+describe('EventsSelection component', () => {
+  it('mounts with correct options', () => {
+    render(<EventsSelection notification={defaultNotification} handleNotificationEdit={vi.fn()} />);
+
+    Object.values(eventsSelection.options).forEach((option) => {
+      expect(screen.getByText(option.text)).toBeTruthy();
+    });
+  });
+});

--- a/apps/microsoft-teams/frontend/src/components/config/EventsSelection/EventsSelection.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/EventsSelection/EventsSelection.tsx
@@ -1,0 +1,52 @@
+import { useMemo } from 'react';
+import { Box, Checkbox, FormControl } from '@contentful/f36-components';
+import { Notification } from '@customTypes/configPage';
+import { AppEventKey, eventsSelection } from '@constants/configCopy';
+
+interface Props {
+  notification: Notification;
+  handleNotificationEdit: (notificationEdit: Partial<Notification>) => void;
+}
+
+const EventsSelection = (props: Props) => {
+  const { notification, handleNotificationEdit } = props;
+
+  // For Checkbox.Group, creates an array of the values of the checkboxes that should be checked
+  const selectedEventsArray = useMemo(
+    () =>
+      Object.values(AppEventKey).reduce((acc: string[], event) => {
+        if (!notification.selectedEvents[event]) {
+          return acc;
+        }
+        return [...acc, event];
+      }, []),
+    [notification.selectedEvents]
+  );
+
+  return (
+    <Box>
+      <FormControl as="fieldset">
+        <FormControl.Label>{eventsSelection.title}</FormControl.Label>
+        <Checkbox.Group
+          name="events-options"
+          onChange={(e) =>
+            handleNotificationEdit({
+              selectedEvents: {
+                ...notification.selectedEvents,
+                [e.target.value]: !notification.selectedEvents[e.target.value as AppEventKey],
+              },
+            })
+          }
+          value={selectedEventsArray}>
+          {Object.values(eventsSelection.options).map((event) => (
+            <Checkbox key={event.id} id={event.id} value={event.id}>
+              {event.text}
+            </Checkbox>
+          ))}
+        </Checkbox.Group>
+      </FormControl>
+    </Box>
+  );
+};
+
+export default EventsSelection;

--- a/apps/microsoft-teams/frontend/src/components/config/EventsSelection/EventsSelection.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/EventsSelection/EventsSelection.tsx
@@ -13,13 +13,7 @@ const EventsSelection = (props: Props) => {
 
   // For Checkbox.Group, creates an array of the values of the checkboxes that should be checked
   const selectedEventsArray = useMemo(
-    () =>
-      Object.values(AppEventKey).reduce((acc: string[], event) => {
-        if (!notification.selectedEvents[event]) {
-          return acc;
-        }
-        return [...acc, event];
-      }, []),
+    () => Object.values(AppEventKey).filter((event) => notification.selectedEvents[event]),
     [notification.selectedEvents]
   );
 

--- a/apps/microsoft-teams/frontend/src/components/config/ModalHeader/ModalHeader.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ModalHeader/ModalHeader.tsx
@@ -1,15 +1,15 @@
 import { Box, Flex, IconButton, Subheading } from '@contentful/f36-components';
 import { CloseIcon } from '@contentful/f36-icons';
-import TeamsLogo from '@components/config/TeamsLogo/TeamsLogo';
 import { styles } from './ModalHeader.styles';
 
 interface Props {
   title: string;
   onClose: () => void;
+  icon?: JSX.Element;
 }
 
 const ModalHeader = (props: Props) => {
-  const { title, onClose } = props;
+  const { title, onClose, icon } = props;
 
   return (
     <Flex
@@ -18,7 +18,7 @@ const ModalHeader = (props: Props) => {
       alignItems="center"
       className={styles.header}>
       <Flex alignItems="center">
-        <TeamsLogo />
+        {icon}
         <Subheading marginBottom="none" marginLeft="spacingXs">
           {title}
         </Subheading>

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.spec.tsx
@@ -12,6 +12,7 @@ describe('NotificationEditMode component', () => {
         deleteNotification={vi.fn()}
         updateNotification={vi.fn()}
         notification={defaultNotification}
+        contentTypes={[]}
       />
     );
 

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.spec.tsx
@@ -1,7 +1,7 @@
 import NotificationEditMode from './NotificationEditMode';
 import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { contentTypeSelection, channelSelection, actionsSection } from '@constants/configCopy';
+import { contentTypeSelection, channelSelection, eventsSelection } from '@constants/configCopy';
 import { defaultNotification } from '@constants/defaultParams';
 
 describe('NotificationEditMode component', () => {
@@ -18,6 +18,6 @@ describe('NotificationEditMode component', () => {
 
     expect(screen.getByText(contentTypeSelection.title)).toBeTruthy();
     expect(screen.getByText(channelSelection.title)).toBeTruthy();
-    expect(screen.getByText(actionsSection.title)).toBeTruthy();
+    expect(screen.getByText(eventsSelection.title)).toBeTruthy();
   });
 });

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.tsx
@@ -1,22 +1,23 @@
 import { useEffect, useState } from 'react';
-import { Box, Checkbox, Flex, FormControl, Text } from '@contentful/f36-components';
-import AddButton from '@components/config/AddButton/AddButton';
+import { Box, Checkbox, FormControl } from '@contentful/f36-components';
+import ContentTypeSelection from '../ContentTypeSelection/ContentTypeSelection';
 import ChannelSelection from '../ChannelSelection/ChannelSelection';
-import ContentfulLogo from '@components/config/ContentfulLogo/ContentfulLogo';
 import NotificationEditModeFooter from '@components/config/NotificationEditModeFooter/NotificationEditModeFooter';
 import { styles } from './NotificationEditMode.styles';
-import { actionsSection, contentTypeSelection } from '@constants/configCopy';
+import { actionsSection } from '@constants/configCopy';
 import { Notification } from '@customTypes/configPage';
+import { ContentTypeProps } from 'contentful-management';
 
 interface Props {
   index: number;
   deleteNotification: (index: number) => void;
   updateNotification: (index: number, editedNotification: Partial<Notification>) => void;
   notification: Notification;
+  contentTypes: ContentTypeProps[];
 }
 
 const NotificationEditMode = (props: Props) => {
-  const { index, deleteNotification, updateNotification, notification } = props;
+  const { index, deleteNotification, updateNotification, notification, contentTypes } = props;
 
   const [editedNotification, setEditedNotification] = useState<Notification>(notification);
 
@@ -39,19 +40,11 @@ const NotificationEditMode = (props: Props) => {
   return (
     <Box className={styles.wrapper}>
       <Box className={styles.main}>
-        <Box marginBottom="spacingL">
-          <Flex marginBottom="spacingS" alignItems="center">
-            <ContentfulLogo />
-            <Text marginLeft="spacingXs" marginBottom="none" fontWeight="fontWeightMedium">
-              {contentTypeSelection.title}
-            </Text>
-          </Flex>
-          <AddButton
-            buttonCopy={contentTypeSelection.addButton}
-            // TODO: update this button to launch the content type selection modal
-            handleClick={() => console.log('click')}
-          />
-        </Box>
+        <ContentTypeSelection
+          notification={editedNotification}
+          handleNotificationEdit={handleNotificationEdit}
+          contentTypes={contentTypes}
+        />
         <ChannelSelection
           notification={editedNotification}
           handleNotificationEdit={handleNotificationEdit}

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from 'react';
-import { Box, Checkbox, FormControl } from '@contentful/f36-components';
-import ContentTypeSelection from '../ContentTypeSelection/ContentTypeSelection';
-import ChannelSelection from '../ChannelSelection/ChannelSelection';
+import { Box } from '@contentful/f36-components';
+import ContentTypeSelection from '@components/config/ContentTypeSelection/ContentTypeSelection';
+import ChannelSelection from '@components/config/ChannelSelection/ChannelSelection';
+import EventsSelection from '@components/config/EventsSelection/EventsSelection';
 import NotificationEditModeFooter from '@components/config/NotificationEditModeFooter/NotificationEditModeFooter';
 import { styles } from './NotificationEditMode.styles';
-import { actionsSection } from '@constants/configCopy';
 import { Notification } from '@customTypes/configPage';
 import { ContentTypeProps } from 'contentful-management';
 
@@ -49,21 +49,10 @@ const NotificationEditMode = (props: Props) => {
           notification={editedNotification}
           handleNotificationEdit={handleNotificationEdit}
         />
-        <Box>
-          <FormControl as="fieldset">
-            <FormControl.Label>{actionsSection.title}</FormControl.Label>
-            <Checkbox.Group name="checkbox-options">
-              {Object.values(actionsSection.options).map((event) => (
-                <Checkbox
-                  key={event.id}
-                  id={`event-${event.id}-${index}`}
-                  value={`event-${event.id}-${index}`}>
-                  {event.text}
-                </Checkbox>
-              ))}
-            </Checkbox.Group>
-          </FormControl>
-        </Box>
+        <EventsSelection
+          notification={editedNotification}
+          handleNotificationEdit={handleNotificationEdit}
+        />
       </Box>
       <NotificationEditModeFooter handleDelete={handleDelete} handleSave={handleSave} />
     </Box>

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationEditModeFooter/NotificationEditModeFooter.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationEditModeFooter/NotificationEditModeFooter.spec.tsx
@@ -28,11 +28,14 @@ describe('NotificationEditModeFooter component', () => {
   });
   it('handles clicking the save button', () => {
     const mockHandleSave = vi.fn();
-    render(<NotificationEditModeFooter handleSave={mockHandleSave} handleDelete={vi.fn()} />);
+    const { unmount } = render(
+      <NotificationEditModeFooter handleSave={mockHandleSave} handleDelete={vi.fn()} />
+    );
 
     const saveButton = screen.getByText(editModeFooter.save);
     saveButton.click();
 
     expect(mockHandleSave).toHaveBeenCalled();
+    unmount();
   });
 });

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.spec.tsx
@@ -1,12 +1,20 @@
 import NotificationsSection from './NotificationsSection';
 import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, renderHook, screen } from '@testing-library/react';
 import { notificationsSection } from '@constants/configCopy';
+import { mockSdk } from '@test/mocks';
+import useGetContentTypes from '@hooks/useGetContentTypes';
+
+vi.mock('@contentful/react-apps-toolkit', () => ({
+  useSDK: () => mockSdk,
+}));
 
 describe('NotificationsSection component', () => {
-  it('mounts with title', () => {
+  it('mounts with title and button', () => {
+    renderHook(() => useGetContentTypes());
     render(<NotificationsSection notifications={[]} dispatch={vi.fn()} />);
 
     expect(screen.getByText(notificationsSection.title)).toBeTruthy();
+    expect(screen.getByText(notificationsSection.createButton)).toBeTruthy();
   });
 });

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.spec.tsx
@@ -1,17 +1,16 @@
 import NotificationsSection from './NotificationsSection';
 import { describe, expect, it, vi } from 'vitest';
-import { render, renderHook, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { notificationsSection } from '@constants/configCopy';
-import { mockSdk } from '@test/mocks';
-import useGetContentTypes from '@hooks/useGetContentTypes';
+import { mockSdk, mockGetManyContentType } from '@test/mocks';
 
 vi.mock('@contentful/react-apps-toolkit', () => ({
   useSDK: () => mockSdk,
+  useGetContentTypes: () => mockGetManyContentType,
 }));
 
 describe('NotificationsSection component', () => {
   it('mounts with title and button', () => {
-    renderHook(() => useGetContentTypes());
     render(<NotificationsSection notifications={[]} dispatch={vi.fn()} />);
 
     expect(screen.getByText(notificationsSection.title)).toBeTruthy();

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.tsx
@@ -6,6 +6,7 @@ import AddButton from '@components/config/AddButton/AddButton';
 import NotificationEditMode from '@components/config/NotificationEditMode/NotificationEditMode';
 import { Notification } from '@customTypes/configPage';
 import { ParameterAction, actions } from '@components/config/parameterReducer';
+import useGetContentTypes from '@hooks/useGetContentTypes';
 
 interface Props {
   notifications: Notification[];
@@ -14,6 +15,8 @@ interface Props {
 
 const NotificationsSection = (props: Props) => {
   const { notifications, dispatch } = props;
+
+  const contentTypes = useGetContentTypes();
 
   const createNewNotification = () => {
     dispatch({ type: actions.ADD_NOTIFICATION });
@@ -46,6 +49,7 @@ const NotificationsSection = (props: Props) => {
             deleteNotification={deleteNotification}
             updateNotification={updateNotification}
             notification={notification}
+            contentTypes={contentTypes}
           />
         );
       })}

--- a/apps/microsoft-teams/frontend/src/constants/configCopy.ts
+++ b/apps/microsoft-teams/frontend/src/constants/configCopy.ts
@@ -36,11 +36,13 @@ const channelSelection = {
   notFound: 'Channel not found',
 };
 
-enum AppEventKey {
+export enum AppEventKey {
   PUBLISH = 'publish',
   UNPUBLISHED = 'unpublish',
   CREATED = 'create',
   DELETED = 'delete',
+  ARCHIVE = 'archive',
+  UNARCHIVE = 'unarchive',
 }
 
 const AppEvents = {
@@ -60,9 +62,17 @@ const AppEvents = {
     id: AppEventKey.DELETED,
     text: 'Delete',
   },
+  [AppEventKey.ARCHIVE]: {
+    id: AppEventKey.ARCHIVE,
+    text: 'Archive',
+  },
+  [AppEventKey.UNARCHIVE]: {
+    id: AppEventKey.UNARCHIVE,
+    text: 'Unarchive',
+  },
 };
 
-const actionsSection = {
+const eventsSelection = {
   title: 'Actions',
   options: AppEvents,
 };
@@ -79,6 +89,6 @@ export {
   notificationsSection,
   contentTypeSelection,
   channelSelection,
-  actionsSection,
+  eventsSelection,
   editModeFooter,
 };

--- a/apps/microsoft-teams/frontend/src/constants/configCopy.ts
+++ b/apps/microsoft-teams/frontend/src/constants/configCopy.ts
@@ -20,6 +20,7 @@ const contentTypeSelection = {
     title: 'Add content type',
     button: 'Next',
   },
+  notFound: 'Content type not found',
 };
 
 const channelSelection = {
@@ -32,6 +33,7 @@ const channelSelection = {
     link: 'Add channel',
     button: 'Next',
   },
+  notFound: 'Channel not found',
 };
 
 enum AppEventKey {

--- a/apps/microsoft-teams/frontend/src/constants/configCopy.ts
+++ b/apps/microsoft-teams/frontend/src/constants/configCopy.ts
@@ -16,7 +16,10 @@ const notificationsSection = {
 const contentTypeSelection = {
   title: 'Content type',
   addButton: 'Add content type',
-  modalButton: 'Next',
+  modal: {
+    title: 'Add content type',
+    button: 'Next',
+  },
 };
 
 const channelSelection = {

--- a/apps/microsoft-teams/frontend/src/constants/defaultParams.ts
+++ b/apps/microsoft-teams/frontend/src/constants/defaultParams.ts
@@ -6,12 +6,11 @@ const initialParameters: AppInstallationParameters = {
   notifications: [],
 };
 
-const getDefaultSelectedEvents = () => {
-  const selectedEvents = {} as SelectedEvents;
-  Object.values(AppEventKey).forEach((event) => {
-    selectedEvents[event] = false;
-  });
-  return selectedEvents;
+const getDefaultSelectedEvents = (): SelectedEvents => {
+  return Object.values(AppEventKey).reduce(
+    (selectedEvents, event) => ({ ...selectedEvents, [event]: false }),
+    {} as SelectedEvents
+  );
 };
 
 const defaultNotification = {

--- a/apps/microsoft-teams/frontend/src/constants/defaultParams.ts
+++ b/apps/microsoft-teams/frontend/src/constants/defaultParams.ts
@@ -1,21 +1,24 @@
-import { AppInstallationParameters } from '@customTypes/configPage';
+import { AppInstallationParameters, SelectedEvents } from '@customTypes/configPage';
+import { AppEventKey } from './configCopy';
 
 const initialParameters: AppInstallationParameters = {
   tenantId: '',
   notifications: [],
 };
 
+const getDefaultSelectedEvents = () => {
+  const selectedEvents = {} as SelectedEvents;
+  Object.values(AppEventKey).forEach((event) => {
+    selectedEvents[event] = false;
+  });
+  return selectedEvents;
+};
+
 const defaultNotification = {
   channelId: '',
   contentTypeId: '',
   isEnabled: true,
-  selectedEvents: {
-    publish: false,
-    unpublish: false,
-    create: false,
-    delete: false,
-    edit: false,
-  },
+  selectedEvents: getDefaultSelectedEvents(),
 };
 
 export { initialParameters, defaultNotification };

--- a/apps/microsoft-teams/frontend/src/customTypes/configPage.ts
+++ b/apps/microsoft-teams/frontend/src/customTypes/configPage.ts
@@ -1,3 +1,5 @@
+import { AppEventKey } from '@constants/configCopy';
+
 export interface AppInstallationParameters {
   tenantId: string;
   notifications: Notification[];
@@ -10,10 +12,6 @@ export interface Notification {
   selectedEvents: SelectedEvents;
 }
 
-export interface SelectedEvents {
-  publish: boolean;
-  unpublish: boolean;
-  create: boolean;
-  delete: boolean;
-  edit: boolean;
-}
+export type SelectedEvents = {
+  [K in AppEventKey]: boolean;
+};

--- a/apps/microsoft-teams/frontend/src/hooks/useGetContentTypes.spec.ts
+++ b/apps/microsoft-teams/frontend/src/hooks/useGetContentTypes.spec.ts
@@ -1,0 +1,17 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import useGetContentTypes from './useGetContentTypes';
+import { mockCma, mockSdk, mockGetManyContentType } from '@test/mocks';
+
+vi.mock('@contentful/react-apps-toolkit', () => ({
+  useSDK: () => mockSdk,
+  useCMA: () => mockCma,
+}));
+
+describe('useGetContentTypes', () => {
+  it('should return content types', async () => {
+    mockSdk.cma.contentType.getMany = vi.fn().mockReturnValueOnce(mockGetManyContentType);
+    const { result } = renderHook(() => useGetContentTypes());
+    await waitFor(() => expect(result.current).toEqual(mockGetManyContentType.items));
+  });
+});

--- a/apps/microsoft-teams/frontend/src/hooks/useGetContentTypes.ts
+++ b/apps/microsoft-teams/frontend/src/hooks/useGetContentTypes.ts
@@ -1,0 +1,31 @@
+import { useEffect, useCallback, useState } from 'react';
+import { useSDK } from '@contentful/react-apps-toolkit';
+import { ConfigAppSDK } from '@contentful/app-sdk';
+import { ContentTypeProps } from 'contentful-management';
+
+/**
+ * This hook is used to get all the content types for the space
+ *
+ * @returns allContentTypes
+ */
+const useGetContentTypes = () => {
+  const [allContentTypes, setAllContentTypes] = useState<ContentTypeProps[]>([]);
+  const sdk = useSDK<ConfigAppSDK>();
+
+  const getAllContentTypes = useCallback(async () => {
+    try {
+      const contentTypesResponse = await sdk.cma.contentType.getMany({});
+      setAllContentTypes(contentTypesResponse.items || []);
+    } catch (error) {
+      console.error(error);
+    }
+  }, [sdk.cma.contentType]);
+
+  useEffect(() => {
+    getAllContentTypes();
+  }, [sdk, getAllContentTypes]);
+
+  return allContentTypes;
+};
+
+export default useGetContentTypes;

--- a/apps/microsoft-teams/frontend/src/hooks/useGetContentTypes.ts
+++ b/apps/microsoft-teams/frontend/src/hooks/useGetContentTypes.ts
@@ -14,10 +14,12 @@ const useGetContentTypes = () => {
 
   const getAllContentTypes = useCallback(async () => {
     try {
+      // TODO: Implement pagination for content types
       const contentTypesResponse = await sdk.cma.contentType.getMany({});
       setAllContentTypes(contentTypesResponse.items || []);
     } catch (error) {
       console.error(error);
+      throw new Error('Unable to get content types');
     }
   }, [sdk.cma.contentType]);
 

--- a/apps/microsoft-teams/frontend/test/mocks/index.ts
+++ b/apps/microsoft-teams/frontend/test/mocks/index.ts
@@ -1,2 +1,8 @@
 export { mockCma } from './mockCma';
 export { mockParameters, mockSdk } from './mockSdk';
+export {
+  mockContentType,
+  mockGetManyContentType,
+  mockSelectedContentTypes,
+  mockEditorInterface,
+} from './mockContentTypes';

--- a/apps/microsoft-teams/frontend/test/mocks/mockContentTypes.ts
+++ b/apps/microsoft-teams/frontend/test/mocks/mockContentTypes.ts
@@ -1,0 +1,106 @@
+const mockContentType = {
+  sys: {
+    space: {
+      sys: {
+        type: 'Link',
+        linkType: 'Space',
+        id: 'abc123',
+      },
+    },
+    id: 'page',
+    type: 'ContentType',
+    createdAt: '2023-03-27T18:48:05.440Z',
+    updatedAt: '2023-08-16T15:56:07.990Z',
+    environment: {
+      sys: {
+        id: 'testing',
+        type: 'Link',
+        linkType: 'Environment',
+      },
+    },
+    publishedVersion: 49,
+    publishedAt: '2023-08-16T15:56:07.990Z',
+    firstPublishedAt: '2023-03-27T18:48:05.757Z',
+    createdBy: {
+      sys: {
+        type: 'Link',
+        linkType: 'User',
+        id: '456',
+      },
+    },
+    updatedBy: {
+      sys: {
+        type: 'Link',
+        linkType: 'User',
+        id: '456',
+      },
+    },
+    publishedCounter: 25,
+    version: 50,
+    publishedBy: {
+      sys: {
+        type: 'Link',
+        linkType: 'User',
+        id: '456',
+      },
+    },
+  },
+  displayField: 'title',
+  name: 'Page',
+  description: '',
+  fields: [
+    {
+      id: 'title',
+      name: 'Title',
+      type: 'Symbol',
+      localized: true,
+      required: true,
+      validations: [
+        {
+          size: {
+            min: 40,
+            max: 60,
+          },
+        },
+      ],
+      disabled: false,
+      omitted: false,
+    },
+    {
+      id: 'slug',
+      name: 'Slug',
+      type: 'Symbol',
+      localized: true,
+      required: true,
+      validations: [
+        {
+          unique: true,
+        },
+      ],
+      disabled: false,
+      omitted: false,
+    },
+  ],
+};
+
+const mockGetManyContentType = {
+  items: [mockContentType],
+  limit: 100,
+  skip: 100,
+  sys: {
+    type: 'Array',
+  },
+  total: 1,
+};
+
+const mockSelectedContentTypes = new Set(['page', 'article']);
+
+const mockEditorInterface = {
+  page: {
+    sidebar: {
+      position: 1,
+    },
+  },
+};
+
+export { mockContentType, mockGetManyContentType, mockSelectedContentTypes, mockEditorInterface };

--- a/apps/microsoft-teams/frontend/test/mocks/mockSdk.ts
+++ b/apps/microsoft-teams/frontend/test/mocks/mockSdk.ts
@@ -16,6 +16,11 @@ const mockSdk: any = {
   ids: {
     app: 'test-app',
   },
+  cma: {
+    contentType: {
+      getMany: vi.fn().mockReturnValueOnce({}),
+    },
+  },
 };
 
 export { mockSdk, mockParameters };


### PR DESCRIPTION
## Purpose

This PR creates the content type selection modal for the MS Teams app config page. It also adds the ability to save and persist the selected content type and app events for a notification.

## Approach

Added modal for content type selection and now selected content type, channel, and events are all persisted in app installation parameters.

New modal:
![Screenshot 2023-11-13 at 10 51 00 AM](https://github.com/contentful/apps/assets/62958907/af51c217-0089-4c8b-9009-049080d59f9c)

App Events/Action selection:
![Screenshot 2023-11-13 at 10 51 17 AM](https://github.com/contentful/apps/assets/62958907/02dde865-7a44-4682-bf83-aa2e860b88cc)

## Testing steps

Run locally in MS Teams development app.

## Breaking Changes

## Dependencies and/or References

## Deployment
