### PR TITLE
feat: add toast confirmation for test message

### DIFF
--- a/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.tsx
@@ -72,13 +72,14 @@ const NotificationEditMode = (props: Props) => {
       const body = JSON.parse(response.body);
 
       if (body.ok) {
-        // TODO: display success toast
-        console.log(`Test sent successfully, message id: ${body.data}`);
+        sdk.notifier.success('A test message was sent');
       } else {
         throw new Error(`Failed to send test message: ${body.errors?.[0]?.message}`);
       }
     } catch (error) {
-      // TODO: display error to user if test notification fails
+      if (error instanceof Error) {
+        sdk.notifier.error(error.message || 'Failed to send test message');
+      }
       console.error(error);
     }
   };


### PR DESCRIPTION
## Purpose

When a user sends a test notification from the app config page, we want them to know whether or not it succeeded.

## Approach

Display toast message on success or error for the test notification:

![Screenshot 2024-01-22 at 8 38 26 AM](https://github.com/contentful/apps/assets/62958907/6b570a17-ae75-45db-b7ac-dcdcbc0316fe)

![Screenshot 2024-01-22 at 8 35 19 AM](https://github.com/contentful/apps/assets/62958907/e37ed79d-9148-4e40-a1e9-79a567f023fe)

## Testing steps

Note: we need to make some changes in the bot service in order for the full error message to display as is shown in the screenshot above.

## Breaking Changes

## Dependencies and/or References

## Deployment
