### PR TITLE
feat: add empty state for content type selection [INTEG-1579]

### DIFF
--- a/apps/microsoft-teams/frontend/package-lock.json
+++ b/apps/microsoft-teams/frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@contentful/microsoft-teams-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@contentful/app-sdk": "4.22.0",
+        "@contentful/app-sdk": "^4.23.1",
         "@contentful/f36-components": "4.45.0",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "4.0.2",
@@ -558,9 +558,9 @@
       }
     },
     "node_modules/@contentful/app-sdk": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.22.0.tgz",
-      "integrity": "sha512-ljXNwqdCA1GCsD32SKGcUpLnuQAmAHSyW9ebHw185UBwNgqM02n20tODWftUYH94TlPiQnQmqDSDFX7TGRYW2g==",
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.23.1.tgz",
+      "integrity": "sha512-bDl3gz2Hw/7c+3yCkvs81/PO7c4WAv6xXGA6gCg2xWnkjrVvg5zMkGZxASzaqazevtikWg3fm5ktN5qfAT/iQQ==",
       "dependencies": {
         "contentful-management": ">=7.30.0"
       }
@@ -8359,9 +8359,9 @@
       }
     },
     "@contentful/app-sdk": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.22.0.tgz",
-      "integrity": "sha512-ljXNwqdCA1GCsD32SKGcUpLnuQAmAHSyW9ebHw185UBwNgqM02n20tODWftUYH94TlPiQnQmqDSDFX7TGRYW2g==",
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.23.1.tgz",
+      "integrity": "sha512-bDl3gz2Hw/7c+3yCkvs81/PO7c4WAv6xXGA6gCg2xWnkjrVvg5zMkGZxASzaqazevtikWg3fm5ktN5qfAT/iQQ==",
       "requires": {
         "contentful-management": ">=7.30.0"
       }

--- a/apps/microsoft-teams/frontend/package.json
+++ b/apps/microsoft-teams/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@contentful/app-sdk": "4.22.0",
+    "@contentful/app-sdk": "^4.23.1",
     "@contentful/f36-components": "4.45.0",
     "@contentful/f36-icons": "^4.27.0",
     "@contentful/f36-tokens": "4.0.2",

