### PR TITLE
chore: [ZEND-4323] - Update token setters for auth persistence

### DIFF
--- a/apps/ai-content-generator/package-lock.json
+++ b/apps/ai-content-generator/package-lock.json
@@ -2486,9 +2486,9 @@
       }
     },
     "node_modules/@segment/analytics-next": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@segment/analytics-next/-/analytics-next-1.59.0.tgz",
-      "integrity": "sha512-1DE95SSJ6pS1t8tshoo5B2qOrzM4ede1JIxXoaiCG475xG5h2bVMXWoKayZ2Hh3vU9te3ZFV/kOMkS32vLDaUA==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-next/-/analytics-next-1.61.0.tgz",
+      "integrity": "sha512-cPZ2YDqOzjGQEanEID09Fz7To71ep8GUb46ggY4pgbtYefM3uwUzSKeV8cdVJenun3Rzmyqz2s6Z1/qZkDTu7Q==",
       "dependencies": {
         "@lukeed/uuid": "^2.0.0",
         "@segment/analytics-core": "1.3.2",
@@ -13609,9 +13609,9 @@
       }
     },
     "@segment/analytics-next": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@segment/analytics-next/-/analytics-next-1.59.0.tgz",
-      "integrity": "sha512-1DE95SSJ6pS1t8tshoo5B2qOrzM4ede1JIxXoaiCG475xG5h2bVMXWoKayZ2Hh3vU9te3ZFV/kOMkS32vLDaUA==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-next/-/analytics-next-1.61.0.tgz",
+      "integrity": "sha512-cPZ2YDqOzjGQEanEID09Fz7To71ep8GUb46ggY4pgbtYefM3uwUzSKeV8cdVJenun3Rzmyqz2s6Z1/qZkDTu7Q==",
       "requires": {
         "@lukeed/uuid": "^2.0.0",
         "@segment/analytics-core": "1.3.2",

--- a/apps/google-analytics-4/frontend/package-lock.json
+++ b/apps/google-analytics-4/frontend/package-lock.json
@@ -4532,9 +4532,9 @@
       }
     },
     "node_modules/@segment/analytics-next": {
-      "version": "1.59.0",
-      "resolved": "https://registry.npmjs.org/@segment/analytics-next/-/analytics-next-1.59.0.tgz",
-      "integrity": "sha512-1DE95SSJ6pS1t8tshoo5B2qOrzM4ede1JIxXoaiCG475xG5h2bVMXWoKayZ2Hh3vU9te3ZFV/kOMkS32vLDaUA==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-next/-/analytics-next-1.61.0.tgz",
+      "integrity": "sha512-cPZ2YDqOzjGQEanEID09Fz7To71ep8GUb46ggY4pgbtYefM3uwUzSKeV8cdVJenun3Rzmyqz2s6Z1/qZkDTu7Q==",
       "dependencies": {
         "@lukeed/uuid": "^2.0.0",
         "@segment/analytics-core": "1.3.2",

--- a/apps/google-analytics-4/lambda/package-lock.json
+++ b/apps/google-analytics-4/lambda/package-lock.json
@@ -1077,11 +1077,11 @@
       }
     },
     "node_modules/@aws-sdk/lib-dynamodb": {
-      "version": "3.449.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.449.0.tgz",
-      "integrity": "sha512-w9cxP0b3aafufPhNlJ7bLW6bdv5+ccZlNzEY1khv43j+IomwAugLFwCeDrae/h8n1b2BAePRhut1bdbnnI3CsQ==",
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.451.0.tgz",
+      "integrity": "sha512-k0VrjPDpEZHrKpW4/8eY4s8y8RuIFP3BG3NP0JLaPJe3oOa29tvZtdep/+iY10zoIWEn5TLQtsyS7mnbFyqAtg==",
       "dependencies": {
-        "@aws-sdk/util-dynamodb": "3.449.0",
+        "@aws-sdk/util-dynamodb": "3.451.0",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -1556,9 +1556,9 @@
       }
     },
     "node_modules/@aws-sdk/util-dynamodb": {
-      "version": "3.449.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.449.0.tgz",
-      "integrity": "sha512-3Y0ZMcMTcwP8EM/twMVcA0mr7rnarcmRchLM+Lxgt4172K9YJ5Iy895Xy03g0aOgiAwAE8ogkzum0hwbv6RClg==",
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.451.0.tgz",
+      "integrity": "sha512-i1pPCD03blN1gmy/+KiVCwiMjvRN9qj0YnmqfSvkE2tlug1GnO7LzUDlNmw/awXanVTu0ijiJhOh2m4XhtQBEg==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -12994,11 +12994,11 @@
       }
     },
     "@aws-sdk/lib-dynamodb": {
-      "version": "3.449.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.449.0.tgz",
-      "integrity": "sha512-w9cxP0b3aafufPhNlJ7bLW6bdv5+ccZlNzEY1khv43j+IomwAugLFwCeDrae/h8n1b2BAePRhut1bdbnnI3CsQ==",
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.451.0.tgz",
+      "integrity": "sha512-k0VrjPDpEZHrKpW4/8eY4s8y8RuIFP3BG3NP0JLaPJe3oOa29tvZtdep/+iY10zoIWEn5TLQtsyS7mnbFyqAtg==",
       "requires": {
-        "@aws-sdk/util-dynamodb": "3.449.0",
+        "@aws-sdk/util-dynamodb": "3.451.0",
         "tslib": "^2.5.0"
       }
     },
@@ -13375,9 +13375,9 @@
       }
     },
     "@aws-sdk/util-dynamodb": {
-      "version": "3.449.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.449.0.tgz",
-      "integrity": "sha512-3Y0ZMcMTcwP8EM/twMVcA0mr7rnarcmRchLM+Lxgt4172K9YJ5Iy895Xy03g0aOgiAwAE8ogkzum0hwbv6RClg==",
+      "version": "3.451.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.451.0.tgz",
+      "integrity": "sha512-i1pPCD03blN1gmy/+KiVCwiMjvRN9qj0YnmqfSvkE2tlug1GnO7LzUDlNmw/awXanVTu0ijiJhOh2m4XhtQBEg==",
       "requires": {
         "tslib": "^2.5.0"
       }

--- a/apps/microsoft-teams/frontend/package-lock.json
+++ b/apps/microsoft-teams/frontend/package-lock.json
@@ -15,12 +15,14 @@
         "@contentful/react-apps-toolkit": "1.2.16",
         "contentful-management": "10.38.3",
         "emotion": "10.0.27",
+        "lodash": "^4.17.21",
         "react": "18.2.0",
         "react-dom": "18.2.0"
       },
       "devDependencies": {
         "@contentful/app-scripts": "1.10.2",
         "@testing-library/react": "14.0.0",
+        "@types/lodash": "^4.14.201",
         "@types/node": "16.18.38",
         "@types/react": "18.2.14",
         "@types/react-dom": "18.2.6",
@@ -2316,6 +2318,12 @@
       "version": "7.0.14",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.14.tgz",
       "integrity": "sha512-U3PUjAudAdJBeC2pgN8uTIKgxrb4nlDF3SF0++EldXQvQBGkpFZMSnwQiIoDU77tv45VgNkl/L4ouD+rEomujw==",
+      "dev": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.201",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.201.tgz",
+      "integrity": "sha512-y9euML0cim1JrykNxADLfaG0FgD1g/yTHwUs/Jg9ZIU7WKj2/4IW9Lbb1WZbvck78W/lfGXFfe+u2EGfIJXdLQ==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -5596,8 +5604,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
@@ -9352,6 +9359,12 @@
       "integrity": "sha512-U3PUjAudAdJBeC2pgN8uTIKgxrb4nlDF3SF0++EldXQvQBGkpFZMSnwQiIoDU77tv45VgNkl/L4ouD+rEomujw==",
       "dev": true
     },
+    "@types/lodash": {
+      "version": "4.14.201",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.201.tgz",
+      "integrity": "sha512-y9euML0cim1JrykNxADLfaG0FgD1g/yTHwUs/Jg9ZIU7WKj2/4IW9Lbb1WZbvck78W/lfGXFfe+u2EGfIJXdLQ==",
+      "dev": true
+    },
     "@types/node": {
       "version": "16.18.38",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.38.tgz",
@@ -11756,8 +11769,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.isplainobject": {
       "version": "4.0.6",

--- a/apps/microsoft-teams/frontend/package.json
+++ b/apps/microsoft-teams/frontend/package.json
@@ -10,6 +10,7 @@
     "@contentful/react-apps-toolkit": "1.2.16",
     "contentful-management": "10.38.3",
     "emotion": "10.0.27",
+    "lodash": "^4.17.21",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },
@@ -23,6 +24,7 @@
   "devDependencies": {
     "@contentful/app-scripts": "1.10.2",
     "@testing-library/react": "14.0.0",
+    "@types/lodash": "^4.14.201",
     "@types/node": "16.18.38",
     "@types/react": "18.2.14",
     "@types/react-dom": "18.2.6",

--- a/apps/microsoft-teams/frontend/src/components/config/ChannelSelection/ChannelSelection.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ChannelSelection/ChannelSelection.tsx
@@ -8,6 +8,7 @@ import { EditIcon } from '@contentful/f36-icons';
 import { styles } from './ChannelSelection.styles';
 // TODO: update this when we start fetching channel installations
 import mockChannels from '@test/mocks/mockChannels.json';
+import { getChannelName } from '@helpers/configHelpers';
 
 interface Props {
   notification: Notification;
@@ -30,15 +31,6 @@ const ChannelSelection = (props: Props) => {
     ));
   };
 
