### PR TITLE
feat: introduce provider with custom api for self installs

### DIFF
--- a/apps/microsoft-teams/frontend/src/context/SdkWithCustomApiProvider.tsx
+++ b/apps/microsoft-teams/frontend/src/context/SdkWithCustomApiProvider.tsx
@@ -1,0 +1,86 @@
+import { KnownAppSDK, init as sdkInit } from '@contentful/app-sdk';
+import { FC, PropsWithChildren, ReactElement, createContext, useEffect, useState } from 'react';
+import { FreeFormParameters } from 'contentful-management/types';
+
+const DELAY_TIMEOUT = 4 * 1000;
+
+// reimplimentated type defintiion for Channel class which is not exported from https://github.com/contentful/ui-extensions-sdk/blob/master/lib/channel.ts
+interface Channel {
+  send(event: string, ...args: Array<any>): Promise<any>; // eslint-disable-line @typescript-eslint/no-explicit-any
+  call<T>(channelName: T, methodName: string, args?: Array<any>): Promise<any>; // eslint-disable-line @typescript-eslint/no-explicit-any
+  addHandler<T, V>(channelName: T, callback: (value: V) => void): void;
+}
+
+type CustomApiMaker = (channel: Channel) => CustomApi;
+
+// this is the "correct" type definition for the `init` function, as opposed to the "fake" type we define
+// here https://github.com/contentful/ui-extensions-sdk/blob/v4.23.1/lib/index.ts#L8-L13 which masks
+// the presence of the `makeCustomApi` option
+type InitFunction = <T>(
+  initCb: (sdk: KnownAppSDK, customSdk: T) => void,
+  {
+    makeCustomApi,
+    supressIframeWarning,
+  }: { makeCustomApi?: CustomApiMaker; supressIframeWarning?: boolean }
+) => [KnownAppSDK, T] | void;
+
+const init = sdkInit as InitFunction;
+
+interface CustomSDKProviderProps {
+  loading?: ReactElement;
+}
+
+// methods can be implemented here that call the low level channel directly. those methods must be defined
+// on the "receiving" end in user interface / experience pacakges
+export class CustomApi {
+  constructor(private readonly channel: Channel) {}
+
+  async install(parameters: FreeFormParameters): Promise<void> {
+    // eslint-disable-line @typescript-eslint/no-explicit-any
+    return this.channel.call('callAppMethod', 'install', [parameters]);
+  }
+}
+
+const makeCustomApi: CustomApiMaker = (channel: Channel) => new CustomApi(channel);
+
+// this context and the below provider is a reimplimentation of the SdkProvider that includes a customApi attribute, which is secretly
+// supported by the App SDK. We will use it to expose the ability to self install to our app.
+export const SDKWithCustomApiContext = createContext<{
+  sdk: KnownAppSDK | null;
+  customApi: CustomApi | null;
+}>({ sdk: null, customApi: null });
+
+export const SdkWithCustomApiProvider: FC<PropsWithChildren<CustomSDKProviderProps>> = (props) => {
+  const [sdk, setSDK] = useState<KnownAppSDK | undefined>();
+  const [customApi, setCustomApi] = useState<CustomApi | undefined>();
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      console.warn(
+        "Your app is taking longer than expected to initialize. If you think this is an error with Contentful's App SDK, let us know: https://github.com/contentful/ui-extensions-sdk/issues"
+      );
+    }, DELAY_TIMEOUT);
+    init<CustomApi>(
+      (sdk: KnownAppSDK, customApi: CustomApi) => {
+        setSDK(sdk);
+        setCustomApi(customApi);
+        window.clearTimeout(timeout);
+      },
+      { makeCustomApi }
+    );
+    return () => window.clearTimeout(timeout);
+  }, []);
+
+  if (!sdk || !customApi) {
+    if (props.loading) {
+      return props.loading;
+    }
+    return null;
+  }
+
+  return (
+    <SDKWithCustomApiContext.Provider value={{ sdk, customApi }}>
+      {props.children}
+    </SDKWithCustomApiContext.Provider>
+  );
+};

