### PR TITLE
feat: improve logout flow for MS Teams [INTEG-1785]

### DIFF
--- a/apps/microsoft-teams/frontend/package.json
+++ b/apps/microsoft-teams/frontend/package.json
@@ -19,6 +19,7 @@
   },
   "scripts": {
     "start": "vite",
+    "dev": "vite --force",
     "build": "tsc && vite build",
     "lint": "eslint . --max-warnings 0",
     "test": "vitest --logHeapUsage --coverage",

--- a/apps/microsoft-teams/frontend/src/components/config/AccessSection/AccessSection.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/AccessSection/AccessSection.tsx
@@ -40,11 +40,11 @@ const AccessSection = (props: Props) => {
       const authResult = await instance.loginPopup(loginRequest);
       if (!isAppInstalled) {
         await customApi.saveConfiguration({ ...parameters, tenantId: authResult.tenantId });
-        dispatch({
-          type: actions.UPDATE_TENANT_ID,
-          payload: authResult.tenantId,
-        });
       }
+      dispatch({
+        type: actions.UPDATE_TENANT_ID,
+        payload: authResult.tenantId,
+      });
     } catch (e) {
       const message = e instanceof Error ? e.message : 'Failed to authenticate with Microsoft';
       sdk.notifier.error(message);
@@ -63,7 +63,12 @@ const AccessSection = (props: Props) => {
           handleDisconnect={async () => {
             onClose(true);
             await instance.logoutPopup({
-              mainWindowRedirectUri: '/',
+              postLogoutRedirectUri: '/',
+              account: accounts[0],
+            });
+            dispatch({
+              type: actions.UPDATE_TENANT_ID,
+              payload: '',
             });
           }}
         />


### PR DESCRIPTION
## Purpose

Ideally we don't want to rely on a logout flow from MS where you have to select which account you are logging out of if you want to switch accounts on the MS Teams app config page. After digging around the MSAL documentation, I same across this [promptless logout](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/e7a55511680aec602310f63db0bb5b7d2b07fab3/lib/msal-browser/docs/logout.md#promptless-logout)

## Approach

Implemented promptless logout. This required adding the `login_hint` optional claim for our app in the MS Entra admin center. Then, I passed in the logged in account to the `logoutPopup` method in order to create a logout experience where you don't need to select an account. You still do see a popup, but I could not find a away to work around this.

In addition, I ensured that the parameters were being updated on logout and when you change accounts. These are not being persisted in the installation parameters; saving the updated tenant id still requires the user to click "Save" at the moment, until we figure out next steps with triggering save from the app config page.

Promptless logout experience:
![Screenshot 2024-02-05 at 12 25 51 PM](https://github.com/contentful/apps/assets/62958907/7569093c-d862-40c5-8158-1f1147805399)

## Testing steps

Tested logging in and out of two accounts locally.

## Breaking Changes

## Dependencies and/or References

https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/e7a55511680aec602310f63db0bb5b7d2b07fab3/lib/msal-browser/docs/logout.md#promptless-logout

## Deployment
