### PR TITLE
feat: [INTEG-1692] - Add status under token field

### DIFF
--- a/apps/vercel/src/App.tsx
+++ b/apps/vercel/src/App.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { locations } from '@contentful/app-sdk';
 import { useSDK } from '@contentful/react-apps-toolkit';
 import { useMemo } from 'react';

--- a/apps/vercel/src/components/config-screen/ConfigScreen.styles.tsx
+++ b/apps/vercel/src/components/config-screen/ConfigScreen.styles.tsx
@@ -28,6 +28,9 @@ export const styles = {
     width: '100%',
     marginTop: '22px',
   },
+  badgeContainer: {
+    width: '100%',
+  },
   icon: {
     marginTop: '41px',
   },

--- a/apps/vercel/src/components/parameterReducer.ts
+++ b/apps/vercel/src/components/parameterReducer.ts
@@ -1,0 +1,44 @@
+import { AppInstallationParameters } from '../types';
+
+export enum actions {
+  UPDATE_VERCEL_ACCESS_TOKEN = 'updateVercelAccessToken',
+  APPLY_CONTENTFUL_PARAMETERS = 'applyContentfulParameters',
+}
+
+type TenantIdAction = {
+  type: actions.UPDATE_VERCEL_ACCESS_TOKEN;
+  payload: string;
+};
+
+type ApplyContentfulParametersAction = {
+  type: actions.APPLY_CONTENTFUL_PARAMETERS;
+  payload: AppInstallationParameters;
+};
+
+export type ParameterAction = TenantIdAction | ApplyContentfulParametersAction;
+
+const { UPDATE_VERCEL_ACCESS_TOKEN, APPLY_CONTENTFUL_PARAMETERS } = actions;
+
+const parameterReducer = (
+  state: AppInstallationParameters,
+  action: ParameterAction
+): AppInstallationParameters => {
+  switch (action.type) {
+    case UPDATE_VERCEL_ACCESS_TOKEN:
+      return {
+        ...state,
+        vercelAccessToken: action.payload,
+      };
+    case APPLY_CONTENTFUL_PARAMETERS: {
+      const parameters = action.payload;
+      return {
+        ...state,
+        vercelAccessToken: parameters.vercelAccessToken ?? '',
+      };
+    }
+    default:
+      return state;
+  }
+};
+
+export default parameterReducer;

--- a/apps/vercel/src/components/parameterReducer.ts
+++ b/apps/vercel/src/components/parameterReducer.ts
@@ -5,7 +5,7 @@ export enum actions {
   APPLY_CONTENTFUL_PARAMETERS = 'applyContentfulParameters',
 }
 
