### PR TITLE
fix: [INTEG-1697] - Add missing deps to copysharp method

### DIFF
--- a/apps/ai-image-generator/bundle-sharp.js
+++ b/apps/ai-image-generator/bundle-sharp.js
@@ -40,6 +40,12 @@ const copySharp = async () => {
   await fs.cp('./node_modules/simple-swizzle', './build/node_modules/simple-swizzle', {
     recursive: true,
   });
+  await fs.cp('./node_modules/lru-cache', './build/node_modules/lru-cache', {
+    recursive: true,
+  });
+  await fs.cp('./node_modules/yallist', './build/node_modules/yallist', {
+    recursive: true,
+  });
 };
 
 copySharp();


### PR DESCRIPTION
## Purpose

Adds missing deps to `copy-sharp.js` for bundling correctly
