### PR TITLE
fix(deps): bump @contentful/f36-components from 4.40.6 to 4.59.1

### DIFF
--- a/apps/dropbox/package-lock.json
+++ b/apps/dropbox/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@contentful/dropbox-assets",
       "version": "1.6.74",
       "dependencies": {
-        "@contentful/dam-app-base": "^2.0.35",
+        "@contentful/dam-app-base": "2.0.55",
         "react": "16.12.0",
         "react-dom": "16.12.0"
       },

--- a/apps/dropbox/package.json
+++ b/apps/dropbox/package.json
@@ -8,7 +8,7 @@
     "react-scripts": "4.0.3"
   },
   "dependencies": {
-    "@contentful/dam-app-base": "^2.0.35",
+    "@contentful/dam-app-base": "2.0.55",
     "react": "16.12.0",
     "react-dom": "16.12.0"
   },

--- a/apps/frontify/package-lock.json
+++ b/apps/frontify/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@contentful/frontify-assets",
       "version": "1.5.75",
       "dependencies": {
-        "@contentful/dam-app-base": "^2.0.35",
+        "@contentful/dam-app-base": "2.0.38",
         "react": "16.12.0",
         "react-dom": "16.12.0"
       },

--- a/apps/frontify/package.json
+++ b/apps/frontify/package.json
@@ -8,7 +8,7 @@
     "react-scripts": "4.0.3"
   },
   "dependencies": {
-    "@contentful/dam-app-base": "^2.0.35",
+    "@contentful/dam-app-base": "2.0.38",
     "react": "16.12.0",
     "react-dom": "16.12.0"
   },

--- a/apps/mux/package-lock.json
+++ b/apps/mux/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.10.14",
       "dependencies": {
         "@contentful/app-sdk": "4.12.0",
-        "@contentful/dam-app-base": "^2.0.35",
+        "@contentful/dam-app-base": "2.0.46",
         "@contentful/f36-components": "4.40.6",
         "@contentful/react-apps-toolkit": "1.2.16",
         "@mux/mux-player-react": "^1.10.1",

--- a/apps/mux/package.json
+++ b/apps/mux/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@contentful/app-sdk": "4.12.0",
-    "@contentful/dam-app-base": "^2.0.35",
+    "@contentful/dam-app-base": "2.0.46",
     "@contentful/f36-components": "4.40.6",
     "@contentful/react-apps-toolkit": "1.2.16",
     "@mux/mux-player-react": "^1.10.1",

--- a/packages/dam-app-base/package-lock.json
+++ b/packages/dam-app-base/package-lock.json
@@ -540,15 +540,15 @@
       }
     },
     "node_modules/@contentful/f36-accordion": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.40.6.tgz",
-      "integrity": "sha512-elfOt3keM7Nf9iSnVE+apG4JrZI1WAwy8Agky7C8j4xtq47t9au7dL7bGKUBftY7FAP6/2VrdiiaGH+riQ5mjw==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.59.1.tgz",
+      "integrity": "sha512-qrU7EC84GIGjNWvY4XgskfuCP3+2gPFLT2nMyFANQalNGR3/6NB8UsSKteVLXBZ3dzFIFvKHPIErUF2b7oBptw==",
       "dependencies": {
-        "@contentful/f36-collapse": "^4.40.6",
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.40.6",
+        "@contentful/f36-collapse": "^4.59.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-icons": "^4.27.0",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.59.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -557,15 +557,15 @@
       }
     },
     "node_modules/@contentful/f36-asset": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.40.6.tgz",
-      "integrity": "sha512-i2J5Fq3yaFMeevy4N1+/AObhFCwYOaaiooofn0ppRTC1r5ej3gEwaZ7oy5MlwvK4uOXYEyeLHbb5ZEOlQWyp4Q==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.59.1.tgz",
+      "integrity": "sha512-ysm6TZ1+sE4DYWBKjroudWjcs1K+vaS1oJxW612p/jIZKw6ntWMb1VKPg1ZzXYMvAURexpbWFwU06Areo+dzcQ==",
       "dependencies": {
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-icon": "^4.40.6",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.40.6",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-icon": "^4.59.1",
+        "@contentful/f36-icons": "^4.27.0",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.59.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -574,19 +574,19 @@
       }
     },
     "node_modules/@contentful/f36-autocomplete": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.40.6.tgz",
-      "integrity": "sha512-M98tcNEKRcfd3mdAAmi9IijPvCDf8ZvvyRPJ9zSfAXaA+XRldB7CguOpqqRude/N2OixXujY2fi4juDZERJ+Kg==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.59.1.tgz",
+      "integrity": "sha512-49fg7LzLspbv1SpcJUsB1yGbYj4FWKlFXGQjErRy6hyUWL7tNoEppg7hkN0J9CJeOu1offh2TNmRrL0kgKMDMQ==",
       "dependencies": {
-        "@contentful/f36-button": "^4.40.6",
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-forms": "^4.40.6",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-popover": "^4.40.6",
-        "@contentful/f36-skeleton": "^4.40.6",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.40.6",
-        "@contentful/f36-utils": "^4.23.2",
+        "@contentful/f36-button": "^4.59.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-forms": "^4.59.1",
+        "@contentful/f36-icons": "^4.27.0",
+        "@contentful/f36-popover": "^4.59.1",
+        "@contentful/f36-skeleton": "^4.59.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.59.1",
+        "@contentful/f36-utils": "^4.24.3",
         "downshift": "^6.1.12",
         "emotion": "^10.0.17"
       },
@@ -596,13 +596,13 @@
       }
     },
     "node_modules/@contentful/f36-badge": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.40.6.tgz",
-      "integrity": "sha512-8UJUkFQC2KNcHgt+SWfLUwAWFjKD3tFlsKIBvXFBhpup9pQ2ATzygSNM/Q75wSzWz66s2fmI0WANSpqr9Paqjg==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.59.1.tgz",
+      "integrity": "sha512-g7UiOxpmlSBfl65j0QPoCI5YUmDnoOywCv9esFE5k61fEqNb6zEU7nXHyc6CWNdw+6XYxpaFqVRe14Q8jaaI0A==",
       "dependencies": {
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-icons": "^4.25.0",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-icons": "^4.27.0",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -611,14 +611,14 @@
       }
     },
     "node_modules/@contentful/f36-button": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.40.6.tgz",
-      "integrity": "sha512-hQ7sS2GwwDUTozNPOLE2fICh5kg8H35PhVhrzuRsvF9Q7Ux6aLj+fQwFEfhVkibs8Jp8kAcFoR/hLIX35O5ocA==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.59.1.tgz",
+      "integrity": "sha512-jETbDGXLqzdkuWB+rX+HrMvcuFnwS87w5ZmAV5SKtA4JZerC5wSXZd6TPssuDEBsEkd2YrXZozd/1Rb73V8kTg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-spinner": "^4.40.6",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-utils": "^4.24.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-spinner": "^4.59.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -627,22 +627,22 @@
       }
     },
     "node_modules/@contentful/f36-card": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.40.6.tgz",
-      "integrity": "sha512-MJz+GRMl3p/9Vvgg3j73P5+Yv3FqLNGSDJOMgr544YmJZuS/Ic+jusoc0yGW1nSGt/+2EwWg2nHmoFHsdtfcug==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.59.1.tgz",
+      "integrity": "sha512-W3zSrZ2RB2e28zCHWriYrBWJdew7oEFc71MSBtuYBKhDwZMbYXNV3BTcXv9+hsvpOTW/KJWdFCD8vsX61tcIyg==",
       "dependencies": {
-        "@contentful/f36-asset": "^4.40.6",
-        "@contentful/f36-badge": "^4.40.6",
-        "@contentful/f36-button": "^4.40.6",
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-drag-handle": "^4.40.6",
-        "@contentful/f36-icon": "^4.40.6",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-menu": "^4.40.6",
-        "@contentful/f36-skeleton": "^4.40.6",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-tooltip": "^4.40.6",
-        "@contentful/f36-typography": "^4.40.6",
+        "@contentful/f36-asset": "^4.59.1",
+        "@contentful/f36-badge": "^4.59.1",
+        "@contentful/f36-button": "^4.59.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-drag-handle": "^4.59.1",
+        "@contentful/f36-icon": "^4.59.1",
+        "@contentful/f36-icons": "^4.27.0",
+        "@contentful/f36-menu": "^4.59.1",
+        "@contentful/f36-skeleton": "^4.59.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-tooltip": "^4.59.1",
+        "@contentful/f36-typography": "^4.59.1",
         "emotion": "^10.0.17",
         "truncate": "^3.0.0"
       },
@@ -652,12 +652,12 @@
       }
     },
     "node_modules/@contentful/f36-collapse": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.40.6.tgz",
-      "integrity": "sha512-L6UTj/U+dUVYEeJLMwa3ztVehBTnsgv4mIfXgW2ZU7MrS1iI8gx8svyey1pFIQxnS9UMp6cx2sWlE+mzy2CKVA==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.59.1.tgz",
+      "integrity": "sha512-Hsv5IK4EKKsUgbWX3K8Au1hskmX5WO6BF02fgri9wbmyOEDSgG6J873KET6xCylDjgKwLiuyscX2WJnUu16QuA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -666,80 +666,71 @@
       }
     },
     "node_modules/@contentful/f36-components": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.40.6.tgz",
