### PR TITLE
ContentTypeSelectionModal & ChannelSelectionModalProps - Clicking entire row should select the option.

### DIFF
--- a/apps/microsoft-teams/frontend/src/components/config/ChannelSelectionModal/ChannelSelectionModal.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ChannelSelectionModal/ChannelSelectionModal.spec.tsx
@@ -1,8 +1,9 @@
 import ChannelSelectionModal from './ChannelSelectionModal';
 import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { channelSelection } from '@constants/configCopy';
 import { defaultNotification } from '@constants/defaultParams';
+import { mockChannels } from '@test/mocks/mockChannels';
 
 describe('ChannelSelectionModal component', () => {
   it('mounts and renders the empty state when no channels are present', () => {
@@ -35,5 +36,39 @@ describe('ChannelSelectionModal component', () => {
     );
 
     expect(screen.getByText(errorMessage)).toBeTruthy();
+  });
+
+  describe('selecting a channel', () => {
+    it('clicking the entire row selects the channel', () => {
+      const notificationEditSpy = vi.fn();
+
+      render(
+        <ChannelSelectionModal
+          isShown={true}
+          onClose={vi.fn()}
+          savedChannel={defaultNotification.channel}
+          handleNotificationEdit={notificationEditSpy}
+          channels={[mockChannels[0]]}
+          error={false}
+        />
+      );
+
+      const row = screen.getByText(mockChannels[0].teamName).closest('tr');
+      fireEvent.click(row as Element);
+
+      // verify that radio button is checked
+      const radioBtn = screen.getByRole('radio') as HTMLInputElement;
+      expect(radioBtn.checked).toEqual(true);
+
+      // submit form
+      const submitBtn = screen.getByRole('button', { name: 'Select' });
+      fireEvent.click(submitBtn);
+
+      // ensure that notificationEdit() was called with correct value
+      expect(notificationEditSpy).toHaveBeenCalledTimes(1);
+
+      // todo: move this to a before/after block.  Ideally an after
+      vi.restoreAllMocks();
+    });
   });
 });

--- a/apps/microsoft-teams/frontend/src/components/config/ChannelSelectionModal/ChannelSelectionModal.styles.ts
+++ b/apps/microsoft-teams/frontend/src/components/config/ChannelSelectionModal/ChannelSelectionModal.styles.ts
@@ -3,8 +3,12 @@ import tokens from '@contentful/f36-tokens';
 
 export const styles = {
   table: css({
-    borderRadius: 'none !important',
+    borderRadius: '0 !important',
     boxShadow: 'none !important',
     borderBottom: `1px solid ${tokens.gray200}`,
+  }),
+
+  tableRow: css({
+    cursor: 'pointer',
   }),
 };

--- a/apps/microsoft-teams/frontend/src/components/config/ChannelSelectionModal/ChannelSelectionModal.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ChannelSelectionModal/ChannelSelectionModal.tsx
@@ -57,12 +57,17 @@ const ChannelSelectionModal = (props: ChannelSelectionModalProps) => {
             <Table className={styles.table}>
               <Table.Body>
                 {channels.map((channel) => (
-                  <Table.Row key={channel.id}>
+                  <Table.Row
+                    key={channel.id}
+                    onClick={() => setSelectedChannel(channel)}
+                    className={styles.tableRow}>
                     <Table.Cell>
                       <Radio
                         id={channel.id}
                         isChecked={selectedChannel.id === channel.id}
-                        onChange={() => setSelectedChannel(channel)}
+                        onChange={() => {
+                          /* clicking entire row checks this radio, i.e. do nothing here */
+                        }}
                         helpText={channel.teamName}>
                         {channel.name}
                       </Radio>

--- a/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelectionModal/ContentTypeSelectionModal.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelectionModal/ContentTypeSelectionModal.spec.tsx
@@ -1,7 +1,8 @@
 import ContentTypeSelectionModal from './ContentTypeSelectionModal';
 import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { contentTypeSelection } from '@constants/configCopy';
+import { mockContentType } from '@test/mocks';
 
 describe('ContentTypeSelectionModal component', () => {
   it('mounts and renders the correct content', () => {
@@ -35,5 +36,40 @@ describe('ContentTypeSelectionModal component', () => {
     );
 
     expect(screen.getByText(errorMessage)).toBeTruthy();
+  });
+
+  describe('selecting a content type', () => {
+    it("clicking the entire row, selects the row's content type", () => {
+      const notificationEditSpy = vi.fn();
+
+      render(
+        <ContentTypeSelectionModal
+          isShown={true}
+          onClose={vi.fn()}
+          savedContentTypeId=""
+          handleNotificationEdit={notificationEditSpy}
+          contentTypes={[mockContentType]}
+          contentTypeConfigLink=""
+          error={false}
+        />
+      );
+
+      const row = screen.getByText(mockContentType.name).closest('tr');
+      fireEvent.click(row as Element);
+
+      // verify that radio button is checked
+      const radioBtn = screen.getByRole('radio') as HTMLInputElement;
+      expect(radioBtn.checked).toEqual(true);
+
+      // submit form
+      const submitBtn = screen.getByRole('button', { name: 'Select' });
+      fireEvent.click(submitBtn);
+
+      // ensure that notificationEdit() was called with correct value
+      expect(notificationEditSpy).toHaveBeenCalledTimes(1);
+
+      // todo: move this to a before/after block.  Ideally an after
+      vi.restoreAllMocks();
+    });
   });
 });

--- a/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelectionModal/ContentTypeSelectionModal.styles.ts
+++ b/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelectionModal/ContentTypeSelectionModal.styles.ts
@@ -3,8 +3,12 @@ import tokens from '@contentful/f36-tokens';
 
 export const styles = {
   table: css({
-    borderRadius: 'none !important',
+    borderRadius: '0 !important',
     boxShadow: 'none !important',
     borderBottom: `1px solid ${tokens.gray200}`,
+  }),
+
+  tableRow: css({
+    cursor: 'pointer',
   }),
 };

--- a/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelectionModal/ContentTypeSelectionModal.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelectionModal/ContentTypeSelectionModal.tsx
@@ -52,12 +52,17 @@ const ContentTypeSelectionModal = (props: Props) => {
               <Table className={styles.table}>
                 <Table.Body>
                   {contentTypes.map((contentType) => (
-                    <Table.Row key={contentType.sys.id}>
+                    <Table.Row
+                      key={contentType.sys.id}
+                      onClick={() => setSelectedContentTypeId(contentType.sys.id)}
+                      className={styles.tableRow}>
                       <Table.Cell>
                         <Radio
                           id={contentType.sys.id}
                           isChecked={selectedContentTypeId === contentType.sys.id}
-                          onChange={() => setSelectedContentTypeId(contentType.sys.id)}>
+                          onChange={() => {
+                            /* clicking entire row checks this radio, i.e. do nothing here */
+                          }}>
                           {contentType.name}
                         </Radio>
                       </Table.Cell>


### PR DESCRIPTION
## Purpose
When selecting a Channel or Content Type from the `<ContentTypeSelectionModal>` or `<ChannelSelectionModalProps>`, clicking anywhere inside the table's row should select that option.

![channels](https://github.com/contentful/apps/assets/158083968/fccbd684-1f40-431e-a309-d068e91b26e7)


### Context
This is from a Mob QA feedback session demo'ing MS-teams.

## Approach
Instead of adding the `onClick` callback to the `<Radio>`, add it to the `<Table.Row>`.  React will complain that you did not provide a `onChange` handler to the `<Radio>`, so just add a noop to placate react.  If there is a better solution, I'm all ears :)

## Testing steps
Tested in "Apps - Development and Testing Org", "Microsoft Teams (development)", master env.

## Breaking Changes
None

## Dependencies and/or References
