### PR TITLE
feat: [INTEG-1587] - Add notification dedupe modal

### DIFF
--- a/apps/microsoft-teams/frontend/src/components/config/DuplicateModal/DuplicateModal.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/DuplicateModal/DuplicateModal.spec.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import { notificationsSection } from '@constants/configCopy';
 import DuplicateModal from './DuplicateModal';
 
-describe('DeleteModal component', () => {
+describe('DuplicateModal component', () => {
   it('mounts and renders the correct content', () => {
     render(<DuplicateModal isShown={true} handleCancel={vi.fn()} handleConfirm={vi.fn()} />);
 

--- a/apps/microsoft-teams/frontend/src/components/config/DuplicateModal/DuplicateModal.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/DuplicateModal/DuplicateModal.spec.tsx
@@ -1,0 +1,12 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { notificationsSection } from '@constants/configCopy';
+import DuplicateModal from './DuplicateModal';
+
+describe('DeleteModal component', () => {
+  it('mounts and renders the correct content', () => {
+    render(<DuplicateModal isShown={true} handleCancel={vi.fn()} handleConfirm={vi.fn()} />);
+
+    expect(screen.getByText(notificationsSection.duplicateModal.confirmDuplicate)).toBeTruthy();
+  });
+});

--- a/apps/microsoft-teams/frontend/src/components/config/DuplicateModal/DuplicateModal.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/DuplicateModal/DuplicateModal.tsx
@@ -1,0 +1,27 @@
+import { ModalConfirm, Text } from '@contentful/f36-components';
+import { notificationsSection } from '@constants/configCopy';
+
+interface Props {
+  isShown: boolean;
+  handleCancel: () => void;
+  handleConfirm: () => void;
+}
+
+const CancelModal = (props: Props) => {
+  const { isShown, handleCancel, handleConfirm } = props;
+
+  return (
+    <ModalConfirm
+      intent="primary"
+      modalHeaderProps={{ title: 'Duplicate Notification' }}
+      isShown={isShown}
+      onCancel={handleCancel}
+      onConfirm={handleConfirm}
+      confirmLabel={notificationsSection.duplicateModal.confirmDuplicate}
+      cancelLabel={notificationsSection.duplicateModal.goBack}>
+      <Text>{notificationsSection.duplicateModal.confirmDuplicateDescription}</Text>
+    </ModalConfirm>
+  );
+};
+
+export default CancelModal;

--- a/apps/microsoft-teams/frontend/src/components/config/DuplicateModal/DuplicateModal.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/DuplicateModal/DuplicateModal.tsx
@@ -1,13 +1,13 @@
 import { ModalConfirm, Text } from '@contentful/f36-components';
 import { notificationsSection } from '@constants/configCopy';
 
-interface Props {
+interface DuplicateModalProps {
   isShown: boolean;
   handleCancel: () => void;
   handleConfirm: () => void;
 }
 
-const CancelModal = (props: Props) => {
+const DuplicateModal = (props: DuplicateModalProps) => {
   const { isShown, handleCancel, handleConfirm } = props;
 
   return (
@@ -24,4 +24,4 @@ const CancelModal = (props: Props) => {
   );
 };
 
-export default CancelModal;
+export default DuplicateModal;

--- a/apps/microsoft-teams/frontend/src/components/config/DuplicateModal/DuplicateModal.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/DuplicateModal/DuplicateModal.tsx
@@ -13,7 +13,9 @@ const DuplicateModal = (props: DuplicateModalProps) => {
   return (
     <ModalConfirm
       intent="primary"
-      modalHeaderProps={{ title: 'Duplicate Notification' }}
+      modalHeaderProps={{
+        title: notificationsSection.duplicateModal.modalHeaderTitle,
+      }}
       isShown={isShown}
       onCancel={handleCancel}
       onConfirm={handleConfirm}

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.tsx
@@ -16,7 +16,11 @@ import CancelModal from '@components/config/CancelModal/CancelModal';
 interface Props {
   index: number;
   deleteNotification: (index: number) => void;
-  updateNotification: (index: number, editedNotification: Partial<Notification>) => void;
+  updateNotification: (
+    index: number,
+    editedNotification: Partial<Notification>,
+    isNew?: boolean
+  ) => void;
   notification: Notification;
   setNotificationIndexToEdit: Dispatch<SetStateAction<number | null>>;
   channels: TeamsChannel[];
@@ -43,8 +47,8 @@ const NotificationEditMode = (props: Props) => {
   };
 
   const handleSave = () => {
-    updateNotification(index, editedNotification);
-    setNotificationIndexToEdit(null);
+    const isNew = isNotificationNew(notification);
+    updateNotification(index, editedNotification, isNew);
   };
 
   const handleCancel = () => {

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationViewMode/NotificationViewMode.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationViewMode/NotificationViewMode.tsx
@@ -22,7 +22,11 @@ import {
 
 interface Props {
   index: number;
-  updateNotification: (index: number, editedNotification: Partial<Notification>) => void;
+  updateNotification: (
+    index: number,
+    editedNotification: Partial<Notification>,
+    isNew?: boolean
+  ) => void;
   notification: Notification;
   handleEdit: () => void;
   isMenuDisabled: boolean;

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.tsx
@@ -63,7 +63,7 @@ const NotificationsSection = (props: Props) => {
     notificationsPayload[index] = updatedNotification;
 
     // Use a Set to keep track of unique keys
-    const uniqueKeys = new Set();
+    const uniqueKeys = new Set<string>();
 
     // Deduplicate based on content
     const uniqueNotifications = notificationsPayload.filter((notification) => {

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.tsx
@@ -6,11 +6,11 @@ import AddButton from '@components/config/AddButton/AddButton';
 import NotificationEditMode from '@components/config/NotificationEditMode/NotificationEditMode';
 import NotificationViewMode from '@components/config/NotificationViewMode/NotificationViewMode';
 import DeleteModal from '@components/config/DeleteModal/DeleteModal';
+import DuplicateModal from '../DuplicateModal/DuplicateModal';
 import { Notification } from '@customTypes/configPage';
 import { ParameterAction, actions } from '@components/config/parameterReducer';
 import useGetTeamsChannels from '@hooks/useGetTeamsChannels';
 import { ContentTypeContextProvider } from '@context/ContentTypeProvider';
-import DuplicateModal from '../DuplicateModal/DuplicateModal';
 
 interface Props {
   notifications: Notification[];
@@ -62,14 +62,18 @@ const NotificationsSection = (props: Props) => {
     const updatedNotification = { ...existingNotification, ...editedNotification };
     notificationsPayload[index] = updatedNotification;
 
+    // Use a Set to keep track of unique keys
+    const uniqueKeys = new Set();
+
     // Deduplicate based on content
-    const uniqueNotifications = notificationsPayload.filter(
-      (notification, idx) =>
-        notificationsPayload.findIndex(
-          (n) =>
-            n.channelId === notification.channelId && n.contentTypeId === notification.contentTypeId
-        ) === idx
-    );
+    const uniqueNotifications = notificationsPayload.filter((notification) => {
+      const key = `${notification.channelId}-${notification.contentTypeId}`;
+      if (!uniqueKeys.has(key)) {
+        uniqueKeys.add(key);
+        return true;
+      }
+      return false;
+    });
 
     // Check if the updated notification is unique
     const isUnique = uniqueNotifications.length === notificationsPayload.length;

--- a/apps/microsoft-teams/frontend/src/constants/configCopy.ts
+++ b/apps/microsoft-teams/frontend/src/constants/configCopy.ts
@@ -23,6 +23,12 @@ const notificationsSection = {
   delete: 'Delete',
   confirmDelete:
     'If you delete this notification you will no longer get updates about this content type in Microsoft Teams.',
+  duplicateModal: {
+    confirmDuplicate: 'Update existing notification',
+    goBack: 'Go back to editing',
+    confirmDuplicateDescription:
+      'You already have a notification set up for this content type and Teams channel. Would you like to update the existing notification instead of creating a new one?',
+  },
 };
 
 const contentTypeSelection = {

--- a/apps/microsoft-teams/frontend/src/constants/configCopy.ts
+++ b/apps/microsoft-teams/frontend/src/constants/configCopy.ts
@@ -28,7 +28,7 @@ const notificationsSection = {
     confirmDuplicate: 'Update existing notification',
     goBack: 'Go back to editing',
     confirmDuplicateDescription:
-      'You already have a notification set up for this content type and Teams channel. Would you like to update the existing notification instead of creating a new one?',
+      'You already have a notification set up for this content type and MS Teams channel. Would you like to update the existing notification instead of creating a new one?',
   },
 };
 

--- a/apps/microsoft-teams/frontend/src/constants/configCopy.ts
+++ b/apps/microsoft-teams/frontend/src/constants/configCopy.ts
@@ -24,6 +24,7 @@ const notificationsSection = {
   confirmDelete:
     'If you delete this notification you will no longer get updates about this content type in Microsoft Teams.',
   duplicateModal: {
+    modalHeaderTitle: 'Duplicate Notification',
     confirmDuplicate: 'Update existing notification',
     goBack: 'Go back to editing',
     confirmDuplicateDescription:

--- a/apps/microsoft-teams/frontend/src/helpers/configHelpers.spec.ts
+++ b/apps/microsoft-teams/frontend/src/helpers/configHelpers.spec.ts
@@ -5,6 +5,8 @@ import {
   isNotificationReadyToSave,
   isNotificationNew,
   doesNotificationHaveChanges,
+  getUniqueNotifications,
+  getDuplicateNotificationIndex,
 } from './configHelpers';
 import { mockChannels, mockContentType } from '@test/mocks';
 import { channelSelection, contentTypeSelection } from '@constants/configCopy';
@@ -70,5 +72,41 @@ describe('doesNotificationHaveChanges', () => {
 
   it('should return true when there are changes', () => {
     expect(doesNotificationHaveChanges(mockNotification, defaultNotification)).toEqual(true);
+  });
+});
+
+describe('getUniqueNotifications', () => {
+  it('should return a list of unique notifications when there are duplicates', () => {
+    expect(getUniqueNotifications([mockNotification, mockNotification]).length).toEqual(1);
+  });
+});
+
+describe('getDuplicateNotificationIndex', () => {
+  it('should return -1 when there are no duplicates', () => {
+    expect(
+      getDuplicateNotificationIndex([mockNotification], {
+        ...mockNotification,
+        contentTypeId: 'page',
+      })
+    ).toEqual(-1);
+  });
+
+  it('should return the correct index when there are duplicates', () => {
+    expect(
+      getDuplicateNotificationIndex(
+        [mockNotification, { ...mockNotification, contentTypeId: 'page' }],
+        mockNotification
+      )
+    ).toEqual(0);
+  });
+
+  it('should return the correct index when there are duplicates and index is passed in', () => {
+    expect(
+      getDuplicateNotificationIndex(
+        [{ ...mockNotification, contentTypeId: 'page' }, mockNotification, mockNotification],
+        mockNotification,
+        2
+      )
+    ).toEqual(1);
   });
 });

--- a/apps/microsoft-teams/frontend/src/helpers/configHelpers.ts
+++ b/apps/microsoft-teams/frontend/src/helpers/configHelpers.ts
@@ -82,10 +82,62 @@ const doesNotificationHaveChanges = (
   return !isEqual(editedNotification, notification);
 };
 
+/**
+ * Returns a list of unique notifications with duplicates removed
+ * Duplicates are ones that have the same content type and channel
+ * @param notifications
+ * @returns Notification[]
+ */
+const getUniqueNotifications = (notifications: Notification[]): Notification[] => {
+  // Use a Set to keep track of unique keys
+  const uniqueKeys = new Set<string>();
+
+  // Deduplicate based on content
+  const uniqueNotifications = notifications.filter((notification) => {
+    const key = `${notification.channelId}-${notification.contentTypeId}`;
+    if (!uniqueKeys.has(key)) {
+      uniqueKeys.add(key);
+      return true;
+    }
+    return false;
+  });
+
+  return uniqueNotifications;
+};
+
+/**
+ * Finds the index of the notification that is a duplicate of another
+ * @param notifications
+ * @param notificationToFind
+ * @param index
+ * @returns number
+ */
+const getDuplicateNotificationIndex = (
+  notifications: Notification[],
+  notificationToFind: Notification,
+  index?: number
+): number => {
+  const duplicateNotificationIndex = notifications.reduce((matchedIndex, notification, idx) => {
+    const isDuplicate =
+      notification.channelId === notificationToFind.channelId &&
+      notification.contentTypeId === notificationToFind.contentTypeId &&
+      index !== idx;
+    if (isDuplicate) {
+      matchedIndex = idx;
+    }
+
+    return matchedIndex;
+  }, -1);
+
+  return duplicateNotificationIndex;
+};
+
 export {
   getContentTypeName,
   getChannelName,
   isNotificationReadyToSave,
   isNotificationNew,
   doesNotificationHaveChanges,
+  getUniqueNotifications,
+  getDuplicateNotificationIndex,
 };

--- a/apps/microsoft-teams/frontend/src/hooks/useGetTeamsChannels.ts
+++ b/apps/microsoft-teams/frontend/src/hooks/useGetTeamsChannels.ts
@@ -2,6 +2,7 @@ import { useEffect, useCallback, useState } from 'react';
 import { useSDK } from '@contentful/react-apps-toolkit';
 import { ConfigAppSDK } from '@contentful/app-sdk';
 import { AppInstallationParameters, TeamsChannel } from '@customTypes/configPage';
+import { mockChannels } from '@test/mocks/mockChannels';
 
 const useGetTeamsChannels = () => {
   const [channels, setChannels] = useState<TeamsChannel[]>([]);
@@ -38,7 +39,7 @@ const useGetTeamsChannels = () => {
     getAllChannels();
   }, [getAllChannels]);
 
-  return channels;
+  return import.meta.env.DEV ? mockChannels : channels;
 };
 
 export default useGetTeamsChannels;


### PR DESCRIPTION
## Purpose

We want to avoid allowing the creation and configuration of duplicate notifications, this adds that logic and a modal for confirming or canceling editing of existing notification.

Ticket: https://contentful.atlassian.net/browse/INTEG-1587

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

1.) Navigate to the development space, and start the app.

2.) Make sure there is a configured notification for content type and channel.

3.) Attempt to create a new notification with the same content type, and same channel.

4.) Observe this modal:

<img width="905" alt="Screenshot 2023-12-13 at 3 26 59 PM" src="https://github.com/contentful/apps/assets/22120469/64c501ae-328f-4845-bad9-d049ae26e790">

5.) Test CTA(s)
 - Click `Go back to editing` to cancel creation
 - Click `Update existing notification` to edit the existing notification
 
6.) Observe editing state for previously existing notification:
<img width="915" alt="Screenshot 2023-12-13 at 3 27 11 PM" src="https://github.com/contentful/apps/assets/22120469/25c153cb-0f7f-4114-8e63-889dc53254d8">

