### PR TITLE
chore: reapply changes to migrate to GitHub packages [INTEG-1809]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,10 +11,10 @@ commands:
           template-preset: 'semantic-release-ecosystem'
       - vault/configure-lerna
       - run:
-          name: Setup NPM
+          name: Setup GitHub packages
           command: |
-            echo $'@contentful:registry=https://registry.npmjs.org/
-            //registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> ~/.npmrc
+            echo "//npm.pkg.github.com/:_authToken=${GITHUB_PACKAGES_WRITE_TOKEN}" > ~/.npmrc
+            echo "@contentful:registry=https://npm.pkg.github.com" >> ~/.npmrc
       - run:
           name: Publish packages
           command: npm run publish-packages

--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
     "*.{js,jsx,ts,tsx}": [
       "npm run prettier:write"
     ]
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
   }
 }


### PR DESCRIPTION
## Purpose

The original PR (https://github.com/contentful/apps/pull/6625) was reverted (https://github.com/contentful/apps/pull/6647) while we worked to troubleshoot the GitHub packages migration. We are now ok to reapply these changes now that we have confirmed that the migration script should be updated with the vault policy used in this repo.

## Approach

Reapply changes in the original PR, with the exception of changing the vault policy. It should remain as `semantic-release-ecosystem`, and the GH package to npm mirroring script has been updated accordingly.

## Testing steps

## Breaking Changes

## Dependencies and/or References

## Deployment
