### PR TITLE
fix: separate custom api and sdk contexts

### DIFF
--- a/apps/microsoft-teams/frontend/src/context/SdkWithCustomApiProvider.tsx
+++ b/apps/microsoft-teams/frontend/src/context/SdkWithCustomApiProvider.tsx
@@ -1,6 +1,7 @@
 import { KnownAppSDK, init as sdkInit } from '@contentful/app-sdk';
 import { FC, PropsWithChildren, ReactElement, createContext, useEffect, useState } from 'react';
 import { FreeFormParameters } from 'contentful-management/types';
+import { SDKContext } from '@contentful/react-apps-toolkit';
 
 const DELAY_TIMEOUT = 4 * 1000;
 
@@ -48,10 +49,9 @@ const makeCustomApi: CustomApiMaker = (channel: Channel) => new CustomApi(channe
 
 // this context and the below provider is a reimplimentation of the SdkProvider that includes a customApi attribute, which is secretly
 // supported by the App SDK. We will use it to expose the ability to self install to our app.
-export const SDKWithCustomApiContext = createContext<{
-  sdk: KnownAppSDK | null;
+export const CustomApiContext = createContext<{
   customApi: CustomApi | null;
-}>({ sdk: null, customApi: null });
+}>({ customApi: null });
 
 export const SdkWithCustomApiProvider: FC<PropsWithChildren<CustomSDKProviderProps>> = (props) => {
   const [sdk, setSDK] = useState<KnownAppSDK | undefined>();
@@ -82,8 +82,8 @@ export const SdkWithCustomApiProvider: FC<PropsWithChildren<CustomSDKProviderPro
   }
 
   return (
-    <SDKWithCustomApiContext.Provider value={{ sdk, customApi }}>
-      {props.children}
-    </SDKWithCustomApiContext.Provider>
+    <CustomApiContext.Provider value={{ customApi }}>
+      <SDKContext.Provider value={{ sdk }}>{props.children}</SDKContext.Provider>
+    </CustomApiContext.Provider>
   );
 };

--- a/apps/microsoft-teams/frontend/src/hooks/useCustomApi.ts
+++ b/apps/microsoft-teams/frontend/src/hooks/useCustomApi.ts
@@ -1,8 +1,8 @@
-import { CustomApi, SDKWithCustomApiContext } from '@context/SdkWithCustomApiProvider';
+import { CustomApi, CustomApiContext } from '@context/SdkWithCustomApiProvider';
 import { useContext } from 'react';
 
 export function useCustomApi(): CustomApi {
-  const { customApi } = useContext(SDKWithCustomApiContext);
+  const { customApi } = useContext(CustomApiContext);
 
   if (!customApi) {
     throw new Error(


### PR DESCRIPTION
## Purpose

The `useSDK` hook was no longer working after we introduced the `SdkWithCustomApiProvider`. The problem was that the `SDKContext` needed to be populated with a provider, which was missing.

## Approach

* Just split the two contexts and include the SDK provider in the custom provider as a child element

Screenshot of config actually working:

<img width="1215" alt="image" src="https://github.com/contentful/apps/assets/235836/5cfbc32c-f096-4723-95ea-c2a301697cf8">


## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
