### PR TITLE
fix: remove content type param

### DIFF
--- a/apps/vercel/app-actions/src/actions/get-preview-envs.spec.ts
+++ b/apps/vercel/app-actions/src/actions/get-preview-envs.spec.ts
@@ -10,9 +10,7 @@ describe('get-preview-env.handler', () => {
   let cmaRequestStub: sinon.SinonStub;
   let context: AppActionCallContext;
 
-  const callParameters = {
-    contentTypeId: 'contentTypeId',
-  };
+  const callParameters = {};
 
   const cmaClientMockResponses: [AppInstallationProps] = [
     {

--- a/apps/vercel/app-actions/src/actions/get-preview-envs.ts
+++ b/apps/vercel/app-actions/src/actions/get-preview-envs.ts
@@ -2,18 +2,13 @@ import { AppActionCallContext } from '@contentful/node-apps-toolkit';
 import { AppActionCallResponse, ContentPreviewEnvironment } from '../types';
 import { withAsyncAppActionErrorHandling } from '../helpers/error-handling';
 
-interface AppActionCallParameters {
-  contentTypeId?: string;
-}
+interface AppActionCallParameters {}
 
 export const handler = withAsyncAppActionErrorHandling(
   async (
-    parameters: AppActionCallParameters,
+    _parameters: AppActionCallParameters,
     _context: AppActionCallContext
   ): Promise<AppActionCallResponse<ContentPreviewEnvironment[]>> => {
-    const { contentTypeId } = parameters;
-    if (typeof contentTypeId !== 'string')
-      throw new TypeError('invalid or missing contentTypeId in app action call parameters');
     const envId = 'vercel-app-preview-environment';
     return {
       ok: true,
@@ -30,12 +25,21 @@ export const handler = withAsyncAppActionErrorHandling(
           description: 'Content preview environment provided by Vercel app',
           configurations: [
             {
-              contentType: contentTypeId,
+              contentType: 'post',
               enabled: true,
               example: false,
               name: '',
               // hardcoded URL is for intentional testing purposes
-              url: 'https://team-integrations-vercel-playground-{env_id}.vercel.app/api/enable-draft?slug={entry.fields.slug}&x-vercel-protection-bypass=ukkdTdqAgnG5DQHwFkIeQ22N1nUDWeU7&x-vercel-bypass-cookie=samesitenone',
+              url: 'https://team-integrations-vercel-playground-{env_id}.vercel.app/api/enable-draft?path=/blogs/{entry.fields.slug}&x-vercel-protection-bypass=ukkdTdqAgnG5DQHwFkIeQ22N1nUDWeU7',
+              contentTypeFields: [],
+            },
+            {
+              contentType: 'food',
+              enabled: true,
+              example: false,
+              name: '',
+              // hardcoded URL is for intentional testing purposes
+              url: 'https://team-integrations-vercel-playground-{env_id}.vercel.app/api/enable-draft?path=/food/{entry.fields.slug}&x-vercel-protection-bypass=ukkdTdqAgnG5DQHwFkIeQ22N1nUDWeU7',
               contentTypeFields: [],
             },
           ],

--- a/apps/vercel/contentful-app-manifest.json
+++ b/apps/vercel/contentful-app-manifest.json
@@ -9,13 +9,7 @@
       "path": "actions/get-preview-envs.js",
       "entryFile": "./app-actions/src/actions/get-preview-envs.ts",
       "allowNetworks": [],
-      "parameters": [
-        {
-          "id": "contentTypeId",
-          "name": "Content type id",
-          "type": "Symbol"
-        }
-      ]
+      "parameters": []
     }
   ]
 }


### PR DESCRIPTION
## Purpose

The `PreviewEnvironment` objects returned from our API look like this:

```
{
    "total": 2,
    "limit": 100,
    "skip": 0,
    "sys": {
        "type": "Array"
    },
    "items": [
        {
            "name": "Basic Website Preview",
            "description": "New test",
            "sys": {
                "type": "PreviewEnvironment",
                "id": "6zBSooMWPFS3T5KNisBPQI",
                "version": 2,
                "space": {
                    "sys": {
                        "type": "Link",
                        "linkType": "Space",
                        "id": "89g1bvvv07u0"
                    }
                },
                "createdAt": "2024-03-13T19:50:18Z",
                "updatedAt": "2024-03-18T14:38:45Z"
            },
            "configurations": [
                {
                    "url": "http://www.example.com",
                    "contentType": "author",
                    "enabled": true,
                    "example": false
                },
                {
                    "url": "http://www.example.com",
                    "contentType": "food",
                    "enabled": true,
                    "example": false
                }
            ]
        },
        {
            "name": "Test",
            "description": "",
            "sys": {
                "type": "PreviewEnvironment",
                "id": "45jZnNXTa1WgQg4WQkXSjF",
                "version": 0,
                "space": {
                    "sys": {
                        "type": "Link",
                        "linkType": "Space",
                        "id": "89g1bvvv07u0"
                    }
                },
                "createdAt": "2024-03-22T17:49:58Z",
                "updatedAt": "2024-03-22T17:49:58Z"
            },
            "configurations": [
                {
                    "url": "https://team-integrations-vercel-playground-master.vercel.app/api/enable-draft?path=/blogs/{entry.fields.slug}&x-vercel-protection-bypass=ukkdTdqAgnG5DQHwFkIeQ22N1nUDWeU7",
                    "contentType": "post",
                    "enabled": true,
                    "example": false
                }
            ]
        }
    ]
}
```

That is, each preview environment includes all the content types it is configured for. These are then filtered _later_ on the client side so that only relevant environments are shown.

Therefore it doesn't make sense for us to pass a content type id and scope them down when we fetch from our Vercel hosted app action. Instead we should just return all of the content types they are configured for.

## Approach

* Remove paramater and update example copies and handler function

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
