### PR TITLE
chore: Vercel API path selection clean-up

### DIFF
--- a/apps/vercel/frontend/src/clients/Vercel.ts
+++ b/apps/vercel/frontend/src/clients/Vercel.ts
@@ -79,6 +79,7 @@ export default class VercelClient implements VercelAPIClient {
 
     const data = await res.json();
 
+    // Vercel returns deployments sorted by date in descending order
     return data.deployments[0].uid;
   }
 

--- a/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/ApiPathSelectionSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/ApiPathSelectionSection.tsx
@@ -16,7 +16,7 @@ interface Props {
 export const ApiPathSelectionSection = ({ parameters, dispatch, paths }: Props) => {
   const { heading, subHeading, footer } = copies.configPage.pathSelectionSection;
   return (
-    <Box className={styles.box}>
+    <Box data-testid="api-path-selection-section" className={styles.box}>
       <Heading marginBottom="none" className={styles.heading}>
         {heading}
       </Heading>

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSection.tsx
@@ -19,7 +19,7 @@ export const ContentTypePreviewPathSection = ({ parameters, dispatch, contentTyp
   const { contentTypePreviewPathSelections } = parameters;
 
   return (
-    <Box className={styles.box}>
+    <Box data-testid="content-type-preview-path-section" className={styles.box}>
       <Heading marginBottom="none" className={styles.heading}>
         Content type and preview path and token
       </Heading>

--- a/apps/vercel/frontend/src/components/config-screen/ProjectSelectionSection/ProjectSelectionSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ProjectSelectionSection/ProjectSelectionSection.tsx
@@ -16,7 +16,7 @@ interface Props {
 export const ProjectSelectionSection = ({ parameters, dispatch, projects }: Props) => {
   const { heading, subHeading, link, footer } = copies.configPage.projectSelectionSection;
   return (
-    <Box className={styles.box}>
+    <Box data-testid="project-selection-section" className={styles.box}>
       <Heading marginBottom="none" className={styles.heading}>
         {heading}
       </Heading>

--- a/apps/vercel/frontend/src/locations/ConfigScreen.spec.tsx
+++ b/apps/vercel/frontend/src/locations/ConfigScreen.spec.tsx
@@ -17,6 +17,9 @@ describe('ConfigScreen', () => {
 
     expect(screen.getByText('Connect Vercel')).toBeTruthy();
     expect(screen.getByText('Vercel Access Token')).toBeTruthy();
+    expect(screen.getByTestId('project-selection-section')).toBeTruthy();
+    expect(screen.getByTestId('api-path-selection-section')).toBeTruthy();
+    expect(screen.getByTestId('content-type-preview-path-section')).toBeTruthy();
     unmount();
   });
 });

--- a/apps/vercel/frontend/src/locations/ConfigScreen.tsx
+++ b/apps/vercel/frontend/src/locations/ConfigScreen.tsx
@@ -121,7 +121,17 @@ const ConfigScreen = () => {
       }
     }
 
-    if (parameters.selectedProject) getApiPaths();
+    if (parameters.selectedProject) {
+      // reset the selected api path only when the project changes
+      if (apiPaths.length) {
+        dispatchParameters({
+          type: actions.APPLY_API_PATH,
+          payload: '',
+        });
+      }
+
+      getApiPaths();
+    }
   }, [parameters.selectedProject]);
 
   const handleTokenChange = (e: ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## Purpose

The purpose of this PR is to do some minor cleanup with the configuration of Api paths on the Vercel configuration page. 

## Approach

1. I ensured that when the user changes the project, but there is an already selected API path, then it clears this state so as not to render API paths that may not existed with the new project. 
2. I added a broader test for the Config page
3. I tested pretty thoroughly that the list of deployments returned from Vercel does in fact return the deployments in order of most recent to least recent. I added a note within the code about this. 

