### PR TITLE
Refactor(MS-Teams) - Lift "notification index to edit" state from <NotificationSection> to <ConfigPage>

### DIFF
--- a/apps/microsoft-teams/frontend/src/components/config/ConfigPage/ConfigPage.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ConfigPage/ConfigPage.tsx
@@ -14,6 +14,7 @@ import { Box, Heading, Paragraph } from '@contentful/f36-components';
 const ConfigPage = () => {
   const [parameters, dispatchParameters] = useReducer(parameterReducer, initialParameters);
   const [isAppInstalled, setIsAppInstalled] = useState(false);
+  const [notificationIndexToEdit, setNotificationIndexToEdit] = useState<number | null>(null);
 
   const sdk = useSDK<ConfigAppSDK>();
   // A hook that returns the PublicClientApplication instance from MSAL to see if there is an authenticated account
@@ -66,6 +67,8 @@ const ConfigPage = () => {
         <NotificationsSection
           notifications={parameters.notifications}
           dispatch={dispatchParameters}
+          notificationIndexToEdit={notificationIndexToEdit}
+          setNotificationIndexToEdit={setNotificationIndexToEdit}
         />
       ) : null}
     </>

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.spec.tsx
@@ -10,7 +10,14 @@ vi.mock('@contentful/react-apps-toolkit', () => ({
 
 describe('NotificationsSection component', () => {
   it('mounts with title and button', () => {
-    render(<NotificationsSection notifications={[]} dispatch={vi.fn()} />);
+    render(
+      <NotificationsSection
+        notifications={[]}
+        dispatch={vi.fn()}
+        setNotificationIndexToEdit={vi.fn()}
+        notificationIndexToEdit={null}
+      />
+    );
 
     expect(screen.getByText(notificationsSection.title)).toBeTruthy();
     expect(screen.getByText(notificationsSection.createButton)).toBeTruthy();

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, useState } from 'react';
+import { Dispatch, SetStateAction } from 'react';
 import { Box, ModalLauncher, Subheading } from '@contentful/f36-components';
 import { styles } from './NotificationsSection.styles';
 import { notificationsSection } from '@constants/configCopy';
@@ -22,11 +22,12 @@ import { useSDK } from '@contentful/react-apps-toolkit';
 interface Props {
   notifications: Notification[];
   dispatch: Dispatch<ParameterAction>;
+  notificationIndexToEdit: number | null;
+  setNotificationIndexToEdit: Dispatch<SetStateAction<number | null>>;
 }
 
 const NotificationsSection = (props: Props) => {
-  const { notifications, dispatch } = props;
-  const [notificationIndexToEdit, setNotificationIndexToEdit] = useState<number | null>(null);
+  const { notifications, dispatch, notificationIndexToEdit, setNotificationIndexToEdit } = props;
 
   const sdk = useSDK<ConfigAppSDK>();
 


### PR DESCRIPTION
### No Functional change, just refactor

Lifting the state up <NotificationSection> up to <ConfigPage> will enable the <ConfigPage> to be run validations on a currently open (in edit mode) notification.

## Purpose
There is an [existing concept in MS Teams of whether or not a notification is being edited](https://github.com/contentful/apps/blob/master/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.tsx#L29).  As part of the effort to improve validations for MS-Teams, we want to check to see if there are any "pending changes" when a user attempts to save by clicking the save button in the top right.  In order to detect any pending changes from the `<ConfigPage>`, the `notificationIndexToEdit` state needs to be lifted up one level.

## Screen recording of a notification being put into "edit" mode
![editting](https://github.com/contentful/apps/assets/158083968/9ca90734-8134-4620-993c-83492af66b0d)

## Testing steps

Tested manually and with unit tests.

## Breaking Changes

None

