### PR TITLE
feat: add notification view mode [INTEG-1552]

### DIFF
--- a/apps/microsoft-teams/frontend/package-lock.json
+++ b/apps/microsoft-teams/frontend/package-lock.json
@@ -15,12 +15,14 @@
         "@contentful/react-apps-toolkit": "1.2.16",
         "contentful-management": "10.38.3",
         "emotion": "10.0.27",
+        "lodash": "^4.17.21",
         "react": "18.2.0",
         "react-dom": "18.2.0"
       },
       "devDependencies": {
         "@contentful/app-scripts": "1.10.2",
         "@testing-library/react": "14.0.0",
+        "@types/lodash": "^4.14.201",
         "@types/node": "16.18.38",
         "@types/react": "18.2.14",
         "@types/react-dom": "18.2.6",
@@ -2316,6 +2318,12 @@
       "version": "7.0.14",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.14.tgz",
       "integrity": "sha512-U3PUjAudAdJBeC2pgN8uTIKgxrb4nlDF3SF0++EldXQvQBGkpFZMSnwQiIoDU77tv45VgNkl/L4ouD+rEomujw==",
+      "dev": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.201",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.201.tgz",
+      "integrity": "sha512-y9euML0cim1JrykNxADLfaG0FgD1g/yTHwUs/Jg9ZIU7WKj2/4IW9Lbb1WZbvck78W/lfGXFfe+u2EGfIJXdLQ==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -5596,8 +5604,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
@@ -9352,6 +9359,12 @@
       "integrity": "sha512-U3PUjAudAdJBeC2pgN8uTIKgxrb4nlDF3SF0++EldXQvQBGkpFZMSnwQiIoDU77tv45VgNkl/L4ouD+rEomujw==",
       "dev": true
     },
+    "@types/lodash": {
+      "version": "4.14.201",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.201.tgz",
+      "integrity": "sha512-y9euML0cim1JrykNxADLfaG0FgD1g/yTHwUs/Jg9ZIU7WKj2/4IW9Lbb1WZbvck78W/lfGXFfe+u2EGfIJXdLQ==",
+      "dev": true
+    },
     "@types/node": {
       "version": "16.18.38",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.38.tgz",
@@ -11756,8 +11769,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.isplainobject": {
       "version": "4.0.6",

--- a/apps/microsoft-teams/frontend/package.json
+++ b/apps/microsoft-teams/frontend/package.json
@@ -10,6 +10,7 @@
     "@contentful/react-apps-toolkit": "1.2.16",
     "contentful-management": "10.38.3",
     "emotion": "10.0.27",
+    "lodash": "^4.17.21",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },
@@ -23,6 +24,7 @@
   "devDependencies": {
     "@contentful/app-scripts": "1.10.2",
     "@testing-library/react": "14.0.0",
+    "@types/lodash": "^4.14.201",
     "@types/node": "16.18.38",
     "@types/react": "18.2.14",
     "@types/react-dom": "18.2.6",

--- a/apps/microsoft-teams/frontend/src/components/config/ChannelSelection/ChannelSelection.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ChannelSelection/ChannelSelection.tsx
@@ -8,6 +8,7 @@ import { EditIcon } from '@contentful/f36-icons';
 import { styles } from './ChannelSelection.styles';
 // TODO: update this when we start fetching channel installations
 import mockChannels from '@test/mocks/mockChannels.json';
+import { getChannelName } from '@helpers/configHelpers';
 
 interface Props {
   notification: Notification;
@@ -30,15 +31,6 @@ const ChannelSelection = (props: Props) => {
     ));
   };
 
