### PR TITLE
fix(ContentTypeSelectionModal & ChannelSelectionModalProps): Clicking…

### DIFF
--- a/apps/microsoft-teams/README.md
+++ b/apps/microsoft-teams/README.md
@@ -2,7 +2,41 @@
 
 An app that allows space admins to set up notifications to push messages to selected MS Teams channels whenever an app event occurs.
 
+## System Architecture
+
+### Front end
+
+Located in `./frontend`, `create-contentful-app` app to allow users to configure how they'd like to integrate contentful into Microsoft teams. Examples: what Entry Types/App Events to subscribe to, where to send channel notifications, log into their microsoft account etc.
+
+### Back end - Hosted App Actions
+
+Located in `./app-actions`
+
+1. List teams with channel
+2. Send card message to team/channel
+3. Send card to appropriate channels per notification configurations
+
+### Back end - MS Teams Bot Service
+
+A "bot" service that interfaces with MS Teams, to support Contentful's MS Teams App. Basically a container for handling Contentful and Microsoft authentication, as well as proxying some requests from hosted app actions to Microsoft, or Dynamo DB. [Read more](https://github.com/contentful/msteams-bot-service) in msteams-bot-service repo.
+
 ## Testing
+
+### Mocking Data for Frontend development.
+
+It is possible to run the Frontend app in isolation, but will likely require passing mocked data.
+
+**Mocking MS-Teams Channels for Frontend**
+
+```js
+// apps/microsoft-teams/frontend/src/hooks/useGetTeamsChannels.ts
++ import { mockChannels } from '@test/mocks/mockChannels';
+
++  return import.meta.env.DEV ? mockChannels : channels;
+-  return channels;
+```
+
+// Todo: Other mocking use cases?
 
 ### Local development (frontend)
 

--- a/apps/microsoft-teams/frontend/src/components/config/ChannelSelectionModal/ChannelSelectionModal.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ChannelSelectionModal/ChannelSelectionModal.spec.tsx
@@ -1,8 +1,9 @@
 import ChannelSelectionModal from './ChannelSelectionModal';
 import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { channelSelection } from '@constants/configCopy';
 import { defaultNotification } from '@constants/defaultParams';
