### PR TITLE
MS-Teams - batch requests to fetch content types.

### DIFF
--- a/apps/microsoft-teams/frontend/src/constants/contentTypeLimit.ts
+++ b/apps/microsoft-teams/frontend/src/constants/contentTypeLimit.ts
@@ -1,0 +1,6 @@
+/**
+ * @description - defines the max number of content types to be fetched via SDK per call.
+ * This is used for pagination. The SDK defines a max of 1000, and default of 100. Abstracting
+ * this to a const makes unit testing/configuration *hopefully* easier.
+ */
+export const CONTENT_TYPE_LIMIT = 100;

--- a/apps/microsoft-teams/frontend/src/hooks/useGetContentTypes.spec.ts
+++ b/apps/microsoft-teams/frontend/src/hooks/useGetContentTypes.spec.ts
@@ -3,6 +3,10 @@ import { describe, expect, it, vi } from 'vitest';
 import useGetContentTypes from './useGetContentTypes';
 import { mockCma, mockSdk, mockGetManyContentType } from '@test/mocks';
 
+vi.mock('@constants/contentTypeLimit', () => ({
+  CONTENT_TYPE_LIMIT: 1,
+}));
+
 vi.mock('@contentful/react-apps-toolkit', () => ({
   useSDK: () => mockSdk,
   useCMA: () => mockCma,
@@ -16,6 +20,8 @@ describe('useGetContentTypes', () => {
       expect(result.current.contentTypes).toEqual(mockGetManyContentType.items);
       expect(result.current.loading).toEqual(false);
     });
+
+    vi.restoreAllMocks();
   });
 
   it('should return generalized error if error is thrown', async () => {
@@ -26,5 +32,21 @@ describe('useGetContentTypes', () => {
       expect(result.current.error?.message).toEqual('Unable to get content types');
       expect(result.current.loading).toEqual(false);
     });
+
+    vi.restoreAllMocks();
+  });
+
+  it('batches requests if the number of available content types exceeds the request limit', async () => {
+    const getManyResponse = { ...mockGetManyContentType, total: 2 };
+    getManyResponse.total = 2;
+    const getManySpy = (mockSdk.cma.contentType.getMany = vi.fn().mockReturnValue(getManyResponse));
+
+    renderHook(() => useGetContentTypes());
+
+    await waitFor(() => {
+      expect(getManySpy).toHaveBeenCalledTimes(2);
+    });
+
+    vi.restoreAllMocks();
   });
 });

--- a/apps/microsoft-teams/frontend/src/hooks/useGetContentTypes.ts
+++ b/apps/microsoft-teams/frontend/src/hooks/useGetContentTypes.ts
@@ -2,6 +2,7 @@ import { useEffect, useCallback, useState } from 'react';
 import { useSDK } from '@contentful/react-apps-toolkit';
 import { ConfigAppSDK } from '@contentful/app-sdk';
 import { ContentTypeProps } from 'contentful-management';
+import { CONTENT_TYPE_LIMIT } from '@constants/contentTypeLimit';
 
 /**
  * This hook is used to get all the content types for the space
@@ -18,9 +19,33 @@ const useGetContentTypes = () => {
   const getAllContentTypes = useCallback(async () => {
     try {
       setLoading(true);
-      // TODO: Implement pagination for content types
-      const contentTypesResponse = await sdk.cma.contentType.getMany({});
-      setAllContentTypes(contentTypesResponse.items || []);
+
+      const contentTypesSuperset: ContentTypeProps[] = [];
+      let skip = 0;
+      let needToFetchNextBatch = true;
+
+      while (needToFetchNextBatch) {
+        const contentTypesResponse = await sdk.cma.contentType.getMany({
+          query: {
+            limit: CONTENT_TYPE_LIMIT,
+            skip,
+            order: 'name',
+          },
+        });
+
+        const totalNumOfContentTypes = contentTypesResponse.total;
+        contentTypesSuperset.push(...contentTypesResponse.items);
+
+        if (contentTypesSuperset.length >= totalNumOfContentTypes) {
+          // we have fetched all possible content types, exit while
+          needToFetchNextBatch = false;
+        } else {
+          // we need to fetch the next batch of content types, re-execute while
+          skip += CONTENT_TYPE_LIMIT;
+        }
+      }
+
+      setAllContentTypes(contentTypesSuperset);
     } catch (error) {
       const err = new Error('Unable to get content types');
       setError(err);
@@ -28,7 +53,7 @@ const useGetContentTypes = () => {
     }
 
     setLoading(false);
-  }, [sdk.cma.contentType]);
+  }, []);
 
   useEffect(() => {
     getAllContentTypes();


### PR DESCRIPTION
## Purpose
In order to support customers who have 100+ content types, we need to batch multiple requests (of 100 at a time, configurable) to retrieve all content types.  This also will be needed for pagination.

![batches](https://github.com/contentful/apps/assets/158083968/dd1a7f6d-4ed8-41af-b28f-deb43570bf9b)


## Approach
I chose to use a `while` loop, despite the fact that I usually despise `while` loops.  But in this case I think it makes the most sense, since we know we will have to enter a loop at least one time to get the first 100 content types, and then _if_ we have to batch request more, then we can restart the loop.  I'm definitely open to other ways of solving this.

## Testing steps
Unit testing and locally

## Follow up PR
This hook is a good candidate to be moved to the [integration-frontend-toolkit](https://github.com/contentful/integration-frontend-toolkit/tree/master).  In the name of speed/scope this PR will implement the hook directly, but we should abstract this hook to that library and also ensure that it will support `async/await` as well as `.then()` patterns.  We were lucky to already have a robust `{ loading, error }` state, but not all apps that could use this hook might want to pause program execution with `await`.  I think, this theory might need some investigation.

