### PR TITLE
feat: add entry id to EntryActivity [INTEG-1922]

### DIFF
--- a/apps/microsoft-teams/app-actions/src/actions/handle-app-event.spec.ts
+++ b/apps/microsoft-teams/app-actions/src/actions/handle-app-event.spec.ts
@@ -78,6 +78,7 @@ describe('handle-app-event.handler', () => {
         action: 'published',
         eventDatetime: '2024-01-18T21:43:54.267Z',
         entryUrl: 'https://example.com/asdf',
+        entryId: '1234',
       });
 
       try {

--- a/apps/microsoft-teams/app-actions/src/actions/handle-app-event.ts
+++ b/apps/microsoft-teams/app-actions/src/actions/handle-app-event.ts
@@ -131,13 +131,13 @@ export const handler = withAsyncAppActionErrorHandling(
       return { sendMessageResult, entryActivityMessage };
     });
 
-    const sendEntryActiviyMessageResult: SendEntryActivityMessageResult[] = await Promise.all(
+    const sendEntryActivityMessageResult: SendEntryActivityMessageResult[] = await Promise.all(
       entryActivityMessages
     );
 
     return {
       ok: true,
-      data: sendEntryActiviyMessageResult,
+      data: sendEntryActivityMessageResult,
     };
   }
 );

--- a/apps/microsoft-teams/app-actions/src/helpers/entry-activity.spec.ts
+++ b/apps/microsoft-teams/app-actions/src/helpers/entry-activity.spec.ts
@@ -45,6 +45,7 @@ describe('buildEntryActivity', () => {
     expect(result).to.have.property('action', 'archived');
     expect(result).to.have.property('eventDatetime', entryEvent.eventDatetime);
     expect(result).to.have.property('entryUrl', url);
+    expect(result).to.have.property('entryId', entryId);
   });
 
   describe('when no displayField in content type', () => {

--- a/apps/microsoft-teams/app-actions/src/helpers/entry-activity.ts
+++ b/apps/microsoft-teams/app-actions/src/helpers/entry-activity.ts
@@ -20,12 +20,15 @@ export const buildEntryActivity = async (
 
   const entryUrl = computeEntryUrl(entry, cmaHost);
 
+  const entryId = entry.sys.id;
+
   return {
     contentTypeName,
     entryTitle,
     action,
     eventDatetime,
     entryUrl,
+    entryId,
   };
 };
 

--- a/apps/microsoft-teams/app-actions/src/types.ts
+++ b/apps/microsoft-teams/app-actions/src/types.ts
@@ -73,13 +73,14 @@ export type SelectedEvents = {
   [K in AppEventKey]: boolean;
 };
 
-// this is jsut a simple starter for now
+// this is just a simple starter for now
 export interface EntryActivity {
   contentTypeName: string;
   entryTitle: string;
   action: string; // published | deleted | created | etc
   eventDatetime: string;
   entryUrl: string;
+  entryId: string;
 }
 
 export interface WorkflowUpdateMessage {


### PR DESCRIPTION
## Purpose

For `create`, `unpublish`, and `delete` events, we do not have access to the entry title. This needs to be addressed to unblock us on the testing/validation from Microsoft since this was labeled as a mandatory fix from them.

## Approach

So we are no going to pass `entryId` as part of the payload for the `entry_activity_message` endpoint. There is a companion PR in the bot service to implement changes in the adaptive card.

We construct a title with the entry ID in the app action and displayed that in the adaptive card. I kept this login in there as a fallback.

## Testing steps

## Breaking Changes

## Dependencies and/or References

## Deployment
