### PR TITLE
Extend "handle-app-event" to support workflows

### DIFF
--- a/apps/microsoft-teams/app-actions/src/constants.ts
+++ b/apps/microsoft-teams/app-actions/src/constants.ts
@@ -5,4 +5,5 @@ export const TOPIC_ACTION_MAP = {
   'ContentManagement.Entry.publish': 'published',
   'ContentManagement.Entry.unpublish': 'unpublished',
   'ContentManagement.Entry.delete': 'deleted',
+  'Workflow.Step.notifyMicrosoftTeams': 'Workflow.Step.notifyMicrosoftTeams',
 } as const;

--- a/apps/microsoft-teams/app-actions/src/services/msteams-bot-service.ts
+++ b/apps/microsoft-teams/app-actions/src/services/msteams-bot-service.ts
@@ -5,10 +5,33 @@ import {
   MsTeamsBotServiceResponse,
   TeamInstallation,
   TestMessage,
+  WorkflowUpdateMessage,
 } from '../types';
 
 export class MsTeamsBotService {
   constructor(public readonly botServiceUrl: string, public readonly apiKey: string) {}
+
+  async sendWorkflowUpdateMessage(
+    workflowUpdateMessage: WorkflowUpdateMessage,
+    tenantId: string,
+    requestContext: AppActionRequestContext
+  ): Promise<MsTeamsBotServiceResponse<MessageResponse>> {
+    const res = await fetch(
+      `${this.botServiceUrl}/api/tenant/${tenantId}/workflow_update_messages`,
+      {
+        method: 'POST',
+        headers: this.getRequestHeaders(requestContext),
+        body: JSON.stringify(workflowUpdateMessage),
+      }
+    );
+
+    const responseBody = await res.json();
+    this.assertMsTeamsBotServiceCallResult<MessageResponse>(
+      responseBody,
+      this.assertMessageResponse
+    );
+    return responseBody;
+  }
 
   async sendEntryActivityMessage(
     entryActivityMessage: EntryActivityMessage,

--- a/apps/microsoft-teams/app-actions/src/types.ts
+++ b/apps/microsoft-teams/app-actions/src/types.ts
@@ -82,6 +82,15 @@ export interface EntryActivity {
   entryUrl: string;
 }
 
+export interface WorkflowUpdateMessage {
+  title: string;
+  currentStep: string;
+  previousStep: string;
+  contentType: string;
+  callToActionUrl: string; // URL
+  updateDateTime: string; // DateTime '2024-01-18T21:43:54.267Z',
+}
+
 export interface EntryActivityMessage {
   channel: {
     teamId: string;
@@ -126,6 +135,11 @@ export type MsTeamsBotServiceResponse<T> =
 export interface SendEntryActivityMessageResult {
   entryActivityMessage: EntryActivityMessage;
   sendMessageResult: MsTeamsBotServiceResponse<MessageResponse>;
+}
+
+export interface SendWorkflowUpdateMessageResult {
+  workflowUpdateMessage: WorkflowUpdateMessage;
+  sendWorkflowUpdateResult: MsTeamsBotServiceResponse<MessageResponse>;
 }
 
 export interface EntryEvent {

--- a/apps/microsoft-teams/frontend/src/hooks/useGetTeamsChannels.ts
+++ b/apps/microsoft-teams/frontend/src/hooks/useGetTeamsChannels.ts
@@ -1,14 +1,13 @@
 import { useEffect, useCallback, useState } from 'react';
 import { useSDK } from '@contentful/react-apps-toolkit';
 import { ConfigAppSDK } from '@contentful/app-sdk';
-import { AppInstallationParameters, TeamsChannel } from '@customTypes/configPage';
+import { TeamsChannel } from '@customTypes/configPage';
 
 const useGetTeamsChannels = () => {
   const [channels, setChannels] = useState<TeamsChannel[]>([]);
   const [error, setError] = useState<Error>();
   const [loading, setLoading] = useState<boolean>(true);
   const sdk = useSDK<ConfigAppSDK>();
-  const { tenantId } = sdk.parameters.installation as AppInstallationParameters;
 
   const getAllChannels = useCallback(async () => {
     try {
@@ -43,7 +42,7 @@ const useGetTeamsChannels = () => {
     }
 
     setLoading(false);
-  }, [sdk.cma.appActionCall, sdk.ids.environment, sdk.ids.space, sdk.ids.app, tenantId]);
+  }, [sdk.cma.appActionCall, sdk.ids.environment, sdk.ids.space, sdk.ids.app]);
 
   useEffect(() => {
     getAllChannels();


### PR DESCRIPTION
**DO NOT MERGE**

- [x] Do not merge this PR before the supporting [ms-teams-bot-service PR](https://github.com/contentful/msteams-bot-service/pull/352)

## Purpose
Extend the existing `"handle-app-event"` app action to also handle Workflows.  


## Approach
In the interest of time, as well as prototyping/learning we made the explicit choice
to re-use/extend this "app-events" app-action to handle "workflow" events as well.

This block of code to handle workflow topics is intentionally repetative and intrusive.
The end goal is to create a new app action to specifically handle "workflow" events.
Ideally, at that time, it will be a simple copy/paste operation, leaving this
app-action unchanged.

So, obviously an alternative would be to create a distinct app-action solely to handle workflows.  I'm not sure what the pros/cons of that decision would be beyond cleaner code. 

## Testing steps
Unit tested.

### Open questions
1. Exact structure/format of payload coming to this app from `workflow-consumer-api`.  
~~- [ ] todo: get example payload~~ 🚢  it

2. Ensure that the payload that this app sends to `config.msTeamsBotService.sendWorkflowUpdateMessage()` contains everything that we will need to render an adaptive card. **With the exception** of "colors" see [colors jira ticket](https://contentful.atlassian.net/browse/INTEG-1899)




## Deployment
Although it would not a catastrophic ka-boom to merge this PR before the supporting [ms-teams-bot-service PR](https://github.com/contentful/msteams-bot-service/pull/352) has been merged, it's a good habit (imo) to merge code only once the dependencies (in our case, `config.msTeamsBotService.sendWorkflowUpdateMessage()`) have been implemented/satisfied.

