### PR TITLE
dependency(forma-36): Bump MS-Teams version of forma-36 to 4.60.1

### DIFF
--- a/apps/microsoft-teams/frontend/package-lock.json
+++ b/apps/microsoft-teams/frontend/package-lock.json
@@ -11,7 +11,7 @@
         "@azure/msal-browser": "^3.7.1",
         "@azure/msal-react": "^2.0.10",
         "@contentful/app-sdk": "^4.23.1",
-        "@contentful/f36-components": "4.60.0",
+        "@contentful/f36-components": "4.60.1",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "4.0.4",
         "@contentful/integration-frontend-toolkit": "^1.2.44",
@@ -618,15 +618,15 @@
       }
     },
     "node_modules/@contentful/f36-accordion": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.60.0.tgz",
-      "integrity": "sha512-oAX1LIUwFcmFIJRvgbjYEwiZDT7XwGRZ37bwBMkoTRrMgrXTGSEdNxLnjpSUco6pxAIt393vyycbxcNEBTUKDA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.60.1.tgz",
+      "integrity": "sha512-O+N/srnD4g7fmMAdEF3CXL9IV397BQV1tXlkCKJUx6e4ArxpYt0esTygQtY9q+7H4MHyRd8an5Exed4ZDTTF9Q==",
       "dependencies": {
-        "@contentful/f36-collapse": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-collapse": "^4.60.1",
+        "@contentful/f36-core": "^4.60.1",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -635,15 +635,15 @@
       }
     },
     "node_modules/@contentful/f36-asset": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.60.0.tgz",
-      "integrity": "sha512-93oH0l5whXCIWnK50WBzmnzEFTMzddgVdoLySbZj+fJcfD4dX7GGSNg5JOi9uJwIlZjCLLWlwS4G7QuwFLiX0Q==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.60.1.tgz",
+      "integrity": "sha512-9qX4SeaiR7AMSMvs/P8iFPhwJFnhi79aVaLFRzwO8VPbpk1SJDVxaIG5YWfkS8S7RCBC1QIBNZRVn8L/SvsePQ==",
       "dependencies": {
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-icon": "^4.60.0",
+        "@contentful/f36-core": "^4.60.1",
+        "@contentful/f36-icon": "^4.60.1",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -652,18 +652,18 @@
       }
     },
     "node_modules/@contentful/f36-autocomplete": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.60.0.tgz",
-      "integrity": "sha512-sFf0mQuss52RcBoHo2NBfceVrMqgvv1TJUPqfImXBIFZiIeI5xRl+R0Rgt6Qc8nH9WG4lg6oYzQgrZOxEnbkzA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.60.1.tgz",
+      "integrity": "sha512-hNFU8E/Ijp6wlDkO8QysCcevo1R71Pow3p8gCxfNEq4t99ZPICy7y++ypo4JJ5ewU13OnoAA8pdI+G5XZ7tfGQ==",
       "dependencies": {
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-forms": "^4.60.0",
+        "@contentful/f36-button": "^4.60.1",
+        "@contentful/f36-core": "^4.60.1",
+        "@contentful/f36-forms": "^4.60.1",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-popover": "^4.60.0",
-        "@contentful/f36-skeleton": "^4.60.0",
+        "@contentful/f36-popover": "^4.60.1",
+        "@contentful/f36-skeleton": "^4.60.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.1",
         "@contentful/f36-utils": "^4.24.3",
         "downshift": "^6.1.12",
         "emotion": "^10.0.17"
@@ -674,11 +674,11 @@
       }
     },
     "node_modules/@contentful/f36-badge": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.60.0.tgz",
-      "integrity": "sha512-tUceZPFS8/ynENGUKcw1tVSisIW3xrhH7S9QB5JRSSaL1ccOLT3AVZQjIxm5MmHUw2l1EhSZngpEPFZyHvWEdQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.60.1.tgz",
+      "integrity": "sha512-V1gnULoheIwTafCVGQ+IkGwYO9lm3xoPQXePHt+p4U8pC7LB9bJD+plZrC40nyrDNGxNrU0yC2NktdHKxoU5oA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.1",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
@@ -689,12 +689,12 @@
       }
     },
     "node_modules/@contentful/f36-button": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.60.0.tgz",
-      "integrity": "sha512-F4wAzsW8FR1bZBVdj3MI6l9/ugAJfouROaBihaCCLV+ebpqYB9Yg5urv304ZHl3vXA71n3/D39LGTasxBTuIVg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.60.1.tgz",
+      "integrity": "sha512-KYFLM22lhG3/Me+IL2pWeN5+r02fh+wCdGZOPv0K2S4w1RNMJp5HW/z8XxdYm5M2RU838Y7BcetF7L7ApjVFEA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-spinner": "^4.60.0",
+        "@contentful/f36-core": "^4.60.1",
+        "@contentful/f36-spinner": "^4.60.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
@@ -705,22 +705,22 @@
       }
     },
     "node_modules/@contentful/f36-card": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.60.0.tgz",
-      "integrity": "sha512-bl5BmrYipIZVSQARfKz8e6Ujgkb0pjCMfX2lM/2GslfNre3IlUJhv2/d4Cq7eatfhioMbQpk5lblV/wORvsAkw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.60.1.tgz",
+      "integrity": "sha512-PAJUvYTmsZ7ljrxdJ9P/WkJnPmKDvw4FIy9BLnhjbEZBCceITgmCWv6TlRnpH/ZgAA73Sge07zr4WCZrMvFsCQ==",
       "dependencies": {
-        "@contentful/f36-asset": "^4.60.0",
-        "@contentful/f36-badge": "^4.60.0",
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-drag-handle": "^4.60.0",
-        "@contentful/f36-icon": "^4.60.0",
+        "@contentful/f36-asset": "^4.60.1",
+        "@contentful/f36-badge": "^4.60.1",
+        "@contentful/f36-button": "^4.60.1",
+        "@contentful/f36-core": "^4.60.1",
+        "@contentful/f36-drag-handle": "^4.60.1",
+        "@contentful/f36-icon": "^4.60.1",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-menu": "^4.60.0",
-        "@contentful/f36-skeleton": "^4.60.0",
+        "@contentful/f36-menu": "^4.60.1",
+        "@contentful/f36-skeleton": "^4.60.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.60.0",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-tooltip": "^4.60.1",
+        "@contentful/f36-typography": "^4.60.1",
         "emotion": "^10.0.17",
         "truncate": "^3.0.0"
       },
@@ -730,11 +730,11 @@
       }
     },
     "node_modules/@contentful/f36-collapse": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.60.0.tgz",
-      "integrity": "sha512-Q5Jk7irONzrfOpSFw5C+Xdh//dVU4ismnaGEVi1mk+DgMvAR8AkVrcuP5jgeAVX7zk/ZSFzzlNc+1WBWEAIFQQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.60.1.tgz",
+      "integrity": "sha512-ocYyJC5KdWVTF/zWgBI/Q5aPg3wQyMTuPX8TzfF3RdIgOD19n8wGb8Fz0vkX/P7LfH3ClHscFiXWexz9bq4PEw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -744,44 +744,44 @@
       }
     },
     "node_modules/@contentful/f36-components": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.60.0.tgz",
