### PR TITLE
feat: add support for actually sending messages

### DIFF
--- a/apps/microsoft-teams/app-actions/src/actions/handle-app-event.spec.ts
+++ b/apps/microsoft-teams/app-actions/src/actions/handle-app-event.spec.ts
@@ -3,24 +3,40 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { AppInstallationProps } from 'contentful-management';
 import { AppActionCallContext } from '@contentful/node-apps-toolkit';
-import { AppActionCallResponseSuccess, EntryActivity, EntryActivityMessage } from '../types';
+import {
+  AppActionCallResponseError,
+  AppActionCallResponseSuccess,
+  EntryActivity,
+  EntryActivityMessage,
+  SendEntryActivityMessageResult,
+  SendMessageResult,
+} from '../types';
 import { makeMockAppActionCallContext, mockAppInstallation, mockEntry } from '../../test/mocks';
 import { handler } from './handle-app-event';
 import helpers from '../helpers';
+import { config } from '../config';
+import { MsTeamsBotService } from '../services/msteams-bot-service';
 
 chai.use(sinonChai);
 
 describe('handle-app-event.handler', () => {
   let cmaRequestStub: sinon.SinonStub;
   let context: AppActionCallContext;
+  let buildEntryActivityStub: sinon.SinonStub;
   const mockEntryActivity = {} as EntryActivity;
-
+  const sendMessageResult: SendMessageResult = {
+    ok: true,
+    data: { messageResponseId: 'message-response-id' },
+  };
   const cmaClientMockResponses: [AppInstallationProps] = [mockAppInstallation];
 
   beforeEach(() => {
+    const mockMsTeamsBotService = sinon.createStubInstance(MsTeamsBotService);
     cmaRequestStub = sinon.stub();
     context = makeMockAppActionCallContext(cmaClientMockResponses, cmaRequestStub);
-    sinon.stub(helpers, 'buildEntryActivity').resolves(mockEntryActivity);
+    buildEntryActivityStub = sinon.stub(helpers, 'buildEntryActivity').resolves(mockEntryActivity);
+    sinon.stub(config, 'msTeamsBotService').value(mockMsTeamsBotService);
+    mockMsTeamsBotService.sendEntryActivityMessage.resolves(sendMessageResult);
   });
 
   it('returns the ok result', async () => {
@@ -31,15 +47,38 @@ describe('handle-app-event.handler', () => {
         eventDatetime: '2024-01-18T21:43:54.267Z',
       },
       context
-    )) as AppActionCallResponseSuccess<EntryActivityMessage[]>;
+    )) as AppActionCallResponseSuccess<SendEntryActivityMessageResult[]>;
 
     expect(result).to.have.property('ok', true);
     expect(result.data).to.deep.include({
-      channel: {
-        channelId: 'channel-id',
-        teamId: 'team-id',
+      sendMessageResult: { ok: true, data: { messageResponseId: 'message-response-id' } },
+      entryActivityMessage: {
+        channel: {
+          channelId: 'channel-id',
+          teamId: 'team-id',
+        },
+        entryActivity: mockEntryActivity,
       },
-      entryActivity: mockEntryActivity,
+    });
+  });
+
+  describe('when an error is encountered', () => {
+    beforeEach(() => {
+      buildEntryActivityStub.throws('Boom!');
+    });
+
+    it('returns the ok result', async () => {
+      const result = (await handler(
+        {
+          payload: JSON.stringify(mockEntry),
+          topic: 'ContentManagement.Entry.publish',
+          eventDatetime: '2024-01-18T21:43:54.267Z',
+        },
+        context
+      )) as AppActionCallResponseError;
+
+      expect(result).to.have.property('ok', false);
+      expect(result.error).to.have.property('type', 'Error');
     });
   });
 });

--- a/apps/microsoft-teams/app-actions/src/actions/handle-app-event.ts
+++ b/apps/microsoft-teams/app-actions/src/actions/handle-app-event.ts
@@ -1,8 +1,14 @@
 import { AppActionCallContext } from '@contentful/node-apps-toolkit';
-import { AppActionCallResponse, EntryActivityMessage, Topic } from '../types';
+import {
+  AppActionCallResponse,
+  EntryActivityMessage,
+  SendEntryActivityMessageResult,
+  Topic,
+} from '../types';
 import { EntryProps } from 'contentful-management/types';
 import helpers from '../helpers';
 import { parametersFromAppInstallation } from '../helpers/app-installation';
