### PR TITLE
feat: save org details as params from auth flow [INTEG-1818]

### DIFF
--- a/apps/microsoft-teams/app-actions/src/types.ts
+++ b/apps/microsoft-teams/app-actions/src/types.ts
@@ -57,6 +57,9 @@ export interface TeamInstallation {
 
 export interface AppInstallationParameters {
   tenantId: string;
+  orgName: string;
+  orgLogo: string;
+  authenticatedUsername: string;
   notifications: Notification[];
 }
 

--- a/apps/microsoft-teams/app-actions/test/mocks.ts
+++ b/apps/microsoft-teams/app-actions/test/mocks.ts
@@ -145,6 +145,9 @@ export const mockNotificationUnsubscribed = {
 
 export const mockAppInstallationParameters: AppInstallationParameters = {
   tenantId: 'tenant-id',
+  orgName: 'Company ABC',
+  orgLogo: 'https://example.image/squareLogo',
+  authenticatedUsername: 'person1@companyabc.com',
   notifications: [mockNotification, mockNotificationUnsubscribed],
 };
 

--- a/apps/microsoft-teams/frontend/src/components/config/AccessSection/AccessSection.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/AccessSection/AccessSection.spec.tsx
@@ -7,6 +7,7 @@ import {
   mockParameters,
   mockSdk,
 } from '@test/mocks';
+import { accessSection } from '@constants/configCopy';
 
 const mocks = vi.hoisted(() => {
   return { useMsal: vi.fn() };
@@ -31,18 +32,21 @@ describe('AccessSection component', () => {
 
   it('displays correct copy when unathorized', () => {
     mocks.useMsal.mockReturnValue(mockMsalWithoutAccounts);
-    render(<AccessSection dispatch={vi.fn()} parameters={mockParameters} isAppInstalled={false} />);
+    const { unmount } = render(
+      <AccessSection dispatch={vi.fn()} parameters={mockParameters} isAppInstalled={false} />
+    );
 
-    expect(screen.getByText('Connect to Teams')).toBeTruthy();
+    waitFor(() => expect(screen.getByText(accessSection.login)).toBeTruthy());
+    unmount();
   });
 
   it('displays correct copy when authorized', async () => {
     mocks.useMsal.mockReturnValue(mockMsalWithAccounts);
-    render(<AccessSection dispatch={vi.fn()} parameters={mockParameters} isAppInstalled={true} />);
+    const { unmount } = render(
+      <AccessSection dispatch={vi.fn()} parameters={mockParameters} isAppInstalled={true} />
+    );
 
-    expect(screen.getByText('Disconnect')).toBeTruthy();
-    expect(screen.getByText('username@companyabc.com')).toBeTruthy();
-    await waitFor(() => expect(screen.getByText('Company ABC')).toBeTruthy());
-    await waitFor(() => expect(screen.getByRole('img')).toBeTruthy());
+    waitFor(() => expect(screen.getByText(accessSection.teamsAppLink)).toBeTruthy());
+    unmount();
   });
 });

--- a/apps/microsoft-teams/frontend/src/components/config/AccessSection/AccessSection.styles.ts
+++ b/apps/microsoft-teams/frontend/src/components/config/AccessSection/AccessSection.styles.ts
@@ -7,8 +7,4 @@ export const styles = {
     width: 16px;
   }
 `),
-  orgLogo: css({
-    /** Setting size to default size for favicon in MS organizational branding */
-    height: 32,
-  }),
 };

--- a/apps/microsoft-teams/frontend/src/components/config/AccessSectionCard/AccessSectionCard.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/AccessSectionCard/AccessSectionCard.spec.tsx
@@ -1,0 +1,64 @@
+import AccessSectionCard from './AccessSectionCard';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { mockParameters } from '@test/mocks';
+import { accessSection } from '@constants/configCopy';
+
+describe('AccessSectionCard component', () => {
+  it('displays correct copy when authorized', () => {
+    const { unmount } = render(
+      <AccessSectionCard
+        parameters={mockParameters}
+        loginInProgress={false}
+        logoutInProgress={false}
+        handleLogin={vi.fn()}
+        handleLogout={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText(mockParameters.orgName)).toBeTruthy();
+    expect(screen.getByAltText('logo')).toBeTruthy();
+    unmount();
+  });
+
+  it('displays correct copy when unauthorized', () => {
+    const { unmount } = render(
+      <AccessSectionCard
+        parameters={{ ...mockParameters, orgName: '' }}
+        loginInProgress={false}
+        logoutInProgress={false}
+        handleLogin={vi.fn()}
+        handleLogout={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText(mockParameters.authenticatedUsername)).toBeTruthy();
+    expect(screen.getByText(accessSection.orgDetailsError)).toBeTruthy();
+    unmount();
+  });
+
+  it('calls handlers when buttons are clicked', () => {
+    const loginSpy = vi.fn();
+    const logoutSpy = vi.fn();
+
+    const { unmount } = render(
+      <AccessSectionCard
+        parameters={{ ...mockParameters, orgName: '' }}
+        loginInProgress={false}
+        logoutInProgress={false}
+        handleLogin={loginSpy}
+        handleLogout={logoutSpy}
+      />
+    );
+
+    const loginButton = screen.getByText(accessSection.retry);
+    const logoutButton = screen.getByText(accessSection.logout);
+
+    loginButton.click();
+    logoutButton.click();
+
+    expect(loginSpy).toHaveBeenCalledOnce();
+    expect(logoutSpy).toHaveBeenCalledOnce();
+    unmount();
+  });
+});

--- a/apps/microsoft-teams/frontend/src/components/config/AccessSectionCard/AccessSectionCard.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/AccessSectionCard/AccessSectionCard.spec.tsx
@@ -5,7 +5,7 @@ import { mockParameters } from '@test/mocks';
 import { accessSection } from '@constants/configCopy';
 
 describe('AccessSectionCard component', () => {
-  it('displays correct copy when authorized', () => {
+  it('displays correct copy when authorized with full org details', () => {
     const { unmount } = render(
       <AccessSectionCard
         parameters={mockParameters}
@@ -21,7 +21,7 @@ describe('AccessSectionCard component', () => {
     unmount();
   });
 
-  it('displays correct copy when unauthorized', () => {
+  it('displays correct copy when authorized with no org details', () => {
     const { unmount } = render(
       <AccessSectionCard
         parameters={{ ...mockParameters, orgName: '' }}

--- a/apps/microsoft-teams/frontend/src/components/config/AccessSectionCard/AccessSectionCard.styles.ts
+++ b/apps/microsoft-teams/frontend/src/components/config/AccessSectionCard/AccessSectionCard.styles.ts
@@ -1,0 +1,19 @@
+import { css } from 'emotion';
+import tokens from '@contentful/f36-tokens';
+
+export const styles = {
+  orgLogo: css({
+    // Setting size to default size for favicon in MS organizational branding
+    height: 32,
+    marginRight: tokens.spacingM,
+  }),
+  cardError: css({
+    borderColor: tokens.colorNegative,
+  }),
+  errorText: css({
+    color: tokens.colorNegative,
+  }),
+  username: css({
+    fontWeight: tokens.fontWeightDemiBold,
+  }),
+};

--- a/apps/microsoft-teams/frontend/src/components/config/AccessSectionCard/AccessSectionCard.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/AccessSectionCard/AccessSectionCard.tsx
@@ -1,0 +1,76 @@
+import { Button, Card, Flex, Paragraph, Subheading } from '@contentful/f36-components';
+import { styles } from './AccessSectionCard.styles';
+import { accessSection } from '@constants/configCopy';
+import { ErrorCircleOutlineIcon } from '@contentful/f36-icons';
+import { AppInstallationParameters } from '@customTypes/configPage';
+
+interface Props {
+  parameters: AppInstallationParameters;
+  loginInProgress: boolean;
+  logoutInProgress: boolean;
+  handleLogin: () => Promise<void>;
+  handleLogout: () => void;
+}
+
+const AccessSectionCard = (props: Props) => {
+  const { parameters, loginInProgress, logoutInProgress, handleLogin, handleLogout } = props;
+  const { logout, orgDetailsError, retry } = accessSection;
+  const hasOrgDetails = !!parameters.orgName;
+
+  const renderCardContent = () => {
+    if (hasOrgDetails) {
+      return (
+        <>
+          <Flex alignItems="center">
+            {parameters.orgLogo && (
+              <img className={styles.orgLogo} src={parameters.orgLogo} alt="logo"></img>
+            )}
+            <Subheading marginBottom="none">{parameters.orgName}</Subheading>
+          </Flex>
+          <Button
+            onClick={() => handleLogout()}
+            isDisabled={logoutInProgress}
+            isLoading={logoutInProgress}>
+            {logout}
+          </Button>
+        </>
+      );
+    }
+
+    return (
+      <>
+        <Flex flexDirection="column">
+          <Paragraph marginBottom="none" className={styles.username}>
+            {parameters.authenticatedUsername}
+          </Paragraph>
+          <Flex className={styles.errorText}>
+            <ErrorCircleOutlineIcon variant="negative" marginRight="spacing2Xs" />
+            {orgDetailsError}
+          </Flex>
+        </Flex>
+        <Flex gap="spacingXs">
+          <Button
+            onClick={() => handleLogout()}
+            isDisabled={logoutInProgress}
+            isLoading={logoutInProgress}>
+            {logout}
+          </Button>
+          <Button
+            onClick={() => handleLogin()}
+            isDisabled={loginInProgress}
+            isLoading={loginInProgress}>
+            {retry}
+          </Button>
+        </Flex>
+      </>
+    );
+  };
+
+  return (
+    <Card padding="large" className={!hasOrgDetails ? styles.cardError : ''}>
+      <Flex justifyContent="space-between">{renderCardContent()}</Flex>
+    </Card>
+  );
+};
+
+export default AccessSectionCard;

--- a/apps/microsoft-teams/frontend/src/components/config/ConfigPage/ConfigPage.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ConfigPage/ConfigPage.tsx
@@ -6,7 +6,6 @@ import NotificationsSection from '@components/config/NotificationsSection/Notifi
 import parameterReducer from '@components/config/parameterReducer';
 import { initialParameters } from '@constants/defaultParams';
 import useInitializeParameters from '@hooks/useInitializeParameters';
-import { useMsal } from '@azure/msal-react';
 import { styles } from './ConfigPage.styles';
 import { headerSection, notificationsSection } from '@constants/configCopy';
 import { Box, Heading, Paragraph } from '@contentful/f36-components';
@@ -17,8 +16,6 @@ const ConfigPage = () => {
   const [notificationIndexToEdit, setNotificationIndexToEdit] = useState<number | null>(null);
 
   const sdk = useSDK<ConfigAppSDK>();
-  // A hook that returns the PublicClientApplication instance from MSAL to see if there is an authenticated account
-  const { accounts } = useMsal();
 
   useInitializeParameters(dispatchParameters);
 
@@ -70,7 +67,7 @@ const ConfigPage = () => {
           isAppInstalled={isAppInstalled}
         />
       </Box>
-      {isAppInstalled && accounts.length ? (
+      {isAppInstalled && parameters.tenantId ? (
         <NotificationsSection
           notifications={parameters.notifications}
           dispatch={dispatchParameters}

--- a/apps/microsoft-teams/frontend/src/components/config/parameterReducer.ts
+++ b/apps/microsoft-teams/frontend/src/components/config/parameterReducer.ts
@@ -2,15 +2,15 @@ import { AppInstallationParameters, Notification } from '@customTypes/configPage
 import { defaultNotification } from '@constants/defaultParams';
 
 export enum actions {
-  UPDATE_TENANT_ID = 'updateTenantId',
+  UPDATE_MS_ACCOUNT_INFO = 'updateMsAccountInfo',
   UPDATE_NOTIFICATIONS = 'updateNotifications',
   ADD_NOTIFICATION = 'addNotification',
   APPLY_CONTENTFUL_PARAMETERS = 'applyContentfulParameters',
 }
 
-type TenantIdAction = {
-  type: actions.UPDATE_TENANT_ID;
-  payload: string;
+type MsAccountInfoAction = {
+  type: actions.UPDATE_MS_ACCOUNT_INFO;
+  payload: Omit<AppInstallationParameters, 'notifications'>;
 };
 
 type NotificationsAction = {
@@ -28,24 +28,33 @@ type ApplyContentfulParametersAction = {
 };
 
 export type ParameterAction =
-  | TenantIdAction
+  | MsAccountInfoAction
   | NotificationsAction
   | AddNotificationAction
   | ApplyContentfulParametersAction;
 
-const { UPDATE_TENANT_ID, UPDATE_NOTIFICATIONS, ADD_NOTIFICATION, APPLY_CONTENTFUL_PARAMETERS } =
-  actions;
+const {
+  UPDATE_MS_ACCOUNT_INFO,
+  UPDATE_NOTIFICATIONS,
+  ADD_NOTIFICATION,
+  APPLY_CONTENTFUL_PARAMETERS,
+} = actions;
 
 const parameterReducer = (
   state: AppInstallationParameters,
   action: ParameterAction
 ): AppInstallationParameters => {
   switch (action.type) {
-    case UPDATE_TENANT_ID:
+    case UPDATE_MS_ACCOUNT_INFO: {
+      const msAccountInfo = action.payload;
       return {
         ...state,
-        tenantId: action.payload,
+        tenantId: msAccountInfo.tenantId,
+        orgName: msAccountInfo.orgName,
+        orgLogo: msAccountInfo.orgLogo,
+        authenticatedUsername: msAccountInfo.authenticatedUsername,
       };
+    }
     case UPDATE_NOTIFICATIONS:
       return {
         ...state,
@@ -60,8 +69,10 @@ const parameterReducer = (
     case APPLY_CONTENTFUL_PARAMETERS: {
       const parameters = action.payload;
       return {
-        ...state,
         tenantId: parameters.tenantId ?? '',
+        orgName: parameters.orgName ?? '',
+        orgLogo: parameters.orgLogo ?? '',
+        authenticatedUsername: parameters.authenticatedUsername ?? '',
         notifications: parameters.notifications ?? [],
       };
     }

--- a/apps/microsoft-teams/frontend/src/constants/configCopy.ts
+++ b/apps/microsoft-teams/frontend/src/constants/configCopy.ts
@@ -16,6 +16,7 @@ const accessSection = {
   fieldName: 'Tenant Id',
   login: 'Connect to Teams',
   logout: 'Disconnect',
+  retry: 'Retry Authorization',
   teamsAppInfo:
     'Install the Contentful app in Microsoft Teams channels where you would like to receive notifications.  View Teams docs',
   teamsAppLink: 'View Teams docs',
@@ -27,7 +28,7 @@ const accessSection = {
   },
   updateConfirmation: 'Microsoft organization updated',
   saveWarning: 'Save the app to persist these settings',
-  authError: 'Failed to authenticate with Microsoft',
+  authError: 'Unable to connect to Microsoft. Check your credentials and try again.',
   orgDetailsError: 'Failed to get Microsoft organization details',
 };
 

--- a/apps/microsoft-teams/frontend/src/constants/defaultParams.ts
+++ b/apps/microsoft-teams/frontend/src/constants/defaultParams.ts
@@ -2,6 +2,9 @@ import { AppEventKey, AppInstallationParameters, SelectedEvents } from '@customT
 
 const initialParameters: AppInstallationParameters = {
   tenantId: '',
+  orgName: '',
+  orgLogo: '',
+  authenticatedUsername: '',
   notifications: [],
 };
 

--- a/apps/microsoft-teams/frontend/src/customTypes/configPage.ts
+++ b/apps/microsoft-teams/frontend/src/customTypes/configPage.ts
@@ -9,6 +9,9 @@ export enum AppEventKey {
 
 export interface AppInstallationParameters {
   tenantId: string;
+  orgName: string;
+  orgLogo: string;
+  authenticatedUsername: string;
   notifications: Notification[];
 }
 

--- a/apps/microsoft-teams/frontend/test/mocks/mockSdk.ts
+++ b/apps/microsoft-teams/frontend/test/mocks/mockSdk.ts
@@ -1,8 +1,12 @@
 import { vi } from 'vitest';
 import { mockChannels } from './mockChannels';
+import { AppInstallationParameters } from '@customTypes/configPage';
 
-const mockParameters = {
+const mockParameters: AppInstallationParameters = {
   tenantId: 'abc-123',
+  orgName: 'Company ABC',
+  orgLogo: 'https://example.image/squareLogo',
+  authenticatedUsername: 'person1@companyabc.com',
   notifications: [],
 };
 
@@ -34,9 +38,7 @@ const mockSdk: any = {
   },
   parameters: {
     instance: [],
-    installation: {
-      tenantId: mockParameters.tenantId,
-    },
+    installation: mockParameters,
   },
   ids: {
     app: 'test-app',


### PR DESCRIPTION
## Purpose

In order to prevent a user from having to regularly authenticate to Microsoft on the app config page, this PR updates the app installation parameters so that the org details (name, logo, and username) are persisted. 

## Approach

Persist additional information from Microsoft in the installation parameters. Also updated error handling for the Auth flow to align with designs. 

Here's the error a user sees if they are unable to authenticate to Microsoft
![Screenshot 2024-02-20 at 9 42 51 AM](https://github.com/contentful/apps/assets/62958907/b148bbff-21d3-46c9-a00f-c7d3e4e31c8f)

Here's the error a user sees if they cannot get the organization details from Microsoft
![Screenshot 2024-02-19 at 12 43 42 PM](https://github.com/contentful/apps/assets/62958907/9a2129ab-bfc6-448a-b3af-6c5f1c94bc66)

Here's an updated version of what successful authentication looks like (removed username)
![Screenshot 2024-02-20 at 9 40 16 AM](https://github.com/contentful/apps/assets/62958907/1c8aefd1-e9e2-4531-8fe7-f017ea095a05)

## Testing steps

Run the MS Teams frontend app locally in our testing environment

## Breaking Changes

This PR introduces new installation parameters, so an app might need to be reinstalled to see the full changes.

## Dependencies and/or References

## Deployment
