### PR TITLE
fix: remove errors field from appevent-filter example response [EXT-4976]

### DIFF
--- a/examples/function-appevent-filter/javascript/example.js
+++ b/examples/function-appevent-filter/javascript/example.js
@@ -2,7 +2,6 @@ const appEventFilteringHandler = (event, context) => {
   // Filter out all events that are not of type 'Entry' (Assets, etc.)
   return {
     result: event.entityType === 'Entry',
-    errors: [],
   };
 };
 

--- a/examples/function-appevent-filter/typescript/example.ts
+++ b/examples/function-appevent-filter/typescript/example.ts
@@ -4,7 +4,6 @@ const appEventFilteringHandler: EventHandler<'appevent.filter'> = (event, contex
   // Filter out all events that are not of type 'Entry' (Assets, etc.)
   return {
     result: event.entityType === 'Entry',
-    errors: [],
   };
 };
 


### PR DESCRIPTION
## Purpose

<!-- Why are we introducing this change now? What problem does it solve? What is the story/background for it? -->

The errors field has been removed for appevent.filter functions, as there is no way to have a partial success of an appevent filter function. 

## Approach

<!-- Why did we do it the way we did? Did we consider alternatives? What other implementation details or artifacts (screenshots etc.) would help reviewers contextualize change? -->

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
