### PR TITLE
chore: pin ecommerce app to explicit version

### DIFF
--- a/apps/sap-commerce-cloud-with-air/frontend/package-lock.json
+++ b/apps/sap-commerce-cloud-with-air/frontend/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@contentful/app-scripts": "^1.7.13",
         "@contentful/app-sdk": "^4.23.0",
-        "@contentful/ecommerce-app-base": "^1.0.5",
+        "@contentful/ecommerce-app-base": "1.0.7",
         "@contentful/f36-components": "4.59.3",
         "@contentful/f36-tokens": "4.0.4",
         "@contentful/field-editor-single-line": "^0.16.0",

--- a/apps/sap-commerce-cloud-with-air/frontend/package.json
+++ b/apps/sap-commerce-cloud-with-air/frontend/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@contentful/app-scripts": "^1.7.13",
     "@contentful/app-sdk": "^4.23.0",
-    "@contentful/ecommerce-app-base": "^1.0.5",
+    "@contentful/ecommerce-app-base": "1.0.7",
     "@contentful/field-editor-single-line": "^0.16.0",
     "@contentful/field-editor-test-utils": "^0.9.0",
     "@contentful/forma-36-fcss": "^0.3.1",

--- a/apps/sap-commerce-cloud/package-lock.json
+++ b/apps/sap-commerce-cloud/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@contentful/app-scripts": "^1.7.13",
         "@contentful/app-sdk": "^4.23.0",
-        "@contentful/ecommerce-app-base": "^1.0.5",
+        "@contentful/ecommerce-app-base": "1.0.7",
         "@contentful/field-editor-single-line": "^1.3.1",
         "@contentful/field-editor-test-utils": "^1.4.1",
         "@contentful/forma-36-fcss": "^0.3.1",

--- a/apps/sap-commerce-cloud/package.json
+++ b/apps/sap-commerce-cloud/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@contentful/app-scripts": "^1.7.13",
     "@contentful/app-sdk": "^4.23.0",
-    "@contentful/ecommerce-app-base": "^1.0.5",
+    "@contentful/ecommerce-app-base": "1.0.7",
     "@contentful/field-editor-single-line": "^1.3.1",
     "@contentful/field-editor-test-utils": "^1.4.1",
     "@contentful/forma-36-fcss": "^0.3.1",

--- a/examples/commercelayer/package-lock.json
+++ b/examples/commercelayer/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@commercelayer/js-auth": "2.0.1",
         "@contentful/app-sdk": "^4.17.1",
-        "@contentful/ecommerce-app-base": "^3.1.16",
+        "@contentful/ecommerce-app-base": "3.1.16",
         "core-js": "3.4.1",
         "react": "17.0.1",
         "react-dom": "17.0.1"

--- a/examples/commercelayer/package.json
+++ b/examples/commercelayer/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@commercelayer/js-auth": "2.0.1",
     "@contentful/app-sdk": "^4.17.1",
-    "@contentful/ecommerce-app-base": "^3.1.16",
+    "@contentful/ecommerce-app-base": "3.1.16",
     "core-js": "3.4.1",
     "react": "17.0.1",
     "react-dom": "17.0.1"


### PR DESCRIPTION
## Purpose

To prevent inadvertent upgrades due to lerna symlinking to the local version instead of using the version specified in the dependency, we will hard pin all `ecommerce-app-base` dependency references.

## Approach

<!-- Why did we do it the way we did? Did we consider alternatives? What other implementation details or artifacts (screenshots etc.) would help reviewers contextualize change? -->

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