-      "integrity": "sha512-9vDuLm0hQJPyKG+XpBle41AXRzRDcLqPl10HZ19bA+E/K1Pen9XFfkqH3qZqigF/peEyGJvzYomAmr2PCfJGRA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.60.1.tgz",
+      "integrity": "sha512-SOHI2R6ygDbVKERMuz6JMfo1RWNNdndVSaOiU89MkY/n4WGtjZ5n6PwQzpJx575yrp9p8ZpD0holCYCy6MStAA==",
       "dependencies": {
-        "@contentful/f36-accordion": "^4.60.0",
-        "@contentful/f36-asset": "^4.60.0",
-        "@contentful/f36-autocomplete": "^4.60.0",
-        "@contentful/f36-badge": "^4.60.0",
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-card": "^4.60.0",
-        "@contentful/f36-collapse": "^4.60.0",
-        "@contentful/f36-copybutton": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-datepicker": "^4.60.0",
-        "@contentful/f36-datetime": "^4.60.0",
-        "@contentful/f36-drag-handle": "^4.60.0",
-        "@contentful/f36-empty-state": "^4.60.0",
-        "@contentful/f36-entity-list": "^4.60.0",
-        "@contentful/f36-forms": "^4.60.0",
-        "@contentful/f36-icon": "^4.60.0",
+        "@contentful/f36-accordion": "^4.60.1",
+        "@contentful/f36-asset": "^4.60.1",
+        "@contentful/f36-autocomplete": "^4.60.1",
+        "@contentful/f36-badge": "^4.60.1",
+        "@contentful/f36-button": "^4.60.1",
+        "@contentful/f36-card": "^4.60.1",
+        "@contentful/f36-collapse": "^4.60.1",
+        "@contentful/f36-copybutton": "^4.60.1",
+        "@contentful/f36-core": "^4.60.1",
+        "@contentful/f36-datepicker": "^4.60.1",
+        "@contentful/f36-datetime": "^4.60.1",
+        "@contentful/f36-drag-handle": "^4.60.1",
+        "@contentful/f36-empty-state": "^4.60.1",
+        "@contentful/f36-entity-list": "^4.60.1",
+        "@contentful/f36-forms": "^4.60.1",
+        "@contentful/f36-icon": "^4.60.1",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-list": "^4.60.0",
-        "@contentful/f36-menu": "^4.60.0",
-        "@contentful/f36-modal": "^4.60.0",
+        "@contentful/f36-list": "^4.60.1",
+        "@contentful/f36-menu": "^4.60.1",
+        "@contentful/f36-modal": "^4.60.1",
         "@contentful/f36-navbar": "^4.1.0",
-        "@contentful/f36-note": "^4.60.0",
-        "@contentful/f36-notification": "^4.60.0",
-        "@contentful/f36-pagination": "^4.60.0",
-        "@contentful/f36-pill": "^4.60.0",
-        "@contentful/f36-popover": "^4.60.0",
-        "@contentful/f36-skeleton": "^4.60.0",
-        "@contentful/f36-spinner": "^4.60.0",
-        "@contentful/f36-table": "^4.60.0",
-        "@contentful/f36-tabs": "^4.60.0",
-        "@contentful/f36-text-link": "^4.60.0",
+        "@contentful/f36-note": "^4.60.1",
+        "@contentful/f36-notification": "^4.60.1",
+        "@contentful/f36-pagination": "^4.60.1",
+        "@contentful/f36-pill": "^4.60.1",
+        "@contentful/f36-popover": "^4.60.1",
+        "@contentful/f36-skeleton": "^4.60.1",
+        "@contentful/f36-spinner": "^4.60.1",
+        "@contentful/f36-table": "^4.60.1",
+        "@contentful/f36-tabs": "^4.60.1",
+        "@contentful/f36-text-link": "^4.60.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.60.0",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-tooltip": "^4.60.1",
+        "@contentful/f36-typography": "^4.60.1",
         "@contentful/f36-utils": "^4.24.3"
       },
       "peerDependencies": {
@@ -800,15 +800,15 @@
       }
     },
     "node_modules/@contentful/f36-copybutton": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.60.0.tgz",
-      "integrity": "sha512-fkxC4bk4YDH/GKjC0Djg/wLCgrvvoOVP+Fcx21Vogf1jlSmnJN4Ju3yOzdDKT8vPoKLlDNWRz3CbYHmH2rdqvA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.60.1.tgz",
+      "integrity": "sha512-mRq7IDZxCCLPtUPkmAoXXwmBymqwzib+9vFTngS/Zf/cqnsAgECJndj/V8i05T4wngV3H3AF0tLxzJZY9LrRsA==",
       "dependencies": {
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-button": "^4.60.1",
+        "@contentful/f36-core": "^4.60.1",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.60.0",
+        "@contentful/f36-tooltip": "^4.60.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -817,9 +817,9 @@
       }
     },
     "node_modules/@contentful/f36-core": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.60.0.tgz",
-      "integrity": "sha512-gJhZzmgjb+6jljgofnQnuaz5s2dP+tSeHzlpIzppW2KbFNvZfk408jbIZn9Ny2xw9LodXcEiFTuCewyYVQ7Dzw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.60.1.tgz",
+      "integrity": "sha512-S8jEQYR5FBrrKsTSe+Mf1X2foE19vWy0YpYi3qHgsre4hq53ZP879+2Ijaw9XSuL4TDIhkPErw9MICTDmo29zA==",
       "dependencies": {
         "@contentful/f36-tokens": "^4.0.4",
         "@emotion/core": "^10.1.1",
@@ -833,17 +833,17 @@
       }
     },
     "node_modules/@contentful/f36-datepicker": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.60.0.tgz",
-      "integrity": "sha512-mnXYlPRy0nMaS3REoV86nSc/iJ1QuX43gz5msFxqz4ZHazjYYgXa0fk48Qd5WNpUC1jXbW2H0rGX84o2Aa5BFA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.60.1.tgz",
+      "integrity": "sha512-Fui/bncpo0520N2S4/4Ypr8BDHM7249veKsr/dcFf4vprkDdFPvLm0Seyr6L54BShQ+Sp75CeLlZp0U+cOtQNw==",
       "dependencies": {
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-forms": "^4.60.0",
+        "@contentful/f36-button": "^4.60.1",
+        "@contentful/f36-core": "^4.60.1",
+        "@contentful/f36-forms": "^4.60.1",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-popover": "^4.60.0",
+        "@contentful/f36-popover": "^4.60.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.1",
         "date-fns": "^2.28.0",
         "emotion": "^10.0.17",
         "react-day-picker": "^8.7.1",
@@ -855,11 +855,11 @@
       }
     },
     "node_modules/@contentful/f36-datetime": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.60.0.tgz",
-      "integrity": "sha512-OXyAXS8DS2akxisCOfN5AkG0miPflNbtHWlo+XR2JjuCPBY5YJ0Hm6EzC304g5BnZlOEQ5nf5if87Gfzca4eLw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.60.1.tgz",
+      "integrity": "sha512-wynF24+1jnDLqXBVM8VPvsXCZW/kGq+VUycZpOYk8fWoW51hXm22X+h7fgbuZRJc8lGdeWx42pYVe3tdoeH2OA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.1",
         "@contentful/f36-tokens": "^4.0.4",
         "dayjs": "^1.11.5",
         "emotion": "^10.0.17"
@@ -870,11 +870,11 @@
       }
     },
     "node_modules/@contentful/f36-drag-handle": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.60.0.tgz",
-      "integrity": "sha512-VZE+iZnGO+ZRdu/KFlKZn9wbMB3LzYWMH+LVSLXZkKDtZm1agWOzovSLHZxsxIFkmZA7s3YphBo7vs5FOxEoQw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.60.1.tgz",
+      "integrity": "sha512-jUYFNNQBVr51sqUkbTgjDA5h8r9XZCee6jOtfFOq0UybgfUcQCg0J3ex6r35VxRBxMaGGI6ZpjYazhDpFgW1uA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.1",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
@@ -886,12 +886,12 @@
       }
     },
     "node_modules/@contentful/f36-empty-state": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.60.0.tgz",