--- a/apps/microsoft-teams/frontend/src/context/SdkWithCustomApiProvider.tsx
+++ b/apps/microsoft-teams/frontend/src/context/SdkWithCustomApiProvider.tsx
@@ -35,7 +35,10 @@ interface CustomSDKProviderProps {
 export class CustomApi {
   constructor(private readonly channel: Channel) {}
 
-  async install(parameters: FreeFormParameters): Promise<void> {
+  // calling this method will trigger a save of the app config with the provided paramaters. if the app
+  // is not yet installed, it will be installed. the parameters will still pass through parameter handlers
+  // attached by the app
+  async saveConfiguration(parameters: FreeFormParameters): Promise<void> {
     // eslint-disable-line @typescript-eslint/no-explicit-any
     return this.channel.call('callAppMethod', 'install', [parameters]);
   }

--- a/apps/microsoft-teams/frontend/src/hooks/useCustomApi.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/hooks/useCustomApi.spec.tsx
@@ -1,0 +1,16 @@
+import { ReactNode } from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useCustomApi } from './useCustomApi';
+import { SdkWithCustomApiProvider } from '@context/SdkWithCustomApiProvider';
+
+describe('useCustomApi', () => {
+  // by default the context returns null, before the it's popuplated by the init call in the provider
+  it('returns null', async () => {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <SdkWithCustomApiProvider>{children}</SdkWithCustomApiProvider>
+    );
+    const { result } = renderHook(() => useCustomApi(), { wrapper });
+    await waitFor(() => expect(result.current).toEqual(null));
+  });
+});

--- a/apps/microsoft-teams/frontend/src/hooks/useCustomApi.ts
+++ b/apps/microsoft-teams/frontend/src/hooks/useCustomApi.ts
@@ -1,0 +1,14 @@
+import { CustomApi, SDKWithCustomApiContext } from '@context/SdkWithCustomApiProvider';
+import { useContext } from 'react';
+
+export function useCustomApi(): CustomApi {
+  const { customApi } = useContext(SDKWithCustomApiContext);
+
+  if (!customApi) {
+    throw new Error(
+      'API context not found. Make sure this hook is used inside the SdkWithCustomApiProvider'
+    );
+  }
+
+  return customApi;
+}

--- a/apps/microsoft-teams/frontend/src/index.tsx
+++ b/apps/microsoft-teams/frontend/src/index.tsx
@@ -1,10 +1,10 @@
 import { createRoot } from 'react-dom/client';
 
 import { GlobalStyles } from '@contentful/f36-components';
-import { SDKProvider } from '@contentful/react-apps-toolkit';
 
 import App from './App';
 import LocalhostWarning from '@components/LocalhostWarning';
+import { SdkWithCustomApiProvider } from '@context/SdkWithCustomApiProvider';
 
 const container = document.getElementById('root')!;
 const root = createRoot(container);
@@ -14,9 +14,9 @@ if (import.meta.env.DEV && window.self === window.top) {
   root.render(<LocalhostWarning />);
 } else {
   root.render(
-    <SDKProvider>
+    <SdkWithCustomApiProvider>
       <GlobalStyles />
       <App />
-    </SDKProvider>
+    </SdkWithCustomApiProvider>
   );
 }


### PR DESCRIPTION
## Purpose

We want to support the ability for the MS Teams app to trigger a save of configurations directly.

## Approach

* Expose the undisclosed API (implemented in experience packages) that allows for self installs to be triggered via the SDK (via an undocumented ability to provide a custom API to the SDK set up)
* Provide a custom SDK provider which leverages the custom API
* Provide a hook to expose the API itself
* Named it `saveConfiguration` in the API we use to make it more clear what's actually happening

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