-  // TODO: update this when we start fetching channel installations
-  const getChannelName = (channelId: string) => {
-    const channel = mockChannels.find((channel) => channelId === channel.id);
-    const displayName = channel
-      ? `${channel.name}, ${channel.teamName}`
-      : channelSelection.notFound;
-    return displayName;
-  };
-
   return (
     <Box marginBottom="spacingL">
       <Flex marginBottom="spacingS" alignItems="center" className={styles.logo}>
@@ -52,7 +44,7 @@ const ChannelSelection = (props: Props) => {
           <TextInput
             id="selected-channel"
             isDisabled={true}
-            value={getChannelName(notification.channelId)}
+            value={getChannelName(notification.channelId, mockChannels, channelSelection.notFound)}
             className={styles.input}
           />
           <IconButton

--- a/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelection/ContentTypeSelection.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelection/ContentTypeSelection.tsx
@@ -7,6 +7,7 @@ import { Notification } from '@customTypes/configPage';
 import { EditIcon } from '@contentful/f36-icons';
 import { styles } from './ContentTypeSelection.styles';
 import { ContentTypeProps } from 'contentful-management';
+import { getContentTypeName } from '@helpers/configHelpers';
 
 interface Props {
   notification: Notification;
@@ -31,11 +32,6 @@ const ContentTypeSelection = (props: Props) => {
     ));
   };
 
-  const getContentTypeName = (contentTypeId: string) => {
-    const contentType = contentTypes.find((contentType) => contentType.sys.id === contentTypeId);
-    return contentType ? contentType.name : contentTypeSelection.notFound;
-  };
-
   return (
     <Box marginBottom="spacingL">
       <Flex marginBottom="spacingS" alignItems="center">
@@ -49,7 +45,11 @@ const ContentTypeSelection = (props: Props) => {
           <TextInput
             id="selected-content-type"
             isDisabled={true}
-            value={getContentTypeName(notification.contentTypeId)}
+            value={getContentTypeName(
+              notification.contentTypeId,
+              contentTypes,
+              contentTypeSelection.notFound
+            )}
             className={styles.input}
           />
           <IconButton

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.spec.tsx
@@ -13,6 +13,7 @@ describe('NotificationEditMode component', () => {
         updateNotification={vi.fn()}
         notification={defaultNotification}
         contentTypes={[]}
+        setNotificationIndexToEdit={vi.fn()}
       />
     );
 

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { Box } from '@contentful/f36-components';
 import ContentTypeSelection from '@components/config/ContentTypeSelection/ContentTypeSelection';
 import ChannelSelection from '@components/config/ChannelSelection/ChannelSelection';
@@ -7,6 +7,7 @@ import NotificationEditModeFooter from '@components/config/NotificationEditModeF
 import { styles } from './NotificationEditMode.styles';
 import { Notification } from '@customTypes/configPage';
 import { ContentTypeProps } from 'contentful-management';
+import { isNotificationReadyToSave, isNotificationDefault } from '@helpers/configHelpers';
 
 interface Props {
   index: number;
@@ -14,10 +15,18 @@ interface Props {
   updateNotification: (index: number, editedNotification: Partial<Notification>) => void;
   notification: Notification;
   contentTypes: ContentTypeProps[];
+  setNotificationIndexToEdit: Dispatch<SetStateAction<number | null>>;
 }
 
 const NotificationEditMode = (props: Props) => {
-  const { index, deleteNotification, updateNotification, notification, contentTypes } = props;
+  const {
+    index,
+    deleteNotification,
+    updateNotification,
+    notification,
+    contentTypes,
+    setNotificationIndexToEdit,
+  } = props;
 
   const [editedNotification, setEditedNotification] = useState<Notification>(notification);
 
@@ -31,10 +40,16 @@ const NotificationEditMode = (props: Props) => {
 
   const handleDelete = () => {
     deleteNotification(index);
+    setNotificationIndexToEdit(null);
   };
 
   const handleSave = () => {
     updateNotification(index, editedNotification);
+    setNotificationIndexToEdit(null);
+  };
+
+  const handleCancel = () => {
+    setNotificationIndexToEdit(null);
   };
 
   return (
@@ -54,7 +69,13 @@ const NotificationEditMode = (props: Props) => {
           handleNotificationEdit={handleNotificationEdit}
         />
       </Box>
-      <NotificationEditModeFooter handleDelete={handleDelete} handleSave={handleSave} />
+      <NotificationEditModeFooter
+        handleCancel={handleCancel}
+        isCancelDisabled={isNotificationDefault(editedNotification)}
+        handleDelete={handleDelete}
+        handleSave={handleSave}
+        isSaveDisabled={!isNotificationReadyToSave(editedNotification, notification)}
+      />
     </Box>
   );
 };

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationEditModeFooter/NotificationEditModeFooter.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationEditModeFooter/NotificationEditModeFooter.spec.tsx
@@ -6,18 +6,31 @@ import { editModeFooter } from '@constants/configCopy';
 describe('NotificationEditModeFooter component', () => {
   it('mounts with correct button copy', () => {
     const { unmount } = render(
-      <NotificationEditModeFooter handleSave={vi.fn()} handleDelete={vi.fn()} />
+      <NotificationEditModeFooter
+        handleCancel={vi.fn()}
+        isCancelDisabled={false}
+        handleSave={vi.fn()}
+        handleDelete={vi.fn()}
+        isSaveDisabled={false}
+      />
     );
 
     expect(screen.getByText(editModeFooter.test)).toBeTruthy();
     expect(screen.getByText(editModeFooter.delete)).toBeTruthy();
+    expect(screen.getByText(editModeFooter.cancel)).toBeTruthy();
     expect(screen.getByText(editModeFooter.save)).toBeTruthy();
     unmount();
   });
   it('handles clicking the delete button', () => {
     const mockHandleDelete = vi.fn();
     const { unmount } = render(
-      <NotificationEditModeFooter handleSave={vi.fn()} handleDelete={mockHandleDelete} />
+      <NotificationEditModeFooter
+        handleCancel={vi.fn()}
+        isCancelDisabled={false}
+        handleSave={vi.fn()}
+        handleDelete={mockHandleDelete}
+        isSaveDisabled={false}
+      />
     );
 
     const deleteButton = screen.getByText(editModeFooter.delete);
@@ -26,16 +39,74 @@ describe('NotificationEditModeFooter component', () => {
     expect(mockHandleDelete).toHaveBeenCalled();
     unmount();
   });
-  it('handles clicking the save button', () => {
+  it('handles clicking the save button when it is enabled', () => {
     const mockHandleSave = vi.fn();
-    const { unmount } = render(
-      <NotificationEditModeFooter handleSave={mockHandleSave} handleDelete={vi.fn()} />
+    const { unmount, rerender } = render(
+      <NotificationEditModeFooter
+        handleCancel={vi.fn()}
+        isCancelDisabled={false}
+        handleSave={mockHandleSave}
+        handleDelete={vi.fn()}
+        isSaveDisabled={false}
+      />
     );
 
     const saveButton = screen.getByText(editModeFooter.save);
     saveButton.click();
 
     expect(mockHandleSave).toHaveBeenCalled();
+
+    const mockHandleSaveDisabled = vi.fn();
+    rerender(
+      <NotificationEditModeFooter
+        handleCancel={vi.fn()}
+        isCancelDisabled={false}
+        handleSave={mockHandleSaveDisabled}
+        handleDelete={vi.fn()}
+        isSaveDisabled={true}
+      />
+    );
+
+    const saveButtonDisabled = screen.getByText(editModeFooter.save);
+    saveButtonDisabled.click();
+
+    expect(mockHandleSaveDisabled).not.toHaveBeenCalled();
+
+    unmount();
+  });
+  it('handles clicking the cancel button when it is enabled', () => {
+    const mockHandleCancel = vi.fn();
+    const { unmount, rerender } = render(
+      <NotificationEditModeFooter
+        handleCancel={mockHandleCancel}
+        isCancelDisabled={false}
+        handleSave={vi.fn()}
+        handleDelete={vi.fn()}
+        isSaveDisabled={false}
+      />
+    );
+
+    const cancelButton = screen.getByText(editModeFooter.cancel);
+    cancelButton.click();
+
+    expect(mockHandleCancel).toHaveBeenCalled();
+
+    const mockHandleCancelDisabled = vi.fn();
+    rerender(
+      <NotificationEditModeFooter
+        handleCancel={vi.fn()}
+        isCancelDisabled={false}
+        handleSave={mockHandleCancelDisabled}
+        handleDelete={vi.fn()}
+        isSaveDisabled={true}
+      />
+    );
+
+    const cancelButtonDisabled = screen.getByText(editModeFooter.cancel);
+    cancelButtonDisabled.click();
+
+    expect(mockHandleCancelDisabled).not.toHaveBeenCalled();
+
     unmount();
   });
 });

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationEditModeFooter/NotificationEditModeFooter.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationEditModeFooter/NotificationEditModeFooter.tsx
@@ -3,12 +3,15 @@ import { styles } from './NotificationEditModeFooter.styles';
 import { editModeFooter } from '@constants/configCopy';
 
 interface Props {
+  handleCancel: () => void;
+  isCancelDisabled: boolean;
   handleDelete: () => void;
   handleSave: () => void;
+  isSaveDisabled: boolean;
 }
 
 const NotificationEditModeFooter = (props: Props) => {
-  const { handleDelete, handleSave } = props;
+  const { handleCancel, isCancelDisabled, handleDelete, handleSave, isSaveDisabled } = props;
 
   return (
     <Box className={styles.footer}>
@@ -19,7 +22,10 @@ const NotificationEditModeFooter = (props: Props) => {
           <Button variant="negative" onClick={handleDelete}>
             {editModeFooter.delete}
           </Button>
-          <Button variant="primary" onClick={handleSave}>
+          <Button variant="secondary" onClick={handleCancel} isDisabled={isCancelDisabled}>
+            {editModeFooter.cancel}
+          </Button>
+          <Button variant="primary" onClick={handleSave} isDisabled={isSaveDisabled}>
             {editModeFooter.save}
           </Button>
         </ButtonGroup>

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationViewMode/NotificationViewMode.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationViewMode/NotificationViewMode.spec.tsx
@@ -1,0 +1,80 @@
+import NotificationViewMode from './NotificationViewMode';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { notificationsSection } from '@constants/configCopy';
+import { defaultNotification } from '@constants/defaultParams';
+
+describe('NotificationViewMode component', () => {
+  it('mounts with correct copy', () => {
+    const { unmount } = render(
+      <NotificationViewMode
+        index={0}
+        updateNotification={vi.fn()}
+        notification={defaultNotification}
+        contentTypes={[]}
+        handleEdit={vi.fn()}
+        isEditDisabled={false}
+      />
+    );
+
+    expect(screen.getByText(notificationsSection.enabledToggle)).toBeTruthy();
+    expect(screen.getByText(notificationsSection.editButton)).toBeTruthy();
+    unmount();
+  });
+  it('handles clicking the enable toggle', () => {
+    const mockUpdateNotification = vi.fn();
+    const { unmount } = render(
+      <NotificationViewMode
+        index={0}
+        updateNotification={mockUpdateNotification}
+        notification={defaultNotification}
+        contentTypes={[]}
+        handleEdit={vi.fn()}
+        isEditDisabled={false}
+      />
+    );
+
+    const enableToggle = screen.getByRole('switch');
+    enableToggle.click();
+
+    expect(mockUpdateNotification).toHaveBeenCalled();
+    unmount();
+  });
+  it('handles clicking the edit button when it is enabled', () => {
+    const mockHandleEdit = vi.fn();
+    const { unmount, rerender } = render(
+      <NotificationViewMode
+        index={0}
+        updateNotification={vi.fn()}
+        notification={defaultNotification}
+        contentTypes={[]}
+        handleEdit={mockHandleEdit}
+        isEditDisabled={false}
+      />
+    );
+
+    const editButton = screen.getByText(notificationsSection.editButton);
+    editButton.click();
+
+    expect(mockHandleEdit).toHaveBeenCalled();
+
+    const mockHandleEditDisabled = vi.fn();
+    rerender(
+      <NotificationViewMode
+        index={0}
+        updateNotification={vi.fn()}
+        notification={defaultNotification}
+        contentTypes={[]}
+        handleEdit={mockHandleEdit}
+        isEditDisabled={true}
+      />
+    );
+
+    const editButtonDisabled = screen.getByText(notificationsSection.editButton);
+    editButtonDisabled.click();
+
+    expect(mockHandleEditDisabled).not.toHaveBeenCalled();
+
+    unmount();
+  });
+});

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationViewMode/NotificationViewMode.styles.ts
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationViewMode/NotificationViewMode.styles.ts
@@ -10,8 +10,6 @@ export const styles = {
     borderRadius: '6px',
     border: `1px solid ${tokens.gray300}`,
     zIndex: 2,
-  }),
-  main: css({
     padding: `${tokens.spacingM}`,
   }),
 };

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationViewMode/NotificationViewMode.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationViewMode/NotificationViewMode.tsx
@@ -1,0 +1,67 @@
+import { Box, Button, Flex, Subheading, Paragraph, Switch } from '@contentful/f36-components';
+import { styles } from './NotificationViewMode.styles';
+import { getContentTypeName, getChannelName } from '@helpers/configHelpers';
+import { Notification } from '@customTypes/configPage';
+import { ContentTypeProps } from 'contentful-management';
+import {
+  channelSelection,
+  contentTypeSelection,
+  notificationsSection,
+} from '@constants/configCopy';
+// TODO: update this when we start fetching channel installations
+import mockChannels from '@test/mocks/mockChannels.json';
+
+interface Props {
+  index: number;
+  updateNotification: (index: number, editedNotification: Partial<Notification>) => void;
+  notification: Notification;
+  contentTypes: ContentTypeProps[];
+  handleEdit: () => void;
+  isEditDisabled: boolean;
+}
+
+const NotificationViewMode = (props: Props) => {
+  const { index, notification, updateNotification, contentTypes, handleEdit, isEditDisabled } =
+    props;
+
+  return (
+    <Box className={styles.wrapper}>
+      <Flex justifyContent="space-between">
+        <Flex flexDirection="column">
+          <Subheading marginBottom="none">
+            {getContentTypeName(
+              notification.contentTypeId,
+              contentTypes,
+              contentTypeSelection.notFound
+            )}
+          </Subheading>
+          <Paragraph marginBottom="none">
+            {getChannelName(notification.channelId, mockChannels, channelSelection.notFound)}
+          </Paragraph>
+        </Flex>
+        <Flex alignItems="center">
+          <Paragraph marginBottom="none" marginRight="spacingXs">
+            {notificationsSection.enabledToggle}
+          </Paragraph>
+          <Switch
+            name="enable-notification"
+            id="enable-notification"
+            isChecked={notification.isEnabled}
+            onChange={() => updateNotification(index, { isEnabled: !notification.isEnabled })}
+          />
+          <Box marginLeft="spacingXs">
+            <Button
+              variant="secondary"
+              size="small"
+              onClick={handleEdit}
+              isDisabled={isEditDisabled}>
+              {notificationsSection.editButton}
+            </Button>
+          </Box>
+        </Flex>
+      </Flex>
+    </Box>
+  );
+};
+
+export default NotificationViewMode;

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.tsx
@@ -1,9 +1,10 @@
-import { Dispatch } from 'react';
+import { Dispatch, useState } from 'react';
 import { Box, Subheading } from '@contentful/f36-components';
 import { styles } from './NotificationsSection.styles';
 import { notificationsSection } from '@constants/configCopy';
 import AddButton from '@components/config/AddButton/AddButton';
 import NotificationEditMode from '@components/config/NotificationEditMode/NotificationEditMode';
+import NotificationViewMode from '@components/config/NotificationViewMode/NotificationViewMode';
 import { Notification } from '@customTypes/configPage';
 import { ParameterAction, actions } from '@components/config/parameterReducer';
 import useGetContentTypes from '@hooks/useGetContentTypes';
@@ -16,10 +17,13 @@ interface Props {
 const NotificationsSection = (props: Props) => {
   const { notifications, dispatch } = props;
 
+  const [notificationIndexToEdit, setNotificationIndexToEdit] = useState<number | null>(null);
+
   const contentTypes = useGetContentTypes();
 
   const createNewNotification = () => {
     dispatch({ type: actions.ADD_NOTIFICATION });
+    setNotificationIndexToEdit(0);
   };
 
   const deleteNotification = (index: number) => {
@@ -37,21 +41,40 @@ const NotificationsSection = (props: Props) => {
   return (
     <Box className={styles.box}>
       <Subheading>{notificationsSection.title}</Subheading>
-      <AddButton
-        buttonCopy={notificationsSection.createButton}
-        handleClick={createNewNotification}
-      />
+      <Box marginBottom="spacingXl">
+        <AddButton
+          buttonCopy={notificationsSection.createButton}
+          handleClick={createNewNotification}
+        />
+      </Box>
       {notifications.map((notification, index) => {
-        return (
-          <NotificationEditMode
-            key={`notification-${index}`}
-            index={index}
-            deleteNotification={deleteNotification}
-            updateNotification={updateNotification}
-            notification={notification}
-            contentTypes={contentTypes}
-          />
-        );
+        const inEditMode = notificationIndexToEdit === index;
+
+        if (inEditMode) {
+          return (
+            <NotificationEditMode
+              key={`notification-${index}`}
+              index={index}
+              deleteNotification={deleteNotification}
+              updateNotification={updateNotification}
+              notification={notification}
+              contentTypes={contentTypes}
+              setNotificationIndexToEdit={setNotificationIndexToEdit}
+            />
+          );
+        } else {
+          return (
+            <NotificationViewMode
+              key={`notification-${index}`}
+              index={index}
+              updateNotification={updateNotification}
+              notification={notification}
+              contentTypes={contentTypes}
+              handleEdit={() => setNotificationIndexToEdit(index)}
+              isEditDisabled={notificationIndexToEdit !== null}
+            />
+          );
+        }
       })}
     </Box>
   );

--- a/apps/microsoft-teams/frontend/src/constants/configCopy.ts
+++ b/apps/microsoft-teams/frontend/src/constants/configCopy.ts
@@ -11,6 +11,8 @@ const accessSection = {
 const notificationsSection = {
   title: 'Notifications',
   createButton: 'Create notification',
+  enabledToggle: 'Notifications enabled',
+  editButton: 'Edit',
 };
 
 const contentTypeSelection = {
@@ -80,6 +82,7 @@ const eventsSelection = {
 const editModeFooter = {
   test: 'Test',
   delete: 'Delete',
+  cancel: 'Cancel',
   save: 'Save',
 };
 

--- a/apps/microsoft-teams/frontend/src/customTypes/configPage.ts
+++ b/apps/microsoft-teams/frontend/src/customTypes/configPage.ts
@@ -15,3 +15,10 @@ export interface Notification {
 export type SelectedEvents = {
   [K in AppEventKey]: boolean;
 };
+
+export interface TeamsChannel {
+  id: string;
+  name: string;
+  teamId: string;
+  teamName: string;
+}

--- a/apps/microsoft-teams/frontend/src/helpers/configHelpers.spec.ts
+++ b/apps/microsoft-teams/frontend/src/helpers/configHelpers.spec.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getChannelName,
+  getContentTypeName,
+  isNotificationReadyToSave,
+  isNotificationDefault,
+} from './configHelpers';
+import mockChannels from '@test/mocks/mockChannels.json';
+import { mockContentType } from '@test/mocks';
+import { channelSelection, contentTypeSelection } from '@constants/configCopy';
+import { defaultNotification } from '@constants/defaultParams';
+import { mockNotification } from '@test/mocks';
+
+describe('getChannelName', () => {
+  it('should return the channel name', () => {
+    expect(
+      getChannelName(
+        '19:e3a386bd1e0f4e00a286b4e86b0cfbe9@thread.tacv2',
+        mockChannels,
+        channelSelection.notFound
+      )
+    ).toEqual('General, Marketing Team');
+  });
+
+  it('should return not found message if channel does not exist', () => {
+    expect(getChannelName('test-not-found', mockChannels, channelSelection.notFound)).toEqual(
+      channelSelection.notFound
+    );
+  });
+});
+
+describe('getContentTypeName', () => {
+  it('should return the channel name', () => {
+    expect(getContentTypeName('page', [mockContentType], contentTypeSelection.notFound)).toEqual(
+      'Page'
+    );
+  });
+
+  it('should return not found message if channel does not exist', () => {
+    expect(
+      getContentTypeName('test-not-found', [mockContentType], contentTypeSelection.notFound)
+    ).toEqual(contentTypeSelection.notFound);
+  });
+});
+
+describe('isNotificationReadyToSave', () => {
+  it('should return false when it is not ready', () => {
+    expect(isNotificationReadyToSave(defaultNotification, defaultNotification)).toEqual(false);
+  });
+
+  it('should return true when it is ready', () => {
+    expect(isNotificationReadyToSave(mockNotification, defaultNotification)).toEqual(true);
+  });
+});
+
+describe('isNotificationDefault', () => {
+  it('should return false when edited notification is not the same as default', () => {
+    expect(isNotificationDefault(mockNotification)).toEqual(false);
+  });
+
+  it('should return true when edited notification is the same as default', () => {
+    expect(isNotificationDefault(defaultNotification)).toEqual(true);
+  });
+});

--- a/apps/microsoft-teams/frontend/src/helpers/configHelpers.ts
+++ b/apps/microsoft-teams/frontend/src/helpers/configHelpers.ts
@@ -1,0 +1,72 @@
+import { ContentTypeProps } from 'contentful-management';
+import { Notification, TeamsChannel } from '@customTypes/configPage';
+import isEqual from 'lodash/isEqual';
+import { defaultNotification } from '@constants/defaultParams';
+
+/**
+ * Gets the content type name for a given content type id
+ * returns a not found string if the content type is not found
+ * @param contentTypeId
+ * @param contentTypes
+ * @param notFoundCopy
+ * @returns string
+ */
+const getContentTypeName = (
+  contentTypeId: string,
+  contentTypes: ContentTypeProps[],
+  notFoundCopy: string
+): string => {
+  const contentType = contentTypes.find((contentType) => contentType.sys.id === contentTypeId);
+  return contentType ? contentType.name : notFoundCopy;
+};
+
+// TODO: update this function when we start fetching channel installations
+/**
+ * Gets the channel and team name for a given channel id
+ * returns a not found string if the channel is not found
+ * @param channelId
+ * @param channels
+ * @param notFoundCopy
+ * @returns string
+ */
+const getChannelName = (
+  channelId: string,
+  channels: TeamsChannel[],
+  notFoundCopy: string
+): string => {
+  const channel = channels.find((channel) => channelId === channel.id);
+  const displayName = channel ? `${channel.name}, ${channel.teamName}` : notFoundCopy;
+  return displayName;
+};
+
+/**
+ * Evaluates whether the edited notification is different from the saved notification
+ * and whether all of the necessary fields are completed
+ * @param editedNotification
+ * @param notification
+ * @returns boolean
+ */
+const isNotificationReadyToSave = (
+  editedNotification: Notification,
+  notification: Notification
+): boolean => {
+  const hasChanges = !isEqual(editedNotification, notification);
+
+  const hasContentType = !!editedNotification.contentTypeId;
+  const hasChannel = !!editedNotification.channelId;
+  const hasEventEnabled = Object.values(editedNotification.selectedEvents).includes(true);
+  const hasAllFieldsCompleted = hasContentType && hasChannel && hasEventEnabled;
+
+  return hasChanges && hasAllFieldsCompleted;
+};
+
+/**
+ * Evaluates whether the edited notification is different from the default notification
+ * @param editedNotification
+ * @returns boolean
+ */
+const isNotificationDefault = (editedNotification: Notification): boolean => {
+  return isEqual(editedNotification, defaultNotification);
+};
+
+export { getContentTypeName, getChannelName, isNotificationReadyToSave, isNotificationDefault };

--- a/apps/microsoft-teams/frontend/test/mocks/index.ts
+++ b/apps/microsoft-teams/frontend/test/mocks/index.ts
@@ -1,8 +1,4 @@
 export { mockCma } from './mockCma';
 export { mockParameters, mockSdk } from './mockSdk';
-export {
-  mockContentType,
-  mockGetManyContentType,
-  mockSelectedContentTypes,
-  mockEditorInterface,
-} from './mockContentTypes';
+export { mockContentType, mockGetManyContentType } from './mockContentTypes';
+export { mockNotification } from './mockNotification';

--- a/apps/microsoft-teams/frontend/test/mocks/mockContentTypes.ts
+++ b/apps/microsoft-teams/frontend/test/mocks/mockContentTypes.ts
@@ -93,14 +93,4 @@ const mockGetManyContentType = {
   total: 1,
 };
 
-const mockSelectedContentTypes = new Set(['page', 'article']);
-
-const mockEditorInterface = {
-  page: {
-    sidebar: {
-      position: 1,
-    },
-  },
-};
-
-export { mockContentType, mockGetManyContentType, mockSelectedContentTypes, mockEditorInterface };
+export { mockContentType, mockGetManyContentType };

--- a/apps/microsoft-teams/frontend/test/mocks/mockNotification.ts
+++ b/apps/microsoft-teams/frontend/test/mocks/mockNotification.ts
@@ -1,0 +1,15 @@
+const mockNotification = {
+  channelId: 'abc-123',
+  contentTypeId: 'blogPost',
+  isEnabled: true,
+  selectedEvents: {
+    publish: true,
+    unpublish: false,
+    create: false,
+    delete: false,
+    archive: false,
+    unarchive: false,
+  },
+};
+
+export { mockNotification };

--- a/apps/microsoft-teams/frontend/tsconfig.json
+++ b/apps/microsoft-teams/frontend/tsconfig.json
@@ -18,9 +18,10 @@
     "paths": {
       "@components/*": ["./src/components/*"],
       "@constants/*": ["./src/constants/*"],
+      "@customTypes/*": ["./src/customTypes/*"],
+      "@helpers/*": ["./src/helpers/*"],
       "@hooks/*": ["./src/hooks/*"],
       "@locations/*": ["./src/locations/*"],
-      "@customTypes/*": ["./src/customTypes/*"],
       "@test/*": ["./test/*"]
     }
   },

--- a/apps/microsoft-teams/frontend/vite.config.ts
+++ b/apps/microsoft-teams/frontend/vite.config.ts
@@ -26,9 +26,10 @@ export default defineConfig(() => ({
     alias: {
       '@components': path.resolve(__dirname, './src/components'),
       '@constants': path.resolve(__dirname, './src/constants'),
+      '@customTypes': path.resolve(__dirname, './src/customTypes'),
+      '@helpers': path.resolve(__dirname, './src/helpers'),
       '@hooks': path.resolve(__dirname, './src/hooks'),
       '@locations': path.resolve(__dirname, './src/locations'),
-      '@customTypes': path.resolve(__dirname, './src/customTypes'),
       '@test': path.resolve(__dirname, './test'),
     },
   },

--- a/apps/smartling/frontend/src/Sidebar.tsx
+++ b/apps/smartling/frontend/src/Sidebar.tsx
@@ -23,8 +23,8 @@ interface Props {
 
 interface State {
   smartlingEntry: SmartlingContentfulEntry | null;
-  token: string;
-  refreshToken: string;
+  token: string | null;
+  refreshToken: string | null;
   showAllSubs: boolean;
   generalError: boolean;
 }
@@ -156,8 +156,8 @@ function formatSmartlingEntry(entry: SmartlingContentfulEntry): SmartlingContent
 export default class Sidebar extends React.Component<Props, State> {
   state: State = {
     smartlingEntry: null,
-    token: window.localStorage.getItem('token') || '',
-    refreshToken: window.localStorage.getItem('refreshToken') || '',
+    token: window.localStorage.getItem('token') ?? null,
+    refreshToken: window.localStorage.getItem('refreshToken') ?? null,
     showAllSubs: false,
     generalError: false,
   };
@@ -169,10 +169,10 @@ export default class Sidebar extends React.Component<Props, State> {
   }
 
   runAuthFlow = async (tryRefreshOnly = false) => {
-    const refresh = await smartlingClient.refresh(this.state.refreshToken);
+    const refresh = await smartlingClient.refresh(this.state.refreshToken as string);
 
     if (tryRefreshOnly && refresh.failed) {
-      this.setState({ token: '', refreshToken: '' });
+      this.setState({ token: null, refreshToken: null });
     } else if (refresh.failed) {
       const smartlingWindow = window.open('/openauth', '', 'height=600,width=600,top=50,left=50');
 
@@ -185,6 +185,9 @@ export default class Sidebar extends React.Component<Props, State> {
 
         if (token) {
           this.setState({ token, refreshToken }, this.getJobs);
+
+          window.localStorage.setItem('token', token);
+          window.localStorage.setItem('refreshToken', refreshToken);
 
           if (smartlingWindow) {
             smartlingWindow.close();
@@ -204,7 +207,12 @@ export default class Sidebar extends React.Component<Props, State> {
     const { sdk, projectId } = this.props;
     const { token } = this.state;
 
-    const res = await smartlingClient.getLinkedJobs(token, sdk.ids.space, projectId, sdk.ids.entry);
+    const res = await smartlingClient.getLinkedJobs(
+      token as string,
+      sdk.ids.space,
+      projectId,
+      sdk.ids.entry
+    );
 
     if (res.code === 'AUTHENTICATION_ERROR') {
       this.runAuthFlow(true);

--- a/apps/smartling/frontend/src/Sidebar.tsx
+++ b/apps/smartling/frontend/src/Sidebar.tsx
@@ -207,12 +207,17 @@ export default class Sidebar extends React.Component<Props, State> {
     const { sdk, projectId } = this.props;
     const { token } = this.state;
 
-    if (!token) {
-      this.runAuthFlow(true);
-      return;
-    }
+    // if (!token) {
+    //   this.runAuthFlow(true);
+    //   return;
+    // }
 
-    const res = await smartlingClient.getLinkedJobs(token, sdk.ids.space, projectId, sdk.ids.entry);
+    const res = await smartlingClient.getLinkedJobs(
+      token!,
+      sdk.ids.space,
+      projectId,
+      sdk.ids.entry
+    );
 
     if (res.code === 'AUTHENTICATION_ERROR') {
       this.runAuthFlow(true);

--- a/apps/smartling/frontend/src/Sidebar.tsx
+++ b/apps/smartling/frontend/src/Sidebar.tsx
@@ -207,10 +207,10 @@ export default class Sidebar extends React.Component<Props, State> {
     const { sdk, projectId } = this.props;
     const { token } = this.state;
 
-    // if (!token) {
-    //   this.runAuthFlow(true);
-    //   return;
-    // }
+    if (!token) {
+      this.runAuthFlow(true);
+      return;
+    }
 
     const res = await smartlingClient.getLinkedJobs(
       token!,

--- a/apps/smartling/frontend/src/Sidebar.tsx
+++ b/apps/smartling/frontend/src/Sidebar.tsx
@@ -207,12 +207,12 @@ export default class Sidebar extends React.Component<Props, State> {
     const { sdk, projectId } = this.props;
     const { token } = this.state;
 
-    const res = await smartlingClient.getLinkedJobs(
-      token as string,
-      sdk.ids.space,
-      projectId,
-      sdk.ids.entry
-    );
+    if (!token) {
+      this.runAuthFlow(true);
+      return;
+    }
+
+    const res = await smartlingClient.getLinkedJobs(token, sdk.ids.space, projectId, sdk.ids.entry);
 
     if (res.code === 'AUTHENTICATION_ERROR') {
       this.runAuthFlow(true);

--- a/examples/hosted-delivery-function-potterdb-rest-api/package-lock.json
+++ b/examples/hosted-delivery-function-potterdb-rest-api/package-lock.json
@@ -22,7 +22,7 @@
         "react-scripts": "5.0.1"
       },
       "devDependencies": {
-        "@contentful/app-scripts": "1.13.0",
+        "@contentful/app-scripts": "1.13.1",
         "@contentful/node-apps-toolkit": "^2.6.2",
         "@testing-library/jest-dom": "5.17.0",
         "@testing-library/react": "14.0.0",
@@ -2133,17 +2133,17 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
     "node_modules/@contentful/app-scripts": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@contentful/app-scripts/-/app-scripts-1.13.0.tgz",
-      "integrity": "sha512-d2lysudGLPN7vBO8UNcoVyEcUwaY3VMkIMpjKTgWPcyixhLBDWv29UNoAUqGZ6neKR7WVOu8c0BofaauCJaihg==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@contentful/app-scripts/-/app-scripts-1.13.1.tgz",
+      "integrity": "sha512-QrvV8RE0w8lnELU1tBFRTBynvh5R/tNdcXrXRyMu1x7dl2zKe8LdiPqyBs/Jhl8q/vj/17KhxXTQ5louEsv4LA==",
       "dev": true,
       "dependencies": {
+        "@segment/analytics-node": "^1.1.3",
         "adm-zip": "0.5.10",
-        "analytics-node": "^6.2.0",
         "bottleneck": "2.19.5",
         "chalk": "4.1.2",
-        "commander": "11.0.0",
-        "contentful-management": "10.40.1",
+        "commander": "11.1.0",
+        "contentful-management": "11.5.1",
         "dotenv": "16.3.1",
         "ignore": "5.2.4",
         "inquirer": "8.2.6",
@@ -2159,24 +2159,13 @@
         "npm": ">=6"
       }
     },
-    "node_modules/@contentful/app-scripts/node_modules/axios": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
-      "integrity": "sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==",
-      "dev": true,
-      "dependencies": {
-        "follow-redirects": "^1.15.0",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/@contentful/app-scripts/node_modules/contentful-management": {
-      "version": "10.40.1",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-10.40.1.tgz",
-      "integrity": "sha512-RVg1EcdceKG2V/vTwX4fP02ibkm2v/xTysipThUHe+b8aEYm4hDlCUlj6obWviBZIW7tQ8sadEj95DZwVfmhAA==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.5.1.tgz",
+      "integrity": "sha512-t3PN28A1p+qE5sGliiNiBljGtHcVQXCTMB3HVer5yRPMtqkzpINqzxl5qzFPKliY4i8lms2wMLUi5l4lWrcrAg==",
       "dev": true,
       "dependencies": {
-        "@contentful/rich-text-types": "^16.0.3",
+        "@contentful/rich-text-types": "^16.3.0",
         "@types/json-patch": "0.0.30",
         "axios": "^1.4.0",
         "contentful-sdk-core": "^8.1.0",
@@ -2185,7 +2174,7 @@
         "type-fest": "^4.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/@contentful/app-sdk": {
@@ -4752,6 +4741,27 @@
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
     },
+    "node_modules/@lukeed/csprng": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
+      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@lukeed/uuid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@lukeed/uuid/-/uuid-2.0.1.tgz",
+      "integrity": "sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==",
+      "dev": true,
+      "dependencies": {
+        "@lukeed/csprng": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
@@ -5243,14 +5253,62 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.4.0.tgz",
       "integrity": "sha512-cEjvTPU32OM9lUFegJagO0mRnIn+rbqrG89vV8/xLnLFX0DoR0r1oy5IlTga71Q7uT3Qus7qm7wgeiMT/+Irlg=="
     },
-    "node_modules/@segment/loosely-validate-event": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@segment/loosely-validate-event/-/loosely-validate-event-2.0.0.tgz",
-      "integrity": "sha512-ZMCSfztDBqwotkl848ODgVcAmN4OItEWDCkshcKz0/W6gGSQayuuCtWV/MlodFivAZD793d6UgANd6wCXUfrIw==",
+    "node_modules/@segment/analytics-core": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-core/-/analytics-core-1.3.2.tgz",
+      "integrity": "sha512-NpeBCfOyMdO2/BDKfhCUNHcEwxg88N2iTnswBoEMh38rtsQ03TWLVYwgiTakPjNQFezdKkR6jq3JhQ3WWgq67g==",
       "dev": true,
       "dependencies": {
-        "component-type": "^1.2.1",
-        "join-component": "^1.1.0"
+        "@lukeed/uuid": "^2.0.0",
+        "dset": "^3.1.2",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@segment/analytics-generic-utils": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-generic-utils/-/analytics-generic-utils-1.0.0.tgz",
+      "integrity": "sha512-rAqcIQESnCsc80DMAxH06C4sJQ1MjwRLrWsih9qA2E0XwxydrMYgLA8eazxLW/wqEdctSJHCPnkMynpPIQgatw==",
+      "dev": true
+    },
+    "node_modules/@segment/analytics-node": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-node/-/analytics-node-1.1.3.tgz",
+      "integrity": "sha512-RGmD/VIW4iHqY+raeHlxdGY/FQpE6ATZHU8LrbwI+16uvT+sfw8d725J/lmzJIgNScJ/NFLg3LyHjitwPpqTxw==",
+      "dev": true,
+      "dependencies": {
+        "@lukeed/uuid": "^2.0.0",
+        "@segment/analytics-core": "1.3.2",
+        "@segment/analytics-generic-utils": "1.0.0",
+        "buffer": "^6.0.3",
+        "node-fetch": "^2.6.7",
+        "tslib": "^2.4.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@segment/analytics-node/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -6678,25 +6736,6 @@
         "ajv": "^6.9.1"
       }
     },
-    "node_modules/analytics-node": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/analytics-node/-/analytics-node-6.2.0.tgz",
-      "integrity": "sha512-NLU4tCHlWt0tzEaFQL7NIoWhq2KmQSmz0JvyS2lYn6fc4fEjTMSabhJUx8H1r5995FX8fE3rZ15uIHU6u+ovlQ==",
-      "dev": true,
-      "dependencies": {
-        "@segment/loosely-validate-event": "^2.0.0",
-        "axios": "^0.27.2",
-        "axios-retry": "3.2.0",
-        "lodash.isstring": "^4.0.1",
-        "md5": "^2.2.1",
-        "ms": "^2.0.0",
-        "remove-trailing-slash": "^0.1.0",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -7030,22 +7069,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "dev": true,
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
       "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
-      }
-    },
-    "node_modules/axios-retry": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.2.0.tgz",
-      "integrity": "sha512-RK2cLMgIsAQBDhlIsJR5dOhODPigvel18XUv1dDXW+4k1FzebyfRk+C+orot6WPZOYFKSfhLwHPwVmTVOODQ5w==",
-      "dev": true,
-      "dependencies": {
-        "is-retry-allowed": "^1.1.0"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -7761,15 +7791,6 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
-    "node_modules/charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/check-types": {
       "version": "11.2.3",
       "resolved": "https://registry.npmjs.org/check-types/-/check-types-11.2.3.tgz",
@@ -8059,9 +8080,9 @@
       }
     },
     "node_modules/commander": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.0.0.tgz",
-      "integrity": "sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
       "dev": true,
       "engines": {
         "node": ">=16"
@@ -8084,12 +8105,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg=="
-    },
-    "node_modules/component-type": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/component-type/-/component-type-1.2.1.tgz",
-      "integrity": "sha512-Kgy+2+Uwr75vAi6ChWXgHuLvd+QLD7ssgpaRq2zCvt80ptvAfMc/hijcJxXkBa2wMlEZcJvC2H8Ubo+A9ATHIg==",
-      "dev": true
     },
     "node_modules/compressible": {
       "version": "2.0.18",
@@ -8194,16 +8209,6 @@
       },
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/contentful-management/node_modules/axios": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
-      "integrity": "sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==",
-      "dependencies": {
-        "follow-redirects": "^1.15.0",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/contentful-sdk-core": {
@@ -8335,15 +8340,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/crypto-random-string": {
@@ -11748,12 +11744,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
-    },
     "node_modules/is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -11970,15 +11960,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
       "integrity": "sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-retry-allowed": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
-      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14075,12 +14056,6 @@
         "jiti": "bin/jiti.js"
       }
     },
-    "node_modules/join-component": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/join-component/-/join-component-1.1.0.tgz",
-      "integrity": "sha512-bF7vcQxbODoGK1imE2P9GS9aw4zD0Sd+Hni68IMZLj7zRnquH7dXUmMw9hDI5S/Jzt7q+IyTXN0rSg2GI0IKhQ==",
-      "dev": true
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -14601,17 +14576,6 @@
         "tmpl": "1.0.5"
       }
     },
-    "node_modules/md5": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-      "dev": true,
-      "dependencies": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "~1.1.6"
-      }
-    },
     "node_modules/mdn-data": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
@@ -14924,6 +14888,48 @@
       },
       "engines": {
         "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/node-forge": {
@@ -17471,12 +17477,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/remove-trailing-slash": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/remove-trailing-slash/-/remove-trailing-slash-0.1.1.tgz",
-      "integrity": "sha512-o4S4Qh6L2jpnCy83ysZDau+VORNvnFw07CKSAymkd6ICNVEPisMyzlc00KlvvicsxKck94SEwhDnMNdICzO+tA==",
-      "dev": true
     },
     "node_modules/renderkid": {
       "version": "3.0.0",

--- a/examples/hosted-delivery-function-potterdb-rest-api/package.json
+++ b/examples/hosted-delivery-function-potterdb-rest-api/package.json
@@ -42,7 +42,7 @@
     ]
   },
   "devDependencies": {
-    "@contentful/app-scripts": "1.13.0",
+    "@contentful/app-scripts": "1.13.1",
     "@contentful/node-apps-toolkit": "^2.6.2",
     "@testing-library/jest-dom": "5.17.0",
     "@testing-library/react": "14.0.0",

--- a/examples/javascript/package-lock.json
+++ b/examples/javascript/package-lock.json
@@ -19,7 +19,7 @@
         "react-scripts": "5.0.1"
       },
       "devDependencies": {
-        "@contentful/app-scripts": "1.13.0",
+        "@contentful/app-scripts": "1.13.1",
         "@testing-library/jest-dom": "5.17.0",
         "@testing-library/react": "14.1.0",
         "cross-env": "7.0.3"
@@ -1878,17 +1878,17 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
     "node_modules/@contentful/app-scripts": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@contentful/app-scripts/-/app-scripts-1.13.0.tgz",
-      "integrity": "sha512-d2lysudGLPN7vBO8UNcoVyEcUwaY3VMkIMpjKTgWPcyixhLBDWv29UNoAUqGZ6neKR7WVOu8c0BofaauCJaihg==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@contentful/app-scripts/-/app-scripts-1.13.1.tgz",
+      "integrity": "sha512-QrvV8RE0w8lnELU1tBFRTBynvh5R/tNdcXrXRyMu1x7dl2zKe8LdiPqyBs/Jhl8q/vj/17KhxXTQ5louEsv4LA==",
       "dev": true,
       "dependencies": {
+        "@segment/analytics-node": "^1.1.3",
         "adm-zip": "0.5.10",
-        "analytics-node": "^6.2.0",
         "bottleneck": "2.19.5",
         "chalk": "4.1.2",
-        "commander": "11.0.0",
-        "contentful-management": "10.40.1",
+        "commander": "11.1.0",
+        "contentful-management": "11.5.1",
         "dotenv": "16.3.1",
         "ignore": "5.2.4",
         "inquirer": "8.2.6",
@@ -1917,17 +1917,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@contentful/app-scripts/node_modules/axios": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
-      "integrity": "sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==",
-      "dev": true,
-      "dependencies": {
-        "follow-redirects": "^1.15.0",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/@contentful/app-scripts/node_modules/chalk": {
@@ -1965,21 +1954,21 @@
       "dev": true
     },
     "node_modules/@contentful/app-scripts/node_modules/commander": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.0.0.tgz",
-      "integrity": "sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
       "dev": true,
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@contentful/app-scripts/node_modules/contentful-management": {
-      "version": "10.40.1",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-10.40.1.tgz",
-      "integrity": "sha512-RVg1EcdceKG2V/vTwX4fP02ibkm2v/xTysipThUHe+b8aEYm4hDlCUlj6obWviBZIW7tQ8sadEj95DZwVfmhAA==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.5.1.tgz",
+      "integrity": "sha512-t3PN28A1p+qE5sGliiNiBljGtHcVQXCTMB3HVer5yRPMtqkzpINqzxl5qzFPKliY4i8lms2wMLUi5l4lWrcrAg==",
       "dev": true,
       "dependencies": {
-        "@contentful/rich-text-types": "^16.0.3",
+        "@contentful/rich-text-types": "^16.3.0",
         "@types/json-patch": "0.0.30",
         "axios": "^1.4.0",
         "contentful-sdk-core": "^8.1.0",
@@ -1988,7 +1977,7 @@
         "type-fest": "^4.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/@contentful/app-scripts/node_modules/dotenv": {
@@ -2001,20 +1990,6 @@
       },
       "funding": {
         "url": "https://github.com/motdotla/dotenv?sponsor=1"
-      }
-    },
-    "node_modules/@contentful/app-scripts/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/@contentful/app-scripts/node_modules/has-flag": {
@@ -2065,9 +2040,9 @@
       }
     },
     "node_modules/@contentful/app-scripts/node_modules/type-fest": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.3.1.tgz",
-      "integrity": "sha512-pphNW/msgOUSkJbH58x8sqpq8uQj6b0ZKGxEsLKMUnGorRcDjrUaLS+39+/ub41JNTwrrMyJcUB8+YZs3mbwqw==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.7.1.tgz",
+      "integrity": "sha512-iWr8RUmzAJRfhZugX9O7nZE6pCxDU8CZ3QxsLuTnGcBLJpCaP2ll3s4eMTBoFnU/CeXY/5rfQSuAEsTGJO4y8A==",
       "dev": true,
       "engines": {
         "node": ">=16"
@@ -3784,6 +3759,27 @@
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.3.tgz",
       "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
     },
+    "node_modules/@lukeed/csprng": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
+      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@lukeed/uuid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@lukeed/uuid/-/uuid-2.0.1.tgz",
+      "integrity": "sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==",
+      "dev": true,
+      "dependencies": {
+        "@lukeed/csprng": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -4242,14 +4238,62 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.1.2.tgz",
       "integrity": "sha512-oe5WJEDaVsW8fBlGT7udrSCgOwWfoYHQOmSpnh8X+0GXpqqcRCP8k4y+Dxb0taWJDPpB+rdDUtumIiBwkY9qGA=="
     },
-    "node_modules/@segment/loosely-validate-event": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@segment/loosely-validate-event/-/loosely-validate-event-2.0.0.tgz",
-      "integrity": "sha512-ZMCSfztDBqwotkl848ODgVcAmN4OItEWDCkshcKz0/W6gGSQayuuCtWV/MlodFivAZD793d6UgANd6wCXUfrIw==",
+    "node_modules/@segment/analytics-core": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-core/-/analytics-core-1.3.2.tgz",
+      "integrity": "sha512-NpeBCfOyMdO2/BDKfhCUNHcEwxg88N2iTnswBoEMh38rtsQ03TWLVYwgiTakPjNQFezdKkR6jq3JhQ3WWgq67g==",
       "dev": true,
       "dependencies": {
-        "component-type": "^1.2.1",
-        "join-component": "^1.1.0"
+        "@lukeed/uuid": "^2.0.0",
+        "dset": "^3.1.2",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@segment/analytics-generic-utils": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-generic-utils/-/analytics-generic-utils-1.0.0.tgz",
+      "integrity": "sha512-rAqcIQESnCsc80DMAxH06C4sJQ1MjwRLrWsih9qA2E0XwxydrMYgLA8eazxLW/wqEdctSJHCPnkMynpPIQgatw==",
+      "dev": true
+    },
+    "node_modules/@segment/analytics-node": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-node/-/analytics-node-1.1.3.tgz",
+      "integrity": "sha512-RGmD/VIW4iHqY+raeHlxdGY/FQpE6ATZHU8LrbwI+16uvT+sfw8d725J/lmzJIgNScJ/NFLg3LyHjitwPpqTxw==",
+      "dev": true,
+      "dependencies": {
+        "@lukeed/uuid": "^2.0.0",
+        "@segment/analytics-core": "1.3.2",
+        "@segment/analytics-generic-utils": "1.0.0",
+        "buffer": "^6.0.3",
+        "node-fetch": "^2.6.7",
+        "tslib": "^2.4.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@segment/analytics-node/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -5782,25 +5826,6 @@
         }
       }
     },
-    "node_modules/analytics-node": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/analytics-node/-/analytics-node-6.2.0.tgz",
-      "integrity": "sha512-NLU4tCHlWt0tzEaFQL7NIoWhq2KmQSmz0JvyS2lYn6fc4fEjTMSabhJUx8H1r5995FX8fE3rZ15uIHU6u+ovlQ==",
-      "dev": true,
-      "dependencies": {
-        "@segment/loosely-validate-event": "^2.0.0",
-        "axios": "^0.27.2",
-        "axios-retry": "3.2.0",
-        "lodash.isstring": "^4.0.1",
-        "md5": "^2.2.1",
-        "ms": "^2.0.0",
-        "remove-trailing-slash": "^0.1.0",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -6055,29 +6080,19 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "dev": true,
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
       "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
-      }
-    },
-    "node_modules/axios-retry": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.2.0.tgz",
-      "integrity": "sha512-RK2cLMgIsAQBDhlIsJR5dOhODPigvel18XUv1dDXW+4k1FzebyfRk+C+orot6WPZOYFKSfhLwHPwVmTVOODQ5w==",
-      "dev": true,
-      "dependencies": {
-        "is-retry-allowed": "^1.1.0"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axios/node_modules/form-data": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -6838,15 +6853,6 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
-    "node_modules/charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/check-types": {
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/check-types/-/check-types-11.1.2.tgz",
@@ -7065,12 +7071,6 @@
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
     },
-    "node_modules/component-type": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/component-type/-/component-type-1.2.1.tgz",
-      "integrity": "sha512-Kgy+2+Uwr75vAi6ChWXgHuLvd+QLD7ssgpaRq2zCvt80ptvAfMc/hijcJxXkBa2wMlEZcJvC2H8Ubo+A9ATHIg==",
-      "dev": true
-    },
     "node_modules/compressible": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
@@ -7188,29 +7188,6 @@
       },
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/contentful-management/node_modules/axios": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
-      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
-      "dependencies": {
-        "follow-redirects": "^1.15.0",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/contentful-management/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/contentful-management/node_modules/type-fest": {
@@ -7358,15 +7335,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/crypto-random-string": {
@@ -8169,6 +8137,15 @@
       },
       "peerDependencies": {
         "react": ">=16.12.0"
+      }
+    },
+    "node_modules/dset": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.3.tgz",
+      "integrity": "sha512-20TuZZHCEZ2O71q9/+8BwKwZ0QtD9D8ObhrihJPr+vLLYlSuAU3/zL4cSlgbfeoGHTjCSJBa7NGcrF9/Bx/WJQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/duplexer": {
@@ -10765,12 +10742,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
-    },
     "node_modules/is-callable": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
@@ -10955,15 +10926,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
       "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-retry-allowed": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
-      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12911,12 +12873,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/join-component": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/join-component/-/join-component-1.1.0.tgz",
-      "integrity": "sha512-bF7vcQxbODoGK1imE2P9GS9aw4zD0Sd+Hni68IMZLj7zRnquH7dXUmMw9hDI5S/Jzt7q+IyTXN0rSg2GI0IKhQ==",
-      "dev": true
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -13369,17 +13325,6 @@
         "tmpl": "1.0.5"
       }
     },
-    "node_modules/md5": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-      "dev": true,
-      "dependencies": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "~1.1.6"
-      }
-    },
     "node_modules/mdn-data": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
@@ -13627,6 +13572,48 @@
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/node-forge": {
@@ -16238,12 +16225,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/remove-trailing-slash": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/remove-trailing-slash/-/remove-trailing-slash-0.1.1.tgz",
-      "integrity": "sha512-o4S4Qh6L2jpnCy83ysZDau+VORNvnFw07CKSAymkd6ICNVEPisMyzlc00KlvvicsxKck94SEwhDnMNdICzO+tA==",
-      "dev": true
     },
     "node_modules/renderkid": {
       "version": "3.0.0",
@@ -20178,17 +20159,17 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
     "@contentful/app-scripts": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@contentful/app-scripts/-/app-scripts-1.13.0.tgz",
-      "integrity": "sha512-d2lysudGLPN7vBO8UNcoVyEcUwaY3VMkIMpjKTgWPcyixhLBDWv29UNoAUqGZ6neKR7WVOu8c0BofaauCJaihg==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@contentful/app-scripts/-/app-scripts-1.13.1.tgz",
+      "integrity": "sha512-QrvV8RE0w8lnELU1tBFRTBynvh5R/tNdcXrXRyMu1x7dl2zKe8LdiPqyBs/Jhl8q/vj/17KhxXTQ5louEsv4LA==",
       "dev": true,
       "requires": {
+        "@segment/analytics-node": "^1.1.3",
         "adm-zip": "0.5.10",
-        "analytics-node": "^6.2.0",
         "bottleneck": "2.19.5",
         "chalk": "4.1.2",
-        "commander": "11.0.0",
-        "contentful-management": "10.40.1",
+        "commander": "11.1.0",
+        "contentful-management": "11.5.1",
         "dotenv": "16.3.1",
         "ignore": "5.2.4",
         "inquirer": "8.2.6",
@@ -20204,17 +20185,6 @@
           "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
-          }
-        },
-        "axios": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
-          "integrity": "sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==",
-          "dev": true,
-          "requires": {
-            "follow-redirects": "^1.15.0",
-            "form-data": "^4.0.0",
-            "proxy-from-env": "^1.1.0"
           }
         },
         "chalk": {
@@ -20243,18 +20213,18 @@
           "dev": true
         },
         "commander": {
-          "version": "11.0.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-11.0.0.tgz",
-          "integrity": "sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==",
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+          "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
           "dev": true
         },
         "contentful-management": {
-          "version": "10.40.1",
-          "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-10.40.1.tgz",
-          "integrity": "sha512-RVg1EcdceKG2V/vTwX4fP02ibkm2v/xTysipThUHe+b8aEYm4hDlCUlj6obWviBZIW7tQ8sadEj95DZwVfmhAA==",
+          "version": "11.5.1",
+          "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.5.1.tgz",
+          "integrity": "sha512-t3PN28A1p+qE5sGliiNiBljGtHcVQXCTMB3HVer5yRPMtqkzpINqzxl5qzFPKliY4i8lms2wMLUi5l4lWrcrAg==",
           "dev": true,
           "requires": {
-            "@contentful/rich-text-types": "^16.0.3",
+            "@contentful/rich-text-types": "^16.3.0",
             "@types/json-patch": "0.0.30",
             "axios": "^1.4.0",
             "contentful-sdk-core": "^8.1.0",
@@ -20268,17 +20238,6 @@
           "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
           "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
           "dev": true
-        },
-        "form-data": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-          "dev": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
-          }
         },
         "has-flag": {
           "version": "4.0.0",
@@ -20313,9 +20272,9 @@
           }
         },
         "type-fest": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.3.1.tgz",
-          "integrity": "sha512-pphNW/msgOUSkJbH58x8sqpq8uQj6b0ZKGxEsLKMUnGorRcDjrUaLS+39+/ub41JNTwrrMyJcUB8+YZs3mbwqw==",
+          "version": "4.7.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.7.1.tgz",
+          "integrity": "sha512-iWr8RUmzAJRfhZugX9O7nZE6pCxDU8CZ3QxsLuTnGcBLJpCaP2ll3s4eMTBoFnU/CeXY/5rfQSuAEsTGJO4y8A==",
           "dev": true
         }
       }
@@ -21619,6 +21578,21 @@
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.3.tgz",
       "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
     },
+    "@lukeed/csprng": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
+      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
+      "dev": true
+    },
+    "@lukeed/uuid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@lukeed/uuid/-/uuid-2.0.1.tgz",
+      "integrity": "sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==",
+      "dev": true,
+      "requires": {
+        "@lukeed/csprng": "^1.1.0"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -21862,14 +21836,47 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.1.2.tgz",
       "integrity": "sha512-oe5WJEDaVsW8fBlGT7udrSCgOwWfoYHQOmSpnh8X+0GXpqqcRCP8k4y+Dxb0taWJDPpB+rdDUtumIiBwkY9qGA=="
     },
-    "@segment/loosely-validate-event": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@segment/loosely-validate-event/-/loosely-validate-event-2.0.0.tgz",
-      "integrity": "sha512-ZMCSfztDBqwotkl848ODgVcAmN4OItEWDCkshcKz0/W6gGSQayuuCtWV/MlodFivAZD793d6UgANd6wCXUfrIw==",
+    "@segment/analytics-core": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-core/-/analytics-core-1.3.2.tgz",
+      "integrity": "sha512-NpeBCfOyMdO2/BDKfhCUNHcEwxg88N2iTnswBoEMh38rtsQ03TWLVYwgiTakPjNQFezdKkR6jq3JhQ3WWgq67g==",
       "dev": true,
       "requires": {
-        "component-type": "^1.2.1",
-        "join-component": "^1.1.0"
+        "@lukeed/uuid": "^2.0.0",
+        "dset": "^3.1.2",
+        "tslib": "^2.4.1"
+      }
+    },
+    "@segment/analytics-generic-utils": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-generic-utils/-/analytics-generic-utils-1.0.0.tgz",
+      "integrity": "sha512-rAqcIQESnCsc80DMAxH06C4sJQ1MjwRLrWsih9qA2E0XwxydrMYgLA8eazxLW/wqEdctSJHCPnkMynpPIQgatw==",
+      "dev": true
+    },
+    "@segment/analytics-node": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-node/-/analytics-node-1.1.3.tgz",
+      "integrity": "sha512-RGmD/VIW4iHqY+raeHlxdGY/FQpE6ATZHU8LrbwI+16uvT+sfw8d725J/lmzJIgNScJ/NFLg3LyHjitwPpqTxw==",
+      "dev": true,
+      "requires": {
+        "@lukeed/uuid": "^2.0.0",
+        "@segment/analytics-core": "1.3.2",
+        "@segment/analytics-generic-utils": "1.0.0",
+        "buffer": "^6.0.3",
+        "node-fetch": "^2.6.7",
+        "tslib": "^2.4.1"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        }
       }
     },
     "@sinclair/typebox": {
@@ -23058,22 +23065,6 @@
         "ajv": "^8.0.0"
       }
     },
-    "analytics-node": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/analytics-node/-/analytics-node-6.2.0.tgz",
-      "integrity": "sha512-NLU4tCHlWt0tzEaFQL7NIoWhq2KmQSmz0JvyS2lYn6fc4fEjTMSabhJUx8H1r5995FX8fE3rZ15uIHU6u+ovlQ==",
-      "dev": true,
-      "requires": {
-        "@segment/loosely-validate-event": "^2.0.0",
-        "axios": "^0.27.2",
-        "axios-retry": "3.2.0",
-        "lodash.isstring": "^4.0.1",
-        "md5": "^2.2.1",
-        "ms": "^2.0.0",
-        "remove-trailing-slash": "^0.1.0",
-        "uuid": "^8.3.2"
-      }
-    },
     "ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -23245,35 +23236,25 @@
       "integrity": "sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw=="
     },
     "axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "dev": true,
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
       "requires": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       },
       "dependencies": {
         "form-data": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
           "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-          "dev": true,
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.8",
             "mime-types": "^2.1.12"
           }
         }
-      }
-    },
-    "axios-retry": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.2.0.tgz",
-      "integrity": "sha512-RK2cLMgIsAQBDhlIsJR5dOhODPigvel18XUv1dDXW+4k1FzebyfRk+C+orot6WPZOYFKSfhLwHPwVmTVOODQ5w==",
-      "dev": true,
-      "requires": {
-        "is-retry-allowed": "^1.1.0"
       }
     },
     "axobject-query": {
@@ -23832,12 +23813,6 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
-    "charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
-      "dev": true
-    },
     "check-types": {
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/check-types/-/check-types-11.1.2.tgz",
@@ -24006,12 +23981,6 @@
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
     },