-      "integrity": "sha512-Z0RI2AJ9nDJRYeZJBQ1Xh6B6kNfvDfxTIcOEoX3Lno1KmAzNo+reCKRt1LRCUzt4lpF1IZhwXBYu86jvLhYuuw==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.59.1.tgz",
+      "integrity": "sha512-vUmZJ2AbarOoX0w0PZEdBCrYzeQ2KbySoktev2ZS9PA9JKZ4AMjE1JkonTGJhZx8LAHEQWV78/gejVIr55nwRw==",
       "dependencies": {
-        "@contentful/f36-accordion": "^4.40.6",
-        "@contentful/f36-asset": "^4.40.6",
-        "@contentful/f36-autocomplete": "^4.40.6",
-        "@contentful/f36-badge": "^4.40.6",
-        "@contentful/f36-button": "^4.40.6",
-        "@contentful/f36-card": "^4.40.6",
-        "@contentful/f36-collapse": "^4.40.6",
-        "@contentful/f36-copybutton": "^4.40.6",
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-datepicker": "^4.40.6",
-        "@contentful/f36-datetime": "^4.40.6",
-        "@contentful/f36-drag-handle": "^4.40.6",
-        "@contentful/f36-empty-state": "^4.40.6",
-        "@contentful/f36-entity-list": "^4.40.6",
-        "@contentful/f36-forms": "^4.40.6",
-        "@contentful/f36-icon": "^4.40.6",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-list": "^4.40.6",
-        "@contentful/f36-menu": "^4.40.6",
-        "@contentful/f36-modal": "^4.40.6",
-        "@contentful/f36-note": "^4.40.6",
-        "@contentful/f36-notification": "^4.40.6",
-        "@contentful/f36-pagination": "^4.40.6",
-        "@contentful/f36-pill": "^4.40.6",
-        "@contentful/f36-popover": "^4.40.6",
-        "@contentful/f36-skeleton": "^4.40.6",
-        "@contentful/f36-spinner": "^4.40.6",
-        "@contentful/f36-table": "^4.40.6",
-        "@contentful/f36-tabs": "^4.40.6",
-        "@contentful/f36-text-link": "^4.40.6",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-tooltip": "^4.40.6",
-        "@contentful/f36-typography": "^4.40.6",
-        "@contentful/f36-utils": "^4.23.2",
-        "@types/react": "16.14.22",
-        "@types/react-dom": "16.9.14"
+        "@contentful/f36-accordion": "^4.59.1",
+        "@contentful/f36-asset": "^4.59.1",
+        "@contentful/f36-autocomplete": "^4.59.1",
+        "@contentful/f36-badge": "^4.59.1",
+        "@contentful/f36-button": "^4.59.1",
+        "@contentful/f36-card": "^4.59.1",
+        "@contentful/f36-collapse": "^4.59.1",
+        "@contentful/f36-copybutton": "^4.59.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-datepicker": "^4.59.1",
+        "@contentful/f36-datetime": "^4.59.1",
+        "@contentful/f36-drag-handle": "^4.59.1",
+        "@contentful/f36-empty-state": "^4.59.1",
+        "@contentful/f36-entity-list": "^4.59.1",
+        "@contentful/f36-forms": "^4.59.1",
+        "@contentful/f36-icon": "^4.59.1",
+        "@contentful/f36-icons": "^4.27.0",
+        "@contentful/f36-list": "^4.59.1",
+        "@contentful/f36-menu": "^4.59.1",
+        "@contentful/f36-modal": "^4.59.1",
+        "@contentful/f36-navbar": "^4.1.0",
+        "@contentful/f36-note": "^4.59.1",
+        "@contentful/f36-notification": "^4.59.1",
+        "@contentful/f36-pagination": "^4.59.1",
+        "@contentful/f36-pill": "^4.59.1",
+        "@contentful/f36-popover": "^4.59.1",
+        "@contentful/f36-skeleton": "^4.59.1",
+        "@contentful/f36-spinner": "^4.59.1",
+        "@contentful/f36-table": "^4.59.1",
+        "@contentful/f36-tabs": "^4.59.1",
+        "@contentful/f36-text-link": "^4.59.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-tooltip": "^4.59.1",
+        "@contentful/f36-typography": "^4.59.1",
+        "@contentful/f36-utils": "^4.24.3"
       },
       "peerDependencies": {
+        "@types/react": ">=16.8",
+        "@types/react-dom": ">=16.8",
         "react": ">=16.8",
         "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-components/node_modules/@types/react": {
-      "version": "16.14.22",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.22.tgz",
-      "integrity": "sha512-4NnkxKDd2UO9SiCckuhCQOCzdO+RtE4Epf1D6eGz3f9jZjiIXOVo+Bk3jqSad+8EOT+LBXwKdkFX0V0F+NFzDQ==",
-      "dependencies": {
-        "@types/prop-types": "*",
-        "@types/scheduler": "*",
-        "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@contentful/f36-components/node_modules/@types/react-dom": {
-      "version": "16.9.14",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.14.tgz",
-      "integrity": "sha512-FIX2AVmPTGP30OUJ+0vadeIFJJ07Mh1m+U0rxfgyW34p3rTlXI+nlenvAxNn4BP36YyI9IJ/+UJ7Wu22N1pI7A==",
-      "dependencies": {
-        "@types/react": "^16"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@contentful/f36-copybutton": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.40.6.tgz",
-      "integrity": "sha512-ItW2Y8Hk3UoUGpRtW/YYTWaw6ieXREe4bdyeCJslQEPbgC8QAYlCs33oYYb7Sg7SzVQ3fTPbgcQMDXy4ouLwGg==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.59.1.tgz",
+      "integrity": "sha512-XxnLa5bMyDy39ib0QT2G/Q+78bS7ro6O7x9AyGwRQTZfDgiWGplgDwKzeGfWxF9ygznYGy4dKJ1/dzh6e2ZoIw==",
       "dependencies": {
-        "@contentful/f36-button": "^4.40.6",
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-tooltip": "^4.40.6",
+        "@contentful/f36-button": "^4.59.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-icons": "^4.27.0",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-tooltip": "^4.59.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -748,11 +739,11 @@
       }
     },
     "node_modules/@contentful/f36-core": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.40.6.tgz",
-      "integrity": "sha512-vEfSyU3+R6ZCtd9yXUEZ32T6MEqnuo8PSZL+VYw3RdjUzV70NE0K4y3aav21nBm3p51NCwImMG8XfjwabBQE1A==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.59.1.tgz",
+      "integrity": "sha512-B/8Iv4vodOsWjc+1Z/T6R4V3L3gVUwCaxzzzQa1axm4eteLdoj1ss6mb+yb7HAx/otBOKRWWTtVolED/UO6GNQ==",
       "dependencies": {
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-tokens": "^4.0.4",
         "@emotion/core": "^10.1.1",
         "@emotion/is-prop-valid": "^1.2.0",
         "csstype": "^3.1.1",
@@ -764,20 +755,20 @@
       }
     },
     "node_modules/@contentful/f36-datepicker": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.40.6.tgz",
-      "integrity": "sha512-jiOZHkFULw763jsKtxHgbh3EmpKKAGPT1o1ynUmLsroqJGrCm7w5lUZkrJRX71t3Kvlj3q1h4Bad2VFrwy1pDA==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.59.1.tgz",
+      "integrity": "sha512-z4zs09O+QqN9etHTgI2uUmhZeqnEV74XOjgImankE5Ieyym5YXRAyqIdNs6Q0uPfHo6BokkQXlm40+pDMVBkOw==",
       "dependencies": {
-        "@contentful/f36-button": "^4.40.6",
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-forms": "^4.40.6",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-popover": "^4.40.6",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-typography": "^4.40.6",
+        "@contentful/f36-button": "^4.59.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-forms": "^4.59.1",
+        "@contentful/f36-icons": "^4.27.0",
+        "@contentful/f36-popover": "^4.59.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.59.1",
         "date-fns": "^2.28.0",
         "emotion": "^10.0.17",
-        "react-day-picker": "^8.3.5",
+        "react-day-picker": "^8.7.1",
         "react-focus-lock": "^2.9.1"
       },
       "peerDependencies": {
@@ -786,12 +777,12 @@
       }
     },
     "node_modules/@contentful/f36-datetime": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.40.6.tgz",
-      "integrity": "sha512-kvqtNOD5FBRm9XpWuOtMy0vvFOm3Qwaa7WetOUeFKCbm7yXkxG2G67oAcRjkLOFhUM16yL9Cn2WdlT8KSyiJUA==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.59.1.tgz",
+      "integrity": "sha512-pC/AlWk8/w6J+rwjYtkPFG0WsZsR6rdOg5MGjmux4/cWzPF0t0mN1gKS2d9m5BKZUffUVudPzE0GspN5R70Phg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-tokens": "^4.0.4",
         "dayjs": "^1.11.5",
         "emotion": "^10.0.17"
       },
@@ -801,14 +792,14 @@
       }
     },
     "node_modules/@contentful/f36-drag-handle": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.40.6.tgz",
-      "integrity": "sha512-eVBc9SSghkvxff4zzEoq21Nm0tCx+WkuoB/c5PW0hSdbnjsbXBW9W4nl/2NDfD/XkpJ3ImUi6a9IMn8GSsEIIQ==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.59.1.tgz",
+      "integrity": "sha512-pe4hXiiF524uQ1fjSewUr6cgVbnp6ZSo5Nh5Eh/s2i5OWlZOS/geesYIq+r6TY72rGcoAPT1rUN6DobVPqt7LA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-utils": "^4.24.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-icons": "^4.27.0",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -817,12 +808,12 @@
       }
     },
     "node_modules/@contentful/f36-empty-state": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.40.6.tgz",
-      "integrity": "sha512-bkCJrCJaq0DGHlVDT19EtkJDoUKWhaOBqonvfNXiLjMYIOdtOUF6RH9h5nzH/UZb3Ed7PbARtP6+3JdUimRSJQ==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.59.1.tgz",
+      "integrity": "sha512-UPIWbPCdC01NrRVny9PuO/zkxqeTc6uQf9WUFwxGY5wOG/OD2GhnMb57TOWEGTqfvN2I8/of4hQtb5I9c2M68Q==",
       "dependencies": {
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.40.6",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.59.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -831,20 +822,20 @@
       }
     },
     "node_modules/@contentful/f36-entity-list": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.40.6.tgz",
-      "integrity": "sha512-6dVBZCDvp9G5a/w0OvI5PhfQWd5/InK0hn0Gm3J57DWJIuFYka3SMeGWK5GoAeUJxEn/VtHLoQVUoK1ORPkFAg==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.59.1.tgz",
+      "integrity": "sha512-Hs+tkiqPbZz1Xq0trx7YFljJ1K7ndSpUkcLKZzSco7KvdiPH6FdHceh8c8HPI0Q4ATv1eK51LRJeAqwn1oOXmQ==",
       "dependencies": {
-        "@contentful/f36-badge": "^4.40.6",
-        "@contentful/f36-button": "^4.40.6",
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-drag-handle": "^4.40.6",
-        "@contentful/f36-icon": "^4.40.6",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-menu": "^4.40.6",
-        "@contentful/f36-skeleton": "^4.40.6",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.40.6",
+        "@contentful/f36-badge": "^4.59.1",
+        "@contentful/f36-button": "^4.59.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-drag-handle": "^4.59.1",
+        "@contentful/f36-icon": "^4.59.1",
+        "@contentful/f36-icons": "^4.27.0",
+        "@contentful/f36-menu": "^4.59.1",
+        "@contentful/f36-skeleton": "^4.59.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.59.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -853,14 +844,15 @@
       }
     },
     "node_modules/@contentful/f36-forms": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.40.6.tgz",
-      "integrity": "sha512-TKXSFmvFmaKpKlVMKEjDQNMCqfAFK+/n+HD01slGX9enkDG989fSSp2ot/tHGDZplpfLoSk/hu3pf9rS3XGWUg==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.59.1.tgz",
+      "integrity": "sha512-ow4WG6Fz7TwI/gFzB4F9o63bVY4BAF5CwbIW1rRwI0d5QhopX2/edHl8jnwAQNtvmGdEQ9wcFHrHKgK0CMLT8w==",
       "dependencies": {
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.40.6",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-icons": "^4.27.0",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.59.1",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -869,25 +861,26 @@
       }
     },
     "node_modules/@contentful/f36-icon": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.40.6.tgz",
-      "integrity": "sha512-dXfMLMC2Lxf/fcbPv1sdlowOv8kPRr0CRUqFrI/bj8Td+NUcpSXW4TFTSgqBBmQso0C/rNgF5+3Wab3Q7qOKvQ==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.59.1.tgz",
+      "integrity": "sha512-zm3HyFhQjShYnwVzu7Manvul5Srxv/xhfgSETqgl5AzALij6gVTZlX2/oH3siQ0zyYQbFs4OYWSAgF8MdQVG+w==",
       "dependencies": {
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/@contentful/f36-icons": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-4.25.0.tgz",
-      "integrity": "sha512-PDEvCtoAfP3FF7K+slhOb+LP2MxlUSKQXmRUmtBPXIFz+usZC4FOGQAMWKF9kdnDEq9C/kaYiCzPkZ6BJC4hmg==",
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-4.27.0.tgz",
+      "integrity": "sha512-sEQ5xorjQ2zMOCCv6uljpM+z46Miw5WTa5e1jf0bvRXPWLFYF0hkuQestL/JedObaB3ZEnq0B4NpfI2fslWH+Q==",
       "dependencies": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-icon": "^4.23.2",
+        "@contentful/f36-core": "^4.48.0",
+        "@contentful/f36-icon": "^4.48.0",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
@@ -897,29 +890,30 @@
       }
     },
     "node_modules/@contentful/f36-list": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.40.6.tgz",
-      "integrity": "sha512-LjKIUrbvi4if95kGp8ZaunYfq88soFmTIP9fMy+ufv/egYq+tpLvYpmG0RMsCZz3ECuwxGpuKCX3qD3ZI2sSEQ==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.59.1.tgz",
+      "integrity": "sha512-j82RT/6EdHFOYegm+lv9YanlYN+4vh+nCWbhiqAq2kpPlxUDU0WqrLKJIwYDW+WMYwRs1q7ZwlQ2oZW0OWnH5g==",
       "dependencies": {
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/@contentful/f36-menu": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.40.6.tgz",
-      "integrity": "sha512-GgbyrhSKiN5nT7G3zj34O0RgNg7e4CekqioFCHdbiO7Wmv81GujHWd5wncnLfq6QhN3qpND6/sbTiktWVgtlnA==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.59.1.tgz",
+      "integrity": "sha512-BE0adFI0t9vMY3W8efz1WhePvsHRoOMUf+EU911t66VSgfhfFApzLjoXPKOD1uGZ71CyCTiNbKplWBmsIlWesQ==",
       "dependencies": {
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-popover": "^4.40.6",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.40.6",
-        "@contentful/f36-utils": "^4.23.2",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-icons": "^4.27.0",
+        "@contentful/f36-popover": "^4.59.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.59.1",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -928,15 +922,15 @@
       }
     },
     "node_modules/@contentful/f36-modal": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.40.6.tgz",
