### PR TITLE
feat: add loading state for test message [INTEG-1745]

### DIFF
--- a/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.tsx
@@ -37,6 +37,7 @@ const NotificationEditMode = (props: Props) => {
   } = props;
 
   const [editedNotification, setEditedNotification] = useState<Notification>(notification);
+  const [isTestLoading, setIsTestLoading] = useState<boolean>(false);
 
   const sdk = useSDK<ConfigAppSDK>();
 
@@ -50,6 +51,7 @@ const NotificationEditMode = (props: Props) => {
 
   const handleTest = async (notification: Notification) => {
     try {
+      setIsTestLoading(true);
       const { name: spaceName } = await sdk.cma.space.get({ spaceId: sdk.ids.space });
       const parameters = {
         channelId: notification.channel.id,
@@ -81,6 +83,8 @@ const NotificationEditMode = (props: Props) => {
         sdk.notifier.error(error.message || 'Failed to send test message');
       }
       console.error(error);
+    } finally {
+      setIsTestLoading(false);
     }
   };
 
@@ -137,6 +141,7 @@ const NotificationEditMode = (props: Props) => {
         handleCancel={handleCancel}
         handleSave={handleSave}
         isSaveDisabled={!isNotificationReadyToSave(editedNotification, notification)}
+        isTestLoading={isTestLoading}
       />
     </Box>
   );

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationEditModeFooter/NotificationEditModeFooter.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationEditModeFooter/NotificationEditModeFooter.spec.tsx
@@ -11,6 +11,7 @@ describe('NotificationEditModeFooter component', () => {
         handleCancel={vi.fn()}
         handleSave={vi.fn()}
         isSaveDisabled={false}
+        isTestLoading={false}
       />
     );
 
@@ -27,6 +28,7 @@ describe('NotificationEditModeFooter component', () => {
         handleCancel={vi.fn()}
         handleSave={mockHandleSave}
         isSaveDisabled={false}
+        isTestLoading={false}
       />
     );
 
@@ -42,6 +44,7 @@ describe('NotificationEditModeFooter component', () => {
         handleCancel={vi.fn()}
         handleSave={mockHandleSaveDisabled}
         isSaveDisabled={true}
+        isTestLoading={false}
       />
     );
 
@@ -60,6 +63,7 @@ describe('NotificationEditModeFooter component', () => {
         handleCancel={mockHandleCancel}
         handleSave={vi.fn()}
         isSaveDisabled={false}
+        isTestLoading={false}
       />
     );
 
@@ -75,6 +79,7 @@ describe('NotificationEditModeFooter component', () => {
         handleCancel={vi.fn()}
         handleSave={mockHandleCancelDisabled}
         isSaveDisabled={true}
+        isTestLoading={false}
       />
     );
 

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationEditModeFooter/NotificationEditModeFooter.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationEditModeFooter/NotificationEditModeFooter.tsx
@@ -7,16 +7,21 @@ interface Props {
   handleCancel: () => void;
   handleSave: () => void;
   isSaveDisabled: boolean;
+  isTestLoading: boolean;
 }
 
 const NotificationEditModeFooter = (props: Props) => {
-  const { handleTest, handleCancel, handleSave, isSaveDisabled } = props;
+  const { handleTest, handleCancel, handleSave, isSaveDisabled, isTestLoading } = props;
 
   return (
     <Box className={styles.footer}>
       <Flex justifyContent="flex-end" margin="spacingS">
         <ButtonGroup variant="spaced" spacing="spacingS">
-          <Button variant="transparent" onClick={handleTest}>
+          <Button
+            variant="transparent"
+            onClick={handleTest}
+            isLoading={isTestLoading}
+            isDisabled={isTestLoading}>
             {editModeFooter.test}
           </Button>
           <Button variant="secondary" onClick={handleCancel}>

--- a/apps/microsoft-teams/frontend/src/constants/configCopy.ts
+++ b/apps/microsoft-teams/frontend/src/constants/configCopy.ts
@@ -96,7 +96,7 @@ const eventsSelection = {
 };
 
 const editModeFooter = {
-  test: 'Test',
+  test: 'Send test message',
   cancel: 'Cancel',
   save: 'Save',
   confirmCancelDescription: 'If you cancel, your changes will not be saved.',


### PR DESCRIPTION
## Purpose

This PR adds a loading state for the test message button, since the user didn't have any feedback that the test message had been sent while waiting for a response.

## Approach

- Updated button copy to be more descriptive
- Button now has loading state and is disabled until it receives a response back from the HAA

<img width="205" alt="Screenshot 2024-01-24 at 3 39 12 PM" src="https://github.com/contentful/apps/assets/62958907/57704b21-535c-4e12-9a2c-b9917147242e">

## Testing steps

Pushed to sandbox to test a successful and failure test message.

## Breaking Changes

## Dependencies and/or References

## Deployment