-      "integrity": "sha512-P6k3l4sSo/VXxsGO19SPsf70eeUoL/cL1VvMmnGpFRbDexcJBs3pfcusArc0OBblYdsAVHOPSRxePiD7x/L4rg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.60.1.tgz",
+      "integrity": "sha512-Vw0K3zR3xDXqOMvldHatwrLAdaOzFbsPoX+4TuAgs2EQJ4SLCzaat6g3rIHQxZAYqPBcESmGdLMTtODR6xVcRw==",
       "dependencies": {
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -900,20 +900,20 @@
       }
     },
     "node_modules/@contentful/f36-entity-list": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.60.0.tgz",
-      "integrity": "sha512-O5i3MTg1bew3aSP/8mod7rONBcDpdReULcRq554z5WZUrzs4afMy3aP0qU/RBo/4T62sT142jJ09mulLbRYHwg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.60.1.tgz",
+      "integrity": "sha512-THVLMFgHbIF0w6SUYKpmx0wd0TzKzDIDbzzhSKh7qEdVgfUdO2AA0tN6WZ9RLvzO532tQn/RUT/GBX26YTuZGQ==",
       "dependencies": {
-        "@contentful/f36-badge": "^4.60.0",
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-drag-handle": "^4.60.0",
-        "@contentful/f36-icon": "^4.60.0",
+        "@contentful/f36-badge": "^4.60.1",
+        "@contentful/f36-button": "^4.60.1",
+        "@contentful/f36-core": "^4.60.1",
+        "@contentful/f36-drag-handle": "^4.60.1",
+        "@contentful/f36-icon": "^4.60.1",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-menu": "^4.60.0",
-        "@contentful/f36-skeleton": "^4.60.0",
+        "@contentful/f36-menu": "^4.60.1",
+        "@contentful/f36-skeleton": "^4.60.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -922,14 +922,14 @@
       }
     },
     "node_modules/@contentful/f36-forms": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.60.0.tgz",
-      "integrity": "sha512-m4JoJJEYkP6DwQCwaU8EPnTCAtca1j8aL+QDtEn/Pp92BjPD1hAT7FM7lWKhnAdDXOsK9j+1U6Tp6Oyce157WQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.60.1.tgz",
+      "integrity": "sha512-1xB4I8dBJ1FEshx9phXTdZ9mDhCKF2TOsvkEik0uhmVJJHZZ5s2hOQtHeXrYgz5qMDCzCLKa9MtzIVpVksf1Vw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.1",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.1",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
@@ -939,11 +939,11 @@
       }
     },
     "node_modules/@contentful/f36-icon": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.60.0.tgz",
-      "integrity": "sha512-+zbMsTd0duRhdvTviW49l1xCskgMhlSbE+31xORODqgoeC5bkbLMJNcI5PT4oc/CGGQqbl5NV0fVgBiKOUmSYw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.60.1.tgz",
+      "integrity": "sha512-ptXSWrs0EiKc60gQ9HwI6Uos3vvSCflnpWvW2ZBuLmx/ZTFsexjwaJj3JHWvKcIRuPh38/4a2aIgO+EdtTHErQ==",
       "dependencies": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -968,11 +968,11 @@
       }
     },
     "node_modules/@contentful/f36-list": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.60.0.tgz",
-      "integrity": "sha512-KPUqf/Y9GaD3HWMMZmeBVY1aoN3s7cDzY0z080yvaGCaQpbE0tTOkE/ZFRK8pE0eU94iabrcKg92MTreEEwWeA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.60.1.tgz",
+      "integrity": "sha512-LtoYH3/3HnTKh7AM+AaHpV+aXLlsvY9uLb+Pq/O1z9KQgqZkC37KguOKohi2fSS4trqRApewdzFzpqVX6FM5qA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -982,15 +982,15 @@
       }
     },
     "node_modules/@contentful/f36-menu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.60.0.tgz",
-      "integrity": "sha512-Rjn6WrGrJIPpkJaNQdj17KSHoYC3xj82W9YObtzl/W/huNhXV2IoH8p7q9kOaEuZjG80ERvuuno84xkLMiAaig==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.60.1.tgz",
+      "integrity": "sha512-qyMWv20UHzjAKV882VLWTnjY9eQQzA/0s7vpqEPF2lee0BRJCM8uxj5fJ01OIJ3k1WEBAcAyXULx0CV69wNUuw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.1",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-popover": "^4.60.0",
+        "@contentful/f36-popover": "^4.60.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.1",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
@@ -1000,15 +1000,15 @@
       }
     },
     "node_modules/@contentful/f36-modal": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.60.0.tgz",
-      "integrity": "sha512-9IixUm5RgOgtOviMhvmQKImjKK24XykoJymromOoQPBgI1rIqUxBhlwGWIPOYYtoA32mJNIL2erJhYM+zrR2+A==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.60.1.tgz",
+      "integrity": "sha512-K4nEYnQ8dpYXEr1e9I6RrSRm2CsG9hGMu8dRvReEF6FXNdZ4vrc/GQ7z+2g1DbVSwKqtPusejuXY0ixkrmJQLA==",
       "dependencies": {
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-button": "^4.60.1",
+        "@contentful/f36-core": "^4.60.1",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.1",
         "@types/react-modal": "^3.13.1",
         "emotion": "^10.0.17",
         "react-modal": "^3.16.1"
@@ -1038,16 +1038,16 @@
       }
     },
     "node_modules/@contentful/f36-note": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.60.0.tgz",
-      "integrity": "sha512-XnOMEo2U3jbPzy20bZgoyQjR7bwsMWGUQrcrE3H0cXSHYQaKuvWo6uaEMCsqr00LWkP1537tuWfr3Yalp33aiQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.60.1.tgz",
+      "integrity": "sha512-6jT3nPPtm7yt8VCvUJL1oId+LiMOt7p70bC6iKqJOD7XZKScFuRoGMMV9DwgC32pkzFDars5wsYh5rCkMCXlNQ==",
       "dependencies": {
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-icon": "^4.60.0",
+        "@contentful/f36-button": "^4.60.1",
+        "@contentful/f36-core": "^4.60.1",
+        "@contentful/f36-icon": "^4.60.1",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -1056,16 +1056,16 @@
       }
     },
     "node_modules/@contentful/f36-notification": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.60.0.tgz",
-      "integrity": "sha512-1YZ+eQhBLNEIc1dBcm4Ee0Rq1oXP8VvkYxczRmTaopKLlxUTZpvnjPZEq0wZTZ0Dc/uy8m92yByCCeo0UAVpXw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.60.1.tgz",
+      "integrity": "sha512-5cPKKFo44jnegmrWBpiDIek2eXAUvo3RPXWYcdEaCl2DkmrTCSUrhHxr2pLsgJ6naSHKmsMoJNzVMHSRWc8glQ==",
       "dependencies": {
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-button": "^4.60.1",
+        "@contentful/f36-core": "^4.60.1",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-text-link": "^4.60.0",
+        "@contentful/f36-text-link": "^4.60.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.1",
         "@swc/helpers": "^0.4.14",
         "emotion": "^10.0.17",
         "react-animate-height": "^3.0.4"
@@ -1076,16 +1076,16 @@
       }
     },
     "node_modules/@contentful/f36-pagination": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.60.0.tgz",
-      "integrity": "sha512-m/m+/wZxjO/EDPWGkdMDyGsxEe5iV6RnSMsVABk4QTOe7Zo05rqGUw6IjqzvecDgDwm1jUrYm/lhlNObwpcRlA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.60.1.tgz",
+      "integrity": "sha512-gXyznBc2ASlyDNWKbAIfTtqChQwNs6FDuX/6WrwqVzuK+kKtzXTwFSoljBK0otEJdV9tcl/rrv9g21jhEnKZzQ==",
       "dependencies": {
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-forms": "^4.60.0",
+        "@contentful/f36-button": "^4.60.1",
+        "@contentful/f36-core": "^4.60.1",
+        "@contentful/f36-forms": "^4.60.1",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -1094,16 +1094,16 @@
       }
     },
     "node_modules/@contentful/f36-pill": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.60.0.tgz",