-type TenantIdAction = {
+type VercelAccessTokenAction = {
   type: actions.UPDATE_VERCEL_ACCESS_TOKEN;
   payload: string;
 };
@@ -15,7 +15,7 @@ type ApplyContentfulParametersAction = {
   payload: AppInstallationParameters;
 };
 
-export type ParameterAction = TenantIdAction | ApplyContentfulParametersAction;
+export type ParameterAction = VercelAccessTokenAction | ApplyContentfulParametersAction;
 
 const { UPDATE_VERCEL_ACCESS_TOKEN, APPLY_CONTENTFUL_PARAMETERS } = actions;
 

--- a/apps/vercel/src/constants/defaultParams.ts
+++ b/apps/vercel/src/constants/defaultParams.ts
@@ -1,0 +1,5 @@
+import { AppInstallationParameters } from '../types';
+
+export const initialParameters: AppInstallationParameters = {
+  vercelAccessToken: '',
+};

--- a/apps/vercel/src/hooks/useInitializeParameters.tsx
+++ b/apps/vercel/src/hooks/useInitializeParameters.tsx
@@ -1,0 +1,39 @@
+import { Dispatch, useEffect, useCallback } from 'react';
+import { useSDK } from '@contentful/react-apps-toolkit';
+import type { ConfigAppSDK } from '@contentful/app-sdk';
+import { ParameterAction, actions } from '../components/parameterReducer';
+import { AppInstallationParameters } from '../types';
+
+/**
+ * This hook is used to initialize the parameters of the app.
+ * It will get the parameters from Contentful and dispatch them to the reducer.
+ *
+ * @param dispatch a dispatch function from useReducer
+ * @returns void
+ */
+const useInitializeParameters = (dispatch: Dispatch<ParameterAction>) => {
+  const sdk = useSDK<ConfigAppSDK>();
+
+  const dispatchParameters = useCallback(async () => {
+    try {
+      const parameters = await sdk.app.getParameters<AppInstallationParameters>();
+
+      if (!parameters) return;
+
+      dispatch({
+        type: actions.APPLY_CONTENTFUL_PARAMETERS,
+        payload: parameters,
+      });
+    } catch (error) {
+      console.error(error);
+    } finally {
+      sdk.app.setReady();
+    }
+  }, [dispatch, sdk.app]);
+
+  useEffect(() => {
+    dispatchParameters();
+  }, [sdk, dispatchParameters]);
+};
+
+export default useInitializeParameters;

--- a/apps/vercel/src/hooks/uzeInitializeParameters.spec.tsx
+++ b/apps/vercel/src/hooks/uzeInitializeParameters.spec.tsx
@@ -1,0 +1,38 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import useInitializeParameters from './useInitializeParameters';
+import { mockSdk } from '../../test/mocks';
+import { actions } from '../components/parameterReducer';
+import { mockParameters } from '../../test/mocks/mockSdk';
+
+vi.mock('@contentful/react-apps-toolkit', () => ({
+  useSDK: () => mockSdk,
+}));
+
+describe('useInitializeParameters', () => {
+  it('should dispatch Contentful parameters and call setReady', async () => {
+    const dispatchMock = vi.fn((val) => val);
+    mockSdk.app.getParameters = vi.fn().mockReturnValueOnce(mockParameters);
+
+    renderHook(() => useInitializeParameters(dispatchMock));
+    await waitFor(() => expect(dispatchMock).toBeCalled());
+
+    expect(dispatchMock).toHaveBeenCalledWith({
+      type: actions.APPLY_CONTENTFUL_PARAMETERS,
+      payload: mockParameters,
+    });
+
+    expect(mockSdk.app.setReady).toBeCalled();
+  });
+
+  it('should not dispatch anything if parameters are not present', async () => {
+    const dispatchMock = vi.fn((val) => val);
+    mockSdk.app.getParameters = vi.fn().mockReturnValueOnce(undefined);
+
+    renderHook(() => useInitializeParameters(dispatchMock));
+    await waitFor(() => expect(dispatchMock).not.toBeCalled());
+
+    expect(dispatchMock).not.toBeCalled();
+    expect(mockSdk.app.setReady).toBeCalled();
+  });
+});

--- a/apps/vercel/src/locations/ConfigScreen.tsx
+++ b/apps/vercel/src/locations/ConfigScreen.tsx
@@ -98,6 +98,16 @@ const ConfigScreen = () => {
     });
   };
 
