### PR TITLE
feat: Improve ColorPicker Field

### DIFF
--- a/apps/color-picker/src/locations/ConfigScreen.tsx
+++ b/apps/color-picker/src/locations/ConfigScreen.tsx
@@ -1,4 +1,4 @@
-import { AppExtensionSDK } from '@contentful/app-sdk';
+import { ConfigAppSDK } from '@contentful/app-sdk';
 import {
   Button,
   Card,
@@ -45,7 +45,7 @@ const ConfigScreen = () => {
       },
     ],
   });
-  const sdk = useSDK<AppExtensionSDK>();
+  const sdk = useSDK<ConfigAppSDK>();
 
   const addSwatch = () => {
     setParameters({

--- a/apps/color-picker/src/locations/Field.tsx
+++ b/apps/color-picker/src/locations/Field.tsx
@@ -1,4 +1,4 @@
-import { FieldExtensionSDK } from '@contentful/app-sdk';
+import { FieldAppSDK } from '@contentful/app-sdk';
 import { Flex, Form, Menu } from '@contentful/f36-components';
 import { useFieldValue, useSDK } from '@contentful/react-apps-toolkit';
 import { css } from 'emotion';
@@ -6,6 +6,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { ColorBox } from '../components/ColorBox';
 import { SelectColorButton } from '../components/SelectColorButton';
 import { Color, Theme } from '../types';
+import tokens from '@contentful/f36-tokens';
 
 const styles = {
   displayNone: css({
@@ -14,6 +15,13 @@ const styles = {
   menuList: css({
     width: 'calc(100% - 2px)', // -2px to keep borders visible
     left: 0,
+  }),
+  hexValue: css({
+    color: tokens.gray500,
+    fontVariantNumeric: 'tabular-nums',
+    width: '70px',
+    display: 'inline-block',
+    textAlign: 'left',
   }),
 };
 
@@ -25,15 +33,36 @@ const HEIGHT_ITEM = 36;
 type FieldValue = Color | string | undefined;
 
 const Field = () => {
-  const sdk = useSDK<FieldExtensionSDK>();
+  const sdk = useSDK<FieldAppSDK>();
   const [isOpen, setIsOpen] = useState(false);
   const [value, setValue] = useFieldValue<FieldValue>();
   const customColorPicker = useRef<HTMLInputElement>(null);
 
   const storeHexValue = sdk.field.type === 'Symbol';
-  const allowCustomValue = sdk.parameters.instance.withCustomValue;
+
+  const allowCustomValue = useMemo(() => {
+    const { validations } = sdk.field;
+
+    const instanceParam = sdk.parameters.instance.withCustomValue;
+    const hasValidation = validations.find((validation) => validation.in)?.in;
+
+    return instanceParam && !hasValidation;
+  }, [sdk.field, sdk.parameters.instance]);
+
   // @ts-ignore
   const theme: Theme = sdk.parameters.installation.themes[0];
+
+  const validatedColors = useMemo(() => {
+    const { validations } = sdk.field;
+
+    const acceptedValues = validations.find((validation) => validation.in)?.in;
+
+    if (acceptedValues?.at(0) && theme.colors?.at(0)) {
+      return theme.colors.filter((color) => acceptedValues?.includes(color.value));
+    }
+
+    return theme.colors;
+  }, [sdk.field, theme.colors]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -42,11 +71,11 @@ const Field = () => {
     }
 
     // @ts-ignore
-    const customItemHeight = sdk.parameters.instance.withCustomValue ? HEIGHT_ITEM : 0;
-    const calculatedHeight = HEIGHT_BASE + customItemHeight + theme.colors.length * HEIGHT_ITEM;
+    const customItemHeight = allowCustomValue ? HEIGHT_ITEM : 0;
+    const calculatedHeight = HEIGHT_BASE + customItemHeight + validatedColors.length * HEIGHT_ITEM;
 
     sdk.window.updateHeight(calculatedHeight <= 400 ? calculatedHeight : 400);
-  }, [isOpen, sdk, theme]);
+  }, [isOpen, sdk, validatedColors, allowCustomValue]);
 
   const name = useMemo<string>(() => {
     switch (typeof value) {
@@ -97,13 +126,16 @@ const Field = () => {
             />
           </Menu.Trigger>
           <Menu.List className={styles.menuList}>
-            {theme.colors.map((color: Color) => (
+            {validatedColors.map((color: Color) => (
               <Menu.Item
                 key={color.id}
                 onClick={() => setValue(storeHexValue ? color.value : color)}>
                 <Flex alignItems="center" gap="spacingXs">
                   <ColorBox color={color} />
-                  {color.name}
+                  <Flex gap="spacing2Xs">
+                    {color.name}
+                    <span className={styles.hexValue}>{color.value}</span>
+                  </Flex>
                 </Flex>
               </Menu.Item>
             ))}


### PR DESCRIPTION


## Summary
   - Replace deprecated `AppExtensionSDK`;
   - Replace deprecated `FieldExtensionSDK`;
   - Display only validated colors in a validated field;
   - Show hex value in dropdown;
   - Disable custom values in a validated field.

## Purpose

<!-- Why are we introducing this change now? What problem does it solve? What is the story/background for it? -->
The purpose is to improve UX for the content editor by simplifying the color picker field.

## Approach

<!-- Why did we do it the way we did? Did we consider alternatives? What other implementation details or artifacts (screenshots etc.) would help reviewers contextualize change? -->
I have also considered exposing a boolean in the configuration screen to validate against the label (`white` instead of `#ffffff`) but that would introduce breaking changes. I am thinking about supporting both and converting label to value behind the scenes, but I will leave this for a future PR.

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->
1. Create two text fields with the Color Picker appearance
2. In one of the fields, add validation for some of your theme values
3. Confirm that in the validated field's dropdown you only see the validated items available for selection

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->
App should still function as previously; if there is no validation present, `validatedColors` return the `theme.colors` array unchanged.

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->
N/A

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
N/A

## Screenshots
### Unvalidated Color Picker field
![image](https://github.com/contentful/apps/assets/69549795/82600093-7a90-4127-b798-62cb962f0272)

### Validated Color Picker field
![image](https://github.com/contentful/apps/assets/69549795/a7b895d1-d14d-41e8-83bd-069d5acb5dea)


