### PR TITLE
Add .env file to gitignore of app examples []

### DIFF
--- a/examples/asset-upload/.gitignore
+++ b/examples/asset-upload/.gitignore
@@ -7,6 +7,11 @@
 # production
 /dist
 
+# dotenv environment variables file
+.env
+.env.*
+!.env*.example
+
 # misc
 .DS_Store
 

--- a/examples/commercelayer/.gitignore
+++ b/examples/commercelayer/.gitignore
@@ -9,7 +9,8 @@ yarn-debug.log*
 yarn-error.log*
 
 # dotenv environment variables file
-.env
+.env*
+!.env*.example
 .contentfulrc.json
 
 # Parcel-bundler cache

--- a/examples/compare-entries/.gitignore
+++ b/examples/compare-entries/.gitignore
@@ -11,12 +11,13 @@
 # production
 /build
 
+# dotenv environment variables file
+.env
+.env.*
+!.env*.example
+
 # misc
 .DS_Store
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
 
 npm-debug.log*
 yarn-debug.log*

--- a/examples/dam-app/.gitignore
+++ b/examples/dam-app/.gitignore
@@ -6,12 +6,13 @@
 # production
 /build
 
+# dotenv environment variables file
+.env
+.env.*
+!.env*.example
+
 # misc
 .DS_Store
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
 
 npm-debug.log*
 yarn-debug.log*

--- a/examples/ecommerce-app/.gitignore
+++ b/examples/ecommerce-app/.gitignore
@@ -6,12 +6,13 @@
 # production
 /build
 
+# dotenv environment variables file
+.env
+.env.*
+!.env*.example
+
 # misc
 .DS_Store
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
 
 npm-debug.log*
 yarn-debug.log*

--- a/examples/editor-assignment/.gitignore
+++ b/examples/editor-assignment/.gitignore
@@ -11,12 +11,13 @@
 # production
 /build
 
+# dotenv environment variables file
+.env
+.env.*
+!.env*.example
+
 # misc
 .DS_Store
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
 
 npm-debug.log*
 yarn-debug.log*

--- a/examples/function-potterdb-rest-api/.gitignore
+++ b/examples/function-potterdb-rest-api/.gitignore
@@ -11,12 +11,13 @@
 # production
 /build
 
+# dotenv environment variables file
+.env
+.env.*
+!.env*.example
+
 # misc
 .DS_Store
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
 
 npm-debug.log*
 yarn-debug.log*

--- a/examples/function-potterdb/.gitignore
+++ b/examples/function-potterdb/.gitignore
@@ -11,12 +11,13 @@
 # production
 /build
 
+# dotenv environment variables file
+.env
+.env.*
+!.env*.example
+
 # misc
 .DS_Store
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
 
 npm-debug.log*
 yarn-debug.log*

--- a/examples/home-location/.gitignore
+++ b/examples/home-location/.gitignore
@@ -11,12 +11,13 @@
 # production
 /build
 
+# dotenv environment variables file
+.env
+.env.*
+!.env*.example
+
 # misc
 .DS_Store
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
 
 npm-debug.log*
 yarn-debug.log*

--- a/examples/last-fm/.gitignore
+++ b/examples/last-fm/.gitignore
@@ -11,12 +11,13 @@
 # production
 /build
 
+# dotenv environment variables file
+.env
+.env.*
+!.env*.example
+
 # misc
 .DS_Store
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
 
 npm-debug.log*
 yarn-debug.log*

--- a/examples/nextjs/.gitignore
+++ b/examples/nextjs/.gitignore
@@ -25,8 +25,10 @@ yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
 
-# local env files
-.env*.local
+# dotenv environment variables file
+.env
+.env.*
+!.env*.example
 
 # vercel
 .vercel

--- a/examples/page-location/.gitignore
+++ b/examples/page-location/.gitignore
@@ -7,6 +7,11 @@
 # production
 /dist
 
+# dotenv environment variables file
+.env
+.env.*
+!.env*.example
+
 # misc
 .DS_Store
 

--- a/examples/typescript-github-action/.gitignore
+++ b/examples/typescript-github-action/.gitignore
@@ -11,12 +11,13 @@
 # production
 /build
 
+# dotenv environment variables file
+.env
+.env.*
+!.env*.example
+
 # misc
 .DS_Store
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
 
 npm-debug.log*
 yarn-debug.log*

--- a/examples/typescript/.gitignore
+++ b/examples/typescript/.gitignore
@@ -11,12 +11,13 @@
 # production
 /build
 
+# dotenv environment variables file
+.env
+.env.*
+!.env*.example
+
 # misc
 .DS_Store
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
 
 npm-debug.log*
 yarn-debug.log*

--- a/examples/vite-react/.gitignore
+++ b/examples/vite-react/.gitignore
@@ -7,6 +7,11 @@
 # production
 /dist
 
+# dotenv environment variables file
+.env
+.env.*
+!.env*.example
+
 # misc
 .DS_Store
 

--- a/examples/vue/.gitignore
+++ b/examples/vue/.gitignore
@@ -12,10 +12,14 @@ node_modules
 dist
 dist-ssr
 coverage
-*.local
 
 /cypress/videos/
 /cypress/screenshots/
+
+# dotenv environment variables file
+.env
+.env.*
+!.env*.example
 
 # Editor directories and files
 .vscode/*


### PR DESCRIPTION
## Purpose

I learned recently that using `npm run upload` will automatically create an `.env` file with the OrganizationId, AppDefinitionId and **Access Token**.

We don't want customers to accidentally upload their access token to their git repository as that would create a serious security risk.

Therefore I updated all `.gitignore` files in the app examples to ignore `.env` files. 