-      "integrity": "sha512-VLuim/R52cxv95w11ApEsEMiEdDUbPMQy0FmLujxgXBEQa5P6m271eUIx/d7rnsZ2QMUE7Lj1izw8w472CrvfA==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.59.1.tgz",
+      "integrity": "sha512-Z347bPdkCbA+wEL8KgT+itbCfRU6b+ZkcUx0aMJNCiZiveBg8Q8veah4sopzmcMOjD61gInpxQ7GEnnEgqkCDw==",
       "dependencies": {
-        "@contentful/f36-button": "^4.40.6",
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.40.6",
+        "@contentful/f36-button": "^4.59.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-icons": "^4.27.0",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.59.1",
         "@types/react-modal": "^3.13.1",
         "emotion": "^10.0.17",
         "react-modal": "^3.16.1"
@@ -946,17 +940,36 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/@contentful/f36-note": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.40.6.tgz",
-      "integrity": "sha512-3n81ykV+2lM3WnaH8FS+4RbZkCZyKoZjz292xDE3f0WP+m6c7eLotg+rGgHDwmGCRfl+ReX/EiBdMJ1O1CWnkA==",
+    "node_modules/@contentful/f36-navbar": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-navbar/-/f36-navbar-4.1.1.tgz",
+      "integrity": "sha512-nCLtZ7EgfKhmXWrGZYrZEQOoulOOVPOuZBk0CC4JgQRQmCYeYr2iAnM8zualISFaxX/O+GVvHPQf2hKeoeFRPA==",
       "dependencies": {
-        "@contentful/f36-button": "^4.40.6",
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-icon": "^4.40.6",
+        "@contentful/f36-core": "^4.45.0",
+        "@contentful/f36-icon": "^4.45.0",
         "@contentful/f36-icons": "^4.23.2",
+        "@contentful/f36-menu": "^4.45.0",
+        "@contentful/f36-skeleton": "^4.45.0",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.40.6",
+        "@contentful/f36-utils": "^4.23.2",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-note": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.59.1.tgz",
+      "integrity": "sha512-77B0eaFSvW1ypTC1phdUFmcnylBz8VsqSNwQa9LdlH2QugTyoe4MmqwqhMuJSv8lIOpOhgHGZZKqYATzI3AHuw==",
+      "dependencies": {
+        "@contentful/f36-button": "^4.59.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-icon": "^4.59.1",
+        "@contentful/f36-icons": "^4.27.0",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.59.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -965,16 +978,16 @@
       }
     },
     "node_modules/@contentful/f36-notification": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.40.6.tgz",
-      "integrity": "sha512-777Nl+O5PflsVjJkS+pxpa2sai1zdatJB6XRdMg1TYz2Wao5pSbzJcGde+xQf/+ocs734s1McECF+uIvqjYdbA==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.59.1.tgz",
+      "integrity": "sha512-8ybe2AUCtx1poUObZDvOe8OhQXDycCpsieVF0YyXVfsOncZ4gIhBQSuU5Whfsng7IWfgZItkBdzYIyGPOpWzVw==",
       "dependencies": {
-        "@contentful/f36-button": "^4.40.6",
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-text-link": "^4.40.6",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.40.6",
+        "@contentful/f36-button": "^4.59.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-icons": "^4.27.0",
+        "@contentful/f36-text-link": "^4.59.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.59.1",
         "@swc/helpers": "^0.4.14",
         "emotion": "^10.0.17",
         "react-animate-height": "^3.0.4"
@@ -985,32 +998,34 @@
       }
     },
     "node_modules/@contentful/f36-pagination": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.40.6.tgz",
-      "integrity": "sha512-1bj/nZjDUJ58hWJ7qxeUWoa2t4RRFgCkeCoVsrZC6dT3Qg8oLvK5C8rlSD1k8ul90FtV/yA/cz4fQ6ZA5GbrCg==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.59.1.tgz",
+      "integrity": "sha512-JXlaryD7O3ZFKOIDXqidEw4xzm68rIFkBlFHWUoH9x/ODPqHhnD3XDagQ65cYduLX64LUVot1j991aeTFuCZLA==",
       "dependencies": {
-        "@contentful/f36-button": "^4.40.6",
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-forms": "^4.40.6",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-typography": "^4.40.6",
+        "@contentful/f36-button": "^4.59.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-forms": "^4.59.1",
+        "@contentful/f36-icons": "^4.27.0",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.59.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/@contentful/f36-pill": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.40.6.tgz",
-      "integrity": "sha512-bh1+PqHnDwqYvL+SSQLu+U4TdtGSv2CX8k4F5K5Hd/zS7LxuKbgT33b1iEHSgwqAXmtgn8BnPaQAz5HYIYpmHA==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.59.1.tgz",
+      "integrity": "sha512-UHI+nc5gsLJVYPm/Ixg9nkk4PF69j+6pKnDHDSyX1GiaPeC5v5ZfMF8XRVBp350tdG+h+W3JPtgG4+vUVeBLbA==",
       "dependencies": {
-        "@contentful/f36-button": "^4.40.6",
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-tooltip": "^4.40.6",
+        "@contentful/f36-button": "^4.59.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-drag-handle": "^4.59.1",
+        "@contentful/f36-icons": "^4.27.0",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-tooltip": "^4.59.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -1019,29 +1034,30 @@
       }
     },
     "node_modules/@contentful/f36-popover": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.40.6.tgz",
-      "integrity": "sha512-Bcj0wBDO2YepbcnKE7tcw95Q769u/s+jWGTDeiPrGL45iPTzYI8EBvuIutQXDRDn6qlRbHz3IIKXpY/YXiKhaQ==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.59.1.tgz",
+      "integrity": "sha512-AcSuNxiDnTXxL9VC9qBEIrQofieD3pj3sfNLlh8/VFmZql0fpISPMp0db0rHc4bcpsGAOB6JX5Sej7ywyJat/g==",
       "dependencies": {
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-utils": "^4.23.2",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
         "emotion": "^10.0.17",
         "react-popper": "^2.3.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/@contentful/f36-skeleton": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.40.6.tgz",
-      "integrity": "sha512-zQe8BE27dOizsTcYt33PennNTpXmoaDBBw6IxVhuPerVyXXZ7Rjsg6zhy2bgupNh3unf7aL2jWs3UwSptl9JUQ==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.59.1.tgz",
+      "integrity": "sha512-RzZ+eqW8Rfn+9HAfkXj8WZ3lEDbu8bzuX0Y0ghQ9qvvxBpj4NkcwzRiyuX8qQYGqtyMVI7z/9VyEacbGRyokGQ==",
       "dependencies": {
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-table": "^4.40.6",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-table": "^4.59.1",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -1050,27 +1066,28 @@
       }
     },
     "node_modules/@contentful/f36-spinner": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.40.6.tgz",
-      "integrity": "sha512-q+3pfhL7P4T9fu4JETlEa2ijuIzfw/f+qQ9gHDv1nzrb2D+BDu2QcPiNWRG2vrLxxmQzMAZJ0s+67ecHPe6o9w==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.59.1.tgz",
+      "integrity": "sha512-FirlpLV6zm3Et5vFd9s/kzhsY0E8ppG5UqHPTIGMgb2kCs607+3c+Sgs9wrgVkS0pDaMRBIyrvanKb48/nVhiA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/@contentful/f36-table": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.40.6.tgz",
-      "integrity": "sha512-ZI1xgRDV8aWsCaHlruYppVwc/bqWucd6X8szcKO/Qq8EhXQYRBXXtQcLyVawYTxlrSBFqbaQlrHXT821Y95QbQ==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.59.1.tgz",
+      "integrity": "sha512-uix+eYHmtzdFjlCawSN/EKaxcDmQQHtWgVMDs2iUX7osT2LcBjyXePWMnTef4tsCDgnJyfIRw5KenMsLfT5RdQ==",
       "dependencies": {
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-icons": "^4.25.0",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.40.6",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-icons": "^4.27.0",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.59.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -1079,12 +1096,12 @@
       }
     },
     "node_modules/@contentful/f36-tabs": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.40.6.tgz",
-      "integrity": "sha512-PQzqzM+AEqYOMqitwzac8b0V4IaGSZh3fETLszvI0vkid8jWkhiPrbbxbpc6N6cD8tJ6WxMbrV3RwvqOE4m4kw==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.59.1.tgz",
+      "integrity": "sha512-5zKIiwpL35Xq5lPjHHTgBswu7KN5xgTs+5vN8fOCiTzSPV7JDeQn8cegm3NXXXGtpfksRWAwasRMKPGJLt0Oog==",
       "dependencies": {
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-tokens": "^4.0.4",
         "@radix-ui/react-tabs": "^1.0.1",
         "emotion": "^10.0.17"
       },
@@ -1094,16 +1111,17 @@
       }
     },
     "node_modules/@contentful/f36-text-link": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.40.6.tgz",
-      "integrity": "sha512-UNcBaCOtccdABzMbLSxnJxDHm0zxjy2Ug6yszltciL6eknclQeUNTGepNKIYt+3BG6+6vtRN7KasKrVZRCkJKA==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.59.1.tgz",
+      "integrity": "sha512-VY1GcKt4uR7eJRn1I9wESASZPg5yWnVFyazLm2Y37It5R13J5eVDEeYr94xCEDRXVHfbC1pTAg2MMnlu6SoRiQ==",
       "dependencies": {
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/@contentful/f36-tokens": {
@@ -1112,13 +1130,13 @@
       "integrity": "sha512-yPHNQjHVEuO+5nUoX3EbrQvLoU7ZjNc/w3RyCmYR3F/NWZCy/3n0Knhq5Jfow+CcXkVY6Ch526VlA3+ayEN2kA=="
     },
     "node_modules/@contentful/f36-tooltip": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.40.6.tgz",
-      "integrity": "sha512-n1AMrXIA7Y6bhz3LR2puPZ2zHcpg834Ir1VdT4Ds/sDVW32qgE7NXSaYYmEqf+wMODIL8P06vOBVGW+BRKkKBw==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.59.1.tgz",
+      "integrity": "sha512-XFpRWeLaDwSg2N7YyyzkF3fvdRbUTKQbWcGNG4X4LLLfXp3VUcaxEjzxDlM7dD5HeY7RozHIV0CkaiKR4WV5Sw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-utils": "^4.23.2",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
         "csstype": "^3.1.1",
         "emotion": "^10.0.17",
@@ -1130,22 +1148,24 @@
       }
     },
     "node_modules/@contentful/f36-typography": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.40.6.tgz",
-      "integrity": "sha512-0ygztBogBk6e7U2mbqaj1zVRdleCHjjs1MxR3JaZNALfnW/Cu1hu+fc/dlk60fP7/kniipN1Z+EXWMgNVnLNEw==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.59.1.tgz",
+      "integrity": "sha512-bAexzvgG83VGw5EsMcvDJT+6ZbF9vIvrj2c1rt6XTGyM0nzWATSQxQaiPyTPd/He4f9s1CtMp3seh0fVS001rg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/@contentful/f36-utils": {
-      "version": "4.24.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-utils/-/f36-utils-4.24.1.tgz",
-      "integrity": "sha512-jr+61KiKn7oA38WXgAJoqVNdr6gXzmJSA+MCl7Djapxxf+jsC1vsi8j8okISCm4a/ZcPncKekDYzzWu+kkI7VQ==",
+      "version": "4.24.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-utils/-/f36-utils-4.24.3.tgz",
+      "integrity": "sha512-9+tyDOCjEhW7m4X7Sam0VYlmcgjhLVMiapCnv1EmRstlMaeI5ti9y0y/2aQ04Na2ScoHwrMTjveoZ6V62J62tA==",
       "dependencies": {
         "emotion": "^10.0.17"
       },
@@ -2430,195 +2450,293 @@
       }
     },
     "node_modules/@popperjs/core": {
-      "version": "2.11.7",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.7.tgz",
-      "integrity": "sha512-Cr4OjIkipTtcXKjAsm8agyleBuDHvxzeBoa1v543lbv1YaIwQjESsVcmjiWiPEbC1FIeHOG/Op9kdCmAmiS3Kw==",
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@radix-ui/primitive": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.0.tgz",
-      "integrity": "sha512-3e7rn8FDMin4CgeL7Z/49smCA3rFYY3Ha2rUQ7HRWFadS5iCRw08ZgVT1LaNTCNqgvrUiyczLflrVrF0SRQtNA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.1.tgz",
+      "integrity": "sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       }
     },
     "node_modules/@radix-ui/react-collection": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.0.2.tgz",
