### PR TITLE
fix: don't include configuration if preview path not specified

### DIFF
--- a/apps/vercel/app-actions/src/helpers/build-preview-urls-for-content-types.spec.ts
+++ b/apps/vercel/app-actions/src/helpers/build-preview-urls-for-content-types.spec.ts
@@ -12,4 +12,19 @@ describe('buildPreviewUrlsForContentTypes', () => {
       'https://team-integrations-vercel-playground-gqmys2z3c.vercel.app/api/enable-draft?x-vercel-protection-bypass=ukkdTdqAgnG5DQHwFkIeQ22N1nUDWeU7&path=%2Fblogs%2F{entry.fields.slug}'
     );
   });
+
+  describe('when a contenTypePreviewPath previewPath is empty', () => {
+    const contentTypePreviewPathsWithEmpty = [
+      ...contentTypePreviewPaths,
+      { contentType: 'articles', previewPath: ' ' },
+    ];
+
+    it('does not include the empty path', async () => {
+      const result = buildPreviewUrlsForContentTypes(
+        vercelProject,
+        contentTypePreviewPathsWithEmpty
+      );
+      expect(result['articles']).to.be.undefined;
+    });
+  });
 });

--- a/apps/vercel/app-actions/src/helpers/build-preview-urls-for-content-types.ts
+++ b/apps/vercel/app-actions/src/helpers/build-preview-urls-for-content-types.ts
@@ -32,14 +32,19 @@ export const buildPreviewUrlsForContentTypes = (
   const apiPath = '/api/enable-draft'; // later we won't hard code this but get it from params
 
   const previewUrlsForContentTypes = contentTypePreviewPaths.reduce<PreviewUrlsForContentTypes>(
-    (mapping, contentTypePreviewPath) => ({
-      ...mapping,
-      [contentTypePreviewPath.contentType]: buildPreviewUrl(
-        previewUrlParts,
-        apiPath,
-        contentTypePreviewPath.previewPath
-      ),
-    }),
+    (mapping, contentTypePreviewPath) => {
+      // if a preview path is not specified we don't want to include the configuration at all
+      if (!contentTypePreviewPath.previewPath.trim()) return mapping;
+
+      return {
+        ...mapping,
+        [contentTypePreviewPath.contentType]: buildPreviewUrl(
+          previewUrlParts,
+          apiPath,
+          contentTypePreviewPath.previewPath
+        ),
+      };
+    },
     {}
   );
 


### PR DESCRIPTION
## Purpose

We allow users to save a confiiguration but not specify a preview path for a given content type (ie they can leave it blank). In this case, we want to make sure the configuration doesn't get included in the provided preview environment.

## Approach

* Don't include if the (trimmed) preview path is not found

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