+import { mockChannels } from '@test/mocks/mockChannels';
 
 describe('ChannelSelectionModal component', () => {
   it('mounts and renders the correct content', () => {
@@ -17,5 +18,38 @@ describe('ChannelSelectionModal component', () => {
     );
 
     expect(screen.getByText(channelSelection.modal.title)).toBeTruthy();
+  });
+
+  describe('selecting a channel', () => {
+    it('clicking the entire row selects the channel', () => {
+      const notificationEditSpy = vi.fn();
+
+      render(
+        <ChannelSelectionModal
+          isShown={true}
+          onClose={vi.fn()}
+          savedChannel={defaultNotification.channel}
+          handleNotificationEdit={notificationEditSpy}
+          channels={[mockChannels[0]]}
+        />
+      );
+
+      const row = screen.getByText(mockChannels[0].name).closest('tr');
+      fireEvent.click(row as Element);
+
+      // verify that radio button is checked
+      const radioBtn = screen.getByRole('radio') as HTMLInputElement;
+      expect(radioBtn.checked).toEqual(true);
+
+      // submit form
+      const submitBtn = screen.getByRole('button', { name: 'Select' });
+      fireEvent.click(submitBtn);
+
+      // ensure that notificationEdit() was called with correct value
+      expect(notificationEditSpy).toHaveBeenCalledTimes(1);
+
+      // todo: move this to a before/after block.  Ideally an after
+      vi.restoreAllMocks();
+    });
   });
 });

--- a/apps/microsoft-teams/frontend/src/components/config/ChannelSelectionModal/ChannelSelectionModal.styles.ts
+++ b/apps/microsoft-teams/frontend/src/components/config/ChannelSelectionModal/ChannelSelectionModal.styles.ts
@@ -3,8 +3,12 @@ import tokens from '@contentful/f36-tokens';
 
 export const styles = {
   table: css({
-    borderRadius: 'none !important',
+    borderRadius: '0 !important',
     boxShadow: 'none !important',
     borderBottom: `1px solid ${tokens.gray200}`,
+  }),
+
+  tableRow: css({
+    cursor: 'pointer',
   }),
 };

--- a/apps/microsoft-teams/frontend/src/components/config/ChannelSelectionModal/ChannelSelectionModal.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ChannelSelectionModal/ChannelSelectionModal.tsx
@@ -55,12 +55,17 @@ const ChannelSelectionModal = (props: ChannelSelectionModalProps) => {
                   <Table className={styles.table}>
                     <Table.Body>
                       {channels.map((channel) => (
-                        <Table.Row key={channel.id}>
+                        <Table.Row
+                          key={channel.id}
+                          onClick={() => setSelectedChannel(channel)}
+                          className={styles.tableRow}>
                           <Table.Cell>
                             <Radio
                               id={channel.id}
                               isChecked={selectedChannel.id === channel.id}
-                              onChange={() => setSelectedChannel(channel)}
+                              onChange={() => {
+                                /* clicking entire row checks this radio, i.e. do nothing here */
+                              }}
                               helpText={channel.teamName}>
                               {channel.name}
                             </Radio>

--- a/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelectionModal/ContentTypeSelectionModal.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelectionModal/ContentTypeSelectionModal.spec.tsx
@@ -1,7 +1,8 @@
 import ContentTypeSelectionModal from './ContentTypeSelectionModal';
 import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { contentTypeSelection } from '@constants/configCopy';
+import { mockContentType } from '@test/mocks';
 
 describe('ContentTypeSelectionModal component', () => {
   it('mounts and renders the correct content', () => {
@@ -17,5 +18,39 @@ describe('ContentTypeSelectionModal component', () => {
     );
 
     expect(screen.getByText(contentTypeSelection.modal.title)).toBeTruthy();
+  });
+
+  describe('selecting a content type', () => {
+    it("clicking the entire row, selects the row's content type", () => {
+      const notificationEditSpy = vi.fn();
+
+      render(
+        <ContentTypeSelectionModal
+          isShown={true}
+          onClose={vi.fn()}
+          savedContentTypeId=""
+          handleNotificationEdit={notificationEditSpy}
+          contentTypes={[mockContentType]}
+          contentTypeConfigLink=""
+        />
+      );
+
+      const row = screen.getByText(mockContentType.name).closest('tr');
+      fireEvent.click(row as Element);
+
+      // verify that radio button is checked
+      const radioBtn = screen.getByRole('radio') as HTMLInputElement;
+      expect(radioBtn.checked).toEqual(true);
+
+      // submit form
+      const submitBtn = screen.getByRole('button', { name: 'Select' });
+      fireEvent.click(submitBtn);
+
+      // ensure that notificationEdit() was called with correct value
+      expect(notificationEditSpy).toHaveBeenCalledTimes(1);
+
+      // todo: move this to a before/after block.  Ideally an after
+      vi.restoreAllMocks();
+    });
   });
 });

--- a/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelectionModal/ContentTypeSelectionModal.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelectionModal/ContentTypeSelectionModal.tsx
@@ -43,12 +43,16 @@ const ContentTypeSelectionModal = (props: Props) => {
                   <Table className={styles.table}>
                     <Table.Body>
                       {contentTypes.map((contentType) => (
-                        <Table.Row key={contentType.sys.id}>
+                        <Table.Row
+                          key={contentType.sys.id}
+                          onClick={() => setSelectedContentTypeId(contentType.sys.id)}>
                           <Table.Cell>
                             <Radio
                               id={contentType.sys.id}
                               isChecked={selectedContentTypeId === contentType.sys.id}
-                              onChange={() => setSelectedContentTypeId(contentType.sys.id)}>
+                              onChange={() => {
+                                /* clicking entire row checks this radio, i.e. do nothing here */
+                              }}>
                               {contentType.name}
                             </Radio>
                           </Table.Cell>

--- a/apps/microsoft-teams/frontend/src/constants/configCopy.ts
+++ b/apps/microsoft-teams/frontend/src/constants/configCopy.ts
@@ -41,7 +41,7 @@ const notificationsSection = {
     confirmDuplicate: 'Update existing notification',
     goBack: 'Go back to editing',
     confirmDuplicateDescription:
-      'You already have a notification set up for this content type and MS Teams channel. Would you like to update the existing notification instead of creating a new one?',
+      'You already have a notification set up for this content type and Teams channel. Would you like to update the existing notification or create a new one?',
   },
   updateConfirmation: 'Notification settings updated',
   saveWarning: 'Save the app to persist these settings',

--- a/apps/microsoft-teams/frontend/test/mocks/mockChannels.ts
+++ b/apps/microsoft-teams/frontend/test/mocks/mockChannels.ts
@@ -24,7 +24,7 @@ const mockChannels: TeamsChannel[] = [
   },
   {
     id: '19:3bccfda604454e63bd839399e6752ba3@thread.tacv2',
-    name: 'General',
+    name: 'Sales General',
     teamId: '1a91e6ef-ac80-4b9b-9989-d3416c38671c',
     tenantId: '666e56a6-1f2a-47c7-b88c-1ed9e1bb8668',
     teamName: 'Sales Team',


### PR DESCRIPTION
## Purpose
**copy change:** Duplicate notification modal - change
You already have a notification set up for this content type and ~~MS~~ Teams channel. Would you like to update the existing notification ~~instead of~~ (+or) creating a new one?

This copy change is from a Mob QA feedback session demo'ing MS-teams.  The dependency/readme updates are just quality of life improvements.

**OLD**
<img width="536" alt="Screenshot 2024-02-09 at 2 51 17 PM" src="https://github.com/contentful/apps/assets/158083968/f7fdd8a8-d1b1-4f5d-950a-68d5a46e3e06">

**NEW**
<img width="534" alt="new" src="https://github.com/contentful/apps/assets/158083968/f443864c-d119-479d-9f80-8281b5487fb3">

****

## Secondary Changes
1. chore(deps): explicitly install "rimraf" and "yargs" as project deps.
While bootstrapping the app these dependencies needed to be installed.  I talked to Jim, and we decided it was best to just explicitly add these to the package.

2. docs(FrontendReadme): Add basic system architecture overview section, as well as mocking data for frontend dev.
Hopefully this will be helpful to someone in the future.  I opted to omit links to miro/confluence because those types of documentation rarely stay in one place.

## Approach
N/A

## Testing steps
Tested in development mode, didn't see the need for further testing.

## Breaking Changes
None

## Dependencies and/or References
[INTEG-1747](https://contentful.atlassian.net/browse/INTEG-1747)


[INTEG-1747]: https://contentful.atlassian.net/browse/INTEG-1747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