### PR TITLE
fix: allow additional data to be selectable [INTEG-1627]

### DIFF
--- a/packages/dam-app-base/src/Editor/SortableComponent.tsx
+++ b/packages/dam-app-base/src/Editor/SortableComponent.tsx
@@ -101,9 +101,11 @@ const styles = {
   primaryAdditionalData: css({
     fontWeight: tokens.fontWeightMedium,
     color: tokens.gray800,
+    cursor: 'default',
   }),
   secondaryAdditionalData: css({
     color: tokens.gray500,
+    cursor: 'default',
   }),
   textlink: css({
     marginTop: tokens.spacingXs,
@@ -135,22 +137,24 @@ const DragHandle = SortableHandle<DragHandleProps>(
       // if additional data is provided then the "more details" section will be visible
       if (!url) {
         return (
-          <div>
-            <Flex justifyContent="center" title={alt}>
-              <FileIcon />
-            </Flex>
-            {<AdditionalDataDisplay additionalData={additionalData} />}
-          </div>
+          <>
+            <div>
+              <Flex justifyContent="center" title={alt}>
+                <FileIcon />
+              </Flex>
+            </div>
+            <AdditionalDataDisplay additionalData={additionalData} />
+          </>
         );
       } else {
         return (
           <>
             <div>
               <img src={url} alt={alt} title={alt} />
-              <Collapse isExpanded={isExpanded}>
-                {<AdditionalDataDisplay additionalData={additionalData} />}
-              </Collapse>
             </div>
+            <Collapse isExpanded={isExpanded}>
+              {<AdditionalDataDisplay additionalData={additionalData} />}
+            </Collapse>
             <TextLink
               as="button"
               onClick={() => setIsExpanded((currentIsExpanded) => !currentIsExpanded)}


### PR DESCRIPTION
## Purpose

The drag area was conflicting with the more details section in the `dam-app-base` asset card. This PR makes the more details section selectable, and then the drag are to move assets is the image.

## Approach

Moved the more details section outside of the draggable `div`. Also updated the cursor when selecting the additional info.

<img width="486" alt="Screenshot 2023-12-07 at 9 43 49 AM" src="https://github.com/contentful/apps/assets/62958907/806eb290-4c3a-4101-88ee-0702c6aa86a2">

## Testing steps

Tested the package updates in Bynder using `npm link`.

## Breaking Changes

## Dependencies and/or References

## Deployment
