### PR TITLE
feat: add search by sku functionality to ecommerce base package

### DIFF
--- a/packages/ecommerce-app-base/docs/README.md
+++ b/packages/ecommerce-app-base/docs/README.md
@@ -347,7 +347,7 @@ ___
 
 ### ProductsFn
 
-Ƭ **ProductsFn**<`P`\>: (`search`: `string`, `pagination?`: `Partial`<[`Pagination`](README.md#pagination)\>) => `Promise`<`ProductsFnResponse`<`P`\>\>
+Ƭ **ProductsFn**\<`P`\>: (`search`: `string`, `pagination?`: `Partial`\<[`Pagination`](README.md#pagination)\>, `searchBySku?`: `boolean`) => `Promise`\<`ProductsFnResponse`\<`P`\>\>
 
 #### Type parameters
 
@@ -357,18 +357,19 @@ ___
 
 #### Type declaration
 
-▸ (`search`, `pagination?`): `Promise`<`ProductsFnResponse`<`P`\>\>
+▸ (`search`, `pagination?`, `searchBySku?`): `Promise`\<`ProductsFnResponse`\<`P`\>\>
 
 ##### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `search` | `string` |
-| `pagination?` | `Partial`<[`Pagination`](README.md#pagination)\> |
+| `pagination?` | `Partial`\<[`Pagination`](README.md#pagination)\> |
+| `searchBySku?` | `boolean` |
 
 ##### Returns
 
-`Promise`<`ProductsFnResponse`<`P`\>\>
+`Promise`\<`ProductsFnResponse`\<`P`\>\>
 
 ___
 

--- a/packages/ecommerce-app-base/src/SkuPicker/SkuPicker.spec.tsx
+++ b/packages/ecommerce-app-base/src/SkuPicker/SkuPicker.spec.tsx
@@ -63,6 +63,11 @@ describe('SkuPicker', () => {
     expect(getByTestId('sku-search')).toBeInTheDocument();
   });
 
+  it('should render search by sku option if showSearchBySkuOption is passed', async () => {
+    const { getByTestId } = await renderComponent({ ...defaultProps, showSearchBySkuOption: true });
+    expect(getByTestId('search-by-sku')).toBeInTheDocument();
+  });
+
   describe('when it has infinite scrolling mode pagination', () => {
     it('should render the "Load more" text link if there is a next page', async () => {
       const { findByTestId } = await renderComponent({

--- a/packages/ecommerce-app-base/src/SkuPicker/SkuPicker.spec.tsx
+++ b/packages/ecommerce-app-base/src/SkuPicker/SkuPicker.spec.tsx
@@ -58,12 +58,19 @@ describe('SkuPicker', () => {
   });
   afterEach(cleanup);
 
-  it('should render successfully with no products selected', async () => {
-    const { getByTestId } = await renderComponent(defaultProps);
+  it('should render basic search successfully with no products selected', async () => {
+    const { getByTestId, queryByTestId } = await renderComponent(defaultProps);
     expect(getByTestId('sku-search')).toBeInTheDocument();
+    expect(queryByTestId('search-by-sku')).not.toBeInTheDocument();
   });
 
-  it('should render search by sku option if showSearchBySkuOption is passed', async () => {
+  it('should not render search when hideSearch is true', async () => {
+    const { queryByTestId } = await renderComponent({ ...defaultProps, hideSearch: true });
+    expect(queryByTestId('sku-search')).not.toBeInTheDocument();
+    expect(queryByTestId('search-by-sku')).not.toBeInTheDocument();
+  });
+
+  it('should render search by sku option if showSearchBySkuOption is true', async () => {
     const { getByTestId } = await renderComponent({ ...defaultProps, showSearchBySkuOption: true });
     expect(getByTestId('search-by-sku')).toBeInTheDocument();
   });

--- a/packages/ecommerce-app-base/src/SkuPicker/SkuPicker.tsx
+++ b/packages/ecommerce-app-base/src/SkuPicker/SkuPicker.tsx
@@ -10,7 +10,7 @@ import { ProductSelectionList } from './ProductSelectionList';
 import { styles } from './styles';
 import { mapSort } from '../utils';
 
-import { Button, TextInput } from '@contentful/f36-components';
+import { Button, Checkbox, Text, TextInput } from '@contentful/f36-components';
 
 import { SearchIcon } from '@contentful/f36-icons';
 
@@ -22,6 +22,7 @@ export interface Props {
   skuType?: string;
   makeSaveBtnText?: MakeSaveBtnTextFn;
   hideSearch?: boolean;
+  showSearchBySkuOption?: boolean;
 }
 
 interface State {
@@ -31,6 +32,7 @@ interface State {
   products: Product[];
   selectedProducts: Product[];
   selectedSKUs: string[];
+  searchBySku: boolean;
 }
 
 const DEFAULT_SEARCH_DELAY = 250;
@@ -59,6 +61,7 @@ export class SkuPicker extends Component<Props, State> {
     products: [],
     selectedProducts: [],
     selectedSKUs: get(this.props, ['sdk', 'parameters', 'invocation', 'fieldValue'], []),
+    searchBySku: false,
   };
 
   setSearchCallback: () => void;
@@ -79,6 +82,10 @@ export class SkuPicker extends Component<Props, State> {
     this.setState({ search }, this.setSearchCallback);
   };
 
+  setSearchBySku = () => {
+    this.setState({ searchBySku: !this.state.searchBySku }, this.setSearchCallback);
+  };
+
   updateProducts = async () => {
     try {
       const {
@@ -87,7 +94,7 @@ export class SkuPicker extends Component<Props, State> {
         search,
       } = this.state;
       const offset = (activePage - 1) * limit;
-      const fetched = await this.props.fetchProducts(search, { offset });
+      const fetched = await this.props.fetchProducts(search, { offset }, this.state.searchBySku);
       // If the request has been cancelled because a new one has been launched
       // then fetchProducts will return null
       if (fetched && fetched.pagination && fetched.products) {
@@ -148,35 +155,58 @@ export class SkuPicker extends Component<Props, State> {
   };
 
   render() {
-    const { search, pagination, products, selectedProducts, selectedSKUs } = this.state;
-    const { makeSaveBtnText = defaultGetSaveBtnText, skuType, hideSearch = false } = this.props;
+    const { search, pagination, products, selectedProducts, selectedSKUs, searchBySku } =
+      this.state;
+    const {
+      makeSaveBtnText = defaultGetSaveBtnText,
+      skuType,
+      hideSearch = false,
+      showSearchBySkuOption,
+    } = this.props;
     const infiniteScrollingPaginationMode = 'hasNextPage' in pagination;
     const pageCount = Math.ceil(pagination.total / pagination.limit);
 
     return (
       <>
         <header className={styles.header}>
-          <div className={styles.leftSideControls}>
-            {!hideSearch && (
-              <>
-                <TextInput
-                  placeholder="Search for a product..."
-                  type="search"
-                  name="sku-search"
-                  id="sku-search"
-                  testId="sku-search"
-                  value={search}
-                  onChange={(event) => this.setSearch((event.target as HTMLInputElement).value)}
-                />
-                <SearchIcon variant="muted" />
-              </>
-            )}
-            {!!pagination.total && (
-              <span className={styles.total}>
-                Total results: {pagination.total.toLocaleString()}
-              </span>
-            )}
-          </div>
+          {!hideSearch && (
+            <div>
+              <div className={styles.searchWrapper}>
+                <div className={styles.leftSideControls}>
+                  <TextInput
+                    placeholder="Search for a product..."
+                    type="search"
+                    name="sku-search"
+                    id="sku-search"
+                    testId="sku-search"
+                    value={search}
+                    onChange={(event) => this.setSearch((event.target as HTMLInputElement).value)}
+                  />
+
+                  <SearchIcon variant="muted" />
+                </div>
+
+                {showSearchBySkuOption && (
+                  <div className={styles.skuSearch}>
+                    <Checkbox
+                      name="search-by-sku"
+                      id="search-by-sku"
+                      isChecked={searchBySku}
+                      onChange={() => this.setSearchBySku()}>
+                      Search only by SKU
+                    </Checkbox>
+                  </div>
+                )}
+              </div>
+
+              {!!pagination.total && (
+                <Text className={styles.total}>
+                  {pagination.total.toLocaleString()} total results
+                </Text>
+              )}
+            </div>
+          )}
+
           <div className={styles.rightSideControls}>
             <ProductSelectionList products={selectedProducts} selectProduct={this.selectProduct} />
             <Button

--- a/packages/ecommerce-app-base/src/SkuPicker/SkuPicker.tsx
+++ b/packages/ecommerce-app-base/src/SkuPicker/SkuPicker.tsx
@@ -169,8 +169,8 @@ export class SkuPicker extends Component<Props, State> {
     return (
       <>
         <header className={styles.header}>
-          {!hideSearch && (
-            <div>
+          <div>
+            {!hideSearch && (
               <div className={styles.searchWrapper}>
                 <div className={styles.leftSideControls}>
                   <TextInput
@@ -199,14 +199,14 @@ export class SkuPicker extends Component<Props, State> {
                   </div>
                 )}
               </div>
+            )}
 
-              {!!pagination.total && (
-                <Text className={styles.total}>
-                  {pagination.total.toLocaleString()} total results
-                </Text>
-              )}
-            </div>
-          )}
+            {!!pagination.total && (
+              <Text className={styles.total}>
+                {pagination.total.toLocaleString()} total results
+              </Text>
+            )}
+          </div>
 
           <div className={styles.rightSideControls}>
             <ProductSelectionList products={selectedProducts} selectProduct={this.selectProduct} />

--- a/packages/ecommerce-app-base/src/SkuPicker/SkuPicker.tsx
+++ b/packages/ecommerce-app-base/src/SkuPicker/SkuPicker.tsx
@@ -190,6 +190,7 @@ export class SkuPicker extends Component<Props, State> {
                   <div className={styles.skuSearch}>
                     <Checkbox
                       name="search-by-sku"
+                      testId="search-by-sku"
                       id="search-by-sku"
                       isChecked={searchBySku}
                       onChange={() => this.setSearchBySku()}>

--- a/packages/ecommerce-app-base/src/SkuPicker/renderSkuPicker.tsx
+++ b/packages/ecommerce-app-base/src/SkuPicker/renderSkuPicker.tsx
@@ -12,6 +12,7 @@ interface Props<> {
   skuType?: string;
   makeSaveBtnText?: MakeSaveBtnTextFn;
   hideSearch?: boolean;
+  showSearchBySkuOption?: boolean;
 }
 
 export function renderSkuPicker(
@@ -24,6 +25,7 @@ export function renderSkuPicker(
     skuType,
     makeSaveBtnText,
     hideSearch,
+    showSearchBySkuOption,
   }: Props
 ): void {
   const root = document.getElementById(elementId);
@@ -37,6 +39,7 @@ export function renderSkuPicker(
       skuType={skuType}
       makeSaveBtnText={makeSaveBtnText}
       hideSearch={hideSearch}
+      showSearchBySkuOption={showSearchBySkuOption}
     />,
     root
   );

--- a/packages/ecommerce-app-base/src/SkuPicker/styles.ts
+++ b/packages/ecommerce-app-base/src/SkuPicker/styles.ts
@@ -73,4 +73,15 @@ export const styles = {
   loadMoreButton: css({
     marginTop: tokens.spacingXs,
   }),
+  searchWrapper: css({
+    display: 'flex',
+    alignItems: 'center',
+    whiteSpace: 'nowrap',
+  }),
+  skuSearch: css({
+    display: 'flex',
+    alignItems: 'center',
+    marginLeft: tokens.spacingM,
+    marginRight: tokens.spacingXs,
+  }),
 };

--- a/packages/ecommerce-app-base/src/types/product.ts
+++ b/packages/ecommerce-app-base/src/types/product.ts
@@ -26,5 +26,6 @@ type ProductsFnResponse<P extends Product = Product> = {
 
 export type ProductsFn<P extends Product = Product> = (
   search: string,
-  pagination?: Partial<Pagination>
+  pagination?: Partial<Pagination>,
+  searchBySku?: boolean
 ) => Promise<ProductsFnResponse<P>>;


### PR DESCRIPTION
## Purpose

This PR adds functionality to the ecommerce base package to search products within the SkuPicker by sku only. 

## Approach
This is to at least partially solve a customer issue that they are not able to accurately find a product using the commerce tools app when searching by sku or name. This is a consequence of the commerce tools api, as noted [here](https://github.com/contentful/apps/pull/5880), as the current search implementation will not provide unique results. 

We have introduced a prop to optionally render a "Search by sku" within the search modal itself.

When `showSearchBySkuOption` prop is not provided: 
<img width="253" alt="Screenshot 2024-01-05 at 4 42 38 PM" src="https://github.com/contentful/apps/assets/58186851/a348dc27-2f88-4fc4-8704-d7ffff31985c">


When `showSearchBySkuOption` prop is provided: 
<img width="409" alt="Screenshot 2024-01-05 at 4 42 26 PM" src="https://github.com/contentful/apps/assets/58186851/d2cab193-d5e1-4f6a-96bd-f76e65bade21">

This can easily be seen by running storybook locally on this branch from the package itself. 

## Testing steps

[This](https://github.com/contentful/apps/compare/master...feat/add-sku-search) branch combines both the updates to this ecommerce package and installing the package into the commerce tools app itself. You should be able to pull down this branch, link the ecommerce package locally, and see the changes reflected in [this](https://www.loom.com/share/f03ab5e80ae947ada6da621838973856) loom. 

## Dependencies and/or References

[This](https://github.com/contentful/apps/pull/5880) PR encompasses the changes within the commerce tools app to resolve the customer issue. Once this PR is merged, this other PR will also have the updated ecommerce package version. 

