### PR TITLE
fix: correct Netlify date pattern [INTEG-1670]

### DIFF
--- a/apps/netlify/frontend/src/sidebar/message-processor.js
+++ b/apps/netlify/frontend/src/sidebar/message-processor.js
@@ -77,7 +77,7 @@ export function isDuplicate(msg, previousMessages) {
 function createFormattedTimeString(date) {
   const d = new Date(date);
 
-  return `${formatDistanceToNow(d)} ago at ${format(d, 'h:mm:ss a..aa')}`;
+  return `${formatDistanceToNow(d)} ago at ${format(d, 'h:mm:ss a')}`;
 }
 
 export function messageToState(msg) {

--- a/apps/netlify/frontend/src/sidebar/message-processor.spec.js
+++ b/apps/netlify/frontend/src/sidebar/message-processor.spec.js
@@ -170,7 +170,7 @@ describe('message-processor', () => {
 
       expect(state).toEqual({
         busy: true,
-        info: expect.stringMatching(/at 2:26:02 PM/),
+        info: expect.stringMatching(/at 2:26:02 PM.$/),
         ok: true,
         status: 'Triggering...',
       });
@@ -185,7 +185,7 @@ describe('message-processor', () => {
 
       expect(state).toEqual({
         busy: true,
-        info: expect.stringMatching(/by Jakub.+at 2:26:02 PM/),
+        info: expect.stringMatching(/by Jakub.+at 2:26:02 PM.$/),
         ok: true,
         status: 'Triggering...',
       });
@@ -226,7 +226,7 @@ describe('message-processor', () => {
       expect(state).toEqual({
         busy: false,
         ok: true,
-        info: expect.stringMatching(/Last built.+at 2:26:02 PM/),
+        info: expect.stringMatching(/Last built.+at 2:26:02 PM.$/),
       });
     });
 


### PR DESCRIPTION
## Purpose

See this [original PR](https://github.com/contentful/apps/pull/5082) and [issue](https://github.com/contentful/apps/issues/5081). Our CI checks were not passing on the original PR, so I cherry-picked the commit to open this new PR.

## Approach

Replace date-fns format pattern `a..aa` with `a`. Tests were passing even with the incorrect date pattern, so I also updated the tests to be more specific, so that they will fail with the old pattern.

## Testing steps

## Breaking Changes

## Dependencies and/or References

## Deployment
