### PR TITLE
chore: upgrade TS 5.3.2 for AIIG

### DIFF
--- a/apps/ai-image-generator/backend/package-lock.json
+++ b/apps/ai-image-generator/backend/package-lock.json
@@ -26,7 +26,7 @@
         "sinon": "^15.2.0",
         "sinon-chai": "^3.7.0",
         "ts-node": "^10.9.1",
-        "typescript": "^5.1.6"
+        "typescript": "^5.3.2"
       }
     },
     "node_modules/@contentful/node-apps-toolkit": {
@@ -3548,9 +3548,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/apps/ai-image-generator/backend/package.json
+++ b/apps/ai-image-generator/backend/package.json
@@ -31,6 +31,6 @@
     "sinon": "^15.2.0",
     "sinon-chai": "^3.7.0",
     "ts-node": "^10.9.1",
-    "typescript": "^5.1.6"
+    "typescript": "^5.3.2"
   }
 }

--- a/apps/ai-image-generator/backend/tsconfig.json
+++ b/apps/ai-image-generator/backend/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node18/tsconfig.json",
+  "extends": "./node_modules/@tsconfig/node18/tsconfig.json",
   "compilerOptions": {
     "outDir": "./build",
     "sourceMap": false,


### PR DESCRIPTION
## Purpose

Dependabot can't upgrade TS to 5.3.2. See https://github.com/contentful/apps/pull/5657

We're getting an error "ERROR: error TS6053: File '@tsconfig/node18/tsconfig.json' not found."

Culprit seems to be a change in the internal API of TS. Issue here: https://github.com/TypeStrong/ts-node/issues/2076

## Approach

* Workround here https://github.com/TypeStrong/ts-node/issues/2076#issuecomment-1824874350

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