-      "integrity": "sha512-s8WdQQ6wNXpaxdZ308KSr8fEWGrg4un8i4r/w7fhiS4ElRNjk5rRcl0/C6TANG2LvLOGIxtzo/jAg6Qf73TEBw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.0.3.tgz",
+      "integrity": "sha512-3SzW+0PW7yBBoQlT8wNcGtaxaD0XSu0uLUFgrtHY08Acx05TaHaOmVLR73c0j/cqpDy53KBMO7s0dx2wmOIDIA==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-compose-refs": "1.0.0",
-        "@radix-ui/react-context": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.2",
-        "@radix-ui/react-slot": "1.0.1"
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2"
       },
       "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
         "react": "^16.8 || ^17.0 || ^18.0",
         "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@radix-ui/react-compose-refs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.0.tgz",
-      "integrity": "sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz",
+      "integrity": "sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       },
       "peerDependencies": {
+        "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@radix-ui/react-context": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.0.tgz",
-      "integrity": "sha512-1pVM9RfOQ+n/N5PJK33kRSKsr1glNxomxONs5c49MliinBY6Yw2Q995qfBUUo0/Mbg05B/sGA0gkgPI7kmSHBg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.1.tgz",
+      "integrity": "sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       },
       "peerDependencies": {
+        "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@radix-ui/react-direction": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.0.0.tgz",
-      "integrity": "sha512-2HV05lGUgYcA6xgLQ4BKPDmtL+QbIZYH5fCOTAOOcJ5O0QbWS3i9lKaurLzliYUDhORI2Qr3pyjhJh44lKA3rQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.0.1.tgz",
+      "integrity": "sha512-RXcvnXgyvYvBEOhCBuddKecVkoMiI10Jcm5cTI7abJRAHYfFxeu+FBQs/DvdxSYucxR5mna0dNsL6QFlds5TMA==",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       },
       "peerDependencies": {
+        "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@radix-ui/react-id": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.0.0.tgz",
-      "integrity": "sha512-Q6iAB/U7Tq3NTolBBQbHTgclPmGWE3OlktGGqrClPozSw4vkQ1DfQAOtzgRPecKsMdJINE05iaoDUG8tRzCBjw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.0.1.tgz",
+      "integrity": "sha512-tI7sT/kqYp8p96yGWY1OAnLHrqDgzHefRBKQ2YAkBS5ja7QLcZ9Z/uY7bEjPUatf8RomoXM8/1sMj1IJaE5UzQ==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-use-layout-effect": "1.0.0"
+        "@radix-ui/react-use-layout-effect": "1.0.1"
       },
       "peerDependencies": {
+        "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@radix-ui/react-presence": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.0.0.tgz",
-      "integrity": "sha512-A+6XEvN01NfVWiKu38ybawfHsBjWum42MRPnEuqPsBZ4eV7e/7K321B5VgYMPv3Xx5An6o1/l9ZuDBgmcmWK3w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.0.1.tgz",
+      "integrity": "sha512-UXLW4UAbIY5ZjcvzjfRFo5gxva8QirC9hF7wRE4U5gz+TP0DbRk+//qyuAQ1McDxBt1xNMBTaciFGvEmJvAZCg==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-compose-refs": "1.0.0",
-        "@radix-ui/react-use-layout-effect": "1.0.0"
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1"
       },
       "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
         "react": "^16.8 || ^17.0 || ^18.0",
         "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@radix-ui/react-primitive": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.2.tgz",
-      "integrity": "sha512-zY6G5Qq4R8diFPNwtyoLRZBxzu1Z+SXMlfYpChN7Dv8gvmx9X3qhDqiLWvKseKVJMuedFeU/Sa0Sy/Ia+t06Dw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.3.tgz",
+      "integrity": "sha512-yi58uVyoAcK/Nq1inRY56ZSjKypBNKTa/1mcL8qdl6oJeEaDbOldlzrGn7P6Q3Id5d+SYNGc5AJgc4vGhjs5+g==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-slot": "1.0.1"
+        "@radix-ui/react-slot": "1.0.2"
       },
       "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
         "react": "^16.8 || ^17.0 || ^18.0",
         "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@radix-ui/react-roving-focus": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.0.3.tgz",
-      "integrity": "sha512-stjCkIoMe6h+1fWtXlA6cRfikdBzCLp3SnVk7c48cv/uy3DTGoXhN76YaOYUJuy3aEDvDIKwKR5KSmvrtPvQPQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.0.4.tgz",
+      "integrity": "sha512-2mUg5Mgcu001VkGy+FfzZyzbmuUWzgWkj3rvv4yu+mLw03+mTzbxZHvfcGyFp2b8EkQeMkpRQ5FiA2Vr2O6TeQ==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/primitive": "1.0.0",
-        "@radix-ui/react-collection": "1.0.2",
-        "@radix-ui/react-compose-refs": "1.0.0",
-        "@radix-ui/react-context": "1.0.0",
-        "@radix-ui/react-direction": "1.0.0",
-        "@radix-ui/react-id": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.2",
-        "@radix-ui/react-use-callback-ref": "1.0.0",
-        "@radix-ui/react-use-controllable-state": "1.0.0"
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-collection": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@radix-ui/react-use-controllable-state": "1.0.1"
       },
       "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
         "react": "^16.8 || ^17.0 || ^18.0",
         "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@radix-ui/react-slot": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.1.tgz",
-      "integrity": "sha512-avutXAFL1ehGvAXtPquu0YK5oz6ctS474iM3vNGQIkswrVhdrS52e3uoMQBzZhNRAIE0jBnUyXWNmSjGHhCFcw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.2.tgz",
+      "integrity": "sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-compose-refs": "1.0.0"
+        "@radix-ui/react-compose-refs": "1.0.1"
       },
       "peerDependencies": {
+        "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@radix-ui/react-tabs": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.0.3.tgz",
-      "integrity": "sha512-4CkF/Rx1GcrusI/JZ1Rvyx4okGUs6wEenWA0RG/N+CwkRhTy7t54y7BLsWUXrAz/GRbBfHQg/Odfs/RoW0CiRA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.0.4.tgz",
+      "integrity": "sha512-egZfYY/+wRNCflXNHx+dePvnz9FbmssDTJBtgRfDY7e8SE5oIo3Py2eCB1ckAbh1Q7cQ/6yJZThJ++sgbxibog==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/primitive": "1.0.0",
-        "@radix-ui/react-context": "1.0.0",
-        "@radix-ui/react-direction": "1.0.0",
-        "@radix-ui/react-id": "1.0.0",
-        "@radix-ui/react-presence": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.2",
-        "@radix-ui/react-roving-focus": "1.0.3",
-        "@radix-ui/react-use-controllable-state": "1.0.0"
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-presence": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-roving-focus": "1.0.4",
+        "@radix-ui/react-use-controllable-state": "1.0.1"
       },
       "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
         "react": "^16.8 || ^17.0 || ^18.0",
         "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@radix-ui/react-use-callback-ref": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.0.tgz",
-      "integrity": "sha512-GZtyzoHz95Rhs6S63D2t/eqvdFCm7I+yHMLVQheKM7nBD8mbZIt+ct1jz4536MDnaOGKIxynJ8eHTkVGVVkoTg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.1.tgz",
+      "integrity": "sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ==",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       },
       "peerDependencies": {
+        "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@radix-ui/react-use-controllable-state": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.0.tgz",
-      "integrity": "sha512-FohDoZvk3mEXh9AWAVyRTYR4Sq7/gavuofglmiXB2g1aKyboUD4YtgWxKj8O5n+Uak52gXQ4wKz5IFST4vtJHg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.1.tgz",
+      "integrity": "sha512-Svl5GY5FQeN758fWKrjM6Qb7asvXeiZltlT4U2gVfl8Gx5UAv2sMR0LWo8yhsIZh2oQ0eFdZ59aoOOMV7b47VA==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-use-callback-ref": "1.0.0"
+        "@radix-ui/react-use-callback-ref": "1.0.1"
       },
       "peerDependencies": {
+        "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@radix-ui/react-use-layout-effect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.0.tgz",
-      "integrity": "sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.1.tgz",
+      "integrity": "sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       },
       "peerDependencies": {
+        "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -2640,10 +2758,11 @@
       }
     },
     "node_modules/@swc/helpers": {
-      "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
-      "integrity": "sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.36.tgz",
+      "integrity": "sha512-5lxnyLEYFskErRPenYItLRSge5DjrJngYKdVjRSrWfza9G6KkgHEXi0vUZiyUeMU5JfXH1YnvXZzSp8ul88o2Q==",
       "dependencies": {
+        "legacy-swc-helpers": "npm:@swc/helpers@=0.4.14",
         "tslib": "^2.4.0"
       }
     },
@@ -2904,15 +3023,15 @@
       "version": "18.0.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.3.tgz",
       "integrity": "sha512-1RRW9kst+67gveJRYPxGmVy8eVJ05O43hg77G2j5m76/RFJtMbcfAs2viQ2UNsvvDg8F7OfQZx8qQcl6ymygaQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/react": "*"
       }
     },
     "node_modules/@types/react-modal": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@types/react-modal/-/react-modal-3.16.0.tgz",
-      "integrity": "sha512-iphdqXAyUfByLbxJn5j6d+yh93dbMgshqGP0IuBeaKbZXx0aO+OXsvEkt6QctRdxjeM9/bR+Gp3h9F9djVWTQQ==",
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/@types/react-modal/-/react-modal-3.16.3.tgz",
+      "integrity": "sha512-xXuGavyEGaFQDgBv4UVm8/ZsG+qxeQ7f77yNrW3n+1J6XAstUy5rYHeIHPh1KzsGc6IkCIdu6lQ2xWzu1jBTLg==",
       "dependencies": {
         "@types/react": "*"
       }
@@ -3705,9 +3824,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.7",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
-      "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ=="
+      "version": "1.11.10",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
+      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
     },
     "node_modules/debug": {
       "version": "4.3.3",
@@ -4165,9 +4284,9 @@
       }
     },
     "node_modules/focus-lock": {
-      "version": "0.11.6",
-      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.11.6.tgz",
-      "integrity": "sha512-KSuV3ur4gf2KqMNoZx3nXNVhqCkn42GuTYCX4tXPEwf0MjpFQmNMiN6m7dXaUXgIoivL6/65agoUMg4RLS0Vbg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-1.0.0.tgz",
+      "integrity": "sha512-a8Ge6cdKh9za/GZR/qtigTAk7SrGore56EFcoMshClsh7FLk1zwszc/ltuMfKhx56qeuyL/jWQ4J4axou0iJ9w==",
       "dependencies": {
         "tslib": "^2.0.3"
       },
@@ -7527,6 +7646,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/legacy-swc-helpers": {
+      "name": "@swc/helpers",
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
+      "integrity": "sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -8102,9 +8230,9 @@
       }
     },
     "node_modules/react-animate-height": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/react-animate-height/-/react-animate-height-3.1.1.tgz",
-      "integrity": "sha512-UkC6+V3ZlCneBRaSM7aUctDJ+PRP6ztcGtxvU7MTeoMMWPhz8BQNaX7QWaZrkzp1ih1G8uZZ+DI9nfLvtD6OdQ==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/react-animate-height/-/react-animate-height-3.2.3.tgz",
+      "integrity": "sha512-R6DSvr7ud07oeCixScyvXWEMJY/Mt2+GyOWC1KMaRc69gOBw+SsCg4TJmrp4rKUM1hyd6p+YKw90brjPH93Y2A==",
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8125,15 +8253,15 @@
       }
     },
     "node_modules/react-day-picker": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.7.1.tgz",
