### PR TITLE
fix: add new Netlify configuration keys

### DIFF
--- a/apps/netlify/frontend/src/constants.js
+++ b/apps/netlify/frontend/src/constants.js
@@ -16,8 +16,8 @@ export const NETLIFY_STATE_TO_EVENT = {
   error: EVENT_BUILD_FAILED,
 };
 
-export const PUBNUB_PUBLISH_KEY = 'pub-c-a99421b9-4f21-467b-ac0c-d0292824e8e1';
-export const PUBNUB_SUBSCRIBE_KEY = 'sub-c-3992b1ae-f7c9-11e8-adf7-5a5b31762c0f';
+export const PUBNUB_PUBLISH_KEY = 'pub-c-51df0950-e61c-4547-a621-b83f4a96652a';
+export const PUBNUB_SUBSCRIBE_KEY = 'sub-c-72137dd0-3607-4bf8-b97f-fc223e76ad23';
 
 export const NETLIFY_CLIENT_ID = 'a1d06395eadd312fc45ab6f0f6d7fd6665642c9fcb697839739d157f93bbe918';
 export const NETLIFY_API_BASE = 'https://api.netlify.com/api/v1';


### PR DESCRIPTION
## Purpose

The purpose of this PR is to update the Netlify app with new publish and subscription keys in order to fix the disabled "Build" button that is now present for customers. 

## Approach

The reason we have to update these keys is because we are currently seeing the following production error:
![Screenshot 2024-03-18 at 3 30 02 PM](https://github.com/contentful/apps/assets/58186851/464d9c09-4f70-46a8-ad79-5e730e1e5694)

Given that the Subscribe key is invalid, I took a look at our current PubNub [account](https://admin.pubnub.com/#/user/458113/account/458075/app/35247907/) and noticed that as of 3 days ago, our account was delinquent for the invoice and therefore suspended. This all seemed a bit too coincidental to not be related, even though I could not confirm that the Netlify app was 100% associated with this account. Thankfully Harry and Jeremy resolved this billing issue, and the account is now active. Though, even with the account active, it seems that the original Publish and Subscribe keys were not preserved, so I have added new ones and updated the Netlify app configuration with the new keys. I cannot confirm that this works locally, because of an issue with HTTP vs HTTPS and the PubNub calls unfortunately.

But due to the timing of our account being shut down and the Netlify issues that arose, I feel this resolution has a good chance 🤞  

## Breaking Changes

None. App is already broken.