-    "component-type": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/component-type/-/component-type-1.2.1.tgz",
-      "integrity": "sha512-Kgy+2+Uwr75vAi6ChWXgHuLvd+QLD7ssgpaRq2zCvt80ptvAfMc/hijcJxXkBa2wMlEZcJvC2H8Ubo+A9ATHIg==",
-      "dev": true
-    },
     "compressible": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
@@ -24103,26 +24072,6 @@
         "type-fest": "^4.0.0"
       },
       "dependencies": {
-        "axios": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
-          "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
-          "requires": {
-            "follow-redirects": "^1.15.0",
-            "form-data": "^4.0.0",
-            "proxy-from-env": "^1.1.0"
-          }
-        },
-        "form-data": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
-          }
-        },
         "type-fest": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.0.0.tgz",
@@ -24230,12 +24179,6 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
-    },
-    "crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
-      "dev": true
     },
     "crypto-random-string": {
       "version": "2.0.0",
@@ -24821,6 +24764,12 @@
         "react-is": "^17.0.2",
         "tslib": "^2.3.0"
       }
+    },
+    "dset": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.3.tgz",
+      "integrity": "sha512-20TuZZHCEZ2O71q9/+8BwKwZ0QtD9D8ObhrihJPr+vLLYlSuAU3/zL4cSlgbfeoGHTjCSJBa7NGcrF9/Bx/WJQ==",
+      "dev": true
     },
     "duplexer": {
       "version": "0.1.2",
@@ -26697,12 +26646,6 @@
         "has-tostringtag": "^1.0.0"
       }
     },