-      "integrity": "sha512-Gv426AW8b151CZfh3aP5RUGztLwHB/EyJgWZ5iMgtzbFBkjHfG6Y66CIQFMWGLnYjsQ9DYSJRmJ5S0Pg5HWKjA==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.10.0.tgz",
+      "integrity": "sha512-mz+qeyrOM7++1NCb1ARXmkjMkzWVh2GL9YiPbRjKe0zHccvekk4HE+0MPOZOrosn8r8zTHIIeOUXTmXRqmkRmg==",
       "funding": {
         "type": "individual",
         "url": "https://github.com/sponsors/gpbl"
       },
       "peerDependencies": {
-        "date-fns": "^2.28.0",
+        "date-fns": "^2.28.0 || ^3.0.0",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
@@ -8156,12 +8284,12 @@
       "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
     },
     "node_modules/react-focus-lock": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.4.tgz",
-      "integrity": "sha512-7pEdXyMseqm3kVjhdVH18sovparAzLg5h6WvIx7/Ck3ekjhrrDMEegHSa3swwC8wgfdd7DIdUVRGeiHT9/7Sgg==",
+      "version": "2.9.7",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.7.tgz",
+      "integrity": "sha512-EfhX040SELLqnQ9JftqsmQCG49iByg8F5X5m19Er+n371OaETZ35dlNPZrLOOTlnnwD4c2Zv0KDgabDTc7dPHw==",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
-        "focus-lock": "^0.11.6",
+        "focus-lock": "^1.0.0",
         "prop-types": "^15.6.2",
         "react-clientside-effect": "^1.2.6",
         "use-callback-ref": "^1.3.0",
@@ -8744,9 +8872,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
-      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/type-check": {
       "version": "0.3.2",
@@ -8893,9 +9021,9 @@
       }
     },
     "node_modules/use-callback-ref": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.0.tgz",
-      "integrity": "sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.1.tgz",
+      "integrity": "sha512-Lg4Vx1XZQauB42Hw3kK7JM6yjVjgFmFC5/Ab797s79aARomD2nEErc4mCgM8EZrARLmmbWpi5DGCadmK50DcAQ==",
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -9602,185 +9730,164 @@
       }
     },
     "@contentful/f36-accordion": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.40.6.tgz",
