### PR TITLE
feat: add headers to be passed to bots service

### DIFF
--- a/apps/microsoft-teams/app-actions/src/actions/handle-app-event.ts
+++ b/apps/microsoft-teams/app-actions/src/actions/handle-app-event.ts
@@ -24,7 +24,7 @@ export const handler = withAsyncAppActionErrorHandling(
   ): Promise<AppActionCallResponse<SendEntryActivityMessageResult[]>> => {
     const {
       cma,
-      appActionCallContext: { appInstallationId },
+      appActionCallContext: { appInstallationId, environmentId, spaceId, userId },
     } = context;
 
     const { payload, topic: topicString, eventDatetime } = parameters;
@@ -60,7 +60,8 @@ export const handler = withAsyncAppActionErrorHandling(
 
       const sendMessageResult = await config.msTeamsBotService.sendEntryActivityMessage(
         entryActivityMessage,
-        tenantId
+        tenantId,
+        { appInstallationId, environmentId, userId, spaceId }
       );
 
       return { sendMessageResult, entryActivityMessage };

--- a/apps/microsoft-teams/app-actions/src/actions/list-channels.ts
+++ b/apps/microsoft-teams/app-actions/src/actions/list-channels.ts
@@ -11,11 +11,16 @@ export const handler = withAsyncAppActionErrorHandling(
   ): Promise<AppActionCallResponse<Channel[]>> => {
     const {
       cma,
-      appActionCallContext: { appInstallationId },
+      appActionCallContext: { appInstallationId, userId, environmentId, spaceId },
     } = context;
 
     const tenantId = await fetchTenantId(cma, appInstallationId);
-    const channels = await helpers.getChannelsList(tenantId);
+    const channels = await helpers.getChannelsList(tenantId, {
+      appInstallationId,
+      userId,
+      environmentId,
+      spaceId,
+    });
 
     return {
       ok: true,

--- a/apps/microsoft-teams/app-actions/src/actions/send-test.ts
+++ b/apps/microsoft-teams/app-actions/src/actions/send-test.ts
@@ -18,7 +18,7 @@ export const handler = withAsyncAppActionErrorHandling(
     const { channelId, teamId, contentTypeId } = payload;
     const {
       cma,
-      appActionCallContext: { appInstallationId },
+      appActionCallContext: { appInstallationId, environmentId, userId, spaceId },
     } = context;
     const { name: contentTypeName } = await cma.contentType.get({ contentTypeId });
     const tenantId = await fetchTenantId(cma, appInstallationId);
@@ -33,7 +33,8 @@ export const handler = withAsyncAppActionErrorHandling(
 
     const msTeamsBotServiceResponse = await config.msTeamsBotService.sendTestMessage(
       testMessagePayload,
-      tenantId
+      tenantId,
+      { appInstallationId, environmentId, userId, spaceId }
     );
 
     return msTeamsBotServiceResponse;

--- a/apps/microsoft-teams/app-actions/src/helpers/get-channels-list.ts
+++ b/apps/microsoft-teams/app-actions/src/helpers/get-channels-list.ts
@@ -4,8 +4,11 @@ import { Channel, TeamInstallation } from '../types';
 
 const GENERAL_CHANNEL_NAME = 'general';
 
-export const getChannelsList = async (tenantId: string): Promise<Channel[]> => {
-  const response = await config.msTeamsBotService.getTeamInstallations(tenantId);
+export const getChannelsList = async (
+  tenantId: string,
+  requestContext: any
+): Promise<Channel[]> => {
+  const response = await config.msTeamsBotService.getTeamInstallations(tenantId, requestContext);
 
   if (!response.ok) {
     throw new ApiError(response.error);

--- a/apps/microsoft-teams/app-actions/src/helpers/get-channels-list.ts
+++ b/apps/microsoft-teams/app-actions/src/helpers/get-channels-list.ts
@@ -1,12 +1,12 @@
 import { config } from '../config';
 import { ApiError } from '../errors';
-import { Channel, TeamInstallation } from '../types';
+import { AppActionRequestContext, Channel, TeamInstallation } from '../types';
 
 const GENERAL_CHANNEL_NAME = 'general';
 
 export const getChannelsList = async (
   tenantId: string,
-  requestContext: any
+  requestContext: AppActionRequestContext
 ): Promise<Channel[]> => {
   const response = await config.msTeamsBotService.getTeamInstallations(tenantId, requestContext);
 

--- a/apps/microsoft-teams/app-actions/src/services/msteams-bot-service.ts
+++ b/apps/microsoft-teams/app-actions/src/services/msteams-bot-service.ts
@@ -1,4 +1,5 @@
 import {
+  AppActionRequestContext,
   EntryActivityMessage,
   MessageResponse,
   MsTeamsBotServiceResponse,
@@ -11,13 +12,14 @@ export class MsTeamsBotService {
 
   async sendEntryActivityMessage(
     entryActivityMessage: EntryActivityMessage,
-    tenantId: string
+    tenantId: string,
+    requestContext: AppActionRequestContext
   ): Promise<MsTeamsBotServiceResponse<MessageResponse>> {
     const res = await fetch(
       `${this.botServiceUrl}/api/tenant/${tenantId}/entry_activity_messages`,
       {
         method: 'POST',
-        headers: this.requestHeaders,
+        headers: this.getRequestHeaders(requestContext),
         body: JSON.stringify(entryActivityMessage),
       }
     );
@@ -31,11 +33,12 @@ export class MsTeamsBotService {
 
   async sendTestMessage(
     testMessage: TestMessage,
-    tenantId: string
+    tenantId: string,
+    requestContext: AppActionRequestContext
   ): Promise<MsTeamsBotServiceResponse<MessageResponse>> {
     const res = await fetch(`${this.botServiceUrl}/api/tenant/${tenantId}/test_messages`, {
       method: 'POST',
-      headers: this.requestHeaders,
+      headers: this.getRequestHeaders(requestContext),
       body: JSON.stringify(testMessage),
     });
     const responseBody = await res.json();
@@ -47,11 +50,12 @@ export class MsTeamsBotService {
   }
 
   async getTeamInstallations(
-    tenantId: string
+    tenantId: string,
+    requestContext: AppActionRequestContext
   ): Promise<MsTeamsBotServiceResponse<TeamInstallation[]>> {
     const res = await fetch(`${this.botServiceUrl}/api/tenants/${tenantId}/team_installations`, {
       method: 'GET',
-      headers: this.requestHeaders,
+      headers: this.getRequestHeaders(requestContext),
     });
     const responseBody = await res.json();
     this.assertMsTeamsBotServiceCallResult<TeamInstallation[]>(responseBody, (data) => {
@@ -60,10 +64,15 @@ export class MsTeamsBotService {
     return responseBody;
   }
 
-  private get requestHeaders() {
+  private getRequestHeaders(requestContext: AppActionRequestContext) {
+    const { environmentId, userId, spaceId, appInstallationId } = requestContext;
     return {
       'Content-Type': 'application/json',
       'x-api-key': this.apiKey,
+      'X-Contentful-App': appInstallationId,
+      'X-Contentful-Environment': environmentId,
+      'X-Contentful-Space': spaceId,
+      'X-Contentful-User': userId,
     };
   }
 

--- a/apps/microsoft-teams/app-actions/src/types.ts
+++ b/apps/microsoft-teams/app-actions/src/types.ts
@@ -1,6 +1,7 @@
 import { ChannelInfo as MSChannelInfo, TeamDetails as MSTeamDetails } from 'botbuilder';
 import { TOPIC_ACTION_MAP } from './constants';
 import { EntryProps } from 'contentful-management';
+import { AppActionCallContext } from '@contentful/node-apps-toolkit';
 
 export interface ActionError {
   type: string;
@@ -135,3 +136,7 @@ export interface EntryEvent {
 export type Topic = keyof typeof TOPIC_ACTION_MAP;
 export type Action = (typeof TOPIC_ACTION_MAP)[Topic];
 export type ActionType = 'creation' | 'update' | 'deletion' | 'publication';
+export type AppActionRequestContext = Omit<
+  AppActionCallContext['appActionCallContext'],
+  'cmaHost' | 'uploadHost'
+>;

--- a/apps/microsoft-teams/app-actions/test/mocks.ts
+++ b/apps/microsoft-teams/app-actions/test/mocks.ts
@@ -353,3 +353,12 @@ export const mockChannels: Channel[] = [
     tenantId: '666e56a6-1f2a-47c7-b88c-1ed9e1bb8668',
   },
 ];
+
+export const mockRequestHeaders = {
+  'Content-Type': 'application/json',
+  'x-api-key': 'api-key',
+  'X-Contentful-App': 'app-installation-id',
+  'X-Contentful-Environment': 'environment-id',
+  'X-Contentful-Space': 'space-id',
+  'X-Contentful-User': 'user-id',
+};

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.tsx
@@ -64,6 +64,7 @@ const NotificationEditMode = (props: Props) => {
           environmentId: sdk.ids.environment,
           spaceId: sdk.ids.space,
           appDefinitionId: sdk.ids.app!,
+          userId: sdk.ids.user,
         },
         {
           parameters,

--- a/apps/microsoft-teams/frontend/src/hooks/useGetTeamsChannels.ts
+++ b/apps/microsoft-teams/frontend/src/hooks/useGetTeamsChannels.ts
@@ -16,6 +16,7 @@ const useGetTeamsChannels = () => {
           environmentId: sdk.ids.environment,
           spaceId: sdk.ids.space,
           appDefinitionId: sdk.ids.app!,
+          userId: sdk.ids.user,
         },
         {
           parameters: {},

--- a/apps/microsoft-teams/frontend/src/index.tsx
+++ b/apps/microsoft-teams/frontend/src/index.tsx
@@ -9,8 +9,9 @@ import { sentryMarketplaceAppsSDK } from '@contentful/integration-frontend-toolk
 import AuthProvider from '@context/AuthProvider';
 
 const { client: SentryClient, init: SentryInit } = sentryMarketplaceAppsSDK;
+const environment = import.meta.env.PROD ? 'production' : 'development';
 
-SentryInit();
+SentryInit({ environment });
 
 const container = document.getElementById('root')!;
 const root = createRoot(container);


### PR DESCRIPTION
## Purpose

The purpose of this PR is to pass headers from the app actions to the ms-teams-bots-service API. 

## Approach

Generally we would expect headers that describe the user and browser Contentful details, but since we are using app actions, we have to pass these headers a bit more manually. App actions already have a request context that we can utilize for this to get some information. 

I decided to add `requestContext` as an argument for each method calling the MSTeamsBotService, instead of instantiating the service with the requestContext, to ensure the service remains flexible, and so that we don't need to instantiate it multiple times to save an extra argument . Though I would be happy to adjust, it seems to me that there are pros and cons to both approaches. 

