### PR TITLE
fix: pin ecommerce-app to 3.5.1

### DIFF
--- a/apps/commercetools/package-lock.json
+++ b/apps/commercetools/package-lock.json
@@ -12,12 +12,12 @@
         "@commercetools/sdk-client-v2": "1.4.2",
         "@contentful/app-scripts": "1.2.0",
         "@contentful/app-sdk": "4.23.0",
-        "@contentful/ecommerce-app-base": "^3.5.1",
-        "@contentful/f36-components": "^4.48.1",
-        "@contentful/react-apps-toolkit": "^1.2.16",
+        "@contentful/ecommerce-app-base": "3.5.1",
+        "@contentful/f36-components": "4.48.1",
+        "@contentful/react-apps-toolkit": "1.2.16",
         "react": "17.0.1",
         "react-dom": "17.0.1",
-        "react-scripts": "^5.0.1"
+        "react-scripts": "5.0.1"
       },
       "devDependencies": {
         "@types/react": "17.0.65",
@@ -2571,60 +2571,75 @@
       }
     },
     "node_modules/@contentful/f36-components": {
-      "version": "4.59.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.59.3.tgz",
-      "integrity": "sha512-2nR3d5Dasrr+23XWiT02hY1np6YFTVo8lJhBbz4NVNxzovIq1YCH56GaHR6HngQdeURzV9Pu83SKkJWvCrCJ7Q==",
+      "version": "4.48.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.48.1.tgz",
+      "integrity": "sha512-wDrEAYR18NBi3tk2MGX2ktNoiAC4aGwsJ7SXHH+8HkGx66QOFqtEVfDRr8xEd4eR7YO4M/QzALGj1FbYQ/t1Rg==",
       "dependencies": {
-        "@contentful/f36-accordion": "^4.59.3",
-        "@contentful/f36-asset": "^4.59.3",
-        "@contentful/f36-autocomplete": "^4.59.3",
-        "@contentful/f36-badge": "^4.59.3",
-        "@contentful/f36-button": "^4.59.3",
-        "@contentful/f36-card": "^4.59.3",
-        "@contentful/f36-collapse": "^4.59.3",
-        "@contentful/f36-copybutton": "^4.59.3",
-        "@contentful/f36-core": "^4.59.3",
-        "@contentful/f36-datepicker": "^4.59.3",
-        "@contentful/f36-datetime": "^4.59.3",
-        "@contentful/f36-drag-handle": "^4.59.3",
-        "@contentful/f36-empty-state": "^4.59.3",
-        "@contentful/f36-entity-list": "^4.59.3",
-        "@contentful/f36-forms": "^4.59.3",
-        "@contentful/f36-icon": "^4.59.3",
+        "@contentful/f36-accordion": "^4.48.1",
+        "@contentful/f36-asset": "^4.48.1",
+        "@contentful/f36-autocomplete": "^4.48.1",
+        "@contentful/f36-badge": "^4.48.1",
+        "@contentful/f36-button": "^4.48.1",
+        "@contentful/f36-card": "^4.48.1",
+        "@contentful/f36-collapse": "^4.48.1",
+        "@contentful/f36-copybutton": "^4.48.1",
+        "@contentful/f36-core": "^4.48.1",
+        "@contentful/f36-datepicker": "^4.48.1",
+        "@contentful/f36-datetime": "^4.48.1",
+        "@contentful/f36-drag-handle": "^4.48.1",
+        "@contentful/f36-empty-state": "^4.48.1",
+        "@contentful/f36-entity-list": "^4.48.1",
+        "@contentful/f36-forms": "^4.48.1",
+        "@contentful/f36-icon": "^4.48.1",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-list": "^4.59.3",
-        "@contentful/f36-menu": "^4.59.3",
-        "@contentful/f36-modal": "^4.59.3",
+        "@contentful/f36-list": "^4.48.1",
+        "@contentful/f36-menu": "^4.48.1",
+        "@contentful/f36-modal": "^4.48.1",
         "@contentful/f36-navbar": "^4.1.0",
-        "@contentful/f36-note": "^4.59.3",
-        "@contentful/f36-notification": "^4.59.3",
-        "@contentful/f36-pagination": "^4.59.3",
-        "@contentful/f36-pill": "^4.59.3",
-        "@contentful/f36-popover": "^4.59.3",
-        "@contentful/f36-skeleton": "^4.59.3",
-        "@contentful/f36-spinner": "^4.59.3",
-        "@contentful/f36-table": "^4.59.3",
-        "@contentful/f36-tabs": "^4.59.3",
-        "@contentful/f36-text-link": "^4.59.3",
-        "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.59.3",
-        "@contentful/f36-typography": "^4.59.3",
-        "@contentful/f36-utils": "^4.24.3"
+        "@contentful/f36-note": "^4.48.1",
+        "@contentful/f36-notification": "^4.48.1",
+        "@contentful/f36-pagination": "^4.48.1",
+        "@contentful/f36-pill": "^4.48.1",
+        "@contentful/f36-popover": "^4.48.1",
+        "@contentful/f36-skeleton": "^4.48.1",
+        "@contentful/f36-spinner": "^4.48.1",
+        "@contentful/f36-table": "^4.48.1",
+        "@contentful/f36-tabs": "^4.48.1",
+        "@contentful/f36-text-link": "^4.48.1",
+        "@contentful/f36-tokens": "^4.0.2",
+        "@contentful/f36-tooltip": "^4.48.1",
+        "@contentful/f36-typography": "^4.48.1",
+        "@contentful/f36-utils": "^4.23.2",
+        "@types/react": "16.14.22",
+        "@types/react-dom": "16.9.14"
       },
       "peerDependencies": {
-        "@types/react": ">=16.8",
-        "@types/react-dom": ">=16.8",
         "react": ">=16.8",
         "react-dom": ">=16.8"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
       }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@types/react": {
+      "version": "16.14.22",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.22.tgz",
+      "integrity": "sha512-4NnkxKDd2UO9SiCckuhCQOCzdO+RtE4Epf1D6eGz3f9jZjiIXOVo+Bk3jqSad+8EOT+LBXwKdkFX0V0F+NFzDQ==",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@types/react-dom": {
+      "version": "16.9.14",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.14.tgz",
+      "integrity": "sha512-FIX2AVmPTGP30OUJ+0vadeIFJJ07Mh1m+U0rxfgyW34p3rTlXI+nlenvAxNn4BP36YyI9IJ/+UJ7Wu22N1pI7A==",
+      "dependencies": {
+        "@types/react": "^16"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/@contentful/f36-copybutton": {
       "version": "4.59.3",
@@ -21623,45 +21638,72 @@
       }
     },
     "@contentful/f36-components": {
-      "version": "4.59.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.59.3.tgz",
-      "integrity": "sha512-2nR3d5Dasrr+23XWiT02hY1np6YFTVo8lJhBbz4NVNxzovIq1YCH56GaHR6HngQdeURzV9Pu83SKkJWvCrCJ7Q==",
+      "version": "4.48.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.48.1.tgz",
+      "integrity": "sha512-wDrEAYR18NBi3tk2MGX2ktNoiAC4aGwsJ7SXHH+8HkGx66QOFqtEVfDRr8xEd4eR7YO4M/QzALGj1FbYQ/t1Rg==",
       "requires": {
-        "@contentful/f36-accordion": "^4.59.3",
-        "@contentful/f36-asset": "^4.59.3",
-        "@contentful/f36-autocomplete": "^4.59.3",
-        "@contentful/f36-badge": "^4.59.3",
-        "@contentful/f36-button": "^4.59.3",
-        "@contentful/f36-card": "^4.59.3",
-        "@contentful/f36-collapse": "^4.59.3",
-        "@contentful/f36-copybutton": "^4.59.3",
-        "@contentful/f36-core": "^4.59.3",
-        "@contentful/f36-datepicker": "^4.59.3",
-        "@contentful/f36-datetime": "^4.59.3",
-        "@contentful/f36-drag-handle": "^4.59.3",
-        "@contentful/f36-empty-state": "^4.59.3",
-        "@contentful/f36-entity-list": "^4.59.3",
-        "@contentful/f36-forms": "^4.59.3",
-        "@contentful/f36-icon": "^4.59.3",
+        "@contentful/f36-accordion": "^4.48.1",
+        "@contentful/f36-asset": "^4.48.1",
+        "@contentful/f36-autocomplete": "^4.48.1",
+        "@contentful/f36-badge": "^4.48.1",
+        "@contentful/f36-button": "^4.48.1",
+        "@contentful/f36-card": "^4.48.1",
+        "@contentful/f36-collapse": "^4.48.1",
+        "@contentful/f36-copybutton": "^4.48.1",
+        "@contentful/f36-core": "^4.48.1",
+        "@contentful/f36-datepicker": "^4.48.1",
+        "@contentful/f36-datetime": "^4.48.1",
+        "@contentful/f36-drag-handle": "^4.48.1",
+        "@contentful/f36-empty-state": "^4.48.1",
+        "@contentful/f36-entity-list": "^4.48.1",
+        "@contentful/f36-forms": "^4.48.1",
+        "@contentful/f36-icon": "^4.48.1",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-list": "^4.59.3",
-        "@contentful/f36-menu": "^4.59.3",
-        "@contentful/f36-modal": "^4.59.3",
+        "@contentful/f36-list": "^4.48.1",
+        "@contentful/f36-menu": "^4.48.1",
+        "@contentful/f36-modal": "^4.48.1",
         "@contentful/f36-navbar": "^4.1.0",
-        "@contentful/f36-note": "^4.59.3",
-        "@contentful/f36-notification": "^4.59.3",
-        "@contentful/f36-pagination": "^4.59.3",
-        "@contentful/f36-pill": "^4.59.3",
-        "@contentful/f36-popover": "^4.59.3",
-        "@contentful/f36-skeleton": "^4.59.3",
-        "@contentful/f36-spinner": "^4.59.3",
-        "@contentful/f36-table": "^4.59.3",
-        "@contentful/f36-tabs": "^4.59.3",
-        "@contentful/f36-text-link": "^4.59.3",
-        "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.59.3",
-        "@contentful/f36-typography": "^4.59.3",
-        "@contentful/f36-utils": "^4.24.3"
+        "@contentful/f36-note": "^4.48.1",
+        "@contentful/f36-notification": "^4.48.1",
+        "@contentful/f36-pagination": "^4.48.1",
+        "@contentful/f36-pill": "^4.48.1",
+        "@contentful/f36-popover": "^4.48.1",
+        "@contentful/f36-skeleton": "^4.48.1",
+        "@contentful/f36-spinner": "^4.48.1",
+        "@contentful/f36-table": "^4.48.1",
+        "@contentful/f36-tabs": "^4.48.1",
+        "@contentful/f36-text-link": "^4.48.1",
+        "@contentful/f36-tokens": "^4.0.2",
+        "@contentful/f36-tooltip": "^4.48.1",
+        "@contentful/f36-typography": "^4.48.1",
+        "@contentful/f36-utils": "^4.23.2",
+        "@types/react": "16.14.22",
+        "@types/react-dom": "16.9.14"
+      },
+      "dependencies": {
+        "@types/react": {
+          "version": "16.14.22",
+          "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.22.tgz",
+          "integrity": "sha512-4NnkxKDd2UO9SiCckuhCQOCzdO+RtE4Epf1D6eGz3f9jZjiIXOVo+Bk3jqSad+8EOT+LBXwKdkFX0V0F+NFzDQ==",
+          "requires": {
+            "@types/prop-types": "*",
+            "@types/scheduler": "*",
+            "csstype": "^3.0.2"
+          }
+        },
+        "@types/react-dom": {
+          "version": "16.9.14",
+          "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.14.tgz",
+          "integrity": "sha512-FIX2AVmPTGP30OUJ+0vadeIFJJ07Mh1m+U0rxfgyW34p3rTlXI+nlenvAxNn4BP36YyI9IJ/+UJ7Wu22N1pI7A==",
+          "requires": {
+            "@types/react": "^16"
+          }
+        },
+        "csstype": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+        }
       }
     },
     "@contentful/f36-copybutton": {

--- a/apps/commercetools/package.json
+++ b/apps/commercetools/package.json
@@ -13,12 +13,12 @@
     "@commercetools/sdk-client-v2": "1.4.2",
     "@contentful/app-scripts": "1.2.0",
     "@contentful/app-sdk": "4.23.0",
-    "@contentful/ecommerce-app-base": "^3.5.1",
-    "@contentful/f36-components": "^4.48.1",
-    "@contentful/react-apps-toolkit": "^1.2.16",
+    "@contentful/ecommerce-app-base": "3.5.1",
+    "@contentful/f36-components": "4.48.1",
+    "@contentful/react-apps-toolkit": "1.2.16",
     "react": "17.0.1",
     "react-dom": "17.0.1",
-    "react-scripts": "^5.0.1"
+    "react-scripts": "5.0.1"
   },
   "scripts": {
     "start": "cross-env BROWSER=none react-scripts --openssl-legacy-provider start",


### PR DESCRIPTION
## Purpose

The latest version of ecommerce app breaks commerce tools.

## Approach

* Pin to latest known working version.

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
