### PR TITLE
fix: handle DeletedEntry entry type

### DIFF
--- a/apps/microsoft-teams/app-actions/src/helpers/entry-activity.spec.ts
+++ b/apps/microsoft-teams/app-actions/src/helpers/entry-activity.spec.ts
@@ -4,6 +4,7 @@ import { buildEntryActivity } from './entry-activity';
 import {
   CollectionProp,
   ContentTypeProps,
+  EntryProps,
   LocaleProps,
   PlainClientAPI,
   UserProps,
@@ -58,6 +59,23 @@ describe('buildEntryActivity', () => {
       ];
       cma = makeMockPlainClient(cmaClientMockResponses, cmaRequestStub);
       cmaHost = 'api.contentful.com';
+    });
+
+    it('returns an entry activity object', async () => {
+      const result = await buildEntryActivity(entryEvent, cma, cmaHost);
+      expect(result).to.have.property('entryTitle', 'Entry ID abc123');
+    });
+  });
+
+  describe('when there are no fields in the entry (e.g. entry was deleted)', () => {
+    beforeEach(() => {
+      // Here we are mocking an entry that lacks fields, which is the case when the entry type is DeletedEntry
+      // (i.e. for unpublish and delete events)
+      const mockDeletedEntry = {
+        ...mockEntryEvent.entry,
+        fields: undefined,
+      } as unknown as EntryProps;
+      entryEvent = { ...mockEntryEvent, entry: mockDeletedEntry };
     });
 
     it('returns an entry activity object', async () => {

--- a/apps/microsoft-teams/app-actions/src/helpers/entry-activity.ts
+++ b/apps/microsoft-teams/app-actions/src/helpers/entry-activity.ts
@@ -40,7 +40,10 @@ const computeEntryTitle = (
   if (!displayField) return NO_ENTRY_TITLE;
 
   const defaultLocaleCode = computeDefaultLocaleCode(locales);
-  const entryTitleField = entry.fields[displayField];
+
+  // the entry here could be a DeletedEntry which is lacking a fields attribute. We will do a runtime
+  // check here to catch this
+  const entryTitleField = entry.fields && entry.fields[displayField];
 
   if (!entryTitleField) return NO_ENTRY_TITLE;
 


### PR DESCRIPTION
## Purpose

When we unpublish or delete an entry, the payload we get from the AppEvent is _not_ a regular Entry. Instead it's of type `DeletedEntry`. It looks like this:

```json
{
  "sys": {
    "type": "DeletedEntry",
    "id": "19bRpH5BASo0WIu9i2vH6Z",
    "space": {
      "sys": {
        "type": "Link",
        "linkType": "Space",
        "id": "zl9er5nqimd0"
      }
    },
    "environment": {
      "sys": {
        "id": "master",
        "type": "Link",
        "linkType": "Environment"
      }
    },
    "contentType": {
      "sys": {
        "type": "Link",
        "linkType": "ContentType",
        "id": "blogPost"
      }
    },
    "revision": 7,
    "createdAt": "2024-03-15T18:37:58.806Z",
    "updatedAt": "2024-03-15T18:37:58.806Z",
    "deletedAt": "2024-03-15T18:37:58.806Z"
  }
}
```

The main difference is it's missing fields and thus missing a title.

Our logic was choking on the missing fields.

## Approach

* Provide a backup title if fields are missing (e.g. what we do when entry is created)

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
