### PR TITLE
MS Teams - validate "Pending Changes" when User clicks top-right (widgetRenderer?) save.

### DIFF
--- a/apps/microsoft-teams/frontend/src/components/config/ConfigPage/ConfigPage.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ConfigPage/ConfigPage.spec.tsx
@@ -1,11 +1,15 @@
 import ConfigPage from './ConfigPage';
 import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { mockSdk } from '@test/mocks';
-import { headerSection } from '@constants/configCopy';
+import { headerSection, notificationsSection } from '@constants/configCopy';
 
 vi.mock('@contentful/react-apps-toolkit', () => ({
   useSDK: () => mockSdk,
+}));
+
+vi.mock('@azure/msal-react', () => ({
+  useMsal: vi.fn().mockReturnValue({ accounts: [{ asdf: 'asdf' }] }),
 }));
 
 vi.mock('@components/config/AccessSection/AccessSection', () => ({
@@ -15,15 +19,57 @@ vi.mock('@components/config/AccessSection/AccessSection', () => ({
 }));
 
 vi.mock('@components/config/NotificationsSection/NotificationsSection', () => ({
-  default: () => {
-    return <div>Mock Notification Section</div>;
+  default: ({
+    setNotificationIndexToEdit,
+  }: {
+    setNotificationIndexToEdit: (idx: number) => void;
+  }) => {
+    return (
+      <>
+        <h1>MOCKED NOTIFICATIONS!!!!!</h1>
+        <button
+          onClick={() => {
+            setNotificationIndexToEdit(0);
+          }}
+          data-testid="edit-notification-btn">
+          edit
+        </button>
+      </>
+    );
   },
 }));
 
 describe('ConfigPage component', () => {
   it('mounts and renders title', () => {
-    render(<ConfigPage />);
+    const { unmount } = render(<ConfigPage />);
 
     expect(screen.getByText(headerSection.title)).toBeTruthy();
+
+    unmount();
+  });
+
+  describe('Saving via WidgetRenderer', () => {
+    it('prompts the User to save or cancel their pending changes when they have an open Notification modal', async () => {
+      const { unmount } = render(<ConfigPage />);
+
+      // Open an existing notification to edit it, i.e. pending change
+      const editButton = await waitFor(() => {
+        // waitFor async callbacks to resolve inside useEffects
+        return screen.getByTestId('edit-notification-btn');
+      });
+
+      // this will put <ConfigPage> in a state with pending changes. i.e. User has opened notification to be edited.
+      fireEvent.click(editButton);
+
+      // Mimic user clicking "Save" button in top right of widget Renderer
+      const response = await mockSdk.app.onConfigure.mock.calls.at(-1)[0]();
+
+      expect(response).toEqual(false);
+      expect(mockSdk.notifier.error).toHaveBeenLastCalledWith(
+        notificationsSection.pendingChangesWarning
+      );
+
+      unmount();
+    });
   });
 });

--- a/apps/microsoft-teams/frontend/src/components/config/ConfigPage/ConfigPage.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ConfigPage/ConfigPage.tsx
@@ -8,7 +8,7 @@ import { initialParameters } from '@constants/defaultParams';
 import useInitializeParameters from '@hooks/useInitializeParameters';
 import { useMsal } from '@azure/msal-react';
 import { styles } from './ConfigPage.styles';
-import { headerSection } from '@constants/configCopy';
+import { headerSection, notificationsSection } from '@constants/configCopy';
 import { Box, Heading, Paragraph } from '@contentful/f36-components';
 
 const ConfigPage = () => {
@@ -35,6 +35,13 @@ const ConfigPage = () => {
 
   const onConfigure = useCallback(async () => {
     const currentState = await sdk.app.getCurrentState();
+    // pending changes defined as an notifications that have been opened but not saved via <NotificationEditModeFooter/>
+    const pendingChanges = notificationIndexToEdit !== null;
+
+    if (pendingChanges) {
+      sdk.notifier.error(notificationsSection.pendingChangesWarning);
+      return false;
+    }
 
     if (!parameters.tenantId) {
       sdk.notifier.error('A valid Tenant Id is required');
@@ -45,7 +52,7 @@ const ConfigPage = () => {
       parameters,
       targetState: currentState,
     };
-  }, [parameters, sdk]);
+  }, [parameters, sdk, notificationIndexToEdit]);
 
   useEffect(() => {
     sdk.app.onConfigure(() => onConfigure());

--- a/apps/microsoft-teams/frontend/src/constants/configCopy.ts
+++ b/apps/microsoft-teams/frontend/src/constants/configCopy.ts
@@ -49,6 +49,7 @@ const notificationsSection = {
   },
   updateConfirmation: 'Notification settings updated',
   saveWarning: 'Save the app to persist these settings',
+  pendingChangesWarning: 'Notification changes are not saved. Please try again.',
 };
 
 const contentTypeSelection = {

--- a/apps/microsoft-teams/frontend/test/mocks/mockSdk.ts
+++ b/apps/microsoft-teams/frontend/test/mocks/mockSdk.ts
@@ -1,4 +1,5 @@
 import { vi } from 'vitest';
+import { mockChannels } from './mockChannels';
 
 const mockParameters = {
   tenantId: 'abc-123',
@@ -9,7 +10,23 @@ const mockParameters = {
 const mockSdk: any = {
   app: {
     onConfigure: vi.fn(),
-    getParameters: vi.fn().mockReturnValueOnce({}),
+    getParameters: vi.fn().mockReturnValue({
+      tenantId: 'tenantId',
+      notifications: [
+        {
+          channel: mockChannels[0],
+          contentTypeId: 'blogPost',
+          selectedEvents: {
+            'ContentManagement.Entry.archive': false,
+            'ContentManagement.Entry.create': false,
+            'ContentManagement.Entry.delete': false,
+            'ContentManagement.Entry.publish': false,
+            'ContentManagement.Entry.unarchive': false,
+            'ContentManagement.Entry.unpublish': false,
+          },
+        },
+      ],
+    }),
     setReady: vi.fn(),
     getCurrentState: vi.fn(),
     onConfigurationCompleted: vi.fn(),


### PR DESCRIPTION
## Purpose
Add a validation to MS Teams `onConfigure()` method that checks to see if there are any "pending changes".  If there are, inform the user via modal that they need to cancel/save their changes and return false (do no update configuration).  

### Pending Changes detected, configuration save blocked
The User has pending changes because they are in the process of editing a notification, but have not saved their work.
![validate](https://github.com/contentful/apps/assets/158083968/0a5d18eb-3b23-43e6-99a8-b0c7c421ca86)

### Pending Change detected, pending changes canceled, configuration save successful.
![new_validate](https://github.com/contentful/apps/assets/158083968/9ba90e7e-7f47-4321-9a3c-460d5b205e3f)

## Approach
Use the existing concept of "pending changes", see `notificationIndexToEdit`.  If so launch a modal and return false.

## Testing steps
1. Launch MS Teams FE locally and navigate to [MS Teams development space](https://app.contentful.com/spaces/zgiu00cobrsj/apps/4BaHsPHryAsKkDuNFdKRVM).  Invoke pending changes by editing an existing notification, or creating a new one.  Even if the notification is valid, if it is not saved we should inform the user and require them to save/cancel.

## Breaking Changes
n/a
