### PR TITLE
feat: Add informational table modal to config page

### DIFF
--- a/apps/vercel/frontend/src/components/common/GrayInfoBox/GrayInfoBox.spec.tsx
+++ b/apps/vercel/frontend/src/components/common/GrayInfoBox/GrayInfoBox.spec.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { GrayInfoBox } from './GrayInfoBox';
+
+describe('GrayInfoBox', () => {
+  it('renders content with copy icon', () => {
+    const { unmount } = render(<GrayInfoBox withCopy>Test child</GrayInfoBox>);
+    const text = screen.getByText('Test child');
+    const icon = document.querySelector('svg');
+
+    expect(text).toBeTruthy();
+    expect(icon).toBeTruthy();
+    unmount();
+  });
+
+  it('renders content without copy icon', () => {
+    const { unmount } = render(<GrayInfoBox>Test child</GrayInfoBox>);
+    const text = screen.getByText('Test child');
+    const icon = document.querySelector('svg');
+
+    expect(text).toBeTruthy();
+    expect(icon).toBeFalsy();
+    unmount();
+  });
+});

--- a/apps/vercel/frontend/src/components/common/GrayInfoBox/GrayInfoBox.styles.ts
+++ b/apps/vercel/frontend/src/components/common/GrayInfoBox/GrayInfoBox.styles.ts
@@ -1,0 +1,26 @@
+import tokens from '@contentful/f36-tokens';
+import { css } from 'emotion';
+
+export const useStyles = (rootOptions?: {}) => ({
+  root: css({
+    borderRadius: tokens.borderRadiusSmall,
+    ...rootOptions,
+  }),
+  paragraph: css({
+    backgroundColor: tokens.gray200,
+    color: tokens.gray700,
+    fontWeight: tokens.fontWeightMedium,
+    display: 'flex',
+    alignItems: 'center',
+    padding: `${tokens.spacing2Xs} ${tokens.spacingXs}`,
+    borderRadius: tokens.borderRadiusSmall,
+    gap: tokens.spacing2Xs,
+    marginBottom: 0,
+  }),
+  copyButton: css({
+    padding: 0,
+    margin: 0,
+    minWidth: 'auto',
+    minHeight: 'auto',
+  }),
+});

--- a/apps/vercel/frontend/src/components/common/GrayInfoBox/GrayInfoBox.tsx
+++ b/apps/vercel/frontend/src/components/common/GrayInfoBox/GrayInfoBox.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { CopyIcon } from '@contentful/f36-icons';
+import { Flex, IconButton, Paragraph } from '@contentful/f36-components';
+import tokens from '@contentful/f36-tokens';
+
+import { useStyles } from './GrayInfoBox.styles';
+
+interface Props {
+  children: string;
+  withCopy?: boolean;
+  rootStylingOptions?: React.CSSProperties;
+}
+
+export const GrayInfoBox = ({ children, withCopy, rootStylingOptions }: Props) => {
+  const styles = useStyles(rootStylingOptions);
+  const handleCopyClick = () => {
+    navigator.clipboard.writeText(children);
+  };
+
+  return (
+    <Flex data-testid="info-box" className={styles.root} alignItems="center" gap={tokens.spacingXs}>
+      <Paragraph className={styles.paragraph}>
+        {children}
+        {withCopy && (
+          <IconButton
+            onClick={handleCopyClick}
+            className={styles.copyButton}
+            icon={<CopyIcon variant="muted" />}
+            aria-label={'Copy text'}
+          />
+        )}
+      </Paragraph>
+    </Flex>
+  );
+};

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSection.tsx
@@ -4,6 +4,7 @@ import { Dispatch, SetStateAction } from 'react';
 import { ContentTypePreviewPathSelectionList } from './ContentTypePreviewPathSelectionList/ContentTypePreviewPathSelectionList';
 import { styles } from '../ConfigScreen.styles';
 import { AppInstallationParameters } from '../../../types';
