### PR TITLE
chore: bump NAT version in function-appevent-filter example [EXT-4978]

### DIFF
--- a/examples/function-appevent-filter/typescript/package-lock.json
+++ b/examples/function-appevent-filter/typescript/package-lock.json
@@ -5,17 +5,16 @@
   "packages": {
     "": {
       "devDependencies": {
-        "@contentful/node-apps-toolkit": "^2.6.2",
+        "@contentful/node-apps-toolkit": "^3.3.0",
         "@tsconfig/recommended": "1.0.3",
         "esbuild": "0.19.2"
       }
     },
     "node_modules/@contentful/node-apps-toolkit": {
-      "version": "2.8.2",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/node-apps-toolkit/2.8.2/b900735898a45e426123a432ebcb2041af99fe93",
-      "integrity": "sha512-KgdMC8F5UUO8NoVdlrtyF3MMDY0m3zq9d3Kcs+GDLoE9Tbnm+osAQHN49CeyOw6OczryEg5ITXqXq44bF0MVZw==",
+      "version": "3.3.0",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/node-apps-toolkit/3.3.0/730845192ae46170c16e5352131c867411ac3f8b",
+      "integrity": "sha512-HYMxp6B0rfnS6WTRUuq9d3Uvcg0RIcvdso+AEfLeiQFKEGNvSYx2clKgstGngsHhbINzthcI0soaKTDvrOc6uQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/debug": "^4.1.5",
         "contentful-management": "^11.6.1",

--- a/examples/function-appevent-filter/typescript/package.json
+++ b/examples/function-appevent-filter/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "@contentful/node-apps-toolkit": "^2.6.2",
+    "@contentful/node-apps-toolkit": "^3.3.0",
     "@tsconfig/recommended": "1.0.3",
     "esbuild": "0.19.2"
   }


### PR DESCRIPTION
Fixes types on example appevent-filter
