### PR TITLE
fix: change policy back to semantic-release-ecosystem

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ commands:
   publish:
     steps:
       - vault/get-secrets:
-          template-preset: 'semantic-release'
+          template-preset: 'semantic-release-ecosystem'
       - vault/configure-lerna
       - run:
           name: Setup NPM

--- a/.contentful/vault-secrets.yaml
+++ b/.contentful/vault-secrets.yaml
@@ -5,7 +5,7 @@ services:
       - dependabot
   circleci:
     policies:
-      - semantic-release
+      - semantic-release-ecosystem
       - aws-push-artifacts:
           account-id: '017078452822'
       - npm-read


### PR DESCRIPTION
## Purpose

As part of the GH package migration, we changed the `semantic-release-ecosystem` policy to `semantic-release`. However, this was preventing our packages from publishing to npm, so we are reverting this back.

## Approach

## Testing steps

## Breaking Changes

## Dependencies and/or References

## Deployment