-      "integrity": "sha512-1heXDtENtFUnDrgaVYu3GRTtIzP37AydxOw1BlpRUiKGvEzL8K217d7WVhKoMlUFk+uCS50j6t6cJxl/3E3Xtw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.60.1.tgz",
+      "integrity": "sha512-1Ym49J4O+O3hBcf2x+iQTa/pQ8knzMtsbITpNOsbG9YvnhYZ+PPDBQGT25OKbMsmscYzXtbMn5glyuGAphUQOg==",
       "dependencies": {
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-drag-handle": "^4.60.0",
+        "@contentful/f36-button": "^4.60.1",
+        "@contentful/f36-core": "^4.60.1",
+        "@contentful/f36-drag-handle": "^4.60.1",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.60.0",
+        "@contentful/f36-tooltip": "^4.60.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -1112,11 +1112,11 @@
       }
     },
     "node_modules/@contentful/f36-popover": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.60.0.tgz",
-      "integrity": "sha512-D0XNoO6//TLIzc/LLt7UnbdeGpDO3t/Eb3eKwK4Z0n+pI8bCEm6EltfbVO3mWMmPPSDhjLMa33q3hgGXt/BUAg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.60.1.tgz",
+      "integrity": "sha512-BenoDl0HBkUhJ6sEO/MILMDrJ9vr9nA2APwGRuRjFLQqRZPs0T+hdyC3uc+ie6qo/PtyYOmfqGb/+2ZceFtL2g==",
       "dependencies": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -1129,12 +1129,12 @@
       }
     },
     "node_modules/@contentful/f36-skeleton": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.60.0.tgz",
-      "integrity": "sha512-5WsjDlOxofFpGSqkAVCEdOC7TCyrQ7/AYdxjhzFJClKHIZ0xR/ZqcZyE6yy8DV9dj+XMil8ZIAyrOnwDX6fRNQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.60.1.tgz",
+      "integrity": "sha512-AC+5K4onW+oRkes0m6O/oWyZdE62Tlz6GXxiZ1YLDI00g3fO4louizcohSq+MTCyHdYAIs7wgXJkRkvqds9EGw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-table": "^4.60.0",
+        "@contentful/f36-core": "^4.60.1",
+        "@contentful/f36-table": "^4.60.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -1144,11 +1144,11 @@
       }
     },
     "node_modules/@contentful/f36-spinner": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.60.0.tgz",
-      "integrity": "sha512-T4Lyjr+sL0VC+2z7UVXAvOYxLZfsNECUpQGScI1iaEc6751Zz8HC+ccCFoKY3MUC/9k/bAE85vHTDoH6nmyutg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.60.1.tgz",
+      "integrity": "sha512-iykGHlNYjokA2a/SgEXNY8TeynU0YhBH7jX8cZePxxV7FqBaDqH5AdoEy5fnpL9wpsNmsgAyjUGre3rUi2NbBg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -1158,14 +1158,14 @@
       }
     },
     "node_modules/@contentful/f36-table": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.60.0.tgz",
-      "integrity": "sha512-hOX1x62mWKs1vAC6LOFAxX0+jxwicjIiC693t1oifqaKENwDj+vXZsYZrh+pCAjWILRpFsxjMP79L4pRWrZ0Mw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.60.1.tgz",
+      "integrity": "sha512-r1IFZobH5nD4Z5gXvTCDPtHTw2pwEFvmiKBZqPNkyrjjnwP/rQi10IohOlyzyeljDxDQ5xQskTPOE3kdhnml7g==",
       "dependencies": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.1",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -1174,11 +1174,11 @@
       }
     },
     "node_modules/@contentful/f36-tabs": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.60.0.tgz",
-      "integrity": "sha512-4WzMJ847rbZMm+nWFAWhK4V2cYoPMXHkWif9FDuk4v6RPVhpoANUsSpTX9hBo2fyR99Cyj0qeGtqfJ39ifUTvw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.60.1.tgz",
+      "integrity": "sha512-+vxf6WEYamegrT2ifkYeVlXuneTccfuHJss9FiPWZliOfRLnXe4Dgw2AkPXLlFphMzqS/drTLYnZ8/A+JhjD0g==",
       "dependencies": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@radix-ui/react-tabs": "^1.0.1",
         "emotion": "^10.0.17"
@@ -1189,11 +1189,11 @@
       }
     },
     "node_modules/@contentful/f36-text-link": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.60.0.tgz",
-      "integrity": "sha512-gYP7O8iHQnflVactunb4Ui2Ynu1VD4KnKVDKbXQmk7BxDzMNKy5puvUUIgmI2MqmtA85eMcauWFSC677KJemMw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.60.1.tgz",
+      "integrity": "sha512-qZCpdRPwCDcJUgfO3XpBhTPOM00DEjCCC5cItxSH3hOmRk4uVMjDJWQ+UsqOS1kaOsiPR/1Tssz2n34oXkSm/A==",
       "dependencies": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -1208,11 +1208,11 @@
       "integrity": "sha512-yPHNQjHVEuO+5nUoX3EbrQvLoU7ZjNc/w3RyCmYR3F/NWZCy/3n0Knhq5Jfow+CcXkVY6Ch526VlA3+ayEN2kA=="
     },
     "node_modules/@contentful/f36-tooltip": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.60.0.tgz",
-      "integrity": "sha512-qIdLgj9oOqr69RuRA/9LrV1VlOSHOWuRtSsSZDx87rQwk8OlvdflvCd3Y1TPyrFiAbsRV7QtSmxau+1UKhqQ8A==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.60.1.tgz",
+      "integrity": "sha512-n5aavHS4gwvfpKmXMU6d4RLmbulugkY63HNhckHSDFqne9P+CVJ2+6VyRdcPnkduwwsrOVeJmjZsNBOCB3572g==",
       "dependencies": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -1226,11 +1226,11 @@
       }
     },
     "node_modules/@contentful/f36-typography": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.60.0.tgz",
-      "integrity": "sha512-iEg1VT0wH3nUKZs8jSCxKnQPWVgrqckRuG3UpLzk4FKfyDHopimFMCLqy+XswWpA+aDRueMC4Il+TVVTO5N7qQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.60.1.tgz",
+      "integrity": "sha512-2Zun3++qS/Y1Sv6HLp0NBojIr2r9t9hNZSHQ/kKpF1kl5rrrVga2kIhaMoflL0N3GFIYUJLi54O1lblHSDYEQw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
@@ -5051,9 +5051,9 @@
       "dev": true
     },
     "node_modules/focus-lock": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-1.2.0.tgz",
-      "integrity": "sha512-MGUkR6hFmRNeoQxUtL9jYckpf6DZhlD4crD8FgEO9hS+yXaCg2vi2hat9fB9qUe9YsLa6eE9ykldqaqLU0kYKg==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-1.3.3.tgz",
+      "integrity": "sha512-hfXkZha7Xt4RQtrL1HBfspAuIj89Y0fb6GX0dfJilb8S2G/lvL4akPAcHq6xoD2NuZnDMCnZL/zQesMyeu6Psg==",
       "dependencies": {
         "tslib": "^2.0.3"
       },
@@ -7118,12 +7118,12 @@
       "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
     },
     "node_modules/react-focus-lock": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.10.1.tgz",