-      "integrity": "sha512-elfOt3keM7Nf9iSnVE+apG4JrZI1WAwy8Agky7C8j4xtq47t9au7dL7bGKUBftY7FAP6/2VrdiiaGH+riQ5mjw==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.59.1.tgz",
+      "integrity": "sha512-qrU7EC84GIGjNWvY4XgskfuCP3+2gPFLT2nMyFANQalNGR3/6NB8UsSKteVLXBZ3dzFIFvKHPIErUF2b7oBptw==",
       "requires": {
-        "@contentful/f36-collapse": "^4.40.6",
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.40.6",
+        "@contentful/f36-collapse": "^4.59.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-icons": "^4.27.0",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.59.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-asset": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.40.6.tgz",
-      "integrity": "sha512-i2J5Fq3yaFMeevy4N1+/AObhFCwYOaaiooofn0ppRTC1r5ej3gEwaZ7oy5MlwvK4uOXYEyeLHbb5ZEOlQWyp4Q==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.59.1.tgz",
+      "integrity": "sha512-ysm6TZ1+sE4DYWBKjroudWjcs1K+vaS1oJxW612p/jIZKw6ntWMb1VKPg1ZzXYMvAURexpbWFwU06Areo+dzcQ==",
       "requires": {
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-icon": "^4.40.6",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.40.6",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-icon": "^4.59.1",
+        "@contentful/f36-icons": "^4.27.0",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.59.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-autocomplete": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.40.6.tgz",
-      "integrity": "sha512-M98tcNEKRcfd3mdAAmi9IijPvCDf8ZvvyRPJ9zSfAXaA+XRldB7CguOpqqRude/N2OixXujY2fi4juDZERJ+Kg==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.59.1.tgz",
+      "integrity": "sha512-49fg7LzLspbv1SpcJUsB1yGbYj4FWKlFXGQjErRy6hyUWL7tNoEppg7hkN0J9CJeOu1offh2TNmRrL0kgKMDMQ==",
       "requires": {
-        "@contentful/f36-button": "^4.40.6",
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-forms": "^4.40.6",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-popover": "^4.40.6",
-        "@contentful/f36-skeleton": "^4.40.6",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.40.6",
-        "@contentful/f36-utils": "^4.23.2",
+        "@contentful/f36-button": "^4.59.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-forms": "^4.59.1",
+        "@contentful/f36-icons": "^4.27.0",
+        "@contentful/f36-popover": "^4.59.1",
+        "@contentful/f36-skeleton": "^4.59.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.59.1",
+        "@contentful/f36-utils": "^4.24.3",
         "downshift": "^6.1.12",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-badge": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.40.6.tgz",
-      "integrity": "sha512-8UJUkFQC2KNcHgt+SWfLUwAWFjKD3tFlsKIBvXFBhpup9pQ2ATzygSNM/Q75wSzWz66s2fmI0WANSpqr9Paqjg==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.59.1.tgz",
+      "integrity": "sha512-g7UiOxpmlSBfl65j0QPoCI5YUmDnoOywCv9esFE5k61fEqNb6zEU7nXHyc6CWNdw+6XYxpaFqVRe14Q8jaaI0A==",
       "requires": {
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-icons": "^4.25.0",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-icons": "^4.27.0",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-button": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.40.6.tgz",
-      "integrity": "sha512-hQ7sS2GwwDUTozNPOLE2fICh5kg8H35PhVhrzuRsvF9Q7Ux6aLj+fQwFEfhVkibs8Jp8kAcFoR/hLIX35O5ocA==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.59.1.tgz",
+      "integrity": "sha512-jETbDGXLqzdkuWB+rX+HrMvcuFnwS87w5ZmAV5SKtA4JZerC5wSXZd6TPssuDEBsEkd2YrXZozd/1Rb73V8kTg==",
       "requires": {
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-spinner": "^4.40.6",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-utils": "^4.24.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-spinner": "^4.59.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-card": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.40.6.tgz",
-      "integrity": "sha512-MJz+GRMl3p/9Vvgg3j73P5+Yv3FqLNGSDJOMgr544YmJZuS/Ic+jusoc0yGW1nSGt/+2EwWg2nHmoFHsdtfcug==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.59.1.tgz",
+      "integrity": "sha512-W3zSrZ2RB2e28zCHWriYrBWJdew7oEFc71MSBtuYBKhDwZMbYXNV3BTcXv9+hsvpOTW/KJWdFCD8vsX61tcIyg==",
       "requires": {
-        "@contentful/f36-asset": "^4.40.6",
-        "@contentful/f36-badge": "^4.40.6",
-        "@contentful/f36-button": "^4.40.6",
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-drag-handle": "^4.40.6",
-        "@contentful/f36-icon": "^4.40.6",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-menu": "^4.40.6",
-        "@contentful/f36-skeleton": "^4.40.6",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-tooltip": "^4.40.6",
-        "@contentful/f36-typography": "^4.40.6",
+        "@contentful/f36-asset": "^4.59.1",
+        "@contentful/f36-badge": "^4.59.1",
+        "@contentful/f36-button": "^4.59.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-drag-handle": "^4.59.1",
+        "@contentful/f36-icon": "^4.59.1",
+        "@contentful/f36-icons": "^4.27.0",
+        "@contentful/f36-menu": "^4.59.1",
+        "@contentful/f36-skeleton": "^4.59.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-tooltip": "^4.59.1",
+        "@contentful/f36-typography": "^4.59.1",
         "emotion": "^10.0.17",
         "truncate": "^3.0.0"
       }
     },
     "@contentful/f36-collapse": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.40.6.tgz",
-      "integrity": "sha512-L6UTj/U+dUVYEeJLMwa3ztVehBTnsgv4mIfXgW2ZU7MrS1iI8gx8svyey1pFIQxnS9UMp6cx2sWlE+mzy2CKVA==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.59.1.tgz",
+      "integrity": "sha512-Hsv5IK4EKKsUgbWX3K8Au1hskmX5WO6BF02fgri9wbmyOEDSgG6J873KET6xCylDjgKwLiuyscX2WJnUu16QuA==",
       "requires": {
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-components": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.40.6.tgz",
-      "integrity": "sha512-Z0RI2AJ9nDJRYeZJBQ1Xh6B6kNfvDfxTIcOEoX3Lno1KmAzNo+reCKRt1LRCUzt4lpF1IZhwXBYu86jvLhYuuw==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.59.1.tgz",
+      "integrity": "sha512-vUmZJ2AbarOoX0w0PZEdBCrYzeQ2KbySoktev2ZS9PA9JKZ4AMjE1JkonTGJhZx8LAHEQWV78/gejVIr55nwRw==",
       "requires": {
-        "@contentful/f36-accordion": "^4.40.6",
-        "@contentful/f36-asset": "^4.40.6",
-        "@contentful/f36-autocomplete": "^4.40.6",
-        "@contentful/f36-badge": "^4.40.6",
-        "@contentful/f36-button": "^4.40.6",
-        "@contentful/f36-card": "^4.40.6",
-        "@contentful/f36-collapse": "^4.40.6",
-        "@contentful/f36-copybutton": "^4.40.6",
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-datepicker": "^4.40.6",
-        "@contentful/f36-datetime": "^4.40.6",
-        "@contentful/f36-drag-handle": "^4.40.6",
-        "@contentful/f36-empty-state": "^4.40.6",
-        "@contentful/f36-entity-list": "^4.40.6",
-        "@contentful/f36-forms": "^4.40.6",
-        "@contentful/f36-icon": "^4.40.6",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-list": "^4.40.6",
-        "@contentful/f36-menu": "^4.40.6",
-        "@contentful/f36-modal": "^4.40.6",
-        "@contentful/f36-note": "^4.40.6",
-        "@contentful/f36-notification": "^4.40.6",
-        "@contentful/f36-pagination": "^4.40.6",
-        "@contentful/f36-pill": "^4.40.6",
-        "@contentful/f36-popover": "^4.40.6",
-        "@contentful/f36-skeleton": "^4.40.6",
-        "@contentful/f36-spinner": "^4.40.6",
-        "@contentful/f36-table": "^4.40.6",
-        "@contentful/f36-tabs": "^4.40.6",
-        "@contentful/f36-text-link": "^4.40.6",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-tooltip": "^4.40.6",
-        "@contentful/f36-typography": "^4.40.6",
-        "@contentful/f36-utils": "^4.23.2",
-        "@types/react": "16.14.22",
-        "@types/react-dom": "16.9.14"
-      },
-      "dependencies": {
-        "@types/react": {
-          "version": "16.14.22",
-          "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.22.tgz",
-          "integrity": "sha512-4NnkxKDd2UO9SiCckuhCQOCzdO+RtE4Epf1D6eGz3f9jZjiIXOVo+Bk3jqSad+8EOT+LBXwKdkFX0V0F+NFzDQ==",
-          "requires": {
-            "@types/prop-types": "*",
-            "@types/scheduler": "*",
-            "csstype": "^3.0.2"
-          }
-        },
-        "@types/react-dom": {
-          "version": "16.9.14",
-          "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.14.tgz",
-          "integrity": "sha512-FIX2AVmPTGP30OUJ+0vadeIFJJ07Mh1m+U0rxfgyW34p3rTlXI+nlenvAxNn4BP36YyI9IJ/+UJ7Wu22N1pI7A==",
-          "requires": {
-            "@types/react": "^16"
-          }
-        }
+        "@contentful/f36-accordion": "^4.59.1",
+        "@contentful/f36-asset": "^4.59.1",
+        "@contentful/f36-autocomplete": "^4.59.1",
+        "@contentful/f36-badge": "^4.59.1",
+        "@contentful/f36-button": "^4.59.1",
+        "@contentful/f36-card": "^4.59.1",
+        "@contentful/f36-collapse": "^4.59.1",
+        "@contentful/f36-copybutton": "^4.59.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-datepicker": "^4.59.1",
+        "@contentful/f36-datetime": "^4.59.1",
+        "@contentful/f36-drag-handle": "^4.59.1",
+        "@contentful/f36-empty-state": "^4.59.1",
+        "@contentful/f36-entity-list": "^4.59.1",
+        "@contentful/f36-forms": "^4.59.1",
+        "@contentful/f36-icon": "^4.59.1",
+        "@contentful/f36-icons": "^4.27.0",
+        "@contentful/f36-list": "^4.59.1",
+        "@contentful/f36-menu": "^4.59.1",
+        "@contentful/f36-modal": "^4.59.1",
+        "@contentful/f36-navbar": "^4.1.0",
+        "@contentful/f36-note": "^4.59.1",
+        "@contentful/f36-notification": "^4.59.1",
+        "@contentful/f36-pagination": "^4.59.1",
+        "@contentful/f36-pill": "^4.59.1",
+        "@contentful/f36-popover": "^4.59.1",
+        "@contentful/f36-skeleton": "^4.59.1",
+        "@contentful/f36-spinner": "^4.59.1",
+        "@contentful/f36-table": "^4.59.1",
+        "@contentful/f36-tabs": "^4.59.1",
+        "@contentful/f36-text-link": "^4.59.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-tooltip": "^4.59.1",
+        "@contentful/f36-typography": "^4.59.1",
+        "@contentful/f36-utils": "^4.24.3"
       }
     },
     "@contentful/f36-copybutton": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.40.6.tgz",
-      "integrity": "sha512-ItW2Y8Hk3UoUGpRtW/YYTWaw6ieXREe4bdyeCJslQEPbgC8QAYlCs33oYYb7Sg7SzVQ3fTPbgcQMDXy4ouLwGg==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.59.1.tgz",
+      "integrity": "sha512-XxnLa5bMyDy39ib0QT2G/Q+78bS7ro6O7x9AyGwRQTZfDgiWGplgDwKzeGfWxF9ygznYGy4dKJ1/dzh6e2ZoIw==",
       "requires": {
-        "@contentful/f36-button": "^4.40.6",
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-tooltip": "^4.40.6",
+        "@contentful/f36-button": "^4.59.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-icons": "^4.27.0",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-tooltip": "^4.59.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-core": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.40.6.tgz",
-      "integrity": "sha512-vEfSyU3+R6ZCtd9yXUEZ32T6MEqnuo8PSZL+VYw3RdjUzV70NE0K4y3aav21nBm3p51NCwImMG8XfjwabBQE1A==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.59.1.tgz",
+      "integrity": "sha512-B/8Iv4vodOsWjc+1Z/T6R4V3L3gVUwCaxzzzQa1axm4eteLdoj1ss6mb+yb7HAx/otBOKRWWTtVolED/UO6GNQ==",
       "requires": {
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-tokens": "^4.0.4",
         "@emotion/core": "^10.1.1",
         "@emotion/is-prop-valid": "^1.2.0",
         "csstype": "^3.1.1",
@@ -9788,267 +9895,284 @@
       }
     },
     "@contentful/f36-datepicker": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.40.6.tgz",
-      "integrity": "sha512-jiOZHkFULw763jsKtxHgbh3EmpKKAGPT1o1ynUmLsroqJGrCm7w5lUZkrJRX71t3Kvlj3q1h4Bad2VFrwy1pDA==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.59.1.tgz",
+      "integrity": "sha512-z4zs09O+QqN9etHTgI2uUmhZeqnEV74XOjgImankE5Ieyym5YXRAyqIdNs6Q0uPfHo6BokkQXlm40+pDMVBkOw==",
       "requires": {
-        "@contentful/f36-button": "^4.40.6",
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-forms": "^4.40.6",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-popover": "^4.40.6",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-typography": "^4.40.6",
+        "@contentful/f36-button": "^4.59.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-forms": "^4.59.1",
+        "@contentful/f36-icons": "^4.27.0",
+        "@contentful/f36-popover": "^4.59.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.59.1",
         "date-fns": "^2.28.0",
         "emotion": "^10.0.17",
-        "react-day-picker": "^8.3.5",
+        "react-day-picker": "^8.7.1",
         "react-focus-lock": "^2.9.1"
       }
     },
     "@contentful/f36-datetime": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.40.6.tgz",
-      "integrity": "sha512-kvqtNOD5FBRm9XpWuOtMy0vvFOm3Qwaa7WetOUeFKCbm7yXkxG2G67oAcRjkLOFhUM16yL9Cn2WdlT8KSyiJUA==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.59.1.tgz",
+      "integrity": "sha512-pC/AlWk8/w6J+rwjYtkPFG0WsZsR6rdOg5MGjmux4/cWzPF0t0mN1gKS2d9m5BKZUffUVudPzE0GspN5R70Phg==",
       "requires": {
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-tokens": "^4.0.4",
         "dayjs": "^1.11.5",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-drag-handle": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.40.6.tgz",
-      "integrity": "sha512-eVBc9SSghkvxff4zzEoq21Nm0tCx+WkuoB/c5PW0hSdbnjsbXBW9W4nl/2NDfD/XkpJ3ImUi6a9IMn8GSsEIIQ==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.59.1.tgz",
+      "integrity": "sha512-pe4hXiiF524uQ1fjSewUr6cgVbnp6ZSo5Nh5Eh/s2i5OWlZOS/geesYIq+r6TY72rGcoAPT1rUN6DobVPqt7LA==",
       "requires": {
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-utils": "^4.24.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-icons": "^4.27.0",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-empty-state": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.40.6.tgz",
-      "integrity": "sha512-bkCJrCJaq0DGHlVDT19EtkJDoUKWhaOBqonvfNXiLjMYIOdtOUF6RH9h5nzH/UZb3Ed7PbARtP6+3JdUimRSJQ==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.59.1.tgz",
+      "integrity": "sha512-UPIWbPCdC01NrRVny9PuO/zkxqeTc6uQf9WUFwxGY5wOG/OD2GhnMb57TOWEGTqfvN2I8/of4hQtb5I9c2M68Q==",
       "requires": {
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.40.6",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.59.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-entity-list": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.40.6.tgz",
-      "integrity": "sha512-6dVBZCDvp9G5a/w0OvI5PhfQWd5/InK0hn0Gm3J57DWJIuFYka3SMeGWK5GoAeUJxEn/VtHLoQVUoK1ORPkFAg==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.59.1.tgz",
+      "integrity": "sha512-Hs+tkiqPbZz1Xq0trx7YFljJ1K7ndSpUkcLKZzSco7KvdiPH6FdHceh8c8HPI0Q4ATv1eK51LRJeAqwn1oOXmQ==",
       "requires": {
-        "@contentful/f36-badge": "^4.40.6",
-        "@contentful/f36-button": "^4.40.6",
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-drag-handle": "^4.40.6",
-        "@contentful/f36-icon": "^4.40.6",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-menu": "^4.40.6",
-        "@contentful/f36-skeleton": "^4.40.6",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.40.6",
+        "@contentful/f36-badge": "^4.59.1",
+        "@contentful/f36-button": "^4.59.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-drag-handle": "^4.59.1",
+        "@contentful/f36-icon": "^4.59.1",
+        "@contentful/f36-icons": "^4.27.0",
+        "@contentful/f36-menu": "^4.59.1",
+        "@contentful/f36-skeleton": "^4.59.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.59.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-forms": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.40.6.tgz",
-      "integrity": "sha512-TKXSFmvFmaKpKlVMKEjDQNMCqfAFK+/n+HD01slGX9enkDG989fSSp2ot/tHGDZplpfLoSk/hu3pf9rS3XGWUg==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.59.1.tgz",
+      "integrity": "sha512-ow4WG6Fz7TwI/gFzB4F9o63bVY4BAF5CwbIW1rRwI0d5QhopX2/edHl8jnwAQNtvmGdEQ9wcFHrHKgK0CMLT8w==",
       "requires": {
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.40.6",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-icons": "^4.27.0",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.59.1",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-icon": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.40.6.tgz",
-      "integrity": "sha512-dXfMLMC2Lxf/fcbPv1sdlowOv8kPRr0CRUqFrI/bj8Td+NUcpSXW4TFTSgqBBmQso0C/rNgF5+3Wab3Q7qOKvQ==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.59.1.tgz",
+      "integrity": "sha512-zm3HyFhQjShYnwVzu7Manvul5Srxv/xhfgSETqgl5AzALij6gVTZlX2/oH3siQ0zyYQbFs4OYWSAgF8MdQVG+w==",
       "requires": {
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-icons": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-4.25.0.tgz",
-      "integrity": "sha512-PDEvCtoAfP3FF7K+slhOb+LP2MxlUSKQXmRUmtBPXIFz+usZC4FOGQAMWKF9kdnDEq9C/kaYiCzPkZ6BJC4hmg==",
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-4.27.0.tgz",
+      "integrity": "sha512-sEQ5xorjQ2zMOCCv6uljpM+z46Miw5WTa5e1jf0bvRXPWLFYF0hkuQestL/JedObaB3ZEnq0B4NpfI2fslWH+Q==",
       "requires": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-icon": "^4.23.2",
+        "@contentful/f36-core": "^4.48.0",
+        "@contentful/f36-icon": "^4.48.0",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-list": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.40.6.tgz",
-      "integrity": "sha512-LjKIUrbvi4if95kGp8ZaunYfq88soFmTIP9fMy+ufv/egYq+tpLvYpmG0RMsCZz3ECuwxGpuKCX3qD3ZI2sSEQ==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.59.1.tgz",
+      "integrity": "sha512-j82RT/6EdHFOYegm+lv9YanlYN+4vh+nCWbhiqAq2kpPlxUDU0WqrLKJIwYDW+WMYwRs1q7ZwlQ2oZW0OWnH5g==",
       "requires": {
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-menu": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.40.6.tgz",
-      "integrity": "sha512-GgbyrhSKiN5nT7G3zj34O0RgNg7e4CekqioFCHdbiO7Wmv81GujHWd5wncnLfq6QhN3qpND6/sbTiktWVgtlnA==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.59.1.tgz",
+      "integrity": "sha512-BE0adFI0t9vMY3W8efz1WhePvsHRoOMUf+EU911t66VSgfhfFApzLjoXPKOD1uGZ71CyCTiNbKplWBmsIlWesQ==",
       "requires": {
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-popover": "^4.40.6",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.40.6",
-        "@contentful/f36-utils": "^4.23.2",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-icons": "^4.27.0",
+        "@contentful/f36-popover": "^4.59.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.59.1",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-modal": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.40.6.tgz",
-      "integrity": "sha512-VLuim/R52cxv95w11ApEsEMiEdDUbPMQy0FmLujxgXBEQa5P6m271eUIx/d7rnsZ2QMUE7Lj1izw8w472CrvfA==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.59.1.tgz",
+      "integrity": "sha512-Z347bPdkCbA+wEL8KgT+itbCfRU6b+ZkcUx0aMJNCiZiveBg8Q8veah4sopzmcMOjD61gInpxQ7GEnnEgqkCDw==",
       "requires": {
-        "@contentful/f36-button": "^4.40.6",
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.40.6",
+        "@contentful/f36-button": "^4.59.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-icons": "^4.27.0",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.59.1",
         "@types/react-modal": "^3.13.1",
         "emotion": "^10.0.17",
         "react-modal": "^3.16.1"
       }
     },
-    "@contentful/f36-note": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.40.6.tgz",
-      "integrity": "sha512-3n81ykV+2lM3WnaH8FS+4RbZkCZyKoZjz292xDE3f0WP+m6c7eLotg+rGgHDwmGCRfl+ReX/EiBdMJ1O1CWnkA==",
+    "@contentful/f36-navbar": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-navbar/-/f36-navbar-4.1.1.tgz",
+      "integrity": "sha512-nCLtZ7EgfKhmXWrGZYrZEQOoulOOVPOuZBk0CC4JgQRQmCYeYr2iAnM8zualISFaxX/O+GVvHPQf2hKeoeFRPA==",
       "requires": {
-        "@contentful/f36-button": "^4.40.6",
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-icon": "^4.40.6",
+        "@contentful/f36-core": "^4.45.0",
+        "@contentful/f36-icon": "^4.45.0",
         "@contentful/f36-icons": "^4.23.2",
+        "@contentful/f36-menu": "^4.45.0",
+        "@contentful/f36-skeleton": "^4.45.0",
         "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.40.6",
+        "@contentful/f36-utils": "^4.23.2",
+        "emotion": "^10.0.17"
+      }
+    },
+    "@contentful/f36-note": {
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.59.1.tgz",
+      "integrity": "sha512-77B0eaFSvW1ypTC1phdUFmcnylBz8VsqSNwQa9LdlH2QugTyoe4MmqwqhMuJSv8lIOpOhgHGZZKqYATzI3AHuw==",
+      "requires": {
+        "@contentful/f36-button": "^4.59.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-icon": "^4.59.1",
+        "@contentful/f36-icons": "^4.27.0",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.59.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-notification": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.40.6.tgz",
-      "integrity": "sha512-777Nl+O5PflsVjJkS+pxpa2sai1zdatJB6XRdMg1TYz2Wao5pSbzJcGde+xQf/+ocs734s1McECF+uIvqjYdbA==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.59.1.tgz",
+      "integrity": "sha512-8ybe2AUCtx1poUObZDvOe8OhQXDycCpsieVF0YyXVfsOncZ4gIhBQSuU5Whfsng7IWfgZItkBdzYIyGPOpWzVw==",
       "requires": {
-        "@contentful/f36-button": "^4.40.6",
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-text-link": "^4.40.6",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.40.6",
+        "@contentful/f36-button": "^4.59.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-icons": "^4.27.0",
+        "@contentful/f36-text-link": "^4.59.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.59.1",
         "@swc/helpers": "^0.4.14",
         "emotion": "^10.0.17",
         "react-animate-height": "^3.0.4"
       }
     },
     "@contentful/f36-pagination": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.40.6.tgz",
-      "integrity": "sha512-1bj/nZjDUJ58hWJ7qxeUWoa2t4RRFgCkeCoVsrZC6dT3Qg8oLvK5C8rlSD1k8ul90FtV/yA/cz4fQ6ZA5GbrCg==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.59.1.tgz",
+      "integrity": "sha512-JXlaryD7O3ZFKOIDXqidEw4xzm68rIFkBlFHWUoH9x/ODPqHhnD3XDagQ65cYduLX64LUVot1j991aeTFuCZLA==",
       "requires": {
-        "@contentful/f36-button": "^4.40.6",
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-forms": "^4.40.6",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-typography": "^4.40.6",
+        "@contentful/f36-button": "^4.59.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-forms": "^4.59.1",
+        "@contentful/f36-icons": "^4.27.0",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.59.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-pill": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.40.6.tgz",
-      "integrity": "sha512-bh1+PqHnDwqYvL+SSQLu+U4TdtGSv2CX8k4F5K5Hd/zS7LxuKbgT33b1iEHSgwqAXmtgn8BnPaQAz5HYIYpmHA==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.59.1.tgz",
+      "integrity": "sha512-UHI+nc5gsLJVYPm/Ixg9nkk4PF69j+6pKnDHDSyX1GiaPeC5v5ZfMF8XRVBp350tdG+h+W3JPtgG4+vUVeBLbA==",
       "requires": {
-        "@contentful/f36-button": "^4.40.6",
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-tooltip": "^4.40.6",
+        "@contentful/f36-button": "^4.59.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-drag-handle": "^4.59.1",
+        "@contentful/f36-icons": "^4.27.0",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-tooltip": "^4.59.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-popover": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.40.6.tgz",
-      "integrity": "sha512-Bcj0wBDO2YepbcnKE7tcw95Q769u/s+jWGTDeiPrGL45iPTzYI8EBvuIutQXDRDn6qlRbHz3IIKXpY/YXiKhaQ==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.59.1.tgz",
+      "integrity": "sha512-AcSuNxiDnTXxL9VC9qBEIrQofieD3pj3sfNLlh8/VFmZql0fpISPMp0db0rHc4bcpsGAOB6JX5Sej7ywyJat/g==",
       "requires": {
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-utils": "^4.23.2",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
         "emotion": "^10.0.17",
         "react-popper": "^2.3.0"
       }
     },
     "@contentful/f36-skeleton": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.40.6.tgz",
-      "integrity": "sha512-zQe8BE27dOizsTcYt33PennNTpXmoaDBBw6IxVhuPerVyXXZ7Rjsg6zhy2bgupNh3unf7aL2jWs3UwSptl9JUQ==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.59.1.tgz",
+      "integrity": "sha512-RzZ+eqW8Rfn+9HAfkXj8WZ3lEDbu8bzuX0Y0ghQ9qvvxBpj4NkcwzRiyuX8qQYGqtyMVI7z/9VyEacbGRyokGQ==",
       "requires": {
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-table": "^4.40.6",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-table": "^4.59.1",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-spinner": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.40.6.tgz",
-      "integrity": "sha512-q+3pfhL7P4T9fu4JETlEa2ijuIzfw/f+qQ9gHDv1nzrb2D+BDu2QcPiNWRG2vrLxxmQzMAZJ0s+67ecHPe6o9w==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.59.1.tgz",
+      "integrity": "sha512-FirlpLV6zm3Et5vFd9s/kzhsY0E8ppG5UqHPTIGMgb2kCs607+3c+Sgs9wrgVkS0pDaMRBIyrvanKb48/nVhiA==",
       "requires": {
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-table": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.40.6.tgz",
-      "integrity": "sha512-ZI1xgRDV8aWsCaHlruYppVwc/bqWucd6X8szcKO/Qq8EhXQYRBXXtQcLyVawYTxlrSBFqbaQlrHXT821Y95QbQ==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.59.1.tgz",
+      "integrity": "sha512-uix+eYHmtzdFjlCawSN/EKaxcDmQQHtWgVMDs2iUX7osT2LcBjyXePWMnTef4tsCDgnJyfIRw5KenMsLfT5RdQ==",
       "requires": {
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-icons": "^4.25.0",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.40.6",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-icons": "^4.27.0",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.59.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-tabs": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.40.6.tgz",
-      "integrity": "sha512-PQzqzM+AEqYOMqitwzac8b0V4IaGSZh3fETLszvI0vkid8jWkhiPrbbxbpc6N6cD8tJ6WxMbrV3RwvqOE4m4kw==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.59.1.tgz",
+      "integrity": "sha512-5zKIiwpL35Xq5lPjHHTgBswu7KN5xgTs+5vN8fOCiTzSPV7JDeQn8cegm3NXXXGtpfksRWAwasRMKPGJLt0Oog==",
       "requires": {
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-tokens": "^4.0.4",
         "@radix-ui/react-tabs": "^1.0.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-text-link": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.40.6.tgz",
-      "integrity": "sha512-UNcBaCOtccdABzMbLSxnJxDHm0zxjy2Ug6yszltciL6eknclQeUNTGepNKIYt+3BG6+6vtRN7KasKrVZRCkJKA==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.59.1.tgz",
+      "integrity": "sha512-VY1GcKt4uR7eJRn1I9wESASZPg5yWnVFyazLm2Y37It5R13J5eVDEeYr94xCEDRXVHfbC1pTAg2MMnlu6SoRiQ==",
       "requires": {
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
@@ -10058,13 +10182,13 @@
       "integrity": "sha512-yPHNQjHVEuO+5nUoX3EbrQvLoU7ZjNc/w3RyCmYR3F/NWZCy/3n0Knhq5Jfow+CcXkVY6Ch526VlA3+ayEN2kA=="
     },
     "@contentful/f36-tooltip": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.40.6.tgz",
-      "integrity": "sha512-n1AMrXIA7Y6bhz3LR2puPZ2zHcpg834Ir1VdT4Ds/sDVW32qgE7NXSaYYmEqf+wMODIL8P06vOBVGW+BRKkKBw==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.59.1.tgz",
+      "integrity": "sha512-XFpRWeLaDwSg2N7YyyzkF3fvdRbUTKQbWcGNG4X4LLLfXp3VUcaxEjzxDlM7dD5HeY7RozHIV0CkaiKR4WV5Sw==",
       "requires": {
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-utils": "^4.23.2",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
         "csstype": "^3.1.1",
         "emotion": "^10.0.17",
@@ -10072,19 +10196,20 @@
       }
     },
     "@contentful/f36-typography": {
-      "version": "4.40.6",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.40.6.tgz",
-      "integrity": "sha512-0ygztBogBk6e7U2mbqaj1zVRdleCHjjs1MxR3JaZNALfnW/Cu1hu+fc/dlk60fP7/kniipN1Z+EXWMgNVnLNEw==",
+      "version": "4.59.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.59.1.tgz",
+      "integrity": "sha512-bAexzvgG83VGw5EsMcvDJT+6ZbF9vIvrj2c1rt6XTGyM0nzWATSQxQaiPyTPd/He4f9s1CtMp3seh0fVS001rg==",
       "requires": {
-        "@contentful/f36-core": "^4.40.6",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.59.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-utils": {
-      "version": "4.24.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-utils/-/f36-utils-4.24.1.tgz",
-      "integrity": "sha512-jr+61KiKn7oA38WXgAJoqVNdr6gXzmJSA+MCl7Djapxxf+jsC1vsi8j8okISCm4a/ZcPncKekDYzzWu+kkI7VQ==",
+      "version": "4.24.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-utils/-/f36-utils-4.24.3.tgz",
+      "integrity": "sha512-9+tyDOCjEhW7m4X7Sam0VYlmcgjhLVMiapCnv1EmRstlMaeI5ti9y0y/2aQ04Na2ScoHwrMTjveoZ6V62J62tA==",
       "requires": {
         "emotion": "^10.0.17"
       }
@@ -11118,145 +11243,145 @@
       }
     },
     "@popperjs/core": {
-      "version": "2.11.7",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.7.tgz",
-      "integrity": "sha512-Cr4OjIkipTtcXKjAsm8agyleBuDHvxzeBoa1v543lbv1YaIwQjESsVcmjiWiPEbC1FIeHOG/Op9kdCmAmiS3Kw=="
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
     },
     "@radix-ui/primitive": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.0.tgz",
-      "integrity": "sha512-3e7rn8FDMin4CgeL7Z/49smCA3rFYY3Ha2rUQ7HRWFadS5iCRw08ZgVT1LaNTCNqgvrUiyczLflrVrF0SRQtNA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.1.tgz",
+      "integrity": "sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==",
       "requires": {
         "@babel/runtime": "^7.13.10"
       }
     },
     "@radix-ui/react-collection": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.0.2.tgz",
-      "integrity": "sha512-s8WdQQ6wNXpaxdZ308KSr8fEWGrg4un8i4r/w7fhiS4ElRNjk5rRcl0/C6TANG2LvLOGIxtzo/jAg6Qf73TEBw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.0.3.tgz",
+      "integrity": "sha512-3SzW+0PW7yBBoQlT8wNcGtaxaD0XSu0uLUFgrtHY08Acx05TaHaOmVLR73c0j/cqpDy53KBMO7s0dx2wmOIDIA==",
       "requires": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-compose-refs": "1.0.0",
-        "@radix-ui/react-context": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.2",
-        "@radix-ui/react-slot": "1.0.1"
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2"
       }
     },
     "@radix-ui/react-compose-refs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.0.tgz",
-      "integrity": "sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz",
+      "integrity": "sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==",
       "requires": {
         "@babel/runtime": "^7.13.10"
       }
     },
     "@radix-ui/react-context": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.0.tgz",
-      "integrity": "sha512-1pVM9RfOQ+n/N5PJK33kRSKsr1glNxomxONs5c49MliinBY6Yw2Q995qfBUUo0/Mbg05B/sGA0gkgPI7kmSHBg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.1.tgz",
+      "integrity": "sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==",
       "requires": {
         "@babel/runtime": "^7.13.10"
       }
     },
     "@radix-ui/react-direction": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.0.0.tgz",
-      "integrity": "sha512-2HV05lGUgYcA6xgLQ4BKPDmtL+QbIZYH5fCOTAOOcJ5O0QbWS3i9lKaurLzliYUDhORI2Qr3pyjhJh44lKA3rQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.0.1.tgz",
+      "integrity": "sha512-RXcvnXgyvYvBEOhCBuddKecVkoMiI10Jcm5cTI7abJRAHYfFxeu+FBQs/DvdxSYucxR5mna0dNsL6QFlds5TMA==",
       "requires": {
         "@babel/runtime": "^7.13.10"
       }
     },
     "@radix-ui/react-id": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.0.0.tgz",
-      "integrity": "sha512-Q6iAB/U7Tq3NTolBBQbHTgclPmGWE3OlktGGqrClPozSw4vkQ1DfQAOtzgRPecKsMdJINE05iaoDUG8tRzCBjw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.0.1.tgz",
+      "integrity": "sha512-tI7sT/kqYp8p96yGWY1OAnLHrqDgzHefRBKQ2YAkBS5ja7QLcZ9Z/uY7bEjPUatf8RomoXM8/1sMj1IJaE5UzQ==",
       "requires": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-use-layout-effect": "1.0.0"
+        "@radix-ui/react-use-layout-effect": "1.0.1"
       }
     },
     "@radix-ui/react-presence": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.0.0.tgz",
-      "integrity": "sha512-A+6XEvN01NfVWiKu38ybawfHsBjWum42MRPnEuqPsBZ4eV7e/7K321B5VgYMPv3Xx5An6o1/l9ZuDBgmcmWK3w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.0.1.tgz",
+      "integrity": "sha512-UXLW4UAbIY5ZjcvzjfRFo5gxva8QirC9hF7wRE4U5gz+TP0DbRk+//qyuAQ1McDxBt1xNMBTaciFGvEmJvAZCg==",
       "requires": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-compose-refs": "1.0.0",
-        "@radix-ui/react-use-layout-effect": "1.0.0"
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1"
       }
     },
     "@radix-ui/react-primitive": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.2.tgz",
-      "integrity": "sha512-zY6G5Qq4R8diFPNwtyoLRZBxzu1Z+SXMlfYpChN7Dv8gvmx9X3qhDqiLWvKseKVJMuedFeU/Sa0Sy/Ia+t06Dw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.3.tgz",
+      "integrity": "sha512-yi58uVyoAcK/Nq1inRY56ZSjKypBNKTa/1mcL8qdl6oJeEaDbOldlzrGn7P6Q3Id5d+SYNGc5AJgc4vGhjs5+g==",
       "requires": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-slot": "1.0.1"
+        "@radix-ui/react-slot": "1.0.2"
       }
     },
     "@radix-ui/react-roving-focus": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.0.3.tgz",
-      "integrity": "sha512-stjCkIoMe6h+1fWtXlA6cRfikdBzCLp3SnVk7c48cv/uy3DTGoXhN76YaOYUJuy3aEDvDIKwKR5KSmvrtPvQPQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.0.4.tgz",
+      "integrity": "sha512-2mUg5Mgcu001VkGy+FfzZyzbmuUWzgWkj3rvv4yu+mLw03+mTzbxZHvfcGyFp2b8EkQeMkpRQ5FiA2Vr2O6TeQ==",
       "requires": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/primitive": "1.0.0",
-        "@radix-ui/react-collection": "1.0.2",
-        "@radix-ui/react-compose-refs": "1.0.0",
-        "@radix-ui/react-context": "1.0.0",
-        "@radix-ui/react-direction": "1.0.0",
-        "@radix-ui/react-id": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.2",
-        "@radix-ui/react-use-callback-ref": "1.0.0",
-        "@radix-ui/react-use-controllable-state": "1.0.0"
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-collection": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@radix-ui/react-use-controllable-state": "1.0.1"
       }
     },
     "@radix-ui/react-slot": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.1.tgz",
