### PR TITLE
feat: add mux token signing as HAA

### DIFF
--- a/apps/mux/app-actions/package-lock.json
+++ b/apps/mux/app-actions/package-lock.json
@@ -8,11 +8,13 @@
       "name": "@contentful/mux-app-actions",
       "version": "1.0.0",
       "dependencies": {
-        "@contentful/node-apps-toolkit": "^2.6.0"
+        "@contentful/node-apps-toolkit": "^2.6.0",
+        "jsonwebtoken": "^9.0.2"
       },
       "devDependencies": {
         "@tsconfig/node18": "^18.2.0",
         "@types/chai": "^4.3.5",
+        "@types/jsonwebtoken": "^9.0.6",
         "@types/mocha": "^10.0.1",
         "@types/sinon": "^10.0.16",
         "@types/sinon-chai": "^3.2.9",
@@ -216,6 +218,15 @@
       "version": "0.0.30",
       "resolved": "https://registry.npmjs.org/@types/json-patch/-/json-patch-0.0.30.tgz",
       "integrity": "sha512-MhCUjojzDhVLnZnxwPwa+rETFRDQ0ffjxYdrqOP6TBO2O0/Z64PV5tNeYApo4bc4y4frbWOrRwv/eEkXlI13Rw=="
+    },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.6.tgz",
+      "integrity": "sha512-/5hndP5dCjloafCXns6SZyESp3Ldq7YjH3zwzwczYnjxIT0Fqzk5ROSYVGfFyczIue7IUEj8hkvLbPoLQ18vQw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/keyv": {
       "version": "3.1.4",

--- a/apps/mux/app-actions/package.json
+++ b/apps/mux/app-actions/package.json
@@ -12,11 +12,13 @@
     "test:watch": "NODE_ENV=test TS_NODE_TRANSPILE_ONLY=1 mocha --watch --watch-files src --watch-files test -r dotenv/config"
   },
   "dependencies": {
-    "@contentful/node-apps-toolkit": "^2.6.0"
+    "@contentful/node-apps-toolkit": "^2.6.0",
+    "jsonwebtoken": "^9.0.2"
   },
   "devDependencies": {
     "@tsconfig/node18": "^18.2.0",
     "@types/chai": "^4.3.5",
+    "@types/jsonwebtoken": "^9.0.6",
     "@types/mocha": "^10.0.1",
     "@types/sinon": "^10.0.16",
     "@types/sinon-chai": "^3.2.9",
@@ -28,4 +30,3 @@
     "typescript": "^5.1.6"
   }
 }
-

--- a/apps/mux/app-actions/src/actions/get-jwt-tokens.spec.ts
+++ b/apps/mux/app-actions/src/actions/get-jwt-tokens.spec.ts
@@ -4,12 +4,31 @@ import { makeMockAppActionCallContext } from '../../test/mocks';
 import { AppInstallationProps, SysLink } from 'contentful-management';
 import { AppActionCallContext } from '@contentful/node-apps-toolkit';
 import { handler } from './get-jwt-tokens';
