### PR TITLE
chore: pin dam app to explicit version

### DIFF
--- a/apps/brandfolder/package-lock.json
+++ b/apps/brandfolder/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.9.76",
       "dependencies": {
         "@contentful/app-scripts": "1.2.0",
-        "@contentful/dam-app-base": "^2.0.35",
+        "@contentful/dam-app-base": "2.0.55",
         "react": "16.12.0",
         "react-dom": "16.12.0",
         "react-scripts": "5.0.1"

--- a/apps/brandfolder/package.json
+++ b/apps/brandfolder/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@contentful/app-scripts": "1.2.0",
-    "@contentful/dam-app-base": "^2.0.35",
+    "@contentful/dam-app-base": "2.0.55",
     "react": "16.12.0",
     "react-dom": "16.12.0",
     "react-scripts": "5.0.1"

--- a/apps/wistia-videos/package-lock.json
+++ b/apps/wistia-videos/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@contentful/app-sdk": "^4.16.0",
-        "@contentful/dam-app-base": "^2.0.32",
+        "@contentful/dam-app-base": "2.0.32",
         "@contentful/field-editor-single-line": "^0.16.0",
         "@contentful/field-editor-test-utils": "^1.3.0",
         "@contentful/forma-36-fcss": "^0.3.5",

--- a/apps/wistia-videos/package.json
+++ b/apps/wistia-videos/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "dependencies": {
     "@contentful/app-sdk": "^4.16.0",
-    "@contentful/dam-app-base": "^2.0.32",
+    "@contentful/dam-app-base": "2.0.32",
     "@contentful/field-editor-single-line": "^0.16.0",
     "@contentful/field-editor-test-utils": "^1.3.0",
     "@contentful/forma-36-fcss": "^0.3.5",


### PR DESCRIPTION
## Purpose

To prevent inadvertent upgrades due to lerna symlinking to the local version instead of using the version specified in the dependency, we will hard pin all `dam-app-base` dependency references.

## Approach

<!-- Why did we do it the way we did? Did we consider alternatives? What other implementation details or artifacts (screenshots etc.) would help reviewers contextualize change? -->

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
