### PR TITLE
chore: fix lodash types

### DIFF
--- a/apps/jira/functions/package-lock.json
+++ b/apps/jira/functions/package-lock.json
@@ -8,13 +8,13 @@
       "name": "@contentful/jira-functions",
       "version": "1.4.107",
       "dependencies": {
-        "@types/lodash": "^4.14.108",
         "aws-sdk": "^2.1546.0",
         "node-fetch": "^2.7.0"
       },
       "devDependencies": {
         "@types/aws-lambda": "^8.10.133",
         "@types/chai": "^4.3.11",
+        "@types/lodash": "^4.14.108",
         "@types/mocha": "^9.1.1",
         "@types/node": "^12.12.14",
         "@types/node-fetch": "^2.6.4",
@@ -916,7 +916,8 @@
     "node_modules/@types/lodash": {
       "version": "4.14.108",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.108.tgz",
-      "integrity": "sha512-WD2vUOKfBBVHxWUV9iMR9RMfpuf8HquxWeAq2yqGVL7Nc4JW2+sQama0pREMqzNI3Tutj0PyxYUJwuoxxvX+xA=="
+      "integrity": "sha512-WD2vUOKfBBVHxWUV9iMR9RMfpuf8HquxWeAq2yqGVL7Nc4JW2+sQama0pREMqzNI3Tutj0PyxYUJwuoxxvX+xA==",
+      "dev": true
     },
     "node_modules/@types/mocha": {
       "version": "9.1.1",
@@ -8495,7 +8496,8 @@
     "@types/lodash": {
       "version": "4.14.108",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.108.tgz",
-      "integrity": "sha512-WD2vUOKfBBVHxWUV9iMR9RMfpuf8HquxWeAq2yqGVL7Nc4JW2+sQama0pREMqzNI3Tutj0PyxYUJwuoxxvX+xA=="
+      "integrity": "sha512-WD2vUOKfBBVHxWUV9iMR9RMfpuf8HquxWeAq2yqGVL7Nc4JW2+sQama0pREMqzNI3Tutj0PyxYUJwuoxxvX+xA==",
+      "dev": true
     },
     "@types/mocha": {
       "version": "9.1.1",

--- a/apps/jira/functions/package.json
+++ b/apps/jira/functions/package.json
@@ -14,12 +14,12 @@
     "start": "npm run build && serverless offline --httpPort 3000"
   },
   "dependencies": {
-    "@types/lodash": "^4.14.108",
     "aws-sdk": "^2.1546.0",
     "node-fetch": "^2.7.0"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.133",
+    "@types/lodash": "^4.14.108",
     "@types/chai": "^4.3.11",
     "@types/mocha": "^9.1.1",
     "@types/node": "^12.12.14",


### PR DESCRIPTION
## Purpose

* Upgrade to latest lodash types to unblock dependabot PR https://github.com/contentful/apps/pull/5519
* Move types to devdependencies

## Approach

<!-- Why did we do it the way we did? Did we consider alternatives? What other implementation details or artifacts (screenshots etc.) would help reviewers contextualize change? -->

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
