### PR TITLE
fix: pin f36-core to circumvent missing 4.58.0 package in npm

### DIFF
--- a/examples/javascript/package-lock.json
+++ b/examples/javascript/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@contentful/app-sdk": "^4.23.1",
         "@contentful/f36-components": "4.57.0",
+        "@contentful/f36-core": "4.57.0",
         "@contentful/f36-tokens": "4.0.3",
         "@contentful/react-apps-toolkit": "1.2.16",
         "contentful-management": "10.46.4",

--- a/examples/javascript/package.json
+++ b/examples/javascript/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@contentful/app-sdk": "^4.23.1",
     "@contentful/f36-components": "4.57.0",
+    "@contentful/f36-core": "4.57.0",
     "@contentful/f36-tokens": "4.0.3",
     "@contentful/react-apps-toolkit": "1.2.16",
     "contentful-management": "10.46.4",

--- a/examples/typescript/package-lock.json
+++ b/examples/typescript/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@contentful/app-sdk": "^4.23.1",
         "@contentful/f36-components": "4.57.0",
+        "@contentful/f36-core": "4.57.0",
         "@contentful/f36-tokens": "4.0.3",
         "@contentful/react-apps-toolkit": "1.2.16",
         "contentful-management": "10.46.4",

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@contentful/app-sdk": "^4.23.1",
     "@contentful/f36-components": "4.57.0",
+    "@contentful/f36-core": "4.57.0",
     "@contentful/f36-tokens": "4.0.3",
     "@contentful/react-apps-toolkit": "1.2.16",
     "contentful-management": "10.46.4",


### PR DESCRIPTION
## Purpose

Provide explicit support for the missing version

## Approach

<!-- Why did we do it the way we did? Did we consider alternatives? What other implementation details or artifacts (screenshots etc.) would help reviewers contextualize change? -->

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
