### PR TITLE
Microsoft Teams - add fuzzy search for content types

### DIFF
--- a/apps/microsoft-teams/frontend/package-lock.json
+++ b/apps/microsoft-teams/frontend/package-lock.json
@@ -18,6 +18,7 @@
         "@contentful/react-apps-toolkit": "1.2.16",
         "contentful-management": "10.38.3",
         "emotion": "10.0.27",
+        "fuse.js": "^7.0.0",
         "lodash": "^4.17.21",
         "react": "18.2.0",
         "react-dom": "18.2.0"
@@ -5155,6 +5156,14 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.0.0.tgz",
+      "integrity": "sha512-14F4hBIxqKvD4Zz/XjDc3y94mNZN6pRv3U13Udo0lNLCWRBUsrMv2xwcF/y/Z5sV6+FQW+/ow68cHpm4sunt8Q==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/gensync": {
@@ -12274,6 +12283,11 @@
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "dev": true
+    },
+    "fuse.js": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.0.0.tgz",
+      "integrity": "sha512-14F4hBIxqKvD4Zz/XjDc3y94mNZN6pRv3U13Udo0lNLCWRBUsrMv2xwcF/y/Z5sV6+FQW+/ow68cHpm4sunt8Q=="
     },
     "gensync": {
       "version": "1.0.0-beta.2",

--- a/apps/microsoft-teams/frontend/package.json
+++ b/apps/microsoft-teams/frontend/package.json
@@ -13,6 +13,7 @@
     "@contentful/react-apps-toolkit": "1.2.16",
     "contentful-management": "10.38.3",
     "emotion": "10.0.27",
+    "fuse.js": "^7.0.0",
     "lodash": "^4.17.21",
     "react": "18.2.0",
     "react-dom": "18.2.0"

--- a/apps/microsoft-teams/frontend/src/components/config/DebouncedSearchInput/DebouncedSearchInput.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/DebouncedSearchInput/DebouncedSearchInput.spec.tsx
@@ -1,0 +1,15 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import DebouncedSearchInput from './DebouncedSearchInput';
+
+describe('ContentTypeSearch component', () => {
+  it('mounts and renders the correct content', () => {
+    const placeholderText = 'write some text here';
+    const { unmount } = render(
+      <DebouncedSearchInput placeholder={placeholderText} onChange={vi.fn()} />
+    );
+
+    expect(screen.getByPlaceholderText(placeholderText)).toBeTruthy();
+    unmount();
+  });
+});

--- a/apps/microsoft-teams/frontend/src/components/config/DebouncedSearchInput/DebouncedSearchInput.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/DebouncedSearchInput/DebouncedSearchInput.tsx
@@ -1,0 +1,35 @@
+import React, { useMemo } from 'react';
+import { Box, IconButton, TextInput } from '@contentful/f36-components';
+import { SearchIcon } from '@contentful/f36-icons';
+import { debounce } from 'lodash';
+
+type Props = {
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  placeholder: string;
+  disabled?: boolean;
+};
+
+const DebouncedSearchInput = ({ onChange, placeholder, disabled = false }: Props) => {
+  const debouncedHandleChange = useMemo(() => debounce(onChange, 1000), []);
+
+  return (
+    <Box marginBottom="spacingM">
+      <TextInput.Group>
+        <TextInput
+          placeholder={placeholder}
+          onChange={debouncedHandleChange}
+          isDisabled={disabled}
+        />
+        <IconButton
+          variant="secondary"
+          icon={<SearchIcon />}
+          aria-label="magnifying glass icon"
+          aria-hidden={true}
+          isDisabled={disabled}
+        />
+      </TextInput.Group>
+    </Box>
+  );
+};
+
+export default DebouncedSearchInput;

--- a/apps/microsoft-teams/frontend/src/components/config/SearchableList/SearchableList.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/SearchableList/SearchableList.spec.tsx
@@ -1,0 +1,48 @@
+import SearchableList from './SearchableList';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+describe('ContentTypeSelectionModal component', () => {
+  it('mounts and renders a list of items', () => {
+    const list = ['asdf', 'bsdf'];
+    const renderListItem = vi.fn().mockImplementation((item, idx) => <p key={idx}>{item}</p>);
+    const { unmount } = render(
+      <SearchableList list={list} searchQuery="" renderListItem={renderListItem} searchKeys={[]} />
+    );
+
+    const listItem1 = screen.getByText(list[0]);
+    const listItem2 = screen.getByText(list[1]);
+
+    expect(listItem1).toBeTruthy();
+    expect(listItem2).toBeTruthy();
+    expect(renderListItem).toHaveBeenCalledTimes(2);
+
+    unmount();
+  });
+
+  describe('searching for a content type', () => {
+    it('fuzzy searches for content types', async () => {
+      const list = ['videos', 'blog posts', 'tutorials'];
+      const searchQuery = 'Blgo-Potts'; // intentionally misspelled to trigger fuzzy search
+      const renderListItem = vi.fn().mockImplementation((item, idx) => <p key={idx}>{item}</p>);
+      const { unmount } = render(
+        <SearchableList
+          list={list}
+          searchQuery={searchQuery}
+          renderListItem={renderListItem}
+          searchKeys={[]}
+        />
+      );
+
+      const videos = screen.queryByText(list[0]);
+      const blogPosts = screen.queryByText(list[1]);
+      const tutorials = screen.queryByText(list[2]);
+
+      expect(blogPosts).toBeTruthy();
+      expect(videos).toBeFalsy();
+      expect(tutorials).toBeFalsy();
+
+      unmount();
+    });
+  });
+});

--- a/apps/microsoft-teams/frontend/src/components/config/SearchableList/SearchableList.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/SearchableList/SearchableList.tsx
@@ -1,0 +1,58 @@
+import Fuse from 'fuse.js';
+import { ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
+import React from 'react';
+
+interface Props<T> {
+  list: T[];
+  searchQuery: string;
+  renderListItem: (item: T) => ReactNode;
+  searchKeys: string[];
+}
+
+/**
+ * @description - Higher order component to make a list fuzzy-searchable with fuse.js.  The actual
+ * implementation of the search options, as well as the rendering of filtered items is left up to
+ * the consumer of this component.
+ */
+const SearchableList = <T,>({ list, searchQuery, searchKeys, renderListItem }: Props<T>) => {
+  const [filteredList, setFilteredList] = useState<T[]>(list);
+  const fuseOptions = {
+    isCaseSensitive: false,
+    keys: searchKeys,
+  };
+
+  const fuse = useMemo(
+    () => new Fuse(list, fuseOptions),
+    [list, searchQuery, searchKeys, fuseOptions]
+  );
+
+  const filterList = useCallback((searchPattern: string) => {
+    if (searchPattern === '') {
+      // revert to default full list of available contentTypes
+      setFilteredList(list);
+      return;
+    }
+
+    const fuseSearchResultObj = fuse.search(searchPattern);
+    // extract actual contentType objects from fuse search result object;
+    const extractedSearchResults = fuseSearchResultObj.map((result) => result.item);
+
+    setFilteredList(extractedSearchResults);
+  }, []);
+
+  useEffect(() => {
+    if (searchQuery || searchQuery === '') {
+      filterList(searchQuery);
+    }
+  }, [list, searchQuery]);
+
+  return (
+    <>
+      {filteredList.map((item, idx) => {
+        return <React.Fragment key={idx}>{renderListItem(item)}</React.Fragment>;
+      })}
+    </>
+  );
+};
+
+export default SearchableList;

--- a/apps/microsoft-teams/frontend/src/constants/configCopy.ts
+++ b/apps/microsoft-teams/frontend/src/constants/configCopy.ts
@@ -65,6 +65,7 @@ const contentTypeSelection = {
     emptyContent:
       'There are no content types available. If you create one, you will be able to assign it to the app from this screen. Add content type',
     errorMessage: 'Content types did not load. Please try again later.',
+    searchPlaceholder: 'Search for a content type',
   },
   notFound: 'Content type not found',
 };


### PR DESCRIPTION
## Purpose
Add the ability for Users to search for a specific content type by searching for the content type's `id, displayField, name, or description` attributes.

![ms-search](https://github.com/contentful/apps/assets/158083968/45b7797d-430d-48a8-88f9-022f2c1a3797)

### UI States
1. No content types were returned from `useGetContentTypes()`.  In this case we should show the "No content types" empty state, with the search input disabled.

![Screenshot 2024-03-04 at 2 49 49 PM](https://github.com/contentful/apps/assets/158083968/8d8e7a70-5a19-40eb-a12f-8f1131eef1b9)

2. Ka-boom, an error occurred while attempting to retrieve content types.  In this case, we should show the Error state, without the search input.

![Screenshot 2024-03-04 at 2 49 49 PM](https://github.com/contentful/apps/assets/158083968/83d58cc8-2a5d-4309-bf2d-1589419299fd)

3. N content types were returned from `useGetContentTypes()` and a search query has filtered the set down to a subset (could possibly be entire set).  In this case, we should render the search input.
 
![Screenshot 2024-03-04 at 2 49 49 PM](https://github.com/contentful/apps/assets/158083968/81297d84-834f-41b1-b0a0-fa1dc3fe3acf)

4. N content types were returned from `useGetContentTypes()` and a search query has filtered the set down to 0 results, i.e. failed search.  In this case, render 0 content types, and the search modal.

![Screenshot 2024-03-04 at 2 49 49 PM](https://github.com/contentful/apps/assets/158083968/3e8d1385-93d5-4d0b-9e6f-2b128969ee79)





## Seeking review on
I walked through `<SearchableList>` in code huddle in particular how it is abstract and a good candidate to be added to the react-frontend toolkit.  But any suggestions on how to make it more extensible or clear would be appreciated.  I'm not completely in love with the `renderItem()` prop that defines how to render s searchable item, I think I would prefer to use `props.children`, but the code required to do that got pretty ugly pretty fast.  So I'm going with "render props" for now, but there might be some improvements to be made, idk.

## Approach
This PR introduces a client-side lightweight fuzzy search package called [fuse.js](https://www.fusejs.io/).

## Testing steps
Tested locally and with unit tests.

## Limitations
- real time updates - if a new content type is created after the config is loaded, the config page will need to be refreshed to retrieve the new content types.  This shouldn't be a deal breaker/blocker since there is a workaround, and creating new content types for a mature space is not overwhelmingly common.

