### PR TITLE
Rename app event topics

### DIFF
--- a/apps/microsoft-teams/frontend/src/components/config/EventsSelection/EventsSelection.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/EventsSelection/EventsSelection.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { Box, Checkbox, FormControl } from '@contentful/f36-components';
-import { Notification } from '@customTypes/configPage';
-import { AppEventKey, eventsSelection } from '@constants/configCopy';
+import { AppEventKey, Notification } from '@customTypes/configPage';
+import { eventsSelection } from '@constants/configCopy';
 
 interface Props {
   notification: Notification;

--- a/apps/microsoft-teams/frontend/src/constants/configCopy.ts
+++ b/apps/microsoft-teams/frontend/src/constants/configCopy.ts
@@ -64,28 +64,28 @@ const channelSelection = {
 };
 
 const AppEvents = {
-  [AppEventKey.PUBLISH]: {
-    id: AppEventKey.PUBLISH,
+  [AppEventKey.ENTRY_PUBLISH]: {
+    id: AppEventKey.ENTRY_PUBLISH,
     text: 'Publish',
   },
-  [AppEventKey.UNPUBLISHED]: {
-    id: AppEventKey.UNPUBLISHED,
+  [AppEventKey.ENTRY_UNPUBLISHED]: {
+    id: AppEventKey.ENTRY_UNPUBLISHED,
     text: 'Unpublish',
   },
-  [AppEventKey.CREATED]: {
-    id: AppEventKey.CREATED,
+  [AppEventKey.ENTRY_CREATED]: {
+    id: AppEventKey.ENTRY_CREATED,
     text: 'Create',
   },
-  [AppEventKey.DELETED]: {
-    id: AppEventKey.DELETED,
+  [AppEventKey.ENTRY_DELETED]: {
+    id: AppEventKey.ENTRY_DELETED,
     text: 'Delete',
   },
-  [AppEventKey.ARCHIVE]: {
-    id: AppEventKey.ARCHIVE,
+  [AppEventKey.ENTRY_ARCHIVE]: {
+    id: AppEventKey.ENTRY_ARCHIVE,
     text: 'Archive',
   },
-  [AppEventKey.UNARCHIVE]: {
-    id: AppEventKey.UNARCHIVE,
+  [AppEventKey.ENTRY_UNARCHIVE]: {
+    id: AppEventKey.ENTRY_UNARCHIVE,
     text: 'Unarchive',
   },
 };

--- a/apps/microsoft-teams/frontend/src/constants/configCopy.ts
+++ b/apps/microsoft-teams/frontend/src/constants/configCopy.ts
@@ -1,3 +1,5 @@
+import { AppEventKey } from '@customTypes/configPage';
+
 const headerSection = {
   title: 'Set up the Microsoft Teams App',
   description: 'Get notifications about Contentful content updates directly in Microsoft Teams.',
@@ -60,15 +62,6 @@ const channelSelection = {
       'In Microsoft Teams, add the Contentful app to the general channel of the teams where you want to see notifications. Add app',
   },
 };
-
-export enum AppEventKey {
-  PUBLISH = 'publish',
-  UNPUBLISHED = 'unpublish',
-  CREATED = 'create',
-  DELETED = 'delete',
-  ARCHIVE = 'archive',
-  UNARCHIVE = 'unarchive',
-}
 
 const AppEvents = {
   [AppEventKey.PUBLISH]: {

--- a/apps/microsoft-teams/frontend/src/constants/defaultParams.ts
+++ b/apps/microsoft-teams/frontend/src/constants/defaultParams.ts
@@ -1,5 +1,4 @@
-import { AppInstallationParameters, SelectedEvents } from '@customTypes/configPage';
-import { AppEventKey } from './configCopy';
+import { AppEventKey, AppInstallationParameters, SelectedEvents } from '@customTypes/configPage';
 
 const initialParameters: AppInstallationParameters = {
   tenantId: '',

--- a/apps/microsoft-teams/frontend/src/customTypes/configPage.ts
+++ b/apps/microsoft-teams/frontend/src/customTypes/configPage.ts
@@ -1,14 +1,3 @@
-export const TOPIC_ACTION_MAP = {
-  'ContentManagement.Entry.create': 'created',
-  'ContentManagement.Entry.save': 'saved',
-  'ContentManagement.Entry.auto_save': 'auto saved',
-  'ContentManagement.Entry.archive': 'archived',
-  'ContentManagement.Entry.unarchive': 'unarchived',
-  'ContentManagement.Entry.publish': 'published',
-  'ContentManagement.Entry.unpublish': 'unpublished',
-  'ContentManagement.Entry.delete': 'deleted',
-} as const;
-
 export enum AppEventKey {
   ENTRY_PUBLISH = 'ContentManagement.Entry.publish',
   ENTRY_UNPUBLISHED = 'ContentManagement.Entry.unpublish',

--- a/apps/microsoft-teams/frontend/src/customTypes/configPage.ts
+++ b/apps/microsoft-teams/frontend/src/customTypes/configPage.ts
@@ -10,12 +10,12 @@ export const TOPIC_ACTION_MAP = {
 } as const;
 
 export enum AppEventKey {
-  PUBLISH = 'ContentManagement.Entry.publish',
-  UNPUBLISHED = 'ContentManagement.Entry.unpublish',
-  CREATED = 'ContentManagement.Entry.create',
-  DELETED = 'ContentManagement.Entry.delete',
-  ARCHIVE = 'ContentManagement.Entry.archive',
-  UNARCHIVE = 'ContentManagement.Entry.unarchive',
+  ENTRY_PUBLISH = 'ContentManagement.Entry.publish',
+  ENTRY_UNPUBLISHED = 'ContentManagement.Entry.unpublish',
+  ENTRY_CREATED = 'ContentManagement.Entry.create',
+  ENTRY_DELETED = 'ContentManagement.Entry.delete',
+  ENTRY_ARCHIVE = 'ContentManagement.Entry.archive',
+  ENTRY_UNARCHIVE = 'ContentManagement.Entry.unarchive',
 }
 
 export interface AppInstallationParameters {

--- a/apps/microsoft-teams/frontend/src/customTypes/configPage.ts
+++ b/apps/microsoft-teams/frontend/src/customTypes/configPage.ts
@@ -1,4 +1,22 @@
-import { AppEventKey } from '@constants/configCopy';
+export const TOPIC_ACTION_MAP = {
+  'ContentManagement.Entry.create': 'created',
+  'ContentManagement.Entry.save': 'saved',
+  'ContentManagement.Entry.auto_save': 'auto saved',
+  'ContentManagement.Entry.archive': 'archived',
+  'ContentManagement.Entry.unarchive': 'unarchived',
+  'ContentManagement.Entry.publish': 'published',
+  'ContentManagement.Entry.unpublish': 'unpublished',
+  'ContentManagement.Entry.delete': 'deleted',
+} as const;
+
+export enum AppEventKey {
+  PUBLISH = 'ContentManagement.Entry.publish',
+  UNPUBLISHED = 'ContentManagement.Entry.unpublish',
+  CREATED = 'ContentManagement.Entry.create',
+  DELETED = 'ContentManagement.Entry.delete',
+  ARCHIVE = 'ContentManagement.Entry.archive',
+  UNARCHIVE = 'ContentManagement.Entry.unarchive',
+}
 
 export interface AppInstallationParameters {
   tenantId: string;

--- a/apps/microsoft-teams/frontend/test/mocks/mockNotification.ts
+++ b/apps/microsoft-teams/frontend/test/mocks/mockNotification.ts
@@ -1,4 +1,6 @@
-const mockNotification = {
+import { Notification } from '@customTypes/configPage';
+
+const mockNotification: Notification = {
   channel: {
     id: 'abc-123',
     name: 'Corporate Marketing',
@@ -9,12 +11,12 @@ const mockNotification = {
   contentTypeId: 'blogPost',
   isEnabled: true,
   selectedEvents: {
-    publish: true,
-    unpublish: false,
-    create: false,
-    delete: false,
-    archive: false,
-    unarchive: false,
+    'ContentManagement.Entry.publish': true,
+    'ContentManagement.Entry.unpublish': true,
+    'ContentManagement.Entry.create': true,
+    'ContentManagement.Entry.delete': true,
+    'ContentManagement.Entry.archive': true,
+    'ContentManagement.Entry.unarchive': true,
   },
 };
 


### PR DESCRIPTION
## Purpose

The current topic names we chose for event subscription in the app config are somewhat ambiguous and could cause us problems if we decide to support notifications for other resources in the future. It's also a bit more cumbersome to compare incoming events with the object where those notification subscriptions are specified.

## Approach

* Rename the events to the app event topics
* A bit of reshuffling of files

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
