### PR TITLE
feat: display MS org name logo [INTEG-1782]

### DIFF
--- a/apps/microsoft-teams/frontend/package-lock.json
+++ b/apps/microsoft-teams/frontend/package-lock.json
@@ -36,6 +36,7 @@
         "eslint": "^8.52.0",
         "eslint-plugin-react": "^7.33.2",
         "happy-dom": "9.20.3",
+        "msw": "^2.2.0",
         "typescript": "5.1.6",
         "vite": "4.5.2",
         "vite-plugin-eslint": "^1.8.1",
@@ -544,6 +545,24 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "node_modules/@bundled-es-modules/cookie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/cookie/-/cookie-2.0.0.tgz",
+      "integrity": "sha512-Or6YHg/kamKHpxULAdSqhGqnWFneIXu1NKvvfBBzKGwpVsYuFIQ5aBPHDnnoR3ghW1nvSkALd+EF9iMtY7Vjxw==",
+      "dev": true,
+      "dependencies": {
+        "cookie": "^0.5.0"
+      }
+    },
+    "node_modules/@bundled-es-modules/statuses": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/statuses/-/statuses-1.0.1.tgz",
+      "integrity": "sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==",
+      "dev": true,
+      "dependencies": {
+        "statuses": "^2.0.1"
+      }
     },
     "node_modules/@contentful/app-scripts": {
       "version": "1.10.2",
@@ -1994,6 +2013,115 @@
       "integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
       "dev": true
     },
+    "node_modules/@inquirer/confirm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-3.0.0.tgz",
+      "integrity": "sha512-LHeuYP1D8NmQra1eR4UqvZMXwxEdDXyElJmmZfU44xdNLL6+GcQBS0uE16vyfZVjH8c22p9e+DStROfE/hyHrg==",
+      "dev": true,
+      "dependencies": {
+        "@inquirer/core": "^7.0.0",
+        "@inquirer/type": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-7.0.0.tgz",
+      "integrity": "sha512-g13W5yEt9r1sEVVriffJqQ8GWy94OnfxLCreNSOTw0HPVcszmc/If1KIf7YBmlwtX4klmvwpZHnQpl3N7VX2xA==",
+      "dev": true,
+      "dependencies": {
+        "@inquirer/type": "^1.2.0",
+        "@types/mute-stream": "^0.0.4",
+        "@types/node": "^20.11.16",
+        "@types/wrap-ansi": "^3.0.0",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2",
+        "cli-spinners": "^2.9.2",
+        "cli-width": "^4.1.0",
+        "figures": "^3.2.0",
+        "mute-stream": "^1.0.0",
+        "run-async": "^3.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^6.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/@types/node": {
+      "version": "20.11.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.17.tgz",
+      "integrity": "sha512-QmgQZGWu1Yw9TDyAP9ZzpFJKynYNeOvwMJmaxABfieQoVoiVOS6MN1WSpqpRcbeA5+RW82kraAVxCCJg+780Qw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/mute-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
+      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+      "dev": true,
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/run-async": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
+      "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-/vvkUkYhrjbm+RolU7V1aUFDydZVKNKqKHR5TsE+j5DXgXFwrsOPcoGUJ02K0O7q7O53CU2DOTMYCHeGZ25WHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
@@ -2068,6 +2196,32 @@
       "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.2.tgz",
       "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw=="
     },
+    "node_modules/@mswjs/cookies": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.1.0.tgz",
+      "integrity": "sha512-0ZcCVQxifZmhwNBoQIrystCb+2sWBY2Zw8lpfJBPCHGCA/HWqehITeCRVIv4VMy8MPlaHo2w2pTHFV2pFfqKPw==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.25.16",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.25.16.tgz",
+      "integrity": "sha512-8QC8JyKztvoGAdPgyZy49c9vSHHAZjHagwl4RY9E8carULk8ym3iTaiawrT1YoLF/qb449h48f71XDPgkUSOUg==",
+      "dev": true,
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.2.1",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2102,6 +2256,28 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true
     },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
@@ -2609,6 +2785,12 @@
         "@types/chai": "*"
       }
     },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "dev": true
+    },
     "node_modules/@types/eslint": {
       "version": "8.44.6",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.6.tgz",
@@ -2647,6 +2829,15 @@
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
       "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==",
       "dev": true
+    },
+    "node_modules/@types/mute-stream": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz",
+      "integrity": "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "16.18.38",
@@ -2700,6 +2891,18 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-MMzuxN3GdFwskAnb6fz0orFvhfqi752yjaXylr0Rp4oDg5H0Zn1IuyRhDVvYOwAXoJirx2xuS16I3WjxnAIHiQ==",
+      "dev": true
+    },
+    "node_modules/@types/statuses": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.4.tgz",
+      "integrity": "sha512-eqNDvZsCNY49OAXB0Firg/Sc2BgoWsntsLUdybGFOhAfCD6QJ2n9HXUIHGqt5qjrxmMv4wS8WLAw43ZkKcJ8Pw==",
+      "dev": true
+    },
+    "node_modules/@types/wrap-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
+      "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -3773,9 +3976,9 @@
       }
     },
     "node_modules/cli-spinners": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.1.tgz",
