### PR TITLE
feat: build enteryactity messages for API

### DIFF
--- a/apps/microsoft-teams/app-actions/src/actions/handle-app-event.spec.ts
+++ b/apps/microsoft-teams/app-actions/src/actions/handle-app-event.spec.ts
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { AppInstallationProps } from 'contentful-management';
 import { AppActionCallContext } from '@contentful/node-apps-toolkit';
-import { EntryActivity } from '../types';
+import { AppActionCallResponseSuccess, EntryActivity, EntryActivityMessage } from '../types';
 import { makeMockAppActionCallContext, mockAppInstallation, mockEntry } from '../../test/mocks';
 import { handler } from './handle-app-event';
 import helpers from '../helpers';
@@ -24,20 +24,20 @@ describe('handle-app-event.handler', () => {
   });
 
   it('returns the ok result', async () => {
-    const result = await handler(
+    const result = (await handler(
       {
         payload: JSON.stringify(mockEntry),
         topic: 'ContentManagement.Entry.publish',
         eventDatetime: '2024-01-18T21:43:54.267Z',
       },
       context
-    );
+    )) as AppActionCallResponseSuccess<EntryActivityMessage[]>;
 
     expect(result).to.have.property('ok', true);
-    expect(result).to.have.deep.property('data', {
+    expect(result.data).to.deep.include({
       channel: {
-        channelId: 'TODO-channel-id',
-        teamId: 'TODO-team-id',
+        channelId: 'channel-id',
+        teamId: 'team-id',
       },
       entryActivity: mockEntryActivity,
     });

--- a/apps/microsoft-teams/app-actions/src/actions/handle-app-event.ts
+++ b/apps/microsoft-teams/app-actions/src/actions/handle-app-event.ts
@@ -30,8 +30,7 @@ export const handler = async (
 
   // TODO check app config to see if there are any subscriptions matching, return if none
   const appInstallation = await cma.appInstallation.get({ appDefinitionId: appInstallationId });
-  const appParamaters = parametersFromAppInstallation(appInstallation);
-  const { tenantId, notifications } = appParamaters;
+  const { tenantId, notifications } = parametersFromAppInstallation(appInstallation);
 
   const matchingNotifications = notifications.filter((notification) => {
     // don't send if the notification is for a different content type

--- a/apps/microsoft-teams/app-actions/src/actions/handle-app-event.ts
+++ b/apps/microsoft-teams/app-actions/src/actions/handle-app-event.ts
@@ -2,6 +2,7 @@ import { AppActionCallContext } from '@contentful/node-apps-toolkit';
 import { AppActionCallResponse, EntryActivityMessage, Topic } from '../types';
 import { EntryProps } from 'contentful-management/types';
 import helpers from '../helpers';
+import { parametersFromAppInstallation } from '../helpers/app-installation';
 
 interface AppActionCallParameters {
   payload: string;
@@ -12,7 +13,7 @@ interface AppActionCallParameters {
 export const handler = async (
   parameters: AppActionCallParameters,
   context: AppActionCallContext
-): Promise<AppActionCallResponse<EntryActivityMessage>> => {
+): Promise<AppActionCallResponse<EntryActivityMessage[]>> => {
   const {
     cma,
     appActionCallContext: { appInstallationId },
@@ -22,27 +23,44 @@ export const handler = async (
 
   // TODO parse entry and topic
   const entry = JSON.parse(payload) as EntryProps;
+  const contentTypeId = entry.sys.contentType.sys.id;
   const topic = topicString as Topic;
 
   const entryActivity = await helpers.buildEntryActivity({ entry, topic, eventDatetime }, cma);
 
   // TODO check app config to see if there are any subscriptions matching, return if none
   const appInstallation = await cma.appInstallation.get({ appDefinitionId: appInstallationId });
-  console.log(appInstallation);
+  const appParamaters = parametersFromAppInstallation(appInstallation);
+  const { tenantId, notifications } = appParamaters;
 
-  // TODO fetch all the notification subscriptions
-  // TODO for each notifcation subscription build event message with channel id / team id + entry activity
-  // TODO call the MS teams bot API for each message and collect results
-  // TODO return a list of message results
+  const matchingNotifications = notifications.filter((notification) => {
+    // don't send if the notification is for a different content type
+    if (notification.contentTypeId !== contentTypeId) return false;
+
+    // don't send if the topic is not "checked" in the notification subscription
+    if (!notification.selectedEvents[topic]) return false;
+
+    return true;
+  });
+
+  const entryActivityMessages = matchingNotifications.map((notification) => {
+    const entryActivityMessage: EntryActivityMessage = {
+      channel: {
+        teamId: notification.channel.teamId,
+        channelId: notification.channel.id,
+      },
+      entryActivity,
+    };
+    // TOOD send message via API here
+    console.log(tenantId, entryActivityMessage);
+
+    // TOOD include the message id in the result to innclude in the response
+    // TODO handle errors one by one
+    return entryActivityMessage;
+  });
 
   return {
     ok: true,
-    data: {
-      channel: {
-        channelId: 'TODO-channel-id',
-        teamId: 'TODO-team-id',
-      },
-      entryActivity,
-    },
+    data: entryActivityMessages,
   };
 };

--- a/apps/microsoft-teams/app-actions/src/constants.ts
+++ b/apps/microsoft-teams/app-actions/src/constants.ts
@@ -1,7 +1,5 @@
 export const TOPIC_ACTION_MAP = {
   'ContentManagement.Entry.create': 'created',
-  'ContentManagement.Entry.save': 'saved',
-  'ContentManagement.Entry.auto_save': 'auto saved',
   'ContentManagement.Entry.archive': 'archived',
   'ContentManagement.Entry.unarchive': 'unarchived',
   'ContentManagement.Entry.publish': 'published',

--- a/apps/microsoft-teams/app-actions/src/helpers/app-installation.spec.ts
+++ b/apps/microsoft-teams/app-actions/src/helpers/app-installation.spec.ts
@@ -1,0 +1,12 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { parametersFromAppInstallation } from './app-installation';
+import { mockAppInstallation } from '../../test/mocks';
+import { AppInstallationParameters } from '../types';
+
+describe('parametersFromAppInstallation', () => {
+  it('returns the correctly typoed and formed paramaters from the app installation', () => {
+    const result = parametersFromAppInstallation(mockAppInstallation);
+    expect(result).to.deep.eq(mockAppInstallation.parameters);
+  });
+});

--- a/apps/microsoft-teams/app-actions/src/helpers/app-installation.spec.ts
+++ b/apps/microsoft-teams/app-actions/src/helpers/app-installation.spec.ts
@@ -1,11 +1,9 @@
 import { expect } from 'chai';
-import sinon from 'sinon';
 import { parametersFromAppInstallation } from './app-installation';
 import { mockAppInstallation } from '../../test/mocks';
-import { AppInstallationParameters } from '../types';
 
 describe('parametersFromAppInstallation', () => {
-  it('returns the correctly typoed and formed paramaters from the app installation', () => {
+  it('returns the correctly typed and formed paramaters from the app installation', () => {
     const result = parametersFromAppInstallation(mockAppInstallation);
     expect(result).to.deep.eq(mockAppInstallation.parameters);
   });

--- a/apps/microsoft-teams/app-actions/src/helpers/app-installation.ts
+++ b/apps/microsoft-teams/app-actions/src/helpers/app-installation.ts
@@ -1,0 +1,28 @@
+import { AppInstallationProps, FreeFormParameters } from 'contentful-management';
+import { AppInstallationParameters, Notification } from '../types';
+
+export const parametersFromAppInstallation = (appInstallation: AppInstallationProps) => {
+  const appParameters = appInstallation.parameters;
+  assertAppInstallationParameters(appParameters);
+  return appParameters;
+};
+
+function assertAppInstallationParameters(
+  parameters: FreeFormParameters | undefined
+): asserts parameters is AppInstallationParameters {
+  if (!parameters) throw new Error('No parameters found on appInstallation');
+  if (typeof parameters !== 'object') throw new Error('Invalid parameters type');
+  if (!('tenantId' in parameters)) throw new Error('tenantId missing from parameters');
+  if (!('notifications' in parameters)) throw new Error('notifications missing from parameters');
+  assertNotifications(parameters.notifications);
+}
+
+function assertNotifications(value: any): asserts value is Notification[] {
+  if (!Array.isArray(value))
+    throw new Error('invalid format for parameters.notifications (not an array)');
+  for (const notification of value) {
+    if (typeof notification !== 'object') throw new Error('notification is not an object');
+    // we could check for more details but if the object is formulated correctly to here
+    // we'll assume it's fine
+  }
+}

--- a/apps/microsoft-teams/app-actions/src/helpers/entry-activity.spec.ts
+++ b/apps/microsoft-teams/app-actions/src/helpers/entry-activity.spec.ts
@@ -38,7 +38,7 @@ describe('buildEntryActivity', () => {
     expect(result).to.have.property('entryId', entryEvent.entry.sys.id);
     expect(result).to.have.property('spaceId', entryEvent.entry.sys.space.sys.id);
     expect(result).to.have.property('contentTypeId', mockContentType.sys.id);
-    expect(result).to.have.property('action', 'saved');
+    expect(result).to.have.property('action', 'archived');
     expect(result).to.have.property('actorName', 'Gavin Matthews');
     expect(result).to.have.property('eventDatetime', entryEvent.eventDatetime);
   });

--- a/apps/microsoft-teams/app-actions/src/helpers/entry-activity.ts
+++ b/apps/microsoft-teams/app-actions/src/helpers/entry-activity.ts
@@ -43,8 +43,6 @@ const actionToActionType = (action: Action): ActionType => {
       return 'creation';
     case 'published':
       return 'publication';
-    case 'saved':
-    case 'auto saved':
     case 'archived':
     case 'unarchived':
     case 'unpublished':

--- a/apps/microsoft-teams/app-actions/src/types.ts
+++ b/apps/microsoft-teams/app-actions/src/types.ts
@@ -21,12 +21,12 @@ export interface AppActionCallResponseError {
 export type AppActionCallResponse<T> = AppActionCallResponseSuccess<T> | AppActionCallResponseError;
 
 export enum AppEventKey {
-  PUBLISH = 'publish',
-  UNPUBLISHED = 'unpublish',
-  CREATED = 'create',
-  DELETED = 'delete',
-  ARCHIVE = 'archive',
-  UNARCHIVE = 'unarchive',
+  ENTRY_PUBLISH = 'ContentManagement.Entry.publish',
+  ENTRY_UNPUBLISHED = 'ContentManagement.Entry.unpublish',
+  ENTRY_CREATED = 'ContentManagement.Entry.create',
+  ENTRY_DELETED = 'ContentManagement.Entry.delete',
+  ENTRY_ARCHIVE = 'ContentManagement.Entry.archive',
+  ENTRY_UNARCHIVE = 'ContentManagement.Entry.unarchive',
 }
 
 export type Channel = {

--- a/apps/microsoft-teams/app-actions/test/mocks.ts
+++ b/apps/microsoft-teams/app-actions/test/mocks.ts
@@ -99,6 +99,26 @@ export const mockEntry = {
 
 export const mockNotification = {
   channel: {
+    id: 'channel-id',
+    name: 'Corporate Marketing',
+    teamId: 'team-id',
+    teamName: 'Marketing Department',
+    tenantId: '9876-5432',
+  },
+  contentTypeId: 'blogPost',
+  isEnabled: true,
+  selectedEvents: {
+    'ContentManagement.Entry.publish': true,
+    'ContentManagement.Entry.unpublish': true,
+    'ContentManagement.Entry.create': true,
+    'ContentManagement.Entry.delete': true,
+    'ContentManagement.Entry.archive': true,
+    'ContentManagement.Entry.unarchive': true,
+  },
+};
+
+export const mockNotificationUnsubscribed = {
+  channel: {
     id: 'abc-123',
     name: 'Corporate Marketing',
     teamId: '789-def',
@@ -108,18 +128,18 @@ export const mockNotification = {
   contentTypeId: 'blogPost',
   isEnabled: true,
   selectedEvents: {
-    publish: true,
-    unpublish: false,
-    create: false,
-    delete: false,
-    archive: false,
-    unarchive: false,
+    'ContentManagement.Entry.publish': false,
+    'ContentManagement.Entry.unpublish': false,
+    'ContentManagement.Entry.create': false,
+    'ContentManagement.Entry.delete': false,
+    'ContentManagement.Entry.archive': false,
+    'ContentManagement.Entry.unarchive': false,
   },
 };
 
 export const mockAppInstallationParameters: AppInstallationParameters = {
   tenantId: 'tenant-id',
-  notifications: [mockNotification],
+  notifications: [mockNotification, mockNotificationUnsubscribed],
 };
 
 export const mockAppInstallation: AppInstallationProps = {
@@ -140,7 +160,7 @@ export const mockAppInstallation: AppInstallationProps = {
 
 export const mockEntryEvent: EntryEvent = {
   entry: mockEntry,
-  topic: 'ContentManagement.Entry.save',
+  topic: 'ContentManagement.Entry.archive',
   eventDatetime: '2024-01-22T16:31:13Z',
 };
 


### PR DESCRIPTION
## Purpose

When we receive an incoming app event to our app, we need to possibly send one or more entry activity messages to MS Teams for any matching notifications in their app config parameters.

In a following PR we will send the actual messages (by calling our API endpoint) but this endpoint builds the actual message object to send and returns the result.

## Approach

* Make sure the notificaitions and app instlallation params are in the type we expect
* FIlter down the whole notification set by matching content type ids and selected events
* build the object and just return it in a list for now

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
