### PR TITLE
feat: conditionally render config page sections

### DIFF
--- a/apps/vercel/frontend/src/components/config-screen/AuthenticationSection/AuthenticationSection.spec.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/AuthenticationSection/AuthenticationSection.spec.tsx
@@ -17,7 +17,7 @@ describe('AuthenticationSection', () => {
       <AuthenticationSection
         handleTokenChange={vi.fn()}
         parameters={parameters}
-        isAppInstalled={false}
+        isTokenValid={false}
       />
     );
 
@@ -34,7 +34,7 @@ describe('AuthenticationSection', () => {
       vercelAccessTokenStatus: 'valid',
     } as unknown as AppInstallationParameters;
     render(
-      <AuthenticationSection handleTokenChange={vi.fn()} parameters={parameters} isAppInstalled />
+      <AuthenticationSection handleTokenChange={vi.fn()} parameters={parameters} isTokenValid />
     );
 
     const status = screen.getByText(statusMessages.valid);

--- a/apps/vercel/frontend/src/components/config-screen/AuthenticationSection/AuthenticationSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/AuthenticationSection/AuthenticationSection.tsx
@@ -18,18 +18,18 @@ import { copies } from '@constants/copies';
 
 interface Props {
   parameters: AppInstallationParameters;
-  isAppInstalled: boolean;
+  isTokenValid: boolean;
   handleTokenChange: (e: ChangeEvent<HTMLInputElement>) => void;
 }
 
-export const AuthenticationSection = ({ parameters, isAppInstalled, handleTokenChange }: Props) => {
+export const AuthenticationSection = ({ parameters, handleTokenChange, isTokenValid }: Props) => {
   const { heading, subheading, input, link, statusMessages } =
     copies.configPage.authenticationSection;
 
   const renderStatusBadge = () => {
-    if (isAppInstalled && parameters.vercelAccessToken && parameters.vercelAccessTokenStatus) {
+    if (parameters.vercelAccessToken && isTokenValid) {
       return <Badge variant="positive">{statusMessages.valid}</Badge>;
-    } else if (!parameters.vercelAccessTokenStatus) {
+    } else if (!isTokenValid) {
       return <Badge variant="negative">{statusMessages.invalid}</Badge>;
     } else {
       return <Badge variant="secondary">{statusMessages.notConfigured}</Badge>;
@@ -43,7 +43,7 @@ export const AuthenticationSection = ({ parameters, isAppInstalled, handleTokenC
           {subheading}
         </FormControl.Label>
         <TextInput
-          testId="accessToken"
+          data-testid="access-token"
           spellCheck={false}
           name="accessToken"
           type="password"

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/InformationalModal/InformationalModal.styles.ts
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/InformationalModal/InformationalModal.styles.ts
@@ -5,6 +5,12 @@ export const styles = {
   firstParagraph: css({
     marginBottom: tokens.spacingS,
   }),
+  link: css({
+    '> span': {
+      color: tokens.blue500,
+      fontWeight: 700,
+    },
+  }),
   zeroMarginBottom: css({
     marginBottom: 0,
   }),

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/InformationalModal/InformationalModal.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/InformationalModal/InformationalModal.tsx
@@ -48,6 +48,7 @@ export const InformationalModal = ({ onClose, isShown }: Props) => {
                       {exampleThree.description}{' '}
                       <TextLink
                         href={exampleThree.link.href}
+                        className={styles.link}
                         target="_blank"
                         rel="noopener noreferrer">
                         {exampleThree.link.copy}
@@ -56,13 +57,15 @@ export const InformationalModal = ({ onClose, isShown }: Props) => {
                   </Flex>
                 </Flex>
                 <InformationalTables />
-                <TextLink
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  href={footer.href}
-                  className={styles.footer}>
-                  {footer.copy}
-                </TextLink>{' '}
+                <Box className={styles.footer}>
+                  <TextLink
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={styles.link}
+                    href={footer.href}>
+                    {footer.copy}
+                  </TextLink>{' '}
+                </Box>
               </Flex>
             </Modal.Content>
             <Modal.Controls>

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/InformationalModal/InformationalTables/InfoTable/InfoTable.styles.ts
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/InformationalModal/InformationalTables/InfoTable/InfoTable.styles.ts
@@ -27,8 +27,8 @@ export const styles = {
   }),
   rowDescription: css({
     paddingLeft: tokens.spacingM,
-    paddingTop: tokens.spacingXs,
-    paddingBottom: tokens.spacingXs,
+    paddingTop: tokens.spacing2Xs,
+    paddingBottom: tokens.spacing2Xs,
     margin: 0,
   }),
   rowDescriptionWrapper: css({

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/InformationalModal/InformationalTables/InformationalTables.styles.ts
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/InformationalModal/InformationalTables/InformationalTables.styles.ts
@@ -2,7 +2,13 @@ import tokens from '@contentful/f36-tokens';
 import { css } from 'emotion';
 
 export const styles = {
-  link: css({
+  linkParagraph: css({
     margin: `${tokens.spacingL} 0`,
+  }),
+  link: css({
+    '> span': {
+      color: tokens.blue500,
+      fontWeight: 700,
+    },
   }),
 };

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/InformationalModal/InformationalTables/InformationalTables.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/InformationalModal/InformationalTables/InformationalTables.tsx
@@ -9,6 +9,7 @@ import { INFORMATIONAL_MODAL_COLUMN_WIDTH } from '@constants/styles';
 
 type TableRow = {
   example: string;
+  exampleTwo?: string;
   description: string;
 };
 
@@ -19,15 +20,24 @@ export const InformationalTables = () => {
     copies.configPage.contentTypePreviewPathSection.exampleModal;
   const infoBoxCustomStyling = {
     width: INFORMATIONAL_MODAL_COLUMN_WIDTH,
-    margin: tokens.spacingXs,
+    margin: `0 ${tokens.spacingXs}`,
   };
 
   const renderTableRows = (rows: TableRow[]) =>
     rows.map((row: TableRow) => ({
       example: (
-        <GrayInfoBox rootStylingOptions={infoBoxCustomStyling} withCopy>
-          {row.example}
-        </GrayInfoBox>
+        <>
+          <GrayInfoBox rootStylingOptions={infoBoxCustomStyling} withCopy>
+            {row.example}
+          </GrayInfoBox>
+          {row.exampleTwo && (
+            <GrayInfoBox
+              rootStylingOptions={{ ...infoBoxCustomStyling, marginTop: tokens.spacing2Xs }}
+              withCopy>
+              {row.exampleTwo}
+            </GrayInfoBox>
+          )}
+        </>
       ),
       description: row.description,
     }));
@@ -36,9 +46,13 @@ export const InformationalTables = () => {
     <Box>
       <InfoTable headers={tableOne.headers} rows={renderTableRows(tableOne.rows)} />
 
-      <Paragraph className={styles.link}>
+      <Paragraph className={styles.linkParagraph}>
         Additionally, you can query{' '}
-        <TextLink target="_blank" rel="noopener noreferrer" href={tableTwoSubHeading.link.href}>
+        <TextLink
+          className={styles.link}
+          target="_blank"
+          rel="noopener noreferrer"
+          href={tableTwoSubHeading.link.href}>
           incoming links to entry by
         </TextLink>{' '}
         using the {EXAMPLE_PROPERTY} property (the first entry in response will be used)

--- a/apps/vercel/frontend/src/components/parameterReducer.ts
+++ b/apps/vercel/frontend/src/components/parameterReducer.ts
@@ -6,7 +6,6 @@ import {
 
 export enum actions {
   UPDATE_VERCEL_ACCESS_TOKEN = 'updateVercelAccessToken',
-  UPDATE_VERCEL_ACCESS_TOKEN_STATUS = 'updateVercelAccessTokenStatus',
   APPLY_CONTENTFUL_PARAMETERS = 'applyContentfulParameters',
   APPLY_SELECTED_PROJECT = 'applySelectedProject',
   ADD_CONTENT_TYPE_PREVIEW_PATH_SELECTION = 'addContentTypePreviewPathSelection',
@@ -17,11 +16,6 @@ export enum actions {
 type VercelAccessTokenAction = {
   type: actions.UPDATE_VERCEL_ACCESS_TOKEN;
   payload: string;
-};
-
-type VercelAccessTokenStatusAction = {
-  type: actions.UPDATE_VERCEL_ACCESS_TOKEN_STATUS;
-  payload: boolean;
 };
 
 type VercelSelectedProjectAction = {
@@ -53,14 +47,12 @@ export type ParameterAction =
   | VercelAccessTokenAction
   | ApplyContentfulParametersAction
   | VercelSelectedProjectAction
-  | VercelAccessTokenStatusAction
   | AddContentTypePreviewPathSelectionAction
   | RemoveContentTypePreviewPathSelection
   | ApplyApiPath;
 
 const {
   UPDATE_VERCEL_ACCESS_TOKEN,
-  UPDATE_VERCEL_ACCESS_TOKEN_STATUS,
   APPLY_CONTENTFUL_PARAMETERS,
   APPLY_SELECTED_PROJECT,
   ADD_CONTENT_TYPE_PREVIEW_PATH_SELECTION,
@@ -77,11 +69,6 @@ const parameterReducer = (
       return {
         ...state,
         vercelAccessToken: action.payload,
-      };
-    case UPDATE_VERCEL_ACCESS_TOKEN_STATUS:
-      return {
-        ...state,
-        vercelAccessTokenStatus: action.payload,
       };
     case APPLY_CONTENTFUL_PARAMETERS: {
       const parameters = action.payload;

--- a/apps/vercel/frontend/src/constants/copies.ts
+++ b/apps/vercel/frontend/src/constants/copies.ts
@@ -40,10 +40,11 @@ export const copies = {
         },
       },
       exampleModal: {
-        title: 'Preview URLs',
+        title: 'Preview paths and tokens',
         button: 'Got it',
         exampleOne: {
-          description: 'For each content type, create a URL according to this structure:',
+          description:
+            'For each content type, create a preview path and token according to this structure:',
           example: '[preview_domain]/[placeholder_token]',
         },
         exampleTwo: {
@@ -76,9 +77,14 @@ export const copies = {
             },
             {
               description:
+                'The value of the slug field for the current entry (default locale unless otherwise specified)',
+              example: '{entry.fields.slug}',
+            },
+            {
+              description:
                 'The value of the slug field, based on the localization provided (will not fallback to default locale in case of invalid locale)',
               example: '{entry.fields.slug}',
-              exampleTwo: '[LOCALE_CODE]',
+              exampleTwo: '[locale_code]',
             },
             {
               description:

--- a/apps/vercel/frontend/src/constants/defaultParams.ts
+++ b/apps/vercel/frontend/src/constants/defaultParams.ts
@@ -2,7 +2,6 @@ import { AppInstallationParameters } from '@customTypes/configPage';
 
 export const initialParameters: AppInstallationParameters = {
   vercelAccessToken: '',
-  vercelAccessTokenStatus: null,
   selectedProject: '',
   contentTypePreviewPathSelections: [],
   selectedApiPath: '',

--- a/apps/vercel/frontend/src/customTypes/configPage.ts
+++ b/apps/vercel/frontend/src/customTypes/configPage.ts
@@ -11,7 +11,6 @@ export type ApplyContentTypePreviewPathSelectionPayload = {
 
 export interface AppInstallationParameters {
   vercelAccessToken: string;
-  vercelAccessTokenStatus: boolean | null;
   selectedProject: string;
   contentTypePreviewPathSelections: ContentTypePreviewPathSelection[];
   selectedApiPath: string;


### PR DESCRIPTION
## Purpose

The purpose of this PR is to progressively render the sections on the config page as the user fills out certain steps. Additionally, I adjusted some of the copies and spacing on the informative modal on the config page to match the designs. 
## Approach

The user will not be able to select a project until there is a valid access token, they will not be able to select an API path until there is a project selected, and they will not be able to configure content types and preview paths until all the above is complete. 

The spacing changes within the modal can be seen below:

#### Before
![Screenshot 2024-04-10 at 1 09 37 PM](https://github.com/contentful/apps/assets/58186851/aeaa69da-dc3c-4a6e-a41f-6ec48f261148)

#### After
![Screenshot 2024-04-10 at 1 09 05 PM](https://github.com/contentful/apps/assets/58186851/1e939ba2-a08f-4cd0-a6de-5bd76dbaf77c)

## Testing steps

Follow the workflow as described above ^
