### PR TITLE
Feature/slack private channels

### DIFF
--- a/apps/slack/frontend/src/constants.ts
+++ b/apps/slack/frontend/src/constants.ts
@@ -5,5 +5,5 @@ export const makeOAuthURL = (spaceId: string, environmentId: string) => {
   const redirectUri = encodeURIComponent(
     `${BACKEND_BASE_URL}/oauth?spaceId=${spaceId}&environmentId=${environmentId}`
   );
-  return `https://slack.com/oauth/v2/authorize?client_id=${CLIENT_ID}&scope=chat:write,channels:read,team:read&redirect_uri=${redirectUri}`;
+  return `https://slack.com/oauth/v2/authorize?client_id=${CLIENT_ID}&scope=chat:write,channels:read,groups:read,team:read&redirect_uri=${redirectUri}`;
 };

--- a/apps/slack/lambda/lib/clients/slack.ts
+++ b/apps/slack/lambda/lib/clients/slack.ts
@@ -116,6 +116,7 @@ export class SlackClient {
         cursor,
         limit: 1000,
         exclude_archived: true,
+        types: 'public_channel,private_channel',
       })
     );
 

--- a/apps/slack/lambda/lib/routes/auth-token/controller.test.ts
+++ b/apps/slack/lambda/lib/routes/auth-token/controller.test.ts
@@ -50,15 +50,15 @@ describe('AuthTokenController', () => {
 
         const error = next.getCall(0).args[0];
 
-        assert.include(error.details[0], {
+        assert.include(error.details.error[0], {
           schemaPath: '#/required',
           keyword: 'required',
         });
-        assert.include(error.details[1], {
+        assert.include(error.details.error[1], {
           schemaPath: '#/properties/code/type',
           keyword: 'type',
         });
-        assert.include(error.details[2], {
+        assert.include(error.details.error[2], {
           schemaPath: '#/properties/spaceId/type',
           keyword: 'type',
         });
@@ -146,7 +146,7 @@ describe('AuthTokenController', () => {
 
         const error = next.getCall(0).args[0];
 
-        assert.include(error.details[0], {
+        assert.include(error.details.error[0], {
           schemaPath: '#/properties/refreshToken/type',
           keyword: 'type',
         });

--- a/apps/slack/lambda/lib/routes/auth-token/repository.test.ts
+++ b/apps/slack/lambda/lib/routes/auth-token/repository.test.ts
@@ -4,6 +4,7 @@ import {
   SinonStubbedInstance,
   useFakeTimers,
   stub,
+  restore,
 } from 'sinon';
 
 import { AuthTokenRepository } from './repository';
@@ -45,6 +46,10 @@ describe('AuthTokenRepository', () => {
 
   before(() => {
     stub(helpers, 'getInstallationParametersFromCma').resolves(expectedParams);
+  });
+
+  after(() => {
+    restore();
   });
 
   afterEach(() => {

--- a/apps/slack/lambda/lib/routes/events/service.test.ts
+++ b/apps/slack/lambda/lib/routes/events/service.test.ts
@@ -3,7 +3,7 @@ import { EventsService } from './service';
 import { ACCEPTED_EVENTS } from './constants';
 import { assert } from '../../../test/utils';
 import { NotFoundException } from '../../errors';
-import { createStubInstance, SinonStubbedInstance, stub } from 'sinon';
+import { createStubInstance, SinonStubbedInstance, stub, restore } from 'sinon';
 import { PlainClientAPI } from 'contentful-management';
 import {
   EventEntity,
@@ -24,6 +24,10 @@ describe('EventsService', () => {
 
   before(() => {
     stub(helpers, 'getInstallationParametersFromCma').resolves(expectedParams);
+  });
+
+  after(() => {
+    restore();
   });
 
   beforeEach(() => {

--- a/apps/slack/lambda/package.json
+++ b/apps/slack/lambda/package.json
@@ -5,7 +5,9 @@
   "main": "index.js",
   "scripts": {
     "build": "rimraf build && tsc",
-    "test": "TS_NODE_TRANSPILE_ONLY=1 mocha -r ts-node/register ./lib/**/*.test.ts",
+    "test": "NODE_ENV=test TS_NODE_TRANSPILE_ONLY=1 mocha -r ts-node/register ./lib/**/*.test.ts",
+    "test:ci": "NODE_ENV=test TS_NODE_TRANSPILE_ONLY=1 mocha -r ts-node/register ./lib/**/*.test.ts",
+    "test:watch": "NODE_ENV=test TS_NODE_TRANSPILE_ONLY=1 mocha --watch --watch-files lib --watch-files test -r ts-node/register ./lib/**/*.test.ts",
     "lint": "eslint --ext .ts,.js ./",
     "format": "prettier --write '**/*.{jsx,js,ts,tsx}'",
     "start:dev": "NODE_ENV=development nodemon",


### PR DESCRIPTION
## Purpose

The Slack app should be able to post notifications in both public and private channels.

In order to achieve this, we need to:

* _request_ both private and public channels when we fetch the channel list
* use a token for which the `groups:read` permission has been requested
* provide the `groups:read` permission for the Slack app itself and have the change approved by Slack

Additionally, the various combinations of the above states must all be working, to prevent user errors if e.g. we request private channels but the user doesn't have the permission in their token scope.

## Approach

* Enable the permission on the Slack API call.
* Adds an additional required scope (`groups:read`) to be able to fetch private channels
* This PR also enables testing in CI (by renaming the test script to `test:ci`) and fixes some broken tests that were silently failing until now

## Testing steps

To verify this works, we need to be very explicit about testing the permutations of these permissions. In particular, we want to ensure we can ship this change safely without breaking the Slack experience for users who already have a token with e.g. not enough permissions to request public and private channels (in which case, we can just show public channels).

To test be sure to _uninstall and reinstall_ the app and token to make sure the permission change takes effect.

For each of these tests, we:

* Reset the token db (to ensure a fresh token)
* Verify that the private channel is / is not in the fetch channel list

### States

| Private channel requested | `group:reads` in token scope | `groups:read` in bot scope | `groups:read` in installed slack app scope| *Test Result* | Notes |
| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
| 👍 | 👍 | 👍 | 👍 | ✅  | Private channel in list|
| 👍 | 👍 | 👎 | 👍 | ✅ | Permission shown on approval screen. Private channel in list. |
| 👍 | 👎 | 👍 | 👍 | ✅ | Private channel in list! But not specified on approval screen |
| 👍 | 👎 | 👎 | 👍 | ✅ | Permission not shown on approval screen. Private channel in list. |
| 👎 | 👍 | 👍 | 👍 | ✅ | Private channel not in list, but specified on approval screen |
| 👎 | 👎 | 👎  | 👍 | ✅ | This is the current state (before the PR is merged) |
| 👎 | 👍 | 👎 | 👍 | ✅ | Permissions shows in approval screen. No private channels in list |
| 👎 | 👎 | 👍 | 👍 | ✅ | No private channels in list (as expected) |
| 👍 | 👍 | 👍 | 👎 | n/a  | didn't bother testing |
| 👍 | 👍 | 👎 | 👎 | ✅ | Permission on approval screen; private channel in list  |
| 👍 | 👎 | 👍 | 👎 | n/a | didn't bother testing |
| 👍 | 👎 | 👎 | 👎 | ❌ |  `{ ok: false, error: 'missing_scope', needed: 'groups:read', provided: 'chat:write,channels:read,team:read' }`  |

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

* See https://api.slack.com/methods/users.conversations which details the arguments required for the API call to fetch channels
* See https://api.slack.com/apis/conversations-api#classic_app_scopes of why the `groups:read` permission is required to read private channels
## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
