### PR TITLE
Update null check and persist to localstorage properly

### DIFF
--- a/apps/smartling/frontend/src/Sidebar.tsx
+++ b/apps/smartling/frontend/src/Sidebar.tsx
@@ -23,8 +23,8 @@ interface Props {
 
 interface State {
   smartlingEntry: SmartlingContentfulEntry | null;
-  token: string;
-  refreshToken: string;
+  token: string | null;
+  refreshToken: string | null;
   showAllSubs: boolean;
   generalError: boolean;
 }
@@ -156,8 +156,8 @@ function formatSmartlingEntry(entry: SmartlingContentfulEntry): SmartlingContent
 export default class Sidebar extends React.Component<Props, State> {
   state: State = {
     smartlingEntry: null,
-    token: window.localStorage.getItem('token') || '',
-    refreshToken: window.localStorage.getItem('refreshToken') || '',
+    token: window.localStorage.getItem('token') ?? null,
+    refreshToken: window.localStorage.getItem('refreshToken') ?? null,
     showAllSubs: false,
     generalError: false,
   };
@@ -169,10 +169,10 @@ export default class Sidebar extends React.Component<Props, State> {
   }
 
   runAuthFlow = async (tryRefreshOnly = false) => {
-    const refresh = await smartlingClient.refresh(this.state.refreshToken);
+    const refresh = await smartlingClient.refresh(this.state.refreshToken as string);
 
     if (tryRefreshOnly && refresh.failed) {
-      this.setState({ token: '', refreshToken: '' });
+      this.setState({ token: null, refreshToken: null });
     } else if (refresh.failed) {
       const smartlingWindow = window.open('/openauth', '', 'height=600,width=600,top=50,left=50');
 
@@ -185,6 +185,9 @@ export default class Sidebar extends React.Component<Props, State> {
 
         if (token) {
           this.setState({ token, refreshToken }, this.getJobs);
+
+          window.localStorage.setItem('token', token);
+          window.localStorage.setItem('refreshToken', refreshToken);
 
           if (smartlingWindow) {
             smartlingWindow.close();
@@ -204,7 +207,17 @@ export default class Sidebar extends React.Component<Props, State> {
     const { sdk, projectId } = this.props;
     const { token } = this.state;
 
-    const res = await smartlingClient.getLinkedJobs(token, sdk.ids.space, projectId, sdk.ids.entry);
+    if (!token) {
+      this.runAuthFlow(true);
+      return;
+    }
+
+    const res = await smartlingClient.getLinkedJobs(
+      token!,
+      sdk.ids.space,
+      projectId,
+      sdk.ids.entry
+    );
 
     if (res.code === 'AUTHENTICATION_ERROR') {
       this.runAuthFlow(true);

--- a/apps/smartling/frontend/src/Sidebar.tsx
+++ b/apps/smartling/frontend/src/Sidebar.tsx
@@ -212,12 +212,7 @@ export default class Sidebar extends React.Component<Props, State> {
       return;
     }
 
-    const res = await smartlingClient.getLinkedJobs(
-      token!,
-      sdk.ids.space,
-      projectId,
-      sdk.ids.entry
-    );
+    const res = await smartlingClient.getLinkedJobs(token, sdk.ids.space, projectId, sdk.ids.entry);
 
     if (res.code === 'AUTHENTICATION_ERROR') {
       this.runAuthFlow(true);


### PR DESCRIPTION
## Purpose

This fixes a bug with perpetual auth call out for smartling sidebar app, users were required to re-auth everytime they navigated away from content or configuration.

We were overwriting tokens in local storage with OR || logic for component state, this implicitly sets tokens to null and forces a refresh, or the per usual initial auth flow.