-      "integrity": "sha512-jHgecW0pxkonBJdrKsqxgRX9AcG+u/5k0Q7WPDfi8AogLAdwxEkyYYNWwZ5GvVFoFx2uiY1eNcSK00fh+1+FyQ==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -3791,6 +3994,20 @@
       "dev": true,
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/clone": {
@@ -3899,6 +4116,15 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
+    },
+    "node_modules/cookie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/cosmiconfig": {
       "version": "6.0.0",
@@ -4940,6 +5166,15 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-func-name": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
@@ -5072,6 +5307,15 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
+    "node_modules/graphql": {
+      "version": "16.8.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
+      "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
     "node_modules/happy-dom": {
       "version": "9.20.3",
       "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-9.20.3.tgz",
@@ -5162,6 +5406,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/headers-polyfill": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.2.tgz",
+      "integrity": "sha512-EWGTfnTqAO2L/j5HZgoM/3z82L7necsJ0pO9Tp0X1wil3PDLrkypTBRgVO2ExehEEvUycejZD3FuRaXpZZc3kw==",
+      "dev": true
     },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
@@ -5526,6 +5776,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -6173,6 +6429,62 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
+    "node_modules/msw": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.2.0.tgz",
+      "integrity": "sha512-98cUGcIphhdf3KDbmSxji7XFqLxeSFAmPUNV00N/U76GOkuUKEwp6MHqM6KW70rlpgeJP8qIWueppdnVThzG1g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@bundled-es-modules/cookie": "^2.0.0",
+        "@bundled-es-modules/statuses": "^1.0.1",
+        "@inquirer/confirm": "^3.0.0",
+        "@mswjs/cookies": "^1.1.0",
+        "@mswjs/interceptors": "^0.25.16",
+        "@open-draft/until": "^2.1.0",
+        "@types/cookie": "^0.6.0",
+        "@types/statuses": "^2.0.4",
+        "chalk": "^4.1.2",
+        "graphql": "^16.8.1",
+        "headers-polyfill": "^4.0.2",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.2",
+        "path-to-regexp": "^6.2.0",
+        "strict-event-emitter": "^0.5.1",
+        "type-fest": "^4.9.0",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.7.x <= 5.3.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw/node_modules/type-fest": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.10.2.tgz",
+      "integrity": "sha512-anpAG63wSpdEbLwOqH8L84urkL6PiVIov3EMmgIhhThevh9aiMQov+6Btx0wldNcvm4wV+e2/Rt1QdDwKHFbHw==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/mute-stream": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
@@ -6419,6 +6731,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/outvariant": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.2.tgz",
+      "integrity": "sha512-Ou3dJ6bA/UJ5GVHxah4LnqDwZRwAmWxrG3wtrHrbGnP4RnLCtA64A4F+ae7Y8ww660JaddSoArUR5HjipWSHAQ==",
+      "dev": true
+    },
     "node_modules/p-limit": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
@@ -6546,6 +6864,12 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
+      "dev": true
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -6928,6 +7252,15 @@
       "integrity": "sha512-o4S4Qh6L2jpnCy83ysZDau+VORNvnFw07CKSAymkd6ICNVEPisMyzlc00KlvvicsxKck94SEwhDnMNdICzO+tA==",
       "dev": true
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
@@ -7228,6 +7561,15 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true
     },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/std-env": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.4.3.tgz",
@@ -7245,6 +7587,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -7635,6 +7983,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/update-browserslist-db": {
       "version": "1.0.13",
@@ -8119,6 +8473,15 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -8131,6 +8494,33 @@
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {
@@ -8520,6 +8910,24 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "@bundled-es-modules/cookie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/cookie/-/cookie-2.0.0.tgz",
+      "integrity": "sha512-Or6YHg/kamKHpxULAdSqhGqnWFneIXu1NKvvfBBzKGwpVsYuFIQ5aBPHDnnoR3ghW1nvSkALd+EF9iMtY7Vjxw==",
+      "dev": true,
+      "requires": {
+        "cookie": "^0.5.0"
+      }
+    },
+    "@bundled-es-modules/statuses": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/statuses/-/statuses-1.0.1.tgz",
+      "integrity": "sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==",
+      "dev": true,
+      "requires": {
+        "statuses": "^2.0.1"
+      }
     },
     "@contentful/app-scripts": {
       "version": "1.10.2",
@@ -9555,6 +9963,90 @@
       "integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
       "dev": true
     },
+    "@inquirer/confirm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-3.0.0.tgz",
+      "integrity": "sha512-LHeuYP1D8NmQra1eR4UqvZMXwxEdDXyElJmmZfU44xdNLL6+GcQBS0uE16vyfZVjH8c22p9e+DStROfE/hyHrg==",
+      "dev": true,
+      "requires": {
+        "@inquirer/core": "^7.0.0",
+        "@inquirer/type": "^1.2.0"
+      }
+    },
+    "@inquirer/core": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-7.0.0.tgz",
+      "integrity": "sha512-g13W5yEt9r1sEVVriffJqQ8GWy94OnfxLCreNSOTw0HPVcszmc/If1KIf7YBmlwtX4klmvwpZHnQpl3N7VX2xA==",
+      "dev": true,
+      "requires": {
+        "@inquirer/type": "^1.2.0",
+        "@types/mute-stream": "^0.0.4",
+        "@types/node": "^20.11.16",
+        "@types/wrap-ansi": "^3.0.0",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2",
+        "cli-spinners": "^2.9.2",
+        "cli-width": "^4.1.0",
+        "figures": "^3.2.0",
+        "mute-stream": "^1.0.0",
+        "run-async": "^3.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^6.2.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "20.11.17",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.17.tgz",
+          "integrity": "sha512-QmgQZGWu1Yw9TDyAP9ZzpFJKynYNeOvwMJmaxABfieQoVoiVOS6MN1WSpqpRcbeA5+RW82kraAVxCCJg+780Qw==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        },
+        "cli-width": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+          "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+          "dev": true
+        },
+        "mute-stream": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
+          "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+          "dev": true
+        },
+        "run-async": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
+          "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
+          "dev": true
+        },
+        "signal-exit": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+          "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        }
+      }
+    },
+    "@inquirer/type": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-/vvkUkYhrjbm+RolU7V1aUFDydZVKNKqKHR5TsE+j5DXgXFwrsOPcoGUJ02K0O7q7O53CU2DOTMYCHeGZ25WHA==",
+      "dev": true
+    },
     "@istanbuljs/schema": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
