### PR TITLE
fix: data residency for netlify

### DIFF
--- a/apps/netlify/lambda/helpers/build-hook.js
+++ b/apps/netlify/lambda/helpers/build-hook.js
@@ -5,7 +5,6 @@ const getHost = require('./getHost');
 
 const privateKey = process.env['APP_IDENTITY_PRIVATE_KEY'] || '';
 const appInstallationId = (process.env['APP_DEFINITION_ID'] || '').trim();
-const baseUrl = 'https://api.contentful.com/';
 const buildBaseURL = 'https://api.netlify.com/build_hooks/';
 const assetTypes = ['Asset', 'DeletedAsset'];
 const validEventTypes = ['Entry', 'DeletedEntry', ...assetTypes];
@@ -76,7 +75,7 @@ const getBuildHooksFromAppInstallationParams = async (
   });
 
   const rawResult = await fetch(
-    `${baseUrl}/spaces/${spaceId}/environments/${environmentId}/app_installations/${appInstallationId}`,
+    `https://${host}/spaces/${spaceId}/environments/${environmentId}/app_installations/${appInstallationId}`,
     {
       headers: {
         authorization: `Bearer ${token}`,


### PR DESCRIPTION
## Purpose

There was a missed api url in netlify for the data residency update.

## Approach

Use the host property in the appContextDetails to populate the url