+import { config } from '../config';
 
 interface AppActionCallParameters {
   payload: string;
@@ -13,53 +19,68 @@ interface AppActionCallParameters {
 export const handler = async (
   parameters: AppActionCallParameters,
   context: AppActionCallContext
-): Promise<AppActionCallResponse<EntryActivityMessage[]>> => {
-  const {
-    cma,
-    appActionCallContext: { appInstallationId },
-  } = context;
+): Promise<AppActionCallResponse<SendEntryActivityMessageResult[]>> => {
+  try {
+    const {
+      cma,
+      appActionCallContext: { appInstallationId },
+    } = context;
 
-  const { payload, topic: topicString, eventDatetime } = parameters;
+    const { payload, topic: topicString, eventDatetime } = parameters;
 
-  // TODO parse entry and topic
-  const entry = JSON.parse(payload) as EntryProps;
-  const contentTypeId = entry.sys.contentType.sys.id;
-  const topic = topicString as Topic;
+    // TODO parse entry and topic
+    const entry = JSON.parse(payload) as EntryProps;
+    const contentTypeId = entry.sys.contentType.sys.id;
+    const topic = topicString as Topic;
 
-  const entryActivity = await helpers.buildEntryActivity({ entry, topic, eventDatetime }, cma);
+    const entryActivity = await helpers.buildEntryActivity({ entry, topic, eventDatetime }, cma);
 
-  // TODO check app config to see if there are any subscriptions matching, return if none
-  const appInstallation = await cma.appInstallation.get({ appDefinitionId: appInstallationId });
-  const { tenantId, notifications } = parametersFromAppInstallation(appInstallation);
+    const appInstallation = await cma.appInstallation.get({ appDefinitionId: appInstallationId });
+    const { tenantId, notifications } = parametersFromAppInstallation(appInstallation);
 
-  const matchingNotifications = notifications.filter((notification) => {
-    // don't send if the notification is for a different content type
-    if (notification.contentTypeId !== contentTypeId) return false;
+    const matchingNotifications = notifications.filter((notification) => {
+      // don't send if the notification is for a different content type
+      if (notification.contentTypeId !== contentTypeId) return false;
 
-    // don't send if the topic is not "checked" in the notification subscription
-    if (!notification.selectedEvents[topic]) return false;
+      // don't send if the topic is not "checked" in the notification subscription
+      if (!notification.selectedEvents[topic]) return false;
 
-    return true;
-  });
+      return true;
+    });
 
-  const entryActivityMessages = matchingNotifications.map((notification) => {
-    const entryActivityMessage: EntryActivityMessage = {
-      channel: {
-        teamId: notification.channel.teamId,
-        channelId: notification.channel.id,
-      },
-      entryActivity,
+    const entryActivityMessages = matchingNotifications.map(async (notification) => {
+      const entryActivityMessage: EntryActivityMessage = {
+        channel: {
+          teamId: notification.channel.teamId,
+          channelId: notification.channel.id,
+        },
+        entryActivity,
+      };
+
+      const sendMessageResult = await config.msTeamsBotService.sendEntryActivityMessage(
+        entryActivityMessage,
+        tenantId
+      );
+
+      return { sendMessageResult, entryActivityMessage };
+    });
+
+    const sendEntryActiviyMessageResult: SendEntryActivityMessageResult[] = await Promise.all(
+      entryActivityMessages
+    );
+
+    return {
+      ok: true,
+      data: sendEntryActiviyMessageResult,
     };
-    // TOOD send message via API here
-    console.log(tenantId, entryActivityMessage);
-
-    // TOOD include the message id in the result to innclude in the response
-    // TODO handle errors one by one
-    return entryActivityMessage;
-  });
-
-  return {
-    ok: true,
-    data: entryActivityMessages,
-  };
+  } catch (e) {
+    const error = e as Error;
+    return {
+      ok: false,
+      error: {
+        type: error.constructor.name,
+        message: error.message,
+      },
+    };
+  }
 };

--- a/apps/microsoft-teams/app-actions/src/actions/list-channels.ts
+++ b/apps/microsoft-teams/app-actions/src/actions/list-channels.ts
@@ -23,22 +23,18 @@ export const handler = async (
     if (!(err instanceof Error)) {
       return {
         ok: false,
-        errors: [
-          {
-            message: 'Unknown error occurred',
-            type: 'UnknownError',
-          },
-        ],
+        error: {
+          message: 'Unknown error occurred',
+          type: 'UnknownError',
+        },
       };
     }
     return {
       ok: false,
-      errors: [
-        {
-          message: err.message,
-          type: err.constructor.name,
-        },
-      ],
+      error: {
+        message: err.message,
+        type: err.constructor.name,
+      },
     };
   }
 

--- a/apps/microsoft-teams/app-actions/src/actions/send-test.ts
+++ b/apps/microsoft-teams/app-actions/src/actions/send-test.ts
@@ -42,29 +42,25 @@ export const handler = async (
     );
 
     if (!response.ok) {
-      throw new Error(response.errors?.[0]?.message ?? 'Failed to send test message');
+      throw new Error(response.error.message ?? 'Failed to send test message');
     }
   } catch (err) {
     // TODO: Refactor to utilize an error handler
     if (!(err instanceof Error)) {
       return {
         ok: false,
-        errors: [
-          {
-            message: 'Unknown error occurred',
-            type: 'UnknownError',
-          },
-        ],
+        error: {
+          message: 'Unknown error occurred',
+          type: 'UnknownError',
+        },
       };
     }
     return {
       ok: false,
-      errors: [
-        {
-          message: err.message,
-          type: err.constructor.name,
-        },
-      ],
+      error: {
+        message: err.message,
+        type: err.constructor.name,
+      },
     };
   }
 

--- a/apps/microsoft-teams/app-actions/src/config.ts
+++ b/apps/microsoft-teams/app-actions/src/config.ts
@@ -1,3 +1,5 @@
+import { MsTeamsBotService } from './services/msteams-bot-service';
+
 type EnvironmentVariable = string | null | number | undefined;
 
 // Defining this environmentVariables object since we need to have the explicit strings for the env vars defined
@@ -19,7 +21,15 @@ function getEnvironmentVariable(
   return environmentVariableValue;
 }
 
+const envVars = {
+  botServiceUrl: getEnvironmentVariable('MSTEAMS_BOT_SERVICE_BASE_URL'),
+  apiKey: getEnvironmentVariable('MSTEAMS_CLIENT_API_KEY'),
+};
+
+const msTeamsBotService = new MsTeamsBotService(envVars.botServiceUrl, envVars.apiKey);
+
 export const config = {
   botServiceUrl: getEnvironmentVariable('MSTEAMS_BOT_SERVICE_BASE_URL'),
   apiKey: getEnvironmentVariable('MSTEAMS_CLIENT_API_KEY'),
+  msTeamsBotService,
 };

--- a/apps/microsoft-teams/app-actions/src/helpers/get-channels-list.ts
+++ b/apps/microsoft-teams/app-actions/src/helpers/get-channels-list.ts
@@ -17,7 +17,7 @@ export const getChannelsList = async (
   const response = (await res.json()) as AppActionCallResponse<TeamInstallation[]>;
 
   if (!response.ok) {
-    throw new Error(response.errors?.[0]?.message ?? 'Failed to get channels');
+    throw new Error(response.error.message ?? 'Failed to get channels');
   }
 
   const channelsList = transformInstallationsToChannelsList(response.data, tenantId);

--- a/apps/microsoft-teams/app-actions/src/services/msteams-bot-service.spec.ts
+++ b/apps/microsoft-teams/app-actions/src/services/msteams-bot-service.spec.ts
@@ -1,0 +1,53 @@
+import sinon from 'sinon';
+import chai, { expect } from 'chai';
+import sinonChai from 'sinon-chai';
+import { MsTeamsBotService } from './msteams-bot-service';
+import { makeMockFetchResponse } from '../../test/mocks';
+import { EntryActivityMessage } from '../types';
+
+chai.use(sinonChai);
+
+describe('MsTeamsBotService', () => {
+  const botServiceUrl = 'https://example.com';
+  const apiKey = 'apiKey';
+  const tenantId = 'tenant-id';
+  const entryActivityMessage = { channel: {} } as EntryActivityMessage;
+  const msTeamsBotService = new MsTeamsBotService(botServiceUrl, apiKey);
+  const messageResponseId = 'messageResponseId';
+  let stubbedFetch: sinon.SinonStub;
+
+  beforeEach(() => {
+    const body = {
+      ok: true,
+      data: { ok: true, data: { messageResponseId } },
+    };
+    const mockFetchResponse = makeMockFetchResponse(body);
+    stubbedFetch = sinon.stub(global, 'fetch');
+    stubbedFetch.resolves(mockFetchResponse);
+  });
+
+  describe('sendEntryActivityMessage', () => {
+    it('returns the result object from the service', async () => {
+      const result = await msTeamsBotService.sendEntryActivityMessage(
+        entryActivityMessage,
+        tenantId
+      );
+      expect(result).to.have.property('ok', true);
+    });
+
+    it('calls fetch with the appropriate values', async () => {
+      await msTeamsBotService.sendEntryActivityMessage(entryActivityMessage, tenantId);
+      expect(stubbedFetch).to.have.been.calledWith(
+        'https://example.com/api/tenant/tenant-id/entry_activity_messages',
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-api-key': 'apiKey',
+          },
+          body: '{"channel":{}}',
+        }
+      );
+    });
+  });
+});

--- a/apps/microsoft-teams/app-actions/src/services/msteams-bot-service.ts
+++ b/apps/microsoft-teams/app-actions/src/services/msteams-bot-service.ts
@@ -1,0 +1,32 @@
+import { EntryActivityMessage, SendMessageResult } from '../types';
+
+export class MsTeamsBotService {
+  constructor(public readonly botServiceUrl: string, public readonly apiKey: string) {}
+
+  async sendEntryActivityMessage(
+    entryActivitytMessage: EntryActivityMessage,
+    tenantId: string
+  ): Promise<SendMessageResult> {
+    const res = await fetch(
+      `${this.botServiceUrl}/api/tenant/${tenantId}/entry_activity_messages`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': this.apiKey,
+        },
+        body: JSON.stringify(entryActivitytMessage),
+      }
+    );
+    const responseBody = await res.json();
+    this.assertSendMessageResult(responseBody);
+    return responseBody;
+  }
+
+  private assertSendMessageResult(value: unknown): asserts value is SendMessageResult {
+    if (typeof value !== 'object' || !value)
+      throw new TypeError('invalid type returned from MsTeamsBotService');
+    if (!('ok' in value))
+      throw new TypeError('malformed SendMessageResult returrnd from MsTeamsBotService API');
+  }
+}