@@ -9614,6 +10106,26 @@
       "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.2.tgz",
       "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw=="
     },
+    "@mswjs/cookies": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.1.0.tgz",
+      "integrity": "sha512-0ZcCVQxifZmhwNBoQIrystCb+2sWBY2Zw8lpfJBPCHGCA/HWqehITeCRVIv4VMy8MPlaHo2w2pTHFV2pFfqKPw==",
+      "dev": true
+    },
+    "@mswjs/interceptors": {
+      "version": "0.25.16",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.25.16.tgz",
+      "integrity": "sha512-8QC8JyKztvoGAdPgyZy49c9vSHHAZjHagwl4RY9E8carULk8ym3iTaiawrT1YoLF/qb449h48f71XDPgkUSOUg==",
+      "dev": true,
+      "requires": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.2.1",
+        "strict-event-emitter": "^0.5.1"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -9639,6 +10151,28 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
+    },
+    "@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true
+    },
+    "@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "requires": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true
     },
     "@popperjs/core": {
       "version": "2.11.8",
@@ -9957,6 +10491,12 @@
         "@types/chai": "*"
       }
     },
+    "@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "dev": true
+    },
     "@types/eslint": {
       "version": "8.44.6",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.6.tgz",
@@ -9995,6 +10535,15 @@
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
       "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==",
       "dev": true
+    },
+    "@types/mute-stream": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz",
+      "integrity": "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/node": {
       "version": "16.18.38",
@@ -10048,6 +10597,18 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-MMzuxN3GdFwskAnb6fz0orFvhfqi752yjaXylr0Rp4oDg5H0Zn1IuyRhDVvYOwAXoJirx2xuS16I3WjxnAIHiQ==",
+      "dev": true
+    },
+    "@types/statuses": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.4.tgz",
+      "integrity": "sha512-eqNDvZsCNY49OAXB0Firg/Sc2BgoWsntsLUdybGFOhAfCD6QJ2n9HXUIHGqt5qjrxmMv4wS8WLAw43ZkKcJ8Pw==",
+      "dev": true
+    },
+    "@types/wrap-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
+      "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
@@ -10798,9 +11359,9 @@
       }
     },
     "cli-spinners": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.1.tgz",
-      "integrity": "sha512-jHgecW0pxkonBJdrKsqxgRX9AcG+u/5k0Q7WPDfi8AogLAdwxEkyYYNWwZ5GvVFoFx2uiY1eNcSK00fh+1+FyQ==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
       "dev": true
     },
     "cli-width": {
@@ -10808,6 +11369,17 @@
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
       "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
       "dev": true
+    },
+    "cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      }
     },
     "clone": {
       "version": "1.0.4",
@@ -10898,6 +11470,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true
+    },
+    "cookie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
       "dev": true
     },
     "cosmiconfig": {
@@ -11703,6 +12281,12 @@
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true
     },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
+    },
     "get-func-name": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
@@ -11796,6 +12380,12 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
+    "graphql": {
+      "version": "16.8.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
+      "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==",
+      "dev": true
+    },
     "happy-dom": {
       "version": "9.20.3",
       "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-9.20.3.tgz",
@@ -11856,6 +12446,12 @@
       "requires": {
         "function-bind": "^1.1.2"
       }
+    },
+    "headers-polyfill": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.2.tgz",
+      "integrity": "sha512-EWGTfnTqAO2L/j5HZgoM/3z82L7necsJ0pO9Tp0X1wil3PDLrkypTBRgVO2ExehEEvUycejZD3FuRaXpZZc3kw==",
+      "dev": true
     },
     "hoist-non-react-statics": {
       "version": "3.3.2",
@@ -12108,6 +12704,12 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
       "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
+      "dev": true
+    },
+    "is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
       "dev": true
     },
     "is-number": {
@@ -12600,6 +13202,39 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
+    "msw": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.2.0.tgz",
+      "integrity": "sha512-98cUGcIphhdf3KDbmSxji7XFqLxeSFAmPUNV00N/U76GOkuUKEwp6MHqM6KW70rlpgeJP8qIWueppdnVThzG1g==",
+      "dev": true,
+      "requires": {
+        "@bundled-es-modules/cookie": "^2.0.0",
+        "@bundled-es-modules/statuses": "^1.0.1",
+        "@inquirer/confirm": "^3.0.0",
+        "@mswjs/cookies": "^1.1.0",
+        "@mswjs/interceptors": "^0.25.16",
+        "@open-draft/until": "^2.1.0",
+        "@types/cookie": "^0.6.0",
+        "@types/statuses": "^2.0.4",
+        "chalk": "^4.1.2",
+        "graphql": "^16.8.1",
+        "headers-polyfill": "^4.0.2",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.2",
+        "path-to-regexp": "^6.2.0",
+        "strict-event-emitter": "^0.5.1",
+        "type-fest": "^4.9.0",
+        "yargs": "^17.7.2"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "4.10.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.10.2.tgz",
+          "integrity": "sha512-anpAG63wSpdEbLwOqH8L84urkL6PiVIov3EMmgIhhThevh9aiMQov+6Btx0wldNcvm4wV+e2/Rt1QdDwKHFbHw==",
+          "dev": true
+        }
+      }
+    },
     "mute-stream": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
@@ -12771,6 +13406,12 @@
       "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
       "dev": true
     },
+    "outvariant": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.2.tgz",
+      "integrity": "sha512-Ou3dJ6bA/UJ5GVHxah4LnqDwZRwAmWxrG3wtrHrbGnP4RnLCtA64A4F+ae7Y8ww660JaddSoArUR5HjipWSHAQ==",
+      "dev": true
+    },
     "p-limit": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
