### PR TITLE
fix: support non-image file types in Dropbox

### DIFF
--- a/apps/dropbox/src/index.js
+++ b/apps/dropbox/src/index.js
@@ -15,7 +15,8 @@ const FIELDS_TO_PERSIST = [
 ];
 
 function makeThumbnail(file) {
-  const url = file.thumbnailLink.split('?')[0] + '?bounding_box=256&mode=fit';
+  // TODO: update this to create a fallback for when there isn't an thumbnail
+  const url = file.thumbnailLink?.split('?')[0] + '?bounding_box=256&mode=fit';
   const alt = file.name;
 
   return [url, alt];
@@ -29,7 +30,6 @@ async function openDialog() {
       linkType: 'preview',
       multiselect: true,
       folderselect: false,
-      extensions: ['.jpg', '.jpeg', '.gif', '.svg', '.png'],
     });
   });
 }


### PR DESCRIPTION
## Purpose

This solves a customer issue where they are not able to add non-image file types to their Contentful entry using the Dropbox app.

## Approach

Remove the file type restrictions on the Dropbox picker and ensure that if there isn't a thumbnail image, the app won't break. Confirmed that a non-image file can be added to an entry and here's how it renders.

![Screenshot 2024-02-26 at 3 58 03 PM](https://github.com/contentful/apps/assets/62958907/2935d294-430e-400e-b0a5-76dd631075a1)

Eventually we can update this to have the same fallback images that are used in the Bynder app.


## Testing steps
Tested locally.

## Breaking Changes


## Dependencies and/or References


## Deployment

