### PR TITLE
feat: add notifiers when config page should be saved [INTEG-1802]

### DIFF
--- a/apps/microsoft-teams/frontend/src/components/config/AccessSection/AccessSection.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/AccessSection/AccessSection.tsx
@@ -18,7 +18,9 @@ import { ParameterAction, actions } from '@components/config/parameterReducer';
 import { useCustomApi } from '@hooks/useCustomApi';
 import { AppInstallationParameters } from '@customTypes/configPage';
 import { useSDK } from '@contentful/react-apps-toolkit';
+import { ConfigAppSDK } from '@contentful/app-sdk';
 import DisconnectModal from '@components/config/DisconnectModal/DisconnectModal';
+import { displayConfirmationNotifications } from '@helpers/configHelpers';
 
 interface Props {
   dispatch: Dispatch<ParameterAction>;
@@ -32,7 +34,7 @@ const AccessSection = (props: Props) => {
   const loginInProgress = inProgress === 'login';
   const logoutInProgress = inProgress === 'logout';
   const customApi = useCustomApi();
-  const sdk = useSDK();
+  const sdk = useSDK<ConfigAppSDK>();
   const { logout, login, teamsAppInfo, teamsAppLink, description } = accessSection;
 
   const handleLogin = async () => {
@@ -45,6 +47,13 @@ const AccessSection = (props: Props) => {
         type: actions.UPDATE_TENANT_ID,
         payload: authResult.tenantId,
       });
+      if (isAppInstalled && authResult.tenantId !== parameters.tenantId) {
+        displayConfirmationNotifications(
+          sdk,
+          accessSection.updateConfirmation,
+          accessSection.saveWarning
+        );
+      }
     } catch (e) {
       const message = e instanceof Error ? e.message : 'Failed to authenticate with Microsoft';
       sdk.notifier.error(message);

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.tsx
@@ -11,7 +11,13 @@ import { Notification } from '@customTypes/configPage';
 import { ParameterAction, actions } from '@components/config/parameterReducer';
 import { ContentTypeContextProvider } from '@context/ContentTypeProvider';
 import { ChannelContextProvider } from '@context/ChannelProvider';
-import { getUniqueNotifications, getDuplicateNotificationIndex } from '@helpers/configHelpers';
+import {
+  getUniqueNotifications,
+  getDuplicateNotificationIndex,
+  displayConfirmationNotifications,
+} from '@helpers/configHelpers';
+import { ConfigAppSDK } from '@contentful/app-sdk';
+import { useSDK } from '@contentful/react-apps-toolkit';
 
 interface Props {
   notifications: Notification[];
@@ -21,6 +27,8 @@ interface Props {
 const NotificationsSection = (props: Props) => {
   const { notifications, dispatch } = props;
   const [notificationIndexToEdit, setNotificationIndexToEdit] = useState<number | null>(null);
+
+  const sdk = useSDK<ConfigAppSDK>();
 
   const createNewNotification = () => {
     dispatch({ type: actions.ADD_NOTIFICATION });
@@ -48,6 +56,11 @@ const NotificationsSection = (props: Props) => {
             onClose(true);
             deleteNotification(index);
             setNotificationIndexToEdit(null);
+            displayConfirmationNotifications(
+              sdk,
+              notificationsSection.updateConfirmation,
+              notificationsSection.saveWarning
+            );
           }}
         />
       );
@@ -112,6 +125,11 @@ const NotificationsSection = (props: Props) => {
         type: actions.UPDATE_NOTIFICATIONS,
         payload: uniqueNotifications,
       });
+      displayConfirmationNotifications(
+        sdk,
+        notificationsSection.updateConfirmation,
+        notificationsSection.saveWarning
+      );
     }
   };
 

--- a/apps/microsoft-teams/frontend/src/constants/configCopy.ts
+++ b/apps/microsoft-teams/frontend/src/constants/configCopy.ts
@@ -25,6 +25,8 @@ const accessSection = {
     description:
       'By disconnecting, you will no longer see configured notifications for this tenant. Are you sure you want to disconnect?',
   },
+  updateConfirmation: 'Microsoft organization updated',
+  saveWarning: 'Save the app to persist these settings',
 };
 
 const notificationsSection = {
@@ -33,7 +35,7 @@ const notificationsSection = {
   edit: 'Edit',
   delete: 'Delete',
   confirmDelete:
-    'By disconnecting, the notifications you currently have configured will no longer function. Are you sure you want to disconnect?',
+    'If you delete this notification you will no longer get updates about this content type in Microsoft Teams.',
   duplicateModal: {
     modalHeaderTitle: 'Duplicate Notification',
     confirmDuplicate: 'Update existing notification',
@@ -41,6 +43,8 @@ const notificationsSection = {
     confirmDuplicateDescription:
       'You already have a notification set up for this content type and MS Teams channel. Would you like to update the existing notification instead of creating a new one?',
   },
+  updateConfirmation: 'Notification settings updated',
+  saveWarning: 'Save the app to persist these settings',
 };
 
 const contentTypeSelection = {

--- a/apps/microsoft-teams/frontend/src/helpers/configHelpers.ts
+++ b/apps/microsoft-teams/frontend/src/helpers/configHelpers.ts
@@ -2,6 +2,7 @@ import { ContentTypeProps } from 'contentful-management';
 import { Notification } from '@customTypes/configPage';
 import isEqual from 'lodash/isEqual';
 import { defaultNotification } from '@constants/defaultParams';
+import { ConfigAppSDK } from '@contentful/app-sdk';
 
 /**
  * Gets the content type name for a given content type id
@@ -113,6 +114,22 @@ const getDuplicateNotificationIndex = (
   return duplicateNotificationIndex;
 };
 
+/**
+ * Displays notifications to confirm an update and then a warning to save the app config
+ * @param sdk
+ * @param confirmationCopy
+ * @param warningCopy
+ * @returns void
+ */
+const displayConfirmationNotifications = (
+  sdk: ConfigAppSDK,
+  confirmationCopy: string,
+  warningCopy: string
+) => {
+  sdk.notifier.success(confirmationCopy);
+  setTimeout(() => sdk.notifier.warning(warningCopy), 1000);
+};
+
 export {
   getContentTypeName,
   isNotificationReadyToSave,
@@ -120,4 +137,5 @@ export {
   doesNotificationHaveChanges,
   getUniqueNotifications,
   getDuplicateNotificationIndex,
+  displayConfirmationNotifications,
 };


### PR DESCRIPTION
## Purpose

In order to ensure that space admins are saving their changes after creating/editing/deleting notifications, we want to give a user a warning that they need to save the config page in order for their changes to persist. Note that this is an interim solution while we work on triggering a save from the app config page.

## Approach

Per our designs, after a user creates, edits, or deletes a notification, they will see a confirmation that notifications are updated, followed by a warning that they need to save the app config page.

<img width="584" alt="Screenshot 2024-02-08 at 8 24 17 AM" src="https://github.com/contentful/apps/assets/62958907/3f1814fc-6c93-4e22-9609-d63a65a8ce50">

I also implemented this for the access section/tenant id section:

![Screenshot 2024-02-08 at 8 38 44 AM](https://github.com/contentful/apps/assets/62958907/ff85a8ad-74e0-4cd2-ae0f-414f56ae6a2a)

## Testing steps

In our development space, make changes to the notifications section and authenticate to different tenants to see the notifications.

## Breaking Changes

## Dependencies and/or References

## Deployment
