### PR TITLE
chore: update copy and links [INTEG-1648]

### DIFF
--- a/apps/microsoft-teams/frontend/src/components/config/AccessSection/AccessSection.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/AccessSection/AccessSection.tsx
@@ -8,7 +8,7 @@ import {
   Subheading,
   TextInput,
 } from '@contentful/f36-components';
-import { headerSection, accessSection, appDeepLink } from '@constants/configCopy';
+import { headerSection, accessSection } from '@constants/configCopy';
 import { styles } from './AccessSection.styles';
 import { ParameterAction, actions } from '@components/config/parameterReducer';
 import TeamsLogo from '@components/config/TeamsLogo/TeamsLogo';
@@ -45,7 +45,8 @@ const AccessSection = (props: Props) => {
           <HyperLink
             body={accessSection.teamsAppInfo}
             substring={accessSection.teamsAppLink}
-            href={appDeepLink}
+            // TODO: update link to app documentation
+            href={'https://www.contentful.com/help/apps-at-contentful/'}
           />
         </Box>
       </Flex>

--- a/apps/microsoft-teams/frontend/src/components/config/ChannelSelectionModal/ChannelSelectionModal.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ChannelSelectionModal/ChannelSelectionModal.spec.tsx
@@ -15,6 +15,6 @@ describe('ChannelSelectionModal component', () => {
       />
     );
 
-    expect(screen.getByText(channelSelection.modal.button)).toBeTruthy();
+    expect(screen.getByText(channelSelection.modal.title)).toBeTruthy();
   });
 });