@@ -12852,6 +13493,12 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
+    "path-to-regexp": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
+      "dev": true
     },
     "path-type": {
       "version": "4.0.0",
@@ -13110,6 +13757,12 @@
       "integrity": "sha512-o4S4Qh6L2jpnCy83ysZDau+VORNvnFw07CKSAymkd6ICNVEPisMyzlc00KlvvicsxKck94SEwhDnMNdICzO+tA==",
       "dev": true
     },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true
+    },
     "resolve": {
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
@@ -13314,6 +13967,12 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true
     },
+    "statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "dev": true
+    },
     "std-env": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.4.3.tgz",
@@ -13328,6 +13987,12 @@
       "requires": {
         "internal-slot": "^1.0.4"
       }
+    },
+    "strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true
     },
     "string_decoder": {
       "version": "1.3.0",
@@ -13614,6 +14279,12 @@
         "which-boxed-primitive": "^1.0.2"
       }
     },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    },
     "update-browserslist-db": {
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
@@ -13891,6 +14562,12 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
+    "y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true
+    },
     "yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -13901,6 +14578,27 @@
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
+    },
+    "yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "requires": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      }
+    },
+    "yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true
     },
     "yocto-queue": {
       "version": "1.0.0",

--- a/apps/microsoft-teams/frontend/package.json
+++ b/apps/microsoft-teams/frontend/package.json
@@ -39,6 +39,7 @@
     "eslint": "^8.52.0",
     "eslint-plugin-react": "^7.33.2",
     "happy-dom": "9.20.3",
+    "msw": "^2.2.0",
     "typescript": "5.1.6",
     "vite": "4.5.2",
     "vite-plugin-eslint": "^1.8.1",

--- a/apps/microsoft-teams/frontend/src/components/config/AccessSection/AccessSection.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/AccessSection/AccessSection.spec.tsx
@@ -1,6 +1,6 @@
 import AccessSection from './AccessSection';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import {
   mockMsalWithAccounts,
   mockMsalWithoutAccounts,
@@ -36,10 +36,13 @@ describe('AccessSection component', () => {
     expect(screen.getByText('Connect to Teams')).toBeTruthy();
   });
 
-  it('displays correct copy when authorized', () => {
+  it('displays correct copy when authorized', async () => {
     mocks.useMsal.mockReturnValue(mockMsalWithAccounts);
     render(<AccessSection dispatch={vi.fn()} parameters={mockParameters} isAppInstalled={true} />);
 
     expect(screen.getByText('Disconnect')).toBeTruthy();
+    expect(screen.getByText('username@companyabc.com')).toBeTruthy();
+    await waitFor(() => expect(screen.getByText('Company ABC')).toBeTruthy());
+    await waitFor(() => expect(screen.getByRole('img')).toBeTruthy());
   });
 });

--- a/apps/microsoft-teams/frontend/src/components/config/AccessSection/AccessSection.styles.ts
+++ b/apps/microsoft-teams/frontend/src/components/config/AccessSection/AccessSection.styles.ts
@@ -7,4 +7,8 @@ export const styles = {
     width: 16px;
   }
 `),
+  orgLogo: css({
+    /** Setting size to default size for favicon in MS organizational branding */
+    height: 32,
+  }),
 };

--- a/apps/microsoft-teams/frontend/src/components/config/AccessSection/AccessSection.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/AccessSection/AccessSection.tsx
@@ -135,7 +135,7 @@ const AccessSection = (props: Props) => {
             <Flex justifyContent="space-between">
               <Flex>
                 <Flex alignItems="center" marginRight="spacingM">
-                  {orgLogo && <img className={styles.orgLogo} src={orgLogo}></img>}
+                  {orgLogo && <img className={styles.orgLogo} src={orgLogo} alt="logo"></img>}
                 </Flex>
                 <Flex flexDirection="column">
                   <Subheading marginBottom="none">{orgName}</Subheading>

--- a/apps/microsoft-teams/frontend/src/components/config/AccessSection/AccessSection.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/AccessSection/AccessSection.tsx
@@ -29,10 +29,14 @@ interface Props {
   isAppInstalled: boolean;
 }
 
+const defaultOrgDetails = {
+  orgName: '',
+  orgLogo: '',
+};
+
 const AccessSection = (props: Props) => {
   const { dispatch, parameters, isAppInstalled } = props;
-  const [orgName, setOrgName] = useState<string>('');
-  const [orgLogo, setOrgLogo] = useState<string>('');
+  const [orgDetails, setOrgDetails] = useState(defaultOrgDetails);
 
   const { instance, accounts, inProgress } = useMsal();
   const customApi = useCustomApi();
@@ -40,7 +44,8 @@ const AccessSection = (props: Props) => {
 
   const loginInProgress = inProgress === 'login';
   const logoutInProgress = inProgress === 'logout';
-  const { logout, login, teamsAppInfo, teamsAppLink, description } = accessSection;
+  const { logout, login, teamsAppInfo, teamsAppLink, description, authError, orgDetailsError } =
+    accessSection;
 
   useEffect(() => {
     if (accounts.length && parameters.tenantId) {
@@ -66,7 +71,7 @@ const AccessSection = (props: Props) => {
         );
       }
     } catch (e) {
-      const message = e instanceof Error ? e.message : 'Failed to authenticate with Microsoft';
+      const message = e instanceof Error ? e.message : authError;
       sdk.notifier.error(message);
       console.error(e);
     }
@@ -90,8 +95,7 @@ const AccessSection = (props: Props) => {
               type: actions.UPDATE_TENANT_ID,
               payload: '',
             });
-            setOrgName('');
-            setOrgLogo('');
+            setOrgDetails(defaultOrgDetails);
           }}
         />
       );
@@ -105,9 +109,9 @@ const AccessSection = (props: Props) => {
         msGraph.getOrganizationDisplayName(),
         msGraph.getOrganizationLogo(),
       ]);
-      setOrgName(orgName);
-      setOrgLogo(orgLogo);
+      setOrgDetails({ orgName, orgLogo });
     } catch (e) {
+      sdk.notifier.error(orgDetailsError);
       console.error(e);
     }
   };
@@ -132,13 +136,15 @@ const AccessSection = (props: Props) => {
       return (
         <>
           <Card padding="large">
-            <Flex justifyContent="space-between">
+            <Flex justifyContent="space-between" alignItems="center">
               <Flex>
                 <Flex alignItems="center" marginRight="spacingM">
-                  {orgLogo && <img className={styles.orgLogo} src={orgLogo} alt="logo"></img>}
+                  {orgDetails.orgLogo && (
+                    <img className={styles.orgLogo} src={orgDetails.orgLogo} alt="logo"></img>
+                  )}
                 </Flex>
                 <Flex flexDirection="column">
-                  <Subheading marginBottom="none">{orgName}</Subheading>
+                  <Subheading marginBottom="none">{orgDetails.orgName}</Subheading>
                   <Paragraph marginBottom="none">{accounts[0]?.username}</Paragraph>
                 </Flex>
               </Flex>

--- a/apps/microsoft-teams/frontend/src/components/config/AccessSection/AccessSection.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/AccessSection/AccessSection.tsx
@@ -87,6 +87,7 @@ const AccessSection = (props: Props) => {
           }}
           handleDisconnect={async () => {
             onClose(true);
+            setOrgDetails(defaultOrgDetails);
             await instance.logoutPopup({
               postLogoutRedirectUri: '/',
               account: accounts[0],
@@ -95,7 +96,6 @@ const AccessSection = (props: Props) => {
               type: actions.UPDATE_TENANT_ID,
               payload: '',
             });
-            setOrgDetails(defaultOrgDetails);
           }}
         />
       );

--- a/apps/microsoft-teams/frontend/src/configs/authConfig.ts
+++ b/apps/microsoft-teams/frontend/src/configs/authConfig.ts
@@ -31,5 +31,5 @@ export const loginRequest = {
  * https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-browser/docs/resources-and-scopes.md
  */
 export const graphConfig = {
-  graphMeEndpoint: 'https://graph.microsoft.com/v1.0/me',
+  graphOrgEndpoint: 'https://graph.microsoft.com/v1.0/organization/',
 };

--- a/apps/microsoft-teams/frontend/src/constants/configCopy.ts
+++ b/apps/microsoft-teams/frontend/src/constants/configCopy.ts
@@ -27,6 +27,8 @@ const accessSection = {
   },
   updateConfirmation: 'Microsoft organization updated',
   saveWarning: 'Save the app to persist these settings',
+  authError: 'Failed to authenticate with Microsoft',
+  orgDetailsError: 'Failed to get Microsoft organization details',
 };
 
 const notificationsSection = {

--- a/apps/microsoft-teams/frontend/src/context/AuthProvider.tsx
+++ b/apps/microsoft-teams/frontend/src/context/AuthProvider.tsx
@@ -8,6 +8,7 @@ interface Props {
 }
 
 const msalInstance = new PublicClientApplication(msalConfig);
+await msalInstance.initialize();
 
 const AuthProvider = (props: Props) => {
   const { children } = props;

--- a/apps/microsoft-teams/frontend/src/context/AuthProvider.tsx
+++ b/apps/microsoft-teams/frontend/src/context/AuthProvider.tsx
@@ -8,7 +8,6 @@ interface Props {
 }
 
 const msalInstance = new PublicClientApplication(msalConfig);
-await msalInstance.initialize();
 
 const AuthProvider = (props: Props) => {
   const { children } = props;

--- a/apps/microsoft-teams/frontend/src/utils/msGraphApi.spec.ts
+++ b/apps/microsoft-teams/frontend/src/utils/msGraphApi.spec.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import MsGraph from './msGraphApi';
 import { mockMsalWithAccounts } from '@test/mocks';
 import { server } from '@test/mocks/api/server';
-import { noSquareLogoHandler, noLogosHandler } from '@test/mocks/api/handlers';
+import { noSquareLogoHandler, noLogosHandler, errorHandlers } from '@test/mocks/api/handlers';
 
 const { instance, accounts } = mockMsalWithAccounts;
 const msGraph = new MsGraph(instance as IPublicClientApplication, accounts[0] as AccountInfo);
@@ -13,6 +13,15 @@ describe('MsGraphApi', () => {
     it('returns an organization name', async () => {
       const result = await msGraph.getOrganizationDisplayName();
       expect(result).toEqual('Company ABC');
+    });
+
+    it('throws an error for an invalid token', async () => {
+      server.use(...errorHandlers);
+      try {
+        await msGraph.getOrganizationDisplayName();
+      } catch (error) {
+        expect(error).toEqual(new Error('Lifetime validation failed, the token is expired.'));
+      }
     });
   });
 
@@ -32,6 +41,19 @@ describe('MsGraphApi', () => {
       server.use(...noLogosHandler);
       const result = await msGraph.getOrganizationLogo();
       expect(result).toEqual('');
+    });
+
+    it('throws an error when the branding resource is not found', async () => {
+      server.use(...errorHandlers);
+      try {
+        await msGraph.getOrganizationLogo();
+      } catch (error) {
+        expect(error).toEqual(
+          new Error(
+            "Resource 'mock-tenant' does not exist or one of its queried reference-property objects are not present."
+          )
+        );
+      }
     });
   });
 });

--- a/apps/microsoft-teams/frontend/src/utils/msGraphApi.spec.ts
+++ b/apps/microsoft-teams/frontend/src/utils/msGraphApi.spec.ts
@@ -1,0 +1,37 @@
+import { AccountInfo, IPublicClientApplication } from '@azure/msal-browser';
+import { describe, expect, it } from 'vitest';
+import MsGraph from './msGraphApi';
+import { mockMsalWithAccounts } from '@test/mocks';
+import { server } from '@test/mocks/api/server';
+import { noSquareLogoHandler, noLogosHandler } from '@test/mocks/api/handlers';
+
+const { instance, accounts } = mockMsalWithAccounts;
+const msGraph = new MsGraph(instance as IPublicClientApplication, accounts[0] as AccountInfo);
+
+describe('MsGraphApi', () => {
+  describe('getOrganizationDisplayName', () => {
+    it('returns an organization name', async () => {
+      const result = await msGraph.getOrganizationDisplayName();
+      expect(result).toEqual('Company ABC');
+    });
+  });
+
+  describe('getOrganizationLogo', () => {
+    it('returns the organization logo url for a square image', async () => {
+      const result = await msGraph.getOrganizationLogo();
+      expect(result).toEqual('https://images.example/square');
+    });
+
+    it('returns the organization logo url for a favicon', async () => {
+      server.use(...noSquareLogoHandler);
+      const result = await msGraph.getOrganizationLogo();
+      expect(result).toEqual('https://images.example/favicon');
+    });
+
+    it('returns empty string when there is no logo url', async () => {
+      server.use(...noLogosHandler);
+      const result = await msGraph.getOrganizationLogo();
+      expect(result).toEqual('');
+    });
+  });
+});

--- a/apps/microsoft-teams/frontend/src/utils/msGraphApi.ts
+++ b/apps/microsoft-teams/frontend/src/utils/msGraphApi.ts
@@ -15,7 +15,7 @@ export class MsGraphApiError extends Error {
 
   constructor(res: MsGraphApiErrorType) {
     super(res.message ?? '');
-    this.status = res.status ?? 0;
+    this.status = res.status;
   }
 }
 
@@ -86,7 +86,7 @@ class MsGraph {
 
     const options = {
       method: 'GET',
-      headers: headers,
+      headers,
     };
 
     return options;

--- a/apps/microsoft-teams/frontend/src/utils/msGraphApi.ts
+++ b/apps/microsoft-teams/frontend/src/utils/msGraphApi.ts
@@ -1,0 +1,180 @@
+import {
+  AccountInfo,
+  IPublicClientApplication,
+  InteractionRequiredAuthError,
+} from '@azure/msal-browser';
+import { graphConfig } from '@configs/authConfig';
+
+export interface MsGraphApiErrorType {
+  message: string;
+  status: number;
+}
+
+export class MsGraphApiError extends Error {
+  status: number;
+
+  constructor(res: MsGraphApiErrorType) {
+    super(res.message ?? '');
+    this.status = res.status ?? 0;
+  }
+}
+
+interface OrganizationalBrandingSuccessResponse {
+  '@odata.context': string;
+  cdnList: string[];
+  faviconRelativeUrl: string;
+  squareLogoRelativeUrl: string;
+}
+
+/**
+ * This class is used to interact with the Microsoft Graph API.
+ * Specifically we use this API to get the organization name and logo to display after a user authenticates
+ * @param instance IPublicClientApplication, comes from useMsal hook
+ * @param account AccountInfo, comes from useMsal hook
+ */
+class MsGraph {
+  readonly baseUrl: string;
+  readonly instance: IPublicClientApplication;
+  readonly account: AccountInfo;
+  readonly tenantId: string;
+
+  constructor(instance: IPublicClientApplication, account: AccountInfo) {
+    this.baseUrl = graphConfig.graphOrgEndpoint;
+    this.instance = instance;
+    this.account = account;
+    this.tenantId = account.tenantId;
+  }
+
+  /**
+   * Look for a valid token in the cache, and if it is close to expiring or does not exist, will automatically try to refresh it for you using the cached refresh token
+   * The silent token requests to Microsoft Entra ID might fail for reasons like a password change or updated Conditional Access policies, then call an interactive method
+   * See: https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-browser/docs/acquire-token.md#acquiring-an-access-token
+   * @returns string
+   */
+  private getAccessToken = async (): Promise<string> => {
+    const request = {
+      scopes: ['User.Read'],
+      account: this.account,
+    };
+
+    try {
+      const authSilentResult = await this.instance.acquireTokenSilent(request);
+      return authSilentResult.accessToken;
+    } catch (error) {
+      // if acquiring the token silently fails, then present the user with the popup to get the token
+      if (error instanceof InteractionRequiredAuthError) {
+        const authInteractiveResult = await this.instance.acquireTokenPopup(request);
+        return authInteractiveResult.accessToken;
+      } else {
+        throw error;
+      }
+    }
+  };
+
+  /**
+   * Constructs options object for fetch request
+   * @param headers Headers
+   * @param accessToken string
+   * @returns options: {
+      method: string;
+      headers: Headers;
+    }
+   */
+  private constructOptions = (headers: Headers, accessToken: string) => {
+    const bearer = `Bearer ${accessToken}`;
+    headers.append('Authorization', bearer);
+
+    const options = {
+      method: 'GET',
+      headers: headers,
+    };
+
+    return options;
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private validateResponseStatus = (response: Response, responseJson: any) => {
+    if (response.status >= 400) {
+      const apiErrorResponse = {
+        status: response.status,
+        message: responseJson?.error?.message,
+      };
+
+      throw new MsGraphApiError(apiErrorResponse);
+    }
+  };
+
+  /**
+   * This function calls the Get organization endpoint to get the organization displayName
+   * @returns Promise<string>
+   */
+  getOrganizationDisplayName = async (): Promise<string> => {
+    const endpoint = `${this.baseUrl}${this.tenantId}?$select=displayName`;
+    const headers = new Headers();
+    headers.append('Content-Type', 'application/json');
+
+    let orgName = '';
+
+    try {
+      const accessToken = await this.getAccessToken();
+      const options = this.constructOptions(headers, accessToken);
+
+      const res = await fetch(endpoint, options);
+      const resJson = await res.json();
+      this.validateResponseStatus(res, resJson);
+
+      orgName = resJson.displayName;
+    } catch (error) {
+      console.error(error);
+    }
+
+    return orgName;
+  };
+
+  /**
+   * This function calls the Get organizationalBranding endpoint to get the organization logo
+   * @returns Promise<string>
+   */
+  getOrganizationLogo = async (): Promise<string> => {
+    const endpoint = `${this.baseUrl}${this.tenantId}/branding?$select=cdnList,faviconRelativeUrl,squareLogoRelativeUrl`;
+    const headers = new Headers();
+    headers.append('Content-Type', 'application/json');
+    // Required additional header, passing in 0 returns the default organizational branding object
+    headers.append('Accept-Language', '0');
+
+    let image = '';
+
+    try {
+      const accessToken = await this.getAccessToken();
+      const options = this.constructOptions(headers, accessToken);
+
+      const res = await fetch(endpoint, options);
+      const resJson = await res.json();
+      this.validateResponseStatus(res, resJson);
+
+      image = this.constructImageUrl(resJson);
+    } catch (error) {
+      console.error(error);
+    }
+
+    return image;
+  };
+
+  /**
+   * Constructs the logo image URL from the organizationalBranding API response
+   * @returns string
+   */
+  private constructImageUrl = (response: OrganizationalBrandingSuccessResponse): string => {
+    const { faviconRelativeUrl, squareLogoRelativeUrl, cdnList } = response;
+    // A list of base URLs for all available CDN providers that are serving the assets of the current resource, just using the first one in the list
+    const cdn = cdnList[0];
+    const baseUrl = `https://${cdn}/`;
+
+    // Priority of logos: square logo, then favicon, then fallback to no logo
+    if (squareLogoRelativeUrl) return `${baseUrl}${squareLogoRelativeUrl}`;
+    if (faviconRelativeUrl) return `${baseUrl}${faviconRelativeUrl}`;
+    return '';
+  };
+}
+
+export default MsGraph;