-      "integrity": "sha512-40zZ/Cvl3eMRoHrpcc11WmY+Md/kbjWofNLoGKvt+bti/mAeLZXkqbSIhhVlgXfdV1wD5puopcep5l4KX22Xvg==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.11.1.tgz",
+      "integrity": "sha512-IXLwnTBrLTlKTpASZXqqXJ8oymWrgAlOfuuDYN4XCuN1YJ72dwX198UCaF1QqGUk5C3QOnlMik//n3ufcfe8Ig==",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
-        "focus-lock": "^1.2.0",
+        "focus-lock": "^1.3.2",
         "prop-types": "^15.6.2",
         "react-clientside-effect": "^1.2.6",
         "use-callback-ref": "^1.3.0",
@@ -8975,162 +8975,162 @@
       }
     },
     "@contentful/f36-accordion": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.60.0.tgz",
-      "integrity": "sha512-oAX1LIUwFcmFIJRvgbjYEwiZDT7XwGRZ37bwBMkoTRrMgrXTGSEdNxLnjpSUco6pxAIt393vyycbxcNEBTUKDA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.60.1.tgz",
+      "integrity": "sha512-O+N/srnD4g7fmMAdEF3CXL9IV397BQV1tXlkCKJUx6e4ArxpYt0esTygQtY9q+7H4MHyRd8an5Exed4ZDTTF9Q==",
       "requires": {
-        "@contentful/f36-collapse": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-collapse": "^4.60.1",
+        "@contentful/f36-core": "^4.60.1",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-asset": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.60.0.tgz",
-      "integrity": "sha512-93oH0l5whXCIWnK50WBzmnzEFTMzddgVdoLySbZj+fJcfD4dX7GGSNg5JOi9uJwIlZjCLLWlwS4G7QuwFLiX0Q==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.60.1.tgz",
+      "integrity": "sha512-9qX4SeaiR7AMSMvs/P8iFPhwJFnhi79aVaLFRzwO8VPbpk1SJDVxaIG5YWfkS8S7RCBC1QIBNZRVn8L/SvsePQ==",
       "requires": {
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-icon": "^4.60.0",
+        "@contentful/f36-core": "^4.60.1",
+        "@contentful/f36-icon": "^4.60.1",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-autocomplete": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.60.0.tgz",
-      "integrity": "sha512-sFf0mQuss52RcBoHo2NBfceVrMqgvv1TJUPqfImXBIFZiIeI5xRl+R0Rgt6Qc8nH9WG4lg6oYzQgrZOxEnbkzA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.60.1.tgz",
+      "integrity": "sha512-hNFU8E/Ijp6wlDkO8QysCcevo1R71Pow3p8gCxfNEq4t99ZPICy7y++ypo4JJ5ewU13OnoAA8pdI+G5XZ7tfGQ==",
       "requires": {
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-forms": "^4.60.0",
+        "@contentful/f36-button": "^4.60.1",
+        "@contentful/f36-core": "^4.60.1",
+        "@contentful/f36-forms": "^4.60.1",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-popover": "^4.60.0",
-        "@contentful/f36-skeleton": "^4.60.0",
+        "@contentful/f36-popover": "^4.60.1",
+        "@contentful/f36-skeleton": "^4.60.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.1",
         "@contentful/f36-utils": "^4.24.3",
         "downshift": "^6.1.12",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-badge": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.60.0.tgz",
-      "integrity": "sha512-tUceZPFS8/ynENGUKcw1tVSisIW3xrhH7S9QB5JRSSaL1ccOLT3AVZQjIxm5MmHUw2l1EhSZngpEPFZyHvWEdQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.60.1.tgz",
+      "integrity": "sha512-V1gnULoheIwTafCVGQ+IkGwYO9lm3xoPQXePHt+p4U8pC7LB9bJD+plZrC40nyrDNGxNrU0yC2NktdHKxoU5oA==",
       "requires": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.1",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-button": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.60.0.tgz",
-      "integrity": "sha512-F4wAzsW8FR1bZBVdj3MI6l9/ugAJfouROaBihaCCLV+ebpqYB9Yg5urv304ZHl3vXA71n3/D39LGTasxBTuIVg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.60.1.tgz",
+      "integrity": "sha512-KYFLM22lhG3/Me+IL2pWeN5+r02fh+wCdGZOPv0K2S4w1RNMJp5HW/z8XxdYm5M2RU838Y7BcetF7L7ApjVFEA==",
       "requires": {
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-spinner": "^4.60.0",
+        "@contentful/f36-core": "^4.60.1",
+        "@contentful/f36-spinner": "^4.60.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-card": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.60.0.tgz",
-      "integrity": "sha512-bl5BmrYipIZVSQARfKz8e6Ujgkb0pjCMfX2lM/2GslfNre3IlUJhv2/d4Cq7eatfhioMbQpk5lblV/wORvsAkw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.60.1.tgz",
+      "integrity": "sha512-PAJUvYTmsZ7ljrxdJ9P/WkJnPmKDvw4FIy9BLnhjbEZBCceITgmCWv6TlRnpH/ZgAA73Sge07zr4WCZrMvFsCQ==",
       "requires": {
-        "@contentful/f36-asset": "^4.60.0",
-        "@contentful/f36-badge": "^4.60.0",
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-drag-handle": "^4.60.0",
-        "@contentful/f36-icon": "^4.60.0",
+        "@contentful/f36-asset": "^4.60.1",
+        "@contentful/f36-badge": "^4.60.1",
+        "@contentful/f36-button": "^4.60.1",
+        "@contentful/f36-core": "^4.60.1",
+        "@contentful/f36-drag-handle": "^4.60.1",
+        "@contentful/f36-icon": "^4.60.1",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-menu": "^4.60.0",
-        "@contentful/f36-skeleton": "^4.60.0",
+        "@contentful/f36-menu": "^4.60.1",
+        "@contentful/f36-skeleton": "^4.60.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.60.0",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-tooltip": "^4.60.1",
+        "@contentful/f36-typography": "^4.60.1",
         "emotion": "^10.0.17",
         "truncate": "^3.0.0"
       }
     },
     "@contentful/f36-collapse": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.60.0.tgz",
-      "integrity": "sha512-Q5Jk7irONzrfOpSFw5C+Xdh//dVU4ismnaGEVi1mk+DgMvAR8AkVrcuP5jgeAVX7zk/ZSFzzlNc+1WBWEAIFQQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.60.1.tgz",
+      "integrity": "sha512-ocYyJC5KdWVTF/zWgBI/Q5aPg3wQyMTuPX8TzfF3RdIgOD19n8wGb8Fz0vkX/P7LfH3ClHscFiXWexz9bq4PEw==",
       "requires": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-components": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.60.0.tgz",
-      "integrity": "sha512-9vDuLm0hQJPyKG+XpBle41AXRzRDcLqPl10HZ19bA+E/K1Pen9XFfkqH3qZqigF/peEyGJvzYomAmr2PCfJGRA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.60.1.tgz",
+      "integrity": "sha512-SOHI2R6ygDbVKERMuz6JMfo1RWNNdndVSaOiU89MkY/n4WGtjZ5n6PwQzpJx575yrp9p8ZpD0holCYCy6MStAA==",
       "requires": {
-        "@contentful/f36-accordion": "^4.60.0",
-        "@contentful/f36-asset": "^4.60.0",
-        "@contentful/f36-autocomplete": "^4.60.0",
-        "@contentful/f36-badge": "^4.60.0",
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-card": "^4.60.0",
-        "@contentful/f36-collapse": "^4.60.0",
-        "@contentful/f36-copybutton": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-datepicker": "^4.60.0",
-        "@contentful/f36-datetime": "^4.60.0",
-        "@contentful/f36-drag-handle": "^4.60.0",
-        "@contentful/f36-empty-state": "^4.60.0",
-        "@contentful/f36-entity-list": "^4.60.0",
-        "@contentful/f36-forms": "^4.60.0",
-        "@contentful/f36-icon": "^4.60.0",
+        "@contentful/f36-accordion": "^4.60.1",
+        "@contentful/f36-asset": "^4.60.1",
+        "@contentful/f36-autocomplete": "^4.60.1",
+        "@contentful/f36-badge": "^4.60.1",
+        "@contentful/f36-button": "^4.60.1",
+        "@contentful/f36-card": "^4.60.1",
+        "@contentful/f36-collapse": "^4.60.1",
+        "@contentful/f36-copybutton": "^4.60.1",
+        "@contentful/f36-core": "^4.60.1",
+        "@contentful/f36-datepicker": "^4.60.1",
+        "@contentful/f36-datetime": "^4.60.1",
+        "@contentful/f36-drag-handle": "^4.60.1",
+        "@contentful/f36-empty-state": "^4.60.1",
+        "@contentful/f36-entity-list": "^4.60.1",
+        "@contentful/f36-forms": "^4.60.1",
+        "@contentful/f36-icon": "^4.60.1",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-list": "^4.60.0",
-        "@contentful/f36-menu": "^4.60.0",
-        "@contentful/f36-modal": "^4.60.0",
+        "@contentful/f36-list": "^4.60.1",
+        "@contentful/f36-menu": "^4.60.1",
+        "@contentful/f36-modal": "^4.60.1",
         "@contentful/f36-navbar": "^4.1.0",
-        "@contentful/f36-note": "^4.60.0",
-        "@contentful/f36-notification": "^4.60.0",
-        "@contentful/f36-pagination": "^4.60.0",
-        "@contentful/f36-pill": "^4.60.0",
-        "@contentful/f36-popover": "^4.60.0",
-        "@contentful/f36-skeleton": "^4.60.0",
-        "@contentful/f36-spinner": "^4.60.0",
-        "@contentful/f36-table": "^4.60.0",
-        "@contentful/f36-tabs": "^4.60.0",
-        "@contentful/f36-text-link": "^4.60.0",
+        "@contentful/f36-note": "^4.60.1",
+        "@contentful/f36-notification": "^4.60.1",
+        "@contentful/f36-pagination": "^4.60.1",
+        "@contentful/f36-pill": "^4.60.1",
+        "@contentful/f36-popover": "^4.60.1",
+        "@contentful/f36-skeleton": "^4.60.1",
+        "@contentful/f36-spinner": "^4.60.1",
+        "@contentful/f36-table": "^4.60.1",
+        "@contentful/f36-tabs": "^4.60.1",
+        "@contentful/f36-text-link": "^4.60.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.60.0",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-tooltip": "^4.60.1",
+        "@contentful/f36-typography": "^4.60.1",
         "@contentful/f36-utils": "^4.24.3"
       }
     },
     "@contentful/f36-copybutton": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.60.0.tgz",
-      "integrity": "sha512-fkxC4bk4YDH/GKjC0Djg/wLCgrvvoOVP+Fcx21Vogf1jlSmnJN4Ju3yOzdDKT8vPoKLlDNWRz3CbYHmH2rdqvA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.60.1.tgz",
+      "integrity": "sha512-mRq7IDZxCCLPtUPkmAoXXwmBymqwzib+9vFTngS/Zf/cqnsAgECJndj/V8i05T4wngV3H3AF0tLxzJZY9LrRsA==",
       "requires": {
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-button": "^4.60.1",
+        "@contentful/f36-core": "^4.60.1",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.60.0",
+        "@contentful/f36-tooltip": "^4.60.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-core": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.60.0.tgz",
-      "integrity": "sha512-gJhZzmgjb+6jljgofnQnuaz5s2dP+tSeHzlpIzppW2KbFNvZfk408jbIZn9Ny2xw9LodXcEiFTuCewyYVQ7Dzw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.60.1.tgz",
+      "integrity": "sha512-S8jEQYR5FBrrKsTSe+Mf1X2foE19vWy0YpYi3qHgsre4hq53ZP879+2Ijaw9XSuL4TDIhkPErw9MICTDmo29zA==",
       "requires": {
         "@contentful/f36-tokens": "^4.0.4",
         "@emotion/core": "^10.1.1",
@@ -9140,17 +9140,17 @@
       }
     },
     "@contentful/f36-datepicker": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.60.0.tgz",
-      "integrity": "sha512-mnXYlPRy0nMaS3REoV86nSc/iJ1QuX43gz5msFxqz4ZHazjYYgXa0fk48Qd5WNpUC1jXbW2H0rGX84o2Aa5BFA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.60.1.tgz",
+      "integrity": "sha512-Fui/bncpo0520N2S4/4Ypr8BDHM7249veKsr/dcFf4vprkDdFPvLm0Seyr6L54BShQ+Sp75CeLlZp0U+cOtQNw==",
       "requires": {
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-forms": "^4.60.0",
+        "@contentful/f36-button": "^4.60.1",
+        "@contentful/f36-core": "^4.60.1",
+        "@contentful/f36-forms": "^4.60.1",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-popover": "^4.60.0",
+        "@contentful/f36-popover": "^4.60.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.1",
         "date-fns": "^2.28.0",
         "emotion": "^10.0.17",
         "react-day-picker": "^8.7.1",
@@ -9158,22 +9158,22 @@
       }
     },
     "@contentful/f36-datetime": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.60.0.tgz",
-      "integrity": "sha512-OXyAXS8DS2akxisCOfN5AkG0miPflNbtHWlo+XR2JjuCPBY5YJ0Hm6EzC304g5BnZlOEQ5nf5if87Gfzca4eLw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.60.1.tgz",
+      "integrity": "sha512-wynF24+1jnDLqXBVM8VPvsXCZW/kGq+VUycZpOYk8fWoW51hXm22X+h7fgbuZRJc8lGdeWx42pYVe3tdoeH2OA==",
       "requires": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.1",
         "@contentful/f36-tokens": "^4.0.4",
         "dayjs": "^1.11.5",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-drag-handle": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.60.0.tgz",
-      "integrity": "sha512-VZE+iZnGO+ZRdu/KFlKZn9wbMB3LzYWMH+LVSLXZkKDtZm1agWOzovSLHZxsxIFkmZA7s3YphBo7vs5FOxEoQw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.60.1.tgz",
+      "integrity": "sha512-jUYFNNQBVr51sqUkbTgjDA5h8r9XZCee6jOtfFOq0UybgfUcQCg0J3ex6r35VxRBxMaGGI6ZpjYazhDpFgW1uA==",
       "requires": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.1",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
@@ -9181,52 +9181,52 @@
       }
     },
     "@contentful/f36-empty-state": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.60.0.tgz",
