### PR TITLE
Limit content type configuration

### DIFF
--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionList/ContentTypePreviewPathSelectionList.spec.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionList/ContentTypePreviewPathSelectionList.spec.tsx
@@ -6,7 +6,7 @@ import { mockContentTypePreviewPathSelections } from '@test/mocks/mockContentTyp
 
 describe('ContentTypePreviewPathSelectionList', () => {
   it('renders list of selections', () => {
-    render(
+    const { unmount } = render(
       <ContentTypePreviewPathSelectionList
         contentTypes={mockContentTypes}
         contentTypePreviewPathSelections={mockContentTypePreviewPathSelections}
@@ -22,5 +22,33 @@ describe('ContentTypePreviewPathSelectionList', () => {
     expect(
       screen.getByDisplayValue(mockContentTypePreviewPathSelections[1].previewPath)
     ).toBeTruthy();
+    expect(screen.getByText('Add Content Type')).toBeTruthy();
+
+    unmount();
+  });
+
+  it('hides add button if all content types have been configured', () => {
+    const { unmount } = render(
+      <ContentTypePreviewPathSelectionList
+        contentTypes={mockContentTypes}
+        contentTypePreviewPathSelections={[
+          ...mockContentTypePreviewPathSelections,
+          { contentType: 'article', previewPath: 'test-article-path' },
+        ]}
+        dispatch={() => null}
+      />
+    );
+
+    expect(screen.getAllByText('Blog')).toBeTruthy();
+    expect(
+      screen.getByDisplayValue(mockContentTypePreviewPathSelections[0].previewPath)
+    ).toBeTruthy();
+    expect(screen.getAllByText('News')).toBeTruthy();
+    expect(
+      screen.getByDisplayValue(mockContentTypePreviewPathSelections[1].previewPath)
+    ).toBeTruthy();
+    expect(screen.queryByText('Add Content Type')).toBeFalsy();
+
+    unmount();
   });
 });

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionList/ContentTypePreviewPathSelectionList.spec.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionList/ContentTypePreviewPathSelectionList.spec.tsx
@@ -1,30 +1,26 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
-import { ContentType } from '@contentful/app-sdk';
 import { ContentTypePreviewPathSelectionList } from './ContentTypePreviewPathSelectionList';
+import { mockContentTypes } from '@test/mocks/mockContentTypes';
+import { mockContentTypePreviewPathSelections } from '@test/mocks/mockContentTypePreviewPathSelections';
 
 describe('ContentTypePreviewPathSelectionList', () => {
   it('renders list of selections', () => {
-    const selections = [
-      { contentType: 'blog', previewPath: 'test-blog-path' },
-      { contentType: 'news', previewPath: 'test-news-path' },
-    ];
     render(
       <ContentTypePreviewPathSelectionList
-        contentTypes={
-          [
-            { name: 'blog', sys: { id: '12' } },
-            { name: 'news', sys: { id: '13' } },
-          ] as ContentType[]
-        }
-        contentTypePreviewPathSelections={selections}
+        contentTypes={mockContentTypes}
+        contentTypePreviewPathSelections={mockContentTypePreviewPathSelections}
         dispatch={() => null}
       />
     );
 
-    expect(screen.getAllByText(selections[0].contentType)).toBeTruthy();
-    expect(screen.getByDisplayValue(selections[0].previewPath)).toBeTruthy();
-    expect(screen.getAllByText(selections[1].contentType)).toBeTruthy();
-    expect(screen.getByDisplayValue(selections[1].previewPath)).toBeTruthy();
+    expect(screen.getAllByText('Blog')).toBeTruthy();
+    expect(
+      screen.getByDisplayValue(mockContentTypePreviewPathSelections[0].previewPath)
+    ).toBeTruthy();
+    expect(screen.getAllByText('News')).toBeTruthy();
+    expect(
+      screen.getByDisplayValue(mockContentTypePreviewPathSelections[1].previewPath)
+    ).toBeTruthy();
   });
 });

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionList/ContentTypePreviewPathSelectionList.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionList/ContentTypePreviewPathSelectionList.tsx
@@ -50,6 +50,9 @@ export const ContentTypePreviewPathSelectionList = ({
     setAddRow([...addRow, addRow.length]);
   };
 
+  // render add button if there are content types that are not selected
+  const renderAddButton = contentTypePreviewPathSelections.length !== contentTypes.length;
+  // disable add button if there is a row with empty fields present
   const isAddButtonDisabled =
     Boolean(addRow.length) || contentTypePreviewPathSelections.length === 0;
 
@@ -68,7 +71,7 @@ export const ContentTypePreviewPathSelectionList = ({
     }
     return contentTypePreviewPathSelections.map((contentTypePreviewPathSelection, index) => (
       <ContentTypePreviewPathSelectionRow
-        key={index}
+        key={contentTypePreviewPathSelection.previewPath}
         configuredContentTypePreviewPathSelection={contentTypePreviewPathSelection}
         contentTypes={filterContentTypes(contentTypePreviewPathSelection.contentType)}
         onParameterUpdate={handleUpdateParameters}
@@ -91,9 +94,11 @@ export const ContentTypePreviewPathSelectionList = ({
         />
       ))}
 
-      <Button isDisabled={isAddButtonDisabled} onClick={handleAddRow} startIcon={<PlusIcon />}>
-        Add Content Type
-      </Button>
+      {renderAddButton && (
+        <Button isDisabled={isAddButtonDisabled} onClick={handleAddRow} startIcon={<PlusIcon />}>
+          Add Content Type
+        </Button>
+      )}
     </>
   );
 };

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionList/ContentTypePreviewPathSelectionList.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionList/ContentTypePreviewPathSelectionList.tsx
@@ -6,6 +6,7 @@ import { useState, Dispatch } from 'react';
 import { ParameterAction, actions } from '@components/parameterReducer';
 import { ContentTypePreviewPathSelection } from '@customTypes/configPage';
 import { ContentTypePreviewPathSelectionRow } from '../ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow';
+import { getAvailableContentTypes } from '@utils/getAvailableContentTypes';
 
 interface Props {
   contentTypes: ContentType[];
@@ -19,6 +20,11 @@ export const ContentTypePreviewPathSelectionList = ({
   contentTypePreviewPathSelections = [],
 }: Props) => {
   const [addRow, setAddRow] = useState<number[]>([]);
+
+  const filterContentTypes = getAvailableContentTypes(
+    contentTypes,
+    contentTypePreviewPathSelections
+  );
 
   const handleUpdateParameters = (parameters: ContentTypePreviewPathSelection) => {
     if (parameters.contentType && parameters.previewPath) {
@@ -53,7 +59,7 @@ export const ContentTypePreviewPathSelectionList = ({
     if (!contentTypePreviewPathSelections?.length) {
       return (
         <ContentTypePreviewPathSelectionRow
-          contentTypes={contentTypes}
+          contentTypes={filterContentTypes()}
           onParameterUpdate={handleUpdateParameters}
           onRemoveRow={handleRemoveRow}
           renderLabel
@@ -64,7 +70,7 @@ export const ContentTypePreviewPathSelectionList = ({
       <ContentTypePreviewPathSelectionRow
         key={index}
         configuredContentTypePreviewPathSelection={contentTypePreviewPathSelection}
-        contentTypes={contentTypes}
+        contentTypes={filterContentTypes(contentTypePreviewPathSelection.contentType)}
         onParameterUpdate={handleUpdateParameters}
         onRemoveRow={handleRemoveRow}
         renderLabel={index === 0}
@@ -79,7 +85,7 @@ export const ContentTypePreviewPathSelectionList = ({
       {addRow.map((row) => (
         <ContentTypePreviewPathSelectionRow
           key={row}
-          contentTypes={contentTypes}
+          contentTypes={filterContentTypes()}
           onParameterUpdate={handleUpdateParameters}
           onRemoveRow={handleRemoveRow}
         />

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionList/ContentTypePreviewPathSelectionList.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionList/ContentTypePreviewPathSelectionList.tsx
@@ -53,8 +53,7 @@ export const ContentTypePreviewPathSelectionList = ({
   // render add button if there are content types that are not selected
   const renderAddButton = contentTypePreviewPathSelections.length !== contentTypes.length;
   // disable add button if there is a row with empty fields present
-  const isAddButtonDisabled =
-    Boolean(addRow.length) || contentTypePreviewPathSelections.length === 0;
+  const isAddButtonDisabled = !!addRow.length || contentTypePreviewPathSelections.length === 0;
 
   const renderSelectionRow = () => {
     // TO DO: Handle case where contentTypes are not present - do not render add button etc.

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.spec.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.spec.tsx
@@ -1,12 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-import { ContentType } from '@contentful/app-sdk';
 import { ContentTypePreviewPathSelectionRow } from './ContentTypePreviewPathSelectionRow';
-
-const contentTypes = [
-  { name: 'Blog', sys: { id: 'blog' } },
-  { name: 'News', sys: { id: 'news' } },
-] as ContentType[];
+import { mockContentTypes } from '@test/mocks/mockContentTypes';
 
 vi.mock('lodash', () => ({
   debounce: (fn: { cancel: () => void }) => {
@@ -20,14 +15,14 @@ describe('ContentTypePreviewPathSelectionRow', () => {
     const mockOnUpdate = vi.fn();
     const { unmount } = render(
       <ContentTypePreviewPathSelectionRow
-        contentTypes={contentTypes}
+        contentTypes={mockContentTypes}
         onParameterUpdate={mockOnUpdate}
         onRemoveRow={() => null}
       />
     );
 
     const select = document.querySelector('select');
-    fireEvent.change(select!, { target: { value: contentTypes[0].sys.id } });
+    fireEvent.change(select!, { target: { value: mockContentTypes[0].sys.id } });
 
     expect(mockOnUpdate).not.toHaveBeenCalled();
 
@@ -43,7 +38,7 @@ describe('ContentTypePreviewPathSelectionRow', () => {
     const mockOnRemoveRow = vi.fn();
     const { unmount } = render(
       <ContentTypePreviewPathSelectionRow
-        contentTypes={contentTypes}
+        contentTypes={mockContentTypes}
         onParameterUpdate={() => null}
         onRemoveRow={mockOnRemoveRow}
         configuredContentTypePreviewPathSelection={selection}
@@ -60,7 +55,7 @@ describe('ContentTypePreviewPathSelectionRow', () => {
   it('renders selection row without configured selections provided', () => {
     const { unmount } = render(
       <ContentTypePreviewPathSelectionRow
-        contentTypes={contentTypes}
+        contentTypes={mockContentTypes}
         onParameterUpdate={() => null}
         onRemoveRow={() => null}
       />
@@ -75,7 +70,7 @@ describe('ContentTypePreviewPathSelectionRow', () => {
     const selection = { contentType: 'blog', previewPath: 'test-blog-path' };
     const { unmount } = render(
       <ContentTypePreviewPathSelectionRow
-        contentTypes={contentTypes}
+        contentTypes={mockContentTypes}
         onParameterUpdate={() => null}
         onRemoveRow={() => null}
         configuredContentTypePreviewPathSelection={selection}

--- a/apps/vercel/frontend/src/utils/getAvailableContentTypes.spec.ts
+++ b/apps/vercel/frontend/src/utils/getAvailableContentTypes.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { getAvailableContentTypes } from './getAvailableContentTypes';
+import { mockContentTypes } from '@test/mocks/mockContentTypes';
+import { mockContentTypePreviewPathSelections } from '@test/mocks/mockContentTypePreviewPathSelections';
+import { ContentType } from '@contentful/app-sdk';
+
+describe('getAvailableContentTypes', () => {
+  it('should filter content types when current selection is not provided', () => {
+    const result: ContentType[] = getAvailableContentTypes(
+      mockContentTypes,
+      mockContentTypePreviewPathSelections
+    )();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].sys.id).toBe(mockContentTypes[2].sys.id);
+  });
+
+  it('should filter content types when current selection is provided', () => {
+    const result: ContentType[] = getAvailableContentTypes(
+      mockContentTypes,
+      mockContentTypePreviewPathSelections
+    )('blog');
+
+    expect(result).toHaveLength(2);
+    expect(result[0].sys.id).toBe(mockContentTypes[0].sys.id);
+    expect(result[1].sys.id).toBe(mockContentTypes[2].sys.id);
+  });
+});

--- a/apps/vercel/frontend/src/utils/getAvailableContentTypes.ts
+++ b/apps/vercel/frontend/src/utils/getAvailableContentTypes.ts
@@ -9,9 +9,12 @@ export const getAvailableContentTypes =
   (currentSelection?: string) => {
     if (contentTypes.length) {
       const availableContentTypes = contentTypes.filter((contentType) => {
-        if (currentSelection && contentType.sys.id === currentSelection) return true;
-        return !contentTypePreviewPathSelections.some(
-          (selection) => selection.contentType === contentType.sys.id
+        const currentSelectionExists = currentSelection && contentType.sys.id === currentSelection;
+        return (
+          currentSelectionExists ||
+          !contentTypePreviewPathSelections.some(
+            (selection) => selection.contentType === contentType.sys.id
+          )
         );
       });
 

--- a/apps/vercel/frontend/src/utils/getAvailableContentTypes.ts
+++ b/apps/vercel/frontend/src/utils/getAvailableContentTypes.ts
@@ -1,0 +1,21 @@
+import { ContentType } from '@contentful/app-sdk';
+import { ContentTypePreviewPathSelection } from '@customTypes/configPage';
+
+export const getAvailableContentTypes =
+  (
+    contentTypes: ContentType[],
+    contentTypePreviewPathSelections: ContentTypePreviewPathSelection[]
+  ) =>
+  (currentSelection?: string) => {
+    if (contentTypes.length) {
+      const availableContentTypes = contentTypes.filter((contentType) => {
+        if (currentSelection && contentType.sys.id === currentSelection) return true;
+        return !contentTypePreviewPathSelections.some(
+          (selection) => selection.contentType === contentType.sys.id
+        );
+      });
+
+      return availableContentTypes;
+    }
+    return [];
+  };

--- a/apps/vercel/frontend/test/mocks/index.ts
+++ b/apps/vercel/frontend/test/mocks/index.ts
@@ -1,2 +1,4 @@
 export { mockCma } from './mockCma';
 export { mockSdk } from './mockSdk';
+export { mockContentTypes } from './mockContentTypes';
+export { mockContentTypePreviewPathSelections } from './mockContentTypePreviewPathSelections';

--- a/apps/vercel/frontend/test/mocks/mockContentTypePreviewPathSelections.ts
+++ b/apps/vercel/frontend/test/mocks/mockContentTypePreviewPathSelections.ts
@@ -1,0 +1,4 @@
+export const mockContentTypePreviewPathSelections = [
+  { contentType: 'blog', previewPath: 'test-blog-path' },
+  { contentType: 'news', previewPath: 'test-news-path' },
+];

--- a/apps/vercel/frontend/test/mocks/mockContentTypes.ts
+++ b/apps/vercel/frontend/test/mocks/mockContentTypes.ts
@@ -1,0 +1,7 @@
+import { ContentType } from '@contentful/app-sdk';
+
+export const mockContentTypes = [
+  { name: 'Blog', sys: { id: 'blog' } },
+  { name: 'News', sys: { id: 'news' } },
+  { name: 'Article', sys: { id: 'article' } },
+] as ContentType[];

--- a/apps/vercel/frontend/tsconfig.json
+++ b/apps/vercel/frontend/tsconfig.json
@@ -20,6 +20,8 @@
       "@constants/*": ["./src/constants/*"],
       "@hooks/*": ["./src/hooks/*"],
       "@customTypes/*": ["./src/customTypes/*"],
+      "@utils/*": ["./src/utils/*"],
+      "@test/*": ["./test/*"],
     },
     "jsx": "react-jsx"
   },

--- a/apps/vercel/frontend/vite.config.ts
+++ b/apps/vercel/frontend/vite.config.ts
@@ -20,6 +20,8 @@ export default defineConfig(() => ({
       '@hooks': path.resolve(__dirname, './src/hooks'),
       '@clients': path.resolve(__dirname, './src/clients'),
       '@customTypes': path.resolve(__dirname, './src/customTypes'),
+      '@utils': path.resolve(__dirname, './src/utils'),
+      '@test': path.resolve(__dirname, './test'),
     },
   },
 


### PR DESCRIPTION
## Purpose

The purpose of this PR is to enforce the concept that you can only configure a preview path per content type. Therefore the dropdown selection of the content types filters down appropriately based on selections. 

## Approach

I created a utility function called `getAvailableContentTypes`. I chose not to make this a hook as there is no React logic involved. This utility function takes into account the available contentTypes, the already selected contentTypes within the configuration, and if there exists a current selection within the row. 

I also only render the Add Content Type button if there are more contentTypes to select from and configure.

https://github.com/contentful/apps/assets/58186851/579cf497-1e74-4435-802f-8ff0831154e5


## Testing steps

Feel free to add content type and preview path configurations, ensuring that the content types filter appropriately. (refer to video)

## Follow-up work

There is logic here to be cleaned up around ensuring the user can save en empty state (of preview path or content type). This will affect how the Add Content Type button is rendered/disabled/enabled as well. 