-    "is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
-    },
     "is-callable": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
@@ -26815,12 +26758,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
       "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
-    },
-    "is-retry-allowed": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
-      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
-      "dev": true
     },
     "is-root": {
       "version": "2.1.0",
@@ -28220,12 +28157,6 @@
         }
       }
     },
-    "join-component": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/join-component/-/join-component-1.1.0.tgz",
-      "integrity": "sha512-bF7vcQxbODoGK1imE2P9GS9aw4zD0Sd+Hni68IMZLj7zRnquH7dXUmMw9hDI5S/Jzt7q+IyTXN0rSg2GI0IKhQ==",
-      "dev": true
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -28572,17 +28503,6 @@
         "tmpl": "1.0.5"
       }
     },
-    "md5": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-      "dev": true,
-      "requires": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "~1.1.6"
-      }
-    },
     "mdn-data": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
@@ -28761,6 +28681,39 @@
       "requires": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
+      }
+    },
+    "node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+          "dev": true
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "dev": true,
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
       }
     },
     "node-forge": {
@@ -30511,12 +30464,6 @@
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk="
-    },
-    "remove-trailing-slash": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/remove-trailing-slash/-/remove-trailing-slash-0.1.1.tgz",
-      "integrity": "sha512-o4S4Qh6L2jpnCy83ysZDau+VORNvnFw07CKSAymkd6ICNVEPisMyzlc00KlvvicsxKck94SEwhDnMNdICzO+tA==",
-      "dev": true
     },
     "renderkid": {
       "version": "3.0.0",

--- a/examples/javascript/package.json
+++ b/examples/javascript/package.json
@@ -38,7 +38,7 @@
     ]
   },
   "devDependencies": {
-    "@contentful/app-scripts": "1.13.0",
+    "@contentful/app-scripts": "1.13.1",
     "@testing-library/jest-dom": "5.17.0",
     "@testing-library/react": "14.1.0",
     "cross-env": "7.0.3"

--- a/examples/typescript/package-lock.json
+++ b/examples/typescript/package-lock.json
@@ -19,7 +19,7 @@
         "react-scripts": "5.0.1"
       },
       "devDependencies": {
-        "@contentful/app-scripts": "1.13.0",
+        "@contentful/app-scripts": "1.13.1",
         "@testing-library/jest-dom": "5.17.0",
         "@testing-library/react": "14.1.0",
         "@tsconfig/create-react-app": "2.0.1",
@@ -1995,17 +1995,17 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
     "node_modules/@contentful/app-scripts": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@contentful/app-scripts/-/app-scripts-1.13.0.tgz",
-      "integrity": "sha512-d2lysudGLPN7vBO8UNcoVyEcUwaY3VMkIMpjKTgWPcyixhLBDWv29UNoAUqGZ6neKR7WVOu8c0BofaauCJaihg==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@contentful/app-scripts/-/app-scripts-1.13.1.tgz",
+      "integrity": "sha512-QrvV8RE0w8lnELU1tBFRTBynvh5R/tNdcXrXRyMu1x7dl2zKe8LdiPqyBs/Jhl8q/vj/17KhxXTQ5louEsv4LA==",
       "dev": true,
       "dependencies": {
+        "@segment/analytics-node": "^1.1.3",
         "adm-zip": "0.5.10",
-        "analytics-node": "^6.2.0",
         "bottleneck": "2.19.5",
         "chalk": "4.1.2",
-        "commander": "11.0.0",
-        "contentful-management": "10.40.1",
+        "commander": "11.1.0",
+        "contentful-management": "11.5.1",
         "dotenv": "16.3.1",
         "ignore": "5.2.4",
         "inquirer": "8.2.6",
@@ -2021,24 +2021,13 @@
         "npm": ">=6"
       }
     },
