### PR TITLE
fix: handle errors from ms teams service correctly

### DIFF
--- a/apps/microsoft-teams/app-actions/src/actions/send-test.ts
+++ b/apps/microsoft-teams/app-actions/src/actions/send-test.ts
@@ -36,12 +36,6 @@ export const handler = withAsyncAppActionErrorHandling(
       tenantId
     );
 
-    // if we align the error types from the bot service and our app action error we could just return
-    // the response directly instead of doing this slight redirection
-    if (!msTeamsBotServiceResponse.ok) {
-      throw new Error(msTeamsBotServiceResponse.error ?? 'Failed to send test message');
-    }
-
     return msTeamsBotServiceResponse;
   }
 );

--- a/apps/microsoft-teams/app-actions/src/errors.ts
+++ b/apps/microsoft-teams/app-actions/src/errors.ts
@@ -1,5 +1,7 @@
 import { ApiErrorObject } from './types';
 
+// this is a convenience class that allows us to just "throw" API error objects
+// directly, allowing them to be seamlessly parsed in our error handler
 export class ApiError extends Error {
   public readonly type: ApiErrorObject['type'];
   public readonly details: ApiErrorObject['details'];

--- a/apps/microsoft-teams/app-actions/src/errors.ts
+++ b/apps/microsoft-teams/app-actions/src/errors.ts
@@ -1,0 +1,13 @@
+import { ApiErrorObject } from './types';
+
+export class ApiError extends Error {
+  public readonly type: ApiErrorObject['type'];
+  public readonly details: ApiErrorObject['details'];
+
+  constructor(apiErrorObject: ApiErrorObject) {
+    const { message, type, details } = apiErrorObject;
+    super(message);
+    this.type = type;
+    this.details = details;
+  }
+}

--- a/apps/microsoft-teams/app-actions/src/helpers/error-handling.ts
+++ b/apps/microsoft-teams/app-actions/src/helpers/error-handling.ts
@@ -30,7 +30,7 @@ export const withAsyncAppActionErrorHandling = <
         };
       }
 
-      // an easier handler for directly passing errors from the MS Teams backend through to the app action caller
+      // an easier handler for directly passing errors from the MS Teams backend to the app action caller
       if (e instanceof ApiError) {
         return {
           ok: false,

--- a/apps/microsoft-teams/app-actions/src/helpers/error-handling.ts
+++ b/apps/microsoft-teams/app-actions/src/helpers/error-handling.ts
@@ -11,7 +11,7 @@ type HandlerFunction<TFnReturn, TFnArgs extends unknown[]> = (
 export const withAsyncAppActionErrorHandling = <
   TResponseType,
   TFnReturn extends AppActionCallResponse<TResponseType>,
-  TFnArgs extends unknown[],
+  TFnArgs extends unknown[]
 >(
   fn: HandlerFunction<TFnReturn, TFnArgs>
 ): HandlerFunction<TFnReturn, TFnArgs> => {
@@ -30,7 +30,7 @@ export const withAsyncAppActionErrorHandling = <
         };
       }
 
-      // an easier handler for directly passing errors from the MS Teams backend to the app action caller
+      // an easier handler for directly passing errors from the MS Teams service to the app action caller
       if (e instanceof ApiError) {
         return {
           ok: false,

--- a/apps/microsoft-teams/app-actions/src/helpers/error-handling.ts
+++ b/apps/microsoft-teams/app-actions/src/helpers/error-handling.ts
@@ -1,3 +1,4 @@
+import { ApiError } from '../errors';
 import { AppActionCallResponse, AppActionCallResponseError } from '../types';
 
 // for the purposes of the error handler, a HandlerFunction is one that can take any arguments and return any value -- provided
@@ -10,7 +11,7 @@ type HandlerFunction<TFnReturn, TFnArgs extends unknown[]> = (
 export const withAsyncAppActionErrorHandling = <
   TResponseType,
   TFnReturn extends AppActionCallResponse<TResponseType>,
-  TFnArgs extends unknown[]
+  TFnArgs extends unknown[],
 >(
   fn: HandlerFunction<TFnReturn, TFnArgs>
 ): HandlerFunction<TFnReturn, TFnArgs> => {
@@ -28,6 +29,19 @@ export const withAsyncAppActionErrorHandling = <
           },
         };
       }
+
+      // an easier handler for directly passing errors from the MS Teams backend through to the app action caller
+      if (e instanceof ApiError) {
+        return {
+          ok: false,
+          error: {
+            message: e.message,
+            type: e.type,
+            details: e.details,
+          },
+        };
+      }
+
       return {
         ok: false,
         error: {

--- a/apps/microsoft-teams/app-actions/src/helpers/get-channels-list.ts
+++ b/apps/microsoft-teams/app-actions/src/helpers/get-channels-list.ts
@@ -1,4 +1,5 @@
 import { config } from '../config';
+import { ApiError } from '../errors';
 import { Channel, TeamInstallation } from '../types';
 
 const GENERAL_CHANNEL_NAME = 'general';
@@ -7,7 +8,7 @@ export const getChannelsList = async (tenantId: string): Promise<Channel[]> => {
   const response = await config.msTeamsBotService.getTeamInstallations(tenantId);
 
   if (!response.ok) {
-    throw new Error(response.error ?? 'Failed to get channels');
+    throw new ApiError(response.error);
   }
 
   const channelsList = transformInstallationsToChannelsList(response.data, tenantId);

--- a/apps/microsoft-teams/app-actions/src/types.ts
+++ b/apps/microsoft-teams/app-actions/src/types.ts
@@ -107,8 +107,14 @@ export interface MsTeamsBotServiceSuccessResponse<T> {
 
 export interface MsTeamsBotServiceErrorResponse {
   ok: false;
-  // TODO: this might need to be updated if we return an error object from MS teams bot service
-  error: string;
+  error: ApiErrorObject;
+}
+
+// eslint-disable-next-line  @typescript-eslint/no-explicit-any
+export interface ApiErrorObject<T extends Record<string, any> = Record<string, any>> {
+  type: string;
+  message: string;
+  details?: T;
 }
 
 export type MsTeamsBotServiceResponse<T> =


### PR DESCRIPTION
## Purpose

The MS teams bot service no longer returns simple strings but instead returns error objects. We need to adjust our expectations and handling for this error response as a result.

## Approach

<!-- Why did we do it the way we did? Did we consider alternatives? What other implementation details or artifacts (screenshots etc.) would help reviewers contextualize change? -->

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
