### PR TITLE
chore: remove npm-read and packages-read policies [INTEG-1822]

### DIFF
--- a/.contentful/vault-secrets.yaml
+++ b/.contentful/vault-secrets.yaml
@@ -8,4 +8,3 @@ services:
       - semantic-release-ecosystem
       - aws-push-artifacts:
           account-id: '017078452822'
-      - packages-read

--- a/.contentful/vault-secrets.yaml
+++ b/.contentful/vault-secrets.yaml
@@ -8,5 +8,4 @@ services:
       - semantic-release-ecosystem
       - aws-push-artifacts:
           account-id: '017078452822'
-      - npm-read
       - packages-read


### PR DESCRIPTION
## Purpose

This PR removes the `npm-read` and `packages-read` vault policies from this repo. We are not using private packages in this repo so we should be able to safely remove these policies from here.

## Approach

As part the GH package migration we are removing `npm-read` from repos. We should be ok removing the new `packages-read` policy as well since this is a public repo that is not using private packages.

## Testing steps

## Breaking Changes

## Dependencies and/or References

## Deployment