-    "node_modules/@contentful/app-scripts/node_modules/axios": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
-      "integrity": "sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==",
-      "dev": true,
-      "dependencies": {
-        "follow-redirects": "^1.15.0",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/@contentful/app-scripts/node_modules/contentful-management": {
-      "version": "10.40.1",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-10.40.1.tgz",
-      "integrity": "sha512-RVg1EcdceKG2V/vTwX4fP02ibkm2v/xTysipThUHe+b8aEYm4hDlCUlj6obWviBZIW7tQ8sadEj95DZwVfmhAA==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.5.1.tgz",
+      "integrity": "sha512-t3PN28A1p+qE5sGliiNiBljGtHcVQXCTMB3HVer5yRPMtqkzpINqzxl5qzFPKliY4i8lms2wMLUi5l4lWrcrAg==",
       "dev": true,
       "dependencies": {
-        "@contentful/rich-text-types": "^16.0.3",
+        "@contentful/rich-text-types": "^16.3.0",
         "@types/json-patch": "0.0.30",
         "axios": "^1.4.0",
         "contentful-sdk-core": "^8.1.0",
@@ -2047,21 +2036,7 @@
         "type-fest": "^4.0.0"
       },
       "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@contentful/app-scripts/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
+        "node": ">=18"
       }
     },
     "node_modules/@contentful/app-scripts/node_modules/ignore": {
@@ -2091,9 +2066,9 @@
       }
     },
     "node_modules/@contentful/app-scripts/node_modules/type-fest": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.3.1.tgz",
