### PR TITLE
chore: add design updates for Vercel config page

### DIFF
--- a/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/ApiPathSelectionSection.styles.ts
+++ b/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/ApiPathSelectionSection.styles.ts
@@ -1,0 +1,11 @@
+import tokens from '@contentful/f36-tokens';
+import { css } from 'emotion';
+
+export const styles = {
+  box: css({
+    width: '100%',
+  }),
+  helpText: css({
+    marginBottom: tokens.spacingM,
+  }),
+};

--- a/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/ApiPathSelectionSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/ApiPathSelectionSection.tsx
@@ -1,11 +1,11 @@
-import { Box, Heading, Paragraph } from '@contentful/f36-components';
+import { Box, HelpText } from '@contentful/f36-components';
 import { Dispatch } from 'react';
 
 import { ParameterAction } from '@components/parameterReducer';
 import { copies } from '@constants/copies';
 import { AppInstallationParameters, Path } from '@customTypes/configPage';
-import { styles } from '../ConfigScreen.styles';
 import { ApiPathSelect } from './ApiPathSelect/ApiPathSelect';
+import { styles } from './ApiPathSelectionSection.styles';
 
 interface Props {
   parameters: AppInstallationParameters;
@@ -14,15 +14,11 @@ interface Props {
 }
 
 export const ApiPathSelectionSection = ({ parameters, dispatch, paths }: Props) => {
-  const { heading, subHeading, footer } = copies.configPage.pathSelectionSection;
+  const { helpText } = copies.configPage.pathSelectionSection;
   return (
     <Box data-testid="api-path-selection-section" className={styles.box}>
-      <Heading marginBottom="none" className={styles.heading}>
-        {heading}
-      </Heading>
-      <Paragraph marginTop="spacingXs">{subHeading}</Paragraph>
       <ApiPathSelect parameters={parameters} dispatch={dispatch} paths={paths} />
-      <Paragraph>{footer}</Paragraph>
+      <HelpText className={styles.helpText}>{helpText}</HelpText>
     </Box>
   );
 };

--- a/apps/vercel/frontend/src/components/config-screen/AuthenticationSection/AuthenticationSection.spec.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/AuthenticationSection/AuthenticationSection.spec.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { AppInstallationParameters } from '@customTypes/configPage';
+import { AuthenticationSection } from './AuthenticationSection';
+import { copies } from '@constants/copies';
+
+const { input, statusMessages } = copies.configPage.authenticationSection;
+
+describe('AuthenticationSection', () => {
+  it('renders input when token is not yet inputed', () => {
+    const parameters = {
+      vercelAccessToken: '',
+      vercelAccessTokenStatus: '',
+    } as unknown as AppInstallationParameters;
+    render(
+      <AuthenticationSection
+        handleTokenChange={vi.fn()}
+        parameters={parameters}
+        isAppInstalled={false}
+      />
+    );
+
+    const status = screen.getByText(statusMessages.invalid);
+    const tokenInput = screen.getByPlaceholderText(input.placeholder);
+
+    expect(status).toBeTruthy();
+    expect(tokenInput).toBeTruthy();
+  });
+
+  it('renders hidden token and valid content when token is valid and app is installed', () => {
+    const parameters = {
+      vercelAccessToken: '12345',
+      vercelAccessTokenStatus: 'valid',
+    } as unknown as AppInstallationParameters;
+    render(
+      <AuthenticationSection handleTokenChange={vi.fn()} parameters={parameters} isAppInstalled />
+    );
+
+    const status = screen.getByText(statusMessages.valid);
+    const token = screen.queryByText(parameters.vercelAccessToken);
+
+    expect(status).toBeTruthy();
+    expect(token).toBeFalsy();
+  });
+});

--- a/apps/vercel/frontend/src/components/config-screen/AuthenticationSection/AuthenticationSection.styles.ts
+++ b/apps/vercel/frontend/src/components/config-screen/AuthenticationSection/AuthenticationSection.styles.ts
@@ -1,0 +1,14 @@
+import { css } from 'emotion';
+
+export const styles = {
+  box: css({
+    width: '100%',
+  }),
+  badgeContainer: css({
+    marginTop: '10px',
+    width: '100%',
+  }),
+  heading: css({
+    fontSize: '1rem',
+  }),
+};

--- a/apps/vercel/frontend/src/components/config-screen/AuthenticationSection/AuthenticationSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/AuthenticationSection/AuthenticationSection.tsx
@@ -1,0 +1,77 @@
+import { ChangeEvent } from 'react';
+import {
+  Box,
+  Flex,
+  FormControl,
+  Heading,
+  HelpText,
+  TextInput,
+  TextLink,
+  Text,
+  Badge,
+} from '@contentful/f36-components';
+import { ExternalLinkIcon } from '@contentful/f36-icons';
+
+import { styles } from './AuthenticationSection.styles';
+import { AppInstallationParameters } from '@customTypes/configPage';
+import { copies } from '@constants/copies';
+
+interface Props {
+  parameters: AppInstallationParameters;
+  isAppInstalled: boolean;
+  handleTokenChange: (e: ChangeEvent<HTMLInputElement>) => void;
+}
+
+export const AuthenticationSection = ({ parameters, isAppInstalled, handleTokenChange }: Props) => {
+  const { heading, subheading, input, link, statusMessages } =
+    copies.configPage.authenticationSection;
+
+  const renderStatusBadge = () => {
+    if (isAppInstalled && parameters.vercelAccessToken && parameters.vercelAccessTokenStatus) {
+      return <Badge variant="positive">{statusMessages.valid}</Badge>;
+    } else if (!parameters.vercelAccessTokenStatus) {
+      return <Badge variant="negative">{statusMessages.invalid}</Badge>;
+    } else {
+      return <Badge variant="secondary">{statusMessages.notConfigured}</Badge>;
+    }
+  };
+  return (
+    <Box className={styles.box}>
+      <Heading className={styles.heading}>{heading}</Heading>
+      <FormControl id="accessToken" isRequired={true}>
+        <FormControl.Label aria-label="accessToken" htmlFor="accessToken">
+          {subheading}
+        </FormControl.Label>
+        <TextInput
+          testId="accessToken"
+          spellCheck={false}
+          name="accessToken"
+          type="password"
+          placeholder={input.placeholder}
+          value={parameters.vercelAccessToken}
+          onChange={handleTokenChange}
+        />
+        <HelpText>
+          Follow{' '}
+          <TextLink
+            icon={<ExternalLinkIcon />}
+            alignIcon="end"
+            href={link.href}
+            target="_blank"
+            rel="noopener noreferrer">
+            Vercel instructions
+          </TextLink>{' '}
+          to create an access token for your account.
+        </HelpText>
+        <Box className={styles.badgeContainer}>
+          <Flex fullWidth flexDirection="column">
+            <Text fontWeight="fontWeightDemiBold" marginRight="spacing2Xs">
+              Status
+            </Text>
+            <Box>{renderStatusBadge()}</Box>
+          </Flex>
+        </Box>
+      </FormControl>
+    </Box>
+  );
+};

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSection.tsx
@@ -3,7 +3,7 @@ import { ContentType } from '@contentful/app-sdk';
 import { Dispatch } from 'react';
 
 import { ParameterAction } from '@components/parameterReducer';
-import { styles } from '../../../locations/ConfigScreen.styles';
+import { styles } from '@locations/ConfigScreen.styles';
 import { AppInstallationParameters } from '@customTypes/configPage';
 import { ContentTypePreviewPathSelectionList } from './ContentTypePreviewPathSelectionList/ContentTypePreviewPathSelectionList';
 import { PreviewPathInfoNote } from './PreviewPathInfoNote/PreviewPathInfoNote';

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSection.tsx
@@ -3,7 +3,7 @@ import { ContentType } from '@contentful/app-sdk';
 import { Dispatch } from 'react';
 
 import { ParameterAction } from '@components/parameterReducer';
-import { styles } from '@components/config-screen/ConfigScreen.styles';
+import { styles } from '../../../locations/ConfigScreen.styles';
 import { AppInstallationParameters } from '@customTypes/configPage';
 import { ContentTypePreviewPathSelectionList } from './ContentTypePreviewPathSelectionList/ContentTypePreviewPathSelectionList';
 import { PreviewPathInfoNote } from './PreviewPathInfoNote/PreviewPathInfoNote';

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionList/ContentTypePreviewPathSelectionList.spec.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionList/ContentTypePreviewPathSelectionList.spec.tsx
@@ -27,7 +27,7 @@ describe('ContentTypePreviewPathSelectionList', () => {
     unmount();
   });
 
-  it('hides add button if all content types have been configured', () => {
+  it('disables add button if all content types have been configured', () => {
     const { unmount } = render(
       <ContentTypePreviewPathSelectionList
         contentTypes={mockContentTypes}
@@ -47,7 +47,10 @@ describe('ContentTypePreviewPathSelectionList', () => {
     expect(
       screen.getByDisplayValue(mockContentTypePreviewPathSelections[1].previewPath)
     ).toBeTruthy();
-    expect(screen.queryByText('Add Content Type')).toBeFalsy();
+    expect(screen.getByRole('button', { name: 'Add Content Type' })).toHaveProperty(
+      'disabled',
+      true
+    );
 
     unmount();
   });

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionList/ContentTypePreviewPathSelectionList.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionList/ContentTypePreviewPathSelectionList.tsx
@@ -50,10 +50,11 @@ export const ContentTypePreviewPathSelectionList = ({
     setAddRow(true);
   };
 
-  // render add button if there are content types that are not selected
-  const renderAddButton = contentTypePreviewPathSelections.length !== contentTypes.length;
-  // disable add button if there is a row with empty fields present
-  const isAddButtonDisabled = addRow || contentTypePreviewPathSelections.length === 0;
+  // disable add button if there is a row with empty fields present or when all content types are already selected
+  const isAddButtonDisabled =
+    addRow ||
+    contentTypePreviewPathSelections.length === 0 ||
+    contentTypePreviewPathSelections.length === contentTypes.length;
 
   const renderSelectionRow = () => {
     const selectionsWithBlankRow =
@@ -80,11 +81,9 @@ export const ContentTypePreviewPathSelectionList = ({
     <>
       {renderSelectionRow()}
 
-      {renderAddButton && (
-        <Button isDisabled={isAddButtonDisabled} onClick={handleAddRow} startIcon={<PlusIcon />}>
-          Add Content Type
-        </Button>
-      )}
+      <Button isDisabled={isAddButtonDisabled} onClick={handleAddRow} startIcon={<PlusIcon />}>
+        Add Content Type
+      </Button>
     </>
   );
 };

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/InformationalModal/InformationalModal.styles.ts
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/InformationalModal/InformationalModal.styles.ts
@@ -9,6 +9,6 @@ export const styles = {
     marginBottom: 0,
   }),
   footer: css({
-    margin: `${tokens.spacingL} 0`,
+    margin: `${tokens.spacingXs} 0`,
   }),
 };

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/InformationalModal/InformationalModal.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/InformationalModal/InformationalModal.tsx
@@ -12,7 +12,7 @@ interface Props {
 }
 
 export const InformationalModal = ({ onClose, isShown }: Props) => {
-  const { title, button, exampleOne, exampleTwo, exampleThree } =
+  const { title, button, exampleOne, exampleTwo, exampleThree, footer } =
     copies.configPage.contentTypePreviewPathSection.exampleModal;
 
   return (
@@ -21,7 +21,7 @@ export const InformationalModal = ({ onClose, isShown }: Props) => {
         <>
           <Modal.Header title={title} onClose={onClose} />
           <Modal.Content>
-            <Flex flexDirection="column" gap={tokens.spacingS}>
+            <Flex flexDirection="column" alignItems="baseline" gap={tokens.spacingS}>
               <Flex flexDirection="column" gap={tokens.spacingL}>
                 <Box>
                   <Paragraph className={styles.firstParagraph}>{exampleOne.description}</Paragraph>
@@ -41,16 +41,24 @@ export const InformationalModal = ({ onClose, isShown }: Props) => {
                 <Flex alignItems="flex-start" gap={tokens.spacingS}>
                   <GrayInfoBox>{exampleThree.example}</GrayInfoBox>
                   <Paragraph>
-                    {exampleThree.description} <TextLink>custom preview tokens</TextLink>
+                    {exampleThree.description}{' '}
+                    <TextLink
+                      href={exampleThree.link.href}
+                      target="_blank"
+                      rel="noopener noreferrer">
+                      {exampleThree.link.copy}
+                    </TextLink>
                   </Paragraph>
                 </Flex>
               </Flex>
-
               <InformationalTables />
-
-              <Paragraph className={styles.footer}>
-                For more details about preview URLs, <TextLink>read the docs.</TextLink>{' '}
-              </Paragraph>
+              <TextLink
+                target="_blank"
+                rel="noopener noreferrer"
+                href={footer.href}
+                className={styles.footer}>
+                {footer.copy}
+              </TextLink>{' '}
             </Flex>
           </Modal.Content>
           <Modal.Controls>

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/InformationalModal/InformationalTables/InfoTable/InfoTable.styles.ts
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/InformationalModal/InformationalTables/InfoTable/InfoTable.styles.ts
@@ -23,7 +23,7 @@ export const styles = {
   }),
   rowWrapper: css({
     borderBottom: `1px solid ${tokens.gray200}`,
-    paddingRight: tokens.spacing2Xl,
+    paddingRight: tokens.spacingM,
   }),
   rowDescription: css({
     paddingLeft: tokens.spacingM,

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/InformationalModal/InformationalTables/InformationalTables.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/InformationalModal/InformationalTables/InformationalTables.tsx
@@ -15,7 +15,8 @@ type TableRow = {
 const EXAMPLE_PROPERTY = '{entry.linkedBy}';
 
 export const InformationalTables = () => {
-  const { tableOne, tableTwo } = copies.configPage.contentTypePreviewPathSection.exampleModal;
+  const { tableOne, tableTwo, tableTwoSubHeading } =
+    copies.configPage.contentTypePreviewPathSection.exampleModal;
   const infoBoxCustomStyling = {
     width: INFORMATIONAL_MODAL_COLUMN_WIDTH,
     margin: tokens.spacingXs,
@@ -33,14 +34,17 @@ export const InformationalTables = () => {
 
   return (
     <Box>
-      <InfoTable headers={['Placholder token', 'Definition']} rows={renderTableRows(tableOne)} />
+      <InfoTable headers={tableOne.headers} rows={renderTableRows(tableOne.rows)} />
 
       <Paragraph className={styles.link}>
-        Additionally, you can query <TextLink>incoming links to entry by</TextLink> using the{' '}
-        {EXAMPLE_PROPERTY} property (the first entry in response will be used)
+        Additionally, you can query{' '}
+        <TextLink target="_blank" rel="noopener noreferrer" href={tableTwoSubHeading.link.href}>
+          incoming links to entry by
+        </TextLink>{' '}
+        using the {EXAMPLE_PROPERTY} property (the first entry in response will be used)
       </Paragraph>
 
-      <InfoTable headers={['Linked entries', 'Definition']} rows={renderTableRows(tableTwo)} />
+      <InfoTable headers={tableTwo.headers} rows={renderTableRows(tableTwo.rows)} />
     </Box>
   );
 };

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/PreviewPathInfoNote/PreviewPathInfoNote.spec.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/PreviewPathInfoNote/PreviewPathInfoNote.spec.tsx
@@ -2,16 +2,18 @@ import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
 import { PreviewPathInfoNote } from './PreviewPathInfoNote';
+import { copies } from '@constants/copies';
 
 describe('PreviewPathInfoNote', () => {
+  const { description, link } = copies.configPage.contentTypePreviewPathSection.infoNote;
   it('renders content', () => {
     render(<PreviewPathInfoNote />);
-    const text = screen.getByText('Preview path and token example:');
+    const text = screen.getByText(description);
     const example = screen.getByTestId('info-box');
-    const link = screen.getByText('View more examples');
+    const textLink = screen.getByText(link.copy);
 
     expect(text).toBeTruthy();
     expect(example).toBeTruthy();
-    expect(link).toBeTruthy();
+    expect(textLink).toBeTruthy();
   });
 });

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/PreviewPathInfoNote/PreviewPathInfoNote.styles.ts
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/PreviewPathInfoNote/PreviewPathInfoNote.styles.ts
@@ -7,4 +7,10 @@ export const styles = {
     alignItems: 'center',
     marginBottom: tokens.spacingL,
   }),
+  link: css({
+    '> span': {
+      color: tokens.blue500,
+      fontWeight: 700,
+    },
+  }),
 };

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/PreviewPathInfoNote/PreviewPathInfoNote.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/PreviewPathInfoNote/PreviewPathInfoNote.tsx
@@ -7,11 +7,10 @@ import { InformationalModal } from '../InformationalModal/InformationalModal';
 import { styles } from './PreviewPathInfoNote.styles';
 
 // this gap is tailored specifically to the designs of the modal
-const FLEX_GAP = '11rem';
+const FLEX_GAP = '14rem';
 
 export const PreviewPathInfoNote = () => {
-  const { infoBoxCopyDescription, infoBoxExample, infoBoxTextLink } =
-    copies.configPage.contentTypePreviewPathSection.infoNote;
+  const { description, example, link } = copies.configPage.contentTypePreviewPathSection.infoNote;
 
   const renderExampleInfoModal = () => {
     ModalLauncher.open(({ isShown, onClose }) => (
@@ -23,10 +22,12 @@ export const PreviewPathInfoNote = () => {
     <Note className={styles.root} variant="neutral">
       <Flex justifyContent="space-between" alignItems="center" gap={FLEX_GAP}>
         <Flex alignItems="center" gap={tokens.spacingXs}>
-          {infoBoxCopyDescription}
-          <GrayInfoBox withCopy>{infoBoxExample}</GrayInfoBox>
+          {description}
+          <GrayInfoBox withCopy>{example}</GrayInfoBox>
         </Flex>
-        <TextLink onClick={renderExampleInfoModal}>{infoBoxTextLink}</TextLink>
+        <TextLink className={styles.link} onClick={renderExampleInfoModal}>
+          {link.copy}
+        </TextLink>
       </Flex>
     </Note>
   );

--- a/apps/vercel/frontend/src/components/config-screen/ProjectSelectionSection/ProjectSelectionSection.styles.ts
+++ b/apps/vercel/frontend/src/components/config-screen/ProjectSelectionSection/ProjectSelectionSection.styles.ts
@@ -1,0 +1,11 @@
+import tokens from '@contentful/f36-tokens';
+import { css } from 'emotion';
+
+export const styles = {
+  box: css({
+    width: '100%',
+  }),
+  helpText: css({
+    marginBottom: tokens.spacingM,
+  }),
+};

--- a/apps/vercel/frontend/src/components/config-screen/ProjectSelectionSection/ProjectSelectionSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ProjectSelectionSection/ProjectSelectionSection.tsx
@@ -1,11 +1,11 @@
-import { Box, Heading, Paragraph, TextLink } from '@contentful/f36-components';
+import { Box, HelpText } from '@contentful/f36-components';
 import { Dispatch } from 'react';
 
 import { ParameterAction } from '@components/parameterReducer';
 import { copies } from '@constants/copies';
 import { AppInstallationParameters, Project } from '@customTypes/configPage';
-import { styles } from '../ConfigScreen.styles';
 import { ProjectSelect } from './ProjectSelect/ProjectSelect';
+import { styles } from './ProjectSelectionSection.styles';
 
 interface Props {
   parameters: AppInstallationParameters;
@@ -14,17 +14,11 @@ interface Props {
 }
 
 export const ProjectSelectionSection = ({ parameters, dispatch, projects }: Props) => {
-  const { heading, subHeading, link, footer } = copies.configPage.projectSelectionSection;
+  const { helpText } = copies.configPage.projectSelectionSection;
   return (
     <Box data-testid="project-selection-section" className={styles.box}>
-      <Heading marginBottom="none" className={styles.heading}>
-        {heading}
-      </Heading>
-      <Paragraph marginTop="spacingXs">
-        {subHeading} <TextLink>{link}</TextLink>
-      </Paragraph>
       <ProjectSelect parameters={parameters} dispatch={dispatch} projects={projects} />
-      <Paragraph>{footer}</Paragraph>
+      <HelpText className={styles.helpText}>{helpText}</HelpText>
     </Box>
   );
 };

--- a/apps/vercel/frontend/src/constants/copies.ts
+++ b/apps/vercel/frontend/src/constants/copies.ts
@@ -1,21 +1,30 @@
 export const copies = {
   configPage: {
+    authenticationSection: {
+      heading: 'Connect Vercel',
+      subheading: 'Vercel Access Token',
+      input: {
+        placeholder: 'ex. atE2sdftcIp01O1isdfXc3QTdT4...',
+      },
+      link: {
+        href: 'https://vercel.com/docs/rest-api#creating-an-access-token',
+      },
+      statusMessages: {
+        valid: 'Valid access token',
+        invalid: 'Invalid access token',
+        notConfigured: 'Token not configured',
+      },
+    },
     projectSelectionSection: {
-      heading: 'Configure a live preview for a project',
-      subHeading: 'Select one of your Vercel projects in order to configure live preview.',
-      footer: 'Projects are populated based on your Vercel account.',
-      link: 'Learn how to construct a preview path and token.',
+      helpText: 'Select one of your Vercel projects.',
       dropdown: {
         label: 'Project',
         placeholder: 'Please select a project...',
         emptyMessage: 'No Projects currently configured.',
       },
     },
-    // TO DO: Adjust copies based on future designs
     pathSelectionSection: {
-      heading: 'Configure API path',
-      subHeading: 'Select the API path you want to expose to Contentful.',
-      footer: 'API paths are populated based on your Vercel account.',
+      helpText: 'Select one one of your Vercel routes.',
       dropdown: {
         label: 'API Path',
         placeholder: 'Please select a path...',
@@ -24,65 +33,84 @@ export const copies = {
     },
     contentTypePreviewPathSection: {
       infoNote: {
-        infoBoxExample: '/blogs/{entry.fields.slug}',
-        infoBoxCopyDescription: 'Preview path and token example:',
-        infoBoxTextLink: 'View more examples',
+        example: '/blogs/{entry.fields.slug}',
+        description: 'Preview path and token example:',
+        link: {
+          copy: 'View tokens',
+        },
       },
       exampleModal: {
         title: 'Preview URLs',
         button: 'Got it',
         exampleOne: {
           description: 'For each content type, create a URL according to this structure:',
-          example: 'https://[YOUR_PREVIEW_DOMAIN]/[PLACEHOLDER_TOKEN]',
+          example: '[preview_domain]/[placeholder_token]',
         },
         exampleTwo: {
-          description:
-            'The base path of your preview website or app (Example: https://myapp.com/entities)',
-          example: '[YOUR_PREVIEW_DOMAIN]',
+          description: 'The base path of your preview website or app (Example: /entities)',
+          example: '[preview_domain]',
         },
         exampleThree: {
           description:
             'A token that is resolved into an actual value when a user clicks on the preview link. You can add one or multiple tokens. Premium plan customers can specify',
-          example: '[PLACEHOLDER_TOKEN]',
+          example: '[placeholder_token]',
+          link: {
+            copy: 'custom preview tokens.',
+            href: 'https://www.contentful.com/developers/docs/tutorials/general/content-preview/',
+          },
         },
-        tableOne: [
-          {
-            description: 'The environment ID for the entry',
-            example: '{env_id}',
+        tableOne: {
+          headers: ['Placholder token', 'Definition'],
+          rows: [
+            {
+              description: 'The environment ID for the entry',
+              example: '{env_id}',
+            },
+            {
+              description: 'An object containing all the properties and their values for the entry',
+              example: '{entry}',
+            },
+            {
+              description: 'ID of the current entry',
+              example: '{entry.sys.id}',
+            },
+            {
+              description:
+                'The value of the slug field, based on the localization provided (will not fallback to default locale in case of invalid locale)',
+              example: '{entry.fields.slug}',
+              exampleTwo: '[LOCALE_CODE]',
+            },
+            {
+              description:
+                'The code for your current selected locale. In multi-locale mode it will use the default locale of your space',
+              example: '{locale}',
+            },
+          ],
+        },
+        tableTwo: {
+          headers: ['Linked entries', 'Definition'],
+          rows: [
+            {
+              description:
+                'ID of the entry, which is referencing the current entry (the one you have opened in the editor)',
+              example: '{entry.linkedBy.sys.id}',
+            },
+            {
+              description:
+                'Value of the slug field for the entry, which references entry from the previous example',
+              example: '{entry.linkedBy.fields.slug}',
+            },
+          ],
+        },
+        tableTwoSubHeading: {
+          link: {
+            href: 'https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/search-parameters/links-to-entry',
           },
-          {
-            description: 'An object containing all the properties and their values for the entry',
-            example: '{entry}',
-          },
-          {
-            description: 'ID of the current entry',
-            example: '{entry.sys.id}',
-          },
-          {
-            description:
-              'The value of the slug field, based on the localization provided (will not fallback to default locale in case of invalid locale)',
-            example: '{entry.fields.slug}',
-            exampleTwo: '[LOCALE_CODE]',
-          },
-          {
-            description:
-              'The code for your current selected locale. In multi-locale mode it will use the default locale of your space',
-            example: '{locale}',
-          },
-        ],
-        tableTwo: [
-          {
-            description:
-              'ID of the entry, which is referencing the current entry (the one you have opened in the editor)',
-            example: '{entry.linkedBy.sys.id}',
-          },
-          {
-            description:
-              'Value of the slug field for the entry, which references entry from the previous example',
-            example: '{entry.linkedBy.fields.slug}',
-          },
-        ],
-        footer: 'For more detail about preview URLs, read the docs.',
+        },
+        footer: {
+          copy: 'Learn more about setting up content preview.',
+          href: 'https://www.contentful.com/developers/docs/tutorials/general/content-preview/',
+        },
       },
     },
   },

--- a/apps/vercel/frontend/src/locations/ConfigScreen.styles.tsx
+++ b/apps/vercel/frontend/src/locations/ConfigScreen.styles.tsx
@@ -8,6 +8,7 @@ export const styles = {
     minHeight: '40vh',
     margin: '0 auto',
     marginTop: tokens.spacingXl,
+    marginBottom: tokens.spacingXl,
     padding: `${tokens.spacingXl} ${tokens.spacing2Xl}`,
     maxWidth: '900px',
     backgroundColor: tokens.colorWhite,

--- a/apps/vercel/frontend/src/locations/ConfigScreen.styles.tsx
+++ b/apps/vercel/frontend/src/locations/ConfigScreen.styles.tsx
@@ -1,6 +1,6 @@
 import tokens from '@contentful/f36-tokens';
 import { css } from 'emotion';
-import { VercelBrand } from '../components/common/VercelIcon';
+import { VercelBrand } from '@components/common/VercelIcon';
 
 export const styles = {
   body: css({

--- a/apps/vercel/frontend/src/locations/ConfigScreen.styles.tsx
+++ b/apps/vercel/frontend/src/locations/ConfigScreen.styles.tsx
@@ -1,6 +1,6 @@
 import tokens from '@contentful/f36-tokens';
 import { css } from 'emotion';
-import { VercelBrand } from '../common/VercelIcon';
+import { VercelBrand } from '../components/common/VercelIcon';
 
 export const styles = {
   body: css({
@@ -12,8 +12,8 @@ export const styles = {
     maxWidth: '900px',
     backgroundColor: tokens.colorWhite,
     zIndex: 2,
-    boxShadow: '0px 0px 20px rgba(0, 0, 0, 0.1)',
-    borderRadius: '2px',
+    border: `1px solid ${tokens.gray300}`,
+    borderRadius: tokens.borderRadiusMedium,
   }),
   background: css({
     display: 'block',

--- a/apps/vercel/frontend/src/locations/ConfigScreen.tsx
+++ b/apps/vercel/frontend/src/locations/ConfigScreen.tsx
@@ -1,21 +1,8 @@
 import { useCallback, useState, useEffect, useReducer, ChangeEvent } from 'react';
 import { ConfigAppSDK, ContentType } from '@contentful/app-sdk';
-import {
-  Box,
-  Flex,
-  FormControl,
-  Heading,
-  HelpText,
-  Paragraph,
-  Stack,
-  TextInput,
-  TextLink,
-  Text,
-  Badge,
-} from '@contentful/f36-components';
+import { Box, Heading, Paragraph, Stack } from '@contentful/f36-components';
 import { useSDK } from '@contentful/react-apps-toolkit';
-import { ExternalLinkIcon } from '@contentful/f36-icons';
-import { styles } from '@components/config-screen/ConfigScreen.styles';
+import { styles } from './ConfigScreen.styles';
 import useInitializeParameters from '@hooks/useInitializeParameters';
 import parameterReducer, { actions } from '@components/parameterReducer';
 import { ContentTypePreviewPathSection } from '@components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSection';
@@ -24,10 +11,11 @@ import { initialParameters } from '@constants/defaultParams';
 import VercelClient from '@clients/Vercel';
 import { ApiPath, Project } from '@customTypes/configPage';
 import { ApiPathSelectionSection } from '@components/config-screen/ApiPathSelectionSection/ApiPathSelectionSection';
+import { AuthenticationSection } from '@components/config-screen/AuthenticationSection/AuthenticationSection';
 
 const ConfigScreen = () => {
   const [parameters, dispatchParameters] = useReducer(parameterReducer, initialParameters);
-  const [appInstalled, setIsAppInstalled] = useState(false);
+  const [isAppInstalled, setIsAppInstalled] = useState(false);
   const [contentTypes, setContentTypes] = useState<ContentType[]>([]);
   const [projects, setProjects] = useState<Project[]>([]);
   const [apiPaths, setApiPaths] = useState<ApiPath[]>([]);
@@ -83,7 +71,7 @@ const ConfigScreen = () => {
       }
     }
 
-    if (appInstalled && parameters && parameters.vercelAccessToken) {
+    if (isAppInstalled && parameters && parameters.vercelAccessToken) {
       checkToken();
     }
   }, [parameters.vercelAccessToken]);
@@ -141,16 +129,6 @@ const ConfigScreen = () => {
     });
   };
 
-  const renderStatusBadge = () => {
-    if (appInstalled && parameters.vercelAccessToken && parameters.vercelAccessTokenStatus) {
-      return <Badge variant="positive">Valid access token</Badge>;
-    } else if (!parameters.vercelAccessTokenStatus) {
-      return <Badge variant="negative">Invalid access token</Badge>;
-    } else {
-      return <Badge variant="secondary">Token not configured</Badge>;
-    }
-  };
-
   return (
     <>
       <Box className={styles.body}>
@@ -162,56 +140,21 @@ const ConfigScreen = () => {
         </Box>
         <hr className={styles.splitter} />
         <Stack spacing="spacingS" flexDirection="column">
-          <Box className={styles.box}>
-            <Heading className={styles.heading}>Connect Vercel</Heading>
-            <FormControl id="accessToken" isRequired={true}>
-              <FormControl.Label aria-label="accessToken" htmlFor="accessToken">
-                Vercel Access Token
-              </FormControl.Label>
-              <TextInput
-                testId="accessToken"
-                spellCheck={false}
-                name="accessToken"
-                type="password"
-                placeholder={'ex. atE2sdftcIp01O1isdfXc3QTdT4...'}
-                value={parameters.vercelAccessToken}
-                onChange={handleTokenChange}
-              />
-              <HelpText>
-                Follow{' '}
-                <TextLink
-                  icon={<ExternalLinkIcon />}
-                  alignIcon="end"
-                  href="https://vercel.com/docs/rest-api#creating-an-access-token"
-                  target="_blank"
-                  rel="noopener noreferrer">
-                  these detailed instructions
-                </TextLink>{' '}
-                to create an access token in the Vercel dashboard.
-              </HelpText>
-              <Box className={styles.badgeContainer}>
-                <Flex fullWidth flexDirection="column">
-                  <Text fontWeight="fontWeightDemiBold" marginRight="spacing2Xs">
-                    Status
-                  </Text>
-                  <Box>{renderStatusBadge()}</Box>
-                </Flex>
-              </Box>
-            </FormControl>
-          </Box>
-          <hr className={styles.splitter} />
+          <AuthenticationSection
+            parameters={parameters}
+            isAppInstalled={isAppInstalled}
+            handleTokenChange={handleTokenChange}
+          />
           <ProjectSelectionSection
             parameters={parameters}
             dispatch={dispatchParameters}
             projects={projects}
           />
-          <hr className={styles.splitter} />
           <ApiPathSelectionSection
             parameters={parameters}
             dispatch={dispatchParameters}
             paths={apiPaths}
           />
-          <hr className={styles.splitter} />
           <ContentTypePreviewPathSection
             parameters={parameters}
             dispatch={dispatchParameters}

--- a/apps/vercel/frontend/tsconfig.json
+++ b/apps/vercel/frontend/tsconfig.json
@@ -17,6 +17,7 @@
     "paths": {
       "@clients/*": ["./src/clients/*"],
       "@components/*": ["./src/components/*"],
+      "@locations/*": ["./src/locations/*"],
       "@constants/*": ["./src/constants/*"],
       "@hooks/*": ["./src/hooks/*"],
       "@customTypes/*": ["./src/customTypes/*"],

--- a/apps/vercel/frontend/vite.config.ts
+++ b/apps/vercel/frontend/vite.config.ts
@@ -22,6 +22,7 @@ export default defineConfig(() => ({
       '@customTypes': path.resolve(__dirname, './src/customTypes'),
       '@utils': path.resolve(__dirname, './src/utils'),
       '@test': path.resolve(__dirname, './test'),
+      '@locations': path.resolve(__dirname, './src/locations'),
     },
   },
 


### PR DESCRIPTION
## Purpose

The purpose of this PR is to accomplish the following: 
1. Always render the Add Content type button, but disable it when there are no more content types to select (Mob QA feedback). 
2. Consolidate the sections of the Config page into fewer distinct sections based on design updates. 
3. Add functioning href's into the Config page links. 
4. Adjust some of the copies and layouts on the config page per design updates (small amount of spacing here and there). Most copies are not yet finalized so there is a follow-up ticket to finalize copies. Ensured there is a `marginBottom` to the entire page itself. 

## Approach

I abstracted the authentication logic into its own section/component, as I foresee much more logic to be added and isolated here as we flesh this section out. I also adjusted some file structure and adjusted some testing. 

New consolidated look can be seen below:
![Screenshot 2024-04-09 at 3 10 20 PM](https://github.com/contentful/apps/assets/58186851/ba0cfa3d-f35c-46eb-bea3-38c245946941)


## Testing steps

The only functionality that changes is the first item listed above. Ensure that the Add Content type button is always present on the config page in the bottom section, just disabled when there is an empty row present OR all content types have been selected. 

## Follow-up work

There are several more design updates to make to this page, this is the first batch!