-      "integrity": "sha512-avutXAFL1ehGvAXtPquu0YK5oz6ctS474iM3vNGQIkswrVhdrS52e3uoMQBzZhNRAIE0jBnUyXWNmSjGHhCFcw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.2.tgz",
+      "integrity": "sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==",
       "requires": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-compose-refs": "1.0.0"
+        "@radix-ui/react-compose-refs": "1.0.1"
       }
     },
     "@radix-ui/react-tabs": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.0.3.tgz",
-      "integrity": "sha512-4CkF/Rx1GcrusI/JZ1Rvyx4okGUs6wEenWA0RG/N+CwkRhTy7t54y7BLsWUXrAz/GRbBfHQg/Odfs/RoW0CiRA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.0.4.tgz",
+      "integrity": "sha512-egZfYY/+wRNCflXNHx+dePvnz9FbmssDTJBtgRfDY7e8SE5oIo3Py2eCB1ckAbh1Q7cQ/6yJZThJ++sgbxibog==",
       "requires": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/primitive": "1.0.0",
-        "@radix-ui/react-context": "1.0.0",
-        "@radix-ui/react-direction": "1.0.0",
-        "@radix-ui/react-id": "1.0.0",
-        "@radix-ui/react-presence": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.2",
-        "@radix-ui/react-roving-focus": "1.0.3",
-        "@radix-ui/react-use-controllable-state": "1.0.0"
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-presence": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-roving-focus": "1.0.4",
+        "@radix-ui/react-use-controllable-state": "1.0.1"
       }
     },
     "@radix-ui/react-use-callback-ref": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.0.tgz",