--- a/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelection/ContentTypeSelection.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelection/ContentTypeSelection.spec.tsx
@@ -11,6 +11,7 @@ describe('ContentTypeSelection component', () => {
         notification={defaultNotification}
         handleNotificationEdit={vi.fn()}
         contentTypes={[]}
+        contentTypeConfigLink=""
       />
     );
 
@@ -24,6 +25,7 @@ describe('ContentTypeSelection component', () => {
         notification={{ ...defaultNotification, contentTypeId: 'blogPost' }}
         handleNotificationEdit={vi.fn()}
         contentTypes={[]}
+        contentTypeConfigLink=""
       />
     );
 

--- a/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelection/ContentTypeSelection.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelection/ContentTypeSelection.spec.tsx
@@ -1,18 +1,16 @@
 import ContentTypeSelection from './ContentTypeSelection';
 import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { contentTypeSelection } from '@constants/configCopy';
 import { defaultNotification } from '@constants/defaultParams';
+import { ContentTypeCustomRender } from '@test/helpers/ContentTypeCustomRender';
 
 describe('ContentTypeSelection component', () => {
   it('mounts and renders the correct title and button copy when no content type is selected', () => {
-    const { unmount } = render(
+    const { unmount } = ContentTypeCustomRender(
       <ContentTypeSelection
         notification={defaultNotification}
-        handleNotificationEdit={vi.fn()}
-        contentTypes={[]}
-        contentTypeConfigLink=""
-      />
+        handleNotificationEdit={vi.fn()}></ContentTypeSelection>
     );
 
     expect(screen.getByText(contentTypeSelection.title)).toBeTruthy();
@@ -20,13 +18,10 @@ describe('ContentTypeSelection component', () => {
     unmount();
   });
   it('mounts and renders an input when a content type is selected', () => {
-    const { unmount } = render(
+    const { unmount } = ContentTypeCustomRender(
       <ContentTypeSelection
         notification={{ ...defaultNotification, contentTypeId: 'blogPost' }}
-        handleNotificationEdit={vi.fn()}
-        contentTypes={[]}
-        contentTypeConfigLink=""
-      />
+        handleNotificationEdit={vi.fn()}></ContentTypeSelection>
     );
 
     expect(screen.getByRole('textbox')).toBeTruthy();

--- a/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelection/ContentTypeSelection.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelection/ContentTypeSelection.tsx
@@ -1,3 +1,4 @@
+import { useContext } from 'react';
 import { Box, Flex, IconButton, ModalLauncher, Text, TextInput } from '@contentful/f36-components';
 import AddButton from '@components/config/AddButton/AddButton';
 import ContentTypeSelectionModal from '@components/config/ContentTypeSelectionModal/ContentTypeSelectionModal';
@@ -6,18 +7,17 @@ import { contentTypeSelection } from '@constants/configCopy';
 import { Notification } from '@customTypes/configPage';
 import { EditIcon } from '@contentful/f36-icons';
 import { styles } from './ContentTypeSelection.styles';
-import { ContentTypeProps } from 'contentful-management';
 import { getContentTypeName } from '@helpers/configHelpers';
+import { ContentTypeContext } from '@context/ContentTypeProvider';
 
 interface Props {
   notification: Notification;
   handleNotificationEdit: (notificationEdit: Partial<Notification>) => void;
-  contentTypes: ContentTypeProps[];
-  contentTypeConfigLink: string;
 }
 
 const ContentTypeSelection = (props: Props) => {
-  const { notification, handleNotificationEdit, contentTypes, contentTypeConfigLink } = props;
+  const { notification, handleNotificationEdit } = props;
+  const { contentTypes, contentTypeConfigLink } = useContext(ContentTypeContext);
 
   const openContentTypeSelectionModal = () => {
     return ModalLauncher.open(({ isShown, onClose }) => (

--- a/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelection/ContentTypeSelection.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelection/ContentTypeSelection.tsx
@@ -13,10 +13,11 @@ interface Props {
   notification: Notification;
   handleNotificationEdit: (notificationEdit: Partial<Notification>) => void;
   contentTypes: ContentTypeProps[];
+  contentTypeConfigLink: string;
 }
 
 const ContentTypeSelection = (props: Props) => {
-  const { notification, handleNotificationEdit, contentTypes } = props;
+  const { notification, handleNotificationEdit, contentTypes, contentTypeConfigLink } = props;
 
   const openContentTypeSelectionModal = () => {
     return ModalLauncher.open(({ isShown, onClose }) => (
@@ -28,6 +29,7 @@ const ContentTypeSelection = (props: Props) => {
         handleNotificationEdit={handleNotificationEdit}
         savedContentTypeId={notification.contentTypeId}
         contentTypes={contentTypes}
+        contentTypeConfigLink={contentTypeConfigLink}
       />
     ));
   };

--- a/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelectionModal/ContentTypeSelectionModal.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelectionModal/ContentTypeSelectionModal.spec.tsx
@@ -12,6 +12,7 @@ describe('ContentTypeSelectionModal component', () => {
         savedContentTypeId=""
         handleNotificationEdit={vi.fn()}
         contentTypes={[]}
+        contentTypeConfigLink=""
       />
     );
 

--- a/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelectionModal/ContentTypeSelectionModal.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelectionModal/ContentTypeSelectionModal.tsx
@@ -5,6 +5,8 @@ import { styles } from './ContentTypeSelectionModal.styles';
 import { Notification } from '@customTypes/configPage';
 import ModalHeader from '@components/config/ModalHeader/ModalHeader';
 import { ContentTypeProps } from 'contentful-management';
+import EmptyState from '@components/config/EmptyState/EmptyState';
+import WebApp from '@components/config/EmptyState/WebApp';
 
 interface Props {
   isShown: boolean;
@@ -12,37 +14,57 @@ interface Props {
   savedContentTypeId: string;
   handleNotificationEdit: (notificationEdit: Partial<Notification>) => void;
   contentTypes: ContentTypeProps[];
+  contentTypeConfigLink: string;
 }
 
 const ContentTypeSelectionModal = (props: Props) => {
-  const { isShown, onClose, savedContentTypeId, handleNotificationEdit, contentTypes } = props;
+  const {
+    isShown,
+    onClose,
+    savedContentTypeId,
+    handleNotificationEdit,
+    contentTypes,
+    contentTypeConfigLink,
+  } = props;
 
   const [selectedContentTypeId, setSelectedContentTypeId] = useState(savedContentTypeId ?? '');
+
+  const { title, button, link, emptyContent, emptyHeading } = contentTypeSelection.modal;
 
   return (
     <Modal onClose={onClose} isShown={isShown} size="large">
       {() => (
         <>
-          <ModalHeader title={contentTypeSelection.modal.title} onClose={onClose} />
+          <ModalHeader title={title} onClose={onClose} />
           <Modal.Content>
-            <FormControl as="fieldset" marginBottom="none">
-              <Table className={styles.table}>
-                <Table.Body>
-                  {contentTypes.map((contentType) => (
-                    <Table.Row key={contentType.sys.id}>
-                      <Table.Cell>
-                        <Radio
-                          id={contentType.sys.id}
-                          isChecked={selectedContentTypeId === contentType.sys.id}
-                          onChange={() => setSelectedContentTypeId(contentType.sys.id)}>
-                          {contentType.name}
-                        </Radio>
-                      </Table.Cell>
-                    </Table.Row>
-                  ))}
-                </Table.Body>
-              </Table>
-            </FormControl>
+            {contentTypes.length ? (
+              <FormControl as="fieldset" marginBottom="none">
+                <Table className={styles.table}>
+                  <Table.Body>
+                    {contentTypes.map((contentType) => (
+                      <Table.Row key={contentType.sys.id}>
+                        <Table.Cell>
+                          <Radio
+                            id={contentType.sys.id}
+                            isChecked={selectedContentTypeId === contentType.sys.id}
+                            onChange={() => setSelectedContentTypeId(contentType.sys.id)}>
+                            {contentType.name}
+                          </Radio>
+                        </Table.Cell>
+                      </Table.Row>
+                    ))}
+                  </Table.Body>
+                </Table>
+              </FormControl>
+            ) : (
+              <EmptyState
+                image={<WebApp />}
+                heading={emptyHeading}
+                body={emptyContent}
+                linkSubstring={link}
+                linkHref={contentTypeConfigLink}
+              />
+            )}
           </Modal.Content>
           <Modal.Controls>
             <Button
@@ -53,7 +75,7 @@ const ContentTypeSelectionModal = (props: Props) => {
                 onClose();
               }}
               isDisabled={!selectedContentTypeId}>
-              {contentTypeSelection.modal.button}
+              {button}
             </Button>
           </Modal.Controls>
         </>

--- a/apps/microsoft-teams/frontend/src/components/config/EmptyState/EmptyState.styles.ts
+++ b/apps/microsoft-teams/frontend/src/components/config/EmptyState/EmptyState.styles.ts
@@ -1,0 +1,7 @@
+import { css } from 'emotion';
+
+export const styles = {
+  emptyContent: css({
+    textAlign: 'center',
+  }),
+};

--- a/apps/microsoft-teams/frontend/src/components/config/EmptyState/EmptyState.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/EmptyState/EmptyState.tsx
@@ -1,5 +1,6 @@
-import { Flex, Subheading } from '@contentful/f36-components';
+import { Box, Flex, Subheading } from '@contentful/f36-components';
 import { HyperLink } from '@contentful/integration-component-library';
+import { styles } from './EmptyState.styles';
 
 interface Props {
   image: JSX.Element;
@@ -16,7 +17,9 @@ const EmptyState = (props: Props) => {
     <Flex flexDirection="column" alignItems="center">
       {image}
       <Subheading>{heading}</Subheading>
-      <HyperLink body={body} substring={linkSubstring} href={linkHref} />
+      <Box className={styles.emptyContent}>
+        <HyperLink body={body} substring={linkSubstring} href={linkHref} />
+      </Box>
     </Flex>
   );
 };

--- a/apps/microsoft-teams/frontend/src/components/config/EmptyState/WebApp.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/EmptyState/WebApp.tsx
@@ -1,0 +1,26 @@
+const WebApp = () => {
+  return (
+    <svg
+      width="128"
+      height="120"
+      viewBox="0 0 128 120"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      xmlnsXlink="http://www.w3.org/1999/xlink">
+      <rect width="127.164" height="120" fill="url(#pattern0)" />
+      <defs>
+        <pattern id="pattern0" patternContentUnits="objectBoundingBox" width="1" height="1">
+          <use xlinkHref="#image0_484_37604" transform="scale(0.00469484 0.00497512)" />
+        </pattern>
+        <image
+          id="image0_484_37604"
+          width="213"
+          height="201"
+          xlinkHref="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAANUAAADJCAYAAAC0VHdjAAAACXBIWXMAAAsSAAALEgHS3X78AAAK20lEQVR4nO3dQWwcVx3H8d/ueh17a8dOY9q4KcQkmFDRqqWAWiHaROqliErkliPhjtRKFVIPuEL1BalUDYdyAQlXIERVDkFCAvWCgxAXBDWglra01KWkDa1p7dixnax3B/3XThMS7+xM9j8zb5PvR7IS2bv7Zmfnt+/Nm/felKIoEgA/ZfYl4ItQAc4IFeCMUAHOCBXgjFABzggV4IxQAc4IFeCMUAHOCBXgjFABzggV4IxQAc4IFeCMUAHOCBXgjFABzggV4IxQAc4IFeCMUAHOCBXgjFABzggV4IxQAc4IFeCMUAHOCBXgjFABzggV4IxQAc4IFeCMUAHOCBXgjFABzggV4IxQAc4IFeCMUAHOCBXgjFABzggV4IxQAc4IFeCMUAHOCBXgrC/PHVqa0qikI5Im+CCDZJ/PXUVuWLmkoW6OyyjSSiRtdHjYrKSZaFrzV1tOnFIURVm87hVKU60P64SkfbkUCMRbkvRINK0Z7/2UZ/OPQCEkI5KOb7WeXOUSqtJUq8lHoBAaC9Yx723Kq6YqtJ0OxOjNmgq4nhAqwFmuXerbqVakxltvF1Z+edeoVK0WVj6603zv/UTPb96yVyrnU4cUHqqRQWnh9dcLK7+5b79Uu6Gw8tGlpMfOzXtyC1Vwzb/RgbM6/s1PaP75e7T46y9r5rEDrd8BvSKXUJVLGkj0wPqiZqY+r4ePHtBvS1X9eEk69MCtmv3Bfa2/Ad4qZf/ev1yaf5Wy9jQbnR83MV7T1+4f13MvPa/vzt+meyc/pflzTR2fHNGRQ+M68Ye1PDa3pVwuqTqQfPc0G5Hq57YfHVPd0adypZT4terrG2o2tx/pUqlW1FdN/l24UW+qUU+w869Tdmx6v/PcQpXkc7VQmaPDz+joPYelse989Le7JkdzDdXo+LAGhvpTPeeDU2e0vnL+/35ngfrYRLovQ3sNe63t2GtZ4JOycL4/v0iw2qiUejRUJSVr/s2/u7r5n59NSt9+Wrr9dUuadOJJzf0j3+afHdhpDl7TqDe3+V0j9Wu1q/HM2tJ6K6hJWaiixpXbhewU3vt3qfmFfn3/uTf08GM/lB78ljT3mnTsIZ18cSHXWsqsLq23frplB3W7WudqLL1Hp03oggqVeeTpv2rutUUde2ifdOe9mv3RKzr+nHWb0u2N3hBcqFQd1cwLZzTzwt8u+SWBQu8IIlTDn/lkYWWXd+9SaceOwspHd5r9Bzs/P5KWyyXlM3MwmFAxERhXaectiZ63stSaFZwLBtQCzsI7pwIu06xvaPHPf2/920l1ZEgjd0wWuguDDdXBMWk4xanO8jnp1QW/8q1s24ZLNTcaapy92LV/arHZ+onTVxtQpbZ5me5W9wExndklr/dX8i/XiwXpv79/UfWlZG/i/MKiovqGRu++rbBtDjZUPz+a/jmfe8av/CcekA5f0X9SkVqL/Wz63k/m9eSv3ox9nXK1T3u+ep/uvlU6dMBv+9L46Z96N1gWpqSBumD1X6cJ1XZm30xfU3myWu/y8qONhjYuqaneOVtS/1h89WPNEfP2ovTvAsYEW011pvtr2IWx/Wc/aYJVZKCU1xJltSc0u1bXoe3+NjYk9XNmhxjWBDz7RrKJrNWRYQ2Mj13x+9NL0nZjlAerOrn6uA577n8OZwTPmtBFXstMiy51wFkQNdWXPl5MuTbY+8CYtHOwmPKRn8d/I62ez6e4IEK1u1Zc2Tt3SJ++sgmOa0y6STzdofkHOCNUgDNCBTijS70Nmxkft6yDrQmTcrZ9Llbr7UuxtWdSzMTfVqf9UuuwLmm3z78g7n3aAq0p1sZxR6jaOL0S/8HtHpTGCuxg2Y5t79sdZu4f3N1dGZ32y003SLtiViTp9vnmw3UpblUB+7KbvDH+NbJEqNqwD3YwZu8Mp1toKRdWe+6OuTxQcfj27rRfah2OqE7PH0kwNM0eE7eWTYqV5TJBqNqw1clSrlBWOPuGzrr27Ha/eOzXPN5nN+ioAJwFW1Mtrza0vJp8vbrhWlnDtUqm2wQkEWyofnFyUefryUfQ91dL+sZXujwLBxwEG6ovHKzpXIpQjY1weogwBHsk3rGfUa7oTXRUAM4IFeCMUAHOCBXgjFABzggV4KzwLvU2t7YNwvkN6QPusRa01jjA4bCm4RQeqnZza2yKQLsbGdp8mf27Mt2sVqDarRWHsLy7KI2PhhOsYC/+/vFU58dkGayNJoHqFY2tzyqUUPXsOVXWN1uv9W+unouwWZD2jEh9AR3JwdZUNh16m5u9X/x7DgPShwY2f4A0gg3V/RPSWtx09oAnqeH6FmyobAGQpIuAACHhOhXgjFABzggV4IzpsjHsAnBed4rA1bEu9dDu2hJsqP75Yfy1qP03ZrsKKSMqeod9VjZUKRTBhuql9zo/5vK7x3tarxOoXmGtCRsBE8oFYM6p2rAmxVCKG3mjGIyoSKHTiIqRHEY6WJOCERVh66uEFSiFHKoHJwPYCFuXmwvQSInmH+CMUAHOCBXgjFABzhhREcOuU51ZC3bzwIiKdOzi79K59k+5/SZpZ4bXkSxQtvZB1jOM0T1GVCRkw5TivLucbahW1glUr1g5t1lb9QdyNHNO1QYjKnqHrSUSSqAUck1ltdCZNs0/G20xnkN1z4iK8Nk5VUiBUsihOjQRwEYwogJXgeYf4IxQAc4IFeCMUAHOGFERwy4A24VFhIvevxROzrfvUjdf3CvtyXCtc0ZU9A67ThXSpY9gm39xgTLtbrPjVv4ageoVCyuba1SEgnOqNmxERR43QUD3rKZijYoE7N5TcQNqsx5RYW11u5EYo9TDZudTdtujkAQbqs/eVPw2WLBGubsIUqL5BzgjVIAzQgU4I1SAs2A7Klbr7W9Pal3dWc76vdR6zC1SUTxGVKTwu/n4ZZ+zHlFhFpY3p2ojbIyoSCguUMppRAWB6g02oiKkMZqcU7Vh33yMqOgNtpYIa1QkYM27uNrIbvqWJUZU9AbW/UvBzpeyPmfqhBEVuBo0/wBnhApwRqgAZ4QKcEaoAGeECnBGqABnhApwRqgAZ4QKcFb4MKXV89Lp5WLKttvkLK5JL/+nmPKRj0hSI8pvZxceqkZT+uXLRW8F4IfmH+Asl1BVKzrNB4frRS6hGuzXvE2jAEKzo6p5703KJVSVsl4JbSIZMDzQWjLaPVR5dVTM2XrXlfLm6kS9fDcNm2JPrdv7rOd3a7kE91CVoiifvsa9T2nWbjqfS2FAMn859aju8t5Xefb+HbE3kWN5QBw7Fo9lsYdyq6ku2PtU640cljSRa8GBeufVhVxq79Gbh56tjQ64N3V61NypR3Uiq01vG6rSVOvgzyLJo5LuzOB1e9OZZWkt4wUGB3dIOzO+oRfMs9G0jsV1VExwDpQDO9gHMl5etb8axnu99rVaX3GhoqmQFw76a8WcOp1TlaY0I+nr1/ueAhI4GU23+go6d1SUplpdjse2eu/2sXeBj1gPolU8J6Lpiy27VL1/WwE7stV7x/kWrjdvbZ0WWc/hbDS92dy7XNdd6qWpzSoPXZmLprXILrw25H6dCrjWMZ8KcEaoAGeECnBGqABnhApwRqgAZ4QKcEaoAGeECnBGqABnhApwRqgAZ4QKcEaoAGeECnBGqABnhApwRqgAZ4QKcEaoAGeECnBGqABnhApwRqgAZ4QKcEaoAGeECnBGqABnhApwRqgAZ4QKcEaoAE+S/gcO2G7DK6u4YAAAAABJRU5ErkJggg=="
+        />
+      </defs>
+    </svg>
+  );
+};
+
+export default WebApp;

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.spec.tsx
@@ -1,20 +1,19 @@
 import NotificationEditMode from './NotificationEditMode';
 import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { contentTypeSelection, channelSelection, eventsSelection } from '@constants/configCopy';
 import { defaultNotification } from '@constants/defaultParams';
+import { ContentTypeCustomRender } from '@test/helpers/ContentTypeCustomRender';
 
 describe('NotificationEditMode component', () => {
   it('mounts with correct copy', () => {
-    render(
+    ContentTypeCustomRender(
       <NotificationEditMode
         index={0}
         deleteNotification={vi.fn()}
         updateNotification={vi.fn()}
         notification={defaultNotification}
-        contentTypes={[]}
         setNotificationIndexToEdit={vi.fn()}
-        contentTypeConfigLink=""
       />
     );
 

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.spec.tsx
@@ -14,6 +14,7 @@ describe('NotificationEditMode component', () => {
         notification={defaultNotification}
         contentTypes={[]}
         setNotificationIndexToEdit={vi.fn()}
+        contentTypeConfigLink=""
       />
     );
 

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.tsx
@@ -17,6 +17,7 @@ interface Props {
   notification: Notification;
   contentTypes: ContentTypeProps[];
   setNotificationIndexToEdit: Dispatch<SetStateAction<number | null>>;
+  contentTypeConfigLink: string;
 }
 
 const NotificationEditMode = (props: Props) => {
@@ -27,6 +28,7 @@ const NotificationEditMode = (props: Props) => {
     notification,
     contentTypes,
     setNotificationIndexToEdit,
+    contentTypeConfigLink,
   } = props;
 
   const [editedNotification, setEditedNotification] = useState<Notification>(notification);
@@ -73,6 +75,7 @@ const NotificationEditMode = (props: Props) => {
           notification={editedNotification}
           handleNotificationEdit={handleNotificationEdit}
           contentTypes={contentTypes}
+          contentTypeConfigLink={contentTypeConfigLink}
         />
         <ChannelSelection
           notification={editedNotification}

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.tsx
@@ -7,7 +7,6 @@ import NotificationEditModeFooter from '@components/config/NotificationEditModeF
 import DeleteModal from '@components/config/DeleteModal/DeleteModal';
 import { styles } from './NotificationEditMode.styles';
 import { Notification } from '@customTypes/configPage';
-import { ContentTypeProps } from 'contentful-management';
 import { isNotificationReadyToSave, isNotificationDefault } from '@helpers/configHelpers';
 
 interface Props {
@@ -15,9 +14,7 @@ interface Props {
   deleteNotification: (index: number) => void;
   updateNotification: (index: number, editedNotification: Partial<Notification>) => void;
   notification: Notification;
-  contentTypes: ContentTypeProps[];
   setNotificationIndexToEdit: Dispatch<SetStateAction<number | null>>;
-  contentTypeConfigLink: string;
 }
 
 const NotificationEditMode = (props: Props) => {
@@ -26,9 +23,7 @@ const NotificationEditMode = (props: Props) => {
     deleteNotification,
     updateNotification,
     notification,
-    contentTypes,
     setNotificationIndexToEdit,
-    contentTypeConfigLink,
   } = props;
 
   const [editedNotification, setEditedNotification] = useState<Notification>(notification);
@@ -74,8 +69,6 @@ const NotificationEditMode = (props: Props) => {
         <ContentTypeSelection
           notification={editedNotification}
           handleNotificationEdit={handleNotificationEdit}
-          contentTypes={contentTypes}
-          contentTypeConfigLink={contentTypeConfigLink}
         />
         <ChannelSelection
           notification={editedNotification}

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationViewMode/NotificationViewMode.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationViewMode/NotificationViewMode.spec.tsx
@@ -1,17 +1,20 @@
 import NotificationViewMode from './NotificationViewMode';
 import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { notificationsSection } from '@constants/configCopy';
 import { defaultNotification } from '@constants/defaultParams';
+import {
+  ContentTypeCustomRender,
+  ContentTypeCustomRerender,
+} from '@test/helpers/ContentTypeCustomRender';
 
 describe('NotificationViewMode component', () => {
   it('mounts with correct copy', () => {
-    const { unmount } = render(
+    const { unmount } = ContentTypeCustomRender(
       <NotificationViewMode
         index={0}
         updateNotification={vi.fn()}
         notification={defaultNotification}
-        contentTypes={[]}
         handleEdit={vi.fn()}
         isEditDisabled={false}
       />
@@ -23,12 +26,11 @@ describe('NotificationViewMode component', () => {
   });
   it('handles clicking the enable toggle', () => {
     const mockUpdateNotification = vi.fn();
-    const { unmount } = render(
+    const { unmount } = ContentTypeCustomRender(
       <NotificationViewMode
         index={0}
         updateNotification={mockUpdateNotification}
         notification={defaultNotification}
-        contentTypes={[]}
         handleEdit={vi.fn()}
         isEditDisabled={false}
       />
@@ -42,12 +44,11 @@ describe('NotificationViewMode component', () => {
   });
   it('handles clicking the edit button when it is enabled', () => {
     const mockHandleEdit = vi.fn();
-    const { unmount, rerender } = render(
+    const { unmount, rerender } = ContentTypeCustomRender(
       <NotificationViewMode
         index={0}
         updateNotification={vi.fn()}
         notification={defaultNotification}
-        contentTypes={[]}
         handleEdit={mockHandleEdit}
         isEditDisabled={false}
       />
@@ -59,15 +60,15 @@ describe('NotificationViewMode component', () => {
     expect(mockHandleEdit).toHaveBeenCalled();
 
     const mockHandleEditDisabled = vi.fn();
-    rerender(
+    ContentTypeCustomRerender(
       <NotificationViewMode
         index={0}
         updateNotification={vi.fn()}
         notification={defaultNotification}
-        contentTypes={[]}
         handleEdit={mockHandleEdit}
         isEditDisabled={true}
-      />
+      />,
+      rerender
     );
 
     const editButtonDisabled = screen.getByText(notificationsSection.editButton);

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationViewMode/NotificationViewMode.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationViewMode/NotificationViewMode.tsx
@@ -1,8 +1,9 @@
+import { useContext } from 'react';
+import { ContentTypeContext } from '@context/ContentTypeProvider';
 import { Box, Button, Flex, Subheading, Paragraph, Switch } from '@contentful/f36-components';
 import { styles } from './NotificationViewMode.styles';
 import { getContentTypeName, getChannelName } from '@helpers/configHelpers';
 import { Notification } from '@customTypes/configPage';
-import { ContentTypeProps } from 'contentful-management';
 import {
   channelSelection,
   contentTypeSelection,
@@ -15,14 +16,13 @@ interface Props {
   index: number;
   updateNotification: (index: number, editedNotification: Partial<Notification>) => void;
   notification: Notification;
-  contentTypes: ContentTypeProps[];
   handleEdit: () => void;
   isEditDisabled: boolean;
 }
 
 const NotificationViewMode = (props: Props) => {
-  const { index, notification, updateNotification, contentTypes, handleEdit, isEditDisabled } =
-    props;
+  const { index, notification, updateNotification, handleEdit, isEditDisabled } = props;
+  const { contentTypes } = useContext(ContentTypeContext);
 
   return (
     <Box className={styles.wrapper}>

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.spec.tsx
@@ -7,6 +7,7 @@ import { mockSdk, mockGetManyContentType } from '@test/mocks';
 vi.mock('@contentful/react-apps-toolkit', () => ({
   useSDK: () => mockSdk,
   useGetContentTypes: () => mockGetManyContentType,
+  useGetLinkForContentTypeConfig: () => '',
 }));
 
 describe('NotificationsSection component', () => {

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.spec.tsx
@@ -2,12 +2,10 @@ import NotificationsSection from './NotificationsSection';
 import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { notificationsSection } from '@constants/configCopy';
-import { mockSdk, mockGetManyContentType } from '@test/mocks';
+import { mockSdk } from '@test/mocks';
 
 vi.mock('@contentful/react-apps-toolkit', () => ({
   useSDK: () => mockSdk,
-  useGetContentTypes: () => mockGetManyContentType,
-  useGetLinkForContentTypeConfig: () => '',
 }));
 
 describe('NotificationsSection component', () => {

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.tsx
@@ -8,6 +8,7 @@ import NotificationViewMode from '@components/config/NotificationViewMode/Notifi
 import { Notification } from '@customTypes/configPage';
 import { ParameterAction, actions } from '@components/config/parameterReducer';
 import useGetContentTypes from '@hooks/useGetContentTypes';
+import useGetLinkForContentTypeConfig from '@hooks/useGetContentTypeConfigLink';
 
 interface Props {
   notifications: Notification[];
@@ -18,6 +19,7 @@ const NotificationsSection = (props: Props) => {
   const { notifications, dispatch } = props;
   const [notificationIndexToEdit, setNotificationIndexToEdit] = useState<number | null>(null);
   const contentTypes = useGetContentTypes();
+  const contentTypeConfigLink = useGetLinkForContentTypeConfig();
 
   const createNewNotification = () => {
     dispatch({ type: actions.ADD_NOTIFICATION });
@@ -64,6 +66,7 @@ const NotificationsSection = (props: Props) => {
               notification={notification}
               contentTypes={contentTypes}
               setNotificationIndexToEdit={setNotificationIndexToEdit}
+              contentTypeConfigLink={contentTypeConfigLink}
             />
           );
         } else {

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.tsx
@@ -7,8 +7,7 @@ import NotificationEditMode from '@components/config/NotificationEditMode/Notifi
 import NotificationViewMode from '@components/config/NotificationViewMode/NotificationViewMode';
 import { Notification } from '@customTypes/configPage';
 import { ParameterAction, actions } from '@components/config/parameterReducer';
-import useGetContentTypes from '@hooks/useGetContentTypes';
-import useGetLinkForContentTypeConfig from '@hooks/useGetContentTypeConfigLink';
+import { ContentTypeContextProvider } from '@context/ContentTypeProvider';
 
 interface Props {
   notifications: Notification[];
@@ -18,8 +17,6 @@ interface Props {
 const NotificationsSection = (props: Props) => {
   const { notifications, dispatch } = props;
   const [notificationIndexToEdit, setNotificationIndexToEdit] = useState<number | null>(null);
-  const contentTypes = useGetContentTypes();
-  const contentTypeConfigLink = useGetLinkForContentTypeConfig();
 
   const createNewNotification = () => {
     dispatch({ type: actions.ADD_NOTIFICATION });
@@ -53,36 +50,35 @@ const NotificationsSection = (props: Props) => {
           handleClick={createNewNotification}
         />
       </Box>
-      {notifications.map((notification, index) => {
-        const inEditMode = notificationIndexToEdit === index;
+      <ContentTypeContextProvider>
+        {notifications.map((notification, index) => {
+          const inEditMode = notificationIndexToEdit === index;
 
-        if (inEditMode) {
-          return (
-            <NotificationEditMode
-              key={`notification-${index}`}
-              index={index}
-              deleteNotification={deleteNotification}
-              updateNotification={updateNotification}
-              notification={notification}
-              contentTypes={contentTypes}
-              setNotificationIndexToEdit={setNotificationIndexToEdit}
-              contentTypeConfigLink={contentTypeConfigLink}
-            />
-          );
-        } else {
-          return (
-            <NotificationViewMode
-              key={`notification-${index}`}
-              index={index}
-              updateNotification={updateNotification}
-              notification={notification}
-              contentTypes={contentTypes}
-              handleEdit={() => setNotificationIndexToEdit(index)}
-              isEditDisabled={notificationIndexToEdit !== null}
-            />
-          );
-        }
-      })}
+          if (inEditMode) {
+            return (
+              <NotificationEditMode
+                key={`notification-${index}`}
+                index={index}
+                deleteNotification={deleteNotification}
+                updateNotification={updateNotification}
+                notification={notification}
+                setNotificationIndexToEdit={setNotificationIndexToEdit}
+              />
+            );
+          } else {
+            return (
+              <NotificationViewMode
+                key={`notification-${index}`}
+                index={index}
+                updateNotification={updateNotification}
+                notification={notification}
+                handleEdit={() => setNotificationIndexToEdit(index)}
+                isEditDisabled={notificationIndexToEdit !== null}
+              />
+            );
+          }
+        })}
+      </ContentTypeContextProvider>
     </Box>
   );
 };

--- a/apps/microsoft-teams/frontend/src/constants/configCopy.ts
+++ b/apps/microsoft-teams/frontend/src/constants/configCopy.ts
@@ -28,6 +28,10 @@ const contentTypeSelection = {
   modal: {
     title: 'Add content type',
     button: 'Next',
+    link: 'Add content type',
+    emptyHeading: 'No content types',
+    emptyContent:
+      'There are no content types available. If you create one, you will be able to assign it to the app from this screen. Add content type',
   },
   notFound: 'Content type not found',
 };

--- a/apps/microsoft-teams/frontend/src/context/ContentTypeProvider.tsx
+++ b/apps/microsoft-teams/frontend/src/context/ContentTypeProvider.tsx
@@ -1,0 +1,27 @@
+import { createContext } from 'react';
+import { ContentTypeProps } from 'contentful-management';
+import useGetContentTypes from '@hooks/useGetContentTypes';
+import useGetLinkForContentTypeConfig from '@hooks/useGetContentTypeConfigLink';
+
+interface ContentTypeContextValue {
+  contentTypes: ContentTypeProps[];
+  contentTypeConfigLink: string;
+}
+
+interface ContentTypeContextProviderProps {
+  children: React.ReactNode;
+}
+
+export const ContentTypeContext = createContext({} as ContentTypeContextValue);
+
+export const ContentTypeContextProvider = (props: ContentTypeContextProviderProps) => {
+  const { children } = props;
+  const contentTypes = useGetContentTypes();
+  const contentTypeConfigLink = useGetLinkForContentTypeConfig();
+
+  return (
+    <ContentTypeContext.Provider value={{ contentTypes, contentTypeConfigLink }}>
+      {children}
+    </ContentTypeContext.Provider>
+  );
+};

--- a/apps/microsoft-teams/frontend/src/hooks/useGetContentTypeConfigLink.spec.ts
+++ b/apps/microsoft-teams/frontend/src/hooks/useGetContentTypeConfigLink.spec.ts
@@ -1,0 +1,27 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import useGetContentTypeConfigLink from './useGetContentTypeConfigLink';
+import { mockCma, mockSdk } from '@test/mocks';
+
+vi.mock('@contentful/react-apps-toolkit', () => ({
+  useSDK: () => mockSdk,
+  useCMA: () => mockCma,
+}));
+
+describe('useGetContentTypeConfigLink', () => {
+  it('should return a link for the master environment', () => {
+    const { result } = renderHook(() => useGetContentTypeConfigLink());
+
+    expect(result.current).toEqual(
+      `https://${mockSdk.hostnames.webapp}/spaces/${mockSdk.ids.space}/content_types`
+    );
+  });
+  it('should return a link for a non-master environment', () => {
+    mockSdk.ids.environment = vi.fn().mockReturnValueOnce('testing');
+    const { result } = renderHook(() => useGetContentTypeConfigLink());
+
+    expect(result.current).toEqual(
+      `https://${mockSdk.hostnames.webapp}/spaces/${mockSdk.ids.space}/environments/${mockSdk.ids.environment}/content_types`
+    );
+  });
+});

--- a/apps/microsoft-teams/frontend/src/hooks/useGetContentTypeConfigLink.ts
+++ b/apps/microsoft-teams/frontend/src/hooks/useGetContentTypeConfigLink.ts
@@ -1,0 +1,34 @@
+import { useEffect, useCallback, useState } from 'react';
+import { useSDK } from '@contentful/react-apps-toolkit';
+import { ConfigAppSDK } from '@contentful/app-sdk';
+
+/**
+ * This hook is used to get the link to the page in the Contentful web app where a user can configure content types
+ * This takes into account EU data residency by using the correct hostname
+ *
+ * @returns contentTypeConfigLink
+ */
+const useGetContentTypeConfigLink = () => {
+  const [contentTypeConfigLink, setContentTypeConfigLink] = useState<string>('');
+  const sdk = useSDK<ConfigAppSDK>();
+
+  const getLink = useCallback(() => {
+    const space = sdk.ids.space;
+    const environment = sdk.ids.environment;
+
+    const link =
+      environment === 'master'
+        ? `https://${sdk.hostnames.webapp}/spaces/${space}/content_types`
+        : `https://${sdk.hostnames.webapp}/spaces/${space}/environments/${environment}/content_types`;
+
+    setContentTypeConfigLink(link);
+  }, [sdk.ids]);
+
+  useEffect(() => {
+    getLink();
+  }, [sdk, getLink]);
+
+  return contentTypeConfigLink;
+};
+
+export default useGetContentTypeConfigLink;

--- a/apps/microsoft-teams/frontend/test/helpers/ContentTypeCustomRender.tsx
+++ b/apps/microsoft-teams/frontend/test/helpers/ContentTypeCustomRender.tsx
@@ -1,0 +1,26 @@
+import { render } from '@testing-library/react';
+import { mockGetManyContentType } from '@test/mocks';
+import { ContentTypeContext } from '@context/ContentTypeProvider';
+
+const ContentTypeCustomRender = (component: React.ReactElement) => {
+  return render(
+    <ContentTypeContext.Provider
+      value={{ contentTypes: mockGetManyContentType.items, contentTypeConfigLink: '' }}>
+      {component}
+    </ContentTypeContext.Provider>
+  );
+};
+
+const ContentTypeCustomRerender = (
+  component: React.ReactElement,
+  rerender: (ui: React.ReactElement) => void
+) => {
+  return rerender(
+    <ContentTypeContext.Provider
+      value={{ contentTypes: mockGetManyContentType.items, contentTypeConfigLink: '' }}>
+      {component}
+    </ContentTypeContext.Provider>
+  );
+};
+
+export { ContentTypeCustomRender, ContentTypeCustomRerender };

--- a/apps/microsoft-teams/frontend/test/mocks/mockSdk.ts
+++ b/apps/microsoft-teams/frontend/test/mocks/mockSdk.ts
@@ -15,6 +15,11 @@ const mockSdk: any = {
   },
   ids: {
     app: 'test-app',
+    space: 'xyz789',
+    environment: 'master',
+  },
+  hostnames: {
+    webapp: 'app.contentful.com',
   },
   cma: {
     contentType: {

--- a/apps/microsoft-teams/frontend/tsconfig.json
+++ b/apps/microsoft-teams/frontend/tsconfig.json
@@ -18,6 +18,7 @@
     "paths": {
       "@components/*": ["./src/components/*"],
       "@constants/*": ["./src/constants/*"],
+      "@context/*": ["./src/context/*"],
       "@customTypes/*": ["./src/customTypes/*"],
       "@helpers/*": ["./src/helpers/*"],
       "@hooks/*": ["./src/hooks/*"],

--- a/apps/microsoft-teams/frontend/vite.config.ts
+++ b/apps/microsoft-teams/frontend/vite.config.ts
@@ -26,6 +26,7 @@ export default defineConfig(() => ({
     alias: {
       '@components': path.resolve(__dirname, './src/components'),
       '@constants': path.resolve(__dirname, './src/constants'),
+      '@context': path.resolve(__dirname, './src/context'),
       '@customTypes': path.resolve(__dirname, './src/customTypes'),
       '@helpers': path.resolve(__dirname, './src/helpers'),
       '@hooks': path.resolve(__dirname, './src/hooks'),


### PR DESCRIPTION
## Purpose

This PR adds the empty state in the content type selection modal for MS Teams. This empty state will be visible when the app is installed in an environment where there are no content types.

<img width="697" alt="Screenshot 2023-11-30 at 9 05 11 PM" src="https://github.com/contentful/apps/assets/62958907/78cb0ad7-2e2d-404b-886d-99305a329ca8">

## Approach

I made a few additional updates when adding this feature:
- I added a hook `useGetContentTypeConfigLink` to get the link to navigate to the content type config page within the web app
- I had to bump the `app-sdk` package in order to get `hostname`  from the sdk
- In order to reduce prop drilling the content types and the config link, I created context for the content type and the config link
- The Modal component cannot directly call the hooks to get the content types and config link, nor can it consume the context directly since it doesn't have the sdk context since it's not within the SDKProvider. So I did have to pass the content types and config link to the Modal component via props
- I created a helper to test the components that are consuming the content type context

## Testing steps

Set the content types to an empty array in our MS Teams environment to see the empty state.

## Breaking Changes

## Dependencies and/or References

## Deployment
