### PR TITLE
feat: disable test message and update test errors [INTEG-1812]

### DIFF
--- a/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.tsx
@@ -10,6 +10,7 @@ import {
   isNotificationReadyToSave,
   isNotificationNew,
   doesNotificationHaveChanges,
+  canTestNotificationBeSent,
 } from '@helpers/configHelpers';
 import CancelModal from '@components/config/CancelModal/CancelModal';
 import { ConfigAppSDK } from '@contentful/app-sdk';
@@ -141,6 +142,7 @@ const NotificationEditMode = (props: Props) => {
         handleSave={handleSave}
         isSaveDisabled={!isNotificationReadyToSave(editedNotification, notification)}
         isTestSending={isTestSending}
+        isTestDisabled={!canTestNotificationBeSent(editedNotification, notification)}
       />
     </Box>
   );

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationEditMode/NotificationEditMode.tsx
@@ -15,6 +15,7 @@ import {
 import CancelModal from '@components/config/CancelModal/CancelModal';
 import { ConfigAppSDK } from '@contentful/app-sdk';
 import { useSDK } from '@contentful/react-apps-toolkit';
+import { editModeFooter } from '@constants/configCopy';
 
 interface Props {
   index: number;
@@ -74,13 +75,15 @@ const NotificationEditMode = (props: Props) => {
       const body = JSON.parse(response.body);
 
       if (body.ok) {
-        sdk.notifier.success('A test message was sent');
+        sdk.notifier.success(editModeFooter.testSuccess);
       } else {
-        throw new Error(`Failed to send test message: ${body.errors?.[0]?.message}`);
+        throw new Error(`${editModeFooter.testError}: ${body.error.message}`);
       }
     } catch (error) {
       if (error instanceof Error) {
-        sdk.notifier.error(error.message || 'Failed to send test message');
+        sdk.notifier.error(error.message || editModeFooter.testError);
+      } else {
+        sdk.notifier.error(editModeFooter.testError);
       }
       console.error(error);
     } finally {

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationEditModeFooter/NotificationEditModeFooter.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationEditModeFooter/NotificationEditModeFooter.spec.tsx
@@ -12,6 +12,7 @@ describe('NotificationEditModeFooter component', () => {
         handleSave={vi.fn()}
         isSaveDisabled={false}
         isTestSending={false}
+        isTestDisabled={false}
       />
     );
 
@@ -29,6 +30,7 @@ describe('NotificationEditModeFooter component', () => {
         handleSave={mockHandleSave}
         isSaveDisabled={false}
         isTestSending={false}
+        isTestDisabled={false}
       />
     );
 
@@ -45,6 +47,7 @@ describe('NotificationEditModeFooter component', () => {
         handleSave={mockHandleSaveDisabled}
         isSaveDisabled={true}
         isTestSending={false}
+        isTestDisabled={false}
       />
     );
 
@@ -64,6 +67,7 @@ describe('NotificationEditModeFooter component', () => {
         handleSave={vi.fn()}
         isSaveDisabled={false}
         isTestSending={false}
+        isTestDisabled={false}
       />
     );
 
@@ -80,6 +84,7 @@ describe('NotificationEditModeFooter component', () => {
         handleSave={mockHandleCancelDisabled}
         isSaveDisabled={true}
         isTestSending={false}
+        isTestDisabled={false}
       />
     );
 

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationEditModeFooter/NotificationEditModeFooter.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationEditModeFooter/NotificationEditModeFooter.tsx
@@ -8,10 +8,12 @@ interface Props {
   handleSave: () => void;
   isSaveDisabled: boolean;
   isTestSending: boolean;
+  isTestDisabled: boolean;
 }
 
 const NotificationEditModeFooter = (props: Props) => {
-  const { handleTest, handleCancel, handleSave, isSaveDisabled, isTestSending } = props;
+  const { handleTest, handleCancel, handleSave, isSaveDisabled, isTestSending, isTestDisabled } =
+    props;
 
   return (
     <Box className={styles.footer}>
@@ -21,7 +23,7 @@ const NotificationEditModeFooter = (props: Props) => {
             variant="transparent"
             onClick={handleTest}
             isLoading={isTestSending}
-            isDisabled={isTestSending}>
+            isDisabled={isTestDisabled || isTestSending}>
             {editModeFooter.test}
           </Button>
           <Button variant="secondary" onClick={handleCancel}>

--- a/apps/microsoft-teams/frontend/src/constants/configCopy.ts
+++ b/apps/microsoft-teams/frontend/src/constants/configCopy.ts
@@ -118,6 +118,8 @@ const eventsSelection = {
 
 const editModeFooter = {
   test: 'Send test message',
+  testSuccess: 'A test message was sent',
+  testError: 'Failed to send test message',
   cancel: 'Cancel',
   save: 'Save',
   confirmCancelDescription: 'If you cancel, your changes will not be saved.',

--- a/apps/microsoft-teams/frontend/src/helpers/configHelpers.spec.ts
+++ b/apps/microsoft-teams/frontend/src/helpers/configHelpers.spec.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest';
 import {
   getContentTypeName,
   isNotificationReadyToSave,
+  canTestNotificationBeSent,
+  areAllFieldsCompleted,
   isNotificationNew,
   doesNotificationHaveChanges,
   getUniqueNotifications,
@@ -33,6 +35,26 @@ describe('isNotificationReadyToSave', () => {
 
   it('should return true when it is ready', () => {
     expect(isNotificationReadyToSave(mockNotification, defaultNotification)).toEqual(true);
+  });
+});
+
+describe('canTestNotificationBeSent', () => {
+  it('should return false when it is not ready to be sent', () => {
+    expect(canTestNotificationBeSent(defaultNotification, defaultNotification)).toEqual(false);
+  });
+
+  it('should return true when it is ready to be sent', () => {
+    expect(canTestNotificationBeSent(mockNotification, defaultNotification)).toEqual(true);
+  });
+});
+
+describe('areAllFieldsCompleted', () => {
+  it('should return false when fields are not completed', () => {
+    expect(areAllFieldsCompleted(defaultNotification)).toEqual(false);
+  });
+
+  it('should return true when fields are completed', () => {
+    expect(areAllFieldsCompleted(mockNotification)).toEqual(true);
   });
 });
 

--- a/apps/microsoft-teams/frontend/src/helpers/configHelpers.ts
+++ b/apps/microsoft-teams/frontend/src/helpers/configHelpers.ts
@@ -33,13 +33,40 @@ const isNotificationReadyToSave = (
   notification: Notification
 ): boolean => {
   const hasChanges = doesNotificationHaveChanges(editedNotification, notification);
-
-  const hasContentType = !!editedNotification.contentTypeId;
-  const hasChannel = !!editedNotification.channel.id;
-  const hasEventEnabled = Object.values(editedNotification.selectedEvents).includes(true);
-  const hasAllFieldsCompleted = hasContentType && hasChannel && hasEventEnabled;
+  const hasAllFieldsCompleted = areAllFieldsCompleted(editedNotification);
 
   return hasChanges && hasAllFieldsCompleted;
+};
+
+/**
+ * Evaluates whether a test notification can be sent based on whether all necessary fields are completed
+ * @param editedNotification
+ * @param notification
+ * @returns boolean
+ */
+const canTestNotificationBeSent = (
+  editedNotification: Notification,
+  notification: Notification
+): boolean => {
+  const hasChanges = doesNotificationHaveChanges(editedNotification, notification);
+  const hasAllFieldsCompleted = areAllFieldsCompleted(
+    hasChanges ? editedNotification : notification
+  );
+
+  return hasAllFieldsCompleted;
+};
+
+/**
+ * Evaluates whether all necessary fields (content type, channel, events) are completed for a given notification
+ * @param notification
+ * @returns boolean
+ */
+const areAllFieldsCompleted = (notification: Notification): boolean => {
+  const hasContentType = !!notification.contentTypeId;
+  const hasChannel = !!notification.channel.id;
+  const hasEventEnabled = Object.values(notification.selectedEvents).includes(true);
+
+  return hasContentType && hasChannel && hasEventEnabled;
 };
 
 /**
@@ -133,6 +160,8 @@ const displayConfirmationNotifications = (
 export {
   getContentTypeName,
   isNotificationReadyToSave,
+  canTestNotificationBeSent,
+  areAllFieldsCompleted,
   isNotificationNew,
   doesNotificationHaveChanges,
   getUniqueNotifications,


### PR DESCRIPTION
## Purpose

This PR ensures that the `Test Message` button is disabled when a notification is incomplete. Also, it updates the error handling for sending the message to ensure that an error message is displayed.

## Approach

`Test Message` button should be disabled for incomplete notifications. The error handling for the test message was built on a previous implementation where the body had an errors array, this is now updated to be a single error object. Note that there is additional work that needs to be done in another PR in the bot service to display the proper error message, currently the error message says `malformed MsTeamsBotServiceResponse returned from MsTeamsBotService API`.

## Testing steps

Deployed to sandbox and sent a test to a deleted channel to see an error message.

## Breaking Changes

## Dependencies and/or References

## Deployment