-  // TODO: update this when we start fetching channel installations
-  const getChannelName = (channelId: string) => {
-    const channel = mockChannels.find((channel) => channelId === channel.id);
-    const displayName = channel
-      ? `${channel.name}, ${channel.teamName}`
-      : channelSelection.notFound;
-    return displayName;
-  };
-
   return (
     <Box marginBottom="spacingL">
       <Flex marginBottom="spacingS" alignItems="center" className={styles.logo}>
@@ -52,7 +44,7 @@ const ChannelSelection = (props: Props) => {
           <TextInput
             id="selected-channel"
             isDisabled={true}
-            value={getChannelName(notification.channelId)}
+            value={getChannelName(notification.channelId, mockChannels, channelSelection.notFound)}
             className={styles.input}
           />
           <IconButton

--- a/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelection/ContentTypeSelection.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelection/ContentTypeSelection.tsx
@@ -7,6 +7,7 @@ import { Notification } from '@customTypes/configPage';
 import { EditIcon } from '@contentful/f36-icons';
 import { styles } from './ContentTypeSelection.styles';
 import { ContentTypeProps } from 'contentful-management';
+import { getContentTypeName } from '@helpers/configHelpers';
 
 interface Props {
   notification: Notification;
@@ -31,11 +32,6 @@ const ContentTypeSelection = (props: Props) => {
     ));
   };
 
-  const getContentTypeName = (contentTypeId: string) => {
-    const contentType = contentTypes.find((contentType) => contentType.sys.id === contentTypeId);
-    return contentType ? contentType.name : contentTypeSelection.notFound;
-  };
-
   return (
     <Box marginBottom="spacingL">
       <Flex marginBottom="spacingS" alignItems="center">
@@ -49,7 +45,11 @@ const ContentTypeSelection = (props: Props) => {
           <TextInput
             id="selected-content-type"
             isDisabled={true}
-            value={getContentTypeName(notification.contentTypeId)}
+            value={getContentTypeName(
+              notification.contentTypeId,
+              contentTypes,
+              contentTypeSelection.notFound
+            )}
             className={styles.input}
           />
           <IconButton

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.spec.tsx
@@ -13,6 +13,7 @@ describe('NotificationEditMode component', () => {
         updateNotification={vi.fn()}
         notification={defaultNotification}
         contentTypes={[]}
+        setNotificationIndexToEdit={vi.fn()}
       />
     );
 

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.styles.ts
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.styles.ts
@@ -4,7 +4,7 @@ import tokens from '@contentful/f36-tokens';
 export const styles = {
   wrapper: css({
     height: 'auto',
-    margin: `${tokens.spacingXl} auto`,
+    margin: `${tokens.spacingXs} auto`,
     maxWidth: '900px',
     backgroundColor: tokens.colorWhite,
     borderRadius: '6px',

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.tsx
@@ -7,7 +7,7 @@ import NotificationEditModeFooter from '@components/config/NotificationEditModeF
 import { styles } from './NotificationEditMode.styles';
 import { Notification } from '@customTypes/configPage';
 import { ContentTypeProps } from 'contentful-management';
-import { isNotificationReadyToSave } from '@helpers/configHelpers';
+import { isNotificationReadyToSave, isNotificationDefault } from '@helpers/configHelpers';
 
 interface Props {
   index: number;
@@ -48,6 +48,10 @@ const NotificationEditMode = (props: Props) => {
     setNotificationIndexToEdit(null);
   };
 
+  const handleCancel = () => {
+    setNotificationIndexToEdit(null);
+  };
+
   return (
     <Box className={styles.wrapper}>
       <Box className={styles.main}>
@@ -66,9 +70,11 @@ const NotificationEditMode = (props: Props) => {
         />
       </Box>
       <NotificationEditModeFooter
+        handleCancel={handleCancel}
+        isCancelDisabled={isNotificationDefault(editedNotification)}
         handleDelete={handleDelete}
         handleSave={handleSave}
-        isSaveDisabled={!isNotificationReadyToSave(editedNotification)}
+        isSaveDisabled={!isNotificationReadyToSave(editedNotification, notification)}
       />
     </Box>
   );

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.tsx
@@ -7,6 +7,7 @@ import NotificationEditModeFooter from '@components/config/NotificationEditModeF
 import { styles } from './NotificationEditMode.styles';
 import { Notification } from '@customTypes/configPage';
 import { ContentTypeProps } from 'contentful-management';
+import { isNotificationReadyToSave } from '@helpers/configHelpers';
 
 interface Props {
   index: number;
@@ -64,7 +65,11 @@ const NotificationEditMode = (props: Props) => {
           handleNotificationEdit={handleNotificationEdit}
         />
       </Box>
-      <NotificationEditModeFooter handleDelete={handleDelete} handleSave={handleSave} />
+      <NotificationEditModeFooter
+        handleDelete={handleDelete}
+        handleSave={handleSave}
+        isSaveDisabled={!isNotificationReadyToSave(editedNotification)}
+      />
     </Box>
   );
 };

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { Box } from '@contentful/f36-components';
 import ContentTypeSelection from '@components/config/ContentTypeSelection/ContentTypeSelection';
 import ChannelSelection from '@components/config/ChannelSelection/ChannelSelection';
@@ -14,10 +14,18 @@ interface Props {
   updateNotification: (index: number, editedNotification: Partial<Notification>) => void;
   notification: Notification;
   contentTypes: ContentTypeProps[];
+  setNotificationIndexToEdit: Dispatch<SetStateAction<number | null>>;
 }
 
 const NotificationEditMode = (props: Props) => {
-  const { index, deleteNotification, updateNotification, notification, contentTypes } = props;
+  const {
+    index,
+    deleteNotification,
+    updateNotification,
+    notification,
+    contentTypes,
+    setNotificationIndexToEdit,
+  } = props;
 
   const [editedNotification, setEditedNotification] = useState<Notification>(notification);
 
@@ -31,10 +39,12 @@ const NotificationEditMode = (props: Props) => {
 
   const handleDelete = () => {
     deleteNotification(index);
+    setNotificationIndexToEdit(null);
   };
 
   const handleSave = () => {
     updateNotification(index, editedNotification);
+    setNotificationIndexToEdit(null);
   };
 
   return (

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationEditModeFooter/NotificationEditModeFooter.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationEditModeFooter/NotificationEditModeFooter.spec.tsx
@@ -7,6 +7,8 @@ describe('NotificationEditModeFooter component', () => {
   it('mounts with correct button copy', () => {
     const { unmount } = render(
       <NotificationEditModeFooter
+        handleCancel={vi.fn()}
+        isCancelDisabled={false}
         handleSave={vi.fn()}
         handleDelete={vi.fn()}
         isSaveDisabled={false}
@@ -22,6 +24,8 @@ describe('NotificationEditModeFooter component', () => {
     const mockHandleDelete = vi.fn();
     const { unmount } = render(
       <NotificationEditModeFooter
+        handleCancel={vi.fn()}
+        isCancelDisabled={false}
         handleSave={vi.fn()}
         handleDelete={mockHandleDelete}
         isSaveDisabled={false}
@@ -38,6 +42,8 @@ describe('NotificationEditModeFooter component', () => {
     const mockHandleSave = vi.fn();
     const { unmount, rerender } = render(
       <NotificationEditModeFooter
+        handleCancel={vi.fn()}
+        isCancelDisabled={false}
         handleSave={mockHandleSave}
         handleDelete={vi.fn()}
         isSaveDisabled={false}
@@ -52,6 +58,8 @@ describe('NotificationEditModeFooter component', () => {
     const mockHandleSaveDisabled = vi.fn();
     rerender(
       <NotificationEditModeFooter
+        handleCancel={vi.fn()}
+        isCancelDisabled={false}
         handleSave={mockHandleSaveDisabled}
         handleDelete={vi.fn()}
         isSaveDisabled={true}
@@ -62,6 +70,41 @@ describe('NotificationEditModeFooter component', () => {
     saveButtonDisabled.click();
 
     expect(mockHandleSaveDisabled).not.toHaveBeenCalled();
+
+    unmount();
+  });
+  it('handles clicking the cancel button when it is enabled', () => {
+    const mockHandleCancel = vi.fn();
+    const { unmount, rerender } = render(
+      <NotificationEditModeFooter
+        handleCancel={mockHandleCancel}
+        isCancelDisabled={false}
+        handleSave={vi.fn()}
+        handleDelete={vi.fn()}
+        isSaveDisabled={false}
+      />
+    );
+
+    const cancelButton = screen.getByText(editModeFooter.cancel);
+    cancelButton.click();
+
+    expect(mockHandleCancel).toHaveBeenCalled();
+
+    const mockHandleCancelDisabled = vi.fn();
+    rerender(
+      <NotificationEditModeFooter
+        handleCancel={vi.fn()}
+        isCancelDisabled={false}
+        handleSave={mockHandleCancelDisabled}
+        handleDelete={vi.fn()}
+        isSaveDisabled={true}
+      />
+    );
+
+    const cancelButtonDisabled = screen.getByText(editModeFooter.cancel);
+    cancelButtonDisabled.click();
+
+    expect(mockHandleCancelDisabled).not.toHaveBeenCalled();
 
     unmount();
   });

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationEditModeFooter/NotificationEditModeFooter.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationEditModeFooter/NotificationEditModeFooter.spec.tsx
@@ -17,6 +17,7 @@ describe('NotificationEditModeFooter component', () => {
 
     expect(screen.getByText(editModeFooter.test)).toBeTruthy();
     expect(screen.getByText(editModeFooter.delete)).toBeTruthy();
+    expect(screen.getByText(editModeFooter.cancel)).toBeTruthy();
     expect(screen.getByText(editModeFooter.save)).toBeTruthy();
     unmount();
   });

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationEditModeFooter/NotificationEditModeFooter.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationEditModeFooter/NotificationEditModeFooter.spec.tsx
@@ -6,7 +6,11 @@ import { editModeFooter } from '@constants/configCopy';
 describe('NotificationEditModeFooter component', () => {
   it('mounts with correct button copy', () => {
     const { unmount } = render(
-      <NotificationEditModeFooter handleSave={vi.fn()} handleDelete={vi.fn()} />
+      <NotificationEditModeFooter
+        handleSave={vi.fn()}
+        handleDelete={vi.fn()}
+        isSaveDisabled={false}
+      />
     );
 
     expect(screen.getByText(editModeFooter.test)).toBeTruthy();
@@ -17,7 +21,11 @@ describe('NotificationEditModeFooter component', () => {
   it('handles clicking the delete button', () => {
     const mockHandleDelete = vi.fn();
     const { unmount } = render(
-      <NotificationEditModeFooter handleSave={vi.fn()} handleDelete={mockHandleDelete} />
+      <NotificationEditModeFooter
+        handleSave={vi.fn()}
+        handleDelete={mockHandleDelete}
+        isSaveDisabled={false}
+      />
     );
 
     const deleteButton = screen.getByText(editModeFooter.delete);
@@ -26,16 +34,35 @@ describe('NotificationEditModeFooter component', () => {
     expect(mockHandleDelete).toHaveBeenCalled();
     unmount();
   });
-  it('handles clicking the save button', () => {
+  it('handles clicking the save button when it is enabled', () => {
     const mockHandleSave = vi.fn();
-    const { unmount } = render(
-      <NotificationEditModeFooter handleSave={mockHandleSave} handleDelete={vi.fn()} />
+    const { unmount, rerender } = render(
+      <NotificationEditModeFooter
+        handleSave={mockHandleSave}
+        handleDelete={vi.fn()}
+        isSaveDisabled={false}
+      />
     );
 
     const saveButton = screen.getByText(editModeFooter.save);
     saveButton.click();
 
     expect(mockHandleSave).toHaveBeenCalled();
+
+    const mockHandleSaveDisabled = vi.fn();
+    rerender(
+      <NotificationEditModeFooter
+        handleSave={mockHandleSaveDisabled}
+        handleDelete={vi.fn()}
+        isSaveDisabled={true}
+      />
+    );
+
+    const saveButtonDisabled = screen.getByText(editModeFooter.save);
+    saveButtonDisabled.click();
+
+    expect(mockHandleSaveDisabled).not.toHaveBeenCalled();
+
     unmount();
   });
 });

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationEditModeFooter/NotificationEditModeFooter.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationEditModeFooter/NotificationEditModeFooter.tsx
@@ -5,10 +5,11 @@ import { editModeFooter } from '@constants/configCopy';
 interface Props {
   handleDelete: () => void;
   handleSave: () => void;
+  isSaveDisabled: boolean;
 }
 
 const NotificationEditModeFooter = (props: Props) => {
-  const { handleDelete, handleSave } = props;
+  const { handleDelete, handleSave, isSaveDisabled } = props;
 
   return (
     <Box className={styles.footer}>
@@ -19,7 +20,7 @@ const NotificationEditModeFooter = (props: Props) => {
           <Button variant="negative" onClick={handleDelete}>
             {editModeFooter.delete}
           </Button>
-          <Button variant="primary" onClick={handleSave}>
+          <Button variant="primary" onClick={handleSave} isDisabled={isSaveDisabled}>
             {editModeFooter.save}
           </Button>
         </ButtonGroup>

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationEditModeFooter/NotificationEditModeFooter.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationEditModeFooter/NotificationEditModeFooter.tsx
@@ -3,13 +3,15 @@ import { styles } from './NotificationEditModeFooter.styles';
 import { editModeFooter } from '@constants/configCopy';
 
 interface Props {
+  handleCancel: () => void;
+  isCancelDisabled: boolean;
   handleDelete: () => void;
   handleSave: () => void;
   isSaveDisabled: boolean;
 }
 
 const NotificationEditModeFooter = (props: Props) => {
-  const { handleDelete, handleSave, isSaveDisabled } = props;
+  const { handleCancel, isCancelDisabled, handleDelete, handleSave, isSaveDisabled } = props;
 
   return (
     <Box className={styles.footer}>
@@ -19,6 +21,9 @@ const NotificationEditModeFooter = (props: Props) => {
           {/* TODO: implement modal to confirm deletion */}
           <Button variant="negative" onClick={handleDelete}>
             {editModeFooter.delete}
+          </Button>
+          <Button variant="secondary" onClick={handleCancel} isDisabled={isCancelDisabled}>
+            {editModeFooter.cancel}
           </Button>
           <Button variant="primary" onClick={handleSave} isDisabled={isSaveDisabled}>
             {editModeFooter.save}

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationViewMode/NotificationViewMode.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationViewMode/NotificationViewMode.spec.tsx
@@ -13,6 +13,7 @@ describe('NotificationViewMode component', () => {
         notification={defaultNotification}
         contentTypes={[]}
         handleEdit={vi.fn()}
+        isEditDisabled={false}
       />
     );
 
@@ -29,6 +30,7 @@ describe('NotificationViewMode component', () => {
         notification={defaultNotification}
         contentTypes={[]}
         handleEdit={vi.fn()}
+        isEditDisabled={false}
       />
     );
 
@@ -38,15 +40,16 @@ describe('NotificationViewMode component', () => {
     expect(mockUpdateNotification).toHaveBeenCalled();
     unmount();
   });
-  it('handles clicking the edit button', () => {
+  it('handles clicking the edit button when it is enabled', () => {
     const mockHandleEdit = vi.fn();
-    const { unmount } = render(
+    const { unmount, rerender } = render(
       <NotificationViewMode
         index={0}
         updateNotification={vi.fn()}
         notification={defaultNotification}
         contentTypes={[]}
         handleEdit={mockHandleEdit}
+        isEditDisabled={false}
       />
     );
 
@@ -54,6 +57,24 @@ describe('NotificationViewMode component', () => {
     editButton.click();
 
     expect(mockHandleEdit).toHaveBeenCalled();
+
+    const mockHandleEditDisabled = vi.fn();
+    rerender(
+      <NotificationViewMode
+        index={0}
+        updateNotification={vi.fn()}
+        notification={defaultNotification}
+        contentTypes={[]}
+        handleEdit={mockHandleEdit}
+        isEditDisabled={true}
+      />
+    );
+
+    const editButtonDisabled = screen.getByText(notificationsSection.editButton);
+    editButtonDisabled.click();
+
+    expect(mockHandleEditDisabled).not.toHaveBeenCalled();
+
     unmount();
   });
 });

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationViewMode/NotificationViewMode.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationViewMode/NotificationViewMode.spec.tsx
@@ -1,0 +1,59 @@
+import NotificationViewMode from './NotificationViewMode';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { notificationsSection } from '@constants/configCopy';
+import { defaultNotification } from '@constants/defaultParams';
+
+describe('NotificationViewMode component', () => {
+  it('mounts with correct copy', () => {
+    const { unmount } = render(
+      <NotificationViewMode
+        index={0}
+        updateNotification={vi.fn()}
+        notification={defaultNotification}
+        contentTypes={[]}
+        handleEdit={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText(notificationsSection.enabledToggle)).toBeTruthy();
+    expect(screen.getByText(notificationsSection.editButton)).toBeTruthy();
+    unmount();
+  });
+  it('handles clicking the enable toggle', () => {
+    const mockUpdateNotification = vi.fn();
+    const { unmount } = render(
+      <NotificationViewMode
+        index={0}
+        updateNotification={mockUpdateNotification}
+        notification={defaultNotification}
+        contentTypes={[]}
+        handleEdit={vi.fn()}
+      />
+    );
+
+    const enableToggle = screen.getByRole('switch');
+    enableToggle.click();
+
+    expect(mockUpdateNotification).toHaveBeenCalled();
+    unmount();
+  });
+  it('handles clicking the edit button', () => {
+    const mockHandleEdit = vi.fn();
+    const { unmount } = render(
+      <NotificationViewMode
+        index={0}
+        updateNotification={vi.fn()}
+        notification={defaultNotification}
+        contentTypes={[]}
+        handleEdit={mockHandleEdit}
+      />
+    );
+
+    const editButton = screen.getByText(notificationsSection.editButton);
+    editButton.click();
+
+    expect(mockHandleEdit).toHaveBeenCalled();
+    unmount();
+  });
+});

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationViewMode/NotificationViewMode.styles.ts
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationViewMode/NotificationViewMode.styles.ts
@@ -1,0 +1,15 @@
+import { css } from 'emotion';
+import tokens from '@contentful/f36-tokens';
+
+export const styles = {
+  wrapper: css({
+    height: 'auto',
+    margin: `${tokens.spacingXs} auto`,
+    maxWidth: '900px',
+    backgroundColor: tokens.colorWhite,
+    borderRadius: '6px',
+    border: `1px solid ${tokens.gray300}`,
+    zIndex: 2,
+    padding: `${tokens.spacingM}`,
+  }),
+};

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationViewMode/NotificationViewMode.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationViewMode/NotificationViewMode.tsx
@@ -1,0 +1,61 @@
+import { Box, Button, Flex, Subheading, Paragraph, Switch } from '@contentful/f36-components';
+import { styles } from './NotificationViewMode.styles';
+import { getContentTypeName, getChannelName } from '@helpers/configHelpers';
+import { Notification } from '@customTypes/configPage';
+import { ContentTypeProps } from 'contentful-management';
+import {
+  channelSelection,
+  contentTypeSelection,
+  notificationsSection,
+} from '@constants/configCopy';
+// TODO: update this when we start fetching channel installations
+import mockChannels from '@test/mocks/mockChannels.json';
+
+interface Props {
+  index: number;
+  updateNotification: (index: number, editedNotification: Partial<Notification>) => void;
+  notification: Notification;
+  contentTypes: ContentTypeProps[];
+  handleEdit: () => void;
+}
+
+const NotificationViewMode = (props: Props) => {
+  const { index, notification, updateNotification, contentTypes, handleEdit } = props;
+
+  return (
+    <Box className={styles.wrapper}>
+      <Flex justifyContent="space-between">
+        <Flex flexDirection="column">
+          <Subheading marginBottom="none">
+            {getContentTypeName(
+              notification.contentTypeId,
+              contentTypes,
+              contentTypeSelection.notFound
+            )}
+          </Subheading>
+          <Paragraph marginBottom="none">
+            {getChannelName(notification.channelId, mockChannels, channelSelection.notFound)}
+          </Paragraph>
+        </Flex>
+        <Flex alignItems="center">
+          <Paragraph marginBottom="none" marginRight="spacingXs">
+            {notificationsSection.enabledToggle}
+          </Paragraph>
+          <Switch
+            name="enable-notification"
+            id="enable-notification"
+            isChecked={notification.isEnabled}
+            onChange={() => updateNotification(index, { isEnabled: !notification.isEnabled })}
+          />
+          <Box marginLeft="spacingXs">
+            <Button variant="secondary" size="small" onClick={handleEdit}>
+              {notificationsSection.editButton}
+            </Button>
+          </Box>
+        </Flex>
+      </Flex>
+    </Box>
+  );
+};
+
+export default NotificationViewMode;

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationViewMode/NotificationViewMode.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationViewMode/NotificationViewMode.tsx
@@ -17,10 +17,12 @@ interface Props {
   notification: Notification;
   contentTypes: ContentTypeProps[];
   handleEdit: () => void;
+  isEditDisabled: boolean;
 }
 
 const NotificationViewMode = (props: Props) => {
-  const { index, notification, updateNotification, contentTypes, handleEdit } = props;
+  const { index, notification, updateNotification, contentTypes, handleEdit, isEditDisabled } =
+    props;
 
   return (
     <Box className={styles.wrapper}>
@@ -48,7 +50,11 @@ const NotificationViewMode = (props: Props) => {
             onChange={() => updateNotification(index, { isEnabled: !notification.isEnabled })}
           />
           <Box marginLeft="spacingXs">
-            <Button variant="secondary" size="small" onClick={handleEdit}>
+            <Button
+              variant="secondary"
+              size="small"
+              onClick={handleEdit}
+              isDisabled={isEditDisabled}>
               {notificationsSection.editButton}
             </Button>
           </Box>

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.tsx
@@ -71,6 +71,7 @@ const NotificationsSection = (props: Props) => {
               notification={notification}
               contentTypes={contentTypes}
               handleEdit={() => setNotificationIndexToEdit(index)}
+              isEditDisabled={notificationIndexToEdit !== null}
             />
           );
         }

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.tsx
@@ -1,9 +1,10 @@
-import { Dispatch } from 'react';
+import { Dispatch, useState } from 'react';
 import { Box, Subheading } from '@contentful/f36-components';
 import { styles } from './NotificationsSection.styles';
 import { notificationsSection } from '@constants/configCopy';
 import AddButton from '@components/config/AddButton/AddButton';
 import NotificationEditMode from '@components/config/NotificationEditMode/NotificationEditMode';
+import NotificationViewMode from '@components/config/NotificationViewMode/NotificationViewMode';
 import { Notification } from '@customTypes/configPage';
 import { ParameterAction, actions } from '@components/config/parameterReducer';
 import useGetContentTypes from '@hooks/useGetContentTypes';
@@ -16,10 +17,13 @@ interface Props {
 const NotificationsSection = (props: Props) => {
   const { notifications, dispatch } = props;
 
+  const [notificationIndexToEdit, setNotificationIndexToEdit] = useState<number | null>(null);
+
   const contentTypes = useGetContentTypes();
 
   const createNewNotification = () => {
     dispatch({ type: actions.ADD_NOTIFICATION });
+    setNotificationIndexToEdit(0);
   };
 
   const deleteNotification = (index: number) => {
@@ -37,21 +41,39 @@ const NotificationsSection = (props: Props) => {
   return (
     <Box className={styles.box}>
       <Subheading>{notificationsSection.title}</Subheading>
-      <AddButton
-        buttonCopy={notificationsSection.createButton}
-        handleClick={createNewNotification}
-      />
+      <Box marginBottom="spacingXl">
+        <AddButton
+          buttonCopy={notificationsSection.createButton}
+          handleClick={createNewNotification}
+        />
+      </Box>
       {notifications.map((notification, index) => {
-        return (
-          <NotificationEditMode
-            key={`notification-${index}`}
-            index={index}
-            deleteNotification={deleteNotification}
-            updateNotification={updateNotification}
-            notification={notification}
-            contentTypes={contentTypes}
-          />
-        );
+        const inEditMode = notificationIndexToEdit === index;
+
+        if (inEditMode) {
+          return (
+            <NotificationEditMode
+              key={`notification-${index}`}
+              index={index}
+              deleteNotification={deleteNotification}
+              updateNotification={updateNotification}
+              notification={notification}
+              contentTypes={contentTypes}
+              setNotificationIndexToEdit={setNotificationIndexToEdit}
+            />
+          );
+        } else {
+          return (
+            <NotificationViewMode
+              key={`notification-${index}`}
+              index={index}
+              updateNotification={updateNotification}
+              notification={notification}
+              contentTypes={contentTypes}
+              handleEdit={() => setNotificationIndexToEdit(index)}
+            />
+          );
+        }
       })}
     </Box>
   );

--- a/apps/microsoft-teams/frontend/src/constants/configCopy.ts
+++ b/apps/microsoft-teams/frontend/src/constants/configCopy.ts
@@ -82,6 +82,7 @@ const eventsSelection = {
 const editModeFooter = {
   test: 'Test',
   delete: 'Delete',
+  cancel: 'Cancel',
   save: 'Save',
 };
 

--- a/apps/microsoft-teams/frontend/src/constants/configCopy.ts
+++ b/apps/microsoft-teams/frontend/src/constants/configCopy.ts
@@ -11,6 +11,8 @@ const accessSection = {
 const notificationsSection = {
   title: 'Notifications',
   createButton: 'Create notification',
+  enabledToggle: 'Notifications enabled',
+  editButton: 'Edit',
 };
 
 const contentTypeSelection = {

--- a/apps/microsoft-teams/frontend/src/customTypes/configPage.ts
+++ b/apps/microsoft-teams/frontend/src/customTypes/configPage.ts
@@ -15,3 +15,10 @@ export interface Notification {
 export type SelectedEvents = {
   [K in AppEventKey]: boolean;
 };
+
+export interface TeamsChannel {
+  id: string;
+  name: string;
+  teamId: string;
+  teamName: string;
+}

--- a/apps/microsoft-teams/frontend/src/helpers/configHelpers.spec.ts
+++ b/apps/microsoft-teams/frontend/src/helpers/configHelpers.spec.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { getChannelName, getContentTypeName } from './configHelpers';
+import mockChannels from '@test/mocks/mockChannels.json';
+import { mockContentType } from '@test/mocks';
+import { channelSelection, contentTypeSelection } from '@constants/configCopy';
+
+describe('getChannelName', () => {
+  it('should return the channel name', () => {
+    expect(
+      getChannelName(
+        '19:e3a386bd1e0f4e00a286b4e86b0cfbe9@thread.tacv2',
+        mockChannels,
+        channelSelection.notFound
+      )
+    ).toEqual('General, Marketing Team');
+  });
+
+  it('should return not found message if channel does not exist', () => {
+    expect(getChannelName('test-not-found', mockChannels, channelSelection.notFound)).toEqual(
+      channelSelection.notFound
+    );
+  });
+});
+
+describe('getContentTypeName', () => {
+  it('should return the channel name', () => {
+    expect(getContentTypeName('page', [mockContentType], contentTypeSelection.notFound)).toEqual(
+      'Page'
+    );
+  });
+
+  it('should return not found message if channel does not exist', () => {
+    expect(
+      getContentTypeName('test-not-found', [mockContentType], contentTypeSelection.notFound)
+    ).toEqual(contentTypeSelection.notFound);
+  });
+});

--- a/apps/microsoft-teams/frontend/src/helpers/configHelpers.spec.ts
+++ b/apps/microsoft-teams/frontend/src/helpers/configHelpers.spec.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { getChannelName, getContentTypeName } from './configHelpers';
+import { getChannelName, getContentTypeName, isNotificationReadyToSave } from './configHelpers';
 import mockChannels from '@test/mocks/mockChannels.json';
 import { mockContentType } from '@test/mocks';
 import { channelSelection, contentTypeSelection } from '@constants/configCopy';
+import { defaultNotification } from '@constants/defaultParams';
+import { mockNotification } from '@test/mocks';
 
 describe('getChannelName', () => {
   it('should return the channel name', () => {
@@ -33,5 +35,15 @@ describe('getContentTypeName', () => {
     expect(
       getContentTypeName('test-not-found', [mockContentType], contentTypeSelection.notFound)
     ).toEqual(contentTypeSelection.notFound);
+  });
+});
+
+describe('isNotificationReadyToSave', () => {
+  it('should return false when it is not ready', () => {
+    expect(isNotificationReadyToSave(defaultNotification)).toEqual(false);
+  });
+
+  it('should return true when it is ready', () => {
+    expect(isNotificationReadyToSave(mockNotification)).toEqual(true);
   });
 });

--- a/apps/microsoft-teams/frontend/src/helpers/configHelpers.spec.ts
+++ b/apps/microsoft-teams/frontend/src/helpers/configHelpers.spec.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { getChannelName, getContentTypeName, isNotificationReadyToSave } from './configHelpers';
+import {
+  getChannelName,
+  getContentTypeName,
+  isNotificationReadyToSave,
+  isNotificationDefault,
+} from './configHelpers';
 import mockChannels from '@test/mocks/mockChannels.json';
 import { mockContentType } from '@test/mocks';
 import { channelSelection, contentTypeSelection } from '@constants/configCopy';
@@ -40,10 +45,20 @@ describe('getContentTypeName', () => {
 
 describe('isNotificationReadyToSave', () => {
   it('should return false when it is not ready', () => {
-    expect(isNotificationReadyToSave(defaultNotification)).toEqual(false);
+    expect(isNotificationReadyToSave(defaultNotification, defaultNotification)).toEqual(false);
   });
 
   it('should return true when it is ready', () => {
-    expect(isNotificationReadyToSave(mockNotification)).toEqual(true);
+    expect(isNotificationReadyToSave(mockNotification, defaultNotification)).toEqual(true);
+  });
+});
+
+describe('isNotificationDefault', () => {
+  it('should return false when edited notification is not the same as default', () => {
+    expect(isNotificationDefault(mockNotification)).toEqual(false);
+  });
+
+  it('should return true when edited notification is the same as default', () => {
+    expect(isNotificationDefault(defaultNotification)).toEqual(true);
   });
 });

--- a/apps/microsoft-teams/frontend/src/helpers/configHelpers.ts
+++ b/apps/microsoft-teams/frontend/src/helpers/configHelpers.ts
@@ -1,6 +1,16 @@
 import { ContentTypeProps } from 'contentful-management';
 import { Notification, TeamsChannel } from '@customTypes/configPage';
+import isEqual from 'lodash/isEqual';
+import { defaultNotification } from '@constants/defaultParams';
 
+/**
+ * Gets the content type name for a given content type id
+ * returns a not found string if the content type is not found
+ * @param contentTypeId
+ * @param contentTypes
+ * @param notFoundCopy
+ * @returns string
+ */
 const getContentTypeName = (
   contentTypeId: string,
   contentTypes: ContentTypeProps[],
@@ -10,7 +20,15 @@ const getContentTypeName = (
   return contentType ? contentType.name : notFoundCopy;
 };
 
-// TODO: update this when we start fetching channel installations
+// TODO: update this function when we start fetching channel installations
+/**
+ * Gets the channel and team name for a given channel id
+ * returns a not found string if the channel is not found
+ * @param channelId
+ * @param channels
+ * @param notFoundCopy
+ * @returns string
+ */
 const getChannelName = (
   channelId: string,
   channels: TeamsChannel[],
@@ -21,12 +39,34 @@ const getChannelName = (
   return displayName;
 };
 
-const isNotificationReadyToSave = (notification: Notification): boolean => {
-  const hasContentType = !!notification.contentTypeId;
-  const hasChannel = !!notification.channelId;
-  const hasEventEnabled = Object.values(notification.selectedEvents).includes(true);
+/**
+ * Evaluates whether the edited notification is different from the saved notification
+ * and whether all of the necessary fields are completed
+ * @param editedNotification
+ * @param notification
+ * @returns boolean
+ */
+const isNotificationReadyToSave = (
+  editedNotification: Notification,
+  notification: Notification
+): boolean => {
+  const hasChanges = !isEqual(editedNotification, notification);
 
-  return hasContentType && hasChannel && hasEventEnabled;
+  const hasContentType = !!editedNotification.contentTypeId;
+  const hasChannel = !!editedNotification.channelId;
+  const hasEventEnabled = Object.values(editedNotification.selectedEvents).includes(true);
+  const hasAllFieldsCompleted = hasContentType && hasChannel && hasEventEnabled;
+
+  return hasChanges && hasAllFieldsCompleted;
 };
 
-export { getContentTypeName, getChannelName, isNotificationReadyToSave };
+/**
+ * Evaluates whether the edited notification is different from the default notification
+ * @param editedNotification
+ * @returns boolean
+ */
+const isNotificationDefault = (editedNotification: Notification): boolean => {
+  return isEqual(editedNotification, defaultNotification);
+};
+
+export { getContentTypeName, getChannelName, isNotificationReadyToSave, isNotificationDefault };

--- a/apps/microsoft-teams/frontend/src/helpers/configHelpers.ts
+++ b/apps/microsoft-teams/frontend/src/helpers/configHelpers.ts
@@ -1,0 +1,20 @@
+import { ContentTypeProps } from 'contentful-management';
+import { TeamsChannel } from '@customTypes/configPage';
+
+const getContentTypeName = (
+  contentTypeId: string,
+  contentTypes: ContentTypeProps[],
+  notFoundCopy: string
+): string => {
+  const contentType = contentTypes.find((contentType) => contentType.sys.id === contentTypeId);
+  return contentType ? contentType.name : notFoundCopy;
+};
+
+// TODO: update this when we start fetching channel installations
+const getChannelName = (channelId: string, channels: TeamsChannel[], notFoundCopy: string) => {
+  const channel = channels.find((channel) => channelId === channel.id);
+  const displayName = channel ? `${channel.name}, ${channel.teamName}` : notFoundCopy;
+  return displayName;
+};
+
+export { getContentTypeName, getChannelName };

--- a/apps/microsoft-teams/frontend/src/helpers/configHelpers.ts
+++ b/apps/microsoft-teams/frontend/src/helpers/configHelpers.ts
@@ -1,5 +1,5 @@
 import { ContentTypeProps } from 'contentful-management';
-import { TeamsChannel } from '@customTypes/configPage';
+import { Notification, TeamsChannel } from '@customTypes/configPage';
 
 const getContentTypeName = (
   contentTypeId: string,
@@ -11,10 +11,22 @@ const getContentTypeName = (
 };
 
 // TODO: update this when we start fetching channel installations
-const getChannelName = (channelId: string, channels: TeamsChannel[], notFoundCopy: string) => {
+const getChannelName = (
+  channelId: string,
+  channels: TeamsChannel[],
+  notFoundCopy: string
+): string => {
   const channel = channels.find((channel) => channelId === channel.id);
   const displayName = channel ? `${channel.name}, ${channel.teamName}` : notFoundCopy;
   return displayName;
 };
 
-export { getContentTypeName, getChannelName };
+const isNotificationReadyToSave = (notification: Notification): boolean => {
+  const hasContentType = !!notification.contentTypeId;
+  const hasChannel = !!notification.channelId;
+  const hasEventEnabled = Object.values(notification.selectedEvents).includes(true);
+
+  return hasContentType && hasChannel && hasEventEnabled;
+};
+
+export { getContentTypeName, getChannelName, isNotificationReadyToSave };

--- a/apps/microsoft-teams/frontend/test/mocks/index.ts
+++ b/apps/microsoft-teams/frontend/test/mocks/index.ts
@@ -1,8 +1,3 @@
 export { mockCma } from './mockCma';
 export { mockParameters, mockSdk } from './mockSdk';
-export {
-  mockContentType,
-  mockGetManyContentType,
-  mockSelectedContentTypes,
-  mockEditorInterface,
-} from './mockContentTypes';
+export { mockContentType, mockGetManyContentType } from './mockContentTypes';

--- a/apps/microsoft-teams/frontend/test/mocks/index.ts
+++ b/apps/microsoft-teams/frontend/test/mocks/index.ts
@@ -1,3 +1,4 @@
 export { mockCma } from './mockCma';
 export { mockParameters, mockSdk } from './mockSdk';
 export { mockContentType, mockGetManyContentType } from './mockContentTypes';
+export { mockNotification } from './mockNotification';

--- a/apps/microsoft-teams/frontend/test/mocks/mockContentTypes.ts
+++ b/apps/microsoft-teams/frontend/test/mocks/mockContentTypes.ts
@@ -93,14 +93,4 @@ const mockGetManyContentType = {
   total: 1,
 };
 
-const mockSelectedContentTypes = new Set(['page', 'article']);
-
-const mockEditorInterface = {
-  page: {
-    sidebar: {
-      position: 1,
-    },
-  },
-};
-
-export { mockContentType, mockGetManyContentType, mockSelectedContentTypes, mockEditorInterface };
+export { mockContentType, mockGetManyContentType };

--- a/apps/microsoft-teams/frontend/test/mocks/mockNotification.ts
+++ b/apps/microsoft-teams/frontend/test/mocks/mockNotification.ts
@@ -1,0 +1,15 @@
+const mockNotification = {
+  channelId: 'abc-123',
+  contentTypeId: 'blogPost',
+  isEnabled: true,
+  selectedEvents: {
+    publish: true,
+    unpublish: false,
+    create: false,
+    delete: false,
+    archive: false,
+    unarchive: false,
+  },
+};
+
+export { mockNotification };

--- a/apps/microsoft-teams/frontend/tsconfig.json
+++ b/apps/microsoft-teams/frontend/tsconfig.json
@@ -18,9 +18,10 @@
     "paths": {
       "@components/*": ["./src/components/*"],
       "@constants/*": ["./src/constants/*"],
+      "@customTypes/*": ["./src/customTypes/*"],
+      "@helpers/*": ["./src/helpers/*"],
       "@hooks/*": ["./src/hooks/*"],
       "@locations/*": ["./src/locations/*"],
-      "@customTypes/*": ["./src/customTypes/*"],
       "@test/*": ["./test/*"]
     }
   },

--- a/apps/microsoft-teams/frontend/vite.config.ts
+++ b/apps/microsoft-teams/frontend/vite.config.ts
@@ -26,9 +26,10 @@ export default defineConfig(() => ({
     alias: {
       '@components': path.resolve(__dirname, './src/components'),
       '@constants': path.resolve(__dirname, './src/constants'),
+      '@customTypes': path.resolve(__dirname, './src/customTypes'),
+      '@helpers': path.resolve(__dirname, './src/helpers'),
       '@hooks': path.resolve(__dirname, './src/hooks'),
       '@locations': path.resolve(__dirname, './src/locations'),
-      '@customTypes': path.resolve(__dirname, './src/customTypes'),
       '@test': path.resolve(__dirname, './test'),
     },
   },


### PR DESCRIPTION
## Purpose

This PR creates the "view mode" for configured notifications in the MS Teams app config page.

<img width="922" alt="Screenshot 2023-11-15 at 8 34 46 AM" src="https://github.com/contentful/apps/assets/62958907/ceda0478-cedd-4916-9375-922ed53bdd4d">

## Approach

A couple of additions with this PR:
- Only one notification can be in edit mode at a time. When a notification is in edit mode, other notifications have the `Edit` button disabled
- When a notification is in edit mode, save will only be enabled when all the fields have been filled out
- A cancel button has been added to edit mode

## Testing steps

Run the app locally in an MS Teams development app.

## Breaking Changes

## Dependencies and/or References

## Deployment