+  const renderStatusBadge = () => {
+    if (appInstalled && parameters.vercelAccessToken && tokenValid) {
+      return <Badge variant="positive">Valid access token</Badge>;
+    } else if (tokenError) {
+      return <Badge variant="negative">Invalid access token</Badge>;
+    } else {
+      return <Badge variant="warning">Token not configured</Badge>;
+    }
+  };
+
   return (
     <>
       <Box className={styles.background} />
@@ -140,20 +150,12 @@ const ConfigScreen = () => {
                 to create an access token in the Vercel dashboard.
               </HelpText>
             </FormControl>
-            <Box style={{ width: '100%' }}>
+            <Box style={styles.badgeContainer}>
               <Flex fullWidth flexDirection="column">
                 <Text fontWeight="fontWeightDemiBold" marginRight="spacing2Xs">
                   Status
                 </Text>
-                <Box>
-                  {appInstalled && parameters.vercelAccessToken && tokenValid ? (
-                    <Badge variant="positive">Valid access token</Badge>
-                  ) : tokenError ? (
-                    <Badge variant="negative">Invalid access token</Badge>
-                  ) : (
-                    <Badge variant="warning">Token not configured</Badge>
-                  )}
-                </Box>
+                <Box>{renderStatusBadge()}</Box>
               </Flex>
             </Box>
           </Box>

--- a/apps/vercel/src/locations/ConfigScreen.tsx
+++ b/apps/vercel/src/locations/ConfigScreen.tsx
@@ -65,10 +65,10 @@ const ConfigScreen = () => {
   useEffect(() => {
     async function getDeployments() {
       const res = await fetch('https://api.vercel.com/v6/deployments', {
+        method: 'GET',
         headers: {
           Authorization: `Bearer ${parameters.vercelAccessToken}`,
         },
-        method: 'get',
       });
 
       // TODO: Figure out if we want to continue with deployments

--- a/apps/vercel/src/locations/ConfigScreen.tsx
+++ b/apps/vercel/src/locations/ConfigScreen.tsx
@@ -71,9 +71,9 @@ const ConfigScreen = () => {
         method: 'get',
       });
 
-      // TODO: Figure out if we want to continue wil deployments
+      // TODO: Figure out if we want to continue with deployments
       // Contains deployment response, currently we aren't doing anything with deployments
-      // we just want to make sure a successful call goes through with vali access token
+      // we just want to make sure a successful call goes through with valid access token
 
       // const body = await res.json();
 

--- a/apps/vercel/src/types/index.ts
+++ b/apps/vercel/src/types/index.ts
@@ -1,0 +1,9 @@
+export interface AppInstallationParameters {
+  vercelAccessToken: string;
+}
+
+// interface Deployments {
+//   temporary until we flush out deployment interface further
+//   deployments: { [key: string]: object }[];
+//   pagination: { count: number; next: null; prev: null };
+// }

--- a/apps/vercel/test/mocks/mockSdk.ts
+++ b/apps/vercel/test/mocks/mockSdk.ts
@@ -1,14 +1,30 @@
 import { vi } from 'vitest';
 
+export const mockParameters = {
+  vercelAccessToken: 'abc-123',
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mockSdk: any = {
   app: {
     onConfigure: vi.fn(),
     getParameters: vi.fn().mockReturnValueOnce({}),
     setReady: vi.fn(),
     getCurrentState: vi.fn(),
+    onConfigurationCompleted: vi.fn(),
+    isInstalled: vi.fn().mockReturnValue(true),
+  },
+  parameters: {
+    instance: [],
+    installation: {
+      tenantId: mockParameters.vercelAccessToken,
+    },
   },
   ids: {
     app: 'test-app',
+  },
+  notifier: {
+    error: vi.fn(),
   },
 };
 

--- a/apps/vercel/test/mocks/mockSdk.ts
+++ b/apps/vercel/test/mocks/mockSdk.ts
@@ -17,7 +17,7 @@ const mockSdk: any = {
   parameters: {
     instance: [],
     installation: {
-      tenantId: mockParameters.vercelAccessToken,
+      vercelAccessToken: mockParameters.vercelAccessToken,
     },
   },
   ids: {


### PR DESCRIPTION
## Purpose

<!-- Why are we introducing this change now? What problem does it solve? What is the story/background for it? -->

We want a naive way to verify the status of a vercel access token, this adds that implmentation. This is intentionally very simple, as we flush out technical implementations the network call can be adjusted and better seperated.

Ticket: https://contentful.atlassian.net/browse/INTEG-1692 

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->
1.) Uninstall the app in development if installed, and re-install the custom app
<img width="969" alt="Screenshot 2024-02-05 at 1 37 10 PM" src="https://github.com/contentful/apps/assets/22120469/b9f2a367-8445-4f9a-9e2d-0d8df03c439f">

2.) Confirm error is thrown when trying to install without a token
<img width="960" alt="Screenshot 2024-02-05 at 1 38 34 PM" src="https://github.com/contentful/apps/assets/22120469/617a3ebe-37e1-4864-a5ee-e2692daeb764">

3.) Follow the detailed instructions for creating a vercel token, and attempt to install after token has been created

NOTE: Token cannot be accessed again after creation
<img width="927" alt="Screenshot 2024-02-05 at 1 39 13 PM" src="https://github.com/contentful/apps/assets/22120469/694a8c39-774b-4d59-b240-16f857198a9a">

4.) Malform the saved vercel token, and verify error status is displayed

<img width="941" alt="Screenshot 2024-02-05 at 1 44 00 PM" src="https://github.com/contentful/apps/assets/22120469/053270ba-172c-4775-baae-76b9ee638568">