+import { PreviewPathInfoNote } from './PreviewPathInfoNote/PreviewPathInfoNote';
 
 interface Props {
   parameters: AppInstallationParameters;
@@ -13,6 +14,7 @@ interface Props {
 export const ContentTypePreviewPathSection = ({ parameters, dispatchParameters }: Props) => {
   // TO DO: Adjust logic to limit content type duplication of preview path and token
   const { contentTypes, contentTypePreviewPathSelections } = parameters;
+
   return (
     <Box className={styles.box}>
       <Heading marginBottom="none" className={styles.heading}>
@@ -21,6 +23,7 @@ export const ContentTypePreviewPathSection = ({ parameters, dispatchParameters }
       <Paragraph marginTop="spacingXs">
         Select applicable content types and define corresponding preview paths and preview tokens.
       </Paragraph>
+      <PreviewPathInfoNote />
       <ContentTypePreviewPathSelectionList
         contentTypes={contentTypes}
         contentTypePreviewPathSelections={contentTypePreviewPathSelections}

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.spec.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.spec.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { ContentTypePreviewPathSelectionRow } from './ContentTypePreviewPathSelectionRow';
 import { ContentType } from 'contentful-management';
 

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/InformationalModal/InformationalModal.spec.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/InformationalModal/InformationalModal.spec.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import { InformationalModal } from './InformationalModal';
-import { copies } from '../../../../constants/copies';
+import { copies } from '@constants/copies';
 
 const { title, button, exampleOne, exampleTwo, exampleThree } =
   copies.configPage.contentTypePreviewPathSection.exampleModal;

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/InformationalModal/InformationalModal.spec.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/InformationalModal/InformationalModal.spec.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { InformationalModal } from './InformationalModal';
+import { copies } from '../../../../constants/copies';
+
+const { title, button, exampleOne, exampleTwo, exampleThree } =
+  copies.configPage.contentTypePreviewPathSection.exampleModal;
+
+describe('InformationalModal', () => {
+  it('renders content when modal is shown', () => {
+    render(<InformationalModal onClose={vi.fn()} isShown={true} />);
+    const modalTitle = screen.getByText(title);
+    const modalButton = screen.getByText(button);
+    const exampleOneDescription = screen.getByText(exampleOne.description);
+    const exampleTwoDescription = screen.getByText(exampleTwo.description);
+    const exampleThreeDescription = screen.getByText(exampleThree.description);
+
+    expect(modalTitle).toBeTruthy();
+    expect(modalButton).toBeTruthy();
+    expect(exampleOneDescription).toBeTruthy();
+    expect(exampleTwoDescription).toBeTruthy();
+    expect(exampleThreeDescription).toBeTruthy();
+  });
+});

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/InformationalModal/InformationalModal.styles.ts
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/InformationalModal/InformationalModal.styles.ts
@@ -1,0 +1,14 @@
+import tokens from '@contentful/f36-tokens';
+import { css } from 'emotion';
+
+export const styles = {
+  firstParagraph: css({
+    marginBottom: tokens.spacingS,
+  }),
+  zeroMarginBottom: css({
+    marginBottom: 0,
+  }),
+  footer: css({
+    margin: `${tokens.spacingL} 0`,
+  }),
+};

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/InformationalModal/InformationalModal.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/InformationalModal/InformationalModal.tsx
@@ -1,0 +1,65 @@
+import { Paragraph, Flex, Modal, Button, Box, TextLink } from '@contentful/f36-components';
+import tokens from '@contentful/f36-tokens';
+
+import { GrayInfoBox } from '../../../common/GrayInfoBox/GrayInfoBox';
+import { InformationalTables } from './InformationalTables/InformationalTables';
+import { copies } from '../../../../constants/copies';
+import { styles } from './InformationalModal.styles';
+
+interface Props {
+  onClose: () => void;
+  isShown: boolean;
+}
+
+export const InformationalModal = ({ onClose, isShown }: Props) => {
+  const { title, button, exampleOne, exampleTwo, exampleThree } =
+    copies.configPage.contentTypePreviewPathSection.exampleModal;
+
+  return (
+    <Modal onClose={onClose} isShown={isShown} size="large">
+      {() => (
+        <>
+          <Modal.Header title={title} />
+          <Modal.Content>
+            <Flex flexDirection="column" gap={tokens.spacingS}>
+              <Flex flexDirection="column" gap={tokens.spacingL}>
+                <Box>
+                  <Paragraph className={styles.firstParagraph}>{exampleOne.description}</Paragraph>
+                  <GrayInfoBox>{exampleOne.example}</GrayInfoBox>
+                </Box>
+
+                <Flex
+                  className={styles.zeroMarginBottom}
+                  alignItems="flex-start"
+                  gap={tokens.spacingS}>
+                  <GrayInfoBox>{exampleTwo.example}</GrayInfoBox>
+                  <Paragraph className={styles.zeroMarginBottom}>
+                    {exampleTwo.description}
+                  </Paragraph>
+                </Flex>
+
+                <Flex alignItems="flex-start" gap={tokens.spacingS}>
+                  <GrayInfoBox>{exampleThree.example}</GrayInfoBox>
+                  <Paragraph>
+                    {exampleThree.description} <TextLink>custom preview tokens</TextLink>
+                  </Paragraph>
+                </Flex>
+              </Flex>
+
+              <InformationalTables />
+
+              <Paragraph className={styles.footer}>
+                For more details about preview URLs, <TextLink>read the docs.</TextLink>{' '}
+              </Paragraph>
+            </Flex>
+          </Modal.Content>
+          <Modal.Controls>
+            <Button variant="primary" onClick={onClose}>
+              {button}
+            </Button>
+          </Modal.Controls>
+        </>
+      )}
+    </Modal>
+  );
+};

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/InformationalModal/InformationalModal.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/InformationalModal/InformationalModal.tsx
@@ -1,9 +1,9 @@
 import { Paragraph, Flex, Modal, Button, Box, TextLink } from '@contentful/f36-components';
 import tokens from '@contentful/f36-tokens';
 
-import { GrayInfoBox } from '../../../common/GrayInfoBox/GrayInfoBox';
+import { GrayInfoBox } from '@components/common/GrayInfoBox/GrayInfoBox';
+import { copies } from '@constants/copies';
 import { InformationalTables } from './InformationalTables/InformationalTables';
-import { copies } from '../../../../constants/copies';
 import { styles } from './InformationalModal.styles';
 
 interface Props {

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/InformationalModal/InformationalTables/InfoTable/InfoTable.spec.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/InformationalModal/InformationalTables/InfoTable/InfoTable.spec.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { InfoTable } from './InfoTable';
+
+describe('InfoTable', () => {
+  it('renders content', () => {
+    const headers = ['header1', 'header2'];
+    const rows = [
+      { example: <div>example1</div>, description: 'description1' },
+      { example: <div>example2</div>, description: 'description2' },
+    ];
+    render(<InfoTable headers={headers} rows={rows} />);
+
+    const tableHeaders = screen.getByTestId('info-table-headers');
+    const tableRows = screen.getAllByTestId('info-table-row');
+
+    expect(tableHeaders).toBeTruthy();
+    expect(tableRows).toHaveLength(2);
+  });
+});

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/InformationalModal/InformationalTables/InfoTable/InfoTable.styles.ts
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/InformationalModal/InformationalTables/InfoTable/InfoTable.styles.ts
@@ -1,6 +1,6 @@
 import tokens from '@contentful/f36-tokens';
 import { css } from 'emotion';
-import { INFORMATIONAL_MODAL_COLUMN_WIDTH } from '../../../../../../constants/styles';
+import { INFORMATIONAL_MODAL_COLUMN_WIDTH } from '@constants/styles';
 
 export const styles = {
   headersWrapper: css({

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/InformationalModal/InformationalTables/InfoTable/InfoTable.styles.ts
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/InformationalModal/InformationalTables/InfoTable/InfoTable.styles.ts
@@ -1,0 +1,38 @@
+import tokens from '@contentful/f36-tokens';
+import { css } from 'emotion';
+import { INFORMATIONAL_MODAL_COLUMN_WIDTH } from '../../../../../../constants/styles';
+
+export const styles = {
+  headersWrapper: css({
+    borderBottom: `1px solid ${tokens.gray200}`,
+    paddingRight: tokens.spacing2Xl,
+  }),
+  header: css({
+    margin: `0 ${tokens.spacingXs}`,
+    width: INFORMATIONAL_MODAL_COLUMN_WIDTH,
+    color: tokens.gray700,
+    fontWeight: tokens.fontWeightMedium,
+  }),
+  headerWithBorder: css({
+    width: INFORMATIONAL_MODAL_COLUMN_WIDTH,
+    borderLeft: `1px solid ${tokens.gray200}`,
+    paddingLeft: tokens.spacingM,
+    marginBottom: 0,
+    color: tokens.gray700,
+    fontWeight: tokens.fontWeightMedium,
+  }),
+  rowWrapper: css({
+    borderBottom: `1px solid ${tokens.gray200}`,
+    paddingRight: tokens.spacing2Xl,
+  }),
+  rowDescription: css({
+    paddingLeft: tokens.spacingM,
+    paddingTop: tokens.spacingXs,
+    paddingBottom: tokens.spacingXs,
+    margin: 0,
+  }),
+  rowDescriptionWrapper: css({
+    borderLeft: `1px solid ${tokens.gray200}`,
+    padding: `${tokens.spacing2Xs} 0`,
+  }),
+};

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/InformationalModal/InformationalTables/InfoTable/InfoTable.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/InformationalModal/InformationalTables/InfoTable/InfoTable.tsx
@@ -1,0 +1,34 @@
+import { Paragraph, Flex, Box } from '@contentful/f36-components';
+
+import { styles } from './InfoTable.styles';
+
+interface Props {
+  headers: string[];
+  rows: { example: JSX.Element; description: string }[];
+}
+
+export const InfoTable = ({ headers, rows }: Props) => {
+  return (
+    <Box data-testid="info-table">
+      <Flex data-testid="info-table-headers" className={styles.headersWrapper}>
+        {headers.map((header, index) => (
+          <Paragraph key={index} className={index != 0 ? styles.headerWithBorder : styles.header}>
+            {header}
+          </Paragraph>
+        ))}
+      </Flex>
+      {rows.map((row) => (
+        <Flex
+          key={row.description}
+          data-testid="info-table-row"
+          alignItems="center"
+          className={styles.rowWrapper}>
+          <div>{row.example}</div>
+          <div className={styles.rowDescriptionWrapper}>
+            <Paragraph className={styles.rowDescription}>{row.description}</Paragraph>
+          </div>
+        </Flex>
+      ))}
+    </Box>
+  );
+};

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/InformationalModal/InformationalTables/InformationalTables.spec.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/InformationalModal/InformationalTables/InformationalTables.spec.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { InformationalTables } from './InformationalTables';
+
+describe('InformationalTables', () => {
+  it('renders content', () => {
+    render(<InformationalTables />);
+    const table = screen.getAllByTestId('info-table');
+    const link = screen.getByText('incoming links to entry by');
+
+    expect(table).toHaveLength(2);
+    expect(link).toBeTruthy();
+  });
+});

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/InformationalModal/InformationalTables/InformationalTables.styles.ts
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/InformationalModal/InformationalTables/InformationalTables.styles.ts
@@ -1,0 +1,8 @@
+import tokens from '@contentful/f36-tokens';
+import { css } from 'emotion';
+
+export const styles = {
+  link: css({
+    margin: `${tokens.spacingL} 0`,
+  }),
+};

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/InformationalModal/InformationalTables/InformationalTables.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/InformationalModal/InformationalTables/InformationalTables.tsx
@@ -1,0 +1,46 @@
+import tokens from '@contentful/f36-tokens';
+
+import { InfoTable } from './InfoTable/InfoTable';
+import { GrayInfoBox } from '../../../../common/GrayInfoBox/GrayInfoBox';
+import { copies } from '../../../../../constants/copies';
+import { TextLink, Paragraph, Box } from '@contentful/f36-components';
+import { styles } from './InformationalTables.styles';
+import { INFORMATIONAL_MODAL_COLUMN_WIDTH } from '../../../../../constants/styles';
+
+type TableRow = {
+  example: string;
+  description: string;
+};
+
+const EXAMPLE_PROPERTY = '{entry.linkedBy}';
+
+export const InformationalTables = () => {
+  const { tableOne, tableTwo } = copies.configPage.contentTypePreviewPathSection.exampleModal;
+  const infoBoxCustomStyling = {
+    width: INFORMATIONAL_MODAL_COLUMN_WIDTH,
+    margin: tokens.spacingXs,
+  };
+
+  const renderTableRows = (rows: TableRow[]) =>
+    rows.map((row: TableRow) => ({
+      example: (
+        <GrayInfoBox rootStylingOptions={infoBoxCustomStyling} withCopy>
+          {row.example}
+        </GrayInfoBox>
+      ),
+      description: row.description,
+    }));
+
+  return (
+    <Box>
+      <InfoTable headers={['Placholder token', 'Definition']} rows={renderTableRows(tableOne)} />
+
+      <Paragraph className={styles.link}>
+        Additionally, you can query <TextLink>incoming links to entry by</TextLink> using the{' '}
+        {EXAMPLE_PROPERTY} property (the first entry in response will be used)
+      </Paragraph>
+
+      <InfoTable headers={['Linked entries', 'Definition']} rows={renderTableRows(tableTwo)} />
+    </Box>
+  );
+};

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/InformationalModal/InformationalTables/InformationalTables.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/InformationalModal/InformationalTables/InformationalTables.tsx
@@ -1,11 +1,11 @@
 import tokens from '@contentful/f36-tokens';
 
 import { InfoTable } from './InfoTable/InfoTable';
-import { GrayInfoBox } from '../../../../common/GrayInfoBox/GrayInfoBox';
-import { copies } from '../../../../../constants/copies';
+import { GrayInfoBox } from '@components/common/GrayInfoBox/GrayInfoBox';
+import { copies } from '@constants/copies';
 import { TextLink, Paragraph, Box } from '@contentful/f36-components';
 import { styles } from './InformationalTables.styles';
-import { INFORMATIONAL_MODAL_COLUMN_WIDTH } from '../../../../../constants/styles';
+import { INFORMATIONAL_MODAL_COLUMN_WIDTH } from '@constants/styles';
 
 type TableRow = {
   example: string;

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/PreviewPathInfoNote/PreviewPathInfoNote.spec.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/PreviewPathInfoNote/PreviewPathInfoNote.spec.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { PreviewPathInfoNote } from './PreviewPathInfoNote';
+
+describe('PreviewPathInfoNote', () => {
+  it('renders content', () => {
+    render(<PreviewPathInfoNote />);
+    const text = screen.getByText('Preview path and token example:');
+    const example = screen.getByTestId('info-box');
+    const link = screen.getByText('View more examples');
+
+    expect(text).toBeTruthy();
+    expect(example).toBeTruthy();
+    expect(link).toBeTruthy();
+  });
+});

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/PreviewPathInfoNote/PreviewPathInfoNote.styles.ts
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/PreviewPathInfoNote/PreviewPathInfoNote.styles.ts
@@ -1,0 +1,10 @@
+import tokens from '@contentful/f36-tokens';
+import { css } from 'emotion';
+
+export const styles = {
+  root: css({
+    display: 'flex',
+    alignItems: 'center',
+    marginBottom: tokens.spacingL,
+  }),
+};

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/PreviewPathInfoNote/PreviewPathInfoNote.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/PreviewPathInfoNote/PreviewPathInfoNote.tsx
@@ -1,0 +1,33 @@
+import { Note, TextLink, Flex, ModalLauncher } from '@contentful/f36-components';
+import tokens from '@contentful/f36-tokens';
+
+import { GrayInfoBox } from '../../../common/GrayInfoBox/GrayInfoBox';
+import { InformationalModal } from '../InformationalModal/InformationalModal';
+import { styles } from './PreviewPathInfoNote.styles';
+import { copies } from '../../../../constants/copies';
+
+// this gap is tailored specifically to the designs of the modal
+const FLEX_GAP = '11rem';
+
+export const PreviewPathInfoNote = () => {
+  const { infoBoxCopyDescription, infoBoxExample, infoBoxTextLink } =
+    copies.configPage.contentTypePreviewPathSection.infoNote;
+
+  const renderExampleInfoModal = () => {
+    ModalLauncher.open(({ isShown, onClose }) => (
+      <InformationalModal onClose={onClose} isShown={isShown} />
+    ));
+  };
+
+  return (
+    <Note className={styles.root} variant="neutral">
+      <Flex justifyContent="space-between" alignItems="center" gap={FLEX_GAP}>
+        <Flex alignItems="center" gap={tokens.spacingXs}>
+          {infoBoxCopyDescription}
+          <GrayInfoBox withCopy>{infoBoxExample}</GrayInfoBox>
+        </Flex>
+        <TextLink onClick={renderExampleInfoModal}>{infoBoxTextLink}</TextLink>
+      </Flex>
+    </Note>
+  );
+};

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/PreviewPathInfoNote/PreviewPathInfoNote.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/PreviewPathInfoNote/PreviewPathInfoNote.tsx
@@ -1,10 +1,10 @@
 import { Note, TextLink, Flex, ModalLauncher } from '@contentful/f36-components';
 import tokens from '@contentful/f36-tokens';
 
-import { GrayInfoBox } from '../../../common/GrayInfoBox/GrayInfoBox';
+import { GrayInfoBox } from '@components/common/GrayInfoBox/GrayInfoBox';
 import { InformationalModal } from '../InformationalModal/InformationalModal';
 import { styles } from './PreviewPathInfoNote.styles';
-import { copies } from '../../../../constants/copies';
+import { copies } from '@constants/copies';
 
 // this gap is tailored specifically to the designs of the modal
 const FLEX_GAP = '11rem';

--- a/apps/vercel/frontend/src/constants/copies.ts
+++ b/apps/vercel/frontend/src/constants/copies.ts
@@ -1,0 +1,67 @@
+export const copies = {
+  configPage: {
+    contentTypePreviewPathSection: {
+      infoNote: {
+        infoBoxExample: '/blogs/{entry.fields.slug}',
+        infoBoxCopyDescription: 'Preview path and token example:',
+        infoBoxTextLink: 'View more examples',
+      },
+      exampleModal: {
+        title: 'Preview URLs',
+        button: 'Got it',
+        exampleOne: {
+          description: 'For each content type, create a URL according to this structure:',
+          example: 'https://[YOUR_PREVIEW_DOMAIN]/[PLACEHOLDER_TOKEN]',
+        },
+        exampleTwo: {
+          description:
+            'The base path of your preview website or app (Example: https://myapp.com/entities)',
+          example: '[YOUR_PREVIEW_DOMAIN]',
+        },
+        exampleThree: {
+          description:
+            'A token that is resolved into an actual value when a user clicks on the preview link. You can add one or multiple tokens. Premium plan customers can specify',
+          example: '[PLACEHOLDER_TOKEN]',
+        },
+        tableOne: [
+          {
+            description: 'The environment ID for the entry',
+            example: '{env_id}',
+          },
+          {
+            description: 'An object containing all the properties and their values for the entry',
+            example: '{entry}',
+          },
+          {
+            description: 'ID of the current entry',
+            example: '{entry.sys.id}',
+          },
+          {
+            description:
+              'The value of the slug field, based on the localization provided (will not fallback to default locale in case of invalid locale)',
+            example: '{entry.fields.slug}',
+            exampleTwo: '[LOCALE_CODE]',
+          },
+          {
+            description:
+              'The code for your current selected locale. In multi-locale mode it will use the default locale of your space',
+            example: '{locale}',
+          },
+        ],
+        tableTwo: [
+          {
+            description:
+              'ID of the entry, which is referencing the current entry (the one you have opened in the editor)',
+            example: '{entry.linkedBy.sys.id}',
+          },
+          {
+            description:
+              'Value of the slug field for the entry, which references entry from the previous example',
+            example: '{entry.linkedBy.fields.slug}',
+          },
+        ],
+        footer: 'For more detail about preview URLs, read the docs.',
+      },
+    },
+  },
+};

--- a/apps/vercel/frontend/src/constants/styles.ts
+++ b/apps/vercel/frontend/src/constants/styles.ts
@@ -1,0 +1,2 @@
+// this width is tailored specifically to the designs of the informational modal columns
+export const INFORMATIONAL_MODAL_COLUMN_WIDTH = '14rem';

--- a/apps/vercel/frontend/tsconfig.json
+++ b/apps/vercel/frontend/tsconfig.json
@@ -14,6 +14,13 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
+    "paths": {
+      "@clients/*": ["./src/clients/*"],
+      "@components/*": ["./src/components/*"],
+      "@constants/*": ["./src/constants/*"],
+      "@hooks/*": ["./src/hooks/*"],
+      "@types/*": ["./src/types/*"],
+    },
     "jsx": "react-jsx"
   },
   "include": ["src"]

--- a/apps/vercel/frontend/vite.config.ts
+++ b/apps/vercel/frontend/vite.config.ts
@@ -1,4 +1,5 @@
 import react from '@vitejs/plugin-react';
+import path from 'path';
 import { defineConfig } from 'vite';
 
 export default defineConfig(() => ({
@@ -12,6 +13,16 @@ export default defineConfig(() => ({
     outDir: process.env.BUILD_PATH || './build',
   },
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@components': path.resolve(__dirname, './src/components'),
+      '@constants': path.resolve(__dirname, './src/constants'),
+      '@hooks': path.resolve(__dirname, './src/hooks'),
+      '@clients': path.resolve(__dirname, './src/clients'),
+      '@types': path.resolve(__dirname, './src/types'),
+    },
+  },
+
   test: {
     environment: 'happy-dom',
   },


### PR DESCRIPTION
## Purpose

This PR adds the InformationalModal that will help guide the user when configuring their content types and preview paths on the Vercel config page. 

Designs: https://www.figma.com/file/3zhaUVyNKPZOFjVPL7mG00/Vercel?type=design&node-id=758-43738&mode=design&t=VTfQ2mppRDRTqXiM-4
## Approach

I created several new components to create this modal, some reusable and some very specific. 

## Testing steps
 
Render the modal from the config page link "View more examples".

End result screenshot (can't quite include the footer 😅 )

![Screenshot 2024-03-28 at 2 23 46 PM](https://github.com/contentful/apps/assets/58186851/fe88c421-3204-4627-a2e5-ef1e7678a803)


### TO DO

1. Determine if there should be user feedback onClick of the copy buttons that are throughout the modal. Right now the copy functionality works, but there is nothing telling the user that something has been copied to their clipboard. 


