### PR TITLE
chore: Add functionality to fetch apiPaths

### DIFF
--- a/apps/vercel/frontend/src/clients/Vercel.spec.ts
+++ b/apps/vercel/frontend/src/clients/Vercel.spec.ts
@@ -1,5 +1,6 @@
 import { Mock, afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import VercelClient from './Vercel';
+import { mockDeploymentSummary } from '@test/mocks';
 
 global.fetch = vi.fn();
 
@@ -76,6 +77,37 @@ describe('VercelClient', () => {
 
       expect(data.projects.length).toBe(2);
       expect(data.projects).toBe(expectedProjects.projects);
+    });
+  });
+
+  describe('#listApiPaths', () => {
+    const projectId = '1234';
+    const expectedDeploymentSummary = mockDeploymentSummary;
+    const expectedApiPaths = [
+      { name: 'api/enable-draft', id: 'api/enable-draft' },
+      { name: 'api/disable-draft', id: 'api/disable-draft' },
+    ];
+
+    beforeEach(() => {
+      (fetch as Mock).mockImplementationOnce(() => ({
+        ok: true,
+        json: vi.fn(() => new Promise((resolve) => resolve({ deployments: [{ uid: '1234' }] }))),
+      }));
+      (fetch as Mock).mockImplementationOnce(() => ({
+        ok: true,
+        json: vi.fn(() => new Promise((resolve) => resolve(expectedDeploymentSummary))),
+      }));
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('lists all projects for an authenticated user', async () => {
+      const data = await client.listApiPaths(projectId);
+
+      expect(data.length).toBe(2);
+      expect(data).toStrictEqual(expectedApiPaths);
     });
   });
 });

--- a/apps/vercel/frontend/src/clients/Vercel.spec.ts
+++ b/apps/vercel/frontend/src/clients/Vercel.spec.ts
@@ -103,7 +103,7 @@ describe('VercelClient', () => {
       vi.restoreAllMocks();
     });
 
