### PR TITLE
feat: add delete confirmation modal [INTEG-1449]

### DIFF
--- a/apps/microsoft-teams/frontend/src/components/config/DeleteModal/DeleteModal.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/DeleteModal/DeleteModal.spec.tsx
@@ -1,0 +1,12 @@
+import DeleteModal from './DeleteModal';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { editModeFooter } from '@constants/configCopy';
+
+describe('DeleteModal component', () => {
+  it('mounts and renders the correct content', () => {
+    render(<DeleteModal isShown={true} handleCancel={vi.fn()} handleDelete={vi.fn()} />);
+
+    expect(screen.getByText(editModeFooter.confirmDelete)).toBeTruthy();
+  });
+});

--- a/apps/microsoft-teams/frontend/src/components/config/DeleteModal/DeleteModal.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/DeleteModal/DeleteModal.tsx
@@ -1,0 +1,25 @@
+import { ModalConfirm, Text } from '@contentful/f36-components';
+import { editModeFooter } from '@constants/configCopy';
+
+interface Props {
+  isShown: boolean;
+  handleCancel: () => void;
+  handleDelete: () => void;
+}
+
+const DeleteModal = (props: Props) => {
+  const { isShown, handleCancel, handleDelete } = props;
+
+  return (
+    <ModalConfirm
+      intent="negative"
+      isShown={isShown}
+      onCancel={handleCancel}
+      onConfirm={handleDelete}
+      confirmLabel={editModeFooter.delete}>
+      <Text>{editModeFooter.confirmDelete}</Text>
+    </ModalConfirm>
+  );
+};
+
+export default DeleteModal;

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.tsx
@@ -1,9 +1,10 @@
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
-import { Box } from '@contentful/f36-components';
+import { Box, ModalLauncher } from '@contentful/f36-components';
 import ContentTypeSelection from '@components/config/ContentTypeSelection/ContentTypeSelection';
 import ChannelSelection from '@components/config/ChannelSelection/ChannelSelection';
 import EventsSelection from '@components/config/EventsSelection/EventsSelection';
 import NotificationEditModeFooter from '@components/config/NotificationEditModeFooter/NotificationEditModeFooter';
+import DeleteModal from '@components/config/DeleteModal/DeleteModal';
 import { styles } from './NotificationEditMode.styles';
 import { Notification } from '@customTypes/configPage';
 import { ContentTypeProps } from 'contentful-management';
@@ -39,8 +40,21 @@ const NotificationEditMode = (props: Props) => {
   };
 
   const handleDelete = () => {
-    deleteNotification(index);
-    setNotificationIndexToEdit(null);
+    ModalLauncher.open(({ isShown, onClose }) => {
+      return (
+        <DeleteModal
+          isShown={isShown}
+          handleCancel={() => {
+            onClose(true);
+          }}
+          handleDelete={() => {
+            onClose(true);
+            deleteNotification(index);
+            setNotificationIndexToEdit(null);
+          }}
+        />
+      );
+    });
   };
 
   const handleSave = () => {

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationEditModeFooter/NotificationEditModeFooter.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationEditModeFooter/NotificationEditModeFooter.tsx
@@ -18,7 +18,6 @@ const NotificationEditModeFooter = (props: Props) => {
       <Flex justifyContent="flex-end" margin="spacingS">
         <ButtonGroup variant="spaced" spacing="spacingS">
           <Button variant="transparent">{editModeFooter.test}</Button>
-          {/* TODO: implement modal to confirm deletion */}
           <Button variant="negative" onClick={handleDelete}>
             {editModeFooter.delete}
           </Button>

--- a/apps/microsoft-teams/frontend/src/constants/configCopy.ts
+++ b/apps/microsoft-teams/frontend/src/constants/configCopy.ts
@@ -82,6 +82,8 @@ const eventsSelection = {
 const editModeFooter = {
   test: 'Test',
   delete: 'Delete',
+  confirmDelete:
+    'If you delete this notification you will no longer get updates about this content type in Microsoft Teams.',
   cancel: 'Cancel',
   save: 'Save',
 };


### PR DESCRIPTION
## Purpose

This PR adds the confirmation modal when a user tries to delete a notification.

## Approach

This is the confirmation modal that appears when a user clicks Delete for a notification.
![Screenshot 2023-11-27 at 9 31 13 AM](https://github.com/contentful/apps/assets/62958907/1e7dcf42-b5da-473e-8193-c1d7714f78ab)

## Testing steps

Delete a notification in the MS Teams (development) environment. 

## Breaking Changes

## Dependencies and/or References

## Deployment
