### PR TITLE
feat(ms-teams): seachableList accepts an optional "pinnedItems" list …

### DIFF
--- a/apps/microsoft-teams/frontend/src/components/config/ChannelSelectionModal/ChannelSelectionModal.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ChannelSelectionModal/ChannelSelectionModal.tsx
@@ -66,6 +66,7 @@ const ChannelSelectionModal = (props: ChannelSelectionModalProps) => {
             <Radio
               id={channel.id}
               isChecked={selectedChannel.id === channel.id}
+              onChange={() => null /* noop, since clicking entire row selects this radio */}
               helpText={channel.teamName}>
               {channel.name}
             </Radio>
@@ -84,6 +85,8 @@ const ChannelSelectionModal = (props: ChannelSelectionModalProps) => {
         </Modal.Content>
       );
     }
+
+    const pinnedChannels: TeamsChannel[] = channels.filter((c) => c.id === selectedChannel.id);
 
     if (channels.length) {
       return (
@@ -104,7 +107,8 @@ const ChannelSelectionModal = (props: ChannelSelectionModalProps) => {
               <Table className={styles.table}>
                 <Table.Body>
                   <SearchableList
-                    list={channels}
+                    items={channels}
+                    pinnedItems={pinnedChannels}
                     renderListItem={renderRow}
                     searchKeys={['name', 'teamName']}
                     searchQuery={searchQuery}

--- a/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelectionModal/ContentTypeSelectionModal.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/ContentTypeSelectionModal/ContentTypeSelectionModal.tsx
@@ -50,7 +50,10 @@ const ContentTypeSelectionModal = (props: Props) => {
           onClick={() => setSelectedContentTypeId(contentType.sys.id)}
           className={styles.tableRow}>
           <Table.Cell>
-            <Radio id={contentType.sys.id} isChecked={selectedContentTypeId === contentType.sys.id}>
+            <Radio
+              id={contentType.sys.id}
+              isChecked={selectedContentTypeId === contentType.sys.id}
+              onChange={() => null /* noop, since clicking entire row selects this radio */}>
               {contentType.name}
             </Radio>
           </Table.Cell>
@@ -69,6 +72,10 @@ const ContentTypeSelectionModal = (props: Props) => {
       );
     }
 
+    const pinnedContentTypes: ContentTypeProps[] = contentTypes.filter(
+      (c) => c.sys.id === selectedContentTypeId
+    );
+
     if (contentTypes.length) {
       return (
         <>
@@ -81,9 +88,10 @@ const ContentTypeSelectionModal = (props: Props) => {
               <Table className={styles.table}>
                 <Table.Body>
                   <SearchableList
-                    list={contentTypes}
-                    searchQuery={searchQuery}
+                    items={contentTypes}
+                    pinnedItems={pinnedContentTypes}
                     renderListItem={renderRow}
+                    searchQuery={searchQuery}
                     searchKeys={['sys.id', 'displayField', 'name', 'description']}
                   />
                 </Table.Body>

--- a/apps/microsoft-teams/frontend/src/components/config/DebouncedSearchInput/DebouncedSearchInput.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/DebouncedSearchInput/DebouncedSearchInput.tsx
@@ -21,8 +21,7 @@ const DebouncedSearchInput = ({ onChange = () => {}, placeholder, disabled = fal
           isDisabled={disabled}
         />
         <IconButton
-          variant="secondary"
-          icon={<SearchIcon />}
+          icon={<SearchIcon variant="muted" />}
           aria-label="magnifying glass icon"
           aria-hidden={true}
           isDisabled={true}

--- a/apps/microsoft-teams/frontend/src/components/config/SearchableList/SearchableList.spec.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/SearchableList/SearchableList.spec.tsx
@@ -1,46 +1,95 @@
 import SearchableList from './SearchableList';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 describe('ContentTypeSelectionModal component', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('mounts and renders a list of items', () => {
-    const list = ['asdf', 'bsdf'];
+    const items = ['asdf', 'bsdf'];
     const renderListItem = vi.fn().mockImplementation((item, idx) => <p key={idx}>{item}</p>);
     const { unmount } = render(
-      <SearchableList list={list} searchQuery="" renderListItem={renderListItem} searchKeys={[]} />
+      <SearchableList
+        items={items}
+        searchQuery=""
+        renderListItem={renderListItem}
+        searchKeys={[]}
+      />
     );
 
-    const listItem1 = screen.getByText(list[0]);
-    const listItem2 = screen.getByText(list[1]);
+    const listItem1 = screen.getByText(items[0]);
+    const listItem2 = screen.getByText(items[1]);
 
     expect(listItem1).toBeTruthy();
     expect(listItem2).toBeTruthy();
-    expect(renderListItem).toHaveBeenCalledTimes(2);
+    expect(renderListItem).toHaveBeenCalledWith('asdf');
+    expect(renderListItem).toHaveBeenCalledWith('bsdf');
 
     unmount();
   });
 
   describe('searching for a content type', () => {
     it('fuzzy searches for content types', () => {
-      const list = ['videos', 'blog posts', 'tutorials'];
+      const items = ['videos', 'blog posts', 'tutorials'];
       const searchQuery = 'Blgo-Potts'; // intentionally misspelled to trigger fuzzy search
       const renderListItem = vi.fn().mockImplementation((item, idx) => <p key={idx}>{item}</p>);
       const { unmount } = render(
         <SearchableList
-          list={list}
+          items={items}
           searchQuery={searchQuery}
           renderListItem={renderListItem}
           searchKeys={[]}
         />
       );
 
-      const videos = screen.queryByText(list[0]);
-      const blogPosts = screen.queryByText(list[1]);
-      const tutorials = screen.queryByText(list[2]);
+      const videos = screen.queryByText(items[0]);
+      const blogPosts = screen.queryByText(items[1]);
+      const tutorials = screen.queryByText(items[2]);
 
       expect(blogPosts).toBeTruthy();
       expect(videos).toBeFalsy();
       expect(tutorials).toBeFalsy();
+
+      unmount();
+    });
+  });
+
+  describe('optional pinnedItems prop', () => {
+    it('"pins" the items to the top of the filtered list, so that they are always rendered, even if the fuzzy search did not match them', () => {
+      const renderListItem = vi.fn().mockImplementation((item, idx) => (
+        <p data-testid="car-item" key={idx}>
+          {item.title}
+        </p>
+      ));
+
+      const car1 = {
+        id: 123,
+        title: 'A brand new car! Gotta love that "new car" smell!',
+      };
+      const car2 = {
+        id: 456,
+        title: 'A slightly used car! Fuel efficient and experienced!',
+      };
+      const items = [car1, car2];
+
+      const { unmount } = render(
+        <SearchableList
+          items={items}
+          searchQuery={car2.title} // fuzzy search match ONLY car 2
+          renderListItem={renderListItem}
+          searchKeys={['title']}
+          pinnedItems={[car1]} // Pin car 1 to top
+        />
+      );
+
+      const renderedCarsList = screen.getAllByTestId('car-item');
+
+      // assert both cars were rendered, and the pinned one appears first.
+      expect(renderedCarsList.length).toEqual(2);
+      expect(renderedCarsList[0].textContent).toEqual(car1.title);
+      expect(renderedCarsList[1].textContent).toEqual(car2.title);
 
       unmount();
     });


### PR DESCRIPTION
…to render at top of filtered list, regardless of fuzzy-search matching

## Purpose
`<SearchableList>` now accepts an optional list of "Pinned" items that will always be rendered regardless of whether or not the fuzzy search matched those "pinned" items.  This is useful for MS teams channel & content type selection modals, when a user has already made a selection, then execute a search query that does not match that selected channel or content type. (see Screenshots)

### Pinned Channel
![pinned](https://github.com/contentful/apps/assets/158083968/eda89ff2-e70d-4e5c-aada-5f9024fe01a5)

### pinned Content Type
![pinned_contentTypes](https://github.com/contentful/apps/assets/158083968/7eb0ae0f-ad20-4312-b9f1-25b3741c17c8)

## Approach
`<SearchableList>` now accepts an optional list of "Pinned" items, when determining the "filtered" list (list that will actually be rendered), prepend any pinned items to filtered list.  Note: the filtered list must also be unique, because it is possible that the pinned item can also occur in the original list, to solve this we are using `Set`, this could have also been solved with lodash `uniq()` but the less deps the better imo.


## Testing steps
tested locally & unit tested.
