### PR TITLE
chore: pin saleor to ecomm package

### DIFF
--- a/apps/saleor/package-lock.json
+++ b/apps/saleor/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.6.116",
       "dependencies": {
         "@contentful/app-sdk": "4.13.0",
-        "@contentful/ecommerce-app-base": "^3.1.41",
+        "@contentful/ecommerce-app-base": "3.1.48",
         "@types/lodash": "4.14.202",
         "core-js": "3.35.1",
         "graphql": "15.8.0",

--- a/apps/saleor/package.json
+++ b/apps/saleor/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@contentful/app-sdk": "4.13.0",
-    "@contentful/ecommerce-app-base": "^3.1.41",
+    "@contentful/ecommerce-app-base": "3.1.48",
     "@types/lodash": "4.14.202",
     "core-js": "3.35.1",
     "graphql": "15.8.0",


### PR DESCRIPTION
## Purpose

* Saleor is trying to upgrade to a version of the ecommerce package is not compatible with https://github.com/contentful/apps/pull/6275

## Approach

* Pin ecomm package

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
