### PR TITLE
fix: cleaner sharp install to reduce folder size

### DIFF
--- a/apps/ai-image-generator/bundle-sharp.js
+++ b/apps/ai-image-generator/bundle-sharp.js
@@ -3,7 +3,14 @@ const fs = require('fs/promises');
 console.log('Copying sharp files from node_modules to build/node_modules');
 
 const copySharp = async () => {
-  await fs.cp('./node_modules/@img', './build/node_modules/@img', {
+  await fs.cp(
+    './node_modules/@img/sharp-libvips-linux-x64',
+    './build/node_modules/@img/sharp-libvips-linux-x64',
+    {
+      recursive: true,
+    }
+  );
+  await fs.cp('./node_modules/@img/sharp-linux-x64', './build/node_modules/@img/sharp-linux-x64', {
     recursive: true,
   });
   await fs.cp('./node_modules/sharp', './build/node_modules/sharp', {

--- a/apps/ai-image-generator/package.json
+++ b/apps/ai-image-generator/package.json
@@ -13,9 +13,8 @@
     "deploy": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEFINITIONS_ORG_ID} --definition-id 3RheWQRagirMFgWrhMOBxL --token ${CONTENTFUL_CMA_TOKEN}",
     "deploy:test": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEV_TESTING_ORG_ID} --definition-id 6H2pUZdiYcmo0WY8dlYZn5 --token ${TEST_CMA_TOKEN}",
     "deploy:sandbox": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEV_TESTING_ORG_ID} --definition-id 3vLfusuPgGHcydK5ET8IcG --token ${TEST_CMA_TOKEN}",
-    "replace-installed-sharp": "rimraf ./node_modules/sharp && rimraf ./node_modules/@img && npm run install-linux-sharp && npm run clean-unneeded-sharp-files",
-    "install-linux-sharp": "npm i @img/sharp-linux-x64 @img/sharp-libvips-linux-x64 sharp -f --no-save",
-    "clean-unneeded-sharp-files": "rimraf ./node_modules/@img/sharp-libvips-darwin-arm64 && rimraf ./node_modules/@img/sharp-darwin-arm64"
+    "replace-installed-sharp": "rimraf ./node_modules/sharp && rimraf ./node_modules/@img && npm run install-linux-sharp",
+    "install-linux-sharp": "npm i @img/sharp-linux-x64 @img/sharp-libvips-linux-x64 sharp -f --no-save"
   },
   "dependencies": {
     "@contentful/app-scripts": "1.13.1",


### PR DESCRIPTION
## Purpose

* Previous attempt to fix sharp (#5674) almost worked, but the build artifact was too big: https://app.circleci.com/pipelines/github/contentful/apps/26276/workflows/24c38da4-5537-40a8-bb96-78a70f62d160/jobs/81197?invite=true#step-117-5288_19

## Approach

* Instead of removing unneeded files, copy over only what's needed. This is a better approach and also has the advantage of minimzing the build size

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
