### PR TITLE
chore: pin prettier explicitly to installed version

### DIFF
--- a/.circleci/prettier-check.sh
+++ b/.circleci/prettier-check.sh
@@ -15,7 +15,7 @@ test -z "$CHANGED_FILES" && echo "No files for prettier to check. Skipping..." &
 echo "Running 'prettier -l' against changed files to check for problems..."
 echo ""
 
-PRETTIER_OUTPUT=$(./node_modules/.bin/prettier -l $CHANGED_FILES)
+PRETTIER_OUTPUT=$(npm run prettier:list -- $CHANGED_FILES)
 echo ""
 test -n "$PRETTIER_OUTPUT" && echo "prettier violations found:" || echo "no violations found"
 echo "$PRETTIER_OUTPUT"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,7 @@ updates:
     - dependency-name: "*"
       update-types: ["version-update:semver-major"]
     - dependency-name: "@contentful/app-sdk"
+    - dependency-name: "prettier"
     - dependency-name: "serverless"
       versions:
         - ">=3"

--- a/package.json
+++ b/package.json
@@ -26,8 +26,9 @@
     "deploy:test": "lerna run deploy:test --concurrency=3",
     "post-deploy": "lerna run post-deploy",
     "publish-packages": "lerna version --conventional-commits --no-private --force-git-tag --create-release github --yes && lerna publish from-git --yes",
-    "prettier": "prettier --write '**/*.{js,jsx,ts,tsx}'",
-    "prettier:check": "prettier --check '**/*.{js,jsx,ts,tsx}'",
+    "prettier:list": "npx prettier@2.8.8 --list-different",
+    "prettier:write": "npx prettier@2.8.8 --write",
+    "prettier:check": "npx prettier@2.8.8 --check '**/*.{js,jsx,ts,tsx}'",
     "prepare": "husky install",
     "sentry-release": "SENTRY_RELEASE=$(git rev-parse --short HEAD); sentry-cli releases --log-level=debug new -p marketplace-apps $SENTRY_RELEASE && sentry-cli releases --log-level=debug set-commits --auto --ignore-missing $SENTRY_RELEASE && sentry-cli releases --log-level=debug finalize $SENTRY_RELEASE && sentry-cli releases --log-level=debug deploys $SENTRY_RELEASE new -e production"
   },
@@ -36,7 +37,7 @@
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
-      "prettier --write"
+      "npm run prettier:write"
     ]
   }
 }


### PR DESCRIPTION
## Purpose

There's a problem that can arise for developers in this repository where:

* You haven't installed the root app (i.e. `npm i` at the root level)
* You make some code changes
* Your globally installed prettier has a different version than the version for this repo
* Your prettier post commit hook defers to the globally installed version (since no local is present)
* Your code gets autoformatted in a way that's incompatible with the prettier checks for this repo

## Approach

* Use `npx` for all prettier invocations (directly or indirectly) and fix these to match the declared version
* Prevent dependabot from upgrading prettier and instead force a manual upgrade

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
