### PR TITLE
Microsoft Teams - add fuzzy search for content types

### DIFF
--- a/apps/microsoft-teams/frontend/package-lock.json
+++ b/apps/microsoft-teams/frontend/package-lock.json
@@ -18,6 +18,7 @@
         "@contentful/react-apps-toolkit": "1.2.16",
         "contentful-management": "10.38.3",
         "emotion": "10.0.27",
+        "fuse.js": "^7.0.0",
         "lodash": "^4.17.21",
         "react": "18.2.0",
         "react-dom": "18.2.0"
@@ -5155,6 +5156,14 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.0.0.tgz",
+      "integrity": "sha512-14F4hBIxqKvD4Zz/XjDc3y94mNZN6pRv3U13Udo0lNLCWRBUsrMv2xwcF/y/Z5sV6+FQW+/ow68cHpm4sunt8Q==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/gensync": {
@@ -12274,6 +12283,11 @@
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "dev": true
+    },
+    "fuse.js": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.0.0.tgz",
+      "integrity": "sha512-14F4hBIxqKvD4Zz/XjDc3y94mNZN6pRv3U13Udo0lNLCWRBUsrMv2xwcF/y/Z5sV6+FQW+/ow68cHpm4sunt8Q=="
     },
     "gensync": {
       "version": "1.0.0-beta.2",

--- a/apps/microsoft-teams/frontend/package.json
+++ b/apps/microsoft-teams/frontend/package.json
@@ -13,6 +13,7 @@
     "@contentful/react-apps-toolkit": "1.2.16",
     "contentful-management": "10.38.3",
     "emotion": "10.0.27",
+    "fuse.js": "^7.0.0",
     "lodash": "^4.17.21",
     "react": "18.2.0",
     "react-dom": "18.2.0"

--- a/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelection/ContentTypeSelection.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelection/ContentTypeSelection.tsx
@@ -9,6 +9,7 @@ import { EditIcon } from '@contentful/f36-icons';
 import { styles } from './ContentTypeSelection.styles';
 import { getContentTypeName } from '@helpers/configHelpers';
 import { ContentTypeContext } from '@context/ContentTypeProvider';
+import { SdkWithCustomApiProvider } from '@context/SdkWithCustomApiProvider';
 
 interface Props {
   notification: Notification;
@@ -33,17 +34,19 @@ const ContentTypeSelection = (props: Props) => {
       return;
     } else if (!areContentTypesLoading)
       return ModalLauncher.open(({ isShown, onClose }) => (
-        <ContentTypeSelectionModal
-          isShown={isShown}
-          onClose={() => {
-            onClose(true);
-          }}
-          handleNotificationEdit={handleNotificationEdit}
-          savedContentTypeId={notification.contentTypeId}
-          contentTypes={contentTypes}
-          contentTypeConfigLink={contentTypeConfigLink}
-          error={Boolean(error)}
-        />
+        <SdkWithCustomApiProvider>
+          <ContentTypeSelectionModal
+            isShown={isShown}
+            onClose={() => {
+              onClose(true);
+            }}
+            handleNotificationEdit={handleNotificationEdit}
+            savedContentTypeId={notification.contentTypeId}
+            contentTypes={contentTypes}
+            contentTypeConfigLink={contentTypeConfigLink}
+            error={Boolean(error)}
+          />
+        </SdkWithCustomApiProvider>
       ));
   };
 

--- a/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelectionModal/ContentTypeSearch.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelectionModal/ContentTypeSearch.tsx
@@ -1,0 +1,24 @@
+import React, { useMemo } from 'react';
+import { Box, IconButton, TextInput } from '@contentful/f36-components';
+import { SearchIcon } from '@contentful/f36-icons';
+import { debounce } from 'lodash';
+
+type Props = {
+  placeholder: string;
+  handleChange: (e: React.ChangeEvent<HTMLInputElement>) => Promise<void>;
+};
+
+const ContentTypeSearch = ({ placeholder, handleChange }: Props) => {
+  const debouncedHandleChange = useMemo(() => debounce(handleChange, 1000), []);
+
+  return (
+    <Box marginBottom="spacingM">
+      <TextInput.Group>
+        <TextInput placeholder={placeholder} onChange={debouncedHandleChange} />
+        <IconButton variant="secondary" icon={<SearchIcon />} aria-label="magnifying glass icon" />
+      </TextInput.Group>
+    </Box>
+  );
+};
+
+export default ContentTypeSearch;

--- a/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelectionModal/ContentTypeSelectionModal.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelectionModal/ContentTypeSelectionModal.spec.tsx
@@ -4,6 +4,11 @@ import { fireEvent, render, screen, waitFor, act } from '@testing-library/react'
 import { contentTypeSelection } from '@constants/configCopy';
 import { mockContentType } from '@test/mocks';
 import { cloneDeep } from 'lodash';
+import { mockSdk } from '@test/mocks';
+
+vi.mock('@contentful/react-apps-toolkit', () => ({
+  useSDK: () => mockSdk,
+}));
 
 describe('ContentTypeSelectionModal component', () => {
   it('mounts and renders the correct content', () => {
@@ -78,7 +83,7 @@ describe('ContentTypeSelectionModal component', () => {
   });
 
   describe('searching for a content type', () => {
-    it('fuzzy searches the list of content types', () => {
+    it('fuzzy searches the originally fetched "context" list of content types', () => {
       const blogContentType = cloneDeep(mockContentType);
       blogContentType.displayField = 'Xyz Asdf 78AUB';
       blogContentType.name = 'xyz Asdf 78aub';
@@ -117,5 +122,7 @@ describe('ContentTypeSelectionModal component', () => {
 
       unmount();
     });
+
+    it('attempts to retrieve the content type from API if request content type cannot be found in fuzzy search', () => {});
   });
 });

--- a/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelectionModal/ContentTypeSelectionModal.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelectionModal/ContentTypeSelectionModal.tsx
@@ -1,5 +1,13 @@
-import { useState } from 'react';
-import { Button, FormControl, Modal, Radio, Table } from '@contentful/f36-components';
+import { useState, useMemo, useCallback } from 'react';
+import {
+  Box,
+  Button,
+  FormControl,
+  IconButton,
+  Modal,
+  Radio,
+  Table,
+} from '@contentful/f36-components';
 import { contentTypeSelection } from '@constants/configCopy';
 import { styles } from './ContentTypeSelectionModal.styles';
 import { Notification } from '@customTypes/configPage';
@@ -8,6 +16,10 @@ import { ContentTypeProps } from 'contentful-management';
 import EmptyState from '@components/config/EmptyState/EmptyState';
 import WebApp from '@components/config/EmptyState/WebApp';
 import ErrorMessage from '../ErrorMessage/ErrorMessage';
+import { TextInput } from '@contentful/f36-components';
+import Fuse from 'fuse.js';
+import { debounce } from 'lodash';
+import { SearchIcon } from '@contentful/f36-icons';
 
 interface Props {
   isShown: boolean;
@@ -31,9 +43,34 @@ const ContentTypeSelectionModal = (props: Props) => {
   } = props;
 
   const [selectedContentTypeId, setSelectedContentTypeId] = useState(savedContentTypeId ?? '');
+  const [filteredContentTypes, setFilteredContentTypes] =
+    useState<ContentTypeProps[]>(contentTypes);
 
-  const { title, button, link, emptyContent, emptyHeading, errorMessage } =
+  const { title, button, link, emptyContent, emptyHeading, errorMessage, searchPlaceholder } =
     contentTypeSelection.modal;
+
+  const handleSearch = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.value === '') {
+      // revert to default full list of available contentTypes
+      setFilteredContentTypes(contentTypes);
+      return;
+    }
+
+    const fuseOptions = {
+      isCaseSensitive: false,
+      keys: ['sys.id', 'displayField', 'name', 'description'],
+    };
+
+    const fuse = new Fuse(filteredContentTypes, fuseOptions);
+    const searchPattern = e.target.value;
+    const fuseSearchResultObj = fuse.search(searchPattern);
+    // extract actual contentType objects from fuse search result object;
+    const extractedSearchResults = fuseSearchResultObj.map((result) => result.item);
+
+    setFilteredContentTypes(extractedSearchResults);
+  }, []);
+
+  const debouncedHandleSearchUpdate = useMemo(() => debounce(handleSearch, 1000), []);
 
   const renderModalContent = () => {
     if (error) {
@@ -44,14 +81,27 @@ const ContentTypeSelectionModal = (props: Props) => {
       );
     }
 
-    if (contentTypes.length) {
+    if (filteredContentTypes.length) {
       return (
         <>
           <Modal.Content>
             <FormControl as="fieldset" marginBottom="none">
+              <Box marginBottom="spacingM">
+                <TextInput.Group>
+                  <TextInput
+                    placeholder={searchPlaceholder}
+                    onChange={debouncedHandleSearchUpdate}
+                  />
+                  <IconButton
+                    variant="secondary"
+                    icon={<SearchIcon />}
+                    aria-label="magnifying glass icon"
+                  />
+                </TextInput.Group>
+              </Box>
               <Table className={styles.table}>
                 <Table.Body>
-                  {contentTypes.map((contentType) => (
+                  {filteredContentTypes.map((contentType) => (
                     <Table.Row
                       key={contentType.sys.id}
                       onClick={() => setSelectedContentTypeId(contentType.sys.id)}

--- a/apps/microsoft-teams/frontend/src/constants/configCopy.ts
+++ b/apps/microsoft-teams/frontend/src/constants/configCopy.ts
@@ -65,6 +65,7 @@ const contentTypeSelection = {
     emptyContent:
       'There are no content types available. If you create one, you will be able to assign it to the app from this screen. Add content type',
     errorMessage: 'Content types did not load. Please try again later.',
+    searchPlaceholder: 'Search for a channel',
   },
   notFound: 'Content type not found',
 };


### PR DESCRIPTION
## Todo
- [x] Add Magnifying glass to search input to match figma designs.

## Purpose
Add the ability for Users to search for a specific content type by searching for the content type's `id, displayField, name, or description` attributes.

![ms-search](https://github.com/contentful/apps/assets/158083968/45b7797d-430d-48a8-88f9-022f2c1a3797)


## Approach
This PR introduces a client-side lightweight fuzzy search package called [fuse.js](https://www.fusejs.io/).

## Limitations
Since this is a client side search, the complete searchable set is the exact same set of content types that were fetched via `useGetContentTypes()` and exposed via `ContentTypeContext`.  

There are currently 2 known limitations: 
- No real time updates.
1. User opens the modal
2. Adds an new content type in a separate type
3. The new content type will **not** be rendered.

- 100 results limit
Contentful limits the number of results returned from the API to 100.  If the content type that the user is searching for, was not returned as part of the initial 100 results, they will not be able to find it :( .  This will be address in another PR [ticket tbd]

## Testing steps
Tested locally and with unit tests.