-    it('lists all projects for an authenticated user', async () => {
+    it('lists all api paths for an authenticated user', async () => {
       const data = await client.listApiPaths(projectId);
 
       expect(data.length).toBe(2);

--- a/apps/vercel/frontend/src/clients/Vercel.ts
+++ b/apps/vercel/frontend/src/clients/Vercel.ts
@@ -1,4 +1,11 @@
-import { CreateDeploymentInput, Deployment, ListProjectsResponse } from '@customTypes/configPage';
+import {
+  ApiPath,
+  CreateDeploymentInput,
+  Deployment,
+  ListDeploymentSummaryResponse,
+  ListProjectsResponse,
+  ServerlessFunction,
+} from '@customTypes/configPage';
 
 interface VercelAPIClient {
   checkToken: () => Promise<boolean>;
@@ -37,6 +44,44 @@ export default class VercelClient implements VercelAPIClient {
     return data;
   }
 
+  async listDeploymentSummaries(
+    projectId: string,
+    deploymentId?: string
+  ): Promise<ListDeploymentSummaryResponse> {
+    const latestDeploymentId = deploymentId || (await this.getLatestDeploymentId(projectId));
+    const res = await fetch(
+      `${this.baseEndpoint}/v6/deployments/${latestDeploymentId}/files/outputs?file=..%2Fdeploy_metadata.json`,
+      {
+        headers: this.buildHeaders(),
+        method: 'GET',
+      }
+    );
+
+    const data = await res.json();
+
+    return data;
+  }
+
+  async listApiPaths(projectId: string): Promise<ApiPath[]> {
+    const data = await this.listDeploymentSummaries(projectId);
+
+    const apiPaths = this.filterServerlessFunctions(data.serverlessFunctions);
+    const formattedApiPaths = this.formatApiPaths(apiPaths);
+
+    return formattedApiPaths;
+  }
+
+  async getLatestDeploymentId(projectId: string): Promise<string> {
+    const res = await fetch(`${this.baseEndpoint}/v6/deployments?projectId=${projectId}`, {
+      headers: this.buildHeaders(),
+      method: 'GET',
+    });
+
+    const data = await res.json();
+
+    return data.deployments[0].uid;
+  }
+
   async createDeployment({ project }: CreateDeploymentInput): Promise<Deployment> {
     const res = await fetch(`${this.baseEndpoint}/v13/deployments`, {
       headers: this.buildHeaders(),
@@ -62,5 +107,21 @@ export default class VercelClient implements VercelAPIClient {
     const data = await res.json();
 
     return data;
+  }
+
+  private filterServerlessFunctions(data: ServerlessFunction[]) {
+    return data.filter(
+      (file: ServerlessFunction) => file.type === 'Page' && file.path.includes('api')
+    );
+  }
+
+  private formatApiPaths(data: ServerlessFunction[]): ApiPath[] {
+    return data.map((file: ServerlessFunction) => {
+      const filePath = file.path;
+      return {
+        name: filePath,
+        id: filePath,
+      };
+    });
   }
 }

--- a/apps/vercel/frontend/src/clients/Vercel.ts
+++ b/apps/vercel/frontend/src/clients/Vercel.ts
@@ -118,6 +118,7 @@ export default class VercelClient implements VercelAPIClient {
   private formatApiPaths(data: ServerlessFunction[]): ApiPath[] {
     return data.map((file: ServerlessFunction) => {
       const filePath = file.path;
+      // TO DO: Add compound key for ID property
       return {
         name: filePath,
         id: filePath,

--- a/apps/vercel/frontend/src/clients/Vercel.ts
+++ b/apps/vercel/frontend/src/clients/Vercel.ts
@@ -44,7 +44,7 @@ export default class VercelClient implements VercelAPIClient {
     return data;
   }
 
-  async listDeploymentSummaries(
+  async listDeploymentSummary(
     projectId: string,
     deploymentId?: string
   ): Promise<ListDeploymentSummaryResponse> {
@@ -63,7 +63,7 @@ export default class VercelClient implements VercelAPIClient {
   }
 
   async listApiPaths(projectId: string): Promise<ApiPath[]> {
-    const data = await this.listDeploymentSummaries(projectId);
+    const data = await this.listDeploymentSummary(projectId);
 
     const apiPaths = this.filterServerlessFunctions(data.serverlessFunctions);
     const formattedApiPaths = this.formatApiPaths(apiPaths);

--- a/apps/vercel/frontend/src/customTypes/configPage.ts
+++ b/apps/vercel/frontend/src/customTypes/configPage.ts
@@ -34,13 +34,13 @@ export interface Path {
 }
 
 export interface Deployment {
-  id: string;
   name: string;
   status: string;
   target: string;
   projectId: string;
   bootedAt: Date;
   createdAt: Date;
+  uid: string;
 }
 
 export interface ListProjectsResponse {
@@ -50,3 +50,20 @@ export interface ListProjectsResponse {
 export interface CreateDeploymentInput {
   project: Project;
 }
+
+export type ServerlessFunction = {
+  path: string;
+  regions: string[];
+  runtime: string;
+  size: number;
+  type: string;
+};
+
+export interface ListDeploymentSummaryResponse {
+  serverlessFunctions: ServerlessFunction[];
+}
+
+export type ApiPath = {
+  id: string;
+  name: string;
+};

--- a/apps/vercel/frontend/src/locations/ConfigScreen.tsx
+++ b/apps/vercel/frontend/src/locations/ConfigScreen.tsx
@@ -22,7 +22,7 @@ import { ContentTypePreviewPathSection } from '@components/config-screen/Content
 import { ProjectSelectionSection } from '@components/config-screen/ProjectSelectionSection/ProjectSelectionSection';
 import { initialParameters } from '@constants/defaultParams';
 import VercelClient from '@clients/Vercel';
-import { Project } from '@customTypes/configPage';
+import { ApiPath, Project } from '@customTypes/configPage';
 import { ApiPathSelectionSection } from '@components/config-screen/ApiPathSelectionSection/ApiPathSelectionSection';
 
 const ConfigScreen = () => {
@@ -30,7 +30,7 @@ const ConfigScreen = () => {
   const [appInstalled, setIsAppInstalled] = useState(false);
   const [contentTypes, setContentTypes] = useState<ContentType[]>([]);
   const [projects, setProjects] = useState<Project[]>([]);
-  const [apiPaths, setApiPaths] = useState<any[]>([]);
+  const [apiPaths, setApiPaths] = useState<ApiPath[]>([]);
   const sdk = useSDK<ConfigAppSDK>();
 
   useInitializeParameters(dispatchParameters);

--- a/apps/vercel/frontend/src/locations/ConfigScreen.tsx
+++ b/apps/vercel/frontend/src/locations/ConfigScreen.tsx
@@ -25,17 +25,12 @@ import VercelClient from '@clients/Vercel';
 import { Project } from '@customTypes/configPage';
 import { ApiPathSelectionSection } from '@components/config-screen/ApiPathSelectionSection/ApiPathSelectionSection';
 
-// TO DO: Remove mock paths once api functionality is implemented to fetch these paths
-const mockPaths = [
-  { id: '1', name: 'api/enable-draft' },
-  { id: '2', name: 'api/disable-draft' },
-];
-
 const ConfigScreen = () => {
   const [parameters, dispatchParameters] = useReducer(parameterReducer, initialParameters);
   const [appInstalled, setIsAppInstalled] = useState(false);
   const [contentTypes, setContentTypes] = useState<ContentType[]>([]);
   const [projects, setProjects] = useState<Project[]>([]);
+  const [apiPaths, setApiPaths] = useState<any[]>([]);
   const sdk = useSDK<ConfigAppSDK>();
 
   useInitializeParameters(dispatchParameters);
@@ -117,6 +112,18 @@ const ConfigScreen = () => {
     getProjects();
   }, [parameters.vercelAccessToken]);
 
+  useEffect(() => {
+    async function getApiPaths() {
+      const data = await vercelClient.listApiPaths(parameters.selectedProject);
+
+      if (parameters.vercelAccessToken) {
+        setApiPaths(data);
+      }
+    }
+
+    if (parameters.selectedProject) getApiPaths();
+  }, [parameters.selectedProject]);
+
   const handleTokenChange = (e: ChangeEvent<HTMLInputElement>) => {
     dispatchParameters({
       type: actions.UPDATE_VERCEL_ACCESS_TOKEN,
@@ -192,7 +199,7 @@ const ConfigScreen = () => {
           <ApiPathSelectionSection
             parameters={parameters}
             dispatch={dispatchParameters}
-            paths={mockPaths}
+            paths={apiPaths}
           />
           <hr className={styles.splitter} />
           <ContentTypePreviewPathSection

--- a/apps/vercel/frontend/test/mocks/index.ts
+++ b/apps/vercel/frontend/test/mocks/index.ts
@@ -2,3 +2,4 @@ export { mockCma } from './mockCma';
 export { mockSdk } from './mockSdk';
 export { mockContentTypes } from './mockContentTypes';
 export { mockContentTypePreviewPathSelections } from './mockContentTypePreviewPathSelections';
+export { mockDeploymentSummary } from './mockDeploymentSummary';

--- a/apps/vercel/frontend/test/mocks/mockDeploymentSummary.ts
+++ b/apps/vercel/frontend/test/mocks/mockDeploymentSummary.ts
@@ -1,0 +1,32 @@
+export const mockDeploymentSummary = {
+  serverlessFunctions: [
+    {
+      path: 'api/enable-draft',
+      regions: ['iad1'],
+      runtime: 'nodejs12.x',
+      size: 1024,
+      type: 'Page',
+    },
+    {
+      path: 'api/disable-draft',
+      regions: ['iad1'],
+      runtime: 'nodejs12.x',
+      size: 1024,
+      type: 'Page',
+    },
+    {
+      path: '_not-found',
+      regions: ['iad1'],
+      runtime: 'nodejs12.x',
+      size: 1024,
+      type: 'Page',
+    },
+    {
+      path: 'blogs/[slug]',
+      regions: ['iad1'],
+      runtime: 'nodejs12.x',
+      size: 1024,
+      type: 'ISR',
+    },
+  ],
+};


### PR DESCRIPTION
## Purpose

The purpose of this PR is to render the list of api-paths dynamically on the config page. 

## Approach

We first fetch the latest `deploymentId`, scoped by the selected projectId, and use this `deploymentId` to then fetch a `deploymentSummary`. We filter this data based on `serverlessFunctions` that are of type `Page` and include 'api' within the path. 


https://github.com/contentful/apps/assets/58186851/8d235ef1-802e-4fd0-bec1-67588499c845



## Testing steps

Paste a valid token, select a project, and select an api path on the vercel config page. You should be able to change projects and render the new list of paths as well. 

## Follow-up

As you will notice in the comments I have added there are a few follow-up items: 
1. Ensure we are scoping the `listDeploymentSummary` endpoint appropriately by team. It seems that if we scope by project, this should suffice. 
2. Ensure we grabbing the latest `deploymentId` when fetching it using the `getLatestDeploymentId`. 
3. Cleanup the behavior of the dropdown. i.e ensure that an appropriate default is selected or just render the placeholder, especially when switching between projects. 