-      "integrity": "sha512-pphNW/msgOUSkJbH58x8sqpq8uQj6b0ZKGxEsLKMUnGorRcDjrUaLS+39+/ub41JNTwrrMyJcUB8+YZs3mbwqw==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.7.1.tgz",
+      "integrity": "sha512-iWr8RUmzAJRfhZugX9O7nZE6pCxDU8CZ3QxsLuTnGcBLJpCaP2ll3s4eMTBoFnU/CeXY/5rfQSuAEsTGJO4y8A==",
       "dev": true,
       "engines": {
         "node": ">=16"
@@ -3525,6 +3500,27 @@
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.3.tgz",
       "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
     },
+    "node_modules/@lukeed/csprng": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
+      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@lukeed/uuid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@lukeed/uuid/-/uuid-2.0.1.tgz",
+      "integrity": "sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==",
+      "dev": true,
+      "dependencies": {
+        "@lukeed/csprng": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3983,14 +3979,62 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.1.2.tgz",
       "integrity": "sha512-oe5WJEDaVsW8fBlGT7udrSCgOwWfoYHQOmSpnh8X+0GXpqqcRCP8k4y+Dxb0taWJDPpB+rdDUtumIiBwkY9qGA=="
     },
-    "node_modules/@segment/loosely-validate-event": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@segment/loosely-validate-event/-/loosely-validate-event-2.0.0.tgz",
-      "integrity": "sha512-ZMCSfztDBqwotkl848ODgVcAmN4OItEWDCkshcKz0/W6gGSQayuuCtWV/MlodFivAZD793d6UgANd6wCXUfrIw==",
+    "node_modules/@segment/analytics-core": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-core/-/analytics-core-1.3.2.tgz",
+      "integrity": "sha512-NpeBCfOyMdO2/BDKfhCUNHcEwxg88N2iTnswBoEMh38rtsQ03TWLVYwgiTakPjNQFezdKkR6jq3JhQ3WWgq67g==",
       "dev": true,
       "dependencies": {
-        "component-type": "^1.2.1",
-        "join-component": "^1.1.0"
+        "@lukeed/uuid": "^2.0.0",
+        "dset": "^3.1.2",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@segment/analytics-generic-utils": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-generic-utils/-/analytics-generic-utils-1.0.0.tgz",
+      "integrity": "sha512-rAqcIQESnCsc80DMAxH06C4sJQ1MjwRLrWsih9qA2E0XwxydrMYgLA8eazxLW/wqEdctSJHCPnkMynpPIQgatw==",
+      "dev": true
+    },
+    "node_modules/@segment/analytics-node": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-node/-/analytics-node-1.1.3.tgz",
+      "integrity": "sha512-RGmD/VIW4iHqY+raeHlxdGY/FQpE6ATZHU8LrbwI+16uvT+sfw8d725J/lmzJIgNScJ/NFLg3LyHjitwPpqTxw==",
+      "dev": true,
+      "dependencies": {
+        "@lukeed/uuid": "^2.0.0",
+        "@segment/analytics-core": "1.3.2",
+        "@segment/analytics-generic-utils": "1.0.0",
+        "buffer": "^6.0.3",
+        "node-fetch": "^2.6.7",
+        "tslib": "^2.4.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@segment/analytics-node/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -5339,25 +5383,6 @@
         }
       }
     },
