### PR TITLE
chore: update sentry app name to support consistency

### DIFF
--- a/apps/microsoft-teams/frontend/src/App.tsx
+++ b/apps/microsoft-teams/frontend/src/App.tsx
@@ -20,7 +20,7 @@ const ComponentLocationSettings = {
   [locations.LOCATION_HOME]: Home,
 };
 
-const APP_NAME = 'microsoftTeams';
+const APP_NAME = 'microsoft-teams';
 
 const App = () => {
   const sdk = useSDK();


### PR DESCRIPTION
## Purpose

The purpose of this PR is to update the app name that will be passed on all Sentry exceptions, to be consistent with the backend implementation. 

Perhaps eventually this can be a constant, for all apps, in the frontend-toolkit AND a constant in the future node-toolkit. For now, I have noted how these should be consistent in [this](https://contentful.atlassian.net/wiki/spaces/ECO/pages/4479189315/WIP+Sentry+for+Integrations) WIP documentation. 
