### PR TITLE
chore: skip flaky AICG tests

### DIFF
--- a/apps/ai-content-generator/src/hooks/dialog/useAI.spec.ts
+++ b/apps/ai-content-generator/src/hooks/dialog/useAI.spec.ts
@@ -37,7 +37,8 @@ describe('useAI', () => {
     await waitFor(() => expect(result.current.output).toBeTruthy());
   });
 
-  it('should stop generating when triggered and reset output', async () => {
+  // TODO: Fix this flaky tests
+  it.skip('should stop generating when triggered and reset output', async () => {
     const { result } = renderHook(() => useAI());
     result.current.generateMessage(titlePrompt('this is a test'), 'en-US');
     await waitFor(() => expect(result.current.isGenerating).toBe(true));

--- a/apps/bedrock-content-generator/src/hooks/dialog/useAI.spec.ts
+++ b/apps/bedrock-content-generator/src/hooks/dialog/useAI.spec.ts
@@ -35,7 +35,8 @@ describe('useAI', () => {
     await waitFor(() => expect(result.current.output).toBeTruthy());
   });
 
-  it('should stop generating when triggered and reset output', async () => {
+  // TODO: Fix this flaky tests
+  it.skip('should stop generating when triggered and reset output', async () => {
     const { result } = renderHook(() => useAI());
     result.current.generateMessage(titlePrompt('this is a test'), 'en-US');
     await waitFor(() => expect(result.current.isGenerating).toBe(true));


### PR DESCRIPTION
chore: fix flaky AICG tests

## Purpose

We have some flaky tests, e.g. https://app.circleci.com/pipelines/github/contentful/apps/27834/workflows/8c815bcb-0aff-4164-a6d0-a1c76c1920a5/jobs/88408?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary . Let's disable them.

## Approach

<!-- Why did we do it the way we did? Did we consider alternatives? What other implementation details or artifacts (screenshots etc.) would help reviewers contextualize change? -->

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
