### PR TITLE
feat: enforce contentType requirement when configuring Vercel

### DIFF
--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionList/ContentTypePreviewPathSelectionList.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionList/ContentTypePreviewPathSelectionList.tsx
@@ -56,22 +56,14 @@ export const ContentTypePreviewPathSelectionList = ({
   const isAddButtonDisabled = addRow || contentTypePreviewPathSelections.length === 0;
 
   const renderSelectionRow = () => {
-    // TO DO: Handle case where contentTypes are not present - do not render add button etc.
-    const selectionsWithBlankRow = addRow
-      ? contentTypePreviewPathSelections.concat({ contentType: '', previewPath: '' })
-      : contentTypePreviewPathSelections;
+    const selectionsWithBlankRow =
+      addRow || !contentTypePreviewPathSelections?.length
+        ? contentTypePreviewPathSelections.concat({ contentType: '', previewPath: '' })
+        : contentTypePreviewPathSelections;
 
+    // TO DO: Handle case where contentTypes are not present - do not render add button etc.
     if (!contentTypes?.length) return;
-    if (!contentTypePreviewPathSelections?.length) {
-      return (
-        <ContentTypePreviewPathSelectionRow
-          contentTypes={filterContentTypes()}
-          onParameterUpdate={handleUpdateParameters}
-          onRemoveRow={handleRemoveRow}
-          renderLabel
-        />
-      );
-    }
+
     return selectionsWithBlankRow.map((contentTypePreviewPathSelection, index) => (
       <ContentTypePreviewPathSelectionRow
         key={contentTypePreviewPathSelection.contentType}

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.spec.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.spec.tsx
@@ -11,7 +11,7 @@ vi.mock('lodash', () => ({
 }));
 
 describe('ContentTypePreviewPathSelectionRow', () => {
-  it('calls handler to update parameters when all information is inputed', () => {
+  it('calls handler to update parameters when each input is provided', () => {
     const mockOnUpdate = vi.fn();
     const { unmount } = render(
       <ContentTypePreviewPathSelectionRow
@@ -24,7 +24,7 @@ describe('ContentTypePreviewPathSelectionRow', () => {
     const select = document.querySelector('select');
     fireEvent.change(select!, { target: { value: mockContentTypes[0].sys.id } });
 
-    expect(mockOnUpdate).not.toHaveBeenCalled();
+    expect(mockOnUpdate).toHaveBeenCalled();
 
     const previewPathInput = screen.getByPlaceholderText('Set preview path and token');
     fireEvent.change(previewPathInput, { target: { value: 'test-path' } });
@@ -34,7 +34,7 @@ describe('ContentTypePreviewPathSelectionRow', () => {
   });
 
   it('calls handler to remove row when remove button is clicked', () => {
-    const selection = { contentType: 'blog', previewPath: 'test-blog-path' };
+    const selection = { contentType: 'blog', previewPath: 'test-blog-path-1' };
     const mockOnRemoveRow = vi.fn();
     const { unmount } = render(
       <ContentTypePreviewPathSelectionRow
@@ -67,7 +67,7 @@ describe('ContentTypePreviewPathSelectionRow', () => {
   });
 
   it('renders selection row with configured selection provided', () => {
-    const selection = { contentType: 'blog', previewPath: 'test-blog-path' };
+    const selection = { contentType: 'blog', previewPath: 'test-blog-path-2' };
     const { unmount } = render(
       <ContentTypePreviewPathSelectionRow
         contentTypes={mockContentTypes}
@@ -82,7 +82,7 @@ describe('ContentTypePreviewPathSelectionRow', () => {
   });
 
   it('renders message when no content types exist', () => {
-    const selection = { contentType: 'blog', previewPath: 'test-blog-path' };
+    const selection = { contentType: 'blog', previewPath: 'test-blog-path-3' };
     const { unmount } = render(
       <ContentTypePreviewPathSelectionRow
         contentTypes={[]}

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.tsx
@@ -1,17 +1,20 @@
-import { ChangeEvent, useEffect, useState, useMemo } from 'react';
+import { ChangeEvent, useMemo } from 'react';
 import { Box, FormControl, Select, TextInput, Flex, IconButton } from '@contentful/f36-components';
 import { CloseIcon } from '@contentful/f36-icons';
 import { debounce } from 'lodash';
 import tokens from '@contentful/f36-tokens';
 import { ContentType } from '@contentful/app-sdk';
 
-import { ContentTypePreviewPathSelection } from '@customTypes/configPage';
+import {
+  ApplyContentTypePreviewPathSelectionPayload,
+  ContentTypePreviewPathSelection,
+} from '@customTypes/configPage';
 import { styles } from './ContentTypePreviewPathSelectionRow.styles';
 
 interface Props {
   contentTypes: ContentType[];
   configuredContentTypePreviewPathSelection?: ContentTypePreviewPathSelection;
-  onParameterUpdate: (parameters: ContentTypePreviewPathSelection) => void;
+  onParameterUpdate: (parameters: ApplyContentTypePreviewPathSelectionPayload) => void;
   onRemoveRow: (parameters: ContentTypePreviewPathSelection) => void;
   renderLabel?: boolean;
 }
@@ -23,23 +26,23 @@ export const ContentTypePreviewPathSelectionRow = ({
   onRemoveRow,
   renderLabel,
 }: Props) => {
-  const [contentTypesPreviewPathSelection, setContentTypePreviewPathSelection] = useState({
-    contentType: '',
-    previewPath: '',
-  });
+  const { contentType: configuredContentType, previewPath: configuredPreviewPath } =
+    configuredContentTypePreviewPathSelection;
 
   const handlePreviewPathInput = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setContentTypePreviewPathSelection((prevState) => ({
-      ...prevState,
-      previewPath: event.target.value,
-    }));
+    onParameterUpdate({
+      oldContentType: configuredContentType,
+      newContentType: configuredContentType,
+      newPreviewPath: event.target.value,
+    });
   };
 
   const handleContentTypeChange = (event: ChangeEvent<HTMLSelectElement>) => {
-    setContentTypePreviewPathSelection((prevState) => ({
-      ...prevState,
-      contentType: event.target.value,
-    }));
+    onParameterUpdate({
+      oldContentType: configuredContentType,
+      newContentType: event.target.value,
+      newPreviewPath: configuredPreviewPath,
+    });
   };
 
   const handleRemoveRow = () => {
@@ -50,18 +53,6 @@ export const ContentTypePreviewPathSelectionRow = ({
     () => debounce(handlePreviewPathInput, 700),
     []
   );
-
-  useEffect(() => {
-    if (
-      contentTypesPreviewPathSelection.contentType &&
-      contentTypesPreviewPathSelection.previewPath
-    ) {
-      onParameterUpdate(contentTypesPreviewPathSelection);
-    }
-  }, [contentTypesPreviewPathSelection.contentType, contentTypesPreviewPathSelection.previewPath]);
-
-  const { contentType: configuredContentType, previewPath: configuredPreviewPath } =
-    configuredContentTypePreviewPathSelection;
 
   return (
     <Box className={styles.wrapper}>
@@ -93,6 +84,7 @@ export const ContentTypePreviewPathSelectionRow = ({
           </Select>
           <TextInput
             defaultValue={configuredPreviewPath}
+            isDisabled={!configuredContentType}
             onChange={debouncedHandlePreviewPathInputChange}
             placeholder="Set preview path and token"
           />

--- a/apps/vercel/frontend/src/components/parameterReducer.ts
+++ b/apps/vercel/frontend/src/components/parameterReducer.ts
@@ -1,5 +1,6 @@
 import {
   AppInstallationParameters,
+  ApplyContentTypePreviewPathSelectionPayload,
   ContentTypePreviewPathSelection,
 } from '@customTypes/configPage';
 
@@ -34,7 +35,7 @@ type ApplyContentfulParametersAction = {
 
 type AddContentTypePreviewPathSelectionAction = {
   type: actions.ADD_CONTENT_TYPE_PREVIEW_PATH_SELECTION;
-  payload: ContentTypePreviewPathSelection;
+  payload: ApplyContentTypePreviewPathSelectionPayload;
 };
 
 type RemoveContentTypePreviewPathSelection = {
@@ -91,20 +92,30 @@ const parameterReducer = (
       };
     }
     case ADD_CONTENT_TYPE_PREVIEW_PATH_SELECTION: {
-      const contentTypePreviewPathSelection = action.payload;
-      const currentState = state.contentTypePreviewPathSelections || [];
+      const { oldContentType, newContentType, newPreviewPath } = action.payload;
+      const currentState = state.contentTypePreviewPathSelections;
+      const manipulatedState = currentState.map((obj) => {
+        if (obj.contentType === oldContentType) {
+          obj.previewPath = newPreviewPath;
+          obj.contentType = newContentType;
+        }
+
+        return obj;
+      });
+      const stateWithNewSelection = oldContentType
+        ? manipulatedState
+        : [...manipulatedState, { contentType: newContentType, previewPath: newPreviewPath }];
       return {
         ...state,
-        contentTypePreviewPathSelections: [...currentState, contentTypePreviewPathSelection],
+        contentTypePreviewPathSelections: stateWithNewSelection,
       };
     }
     case REMOVE_CONTENT_TYPE_PREVIEW_PATH_SELECTION: {
       const contentTypePreviewPathSelection = action.payload;
-      const { contentType, previewPath } = contentTypePreviewPathSelection;
+      const { contentType } = contentTypePreviewPathSelection;
 
       const filteredSelections = state.contentTypePreviewPathSelections.filter(
-        (selection) =>
-          selection.contentType !== contentType && selection.previewPath !== previewPath
+        (selection) => selection.contentType !== contentType
       );
       return {
         ...state,

--- a/apps/vercel/frontend/src/customTypes/configPage.ts
+++ b/apps/vercel/frontend/src/customTypes/configPage.ts
@@ -2,6 +2,13 @@ export type ContentTypePreviewPathSelection = {
   contentType: string;
   previewPath: string;
 };
+
+export type ApplyContentTypePreviewPathSelectionPayload = {
+  newPreviewPath: string;
+  oldContentType: string;
+  newContentType: string;
+};
+
 export interface AppInstallationParameters {
   vercelAccessToken: string;
   vercelAccessTokenStatus: boolean | null;


### PR DESCRIPTION
## Purpose

The purpose of this PR is to improve the current approach to saving the `contentType` and `previewPath` parameters on the Vercel config page, from a user and technical perspective. 

## Approach

The original approach was using an awkward debounce (it would lose focus on the input when the debounce ended, blah!), and required that the user input a `contentType` AND `previewPath` to save the parameters (even though this wasn't obvious). We are now requiring that the user input a `contentType`, and sequentially enabling the `previewPath` input field once this `contentType` is filled out. It is not mandatory to have a `previewPath` per `contentType` in order to save the config. Having this mandatory `contentType` helps immensely from a technical standpoint in order to update data and app installation parameters appropriately, and it more importantly encourages the user to configure the app in a logical step-by-step process. 

https://github.com/contentful/apps/assets/58186851/b976c228-f96b-424b-acaf-33b332c8638a

## Testing steps

Play around on the Vercel config page with adding `contentType` and `previewPath` selections, as shown in the video above. 

## Follow-up work
1. Show informative messages (warning or error) when the user saves the selections with empty `previewPaths`. Even though this is allowed, its important to inform the user that this will not 'work' when actually using the app. 
2. Add more specific path validations of the `previewPath` itself i.e should be a valid path, not a random string. 
