### PR TITLE
feat: standardize error handling

### DIFF
--- a/apps/microsoft-teams/app-actions/src/actions/handle-app-event.spec.ts
+++ b/apps/microsoft-teams/app-actions/src/actions/handle-app-event.spec.ts
@@ -7,7 +7,6 @@ import {
   AppActionCallResponseError,
   AppActionCallResponseSuccess,
   EntryActivity,
-  EntryActivityMessage,
   SendEntryActivityMessageResult,
   SendMessageResult,
 } from '../types';

--- a/apps/microsoft-teams/app-actions/src/actions/handle-app-event.ts
+++ b/apps/microsoft-teams/app-actions/src/actions/handle-app-event.ts
@@ -9,6 +9,7 @@ import { EntryProps } from 'contentful-management/types';
 import helpers from '../helpers';
 import { parametersFromAppInstallation } from '../helpers/app-installation';
 import { config } from '../config';
+import { withAsyncAppActionErrorHandling } from '../helpers/error-handling';
 
 interface AppActionCallParameters {
   payload: string;
@@ -16,11 +17,11 @@ interface AppActionCallParameters {
   eventDatetime: string;
 }
 
-export const handler = async (
-  parameters: AppActionCallParameters,
-  context: AppActionCallContext
-): Promise<AppActionCallResponse<SendEntryActivityMessageResult[]>> => {
-  try {
+export const handler = withAsyncAppActionErrorHandling(
+  async (
+    parameters: AppActionCallParameters,
+    context: AppActionCallContext
+  ): Promise<AppActionCallResponse<SendEntryActivityMessageResult[]>> => {
     const {
       cma,
       appActionCallContext: { appInstallationId },
@@ -73,14 +74,5 @@ export const handler = async (
       ok: true,
       data: sendEntryActiviyMessageResult,
     };
-  } catch (e) {
-    const error = e as Error;
-    return {
-      ok: false,
-      error: {
-        type: error.constructor.name,
-        message: error.message,
-      },
-    };
   }
-};
+);

--- a/apps/microsoft-teams/app-actions/src/actions/list-channels.ts
+++ b/apps/microsoft-teams/app-actions/src/actions/list-channels.ts
@@ -3,43 +3,26 @@ import { AppActionCallResponse, Channel } from '../types';
 import { fetchTenantId } from '../utils';
 import helpers from '../helpers';
 import { config } from '../config';
+import { withAsyncAppActionErrorHandling } from '../helpers/error-handling';
 
-export const handler = async (
-  _payload: {},
-  context: AppActionCallContext
-): Promise<AppActionCallResponse<Channel[]>> => {
-  const {
-    cma,
-    appActionCallContext: { appInstallationId },
-  } = context;
+export const handler = withAsyncAppActionErrorHandling(
+  async (
+    _payload: {},
+    context: AppActionCallContext
+  ): Promise<AppActionCallResponse<Channel[]>> => {
+    const {
+      cma,
+      appActionCallContext: { appInstallationId },
+    } = context;
 
-  let channels: Channel[];
+    let channels: Channel[];
 
-  try {
     const tenantId = await fetchTenantId(cma, appInstallationId);
     channels = await helpers.getChannelsList(config.botServiceUrl, config.apiKey, tenantId);
-  } catch (err) {
-    // TODO: Refactor to utilize an error handler
-    if (!(err instanceof Error)) {
-      return {
-        ok: false,
-        error: {
-          message: 'Unknown error occurred',
-          type: 'UnknownError',
-        },
-      };
-    }
+
     return {
-      ok: false,
-      error: {
-        message: err.message,
-        type: err.constructor.name,
-      },
+      ok: true,
+      data: channels,
     };
   }
-
-  return {
-    ok: true,
-    data: channels,
-  };
-};
+);

--- a/apps/microsoft-teams/app-actions/src/actions/send-test.ts
+++ b/apps/microsoft-teams/app-actions/src/actions/send-test.ts
@@ -3,6 +3,7 @@ import { AppActionCallResponse } from '../types';
 import { fetchTenantId } from '../utils';
 import helpers from '../helpers';
 import { config } from '../config';
+import { withAsyncAppActionErrorHandling } from '../helpers/error-handling';
 
 interface AppActionCallParameters {
   channelId: string;
@@ -11,19 +12,19 @@ interface AppActionCallParameters {
   spaceName: string;
 }
 
-export const handler = async (
-  payload: AppActionCallParameters,
-  context: AppActionCallContext
-): Promise<AppActionCallResponse<string>> => {
-  const { channelId, teamId, contentTypeId, spaceName } = payload;
-  const {
-    cma,
-    appActionCallContext: { appInstallationId },
-  } = context;
+export const handler = withAsyncAppActionErrorHandling(
+  async (
+    payload: AppActionCallParameters,
+    context: AppActionCallContext
+  ): Promise<AppActionCallResponse<string>> => {
+    const { channelId, teamId, contentTypeId, spaceName } = payload;
+    const {
+      cma,
+      appActionCallContext: { appInstallationId },
+    } = context;
 
-  let response: AppActionCallResponse<string>;
+    let response: AppActionCallResponse<string>;
 
-  try {
     const { name: contentTypeName } = await cma.contentType.get({ contentTypeId });
     const tenantId = await fetchTenantId(cma, appInstallationId);
 
@@ -44,28 +45,10 @@ export const handler = async (
     if (!response.ok) {
       throw new Error(response.error.message ?? 'Failed to send test message');
     }
-  } catch (err) {
-    // TODO: Refactor to utilize an error handler
-    if (!(err instanceof Error)) {
-      return {
-        ok: false,
-        error: {
-          message: 'Unknown error occurred',
-          type: 'UnknownError',
-        },
-      };
-    }
+
     return {
-      ok: false,
-      error: {
-        message: err.message,
-        type: err.constructor.name,
-      },
+      ok: true,
+      data: response.data ?? '',
     };
   }
-
-  return {
-    ok: true,
-    data: response.data ?? '',
-  };
-};
+);

--- a/apps/microsoft-teams/app-actions/src/helpers/error-handling.spec.ts
+++ b/apps/microsoft-teams/app-actions/src/helpers/error-handling.spec.ts
@@ -1,0 +1,27 @@
+import { expect } from 'chai';
+import { withAsyncAppActionErrorHandling } from './error-handling';
+import { AppActionCallResponse } from '../types';
+
+describe('withAsyncAppActionErrorHandling', () => {
+  const testHandler = async (arg: string): Promise<AppActionCallResponse<string>> => {
+    return { ok: true, data: arg };
+  };
+
+  it('returns a function that continues to work as normal with no errors', async () => {
+    const newFunc = withAsyncAppActionErrorHandling(testHandler);
+    const result = await newFunc('hello');
+    expect(result).to.deep.equal({ ok: true, data: 'hello' });
+  });
+
+  describe('when handler throws an error', () => {
+    const testHandler = async (_arg: string): Promise<AppActionCallResponse<string>> => {
+      throw new TypeError('boom!');
+    };
+
+    it('returns a function that returns an error result without throwing', async () => {
+      const newFunc = withAsyncAppActionErrorHandling(testHandler);
+      const result = await newFunc('hello');
+      expect(result).to.deep.equal({ ok: false, error: { message: 'boom!', type: 'TypeError' } });
+    });
+  });
+});

--- a/apps/microsoft-teams/app-actions/src/helpers/error-handling.ts
+++ b/apps/microsoft-teams/app-actions/src/helpers/error-handling.ts
@@ -1,0 +1,41 @@
+import { AppActionCallResponse, AppActionCallResponseError } from '../types';
+
+// for the purposes of the error handler, a HandlerFunction is one that can take any arguments and return any value -- provided
+// it _can_ return an AppActionCallResponseError
+type HandlerFunction<TFnReturn, TFnArgs extends unknown[]> = (
+  ...args: TFnArgs
+) => Promise<TFnReturn | AppActionCallResponseError>;
+
+// function wrapper intended of handlers (but really any function that returns our AppActionCallResponse type)
+export const withAsyncAppActionErrorHandling = <
+  TResponseType,
+  TFnReturn extends AppActionCallResponse<TResponseType>,
+  TFnArgs extends unknown[]
+>(
+  fn: HandlerFunction<TFnReturn, TFnArgs>
+): HandlerFunction<TFnReturn, TFnArgs> => {
+  const wrappedHandler: HandlerFunction<TFnReturn, TFnArgs> = async (...args) => {
+    try {
+      return await fn(...args);
+    } catch (e) {
+      // this is mostly for typescript, to handle the case where a non-Error object gets thrown
+      if (!(e instanceof Error)) {
+        return {
+          ok: false,
+          error: {
+            message: JSON.stringify(e),
+            type: 'UnknownError',
+          },
+        };
+      }
+      return {
+        ok: false,
+        error: {
+          type: e.constructor.name,
+          message: e.message,
+        },
+      };
+    }
+  };
+  return wrappedHandler;
+};


### PR DESCRIPTION
## Purpose

Our existing error handling is a bit repetitive and non-robust (errors could still be thrown by certain actiions and not "handled".

## Approach

* Provide a wrapper for our handlers

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