--- a/apps/microsoft-teams/app-actions/src/services/msteams-bot-service.ts
+++ b/apps/microsoft-teams/app-actions/src/services/msteams-bot-service.ts
@@ -4,7 +4,7 @@ export class MsTeamsBotService {
   constructor(public readonly botServiceUrl: string, public readonly apiKey: string) {}
 
   async sendEntryActivityMessage(
-    entryActivitytMessage: EntryActivityMessage,
+    entryActivityMessage: EntryActivityMessage,
     tenantId: string
   ): Promise<SendMessageResult> {
     const res = await fetch(
@@ -15,7 +15,7 @@ export class MsTeamsBotService {
           'Content-Type': 'application/json',
           'x-api-key': this.apiKey,
         },
-        body: JSON.stringify(entryActivitytMessage),
+        body: JSON.stringify(entryActivityMessage),
       }
     );
     const responseBody = await res.json();
@@ -27,6 +27,6 @@ export class MsTeamsBotService {
     if (typeof value !== 'object' || !value)
       throw new TypeError('invalid type returned from MsTeamsBotService');
     if (!('ok' in value))
-      throw new TypeError('malformed SendMessageResult returrnd from MsTeamsBotService API');
+      throw new TypeError('malformed SendMessageResult returned from MsTeamsBotService API');
   }
 }

