### PR TITLE
fix: use correct build directory for vercel

### DIFF
--- a/apps/vercel/contentful-app-manifest.json
+++ b/apps/vercel/contentful-app-manifest.json
@@ -9,7 +9,13 @@
       "path": "actions/get-preview-envs.js",
       "entryFile": "./app-actions/src/actions/get-preview-envs.ts",
       "allowNetworks": [],
-      "parameters": [ ]
+      "parameters": [
+        {
+          "id": "contentTypeId",
+          "name": "Content type id",
+          "type": "Symbol"
+        }
+      ]
     }
   ]
 }

--- a/apps/vercel/contentful-app-manifest.json
+++ b/apps/vercel/contentful-app-manifest.json
@@ -2,7 +2,7 @@
   "actions": [
     {
       "id": "vercelGetPreviewEnvironments",
-      "name": "Get preview environments provided by the Vercel app",
+      "name": "Get preview environments from Vercel",
       "category": "Custom",
       "description": "This action returns preview environments provided by Vercel",
       "type": "function",

--- a/apps/vercel/package.json
+++ b/apps/vercel/package.json
@@ -9,8 +9,8 @@
     "build-frontend": "cd frontend && npm ci --include=dev && BUILD_PATH=../build npm run build",
     "build:dev": "rimraf ./build && npm run build-frontend && npm run build-app-actions:dev",
     "build-app-actions:dev": "cd app-actions && npm ci && cd .. && NODE_ENV=development node build-actions.js",
-    "deploy": "contentful-app-scripts upload --ci --bundle-dir ./dist --organization-id ${DEFINITIONS_ORG_ID} --definition-id 4QsJrTg4fFjX7UmQDkeayq --token ${CONTENTFUL_CMA_TOKEN}",
-    "deploy:test": "contentful-app-scripts upload --ci --bundle-dir ./dist --organization-id ${DEV_TESTING_ORG_ID} --definition-id 1oxLxW5fY54lZLmnO11Ofn --token ${TEST_CMA_TOKEN}",
+    "deploy": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEFINITIONS_ORG_ID} --definition-id 4QsJrTg4fFjX7UmQDkeayq --token ${CONTENTFUL_CMA_TOKEN}",
+    "deploy:test": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEV_TESTING_ORG_ID} --definition-id 1oxLxW5fY54lZLmnO11Ofn --token ${TEST_CMA_TOKEN}",
     "deploy:sandbox": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEV_TESTING_ORG_ID} --definition-id 3TeQ7QhyhnRBUMOpBAPhos --token ${TEST_CMA_TOKEN}",
     "call-app-action": "npx ts-node scripts/call-app-action.ts"
   },


### PR DESCRIPTION
## Purpose

Our deploys were failing (silently! 😢 ) for Vercel deploy to production:

```
> **********-app-scripts upload --ci --bundle-dir ./dist --organization-id ${DEFINITIONS_ORG_ID} --definition-id 4QsJrTg4fFjX7UmQDkeayq --token ${CONTENTFUL_CMA_TOKEN}

- Validating your input...

  ----------------------------
  App Actions found in ./**********-app-manifest.json.
  ----------------------------


    Creation error:

      Something went wrong while creating the app upload.

      Message:  ENOENT: no such file or directory, scandir 'dist'
```

Reason appears to be we forgot to update the target directory for the build from `dist` (what vite uses by default for the frontend) to `build` (what we use for our parent apps that bundle front end with app actions)

## Approach



## Testing steps

After fixing and testing (on sandbox) everything in order:

```
$ npm run call-app-action -- -a vercelGetPreviewEnvironments -s q5wv5ajna1af -p '{ "contentTypeId": "content-type-id" }'

> @contentful/vercel-app@1.0.0 call-app-action
> npx ts-node scripts/call-app-action.ts -a vercelGetPreviewEnvironments -s q5wv5ajna1af -p { "contentTypeId": "content-type-id" }

APP ACTION RESULT
{
  sys: {
    id: '61MhBTY6pOSNXn7IvBrWKJ',
    type: 'AppActionCallDetails',
    space: { sys: { type: 'Link', linkType: 'Space', id: 'q5wv5ajna1af' } },
    sys: { type: 'Link', linkType: 'Environment', id: 'master' },
    createdBy: {
      sys: {
        type: 'Link',
        linkType: 'AppAction',
        id: 'vercelGetPreviewEnvironments'
      }
    },
    createdAt: '2024-03-25T22:45:54.657Z'
  },
  request: {
    function: 'actions/get-preview-envs.js',
    parameters: { contentTypeId: 'content-type-id' }
  },
  response: {
    body: '{"ok":true,"data":[{"sys":{"id":"vercel-app-preview-environment","version":1,"type":"PreviewEnvironment"},"name":"Vercel App","description":"Content preview environment provided by Vercel app","configurations":[{"contentType":"content-type-id","enabled":true,"example":false,"name":"","url":"https://team-integrations-vercel-playground-{env_id}.vercel.app/api/enable-draft?slug={entry.fields.slug}&x-vercel-protection-bypass=ukkdTdqAgnG5DQHwFkIeQ22N1nUDWeU7&x-vercel-bypass-cookie=samesitenone","contentTypeFields":[]}],"envId":"vercel-app-preview-environment"}]}',
    statusCode: 200
  },
  statusCode: 200,
  responseAt: '2024-03-25T22:45:55.046Z',
  errors: [],
  eventType: 'call',
  url: 'hosted',
  requestAt: '2024-03-25T22:45:54.657Z',
  environmentId: 'master'
}
Result: **success!**

```

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