-      "integrity": "sha512-P6k3l4sSo/VXxsGO19SPsf70eeUoL/cL1VvMmnGpFRbDexcJBs3pfcusArc0OBblYdsAVHOPSRxePiD7x/L4rg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.60.1.tgz",
+      "integrity": "sha512-Vw0K3zR3xDXqOMvldHatwrLAdaOzFbsPoX+4TuAgs2EQJ4SLCzaat6g3rIHQxZAYqPBcESmGdLMTtODR6xVcRw==",
       "requires": {
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-entity-list": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.60.0.tgz",
-      "integrity": "sha512-O5i3MTg1bew3aSP/8mod7rONBcDpdReULcRq554z5WZUrzs4afMy3aP0qU/RBo/4T62sT142jJ09mulLbRYHwg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.60.1.tgz",
+      "integrity": "sha512-THVLMFgHbIF0w6SUYKpmx0wd0TzKzDIDbzzhSKh7qEdVgfUdO2AA0tN6WZ9RLvzO532tQn/RUT/GBX26YTuZGQ==",
       "requires": {
-        "@contentful/f36-badge": "^4.60.0",
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-drag-handle": "^4.60.0",
-        "@contentful/f36-icon": "^4.60.0",
+        "@contentful/f36-badge": "^4.60.1",
+        "@contentful/f36-button": "^4.60.1",
+        "@contentful/f36-core": "^4.60.1",
+        "@contentful/f36-drag-handle": "^4.60.1",
+        "@contentful/f36-icon": "^4.60.1",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-menu": "^4.60.0",
-        "@contentful/f36-skeleton": "^4.60.0",
+        "@contentful/f36-menu": "^4.60.1",
+        "@contentful/f36-skeleton": "^4.60.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-forms": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.60.0.tgz",
-      "integrity": "sha512-m4JoJJEYkP6DwQCwaU8EPnTCAtca1j8aL+QDtEn/Pp92BjPD1hAT7FM7lWKhnAdDXOsK9j+1U6Tp6Oyce157WQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.60.1.tgz",
+      "integrity": "sha512-1xB4I8dBJ1FEshx9phXTdZ9mDhCKF2TOsvkEik0uhmVJJHZZ5s2hOQtHeXrYgz5qMDCzCLKa9MtzIVpVksf1Vw==",
       "requires": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.1",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.1",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-icon": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.60.0.tgz",
-      "integrity": "sha512-+zbMsTd0duRhdvTviW49l1xCskgMhlSbE+31xORODqgoeC5bkbLMJNcI5PT4oc/CGGQqbl5NV0fVgBiKOUmSYw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.60.1.tgz",
+      "integrity": "sha512-ptXSWrs0EiKc60gQ9HwI6Uos3vvSCflnpWvW2ZBuLmx/ZTFsexjwaJj3JHWvKcIRuPh38/4a2aIgO+EdtTHErQ==",
       "requires": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
@@ -9243,39 +9243,39 @@
       }
     },
     "@contentful/f36-list": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.60.0.tgz",
