### PR TITLE
feat: update app save behavior for auth [INTEG-1804]

### DIFF
--- a/apps/microsoft-teams/app-actions/src/actions/handle-app-event.spec.ts
+++ b/apps/microsoft-teams/app-actions/src/actions/handle-app-event.spec.ts
@@ -60,6 +60,8 @@ describe('handle-app-event.handler', () => {
         entryActivity: mockEntryActivity,
       },
     });
+    // ensures that notifications that don't match tenant id, content type, and selected events are filtered out
+    expect(result.data.length).to.equal(1);
   });
 
   describe('when an error is encountered', () => {

--- a/apps/microsoft-teams/app-actions/src/actions/handle-app-event.ts
+++ b/apps/microsoft-teams/app-actions/src/actions/handle-app-event.ts
@@ -44,6 +44,9 @@ export const handler = withAsyncAppActionErrorHandling(
     const { tenantId, notifications } = parametersFromAppInstallation(appInstallation);
 
     const matchingNotifications = notifications.filter((notification) => {
+      // don't send if tenant id doesn't match
+      if (notification.channel.tenantId !== tenantId) return false;
+
       // don't send if the notification is for a different content type
       if (notification.contentTypeId !== contentTypeId) return false;
 

--- a/apps/microsoft-teams/app-actions/test/mocks.ts
+++ b/apps/microsoft-teams/app-actions/test/mocks.ts
@@ -111,7 +111,7 @@ export const mockNotification = {
     name: 'Corporate Marketing',
     teamId: 'team-id',
     teamName: 'Marketing Department',
-    tenantId: '9876-5432',
+    tenantId: 'tenant-id',
   },
   contentTypeId: 'blogPost',
   selectedEvents: {
@@ -125,14 +125,7 @@ export const mockNotification = {
 };
 
 export const mockNotificationUnsubscribed = {
-  channel: {
-    id: 'abc-123',
-    name: 'Corporate Marketing',
-    teamId: '789-def',
-    teamName: 'Marketing Department',
-    tenantId: '9876-5432',
-  },
-  contentTypeId: 'blogPost',
+  ...mockNotification,
   selectedEvents: {
     'ContentManagement.Entry.publish': false,
     'ContentManagement.Entry.unpublish': false,
@@ -143,12 +136,33 @@ export const mockNotificationUnsubscribed = {
   },
 };
 
+export const mockNotificationDifferentTenant = {
+  ...mockNotification,
+  channel: {
+    id: 'abc-123',
+    name: 'Corporate Marketing',
+    teamId: '789-def',
+    teamName: 'Marketing Department',
+    tenantId: 'different-tenant-id',
+  },
+};
+
+export const mockNotificationDifferentContentType = {
+  ...mockNotification,
+  contentTypeId: 'productPage',
+};
+
 export const mockAppInstallationParameters: AppInstallationParameters = {
   tenantId: 'tenant-id',
   orgName: 'Company ABC',
   orgLogo: 'https://example.image/squareLogo',
   authenticatedUsername: 'person1@companyabc.com',
-  notifications: [mockNotification, mockNotificationUnsubscribed],
+  notifications: [
+    mockNotification,
+    mockNotificationUnsubscribed,
+    mockNotificationDifferentTenant,
+    mockNotificationDifferentContentType,
+  ],
 };
 
 export const mockAppInstallation: AppInstallationProps = {
@@ -161,10 +175,7 @@ export const mockAppInstallation: AppInstallationProps = {
     createdAt: 'createdAt',
     updatedAt: 'updatedAt',
   },
-  parameters: {
-    tenantId: 'tenant-id',
-    notifications: [mockNotification],
-  },
+  parameters: mockAppInstallationParameters,
 };
 
 export const mockEntryEvent: EntryEvent = {

--- a/apps/microsoft-teams/frontend/src/components/config/ConfigPage/ConfigPage.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ConfigPage/ConfigPage.tsx
@@ -40,7 +40,8 @@ const ConfigPage = () => {
       return false;
     }
 
-    if (!parameters.tenantId) {
+    // prevent save on initial installation if there isn't a tenant id
+    if (!parameters.tenantId && !isAppInstalled) {
       sdk.notifier.error('A valid Tenant Id is required');
       return false;
     }

--- a/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/NotificationsSection/NotificationsSection.tsx
@@ -1,5 +1,5 @@
 import { Dispatch, SetStateAction } from 'react';
-import { Box, ModalLauncher, Subheading } from '@contentful/f36-components';
+import { Box, ModalLauncher, Paragraph, Subheading } from '@contentful/f36-components';
 import { styles } from './NotificationsSection.styles';
 import { notificationsSection } from '@constants/configCopy';
 import AddButton from '@components/config/AddButton/AddButton';
@@ -124,6 +124,7 @@ const NotificationsSection = (props: Props) => {
   return (
     <Box className={styles.box}>
       <Subheading>{notificationsSection.title}</Subheading>
+      <Paragraph>{notificationsSection.description}</Paragraph>
       <Box marginBottom="spacingXl">
         <AddButton
           buttonCopy={notificationsSection.createButton}

--- a/apps/microsoft-teams/frontend/src/constants/configCopy.ts
+++ b/apps/microsoft-teams/frontend/src/constants/configCopy.ts
@@ -12,9 +12,9 @@ const appDeepLink = 'https://teams.microsoft.com/';
 const accessSection = {
   title: 'Access',
   description:
-    'Authorize Microsoft Teams here. Then, add the Contentful app to your Teams channel.',
+    'Authorize your Microsoft Account here. Then, add the Contentful app to your Teams channel.',
   fieldName: 'Tenant Id',
-  login: 'Connect to Teams',
+  login: 'Connect Microsoft Account',
   logout: 'Disconnect',
   retry: 'Retry Authorization',
   teamsAppInfo:
@@ -24,7 +24,7 @@ const accessSection = {
     confirmDisonnect: 'Disconnect',
     goBack: 'Go back',
     description:
-      'By disconnecting, you will no longer see configured notifications for this tenant. Are you sure you want to disconnect?',
+      'By disconnecting, you will no longer see configured notifications for this account. Are you sure you want to disconnect?',
   },
   updateConfirmation: 'Microsoft organization updated',
   saveWarning: 'Save the app to persist these settings',
@@ -34,6 +34,7 @@ const accessSection = {
 
 const notificationsSection = {
   title: 'Notifications',
+  description: 'Specify Microsoft Teams channels, content types, and entry actions.',
   createButton: 'Create notification',
   edit: 'Edit',
   delete: 'Delete',
@@ -75,11 +76,11 @@ const channelSelection = {
     title: 'Select Microsoft Teams channel',
     description:
       'Microsoft Teams channels where the Contentful app has been installed can display notifications.',
-    link: 'Add app',
+    link: 'Add the app',
     button: 'Select',
     emptyHeading: 'Add Microsoft Teams channels',
     emptyContent:
-      'In Microsoft Teams, add the Contentful app to the general channel of the teams where you want to see notifications. Add app',
+      'In Microsoft Teams, add the Contentful app to the general channel of the teams where you want to see notifications. Add the app and then refresh the page.',
     errorMessage: 'Channels did not load. Please try again later.',
   },
 };


### PR DESCRIPTION
## Purpose

This PR addresses a few items:

- Some small copy changes
- Updating the app config save when auth information changes 
- Prevent a message from being sent if the tenant id doesn't match

## Approach

Here is the updated approach for the auth flow:

- On initial install if auth is successful, the the app config page will be saved with the tenant id and installed
- If org details are not found and the `Retry Auth` button is pressed and org details are successful, save the app
- If the `Disconnect` button is clicked and the user confirms, then all parameters are reset and config is saved

## Testing steps

Test the auth flow and ensure that the app config page and parameters are saved.

## Breaking Changes

## Dependencies and/or References

## Deployment