--- a/apps/microsoft-teams/app-actions/src/types.ts
+++ b/apps/microsoft-teams/app-actions/src/types.ts
@@ -15,7 +15,7 @@ export interface AppActionCallResponseSuccess<TResult> {
 
 export interface AppActionCallResponseError {
   ok: false;
-  errors: ActionError[];
+  error: ActionError;
 }
 
 export type AppActionCallResponse<T> = AppActionCallResponseSuccess<T> | AppActionCallResponseError;
@@ -91,24 +91,26 @@ export interface EntryActivityMessage {
   entryActivity: EntryActivity;
 }
 
-export interface MessageResponseSuccess {
-  ok: true;
-  data: {
-    messageId: string;
-  };
+interface MessageResponse {
+  messageResponseId: string;
 }
 
-export interface MessageResponseError {
+export interface SendMessageSuccess {
+  ok: true;
+  data: MessageResponse;
+}
+
+export interface SendMessageError {
   ok: false;
+  // TODO: this might need to be updated if we return an error object from MS teams bot service
   error: string;
 }
 
-export type MessageResponse = MessageResponseSuccess | MessageResponseError;
+export type SendMessageResult = SendMessageSuccess | SendMessageError;
 
-export interface MessageResult {
-  notificationId: string;
+export interface SendEntryActivityMessageResult {
   entryActivityMessage: EntryActivityMessage;
-  messageResponse: MessageResponse;
+  sendMessageResult: SendMessageResult;
 }
 
 export interface EntryEvent {

--- a/apps/microsoft-teams/app-actions/test/mocks.ts
+++ b/apps/microsoft-teams/app-actions/test/mocks.ts
@@ -25,6 +25,14 @@ export const makeMockPlainClient = (responses: any[], stub: sinon.SinonStub): Pl
   return createClient({ apiAdapter }, { type: 'plain' });
 };
 
+export const makeMockFetchResponse = (
+  body: object,
+  headers: Record<string, string> = {}
+): Response => {
+  const responseBody = JSON.stringify(body);
+  return new Response(responseBody, { headers });
+};
+
 export const makeMockAppActionCallContext = (
   responses: any[],
   cmaStub = sinon.stub()


### PR DESCRIPTION
## Purpose

Our handle app event knows what message data it needs to send and which channels it needs to send it to. The last step is to _actually_ call the API and send the messages.

## Approach

* made an intentional change to error object in the result type

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