-      "integrity": "sha512-KPUqf/Y9GaD3HWMMZmeBVY1aoN3s7cDzY0z080yvaGCaQpbE0tTOkE/ZFRK8pE0eU94iabrcKg92MTreEEwWeA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.60.1.tgz",
+      "integrity": "sha512-LtoYH3/3HnTKh7AM+AaHpV+aXLlsvY9uLb+Pq/O1z9KQgqZkC37KguOKohi2fSS4trqRApewdzFzpqVX6FM5qA==",
       "requires": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-menu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.60.0.tgz",
-      "integrity": "sha512-Rjn6WrGrJIPpkJaNQdj17KSHoYC3xj82W9YObtzl/W/huNhXV2IoH8p7q9kOaEuZjG80ERvuuno84xkLMiAaig==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.60.1.tgz",
+      "integrity": "sha512-qyMWv20UHzjAKV882VLWTnjY9eQQzA/0s7vpqEPF2lee0BRJCM8uxj5fJ01OIJ3k1WEBAcAyXULx0CV69wNUuw==",
       "requires": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.1",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-popover": "^4.60.0",
+        "@contentful/f36-popover": "^4.60.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.1",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-modal": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.60.0.tgz",
-      "integrity": "sha512-9IixUm5RgOgtOviMhvmQKImjKK24XykoJymromOoQPBgI1rIqUxBhlwGWIPOYYtoA32mJNIL2erJhYM+zrR2+A==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.60.1.tgz",
+      "integrity": "sha512-K4nEYnQ8dpYXEr1e9I6RrSRm2CsG9hGMu8dRvReEF6FXNdZ4vrc/GQ7z+2g1DbVSwKqtPusejuXY0ixkrmJQLA==",
       "requires": {
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-button": "^4.60.1",
+        "@contentful/f36-core": "^4.60.1",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.1",
         "@types/react-modal": "^3.13.1",
         "emotion": "^10.0.17",
         "react-modal": "^3.16.1"
@@ -9297,69 +9297,69 @@
       }
     },
     "@contentful/f36-note": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.60.0.tgz",
-      "integrity": "sha512-XnOMEo2U3jbPzy20bZgoyQjR7bwsMWGUQrcrE3H0cXSHYQaKuvWo6uaEMCsqr00LWkP1537tuWfr3Yalp33aiQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.60.1.tgz",
+      "integrity": "sha512-6jT3nPPtm7yt8VCvUJL1oId+LiMOt7p70bC6iKqJOD7XZKScFuRoGMMV9DwgC32pkzFDars5wsYh5rCkMCXlNQ==",
       "requires": {
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-icon": "^4.60.0",
+        "@contentful/f36-button": "^4.60.1",
+        "@contentful/f36-core": "^4.60.1",
+        "@contentful/f36-icon": "^4.60.1",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-notification": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.60.0.tgz",
-      "integrity": "sha512-1YZ+eQhBLNEIc1dBcm4Ee0Rq1oXP8VvkYxczRmTaopKLlxUTZpvnjPZEq0wZTZ0Dc/uy8m92yByCCeo0UAVpXw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.60.1.tgz",
+      "integrity": "sha512-5cPKKFo44jnegmrWBpiDIek2eXAUvo3RPXWYcdEaCl2DkmrTCSUrhHxr2pLsgJ6naSHKmsMoJNzVMHSRWc8glQ==",
       "requires": {
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-button": "^4.60.1",
+        "@contentful/f36-core": "^4.60.1",
         "@contentful/f36-icons": "^4.27.0",
-        "@contentful/f36-text-link": "^4.60.0",
+        "@contentful/f36-text-link": "^4.60.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.1",
         "@swc/helpers": "^0.4.14",
         "emotion": "^10.0.17",
         "react-animate-height": "^3.0.4"
       }
     },
     "@contentful/f36-pagination": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.60.0.tgz",
-      "integrity": "sha512-m/m+/wZxjO/EDPWGkdMDyGsxEe5iV6RnSMsVABk4QTOe7Zo05rqGUw6IjqzvecDgDwm1jUrYm/lhlNObwpcRlA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.60.1.tgz",
+      "integrity": "sha512-gXyznBc2ASlyDNWKbAIfTtqChQwNs6FDuX/6WrwqVzuK+kKtzXTwFSoljBK0otEJdV9tcl/rrv9g21jhEnKZzQ==",
       "requires": {
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-forms": "^4.60.0",
+        "@contentful/f36-button": "^4.60.1",
+        "@contentful/f36-core": "^4.60.1",
+        "@contentful/f36-forms": "^4.60.1",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-pill": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.60.0.tgz",
-      "integrity": "sha512-1heXDtENtFUnDrgaVYu3GRTtIzP37AydxOw1BlpRUiKGvEzL8K217d7WVhKoMlUFk+uCS50j6t6cJxl/3E3Xtw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.60.1.tgz",
+      "integrity": "sha512-1Ym49J4O+O3hBcf2x+iQTa/pQ8knzMtsbITpNOsbG9YvnhYZ+PPDBQGT25OKbMsmscYzXtbMn5glyuGAphUQOg==",
       "requires": {
-        "@contentful/f36-button": "^4.60.0",
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-drag-handle": "^4.60.0",
+        "@contentful/f36-button": "^4.60.1",
+        "@contentful/f36-core": "^4.60.1",
+        "@contentful/f36-drag-handle": "^4.60.1",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.60.0",
+        "@contentful/f36-tooltip": "^4.60.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-popover": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.60.0.tgz",
-      "integrity": "sha512-D0XNoO6//TLIzc/LLt7UnbdeGpDO3t/Eb3eKwK4Z0n+pI8bCEm6EltfbVO3mWMmPPSDhjLMa33q3hgGXt/BUAg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.60.1.tgz",
+      "integrity": "sha512-BenoDl0HBkUhJ6sEO/MILMDrJ9vr9nA2APwGRuRjFLQqRZPs0T+hdyC3uc+ie6qo/PtyYOmfqGb/+2ZceFtL2g==",
       "requires": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -9368,55 +9368,55 @@
       }
     },
     "@contentful/f36-skeleton": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.60.0.tgz",
