### PR TITLE
chore: [INTEG-2004] - Update app installation parameters

### DIFF
--- a/apps/vercel/app-actions/src/actions/get-preview-envs.ts
+++ b/apps/vercel/app-actions/src/actions/get-preview-envs.ts
@@ -22,6 +22,7 @@ export const handler = withAsyncAppActionErrorHandling(
       vercelAccessToken,
       selectedProject: vercelProjectId,
       contentTypePreviewPathSelections,
+      selectedApiPath,
     } = await fetchAppInstallationParameters(appActionCallContext, cma);
 
     const vercelService = new VercelService(vercelAccessToken);
@@ -29,7 +30,8 @@ export const handler = withAsyncAppActionErrorHandling(
 
     const previewUrlsByContentType = buildPreviewUrlsForContentTypes(
       vercelProject,
-      contentTypePreviewPathSelections
+      contentTypePreviewPathSelections,
+      selectedApiPath
     );
 
     const configurations = Object.entries(

--- a/apps/vercel/app-actions/src/helpers/build-preview-urls-for-content-types.spec.ts
+++ b/apps/vercel/app-actions/src/helpers/build-preview-urls-for-content-types.spec.ts
@@ -5,9 +5,10 @@ import { buildPreviewUrlsForContentTypes } from './build-preview-urls-for-conten
 describe('buildPreviewUrlsForContentTypes', () => {
   const vercelProject = mockVercelProject;
   const contentTypePreviewPaths = mockAppInstallationParameters.contentTypePreviewPathSelections;
+  const apiPath = mockAppInstallationParameters.selectedApiPath;
 
   it('returns a mapping of preview URls by content type', async () => {
-    const result = buildPreviewUrlsForContentTypes(vercelProject, contentTypePreviewPaths);
+    const result = buildPreviewUrlsForContentTypes(vercelProject, contentTypePreviewPaths, apiPath);
     expect(result['blog']).to.eql(
       'https://team-integrations-vercel-playground-gqmys2z3c.vercel.app/api/enable-draft?x-vercel-protection-bypass=ukkdTdqAgnG5DQHwFkIeQ22N1nUDWeU7&path=%2Fblogs%2F{entry.fields.slug}'
     );
@@ -22,7 +23,8 @@ describe('buildPreviewUrlsForContentTypes', () => {
     it('does not include the empty path', async () => {
       const result = buildPreviewUrlsForContentTypes(
         vercelProject,
-        contentTypePreviewPathsWithEmpty
+        contentTypePreviewPathsWithEmpty,
+        apiPath
       );
       expect(result['articles']).to.be.undefined;
     });

--- a/apps/vercel/app-actions/src/helpers/build-preview-urls-for-content-types.ts
+++ b/apps/vercel/app-actions/src/helpers/build-preview-urls-for-content-types.ts
@@ -26,11 +26,10 @@ const decodeCurlyBrackets = (str: string): string => {
 
 export const buildPreviewUrlsForContentTypes = (
   vercelProject: VercelProject,
-  contentTypePreviewPaths: ContentTypePreviewPathSelection[]
+  contentTypePreviewPaths: ContentTypePreviewPathSelection[],
+  apiPath: string
 ): PreviewUrlsForContentTypes => {
   const previewUrlParts = constructVercelPreviewUrlParts(vercelProject);
-  const apiPath = '/api/enable-draft'; // later we won't hard code this but get it from params
-
   const previewUrlsForContentTypes = contentTypePreviewPaths.reduce<PreviewUrlsForContentTypes>(
     (mapping, contentTypePreviewPath) => {
       // if a preview path is not specified we don't want to include the configuration at all

--- a/apps/vercel/app-actions/src/helpers/fetch-app-installation-parameters.ts
+++ b/apps/vercel/app-actions/src/helpers/fetch-app-installation-parameters.ts
@@ -5,6 +5,7 @@ const REQUIRED_PARAMS = [
   'vercelAccessToken',
   'selectedProject',
   'contentTypePreviewPathSelections',
+  'selectedApiPath',
 ];
 
 function assertAppInstallationParameters(

--- a/apps/vercel/app-actions/src/types.ts
+++ b/apps/vercel/app-actions/src/types.ts
@@ -53,6 +53,7 @@ export interface AppInstallationParameters {
   vercelAccessToken: string;
   selectedProject: string;
   contentTypePreviewPathSelections: ContentTypePreviewPathSelection[];
+  selectedApiPath: string;
 }
 
 /* END copied over from frontend app installation types */

--- a/apps/vercel/app-actions/test/mocks.ts
+++ b/apps/vercel/app-actions/test/mocks.ts
@@ -52,6 +52,7 @@ export const mockAppInstallationParameters: AppInstallationParameters = {
   contentTypePreviewPathSelections: [
     { contentType: 'blog', previewPath: '/blogs/{entry.fields.slug}' },
   ],
+  selectedApiPath: 'api/enable-draft',
 };
 
 export const makeMockAppInstallation = (


### PR DESCRIPTION
## Purpose

We want to use the selected api path from Vercel configuration page, this adds the configured `selectedApiPath` pulled from app installation parameters

Ticket: https://contentful.atlassian.net/browse/INTEG-2004