### PR TITLE
chore: bump chart.js and fix font weight type

### DIFF
--- a/apps/google-analytics-4/frontend/package-lock.json
+++ b/apps/google-analytics-4/frontend/package-lock.json
@@ -9945,9 +9945,9 @@
       }
     },
     "node_modules/chart.js": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.0.tgz",
-      "integrity": "sha512-vQEj6d+z0dcsKLlQvbKIMYFHd3t8W/7L2vfJIbYcfyPcRx92CsHqECpueN8qVGNlKyDcr5wBrYAYKnfu/9Q1hQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.1.tgz",
+      "integrity": "sha512-C74QN1bxwV1v2PEujhmKjOZ7iUM4w6BWs23Md/6aOZZSlwMzeCIDGuZay++rBgChYru7/+QFeoQW0fQoP534Dg==",
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },

--- a/apps/google-analytics-4/frontend/src/components/main-app/LineChart/LineChart.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/LineChart/LineChart.tsx
@@ -22,7 +22,7 @@ const defaultFontSize = parseRemToPxInt(tokens.fontSizeS);
 
 ChartJS.defaults.font.size = defaultFontSize;
 ChartJS.defaults.font.family = tokens.fontStackPrimary;
-ChartJS.defaults.font.weight = tokens.fontWeightMedium.toString();
+ChartJS.defaults.font.weight = tokens.fontWeightMedium;
 ChartJS.defaults.borderColor = tokens.gray200;
 ChartJS.defaults.datasets.line.borderColor = tokens.colorPrimary;
 
@@ -69,8 +69,7 @@ const LineChart = (props: Props) => {
         },
         bodyFont: {
           size: defaultFontSize,
-          // TO:DO once font weight is added to F36, replace with token
-          weight: '700',
+          weight: tokens.fontWeightDemiBold,
         },
         displayColors: false,
         callbacks: {


### PR DESCRIPTION
## Purpose

Dependabot tried to update the Chart.js dependency in GA4 and the update failed: https://github.com/contentful/apps/pull/5663

## Approach

[Chart.js version 4.4.1](https://github.com/chartjs/Chart.js/releases/tag/v4.4.1) changes the type of font weight from string to number ([see this PR](https://github.com/chartjs/Chart.js/pull/11605/files)). This PR bumps the package and then changes the font weight for the line chart from a string to a number.

Note: I did change the tooltip font weight from `700` to the `fontWeightDemiBold` token (which equates to `600`), and I still think it looks ok, see screenshot.

![Screenshot 2023-12-19 at 4 31 58 PM](https://github.com/contentful/apps/assets/62958907/c9acc0a3-7afe-4676-b6be-b97f6be349e0)

## Testing steps

I verified that the line chart still renders correctly in the GA4 app sidebar.

## Breaking Changes

## Dependencies and/or References

https://github.com/chartjs/Chart.js/releases/tag/v4.4.1
https://github.com/chartjs/Chart.js/pull/11605
https://github.com/contentful/apps/pull/5663

## Deployment
