### PR TITLE
fix: change semantic release policy in vault config

### DIFF
--- a/.contentful/vault-secrets.yaml
+++ b/.contentful/vault-secrets.yaml
@@ -5,7 +5,7 @@ services:
       - dependabot
   circleci:
     policies:
-      - semantic-release-ecosystem
+      - semantic-release
       - aws-push-artifacts:
           account-id: '017078452822'
       - npm-read


### PR DESCRIPTION
## Purpose

Builds failed after merging the last PR (https://github.com/contentful/apps/pull/6625). This is an attempt to fix it to ensure that the `semantic-release` policy matches in the CircleCI config and `vault-secrets.yml`.

## Approach

## Testing steps

## Breaking Changes

## Dependencies and/or References

## Deployment