-      "integrity": "sha512-GZtyzoHz95Rhs6S63D2t/eqvdFCm7I+yHMLVQheKM7nBD8mbZIt+ct1jz4536MDnaOGKIxynJ8eHTkVGVVkoTg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.1.tgz",
+      "integrity": "sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ==",
       "requires": {
         "@babel/runtime": "^7.13.10"
       }
     },
     "@radix-ui/react-use-controllable-state": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.0.tgz",
-      "integrity": "sha512-FohDoZvk3mEXh9AWAVyRTYR4Sq7/gavuofglmiXB2g1aKyboUD4YtgWxKj8O5n+Uak52gXQ4wKz5IFST4vtJHg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.1.tgz",
+      "integrity": "sha512-Svl5GY5FQeN758fWKrjM6Qb7asvXeiZltlT4U2gVfl8Gx5UAv2sMR0LWo8yhsIZh2oQ0eFdZ59aoOOMV7b47VA==",
       "requires": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-use-callback-ref": "1.0.0"
+        "@radix-ui/react-use-callback-ref": "1.0.1"
       }
     },
     "@radix-ui/react-use-layout-effect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.0.tgz",
-      "integrity": "sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.1.tgz",
+      "integrity": "sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==",
       "requires": {
         "@babel/runtime": "^7.13.10"
       }
@@ -11280,10 +11405,11 @@
       }
     },
     "@swc/helpers": {
-      "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
-      "integrity": "sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.36.tgz",
+      "integrity": "sha512-5lxnyLEYFskErRPenYItLRSge5DjrJngYKdVjRSrWfza9G6KkgHEXi0vUZiyUeMU5JfXH1YnvXZzSp8ul88o2Q==",
       "requires": {
+        "legacy-swc-helpers": "npm:@swc/helpers@=0.4.14",
         "tslib": "^2.4.0"
       }
     },
@@ -11513,15 +11639,15 @@
       "version": "18.0.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.3.tgz",
       "integrity": "sha512-1RRW9kst+67gveJRYPxGmVy8eVJ05O43hg77G2j5m76/RFJtMbcfAs2viQ2UNsvvDg8F7OfQZx8qQcl6ymygaQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "@types/react": "*"
       }
     },
     "@types/react-modal": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@types/react-modal/-/react-modal-3.16.0.tgz",
-      "integrity": "sha512-iphdqXAyUfByLbxJn5j6d+yh93dbMgshqGP0IuBeaKbZXx0aO+OXsvEkt6QctRdxjeM9/bR+Gp3h9F9djVWTQQ==",
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/@types/react-modal/-/react-modal-3.16.3.tgz",
+      "integrity": "sha512-xXuGavyEGaFQDgBv4UVm8/ZsG+qxeQ7f77yNrW3n+1J6XAstUy5rYHeIHPh1KzsGc6IkCIdu6lQ2xWzu1jBTLg==",
       "requires": {
         "@types/react": "*"
       }
@@ -12163,9 +12289,9 @@
       }
     },
     "dayjs": {
-      "version": "1.11.7",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
-      "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ=="
+      "version": "1.11.10",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
+      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
     },
     "debug": {
       "version": "4.3.3",
@@ -12523,9 +12649,9 @@
       }
     },
     "focus-lock": {
-      "version": "0.11.6",
-      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.11.6.tgz",
-      "integrity": "sha512-KSuV3ur4gf2KqMNoZx3nXNVhqCkn42GuTYCX4tXPEwf0MjpFQmNMiN6m7dXaUXgIoivL6/65agoUMg4RLS0Vbg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-1.0.0.tgz",
+      "integrity": "sha512-a8Ge6cdKh9za/GZR/qtigTAk7SrGore56EFcoMshClsh7FLk1zwszc/ltuMfKhx56qeuyL/jWQ4J4axou0iJ9w==",
       "requires": {
         "tslib": "^2.0.3"
       }
@@ -15115,6 +15241,14 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
     },
+    "legacy-swc-helpers": {
+      "version": "npm:@swc/helpers@0.4.14",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
+      "integrity": "sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==",
+      "requires": {
+        "tslib": "^2.4.0"
+      }
+    },
     "leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -15557,9 +15691,9 @@
       }
     },
     "react-animate-height": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/react-animate-height/-/react-animate-height-3.1.1.tgz",
-      "integrity": "sha512-UkC6+V3ZlCneBRaSM7aUctDJ+PRP6ztcGtxvU7MTeoMMWPhz8BQNaX7QWaZrkzp1ih1G8uZZ+DI9nfLvtD6OdQ==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/react-animate-height/-/react-animate-height-3.2.3.tgz",
+      "integrity": "sha512-R6DSvr7ud07oeCixScyvXWEMJY/Mt2+GyOWC1KMaRc69gOBw+SsCg4TJmrp4rKUM1hyd6p+YKw90brjPH93Y2A==",
       "requires": {}
     },
     "react-clientside-effect": {
@@ -15571,9 +15705,9 @@
       }
     },
     "react-day-picker": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.7.1.tgz",
-      "integrity": "sha512-Gv426AW8b151CZfh3aP5RUGztLwHB/EyJgWZ5iMgtzbFBkjHfG6Y66CIQFMWGLnYjsQ9DYSJRmJ5S0Pg5HWKjA==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.10.0.tgz",
+      "integrity": "sha512-mz+qeyrOM7++1NCb1ARXmkjMkzWVh2GL9YiPbRjKe0zHccvekk4HE+0MPOZOrosn8r8zTHIIeOUXTmXRqmkRmg==",
       "requires": {}
     },
     "react-dom": {
@@ -15592,12 +15726,12 @@
       "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
     },
     "react-focus-lock": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.4.tgz",
-      "integrity": "sha512-7pEdXyMseqm3kVjhdVH18sovparAzLg5h6WvIx7/Ck3ekjhrrDMEegHSa3swwC8wgfdd7DIdUVRGeiHT9/7Sgg==",
+      "version": "2.9.7",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.7.tgz",
+      "integrity": "sha512-EfhX040SELLqnQ9JftqsmQCG49iByg8F5X5m19Er+n371OaETZ35dlNPZrLOOTlnnwD4c2Zv0KDgabDTc7dPHw==",
       "requires": {
         "@babel/runtime": "^7.0.0",
-        "focus-lock": "^0.11.6",
+        "focus-lock": "^1.0.0",
         "prop-types": "^15.6.2",
         "react-clientside-effect": "^1.2.6",
         "use-callback-ref": "^1.3.0",
@@ -16023,9 +16157,9 @@
       }
     },
     "tslib": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
-      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "type-check": {
       "version": "0.3.2",
@@ -16128,9 +16262,9 @@
       }
     },
     "use-callback-ref": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.0.tgz",
-      "integrity": "sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.1.tgz",
+      "integrity": "sha512-Lg4Vx1XZQauB42Hw3kK7JM6yjVjgFmFC5/Ab797s79aARomD2nEErc4mCgM8EZrARLmmbWpi5DGCadmK50DcAQ==",
       "requires": {
         "tslib": "^2.0.0"
       }


### PR DESCRIPTION
## Purpose

Update to unblock https://github.com/contentful/apps/pull/6200 . Force a version bump since it appears some downstream dependencies are incompatible with latest version of f36 components

## Approach

* Upgrade f36 in dam app
* Pin dam app version in apps like dropbox and mux, since lerna tries to build them _against the change in this PR_, which they fail. These apps will need to update to this version of the dam app indepdently

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
