### PR TITLE
chore: migrate app-base package publishing to GitHub [INTEG-1809]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,13 +8,13 @@ commands:
   publish:
     steps:
       - vault/get-secrets:
-          template-preset: 'semantic-release-ecosystem'
+          template-preset: 'semantic-release'
       - vault/configure-lerna
       - run:
-          name: Setup NPM
+          name: Setup GitHub packages
           command: |
-            echo $'@contentful:registry=https://registry.npmjs.org/
-            //registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> ~/.npmrc
+            echo "//npm.pkg.github.com/:_authToken=${GITHUB_PACKAGES_WRITE_TOKEN}" > ~/.npmrc
+            echo "@contentful:registry=https://npm.pkg.github.com" >> ~/.npmrc
       - run:
           name: Publish packages
           command: npm run publish-packages

--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
     "*.{js,jsx,ts,tsx}": [
       "npm run prettier:write"
     ]
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
   }
 }


### PR DESCRIPTION
## Purpose

We publish two packages in this repo: `dam-app-base` and `ecommerce-app-base`. This PR migrates the publishing of those packages from npm to GitHub packages. This is PR 2 of 3 after merging in this first one: https://github.com/contentful/apps/pull/6608

## Approach

Followed directions in the migration instructions.

## Testing steps

## Breaking Changes

## Dependencies and/or References

## Deployment