-      "integrity": "sha512-5WsjDlOxofFpGSqkAVCEdOC7TCyrQ7/AYdxjhzFJClKHIZ0xR/ZqcZyE6yy8DV9dj+XMil8ZIAyrOnwDX6fRNQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.60.1.tgz",
+      "integrity": "sha512-AC+5K4onW+oRkes0m6O/oWyZdE62Tlz6GXxiZ1YLDI00g3fO4louizcohSq+MTCyHdYAIs7wgXJkRkvqds9EGw==",
       "requires": {
-        "@contentful/f36-core": "^4.60.0",
-        "@contentful/f36-table": "^4.60.0",
+        "@contentful/f36-core": "^4.60.1",
+        "@contentful/f36-table": "^4.60.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-spinner": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.60.0.tgz",
-      "integrity": "sha512-T4Lyjr+sL0VC+2z7UVXAvOYxLZfsNECUpQGScI1iaEc6751Zz8HC+ccCFoKY3MUC/9k/bAE85vHTDoH6nmyutg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.60.1.tgz",
+      "integrity": "sha512-iykGHlNYjokA2a/SgEXNY8TeynU0YhBH7jX8cZePxxV7FqBaDqH5AdoEy5fnpL9wpsNmsgAyjUGre3rUi2NbBg==",
       "requires": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-table": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.60.0.tgz",
-      "integrity": "sha512-hOX1x62mWKs1vAC6LOFAxX0+jxwicjIiC693t1oifqaKENwDj+vXZsYZrh+pCAjWILRpFsxjMP79L4pRWrZ0Mw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.60.1.tgz",
+      "integrity": "sha512-r1IFZobH5nD4Z5gXvTCDPtHTw2pwEFvmiKBZqPNkyrjjnwP/rQi10IohOlyzyeljDxDQ5xQskTPOE3kdhnml7g==",
       "requires": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.1",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.60.0",
+        "@contentful/f36-typography": "^4.60.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-tabs": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.60.0.tgz",
-      "integrity": "sha512-4WzMJ847rbZMm+nWFAWhK4V2cYoPMXHkWif9FDuk4v6RPVhpoANUsSpTX9hBo2fyR99Cyj0qeGtqfJ39ifUTvw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.60.1.tgz",
+      "integrity": "sha512-+vxf6WEYamegrT2ifkYeVlXuneTccfuHJss9FiPWZliOfRLnXe4Dgw2AkPXLlFphMzqS/drTLYnZ8/A+JhjD0g==",
       "requires": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@radix-ui/react-tabs": "^1.0.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-text-link": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.60.0.tgz",
-      "integrity": "sha512-gYP7O8iHQnflVactunb4Ui2Ynu1VD4KnKVDKbXQmk7BxDzMNKy5puvUUIgmI2MqmtA85eMcauWFSC677KJemMw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.60.1.tgz",
+      "integrity": "sha512-qZCpdRPwCDcJUgfO3XpBhTPOM00DEjCCC5cItxSH3hOmRk4uVMjDJWQ+UsqOS1kaOsiPR/1Tssz2n34oXkSm/A==",
       "requires": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
@@ -9427,11 +9427,11 @@
       "integrity": "sha512-yPHNQjHVEuO+5nUoX3EbrQvLoU7ZjNc/w3RyCmYR3F/NWZCy/3n0Knhq5Jfow+CcXkVY6Ch526VlA3+ayEN2kA=="
     },
     "@contentful/f36-tooltip": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.60.0.tgz",
-      "integrity": "sha512-qIdLgj9oOqr69RuRA/9LrV1VlOSHOWuRtSsSZDx87rQwk8OlvdflvCd3Y1TPyrFiAbsRV7QtSmxau+1UKhqQ8A==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.60.1.tgz",
+      "integrity": "sha512-n5aavHS4gwvfpKmXMU6d4RLmbulugkY63HNhckHSDFqne9P+CVJ2+6VyRdcPnkduwwsrOVeJmjZsNBOCB3572g==",
       "requires": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -9441,11 +9441,11 @@
       }
     },
     "@contentful/f36-typography": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.60.0.tgz",
-      "integrity": "sha512-iEg1VT0wH3nUKZs8jSCxKnQPWVgrqckRuG3UpLzk4FKfyDHopimFMCLqy+XswWpA+aDRueMC4Il+TVVTO5N7qQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.60.1.tgz",
+      "integrity": "sha512-2Zun3++qS/Y1Sv6HLp0NBojIr2r9t9hNZSHQ/kKpF1kl5rrrVga2kIhaMoflL0N3GFIYUJLi54O1lblHSDYEQw==",
       "requires": {
-        "@contentful/f36-core": "^4.60.0",
+        "@contentful/f36-core": "^4.60.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
@@ -12208,9 +12208,9 @@
       "dev": true
     },
     "focus-lock": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-1.2.0.tgz",
-      "integrity": "sha512-MGUkR6hFmRNeoQxUtL9jYckpf6DZhlD4crD8FgEO9hS+yXaCg2vi2hat9fB9qUe9YsLa6eE9ykldqaqLU0kYKg==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-1.3.3.tgz",
+      "integrity": "sha512-hfXkZha7Xt4RQtrL1HBfspAuIj89Y0fb6GX0dfJilb8S2G/lvL4akPAcHq6xoD2NuZnDMCnZL/zQesMyeu6Psg==",
       "requires": {
         "tslib": "^2.0.3"
       }
@@ -13662,12 +13662,12 @@
       "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
     },
     "react-focus-lock": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.10.1.tgz",
-      "integrity": "sha512-40zZ/Cvl3eMRoHrpcc11WmY+Md/kbjWofNLoGKvt+bti/mAeLZXkqbSIhhVlgXfdV1wD5puopcep5l4KX22Xvg==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.11.1.tgz",
+      "integrity": "sha512-IXLwnTBrLTlKTpASZXqqXJ8oymWrgAlOfuuDYN4XCuN1YJ72dwX198UCaF1QqGUk5C3QOnlMik//n3ufcfe8Ig==",
       "requires": {
         "@babel/runtime": "^7.0.0",
-        "focus-lock": "^1.2.0",
+        "focus-lock": "^1.3.2",
         "prop-types": "^15.6.2",
         "react-clientside-effect": "^1.2.6",
         "use-callback-ref": "^1.3.0",

--- a/apps/microsoft-teams/frontend/package.json
+++ b/apps/microsoft-teams/frontend/package.json
@@ -6,7 +6,7 @@
     "@azure/msal-browser": "^3.7.1",
     "@azure/msal-react": "^2.0.10",
     "@contentful/app-sdk": "^4.23.1",
-    "@contentful/f36-components": "4.60.0",
+    "@contentful/f36-components": "4.60.1",
     "@contentful/f36-icons": "^4.27.0",
     "@contentful/f36-tokens": "4.0.4",
     "@contentful/integration-frontend-toolkit": "^1.2.44",


### PR DESCRIPTION
## Purpose

Bump MS-teams version of Forma-36, to use the new `ModalConfirm` Component that has an `x` close icon in the header.

![Screenshot 2024-02-22 at 9 30 15 AM](https://github.com/contentful/apps/assets/158083968/60e16d75-4e35-44c2-9b3e-aea7cd18006e)

## Testing steps
Tested locally