-    "node_modules/analytics-node": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/analytics-node/-/analytics-node-6.2.0.tgz",
-      "integrity": "sha512-NLU4tCHlWt0tzEaFQL7NIoWhq2KmQSmz0JvyS2lYn6fc4fEjTMSabhJUx8H1r5995FX8fE3rZ15uIHU6u+ovlQ==",
-      "dev": true,
-      "dependencies": {
-        "@segment/loosely-validate-event": "^2.0.0",
-        "axios": "^0.27.2",
-        "axios-retry": "3.2.0",
-        "lodash.isstring": "^4.0.1",
-        "md5": "^2.2.1",
-        "ms": "^2.0.0",
-        "remove-trailing-slash": "^0.1.0",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -5612,29 +5637,19 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "dev": true,
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.1.tgz",
+      "integrity": "sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==",
       "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
-      }
-    },
-    "node_modules/axios-retry": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.2.0.tgz",
-      "integrity": "sha512-RK2cLMgIsAQBDhlIsJR5dOhODPigvel18XUv1dDXW+4k1FzebyfRk+C+orot6WPZOYFKSfhLwHPwVmTVOODQ5w==",
-      "dev": true,
-      "dependencies": {
-        "is-retry-allowed": "^1.1.0"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axios/node_modules/form-data": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -6333,15 +6348,6 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
-    "node_modules/charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/check-types": {
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/check-types/-/check-types-11.1.2.tgz",
@@ -6594,9 +6600,9 @@
       }
     },
     "node_modules/commander": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.0.0.tgz",
-      "integrity": "sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
       "dev": true,
       "engines": {
         "node": ">=16"
@@ -6619,12 +6625,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
-    },
-    "node_modules/component-type": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/component-type/-/component-type-1.2.1.tgz",
-      "integrity": "sha512-Kgy+2+Uwr75vAi6ChWXgHuLvd+QLD7ssgpaRq2zCvt80ptvAfMc/hijcJxXkBa2wMlEZcJvC2H8Ubo+A9ATHIg==",
-      "dev": true
     },
     "node_modules/compressible": {
       "version": "2.0.18",
@@ -6729,29 +6729,6 @@
       },
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/contentful-management/node_modules/axios": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
-      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
-      "dependencies": {
-        "follow-redirects": "^1.15.0",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/contentful-management/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/contentful-management/node_modules/type-fest": {
@@ -6904,15 +6881,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/crypto-random-string": {
@@ -7720,6 +7688,15 @@
       },
       "peerDependencies": {
         "react": ">=16.12.0"
+      }
+    },
+    "node_modules/dset": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.3.tgz",
+      "integrity": "sha512-20TuZZHCEZ2O71q9/+8BwKwZ0QtD9D8ObhrihJPr+vLLYlSuAU3/zL4cSlgbfeoGHTjCSJBa7NGcrF9/Bx/WJQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/duplexer": {
@@ -10109,12 +10086,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
-    },
     "node_modules/is-callable": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
@@ -10299,15 +10270,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
       "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-retry-allowed": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
-      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11435,12 +11397,6 @@
         }
       }
     },
-    "node_modules/join-component": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/join-component/-/join-component-1.1.0.tgz",
-      "integrity": "sha512-bF7vcQxbODoGK1imE2P9GS9aw4zD0Sd+Hni68IMZLj7zRnquH7dXUmMw9hDI5S/Jzt7q+IyTXN0rSg2GI0IKhQ==",
-      "dev": true
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -11823,17 +11779,6 @@
         "tmpl": "1.0.5"
       }
     },
-    "node_modules/md5": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-      "dev": true,
-      "dependencies": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "~1.1.6"
-      }
-    },
     "node_modules/mdn-data": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
@@ -12081,6 +12026,48 @@
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/node-forge": {
@@ -14574,12 +14561,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/remove-trailing-slash": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/remove-trailing-slash/-/remove-trailing-slash-0.1.1.tgz",
-      "integrity": "sha512-o4S4Qh6L2jpnCy83ysZDau+VORNvnFw07CKSAymkd6ICNVEPisMyzlc00KlvvicsxKck94SEwhDnMNdICzO+tA==",
-      "dev": true
     },
     "node_modules/renderkid": {
       "version": "3.0.0",
@@ -18597,17 +18578,17 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
     "@contentful/app-scripts": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@contentful/app-scripts/-/app-scripts-1.13.0.tgz",
-      "integrity": "sha512-d2lysudGLPN7vBO8UNcoVyEcUwaY3VMkIMpjKTgWPcyixhLBDWv29UNoAUqGZ6neKR7WVOu8c0BofaauCJaihg==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@contentful/app-scripts/-/app-scripts-1.13.1.tgz",
+      "integrity": "sha512-QrvV8RE0w8lnELU1tBFRTBynvh5R/tNdcXrXRyMu1x7dl2zKe8LdiPqyBs/Jhl8q/vj/17KhxXTQ5louEsv4LA==",
       "dev": true,
       "requires": {
+        "@segment/analytics-node": "^1.1.3",
         "adm-zip": "0.5.10",
-        "analytics-node": "^6.2.0",
         "bottleneck": "2.19.5",
         "chalk": "4.1.2",
-        "commander": "11.0.0",
-        "contentful-management": "10.40.1",
+        "commander": "11.1.0",
+        "contentful-management": "11.5.1",
         "dotenv": "16.3.1",
         "ignore": "5.2.4",
         "inquirer": "8.2.6",
@@ -18616,41 +18597,19 @@
         "ora": "5.4.1"
       },
       "dependencies": {
-        "axios": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
-          "integrity": "sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==",
-          "dev": true,
-          "requires": {
-            "follow-redirects": "^1.15.0",
-            "form-data": "^4.0.0",
-            "proxy-from-env": "^1.1.0"
-          }
-        },
         "contentful-management": {
-          "version": "10.40.1",
-          "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-10.40.1.tgz",
-          "integrity": "sha512-RVg1EcdceKG2V/vTwX4fP02ibkm2v/xTysipThUHe+b8aEYm4hDlCUlj6obWviBZIW7tQ8sadEj95DZwVfmhAA==",
+          "version": "11.5.1",
+          "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.5.1.tgz",
+          "integrity": "sha512-t3PN28A1p+qE5sGliiNiBljGtHcVQXCTMB3HVer5yRPMtqkzpINqzxl5qzFPKliY4i8lms2wMLUi5l4lWrcrAg==",
           "dev": true,
           "requires": {
-            "@contentful/rich-text-types": "^16.0.3",
+            "@contentful/rich-text-types": "^16.3.0",
             "@types/json-patch": "0.0.30",
             "axios": "^1.4.0",
             "contentful-sdk-core": "^8.1.0",
             "fast-copy": "^3.0.0",
             "lodash.isplainobject": "^4.0.6",
             "type-fest": "^4.0.0"
-          }
-        },
-        "form-data": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-          "dev": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
           }
         },
         "ignore": {
@@ -18671,9 +18630,9 @@
           }
         },
         "type-fest": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.3.1.tgz",
