### PR TITLE
feat: support custom update and additional details display [INTEG-1611]

### DIFF
--- a/packages/dam-app-base/README.md
+++ b/packages/dam-app-base/README.md
@@ -51,8 +51,7 @@ setup({
 These Contentful apps use `@contentful/dam-app-base`. Look at their source code to learn how they utilize this library:
 
 - [Brandfolder](../../apps/brandfolder)
-- [Bynder](../../apps/bynder)
-- [Cloudinary](../../apps/cloudinary)
+- [Bynder](https://github.com/contentful/marketplace-partner-apps/tree/main/apps/bynder)
 - [Dropbox](../../apps/dropbox)
 - [Frontify](../../apps/frontify)
 - [Mux](../../apps/mux)

--- a/packages/dam-app-base/docs/README.md
+++ b/packages/dam-app-base/docs/README.md
@@ -17,6 +17,7 @@
 * [Asset](README.md#asset)
 * [CompatibleFields](README.md#compatiblefields)
 * [Config](README.md#config)
+* [CustomUpdateStateValueFn](README.md#customupdatestatevaluefn)
 * [DeleteFn](README.md#deletefn)
 * [DisabledPredicateFn](README.md#disabledpredicatefn)
 * [OpenDialogFn](README.md#opendialogfn)
@@ -53,6 +54,22 @@ ___
 Ƭ **Config**: *Record*<*string*, *any*\>
 
 Object containing all information configured on the app configuration page.
+
+___
+
+### CustomUpdateStateValueFn
+
+Ƭ **CustomUpdateStateValueFn**: (
+  `context`: {
+    `currentValue`: [*Asset*](README.md#asset)[];
+    `result`: [*Asset*](README.md#asset)[];
+    `config`: [*Config*](README.md#config);
+  },
+  `updateStateValue`: (`value`: [*Asset*](README.md#asset)[]) => *void*
+) => *Promise*<*void*>;
+
+Async function that takes in context about the current field value, the result from the dialog, and the app config.
+It also accepts a function to update the field state, and this should be called in the function to update the field
 
 ___
 

--- a/packages/dam-app-base/docs/README.md
+++ b/packages/dam-app-base/docs/README.md
@@ -14,12 +14,14 @@
 
 ### Type aliases
 
+* [AdditionalData](README.md#additionaldata)
 * [Asset](README.md#asset)
 * [CompatibleFields](README.md#compatiblefields)
 * [Config](README.md#config)
 * [CustomUpdateStateValueFn](README.md#customupdatestatevaluefn)
 * [DeleteFn](README.md#deletefn)
 * [DisabledPredicateFn](README.md#disabledpredicatefn)
+* [GetAdditionalDataFn](README.md#getadditionaldatafn)
 * [OpenDialogFn](README.md#opendialogfn)
 * [RenderDialogFn](README.md#renderdialogfn)
 * [SelectedFields](README.md#selectedfields)
@@ -34,6 +36,14 @@
 * [setup](README.md#setup)
 
 ## Type aliases
+
+### AdditionalData
+
+Ƭ **AdditionalData**: { `primary`: *string*; `secondary`: *string* }
+
+Object containing additional data about the asset to display as primary and secondary information in the "more details" section
+
+___
 
 ### Asset
 
@@ -90,6 +100,14 @@ Function that should return true when the button should be disabled.
 **`param`** App configuration
 
 **`returns`** true, if the button in the field location should be disabled. false, if the button should be enabled
+
+___
+
+### GetAdditionalDataFn
+
+Ƭ **GetAdditionalDataFn**: (`asset`: [*Asset*](README.md#asset)) => [*AdditionalData*](README.md#additionaldata)
+
+Function that return an object that represents the primary and secondary data that should be displayed in the "more details" section of the asset card
 
 ___
 

--- a/packages/dam-app-base/src/Editor/Field.tsx
+++ b/packages/dam-app-base/src/Editor/Field.tsx
@@ -3,7 +3,13 @@ import tokens from '@contentful/f36-tokens';
 import { css } from 'emotion';
 import { FieldAppSDK } from '@contentful/app-sdk';
 import { SortableComponent } from './SortableComponent';
-import { ThumbnailFn, OpenDialogFn, DisabledPredicateFn, Asset } from '../interfaces';
+import {
+  ThumbnailFn,
+  OpenDialogFn,
+  DisabledPredicateFn,
+  Asset,
+  CustomUpdateStateValueFn,
+} from '../interfaces';
 
 import { Button, Note, TextLink } from '@contentful/f36-components';
 
@@ -16,6 +22,7 @@ interface Props {
   makeThumbnail: ThumbnailFn;
   openDialog: OpenDialogFn;
   isDisabled: DisabledPredicateFn;
+  customUpdateStateValue: CustomUpdateStateValueFn | null;
 }
 
 interface State {
@@ -88,10 +95,17 @@ export default class Field extends React.Component<Props, State> {
     const config = this.props.sdk.parameters.installation;
     const result = await this.props.openDialog(this.props.sdk, currentValue, config);
 
-    if (result.length > 0) {
-      const newValue = [...(this.state.value || []), ...result];
+    if (this.props.customUpdateStateValue) {
+      await this.props.customUpdateStateValue(
+        { currentValue, result, config },
+        this.updateStateValue
+      );
+    } else {
+      if (result.length > 0) {
+        const newValue = [...(this.state.value || []), ...result];
 
-      await this.updateStateValue(newValue);
+        await this.updateStateValue(newValue);
+      }
     }
   };
 

--- a/packages/dam-app-base/src/Editor/Field.tsx
+++ b/packages/dam-app-base/src/Editor/Field.tsx
@@ -9,6 +9,7 @@ import {
   DisabledPredicateFn,
   Asset,
   CustomUpdateStateValueFn,
+  GetAdditionalDataFn,
 } from '../interfaces';
 
 import { Button, Note, TextLink } from '@contentful/f36-components';
@@ -23,6 +24,7 @@ interface Props {
   openDialog: OpenDialogFn;
   isDisabled: DisabledPredicateFn;
   customUpdateStateValue: CustomUpdateStateValueFn | null;
+  getAdditionalData: GetAdditionalDataFn | null;
 }
 
 interface State {
@@ -138,6 +140,7 @@ export default class Field extends React.Component<Props, State> {
               onChange={this.updateStateValue}
               config={config}
               makeThumbnail={this.props.makeThumbnail}
+              getAdditionalData={this.props.getAdditionalData}
             />
           </div>
         )}

--- a/packages/dam-app-base/src/Editor/SortableComponent.tsx
+++ b/packages/dam-app-base/src/Editor/SortableComponent.tsx
@@ -1,11 +1,18 @@
-import { Card, IconButton } from '@contentful/f36-components';
+import { Card, Collapse, Flex, IconButton, TextLink } from '@contentful/f36-components';
 import { CloseIcon } from '@contentful/f36-icons';
 import tokens from '@contentful/f36-tokens';
 import { css } from 'emotion';
 import arrayMove from 'array-move';
 import * as React from 'react';
 import { SortableContainer, SortableElement, SortableHandle } from 'react-sortable-hoc';
-import { Asset, Config, DeleteFn, ThumbnailFn } from '../interfaces';
+import {
+  Asset,
+  Config,
+  DeleteFn,
+  ThumbnailFn,
+  GetAdditionalDataFn,
+  AdditionalData,
+} from '../interfaces';
 import FileIcon from '../Icons/FileIcon';
 
 interface Props {
@@ -14,6 +21,7 @@ interface Props {
   config: Config;
   resources: Asset[];
   makeThumbnail: ThumbnailFn;
+  getAdditionalData: GetAdditionalDataFn | null;
 }
 
 interface SortableContainerProps {
@@ -22,16 +30,22 @@ interface SortableContainerProps {
   resources: Asset[];
   deleteFn: DeleteFn;
   makeThumbnail: ThumbnailFn;
+  getAdditionalData: GetAdditionalDataFn | null;
 }
 
 interface DragHandleProps {
   url: string | undefined;
   alt: string | undefined;
+  additionalData: AdditionalData | null;
 }
 
+interface AdditionalDataDisplayProps {
+  additionalData: AdditionalData;
+}
 interface SortableElementProps extends DragHandleProps {
   disabled: boolean;
   onDelete: () => void;
+  additionalData: AdditionalData | null;
 }
 
 const styles = {
@@ -51,7 +65,6 @@ const styles = {
       margin: '10px',
       position: 'relative',
       cursor: disabled ? 'move' : 'pointer',
-      color: tokens.gray500,
       img: {
         display: 'block',
         maxWidth: '150px',
@@ -74,6 +87,7 @@ const styles = {
     alignItems: 'center',
     maxWidth: '150px',
     maxHeight: '100px',
+    color: tokens.gray500,
   }),
   altTextDisplay: css({
     wordBreak: 'break-word',
@@ -82,34 +96,96 @@ const styles = {
     display: '-webkit-box',
     WebkitLineClamp: 3,
     WebkitBoxOrient: 'vertical',
+    color: tokens.gray500,
+  }),
+  primaryAdditionalData: css({
+    fontWeight: tokens.fontWeightMedium,
+    color: tokens.gray800,
+  }),
+  secondaryAdditionalData: css({
+    color: tokens.gray500,
+  }),
+  textlink: css({
+    marginTop: tokens.spacingXs,
   }),
 };
 
-const DragHandle = SortableHandle<DragHandleProps>(({ url, alt }: DragHandleProps) => {
-  if (!url && !alt) {
-    return (
-      <div className={styles.altTextContainer}>
-        <p className={styles.altTextDisplay}>Asset not available</p>
-      </div>
-    );
-  } else if (!url) {
-    return (
-      <div className={styles.altTextContainer}>
-        <FileIcon />
-        <p className={styles.altTextDisplay} title={alt}>
-          {alt}
-        </p>
-      </div>
-    );
-  } else {
-    return <img src={url} alt={alt} title={alt} />;
+const AdditionalDataDisplay = ({ additionalData }: AdditionalDataDisplayProps) => {
+  return (
+    <Flex flexDirection="column" marginTop="spacingXs">
+      <p className={styles.primaryAdditionalData}>{additionalData.primary}</p>
+      <p className={styles.secondaryAdditionalData}>{additionalData.secondary}</p>
+    </Flex>
+  );
+};
+
+const DragHandle = SortableHandle<DragHandleProps>(
+  ({ url, alt, additionalData }: DragHandleProps) => {
+    const [isExpanded, setIsExpanded] = React.useState(false);
+
+    if (!url && !alt) {
+      return (
+        <div className={styles.altTextContainer}>
+          <p className={styles.altTextDisplay}>Asset not available</p>
+        </div>
+      );
+    }
+
+    if (additionalData) {
+      // if additional data is provided then the "more details" section will be visible
+      if (!url) {
+        return (
+          <div>
+            <Flex justifyContent="center" title={alt}>
+              <FileIcon />
+            </Flex>
+            {<AdditionalDataDisplay additionalData={additionalData} />}
+          </div>
+        );
+      } else {
+        return (
+          <>
+            <div>
+              <img src={url} alt={alt} title={alt} />
+              <Collapse isExpanded={isExpanded}>
+                {<AdditionalDataDisplay additionalData={additionalData} />}
+              </Collapse>
+            </div>
+            <TextLink
+              as="button"
+              onClick={() => setIsExpanded((currentIsExpanded) => !currentIsExpanded)}
+              className={styles.textlink}>
+              {isExpanded ? 'hide details' : 'more details'}
+            </TextLink>
+          </>
+        );
+      }
+    } else {
+      // display default asset card when no additional data is provided
+      if (!url) {
+        return (
+          <div className={styles.altTextContainer}>
+            <FileIcon />
+            <p className={styles.altTextDisplay} title={alt}>
+              {alt}
+            </p>
+          </div>
+        );
+      } else {
+        return (
+          <div>
+            <img src={url} alt={alt} title={alt} />
+          </div>
+        );
+      }
+    }
   }
-});
+);
 
 const SortableItem = SortableElement<SortableElementProps>((props: SortableElementProps) => {
   return (
     <Card className={styles.card(props.disabled)}>
-      <DragHandle url={props.url} alt={props.alt} />
+      <DragHandle url={props.url} alt={props.alt} additionalData={props.additionalData} />
       {!props.disabled && (
         <IconButton
           variant="transparent"
@@ -128,7 +204,14 @@ const SortableList = SortableContainer<SortableContainerProps>((props: SortableC
   const { list } = props.resources.reduce(
     (acc, resource, index) => {
       const [url, alt] = props.makeThumbnail(resource, props.config);
-      const item = { url, alt, key: `url-unknown-${index}` };
+
+      let additionalData = null;
+
+      if (props.getAdditionalData) {
+        additionalData = props.getAdditionalData(resource);
+      }
+
+      const item = { url, alt, key: `url-unknown-${index}`, additionalData };
       const counts = { ...acc.counts };
 
       // URLs are used as keys.
@@ -152,7 +235,7 @@ const SortableList = SortableContainer<SortableContainerProps>((props: SortableC
   return (
     <div className={styles.container}>
       <div className={styles.grid}>
-        {list.map(({ url, alt, key }, index) => {
+        {list.map(({ url, alt, key, additionalData }, index) => {
           return (
             <SortableItem
               disabled={props.disabled}
@@ -161,6 +244,7 @@ const SortableList = SortableContainer<SortableContainerProps>((props: SortableC
               alt={alt}
               index={index}
               onDelete={() => props.deleteFn(index)}
+              additionalData={additionalData}
             />
           );
         })}
@@ -193,6 +277,7 @@ export class SortableComponent extends React.Component<Props> {
         deleteFn={this.deleteItem}
         useDragHandle
         makeThumbnail={this.props.makeThumbnail}
+        getAdditionalData={this.props.getAdditionalData}
       />
     );
   }

--- a/packages/dam-app-base/src/Editor/SortableComponent.tsx
+++ b/packages/dam-app-base/src/Editor/SortableComponent.tsx
@@ -155,7 +155,7 @@ const DragHandle = SortableHandle<DragHandleProps>(
               as="button"
               onClick={() => setIsExpanded((currentIsExpanded) => !currentIsExpanded)}
               className={styles.textlink}>
-              {isExpanded ? 'hide details' : 'more details'}
+              {isExpanded ? 'Hide details' : 'More details'}
             </TextLink>
           </>
         );
@@ -205,11 +205,7 @@ const SortableList = SortableContainer<SortableContainerProps>((props: SortableC
     (acc, resource, index) => {
       const [url, alt] = props.makeThumbnail(resource, props.config);
 
-      let additionalData = null;
-
-      if (props.getAdditionalData) {
-        additionalData = props.getAdditionalData(resource);
-      }
+      const additionalData = props.getAdditionalData?.(resource) || null;
 
       const item = { url, alt, key: `url-unknown-${index}`, additionalData };
       const counts = { ...acc.counts };

--- a/packages/dam-app-base/src/index.tsx
+++ b/packages/dam-app-base/src/index.tsx
@@ -25,6 +25,7 @@ export function setup(integration: Integration) {
             makeThumbnail={integration.makeThumbnail}
             openDialog={integration.openDialog}
             isDisabled={integration.isDisabled}
+            customUpdateStateValue={integration.customUpdateStateValue ?? null}
           />
         </>,
         root

--- a/packages/dam-app-base/src/index.tsx
+++ b/packages/dam-app-base/src/index.tsx
@@ -26,6 +26,7 @@ export function setup(integration: Integration) {
             openDialog={integration.openDialog}
             isDisabled={integration.isDisabled}
             customUpdateStateValue={integration.customUpdateStateValue ?? null}
+            getAdditionalData={integration.getAdditionalData ?? null}
           />
         </>,
         root

--- a/packages/dam-app-base/src/interfaces.ts
+++ b/packages/dam-app-base/src/interfaces.ts
@@ -120,6 +120,22 @@ export type OpenDialogFn = (
  */
 export type DisabledPredicateFn = (currentValue: Asset[], config: Config) => boolean;
 
+/**
+ * Async function that takes in context about the current field value, the result from the dialog, and the app config
+ * It also accepts a function to update the field state, and this should be called in the function to update the field
+ *
+ * @param context { currentValue, result, config }
+ * @return Promise<void>, calls the async function updateStateValue
+ */
+export type CustomUpdateStateValueFn = (
+  context: {
+    currentValue: Asset[];
+    result: Asset[];
+    config: Config;
+  },
+  updateStateValue: (value: Asset[]) => void
+) => Promise<void>;
+
 export interface Integration {
   /**
    * Text on the button that is displayed in the field location
@@ -216,4 +232,13 @@ export interface Integration {
    * @returns true, if the button in the field location should be disabled. false, if the button should be enabled
    */
   isDisabled: DisabledPredicateFn;
+
+  /**
+   * Optional async function that will override the current updateStateValue function
+   * This custom function accepts context about the asset as well as the updateStateValue function,
+   * which should be called within the custom function
+   * A use case for this is to change the default behavior where newly selected assets are appended to the current field value
+   * This is optional and if not provided, the default behavior of appending the result will be applied
+   */
+  customUpdateStateValue?: CustomUpdateStateValueFn;
 }

--- a/packages/dam-app-base/src/interfaces.ts
+++ b/packages/dam-app-base/src/interfaces.ts
@@ -136,6 +136,20 @@ export type CustomUpdateStateValueFn = (
   updateStateValue: (value: Asset[]) => void
 ) => Promise<void>;
 
+/**
+ * Object containing additional data about the asset to display as primary and secondary information in the "more details" section
+ */
+export type AdditionalData = { primary: string; secondary: string };
+
+/**
+ * Function that return an object that represents the primary and secondary data that should be displayed
+ * in the "more details" section of the asset card
+ *
+ * @param asset an asset
+ * @return object with primary and secondary properties that contain strings to display in the asset card
+ */
+export type GetAdditionalDataFn = (asset: Asset) => AdditionalData;
+
 export interface Integration {
   /**
    * Text on the button that is displayed in the field location
@@ -241,4 +255,12 @@ export interface Integration {
    * This is optional and if not provided, the default behavior of appending the result will be applied
    */
   customUpdateStateValue?: CustomUpdateStateValueFn;
+
+  /**
+   * Optional function to get additional data from the asset to be displayed in the asset card
+   * This function accepts asset info and returns an object that contains primary and secondary information to display
+   * When this function is used, a "more details" section will appear on the asset card
+   * This is optional and if not provided, the default look of the asset card will remain
+   */
+  getAdditionalData?: GetAdditionalDataFn;
 }


### PR DESCRIPTION
## Purpose

This PR updates the `dam-app-base` with two new optional functions. These changes are being made to support feedback from customers to improve the Bynder app, which utilizes this package.

## Approach

I added two new optional functions to be passed into the `dam-app-base` setup integration. Since these functions are optional, adding these will not impact other apps that utilize this package.

1. `customUpdateStateValue`: changes the default save behavior. The current behavior is that newly selected assets are appended to the end of the selected assets. If you want to instead resave all the selected assets each time, this new function will enable you to do so.
2. `getAdditionalData`: passes additional data to display in the asset card. When this function is passed in, then you see a "more details" section on the asset card.

## Testing steps

Use `npm link` to run this package locally with Bynder to see the changes. I also tested with another app, Brandfolder, to ensure that these changes do not impact existing behavior.

## Breaking Changes

None, these additional functions are optional. 

## Dependencies and/or References

## Deployment
