### PR TITLE
feat: add validation for commercetools [MONET-1737]

### DIFF
--- a/apps/commercetools-without-search/src/config.ts
+++ b/apps/commercetools-without-search/src/config.ts
@@ -79,5 +79,9 @@ export function validateParameters(parameters: ConfigurationParameters): string 
     return 'Provide the commercetools data locale.';
   }
 
+  if (parameters.authApiEndpoint?.endsWith('/')) {
+    parameters.apiEndpoint = parameters.apiEndpoint?.slice(0, -1);
+  }
+
   return null;
 }

--- a/apps/commercetools-without-search/src/config.ts
+++ b/apps/commercetools-without-search/src/config.ts
@@ -80,7 +80,7 @@ export function validateParameters(parameters: ConfigurationParameters): string 
   }
 
   if (parameters.authApiEndpoint?.endsWith('/')) {
-    parameters.apiEndpoint = parameters.apiEndpoint?.slice(0, -1);
+    parameters.authApiEndpoint = parameters.authApiEndpoint?.slice(0, -1);
   }
 
   return null;

--- a/apps/commercetools/src/config.ts
+++ b/apps/commercetools/src/config.ts
@@ -79,5 +79,9 @@ export function validateParameters(parameters: ConfigurationParameters): string 
     return 'Provide the commercetools data locale.';
   }
 
+  if (parameters.authApiEndpoint?.endsWith('/')) {
+    parameters.authApiEndpoint = parameters.authApiEndpoint?.slice(0, -1);
+  }
+
   return null;
 }

--- a/apps/commercetools/src/dialog.ts
+++ b/apps/commercetools/src/dialog.ts
@@ -51,6 +51,7 @@ export async function renderDialog(sdk: DialogAppSDK) {
     skuType,
     makeSaveBtnText: makeSaveBtnText(skuType),
     hideSearch: skuType === 'category',
+    showSearchBySkuOption: true,
   });
 
   sdk.window.startAutoResizer();

--- a/apps/commercetools/src/dialog.ts
+++ b/apps/commercetools/src/dialog.ts
@@ -51,7 +51,6 @@ export async function renderDialog(sdk: DialogAppSDK) {
     skuType,
     makeSaveBtnText: makeSaveBtnText(skuType),
     hideSearch: skuType === 'category',
-    showSearchBySkuOption: true,
   });
 
   sdk.window.startAutoResizer();


### PR DESCRIPTION
## Purpose

[Ticket](https://contentful.atlassian.net/browse/MONET-1737)

## Approach

When the API URL contains a trailing / the 3rd-party API request in graph-api fails. This PR removes the '/' if there is one, inside `validateParameters` function. 

## Testing steps

I tested locally by running this app. Only when you refresh the page, the value on the form changes but I think this is not a problem for the bug fix. There were no tests for the application. 

