### PR TITLE
fix: silence excess output

### DIFF
--- a/.circleci/prettier-check.sh
+++ b/.circleci/prettier-check.sh
@@ -15,7 +15,7 @@ test -z "$CHANGED_FILES" && echo "No files for prettier to check. Skipping..." &
 echo "Running 'prettier -l' against changed files to check for problems..."
 echo ""
 
-PRETTIER_OUTPUT=$(npm run prettier:list -- $CHANGED_FILES)
+PRETTIER_OUTPUT=$(npm run --silent prettier:list -- $CHANGED_FILES)
 echo ""
 test -n "$PRETTIER_OUTPUT" && echo "prettier violations found:" || echo "no violations found"
 echo "$PRETTIER_OUTPUT"


### PR DESCRIPTION
## Purpose

In the recent prettier fix we introduced a problem.

When we switched from calling prettier directly to calling it indirectly via `npm run` we failed to realize that npm run sends data to STDOUT which messed with the logic of our script here: https://github.com/contentful/apps/blob/master/.circleci/prettier-check.sh#L18

Basically our script expects NO OUTPUT when the prettier check is okay.

## Approach

* add the `--silent` flag to remove echoing of the command

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
