### PR TITLE
fix: decode curly brackets

### DIFF
--- a/apps/vercel/app-actions/src/helpers/build-preview-urls-for-content-types.spec.ts
+++ b/apps/vercel/app-actions/src/helpers/build-preview-urls-for-content-types.spec.ts
@@ -9,7 +9,7 @@ describe('buildPreviewUrlsForContentTypes', () => {
   it('returns a mapping of preview URls by content type', async () => {
     const result = buildPreviewUrlsForContentTypes(vercelProject, contentTypePreviewPaths);
     expect(result['blog']).to.eql(
-      'https://team-integrations-vercel-playground-gqmys2z3c.vercel.app/api/enable-draft?path=%2Fblogs%2F%7Bentry.fields.slug%7D&x-vercel-protection-bypass=ukkdTdqAgnG5DQHwFkIeQ22N1nUDWeU7'
+      'https://team-integrations-vercel-playground-gqmys2z3c.vercel.app/api/enable-draft?x-vercel-protection-bypass=ukkdTdqAgnG5DQHwFkIeQ22N1nUDWeU7&path=%2Fblogs%2F{entry.fields.slug}'
     );
   });
 });

--- a/apps/vercel/app-actions/src/helpers/build-preview-urls-for-content-types.ts
+++ b/apps/vercel/app-actions/src/helpers/build-preview-urls-for-content-types.ts
@@ -9,9 +9,19 @@ const buildPreviewUrl = (
   previewPath: string
 ): string => {
   const url = new URL(apiPath, previewUrlParts.origin);
-  url.searchParams.set('path', previewPath);
   url.searchParams.set('x-vercel-protection-bypass', previewUrlParts.xVercelProtectionBypass);
-  return url.toString();
+
+  // since `url.searchParams.set` is automatically encoded, our curly brackets are not being read
+  // correctly during variable interpolation on the contentful preview pages. so we have to manually
+  // decode those specific values and then manually add them to the URL
+  const encodedPreviewPath = encodeURIComponent(previewPath);
+  const partiallyDecodedPreviewPath = decodeCurlyBrackets(encodedPreviewPath);
+
+  return `${url.toString()}&path=${partiallyDecodedPreviewPath}`;
+};
+
+const decodeCurlyBrackets = (str: string): string => {
+  return str.replaceAll(/%7B/g, '{').replaceAll(/%7D/g, '}');
 };
 
 export const buildPreviewUrlsForContentTypes = (


### PR DESCRIPTION
## Purpose

When the content preview widget gets a preview URL, it needs to "interpolate" any tokens in the string demarcated by `{` and `}`.

Because we were using `searchParams.set` our path value was encoding those curly brackets as `%7B` and `%7D` respectively, and the value was not getting correctly interpolated.

## Approach

* Just manually decode the curly brackets and leave everything else in it's place

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