--- a/apps/microsoft-teams/frontend/src/components/config/ChannelSelectionModal/ChannelSelectionModal.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ChannelSelectionModal/ChannelSelectionModal.tsx
@@ -34,9 +34,9 @@ const ChannelSelectionModal = (props: ChannelSelectionModalProps) => {
       {() => (
         <>
           <ModalHeader title={title} onClose={onClose} icon={<TeamsLogo />} />
-          <Modal.Content>
-            {channels.length ? (
-              <>
+          {channels.length ? (
+            <>
+              <Modal.Content>
                 <Paragraph>
                   {description}{' '}
                   <TextLink href={appDeepLink} target="_blank" rel="noopener noreferrer">
@@ -62,8 +62,22 @@ const ChannelSelectionModal = (props: ChannelSelectionModalProps) => {
                     </Table.Body>
                   </Table>
                 </FormControl>
-              </>
-            ) : (
+              </Modal.Content>
+              <Modal.Controls>
+                <Button
+                  size="small"
+                  variant="primary"
+                  onClick={() => {
+                    handleNotificationEdit({ channelId: selectedChannelId });
+                    onClose();
+                  }}
+                  isDisabled={!selectedChannelId}>
+                  {button}
+                </Button>
+              </Modal.Controls>
+            </>
+          ) : (
+            <Modal.Content>
               <EmptyState
                 image={<EmptyFishbowl />}
                 heading={emptyHeading}
@@ -71,20 +85,8 @@ const ChannelSelectionModal = (props: ChannelSelectionModalProps) => {
                 linkSubstring={link}
                 linkHref={appDeepLink}
               />
-            )}
-          </Modal.Content>
-          <Modal.Controls>
-            <Button
-              size="small"
-              variant="primary"
-              onClick={() => {
-                handleNotificationEdit({ channelId: selectedChannelId });
-                onClose();
-              }}
-              isDisabled={!selectedChannelId}>
-              {button}
-            </Button>
-          </Modal.Controls>
+            </Modal.Content>
+          )}
         </>
       )}
     </Modal>

--- a/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelectionModal/ContentTypeSelectionModal.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelectionModal/ContentTypeSelectionModal.spec.tsx
@@ -1,7 +1,7 @@
 import ContentTypeSelectionModal from './ContentTypeSelectionModal';
 import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { channelSelection } from '@constants/configCopy';
+import { contentTypeSelection } from '@constants/configCopy';
 
 describe('ContentTypeSelectionModal component', () => {
   it('mounts and renders the correct content', () => {
@@ -16,6 +16,6 @@ describe('ContentTypeSelectionModal component', () => {
       />
     );
 
-    expect(screen.getByText(channelSelection.modal.button)).toBeTruthy();
+    expect(screen.getByText(contentTypeSelection.modal.title)).toBeTruthy();
   });
 });

--- a/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelectionModal/ContentTypeSelectionModal.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelectionModal/ContentTypeSelectionModal.tsx
@@ -36,27 +36,43 @@ const ContentTypeSelectionModal = (props: Props) => {
       {() => (
         <>
           <ModalHeader title={title} onClose={onClose} />
-          <Modal.Content>
-            {contentTypes.length ? (
-              <FormControl as="fieldset" marginBottom="none">
-                <Table className={styles.table}>
-                  <Table.Body>
-                    {contentTypes.map((contentType) => (
-                      <Table.Row key={contentType.sys.id}>
-                        <Table.Cell>
-                          <Radio
-                            id={contentType.sys.id}
-                            isChecked={selectedContentTypeId === contentType.sys.id}
-                            onChange={() => setSelectedContentTypeId(contentType.sys.id)}>
-                            {contentType.name}
-                          </Radio>
-                        </Table.Cell>
-                      </Table.Row>
-                    ))}
-                  </Table.Body>
-                </Table>
-              </FormControl>
-            ) : (
+          {contentTypes.length ? (
+            <>
+              <Modal.Content>
+                <FormControl as="fieldset" marginBottom="none">
+                  <Table className={styles.table}>
+                    <Table.Body>
+                      {contentTypes.map((contentType) => (
+                        <Table.Row key={contentType.sys.id}>
+                          <Table.Cell>
+                            <Radio
+                              id={contentType.sys.id}
+                              isChecked={selectedContentTypeId === contentType.sys.id}
+                              onChange={() => setSelectedContentTypeId(contentType.sys.id)}>
+                              {contentType.name}
+                            </Radio>
+                          </Table.Cell>
+                        </Table.Row>
+                      ))}
+                    </Table.Body>
+                  </Table>
+                </FormControl>
+              </Modal.Content>
+              <Modal.Controls>
+                <Button
+                  size="small"
+                  variant="primary"
+                  onClick={() => {
+                    handleNotificationEdit({ contentTypeId: selectedContentTypeId });
+                    onClose();
+                  }}
+                  isDisabled={!selectedContentTypeId}>
+                  {button}
+                </Button>
+              </Modal.Controls>
+            </>
+          ) : (
+            <Modal.Content>
               <EmptyState
                 image={<WebApp />}
                 heading={emptyHeading}
@@ -64,20 +80,8 @@ const ContentTypeSelectionModal = (props: Props) => {
                 linkSubstring={link}
                 linkHref={contentTypeConfigLink}
               />
-            )}
-          </Modal.Content>
-          <Modal.Controls>
-            <Button
-              size="small"
-              variant="primary"
-              onClick={() => {
-                handleNotificationEdit({ contentTypeId: selectedContentTypeId });
-                onClose();
-              }}
-              isDisabled={!selectedContentTypeId}>
-              {button}
-            </Button>
-          </Modal.Controls>
+            </Modal.Content>
+          )}
         </>
       )}
     </Modal>

--- a/apps/microsoft-teams/frontend/src/components/config/EmptyState/EmptyState.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/EmptyState/EmptyState.tsx
@@ -17,7 +17,7 @@ const EmptyState = (props: Props) => {
     <Flex flexDirection="column" alignItems="center">
       {image}
       <Subheading>{heading}</Subheading>
-      <Box className={styles.emptyContent}>
+      <Box className={styles.emptyContent} marginBottom="spacingM">
         <HyperLink body={body} substring={linkSubstring} href={linkHref} />
       </Box>
     </Flex>

--- a/apps/microsoft-teams/frontend/src/constants/configCopy.ts
+++ b/apps/microsoft-teams/frontend/src/constants/configCopy.ts
@@ -3,9 +3,9 @@ const headerSection = {
   description: 'Get notifications about Contentful content updates directly in Microsoft Teams.',
 };
 
-// TODO: Update deep link with Teams app id
+// TODO: Update to deep link with Teams app id
 // https://learn.microsoft.com/en-us/microsoftteams/platform/concepts/build-and-test/deep-link-application?tabs=teamsjs-v2#deep-link-to-open-application-install-dialog
-const appDeepLink = 'https://teams.microsoft.com/l/app/';
+const appDeepLink = 'https://teams.microsoft.com/';
 
 const accessSection = {
   title: 'Access',
@@ -40,7 +40,7 @@ const contentTypeSelection = {
 };
 
 const channelSelection = {
-  title: 'Channel',
+  title: 'Microsoft Teams channel',
   addButton: 'Select channel',
   modal: {
     title: 'Select Microsoft Teams channel',

--- a/apps/microsoft-teams/frontend/src/constants/configCopy.ts
+++ b/apps/microsoft-teams/frontend/src/constants/configCopy.ts
@@ -43,14 +43,14 @@ const channelSelection = {
   title: 'Channel',
   addButton: 'Select channel',
   modal: {
-    title: 'Select Teams channel',
+    title: 'Select Microsoft Teams channel',
     description:
-      'Teams channels where the Contentful app has been installed can display notifications.',
+      'Microsoft Teams channels where the Contentful app has been installed can display notifications.',
     link: 'Add app',
     button: 'Select',
-    emptyHeading: 'Add Teams channels',
+    emptyHeading: 'Add Microsoft Teams channels',
     emptyContent:
-      'In Teams, add the Contentful app to channels where you want to see notifications. Add app',
+      'In Microsoft Teams, add the Contentful app to the general channel of the teams where you want to see notifications. Add app',
   },
   notFound: 'Channel not found',
 };


### PR DESCRIPTION
## Purpose

This PR updates copy and links in the MS Teams app config page based on feedback in our Mob QA session.

## Approach

Updated copy and links. Also ensured that when the empty state is visible for the content type and channel selection modals, that the "select" button is not visible, see example below:

<img width="723" alt="Screenshot 2023-12-19 at 1 28 16 PM" src="https://github.com/contentful/apps/assets/62958907/0f45844e-c50e-4b6c-b548-94e15e4c65c8">

## Testing steps

Navigate to the MS Teams development app.

## Breaking Changes

## Dependencies and/or References

## Deployment
