### PR TITLE
chore: remove notification activate toggle [INTEG-1742]

### DIFF
--- a/apps/microsoft-teams/app-actions/src/types.ts
+++ b/apps/microsoft-teams/app-actions/src/types.ts
@@ -62,7 +62,6 @@ export interface AppInstallationParameters {
 export interface Notification {
   channel: Channel;
   contentTypeId: string;
-  isEnabled: boolean;
   selectedEvents: SelectedEvents;
 }
 

--- a/apps/microsoft-teams/app-actions/test/mocks.ts
+++ b/apps/microsoft-teams/app-actions/test/mocks.ts
@@ -114,7 +114,6 @@ export const mockNotification = {
     tenantId: '9876-5432',
   },
   contentTypeId: 'blogPost',
-  isEnabled: true,
   selectedEvents: {
     'ContentManagement.Entry.publish': true,
     'ContentManagement.Entry.unpublish': true,
@@ -134,7 +133,6 @@ export const mockNotificationUnsubscribed = {
     tenantId: '9876-5432',
   },
   contentTypeId: 'blogPost',
-  isEnabled: true,
   selectedEvents: {
     'ContentManagement.Entry.publish': false,
     'ContentManagement.Entry.unpublish': false,

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationViewMode/NotificationViewMode.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationViewMode/NotificationViewMode.spec.tsx
@@ -1,44 +1,22 @@
 import NotificationViewMode from './NotificationViewMode';
 import { describe, expect, it, vi } from 'vitest';
 import { screen } from '@testing-library/react';
-import { notificationsSection } from '@constants/configCopy';
-import { defaultNotification } from '@constants/defaultParams';
+import { mockNotification } from '@test/mocks';
 import { ContentTypeCustomRender } from '@test/helpers/ContentTypeCustomRender';
 
 describe('NotificationViewMode component', () => {
-  it('mounts with correct copy and menu', () => {
+  it('mounts with correct copy and menu button', () => {
     const { unmount } = ContentTypeCustomRender(
       <NotificationViewMode
-        index={0}
-        updateNotification={vi.fn()}
-        notification={defaultNotification}
+        notification={mockNotification}
         handleEdit={vi.fn()}
         isMenuDisabled={false}
         handleDelete={vi.fn()}
       />
     );
 
-    expect(screen.getByText(notificationsSection.enabledToggle)).toBeTruthy();
-    expect(screen.getByRole('button')).toBeTruthy();
-    unmount();
-  });
-  it('handles clicking the enable toggle', () => {
-    const mockUpdateNotification = vi.fn();
-    const { unmount } = ContentTypeCustomRender(
-      <NotificationViewMode
-        index={0}
-        updateNotification={mockUpdateNotification}
-        notification={defaultNotification}
-        handleEdit={vi.fn()}
-        isMenuDisabled={false}
-        handleDelete={vi.fn()}
-      />
-    );
-
-    const enableToggle = screen.getByRole('switch');
-    enableToggle.click();
-
-    expect(mockUpdateNotification).toHaveBeenCalled();
+    expect(screen.getByText('Corporate Marketing, Marketing Department')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'toggle menu' })).toBeTruthy();
     unmount();
   });
 });

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationViewMode/NotificationViewMode.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationViewMode/NotificationViewMode.tsx
@@ -1,14 +1,6 @@
 import { useContext } from 'react';
 import { ContentTypeContext } from '@context/ContentTypeProvider';
-import {
-  Box,
-  IconButton,
-  Flex,
-  Menu,
-  Subheading,
-  Paragraph,
-  Switch,
-} from '@contentful/f36-components';
+import { Box, IconButton, Flex, Menu, Subheading, Paragraph } from '@contentful/f36-components';
 import { MoreHorizontalIcon } from '@contentful/f36-icons';
 import { styles } from './NotificationViewMode.styles';
 import { getContentTypeName } from '@helpers/configHelpers';
@@ -16,12 +8,6 @@ import { Notification } from '@customTypes/configPage';
 import { contentTypeSelection, notificationsSection } from '@constants/configCopy';
 
 interface Props {
-  index: number;
-  updateNotification: (
-    index: number,
-    editedNotification: Partial<Notification>,
-    isNew?: boolean
-  ) => void;
   notification: Notification;
   handleEdit: () => void;
   isMenuDisabled: boolean;
@@ -29,8 +15,7 @@ interface Props {
 }
 
 const NotificationViewMode = (props: Props) => {
-  const { index, notification, updateNotification, handleEdit, isMenuDisabled, handleDelete } =
-    props;
+  const { notification, handleEdit, isMenuDisabled, handleDelete } = props;
   const { contentTypes } = useContext(ContentTypeContext);
 
   return (
@@ -48,34 +33,21 @@ const NotificationViewMode = (props: Props) => {
             {`${notification.channel.name}, ${notification.channel.teamName}`}
           </Paragraph>
         </Flex>
-        <Flex alignItems="center">
-          <Paragraph marginBottom="none" marginRight="spacingXs">
-            {notificationsSection.enabledToggle}
-          </Paragraph>
-          <Switch
-            name="enable-notification"
-            id="enable-notification"
-            isChecked={notification.isEnabled}
-            onChange={() => updateNotification(index, { isEnabled: !notification.isEnabled })}
-          />
-          <Box marginLeft="spacingXs">
-            <Menu>
-              <Menu.Trigger>
-                <IconButton
-                  testId="menu-button"
-                  variant="transparent"
-                  icon={<MoreHorizontalIcon />}
-                  aria-label="toggle menu"
-                  isDisabled={isMenuDisabled}
-                />
-              </Menu.Trigger>
-              <Menu.List>
-                <Menu.Item onClick={handleEdit}>{notificationsSection.edit}</Menu.Item>
-                <Menu.Item onClick={handleDelete}>{notificationsSection.delete}</Menu.Item>
-              </Menu.List>
-            </Menu>
-          </Box>
-        </Flex>
+        <Menu>
+          <Menu.Trigger>
+            <IconButton
+              testId="menu-button"
+              variant="transparent"
+              icon={<MoreHorizontalIcon />}
+              aria-label="toggle menu"
+              isDisabled={isMenuDisabled}
+            />
+          </Menu.Trigger>
+          <Menu.List>
+            <Menu.Item onClick={handleEdit}>{notificationsSection.edit}</Menu.Item>
+            <Menu.Item onClick={handleDelete}>{notificationsSection.delete}</Menu.Item>
+          </Menu.List>
+        </Menu>
       </Flex>
     </Box>
   );

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.tsx
@@ -145,8 +145,6 @@ const NotificationsSection = (props: Props) => {
               return (
                 <NotificationViewMode
                   key={`notification-${index}`}
-                  index={index}
-                  updateNotification={updateNotification}
                   notification={notification}
                   handleEdit={() => setNotificationIndexToEdit(index)}
                   isMenuDisabled={notificationIndexToEdit !== null}

--- a/apps/microsoft-teams/frontend/src/constants/configCopy.ts
+++ b/apps/microsoft-teams/frontend/src/constants/configCopy.ts
@@ -20,7 +20,6 @@ const accessSection = {
 const notificationsSection = {
   title: 'Notifications',
   createButton: 'Create notification',
-  enabledToggle: 'Notifications activated',
   edit: 'Edit',
   delete: 'Delete',
   confirmDelete:

--- a/apps/microsoft-teams/frontend/src/constants/defaultParams.ts
+++ b/apps/microsoft-teams/frontend/src/constants/defaultParams.ts
@@ -21,7 +21,6 @@ const defaultNotification = {
     tenantId: '',
   },
   contentTypeId: '',
-  isEnabled: true,
   selectedEvents: getDefaultSelectedEvents(),
 };
 

--- a/apps/microsoft-teams/frontend/src/customTypes/configPage.ts
+++ b/apps/microsoft-teams/frontend/src/customTypes/configPage.ts
@@ -15,7 +15,6 @@ export interface AppInstallationParameters {
 export interface Notification {
   channel: TeamsChannel;
   contentTypeId: string;
-  isEnabled: boolean;
   selectedEvents: SelectedEvents;
 }
 

--- a/apps/microsoft-teams/frontend/test/mocks/mockNotification.ts
+++ b/apps/microsoft-teams/frontend/test/mocks/mockNotification.ts
@@ -9,7 +9,6 @@ const mockNotification: Notification = {
     tenantId: '9876-5432',
   },
   contentTypeId: 'blogPost',
-  isEnabled: true,
   selectedEvents: {
     'ContentManagement.Entry.publish': true,
     'ContentManagement.Entry.unpublish': true,


### PR DESCRIPTION
## Purpose

This PR removes the activate/deactivate toggle from a configured notification, as we decided that this is more of a V2 feature that we can implement later.

## Approach

Remove the toggle from the UI and remove the `isEnabled` installation parameter since it's only purpose is to support activating/deactivating notifications.

Notifications section without the toggle on each notification:
<img width="914" alt="Screenshot 2024-01-26 at 8 21 53 AM" src="https://github.com/contentful/apps/assets/62958907/1f972de8-07d0-4d7b-8141-59a056692053">

## Testing steps

## Breaking Changes

## Dependencies and/or References

## Deployment