--- a/apps/microsoft-teams/frontend/src/utils/msGraphApi.ts
+++ b/apps/microsoft-teams/frontend/src/utils/msGraphApi.ts
@@ -113,22 +113,14 @@ class MsGraph {
     const headers = new Headers();
     headers.append('Content-Type', 'application/json');
 
-    let orgName = '';
+    const accessToken = await this.getAccessToken();
+    const options = this.constructOptions(headers, accessToken);
 
-    try {
-      const accessToken = await this.getAccessToken();
-      const options = this.constructOptions(headers, accessToken);
+    const res = await fetch(endpoint, options);
+    const resJson = await res.json();
+    this.validateResponseStatus(res, resJson);
 
-      const res = await fetch(endpoint, options);
-      const resJson = await res.json();
-      this.validateResponseStatus(res, resJson);
-
-      orgName = resJson.displayName;
-    } catch (error) {
-      console.error(error);
-    }
-
-    return orgName;
+    return resJson.displayName;
   };
 
   /**
@@ -142,22 +134,14 @@ class MsGraph {
     // Required additional header, passing in 0 returns the default organizational branding object
     headers.append('Accept-Language', '0');
 
-    let image = '';
+    const accessToken = await this.getAccessToken();
+    const options = this.constructOptions(headers, accessToken);
 
-    try {
-      const accessToken = await this.getAccessToken();
-      const options = this.constructOptions(headers, accessToken);
+    const res = await fetch(endpoint, options);
+    const resJson = await res.json();
+    this.validateResponseStatus(res, resJson);
 
-      const res = await fetch(endpoint, options);
-      const resJson = await res.json();
-      this.validateResponseStatus(res, resJson);
-
-      image = this.constructImageUrl(resJson);
-    } catch (error) {
-      console.error(error);
-    }
-
-    return image;
+    return this.constructImageUrl(resJson);
   };
 
   /**

--- a/apps/microsoft-teams/frontend/test/mocks/api/handlers.ts
+++ b/apps/microsoft-teams/frontend/test/mocks/api/handlers.ts
@@ -8,6 +8,21 @@ const mockBrandingResponse = {
   squareLogoRelativeUrl: 'square',
 };
 
+const invalidTokenResponse = {
+  error: {
+    code: 'InvalidAuthenticationToken',
+    message: 'Lifetime validation failed, the token is expired.',
+  },
+};
+
+const resourceNotFoundResponse = {
+  error: {
+    code: 'Request_ResourceNotFound',
+    message:
+      "Resource 'mock-tenant' does not exist or one of its queried reference-property objects are not present.",
+  },
+};
+
 export const handlers = [
   http.get(`${graphConfig.graphOrgEndpoint}:tenantId`, () => {
     return HttpResponse.json({ displayName: 'Company ABC' }, { status: 200 });
@@ -33,5 +48,15 @@ export const noLogosHandler = [
       { ...mockBrandingResponse, squareLogoRelativeUrl: null, faviconRelativeUrl: null },
       { status: 200 }
     );
+  }),
+];
+
+export const errorHandlers = [
+  http.get(`${graphConfig.graphOrgEndpoint}:tenantId`, () => {
+    return HttpResponse.json(invalidTokenResponse, { status: 401 });
+  }),
+
+  http.get(`${graphConfig.graphOrgEndpoint}:tenantId/branding`, () => {
+    return HttpResponse.json(resourceNotFoundResponse, { status: 404 });
   }),
 ];

--- a/apps/microsoft-teams/frontend/test/mocks/api/handlers.ts
+++ b/apps/microsoft-teams/frontend/test/mocks/api/handlers.ts
@@ -1,0 +1,37 @@
+import { HttpResponse, http } from 'msw';
+import { graphConfig } from '@configs/authConfig';
+
+const mockBrandingResponse = {
+  '@odata.context': 'test-string',
+  cdnList: ['images.example'],
+  faviconRelativeUrl: 'favicon',
+  squareLogoRelativeUrl: 'square',
+};
+
+export const handlers = [
+  http.get(`${graphConfig.graphOrgEndpoint}:tenantId`, () => {
+    return HttpResponse.json({ displayName: 'Company ABC' }, { status: 200 });
+  }),
+
+  http.get(`${graphConfig.graphOrgEndpoint}:tenantId/branding`, () => {
+    return HttpResponse.json(mockBrandingResponse, { status: 200 });
+  }),
+];
+
+export const noSquareLogoHandler = [
+  http.get(`${graphConfig.graphOrgEndpoint}:tenantId/branding`, () => {
+    return HttpResponse.json(
+      { ...mockBrandingResponse, squareLogoRelativeUrl: '' },
+      { status: 200 }
+    );
+  }),
+];
+
+export const noLogosHandler = [
+  http.get(`${graphConfig.graphOrgEndpoint}:tenantId/branding`, () => {
+    return HttpResponse.json(
+      { ...mockBrandingResponse, squareLogoRelativeUrl: null, faviconRelativeUrl: null },
+      { status: 200 }
+    );
+  }),
+];

--- a/apps/microsoft-teams/frontend/test/mocks/api/server.ts
+++ b/apps/microsoft-teams/frontend/test/mocks/api/server.ts
@@ -1,0 +1,5 @@
+import { setupServer } from 'msw/node';
+import { handlers } from './handlers';
+
+// This configures a Service Worker with the given request handlers.
+export const server = setupServer(...handlers);

--- a/apps/microsoft-teams/frontend/test/mocks/mockMsal.ts
+++ b/apps/microsoft-teams/frontend/test/mocks/mockMsal.ts
@@ -23,6 +23,7 @@ const mockMsalWithAccounts: MockMsal = {
   instance: {
     loginPopup: vi.fn(),
     logoutPopup: vi.fn(),
+    acquireTokenSilent: vi.fn().mockResolvedValue({ accessToken: 'mock-token' }),
   },
   accounts: [
     {

--- a/apps/microsoft-teams/frontend/test/setup.ts
+++ b/apps/microsoft-teams/frontend/test/setup.ts
@@ -1,0 +1,6 @@
+import { server } from './mocks/api/server';
+import { afterAll, afterEach, beforeAll } from 'vitest';
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
+afterAll(() => server.close());
+afterEach(() => server.resetHandlers());

--- a/apps/microsoft-teams/frontend/tsconfig.json
+++ b/apps/microsoft-teams/frontend/tsconfig.json
@@ -24,7 +24,8 @@
       "@helpers/*": ["./src/helpers/*"],
       "@hooks/*": ["./src/hooks/*"],
       "@locations/*": ["./src/locations/*"],
-      "@test/*": ["./test/*"]
+      "@test/*": ["./test/*"],
+      "@utils/*": ["./src/utils/*"]
     }
   },
   "include": ["src", "test"]

--- a/apps/microsoft-teams/frontend/vite.config.ts
+++ b/apps/microsoft-teams/frontend/vite.config.ts
@@ -38,5 +38,6 @@ export default defineConfig(() => ({
   },
   test: {
     environment: 'happy-dom',
+    setupFiles: ['./test/setup.ts'],
   },
 }));

--- a/apps/microsoft-teams/frontend/vite.config.ts
+++ b/apps/microsoft-teams/frontend/vite.config.ts
@@ -33,6 +33,7 @@ export default defineConfig(() => ({
       '@hooks': path.resolve(__dirname, './src/hooks'),
       '@locations': path.resolve(__dirname, './src/locations'),
       '@test': path.resolve(__dirname, './test'),
+      '@utils': path.resolve(__dirname, './src/utils'),
     },
   },
   test: {


### PR DESCRIPTION
## Purpose

This PR updates the access section of the MS Teams app config page to display the organization name and logo after a user authenticates with Microsoft. 

<img width="928" alt="Screenshot 2024-02-14 at 9 38 06 AM" src="https://github.com/contentful/apps/assets/62958907/7eed5f7a-ab8b-4cce-a91d-1c25a6577c51">

## Approach

While the tenant Id and the username can be accessed from the MSAL hook, we need to call the MS Graph API in order to get the organization name and logo. I created a new `msGraphApi` util class to work with the API. This class handles getting the access token for the API request, calling the correct endpoints, and error handling. 

If there is an error getting the organization name and logo, these items won't display and a notification will show saying that there is error getting organization details

![Screenshot 2024-02-14 at 8 45 38 AM](https://github.com/contentful/apps/assets/62958907/5f4a67a5-da47-4910-a44b-0921e183cf9d)

In order to create tests for `msGraphApi`, I utilized MSW to mock the HTTP requests. 

## Testing steps

Navigate to the MS Teams development space and authenticate to our sandbox account to see the org name and logo.

## Breaking Changes

## Dependencies and/or References

See my notes in confluence for more information about working with the MS Graph API.

## Deployment
