### PR TITLE
refactor: add channel context and update installation params [INTEG-1669]

### DIFF
--- a/apps/microsoft-teams/frontend/src/components/config/ChannelSelection/ChannelSelection.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ChannelSelection/ChannelSelection.spec.tsx
@@ -8,11 +8,7 @@ import { mockChannels } from '@test/mocks';
 describe('ChannelSelection component', () => {
   it('mounts and renders the correct title and button copy when no channel is selected', () => {
     const { unmount } = render(
-      <ChannelSelection
-        notification={defaultNotification}
-        handleNotificationEdit={vi.fn()}
-        channels={[]}
-      />
+      <ChannelSelection notification={defaultNotification} handleNotificationEdit={vi.fn()} />
     );
 
     expect(screen.getByText(channelSelection.title)).toBeTruthy();
@@ -27,7 +23,6 @@ describe('ChannelSelection component', () => {
           channel: mockChannels[0],
         }}
         handleNotificationEdit={vi.fn()}
-        channels={[]}
       />
     );
 

--- a/apps/microsoft-teams/frontend/src/components/config/ChannelSelection/ChannelSelection.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ChannelSelection/ChannelSelection.spec.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { channelSelection } from '@constants/configCopy';
 import { defaultNotification } from '@constants/defaultParams';
+import { mockChannels } from '@test/mocks';
 
 describe('ChannelSelection component', () => {
   it('mounts and renders the correct title and button copy when no channel is selected', () => {
@@ -21,7 +22,10 @@ describe('ChannelSelection component', () => {
   it('mounts and renders an input when a channel is selected', () => {
     const { unmount } = render(
       <ChannelSelection
-        notification={{ ...defaultNotification, channelId: 'abc-123' }}
+        notification={{
+          ...defaultNotification,
+          channel: mockChannels[0],
+        }}
         handleNotificationEdit={vi.fn()}
         channels={[]}
       />

--- a/apps/microsoft-teams/frontend/src/components/config/ChannelSelection/ChannelSelection.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ChannelSelection/ChannelSelection.tsx
@@ -1,21 +1,22 @@
+import { useContext } from 'react';
 import { Box, Flex, IconButton, ModalLauncher, Text, TextInput } from '@contentful/f36-components';
 import AddButton from '@components/config/AddButton/AddButton';
 import ChannelSelectionModal from '@components/config/ChannelSelectionModal/ChannelSelectionModal';
 import TeamsLogo from '@components/config/TeamsLogo/TeamsLogo';
 import { channelSelection } from '@constants/configCopy';
-import { Notification, TeamsChannel } from '@customTypes/configPage';
+import { Notification } from '@customTypes/configPage';
 import { EditIcon } from '@contentful/f36-icons';
 import { styles } from './ChannelSelection.styles';
-import { getChannelName } from '@helpers/configHelpers';
+import { ChannelContext } from '@context/ChannelProvider';
 
 interface Props {
   notification: Notification;
   handleNotificationEdit: (notificationEdit: Partial<Notification>) => void;
-  channels: TeamsChannel[];
 }
 
 const ChannelSelection = (props: Props) => {
-  const { notification, handleNotificationEdit, channels } = props;
+  const { notification, handleNotificationEdit } = props;
+  const { channels } = useContext(ChannelContext);
 
   const openChannelSelectionModal = () => {
     return ModalLauncher.open(({ isShown, onClose }) => (
@@ -42,7 +43,7 @@ const ChannelSelection = (props: Props) => {
           <TextInput
             id="selected-channel"
             isDisabled={true}
-            value={getChannelName(notification.channel.id, channels, channelSelection.notFound)}
+            value={`${notification.channel.name}, ${notification.channel.teamName}`}
             className={styles.input}
           />
           <IconButton

--- a/apps/microsoft-teams/frontend/src/components/config/ChannelSelection/ChannelSelection.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ChannelSelection/ChannelSelection.tsx
@@ -23,7 +23,7 @@ const ChannelSelection = (props: Props) => {
         isShown={isShown}
         onClose={() => onClose(true)}
         handleNotificationEdit={handleNotificationEdit}
-        savedChannelId={notification.channelId}
+        savedChannel={notification.channel}
         channels={channels}
       />
     ));
@@ -37,12 +37,12 @@ const ChannelSelection = (props: Props) => {
           {channelSelection.title}
         </Text>
       </Flex>
-      {notification.channelId ? (
+      {notification.channel.id ? (
         <TextInput.Group>
           <TextInput
             id="selected-channel"
             isDisabled={true}
-            value={getChannelName(notification.channelId, channels, channelSelection.notFound)}
+            value={getChannelName(notification.channel.id, channels, channelSelection.notFound)}
             className={styles.input}
           />
           <IconButton

--- a/apps/microsoft-teams/frontend/src/components/config/ChannelSelectionModal/ChannelSelectionModal.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ChannelSelectionModal/ChannelSelectionModal.spec.tsx
@@ -2,6 +2,7 @@ import ChannelSelectionModal from './ChannelSelectionModal';
 import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { channelSelection } from '@constants/configCopy';
+import { defaultNotification } from '@constants/defaultParams';
 
 describe('ChannelSelectionModal component', () => {
   it('mounts and renders the correct content', () => {
@@ -9,7 +10,7 @@ describe('ChannelSelectionModal component', () => {
       <ChannelSelectionModal
         isShown={true}
         onClose={vi.fn()}
-        savedChannelId=""
+        savedChannel={defaultNotification.channel}
         handleNotificationEdit={vi.fn()}
         channels={[]}
       />

--- a/apps/microsoft-teams/frontend/src/components/config/ChannelSelectionModal/ChannelSelectionModal.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ChannelSelectionModal/ChannelSelectionModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   Button,
   FormControl,
@@ -26,11 +26,16 @@ interface ChannelSelectionModalProps {
 }
 
 const ChannelSelectionModal = (props: ChannelSelectionModalProps) => {
-  const { isShown, onClose, savedChannel: savedChannel, handleNotificationEdit, channels } = props;
+  const { isShown, onClose, savedChannel, handleNotificationEdit, channels } = props;
   const [selectedChannel, setSelectedChannel] = useState<TeamsChannel>(
     savedChannel ?? defaultNotification.channel
   );
   const { title, button, link, emptyContent, emptyHeading, description } = channelSelection.modal;
+
+  useEffect(() => {
+    const foundChannel = channels.find((channel) => channel.id === savedChannel.id);
+    setSelectedChannel(foundChannel ?? defaultNotification.channel);
+  }, [savedChannel]);
 
   return (
     <Modal onClose={onClose} isShown={isShown} size="large">

--- a/apps/microsoft-teams/frontend/src/components/config/ChannelSelectionModal/ChannelSelectionModal.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ChannelSelectionModal/ChannelSelectionModal.tsx
@@ -15,18 +15,21 @@ import ModalHeader from '@components/config/ModalHeader/ModalHeader';
 import TeamsLogo from '@components/config/TeamsLogo/TeamsLogo';
 import EmptyState from '@components/config/EmptyState/EmptyState';
 import EmptyFishbowl from '@components/config/EmptyState/EmptyFishbowl';
+import { defaultNotification } from '@constants/defaultParams';
 
 interface ChannelSelectionModalProps {
   isShown: boolean;
   onClose: () => void;
-  savedChannelId: string;
+  savedChannel: TeamsChannel;
   handleNotificationEdit: (notificationEdit: Partial<Notification>) => void;
   channels: TeamsChannel[];
 }
 
 const ChannelSelectionModal = (props: ChannelSelectionModalProps) => {
-  const { isShown, onClose, savedChannelId, handleNotificationEdit, channels } = props;
-  const [selectedChannelId, setSelectedChannelId] = useState<string>(savedChannelId ?? '');
+  const { isShown, onClose, savedChannel: savedChannel, handleNotificationEdit, channels } = props;
+  const [selectedChannel, setSelectedChannel] = useState<TeamsChannel>(
+    savedChannel ?? defaultNotification.channel
+  );
   const { title, button, link, emptyContent, emptyHeading, description } = channelSelection.modal;
 
   return (
@@ -51,8 +54,8 @@ const ChannelSelectionModal = (props: ChannelSelectionModalProps) => {
                           <Table.Cell>
                             <Radio
                               id={channel.id}
-                              isChecked={selectedChannelId === channel.id}
-                              onChange={() => setSelectedChannelId(channel.id)}
+                              isChecked={selectedChannel.id === channel.id}
+                              onChange={() => setSelectedChannel(channel)}
                               helpText={channel.teamName}>
                               {channel.name}
                             </Radio>
@@ -68,10 +71,10 @@ const ChannelSelectionModal = (props: ChannelSelectionModalProps) => {
                   size="small"
                   variant="primary"
                   onClick={() => {
-                    handleNotificationEdit({ channelId: selectedChannelId });
+                    handleNotificationEdit({ channel: selectedChannel });
                     onClose();
                   }}
-                  isDisabled={!selectedChannelId}>
+                  isDisabled={!selectedChannel.id}>
                   {button}
                 </Button>
               </Modal.Controls>

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.spec.tsx
@@ -14,7 +14,6 @@ describe('NotificationEditMode component', () => {
         updateNotification={vi.fn()}
         notification={defaultNotification}
         setNotificationIndexToEdit={vi.fn()}
-        channels={[]}
       />
     );
 

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.tsx
@@ -5,7 +5,7 @@ import ChannelSelection from '@components/config/ChannelSelection/ChannelSelecti
 import EventsSelection from '@components/config/EventsSelection/EventsSelection';
 import NotificationEditModeFooter from '@components/config/NotificationEditModeFooter/NotificationEditModeFooter';
 import { styles } from './NotificationEditMode.styles';
-import { Notification, TeamsChannel } from '@customTypes/configPage';
+import { Notification } from '@customTypes/configPage';
 import {
   isNotificationReadyToSave,
   isNotificationNew,
@@ -23,7 +23,6 @@ interface Props {
   ) => void;
   notification: Notification;
   setNotificationIndexToEdit: Dispatch<SetStateAction<number | null>>;
-  channels: TeamsChannel[];
 }
 
 const NotificationEditMode = (props: Props) => {
@@ -33,7 +32,6 @@ const NotificationEditMode = (props: Props) => {
     updateNotification,
     notification,
     setNotificationIndexToEdit,
-    channels,
   } = props;
 
   const [editedNotification, setEditedNotification] = useState<Notification>(notification);
@@ -88,7 +86,6 @@ const NotificationEditMode = (props: Props) => {
         <ChannelSelection
           notification={editedNotification}
           handleNotificationEdit={handleNotificationEdit}
-          channels={channels}
         />
         <EventsSelection
           notification={editedNotification}

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationViewMode/NotificationViewMode.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationViewMode/NotificationViewMode.spec.tsx
@@ -4,7 +4,6 @@ import { screen } from '@testing-library/react';
 import { notificationsSection } from '@constants/configCopy';
 import { defaultNotification } from '@constants/defaultParams';
 import { ContentTypeCustomRender } from '@test/helpers/ContentTypeCustomRender';
-import { mockChannels } from '@test/mocks';
 
 describe('NotificationViewMode component', () => {
   it('mounts with correct copy and menu', () => {
@@ -16,7 +15,6 @@ describe('NotificationViewMode component', () => {
         handleEdit={vi.fn()}
         isMenuDisabled={false}
         handleDelete={vi.fn()}
-        channels={mockChannels}
       />
     );
 
@@ -34,7 +32,6 @@ describe('NotificationViewMode component', () => {
         handleEdit={vi.fn()}
         isMenuDisabled={false}
         handleDelete={vi.fn()}
-        channels={mockChannels}
       />
     );
 

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationViewMode/NotificationViewMode.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationViewMode/NotificationViewMode.tsx
@@ -11,13 +11,9 @@ import {
 } from '@contentful/f36-components';
 import { MoreHorizontalIcon } from '@contentful/f36-icons';
 import { styles } from './NotificationViewMode.styles';
-import { getContentTypeName, getChannelName } from '@helpers/configHelpers';
-import { Notification, TeamsChannel } from '@customTypes/configPage';
-import {
-  channelSelection,
-  contentTypeSelection,
-  notificationsSection,
-} from '@constants/configCopy';
+import { getContentTypeName } from '@helpers/configHelpers';
+import { Notification } from '@customTypes/configPage';
+import { contentTypeSelection, notificationsSection } from '@constants/configCopy';
 // TODO: update this when we start fetching channel installations
 
 interface Props {
@@ -31,19 +27,11 @@ interface Props {
   handleEdit: () => void;
   isMenuDisabled: boolean;
   handleDelete: () => void;
-  channels: TeamsChannel[];
 }
 
 const NotificationViewMode = (props: Props) => {
-  const {
-    index,
-    notification,
-    updateNotification,
-    handleEdit,
-    isMenuDisabled,
-    handleDelete,
-    channels,
-  } = props;
+  const { index, notification, updateNotification, handleEdit, isMenuDisabled, handleDelete } =
+    props;
   const { contentTypes } = useContext(ContentTypeContext);
 
   return (
@@ -58,7 +46,7 @@ const NotificationViewMode = (props: Props) => {
             )}
           </Subheading>
           <Paragraph marginBottom="none">
-            {getChannelName(notification.channel.id, channels, channelSelection.notFound)}
+            {`${notification.channel.name}, ${notification.channel.teamName}`}
           </Paragraph>
         </Flex>
         <Flex alignItems="center">

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationViewMode/NotificationViewMode.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationViewMode/NotificationViewMode.tsx
@@ -14,7 +14,6 @@ import { styles } from './NotificationViewMode.styles';
 import { getContentTypeName } from '@helpers/configHelpers';
 import { Notification } from '@customTypes/configPage';
 import { contentTypeSelection, notificationsSection } from '@constants/configCopy';
-// TODO: update this when we start fetching channel installations
 
 interface Props {
   index: number;

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationViewMode/NotificationViewMode.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationViewMode/NotificationViewMode.tsx
@@ -58,7 +58,7 @@ const NotificationViewMode = (props: Props) => {
             )}
           </Subheading>
           <Paragraph marginBottom="none">
-            {getChannelName(notification.channelId, channels, channelSelection.notFound)}
+            {getChannelName(notification.channel.id, channels, channelSelection.notFound)}
           </Paragraph>
         </Flex>
         <Flex alignItems="center">

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.tsx
@@ -9,8 +9,8 @@ import DeleteModal from '@components/config/DeleteModal/DeleteModal';
 import DuplicateModal from '../DuplicateModal/DuplicateModal';
 import { Notification } from '@customTypes/configPage';
 import { ParameterAction, actions } from '@components/config/parameterReducer';
-import useGetTeamsChannels from '@hooks/useGetTeamsChannels';
 import { ContentTypeContextProvider } from '@context/ContentTypeProvider';
+import { ChannelContextProvider } from '@context/ChannelProvider';
 import { getUniqueNotifications, getDuplicateNotificationIndex } from '@helpers/configHelpers';
 
 interface Props {
@@ -21,7 +21,6 @@ interface Props {
 const NotificationsSection = (props: Props) => {
   const { notifications, dispatch } = props;
   const [notificationIndexToEdit, setNotificationIndexToEdit] = useState<number | null>(null);
-  const channels = useGetTeamsChannels();
 
   const createNewNotification = () => {
     dispatch({ type: actions.ADD_NOTIFICATION });
@@ -127,36 +126,36 @@ const NotificationsSection = (props: Props) => {
         />
       </Box>
       <ContentTypeContextProvider>
-        {notifications.map((notification, index) => {
-          const inEditMode = notificationIndexToEdit === index;
+        <ChannelContextProvider>
+          {notifications.map((notification, index) => {
+            const inEditMode = notificationIndexToEdit === index;
 
-          if (inEditMode) {
-            return (
-              <NotificationEditMode
-                key={`notification-${index}`}
-                index={index}
-                deleteNotification={deleteNotification}
-                updateNotification={updateNotification}
-                notification={notification}
-                setNotificationIndexToEdit={setNotificationIndexToEdit}
-                channels={channels}
-              />
-            );
-          } else {
-            return (
-              <NotificationViewMode
-                key={`notification-${index}`}
-                index={index}
-                updateNotification={updateNotification}
-                notification={notification}
-                handleEdit={() => setNotificationIndexToEdit(index)}
-                isMenuDisabled={notificationIndexToEdit !== null}
-                handleDelete={() => handleDelete(index)}
-                channels={channels}
-              />
-            );
-          }
-        })}
+            if (inEditMode) {
+              return (
+                <NotificationEditMode
+                  key={`notification-${index}`}
+                  index={index}
+                  deleteNotification={deleteNotification}
+                  updateNotification={updateNotification}
+                  notification={notification}
+                  setNotificationIndexToEdit={setNotificationIndexToEdit}
+                />
+              );
+            } else {
+              return (
+                <NotificationViewMode
+                  key={`notification-${index}`}
+                  index={index}
+                  updateNotification={updateNotification}
+                  notification={notification}
+                  handleEdit={() => setNotificationIndexToEdit(index)}
+                  isMenuDisabled={notificationIndexToEdit !== null}
+                  handleDelete={() => handleDelete(index)}
+                />
+              );
+            }
+          })}
+        </ChannelContextProvider>
       </ContentTypeContextProvider>
     </Box>
   );

--- a/apps/microsoft-teams/frontend/src/constants/configCopy.ts
+++ b/apps/microsoft-teams/frontend/src/constants/configCopy.ts
@@ -59,7 +59,6 @@ const channelSelection = {
     emptyContent:
       'In Microsoft Teams, add the Contentful app to the general channel of the teams where you want to see notifications. Add app',
   },
-  notFound: 'Channel not found',
 };
 
 export enum AppEventKey {

--- a/apps/microsoft-teams/frontend/src/constants/defaultParams.ts
+++ b/apps/microsoft-teams/frontend/src/constants/defaultParams.ts
@@ -14,7 +14,13 @@ const getDefaultSelectedEvents = (): SelectedEvents => {
 };
 
 const defaultNotification = {
-  channelId: '',
+  channel: {
+    id: '',
+    name: '',
+    teamId: '',
+    teamName: '',
+    tenantId: '',
+  },
   contentTypeId: '',
   isEnabled: true,
   selectedEvents: getDefaultSelectedEvents(),

--- a/apps/microsoft-teams/frontend/src/context/ChannelProvider.tsx
+++ b/apps/microsoft-teams/frontend/src/context/ChannelProvider.tsx
@@ -1,0 +1,22 @@
+import { createContext } from 'react';
+import useGetTeamsChannels from '@hooks/useGetTeamsChannels';
+import { TeamsChannel } from '@customTypes/configPage';
+
+interface ChannelContextValue {
+  channels: TeamsChannel[];
+}
+
+interface ChannelContextProviderProps {
+  children: React.ReactNode;
+}
+
+export const ChannelContext = createContext({} as ChannelContextValue);
+
+export const ChannelContextProvider = (props: ChannelContextProviderProps) => {
+  const { children } = props;
+  const channels = useGetTeamsChannels();
+
+  return (
+    <ChannelContext.Provider value={{ channels: channels }}>{children}</ChannelContext.Provider>
+  );
+};

--- a/apps/microsoft-teams/frontend/src/customTypes/configPage.ts
+++ b/apps/microsoft-teams/frontend/src/customTypes/configPage.ts
@@ -6,7 +6,7 @@ export interface AppInstallationParameters {
 }
 
 export interface Notification {
-  channelId: string;
+  channel: TeamsChannel;
   contentTypeId: string;
   isEnabled: boolean;
   selectedEvents: SelectedEvents;

--- a/apps/microsoft-teams/frontend/src/helpers/configHelpers.spec.ts
+++ b/apps/microsoft-teams/frontend/src/helpers/configHelpers.spec.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from 'vitest';
 import {
-  getChannelName,
   getContentTypeName,
   isNotificationReadyToSave,
   isNotificationNew,
@@ -8,37 +7,19 @@ import {
   getUniqueNotifications,
   getDuplicateNotificationIndex,
 } from './configHelpers';
-import { mockChannels, mockContentType } from '@test/mocks';
-import { channelSelection, contentTypeSelection } from '@constants/configCopy';
+import { mockContentType } from '@test/mocks';
+import { contentTypeSelection } from '@constants/configCopy';
 import { defaultNotification } from '@constants/defaultParams';
 import { mockNotification } from '@test/mocks';
 
-describe('getChannelName', () => {
-  it('should return the channel name', () => {
-    expect(
-      getChannelName(
-        '19:e3a386bd1e0f4e00a286b4e86b0cfbe9@thread.tacv2',
-        mockChannels,
-        channelSelection.notFound
-      )
-    ).toEqual('General, Marketing Team');
-  });
-
-  it('should return not found message if channel does not exist', () => {
-    expect(getChannelName('test-not-found', mockChannels, channelSelection.notFound)).toEqual(
-      channelSelection.notFound
-    );
-  });
-});
-
 describe('getContentTypeName', () => {
-  it('should return the channel name', () => {
+  it('should return the content type name', () => {
     expect(getContentTypeName('page', [mockContentType], contentTypeSelection.notFound)).toEqual(
       'Page'
     );
   });
 
-  it('should return not found message if channel does not exist', () => {
+  it('should return not found message if content type does not exist', () => {
     expect(
       getContentTypeName('test-not-found', [mockContentType], contentTypeSelection.notFound)
     ).toEqual(contentTypeSelection.notFound);

--- a/apps/microsoft-teams/frontend/src/helpers/configHelpers.ts
+++ b/apps/microsoft-teams/frontend/src/helpers/configHelpers.ts
@@ -53,7 +53,7 @@ const isNotificationReadyToSave = (
   const hasChanges = doesNotificationHaveChanges(editedNotification, notification);
 
   const hasContentType = !!editedNotification.contentTypeId;
-  const hasChannel = !!editedNotification.channelId;
+  const hasChannel = !!editedNotification.channel.id;
   const hasEventEnabled = Object.values(editedNotification.selectedEvents).includes(true);
   const hasAllFieldsCompleted = hasContentType && hasChannel && hasEventEnabled;
 
@@ -94,7 +94,7 @@ const getUniqueNotifications = (notifications: Notification[]): Notification[] =
 
   // Deduplicate based on content
   const uniqueNotifications = notifications.filter((notification) => {
-    const key = `${notification.channelId}-${notification.contentTypeId}`;
+    const key = `${notification.channel.id}-${notification.contentTypeId}`;
     if (!uniqueKeys.has(key)) {
       uniqueKeys.add(key);
       return true;
@@ -119,7 +119,7 @@ const getDuplicateNotificationIndex = (
 ): number => {
   const duplicateNotificationIndex = notifications.reduce((matchedIndex, notification, idx) => {
     const isDuplicate =
-      notification.channelId === notificationToFind.channelId &&
+      notification.channel.id === notificationToFind.channel.id &&
       notification.contentTypeId === notificationToFind.contentTypeId &&
       index !== idx;
     if (isDuplicate) {

--- a/apps/microsoft-teams/frontend/src/helpers/configHelpers.ts
+++ b/apps/microsoft-teams/frontend/src/helpers/configHelpers.ts
@@ -1,5 +1,5 @@
 import { ContentTypeProps } from 'contentful-management';
-import { Notification, TeamsChannel } from '@customTypes/configPage';
+import { Notification } from '@customTypes/configPage';
 import isEqual from 'lodash/isEqual';
 import { defaultNotification } from '@constants/defaultParams';
 
@@ -18,25 +18,6 @@ const getContentTypeName = (
 ): string => {
   const contentType = contentTypes.find((contentType) => contentType.sys.id === contentTypeId);
   return contentType ? contentType.name : notFoundCopy;
-};
-
-// TODO: update this function when we start fetching channel installations
-/**
- * Gets the channel and team name for a given channel id
- * returns a not found string if the channel is not found
- * @param channelId
- * @param channels
- * @param notFoundCopy
- * @returns string
- */
-const getChannelName = (
-  channelId: string,
-  channels: TeamsChannel[],
-  notFoundCopy: string
-): string => {
-  const channel = channels.find((channel) => channelId === channel.id);
-  const displayName = channel ? `${channel.name}, ${channel.teamName}` : notFoundCopy;
-  return displayName;
 };
 
 /**
@@ -134,7 +115,6 @@ const getDuplicateNotificationIndex = (
 
 export {
   getContentTypeName,
-  getChannelName,
   isNotificationReadyToSave,
   isNotificationNew,
   doesNotificationHaveChanges,

--- a/apps/microsoft-teams/frontend/test/mocks/mockNotification.ts
+++ b/apps/microsoft-teams/frontend/test/mocks/mockNotification.ts
@@ -1,5 +1,11 @@
 const mockNotification = {
-  channelId: 'abc-123',
+  channel: {
+    id: 'abc-123',
+    name: 'Corporate Marketing',
+    teamId: '789-def',
+    teamName: 'Marketing Department',
+    tenantId: '9876-5432',
+  },
   contentTypeId: 'blogPost',
   isEnabled: true,
   selectedEvents: {


### PR DESCRIPTION
## Purpose

This PR makes a few changes to channels in the config page:
- Previously we were only storing channel id and we instead want to store all the channel info returned from the app action
- We are prop drilling channels from the `NotificationsSection` component and this PR refactors that to use context to store the channel info
- Removes a helper function that was previously used to get the channel name

## Approach

In a follow up task we can add additional error handling for channels that are deleted, can't be found, etc.

## Testing steps

This may require you to uninstall and reinstall the app in our development environment to test the changes locally (or at least delete all of the configured notifications).

## Breaking Changes

## Dependencies and/or References

## Deployment