+import { AppActionCallResponseSuccess, SignedUrlTokens } from '../types';
+
+const parseJwt = (token: string) => {
+  return JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString());
+};
+
+const mapParsedValues = (obj: SignedUrlTokens): Record<string, any> => {
+  // iterate over the obj, parse each of the values, and return the object back with the same keys and parsed value
+  return Object.fromEntries(Object.entries(obj).map(([k, v]) => [k, parseJwt(v)]));
+};
 
 describe('get-signed-url-tokens.handler', () => {
   let cmaRequestStub: sinon.SinonStub;
   let context: AppActionCallContext;
 
-  const parameters = {};
+  const playbackId = 'playbackId';
+  const parameters = { playbackId };
+  const appInstallationParameters = {
+    // these test values were derived from an actual signing key issued by mux
+    // note: the keys are intentionally included here in plaintext but are not operational
+    muxEnableSignedUrls: true,
+    muxSigningKeyId: 'F57REGMS9OMS7VBU002nmPP1x6wloRfKuOeS7TPcg8qk',
+    muxSigningKeyPrivate:
+      'LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb2dJQkFBS0NBUUVBcjgvK2pXdGdLc1NiTXBIYmovVnJTbkhLNkxHLzlObW9mS1J4TWgvbG0zVVpZMjA2CktHLy91QXlBRWVSZzVDYTdURVZueGpGVlNXTmhpTlZsbDdzOW91aFE3V2RGa3g4Uk1lTEFTU3NZZ0g4NGdVWVoKQzI4Uy9nTHlNOVBkWFdjeTVEa0Y1bkJjT3JoQWZoN3lwN01LQndvZEZaVnhsbVhxbU9adlBTb3c5YnovYjFhSgpRcEtURm1xSXcrVVREWWZLSmk3OUFUMDYxbXVlNXlZbEVzQm9LZU9VYkdaaTh1eDZWZTlmMzQvNXEyeFhsZEVqClAyNU0xclRkQnVacVh2N0xrNTlncllzVG03TVZQOGtpYnorRnEyY051TE8vbFVWT2hxazg4bjliNEVxNHV0Sk0KM0k1K2o3QnlJNGtGQUtsYUNvL2tRcFNvaXVuaXQzQ29WTEkvZHdJREFRQUJBb0lCQUdBQVNWVmJqcFdMNmRzQgpQazByaTd5SXltMnBzZEcza0lNUElDaG90bTNlMFZBemNwQm1KOUtPTU5pVVJqd08wak5ocXJyVWNXZXpkcXpMCktjQmlvOU55MjgzbW1GMHZsNm9QMFVPaTNxdzd5OVQ3TysyOFp6aUF6MVJ4bWV6SXowZER3KzhDNTduQXBxYTMKcTNUYkZOeW5MeDU4RGh3NzVwQTdNLzdJTFJmaGhZemtTVi9oMVhsQWlVWFZCQTl4ZlJiUE9seVJrTERqL1pZTwpMSlpvbzVVZ1ZHTkxFWWkzWEU4djlLeW1VVHZpS2R0NUpXK0RWdFBEUDZFT3BBenVnUWR6OHVkWkRON3VWYVQ4Clg4SEU2Yzh3TDNqdVhrc0F2QVgyZ1FtWUFHdlNKY3oyYy9adVRuQlI4SmVVUnpac2RGNGkxWlA1SEMraFBBZTgKTmU3eWhTRUNnWUVBNVZQdGNoRFRmOVFlZEE4bjRqamhUYjVEeTFyb2x2dDVRRGpkQkVlMytJbXVmZEZxS3VvTgpxdWwyajB1SHhsMXNCZDZsM1NwRGdZK25EWGVEMWUxOUExWVFaVWRaTjJIOVJpYmgxaE1vdzg1VkpQcU9Ld1BXCmpuTXNHdHo0WEhiQ0szMFd2dmZFSnlHUjErOGRyZHNYWVA2NC9lbGdMV0RoUGViTmRFbmJaUmtDZ1lFQXhFS3YKWlFaUXIxZnhxMk0yMFUvaDBIelZiSmplTmJOSU9YQkxRVm91eDVNRVJuNmFmb3JjSFBjWDJ2bXRsK0lrbmx5MgpGemkrYWY2WjlIRXFpMjdRTDdKWGZ2SDl6eEFZbFE2N0hMT0FaQkI1M0c0MmxUc1JDMjF5KzJ6V1VTMzMyY2J3CkF5MnJjaWJTM2hGTmsxeHRPZUh3YlE5WWtCclFvaDVJQm9JaFN3OENnWUJNSzd4S2p0d3hNVHVNUVJ4MlAzNVcKWEVRWVgzR3g5SVVwbDdtUm1tQzQ1TUpZZUI1VGNycG5jblEyMUZlY3c1c0Z1QlpQaDZJMGZvcDJKcVJiZ2k1cgoxVUpNNFkzNG4wdUk2WkZKa2NPUWhoQXg0Q2Nva25YSml1ZXpaSUg1OUZnNkthcE1jKzlyTC9OSlRkc0Z6Q2ZQCng4dWFTdEh2UUthUDhRRjlCcXNnd1FLQmdHZE03a0xQYXlLUHVJMU1RR3MxajVjTVRjM0dQSmVwVU9laXVvbWcKYlNUd3RmeGc0UEtnSmpFOHdacXBkbnlPTkZZQ1dIbXFqVmIvQW92T0VPV3BJdjBuOHJQSHJaOFNTczRTSGR5QwpncDZvcVd1anV5a2JHT0taN2o1MlQrd1V0UE0wcWRvU2JMNDl2eG5SbzdKZm9NSXBzVUhHSlFoY2hObi85RXN3CnJWTnpBb0dBRnpyUWk5emZ6d2pPajNBeUIxcmpVWmRvMUNXbTM0NytubEl6MnRMTDV0NWFUa2dvSHIveFl5cUsKbVRvaGhRemtHTUVtakJIZ2JPRGxiQWp6TGNQY1h5WFVGSkVWcnBUOHRRSEZWdjVZTDFPcGRhWnNMV2UwM1ZlNgpUYlhQN1MvUkI1cURONkRlV0dIMHZQUEw5WWNnQVRYYjJ0Snc3Nm0xNkFpSnR4eVhZelk9Ci0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg==',
+  };
   const cmaClientMockResponses: [AppInstallationProps] = [
     {
       sys: {
@@ -21,9 +40,7 @@ describe('get-signed-url-tokens.handler', () => {
         createdAt: 'createdAt',
         updatedAt: 'updatedAt',
       },
-      parameters: {
-        apiKey: 'openai-api-key',
-      },
+      parameters: appInstallationParameters,
     },
   ];
 
@@ -32,8 +49,33 @@ describe('get-signed-url-tokens.handler', () => {
     context = makeMockAppActionCallContext(cmaClientMockResponses, cmaRequestStub);
   });
 
-  it('returns the images result', async () => {
+  it('returns a valid set of tokens', async () => {
     const result = await handler(parameters, context);
     expect(result).to.have.property('ok', true);
+
+    const { playbackToken, posterToken, storyboardToken } = mapParsedValues(
+      (result as AppActionCallResponseSuccess<SignedUrlTokens>).data
+    );
+
+    expect(playbackToken).to.have.property('sub', playbackId);
+    expect(playbackToken).to.have.property('aud', 'v');
+    expect(posterToken).to.have.property('sub', playbackId);
+    expect(posterToken).to.have.property('aud', 't');
+    expect(storyboardToken).to.have.property('sub', playbackId);
+    expect(storyboardToken).to.have.property('aud', 's');
+  });
+
+  describe('when mux signed urls is not enabled', () => {
+    beforeEach(() => {
+      context = makeMockAppActionCallContext(
+        [
+          {
+            ...cmaClientMockResponses,
+            parameters: { ...appInstallationParameters, muxEnableSignedUrls: false },
+          },
+        ],
+        cmaRequestStub
+      );
+    });
   });
 });

--- a/apps/mux/app-actions/src/actions/get-jwt-tokens.spec.ts
+++ b/apps/mux/app-actions/src/actions/get-jwt-tokens.spec.ts
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 import { makeMockAppActionCallContext } from '../../test/mocks';
 import { AppInstallationProps, SysLink } from 'contentful-management';
 import { AppActionCallContext } from '@contentful/node-apps-toolkit';
-import { handler } from './get-jwt-tokens';
+import { TOKEN_AUDIENCE, handler } from './get-jwt-tokens';
 import { AppActionCallResponseSuccess, SignedUrlTokens } from '../types';
 
 const parseJwt = (token: string) => {
@@ -58,11 +58,11 @@ describe('get-signed-url-tokens.handler', () => {
     );
 
     expect(playbackToken).to.have.property('sub', playbackId);
-    expect(playbackToken).to.have.property('aud', 'v');
+    expect(playbackToken).to.have.property('aud', TOKEN_AUDIENCE.playback);
     expect(posterToken).to.have.property('sub', playbackId);
-    expect(posterToken).to.have.property('aud', 't');
+    expect(posterToken).to.have.property('aud', TOKEN_AUDIENCE.thumbnail);
     expect(storyboardToken).to.have.property('sub', playbackId);
-    expect(storyboardToken).to.have.property('aud', 's');
+    expect(storyboardToken).to.have.property('aud', TOKEN_AUDIENCE.storyboard);
   });
 
   describe('when mux signed urls is not enabled', () => {

--- a/apps/mux/app-actions/src/actions/get-jwt-tokens.ts
+++ b/apps/mux/app-actions/src/actions/get-jwt-tokens.ts
@@ -4,6 +4,13 @@ import { withAsyncAppActionErrorHandling } from '../helpers/error-handling';
 import * as jwt from 'jsonwebtoken';
 import { AppInstallationProps, FreeFormParameters } from 'contentful-management';
 
+// See https://docs.mux.com/guides/secure-video-playback#4-generate-a-json-web-token-jwt
+export const TOKEN_AUDIENCE = {
+  playback: 'v',
+  thumbnail: 't',
+  storyboard: 's',
+};
+
 interface AppActionCallParameters {
   playbackId: string;
 }
@@ -68,9 +75,24 @@ export const handler = withAsyncAppActionErrorHandling(
     return {
       ok: true,
       data: {
-        playbackToken: sign(playbackId, muxSigningKeyId, muxSigningKeyPrivate, 'v'),
-        posterToken: sign(playbackId, muxSigningKeyId, muxSigningKeyPrivate, 't'),
-        storyboardToken: sign(playbackId, muxSigningKeyId, muxSigningKeyPrivate, 's'),
+        playbackToken: sign(
+          playbackId,
+          muxSigningKeyId,
+          muxSigningKeyPrivate,
+          TOKEN_AUDIENCE.playback
+        ),
+        posterToken: sign(
+          playbackId,
+          muxSigningKeyId,
+          muxSigningKeyPrivate,
+          TOKEN_AUDIENCE.thumbnail
+        ),
+        storyboardToken: sign(
+          playbackId,
+          muxSigningKeyId,
+          muxSigningKeyPrivate,
+          TOKEN_AUDIENCE.storyboard
+        ),
       },
     };
   }

--- a/apps/mux/app-actions/src/actions/get-jwt-tokens.ts
+++ b/apps/mux/app-actions/src/actions/get-jwt-tokens.ts
@@ -1,20 +1,76 @@
 import { AppActionCallContext } from '@contentful/node-apps-toolkit';
 import { AppActionCallResponse, SignedUrlTokens } from '../types';
 import { withAsyncAppActionErrorHandling } from '../helpers/error-handling';
+import * as jwt from 'jsonwebtoken';
+import { AppInstallationProps, FreeFormParameters } from 'contentful-management';
 
-interface AppActionCallParameters {}
+interface AppActionCallParameters {
+  playbackId: string;
+}
+
+interface AppInstallationParameters {
+  muxAccessTokenId?: string;
+  muxAccessTokenSecret?: string;
+  muxEnableSignedUrls?: boolean;
+  muxSigningKeyId?: string;
+  muxSigningKeyPrivate?: string;
+  muxEnableAudioNormalize?: boolean;
+  muxDomain?: string;
+}
+
+export const parametersFromAppInstallation = (appInstallation: AppInstallationProps) => {
+  const appParameters = appInstallation.parameters;
+  assertAppInstallationParameters(appParameters);
+  return appParameters;
+};
+
+function assertAppInstallationParameters(
+  parameters: FreeFormParameters | undefined
+): asserts parameters is AppInstallationParameters {
+  if (!parameters) throw new Error('No parameters found on appInstallation');
+  if (typeof parameters !== 'object') throw new Error('Invalid parameters type');
+}
+
+const getPrivateKey = (key: string) => Buffer.from(key, 'base64');
+
+const sign = (playbackId: string, signingKeyId: string, signingKeyPrivate: string, aud: string) =>
+  jwt.sign({}, getPrivateKey(signingKeyPrivate), {
+    algorithm: 'RS256',
+    keyid: signingKeyId,
+    audience: aud,
+    subject: playbackId,
+    noTimestamp: true,
+    expiresIn: '12h',
+  });
 
 export const handler = withAsyncAppActionErrorHandling(
   async (
-    _payload: AppActionCallParameters,
-    _context: AppActionCallContext
+    parameters: AppActionCallParameters,
+    context: AppActionCallContext
   ): Promise<AppActionCallResponse<SignedUrlTokens>> => {
+    const {
+      cma,
+      appActionCallContext: { appInstallationId },
+    } = context;
+    const { playbackId } = parameters;
+    if (typeof playbackId !== 'string') {
+      throw new TypeError('missing required playbackId from action parameters');
+    }
+
+    const appInstallation = await cma.appInstallation.get({ appDefinitionId: appInstallationId });
+    const { muxSigningKeyId, muxSigningKeyPrivate } =
+      parametersFromAppInstallation(appInstallation);
+
+    if (typeof muxSigningKeyId !== 'string' || typeof muxSigningKeyPrivate !== 'string') {
+      throw new TypeError('missing required mux signing key id or signing key private');
+    }
+
     return {
       ok: true,
       data: {
-        playbackToken: 'token',
-        posterToken: 'token',
-        storyboardToken: 'token',
+        playbackToken: sign(playbackId, muxSigningKeyId, muxSigningKeyPrivate, 'v'),
+        posterToken: sign(playbackId, muxSigningKeyId, muxSigningKeyPrivate, 't'),
+        storyboardToken: sign(playbackId, muxSigningKeyId, muxSigningKeyPrivate, 's'),
       },
     };
   }

--- a/apps/mux/frontend/src/index.tsx
+++ b/apps/mux/frontend/src/index.tsx
@@ -400,17 +400,17 @@ export class App extends React.Component<AppProps, AppState> {
       return;
     }
     this.setState({
-      playbackToken: createSignedPlaybackToken(
+      playbackToken: await createSignedPlaybackToken(
         signedPlaybackId,
         muxSigningKeyId!,
         muxSigningKeyPrivate!
       ),
-      posterToken: createSignedThumbnailToken(
+      posterToken: await createSignedThumbnailToken(
         signedPlaybackId,
         muxSigningKeyId!,
         muxSigningKeyPrivate!
       ),
-      storyboardToken: createSignedStoryboardToken(
+      storyboardToken: await createSignedStoryboardToken(
         signedPlaybackId,
         muxSigningKeyId!,
         muxSigningKeyPrivate!

--- a/apps/mux/frontend/src/index.tsx
+++ b/apps/mux/frontend/src/index.tsx
@@ -400,17 +400,17 @@ export class App extends React.Component<AppProps, AppState> {
       return;
     }
     this.setState({
-      playbackToken: await createSignedPlaybackToken(
+      playbackToken: createSignedPlaybackToken(
         signedPlaybackId,
         muxSigningKeyId!,
         muxSigningKeyPrivate!
       ),
-      posterToken: await createSignedThumbnailToken(
+      posterToken: createSignedThumbnailToken(
         signedPlaybackId,
         muxSigningKeyId!,
         muxSigningKeyPrivate!
       ),
-      storyboardToken: await createSignedStoryboardToken(
+      storyboardToken: createSignedStoryboardToken(
         signedPlaybackId,
         muxSigningKeyId!,
         muxSigningKeyPrivate!


### PR DESCRIPTION
## Purpose

As part of the effort to get the Mux app functional again, we need to move token signing to the backend (since jsonwebtoken is no longer supported in browsers).

This PR introduces token signing in a backend app action. Later, the front end will be updated to call these values instead of attempting to sign on the frontend.

## Approach

* Use jsonwebtoken and move signing to app action

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
