### PR TITLE
Clarify update/cancel duplicate notification instructions for MS Teams

### DIFF
--- a/apps/microsoft-teams/frontend/src/components/config/DuplicateModal/DuplicateModal.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/DuplicateModal/DuplicateModal.tsx
@@ -1,4 +1,4 @@
-import { ModalConfirm, Text } from '@contentful/f36-components';
+import { ModalConfirm, Text, Box } from '@contentful/f36-components';
 import { notificationsSection } from '@constants/configCopy';
 
 interface DuplicateModalProps {
@@ -21,7 +21,12 @@ const DuplicateModal = (props: DuplicateModalProps) => {
       onConfirm={handleConfirm}
       confirmLabel={notificationsSection.duplicateModal.confirmDuplicate}
       cancelLabel={notificationsSection.duplicateModal.goBack}>
-      <Text>{notificationsSection.duplicateModal.confirmDuplicateDescription}</Text>
+      <Box marginBottom="spacingM">
+        <Text>{notificationsSection.duplicateModal.confirmDuplicateDescription}</Text>
+      </Box>
+      <Box>
+        <Text>{notificationsSection.duplicateModal.confirmDuplicateDescriptionTwo}</Text>
+      </Box>
     </ModalConfirm>
   );
 };

--- a/apps/microsoft-teams/frontend/src/constants/configCopy.ts
+++ b/apps/microsoft-teams/frontend/src/constants/configCopy.ts
@@ -38,10 +38,12 @@ const notificationsSection = {
     'If you delete this notification you will no longer get updates about this content type in Microsoft Teams.',
   duplicateModal: {
     modalHeaderTitle: 'Duplicate Notification',
-    confirmDuplicate: 'Update existing notification',
-    goBack: 'Go back to editing',
+    confirmDuplicate: 'Yes',
+    goBack: 'Cancel',
     confirmDuplicateDescription:
-      'You already have a notification set up for this content type and MS Teams channel. Would you like to update the existing notification instead of creating a new one?',
+      'You already have a notification set up for this content type and Teams channel. Do you want to make changes to the existing notification?',
+    confirmDuplicateDescriptionTwo:
+      'If yes, edits to entry actions will apply to your existing notification.  If you prefer to cancel, you can then edit the content type or Teams channel.',
   },
   updateConfirmation: 'Notification settings updated',
   saveWarning: 'Save the app to persist these settings',


### PR DESCRIPTION
## Purpose
Update the copy of `<DuplicateModal>` to better explain to a user their options when they are attempting to make changes to an existing notification.

1. Confirm option => "If yes, edits to entry actions will apply to your existing notification."
2. Cancel option => "If you prefer to cancel, you can then edit the content type or Teams channel."

### New
<img width="539" alt="Screenshot 2024-02-14 at 11 40 16 AM" src="https://github.com/contentful/apps/assets/158083968/e7cd6456-4f4c-4f36-9166-7af3db643a5f">

### Old
<img width="533" alt="Screenshot 2024-02-14 at 11 41 42 AM" src="https://github.com/contentful/apps/assets/158083968/e3f1d305-dcc9-4208-ad49-627fb784e721">




This is part of the Mob QA feedback for MS Teams.