### PR TITLE
fix: disable create notification button when in edit mode [INTEG-1610]

### DIFF
--- a/apps/microsoft-teams/frontend/src/components/config/AddButton/AddButton.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/AddButton/AddButton.spec.tsx
@@ -4,8 +4,17 @@ import { render, screen } from '@testing-library/react';
 
 describe('AddButton component', () => {
   it('mounts with correct button copy', () => {
-    render(<AddButton buttonCopy="test" handleClick={vi.fn()} />);
+    const { unmount } = render(<AddButton buttonCopy="test" handleClick={vi.fn()} />);
 
     expect(screen.getByText('test')).toBeTruthy();
+    unmount();
+  });
+  it('is disabled when prop is true', () => {
+    const { unmount } = render(
+      <AddButton buttonCopy="test" handleClick={vi.fn()} isDisabled={true} />
+    );
+
+    expect(screen.getByRole('button')).toHaveProperty('disabled');
+    unmount();
   });
 });

--- a/apps/microsoft-teams/frontend/src/components/config/AddButton/AddButton.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/AddButton/AddButton.tsx
@@ -5,13 +5,18 @@ import { PlusIcon } from '@contentful/f36-icons';
 interface Props {
   buttonCopy: string;
   handleClick: (e: MouseEvent<HTMLButtonElement>) => void;
+  isDisabled?: boolean;
 }
 
 const AddButton = (props: Props) => {
-  const { buttonCopy, handleClick } = props;
+  const { buttonCopy, handleClick, isDisabled = false } = props;
 
   return (
-    <Button startIcon={<PlusIcon />} variant="secondary" onClick={handleClick}>
+    <Button
+      startIcon={<PlusIcon />}
+      variant="secondary"
+      onClick={handleClick}
+      isDisabled={isDisabled}>
       {buttonCopy}
     </Button>
   );

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.tsx
@@ -67,6 +67,7 @@ const NotificationsSection = (props: Props) => {
         <AddButton
           buttonCopy={notificationsSection.createButton}
           handleClick={createNewNotification}
+          isDisabled={notificationIndexToEdit !== null}
         />
       </Box>
       <ContentTypeContextProvider>


### PR DESCRIPTION
## Purpose

The `Create notification` button should be disabled when you are viewing a notification in edit mode.

## Approach

See new disabled button state:
![Screenshot 2023-12-06 at 1 51 07 PM](https://github.com/contentful/apps/assets/62958907/d3c84d50-fa58-4345-b9b5-8e0f2367b028)

## Testing steps

Navigate to MS Teams (development) app.

## Breaking Changes

## Dependencies and/or References

## Deployment