-          "integrity": "sha512-pphNW/msgOUSkJbH58x8sqpq8uQj6b0ZKGxEsLKMUnGorRcDjrUaLS+39+/ub41JNTwrrMyJcUB8+YZs3mbwqw==",
+          "version": "4.7.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.7.1.tgz",
+          "integrity": "sha512-iWr8RUmzAJRfhZugX9O7nZE6pCxDU8CZ3QxsLuTnGcBLJpCaP2ll3s4eMTBoFnU/CeXY/5rfQSuAEsTGJO4y8A==",
           "dev": true
         }
       }
@@ -19790,6 +19749,21 @@
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.3.tgz",
       "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg=="
     },
+    "@lukeed/csprng": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
+      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
+      "dev": true
+    },
+    "@lukeed/uuid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@lukeed/uuid/-/uuid-2.0.1.tgz",
+      "integrity": "sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==",
+      "dev": true,
+      "requires": {
+        "@lukeed/csprng": "^1.1.0"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -20033,14 +20007,47 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.1.2.tgz",
       "integrity": "sha512-oe5WJEDaVsW8fBlGT7udrSCgOwWfoYHQOmSpnh8X+0GXpqqcRCP8k4y+Dxb0taWJDPpB+rdDUtumIiBwkY9qGA=="
     },
-    "@segment/loosely-validate-event": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@segment/loosely-validate-event/-/loosely-validate-event-2.0.0.tgz",
-      "integrity": "sha512-ZMCSfztDBqwotkl848ODgVcAmN4OItEWDCkshcKz0/W6gGSQayuuCtWV/MlodFivAZD793d6UgANd6wCXUfrIw==",
+    "@segment/analytics-core": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-core/-/analytics-core-1.3.2.tgz",
+      "integrity": "sha512-NpeBCfOyMdO2/BDKfhCUNHcEwxg88N2iTnswBoEMh38rtsQ03TWLVYwgiTakPjNQFezdKkR6jq3JhQ3WWgq67g==",
       "dev": true,
       "requires": {
-        "component-type": "^1.2.1",
-        "join-component": "^1.1.0"
+        "@lukeed/uuid": "^2.0.0",
+        "dset": "^3.1.2",
+        "tslib": "^2.4.1"
+      }
+    },
+    "@segment/analytics-generic-utils": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-generic-utils/-/analytics-generic-utils-1.0.0.tgz",
+      "integrity": "sha512-rAqcIQESnCsc80DMAxH06C4sJQ1MjwRLrWsih9qA2E0XwxydrMYgLA8eazxLW/wqEdctSJHCPnkMynpPIQgatw==",
+      "dev": true
+    },
+    "@segment/analytics-node": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-node/-/analytics-node-1.1.3.tgz",
+      "integrity": "sha512-RGmD/VIW4iHqY+raeHlxdGY/FQpE6ATZHU8LrbwI+16uvT+sfw8d725J/lmzJIgNScJ/NFLg3LyHjitwPpqTxw==",
+      "dev": true,
+      "requires": {
+        "@lukeed/uuid": "^2.0.0",
+        "@segment/analytics-core": "1.3.2",
+        "@segment/analytics-generic-utils": "1.0.0",
+        "buffer": "^6.0.3",
+        "node-fetch": "^2.6.7",
+        "tslib": "^2.4.1"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        }
       }
     },
     "@sinclair/typebox": {
@@ -21099,22 +21106,6 @@
         "ajv": "^8.0.0"
       }
     },
-    "analytics-node": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/analytics-node/-/analytics-node-6.2.0.tgz",
-      "integrity": "sha512-NLU4tCHlWt0tzEaFQL7NIoWhq2KmQSmz0JvyS2lYn6fc4fEjTMSabhJUx8H1r5995FX8fE3rZ15uIHU6u+ovlQ==",
-      "dev": true,
-      "requires": {
-        "@segment/loosely-validate-event": "^2.0.0",
-        "axios": "^0.27.2",
-        "axios-retry": "3.2.0",
-        "lodash.isstring": "^4.0.1",
-        "md5": "^2.2.1",
-        "ms": "^2.0.0",
-        "remove-trailing-slash": "^0.1.0",
-        "uuid": "^8.3.2"
-      }
-    },
     "ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -21286,35 +21277,25 @@
       "integrity": "sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw=="
     },
     "axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "dev": true,
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.1.tgz",
+      "integrity": "sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==",
       "requires": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       },
       "dependencies": {
         "form-data": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
           "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-          "dev": true,
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.8",
             "mime-types": "^2.1.12"
           }
         }
-      }
-    },
-    "axios-retry": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.2.0.tgz",
-      "integrity": "sha512-RK2cLMgIsAQBDhlIsJR5dOhODPigvel18XUv1dDXW+4k1FzebyfRk+C+orot6WPZOYFKSfhLwHPwVmTVOODQ5w==",
-      "dev": true,
-      "requires": {
-        "is-retry-allowed": "^1.1.0"
       }
     },
     "axobject-query": {
@@ -21827,12 +21808,6 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
-    "charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
-      "dev": true
-    },
     "check-types": {
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/check-types/-/check-types-11.1.2.tgz",
@@ -22028,9 +22003,9 @@
       }
     },
     "commander": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.0.0.tgz",
-      "integrity": "sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
       "dev": true
     },
     "common-path-prefix": {
@@ -22047,12 +22022,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
-    },
-    "component-type": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/component-type/-/component-type-1.2.1.tgz",
-      "integrity": "sha512-Kgy+2+Uwr75vAi6ChWXgHuLvd+QLD7ssgpaRq2zCvt80ptvAfMc/hijcJxXkBa2wMlEZcJvC2H8Ubo+A9ATHIg==",
-      "dev": true
     },
     "compressible": {
       "version": "2.0.18",
@@ -22143,26 +22112,6 @@
         "type-fest": "^4.0.0"
       },
       "dependencies": {
-        "axios": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
-          "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
-          "requires": {
-            "follow-redirects": "^1.15.0",
-            "form-data": "^4.0.0",
-            "proxy-from-env": "^1.1.0"
-          }
-        },
-        "form-data": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
-          }
-        },
         "type-fest": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.0.0.tgz",
@@ -22277,12 +22226,6 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
-    },
-    "crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
-      "dev": true
     },
     "crypto-random-string": {
       "version": "2.0.0",
@@ -22870,6 +22813,12 @@
         "react-is": "^17.0.2",
         "tslib": "^2.3.0"
       }
+    },
+    "dset": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.3.tgz",
+      "integrity": "sha512-20TuZZHCEZ2O71q9/+8BwKwZ0QtD9D8ObhrihJPr+vLLYlSuAU3/zL4cSlgbfeoGHTjCSJBa7NGcrF9/Bx/WJQ==",
+      "dev": true
     },
     "duplexer": {
       "version": "0.1.2",
@@ -24626,12 +24575,6 @@
         "has-tostringtag": "^1.0.0"
       }
     },
-    "is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
-    },
     "is-callable": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
@@ -24744,12 +24687,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
       "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
-    },
-    "is-retry-allowed": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
-      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
-      "dev": true
     },
     "is-root": {
       "version": "2.1.0",
@@ -25598,12 +25535,6 @@
         }
       }
     },
-    "join-component": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/join-component/-/join-component-1.1.0.tgz",
-      "integrity": "sha512-bF7vcQxbODoGK1imE2P9GS9aw4zD0Sd+Hni68IMZLj7zRnquH7dXUmMw9hDI5S/Jzt7q+IyTXN0rSg2GI0IKhQ==",
-      "dev": true
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -25899,17 +25830,6 @@
         "tmpl": "1.0.5"
       }
     },
-    "md5": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-      "dev": true,
-      "requires": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "~1.1.6"
-      }
-    },
     "mdn-data": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
@@ -26088,6 +26008,39 @@
       "requires": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
+      }
+    },
+    "node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+          "dev": true
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "dev": true,
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
       }
     },
     "node-forge": {
@@ -27756,12 +27709,6 @@
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk="
-    },
-    "remove-trailing-slash": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/remove-trailing-slash/-/remove-trailing-slash-0.1.1.tgz",
-      "integrity": "sha512-o4S4Qh6L2jpnCy83ysZDau+VORNvnFw07CKSAymkd6ICNVEPisMyzlc00KlvvicsxKck94SEwhDnMNdICzO+tA==",
-      "dev": true
     },
     "renderkid": {
       "version": "3.0.0",

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -38,7 +38,7 @@
     ]
   },
   "devDependencies": {
-    "@contentful/app-scripts": "1.13.0",
+    "@contentful/app-scripts": "1.13.1",
     "@testing-library/jest-dom": "5.17.0",
     "@testing-library/react": "14.1.0",
     "@tsconfig/create-react-app": "2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1573,9 +1573,9 @@
       }
     },
     "node_modules/@sentry/cli": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.21.3.tgz",
-      "integrity": "sha512-gv8SNaMVNggiE/+6fPxEj8+y5uj9PqAQ8QS277aZ/HSXFgoidnNecE4QGHh4n+AkT0qCSQ/byxZsojVXkwkC7g==",
+      "version": "2.21.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.21.5.tgz",
+      "integrity": "sha512-RqKBqE10pb7zh0G/YiYVdX/MqenDYIgLGcaCqbszTAfW2SSLyp9EczsnmHtRgO1fO1OQq76+gaK7UdC1TEIGqQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -10262,9 +10262,9 @@
       "optional": true
     },
     "@sentry/cli": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.21.3.tgz",
-      "integrity": "sha512-gv8SNaMVNggiE/+6fPxEj8+y5uj9PqAQ8QS277aZ/HSXFgoidnNecE4QGHh4n+AkT0qCSQ/byxZsojVXkwkC7g==",
+      "version": "2.21.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.21.5.tgz",
+      "integrity": "sha512-RqKBqE10pb7zh0G/YiYVdX/MqenDYIgLGcaCqbszTAfW2SSLyp9EczsnmHtRgO1fO1OQq76+gaK7UdC1TEIGqQ==",
       "dev": true,
       "requires": {
         "https-proxy-agent": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "prettier": "^2.8.8"
   },
   "scripts": {
-    "bootstrap": "lerna bootstrap --no-ci --since master --include-dependencies",
+    "bootstrap": "lerna bootstrap --no-ci --include-dependencies",
     "bootstrap:ci": "lerna bootstrap --ci --concurrency=1 --since master --include-dependencies",
     "bootstrap:ci-deploy": "lerna bootstrap --ci --concurrency=1",
     "clean": "lerna clean",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "prettier": "^2.8.8"
   },
   "scripts": {
-    "bootstrap": "lerna bootstrap --no-ci --include-dependencies",
+    "bootstrap": "lerna bootstrap --no-ci --since master --include-dependencies",
     "bootstrap:ci": "lerna bootstrap --ci --concurrency=1 --since master --include-dependencies",
     "bootstrap:ci-deploy": "lerna bootstrap --ci --concurrency=1",
     "clean": "lerna clean",


### PR DESCRIPTION
## Purpose

This fixes a bug with perpetual auth call out for smartling sidebar app, users were required to re-auth everytime they navigated away from content or configuration. 

We were overwriting tokens in local storage with OR `||` logic for component state, this implicitly sets tokens to null and forces a refresh, or the per usual initial auth flow.