### PR TITLE
feat: add authentication token error to field

### DIFF
--- a/apps/vercel/frontend/src/components/common/Select/Select.styles.ts
+++ b/apps/vercel/frontend/src/components/common/Select/Select.styles.ts
@@ -1,8 +1,0 @@
-import tokens from '@contentful/f36-tokens';
-import { css } from 'emotion';
-
-export const styles = {
-  formControl: css({
-    marginBottom: tokens.spacingS,
-  }),
-};

--- a/apps/vercel/frontend/src/components/common/Select/Select.tsx
+++ b/apps/vercel/frontend/src/components/common/Select/Select.tsx
@@ -8,6 +8,7 @@ interface Props {
   emptyMessage?: string;
   value: string;
   onChange: (event: ChangeEvent<HTMLSelectElement>) => void;
+  isRequired?: boolean;
 }
 
 export const Select = ({
@@ -17,11 +18,12 @@ export const Select = ({
   value,
   onChange,
   emptyMessage = 'No options to select',
+  isRequired,
 }: Props) => {
   const optionsExist = Boolean(options && options.length);
   return (
     <Box>
-      {label && <FormControl.Label>{label}</FormControl.Label>}
+      {label && <FormControl.Label isRequired={isRequired}>{label}</FormControl.Label>}
       <F36Select
         isDisabled={!optionsExist}
         id="optionsSelect"

--- a/apps/vercel/frontend/src/components/common/Select/Select.tsx
+++ b/apps/vercel/frontend/src/components/common/Select/Select.tsx
@@ -20,12 +20,18 @@ export const Select = ({
   onChange,
   emptyMessage = 'No options to select',
 }: Props) => {
+  const optionsExist = Boolean(options && options.length);
   return (
     <Box>
       <FormControl className={styles.formControl} id="optionsSelect" isRequired={true}>
         <FormControl.Label>{label}</FormControl.Label>
-        <F36Select id="optionsSelect" name="optionsSelect" value={value} onChange={onChange}>
-          {options && options.length ? (
+        <F36Select
+          isDisabled={!optionsExist}
+          id="optionsSelect"
+          name="optionsSelect"
+          value={value}
+          onChange={onChange}>
+          {optionsExist ? (
             <>
               <F36Select.Option value="" isDisabled>
                 {placeholder}

--- a/apps/vercel/frontend/src/components/common/Select/Select.tsx
+++ b/apps/vercel/frontend/src/components/common/Select/Select.tsx
@@ -1,11 +1,9 @@
 import { ChangeEvent } from 'react';
 import { Box, FormControl, Select as F36Select } from '@contentful/f36-components';
 
-import { styles } from './Select.styles';
-
 interface Props {
   options: { id: string; name: string }[];
-  label: string;
+  label?: string;
   placeholder: string;
   emptyMessage?: string;
   value: string;
@@ -23,30 +21,28 @@ export const Select = ({
   const optionsExist = Boolean(options && options.length);
   return (
     <Box>
-      <FormControl className={styles.formControl} id="optionsSelect" isRequired={true}>
-        <FormControl.Label>{label}</FormControl.Label>
-        <F36Select
-          isDisabled={!optionsExist}
-          id="optionsSelect"
-          name="optionsSelect"
-          value={value}
-          onChange={onChange}>
-          {optionsExist ? (
-            <>
-              <F36Select.Option value="" isDisabled>
-                {placeholder}
+      {label && <FormControl.Label>{label}</FormControl.Label>}
+      <F36Select
+        isDisabled={!optionsExist}
+        id="optionsSelect"
+        name="optionsSelect"
+        value={value}
+        onChange={onChange}>
+        {optionsExist ? (
+          <>
+            <F36Select.Option value="" isDisabled>
+              {placeholder}
+            </F36Select.Option>
+            {options.map((option) => (
+              <F36Select.Option key={`option-${option.id}`} value={option.id}>
+                {option.name}
               </F36Select.Option>
-              {options.map((option) => (
-                <F36Select.Option key={`option-${option.id}`} value={option.id}>
-                  {option.name}
-                </F36Select.Option>
-              ))}
-            </>
-          ) : (
-            <F36Select.Option value="">{emptyMessage}</F36Select.Option>
-          )}
-        </F36Select>
-      </FormControl>
+            ))}
+          </>
+        ) : (
+          <F36Select.Option value="">{emptyMessage}</F36Select.Option>
+        )}
+      </F36Select>
     </Box>
   );
 };

--- a/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/ApiPathSelect/ApiPathSelect.spec.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/ApiPathSelect/ApiPathSelect.spec.tsx
@@ -3,14 +3,16 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { AppInstallationParameters } from '@customTypes/configPage';
 import { ApiPathSelect } from './ApiPathSelect';
+import { copies } from '@constants/copies';
 
 const parameters = { selectedApiPath: '' } as AppInstallationParameters;
+const { placeholder } = copies.configPage.pathSelectionSection.dropdown;
 
 describe('ApiPathSelect', () => {
   it('renders list of paths to select', () => {
     const paths = [{ id: 'path-1', name: 'Path/1' }];
     render(<ApiPathSelect dispatch={vi.fn()} parameters={parameters} paths={paths} />);
-    const select = screen.getByText('Please select a path...');
+    const select = screen.getByText(placeholder);
     expect(select).toBeTruthy();
 
     select.click();

--- a/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/ApiPathSelect/ApiPathSelect.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/ApiPathSelect/ApiPathSelect.tsx
@@ -4,6 +4,7 @@ import { ParameterAction, actions } from '@components/parameterReducer';
 import { Select } from '@components/common/Select/Select';
 import { AppInstallationParameters, Path } from '@customTypes/configPage';
 import { copies } from '@constants/copies';
+import { FormControl } from '@contentful/f36-components';
 
 interface Props {
   parameters: AppInstallationParameters;
@@ -23,13 +24,15 @@ export const ApiPathSelect = ({ parameters, paths, dispatch }: Props) => {
   const { selectedApiPath } = parameters;
 
   return (
-    <Select
-      value={selectedApiPath}
-      onChange={handlePathChange}
-      placeholder={placeholder}
-      emptyMessage={emptyMessage}
-      options={paths}
-      label={label}
-    />
+    <FormControl marginBottom="spacingS" id="apiPathSelect" isRequired={true}>
+      <Select
+        value={selectedApiPath}
+        onChange={handlePathChange}
+        placeholder={placeholder}
+        emptyMessage={emptyMessage}
+        options={paths}
+        label={label}
+      />
+    </FormControl>
   );
 };

--- a/apps/vercel/frontend/src/components/config-screen/AuthenticationSection/AuthenticationSection.spec.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/AuthenticationSection/AuthenticationSection.spec.tsx
@@ -5,7 +5,7 @@ import { AppInstallationParameters } from '@customTypes/configPage';
 import { AuthenticationSection } from './AuthenticationSection';
 import { copies } from '@constants/copies';
 
-const { input, invalidTokenMessage } = copies.configPage.authenticationSection;
+const { input } = copies.configPage.authenticationSection;
 
 describe('AuthenticationSection', () => {
   it('renders input when token is not yet inputed', () => {
@@ -53,7 +53,7 @@ describe('AuthenticationSection', () => {
       />
     );
 
-    const status = screen.getByText(invalidTokenMessage);
+    const status = screen.getByText(input.errorMessage);
     const token = screen.queryByText(parameters.vercelAccessToken);
 
     expect(status).toBeTruthy();

--- a/apps/vercel/frontend/src/components/config-screen/AuthenticationSection/AuthenticationSection.spec.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/AuthenticationSection/AuthenticationSection.spec.tsx
@@ -21,14 +21,12 @@ describe('AuthenticationSection', () => {
       />
     );
 
-    const status = screen.getByText(invalidTokenMessage);
     const tokenInput = screen.getByPlaceholderText(input.placeholder);
 
-    expect(status).toBeTruthy();
     expect(tokenInput).toBeTruthy();
   });
 
-  it('renders hidden token and valid content when token is valid and app is installed', () => {
+  it('renders hidden token and valid content when token is valid', () => {
     const parameters = {
       vercelAccessToken: '12345',
       vercelAccessTokenStatus: 'valid',
@@ -39,6 +37,26 @@ describe('AuthenticationSection', () => {
 
     const token = screen.queryByText(parameters.vercelAccessToken);
 
+    expect(token).toBeFalsy();
+  });
+
+  it('renders hidden token and invalid content when token is invalid', () => {
+    const parameters = {
+      vercelAccessToken: '12345',
+      vercelAccessTokenStatus: 'valid',
+    } as unknown as AppInstallationParameters;
+    render(
+      <AuthenticationSection
+        handleTokenChange={vi.fn()}
+        parameters={parameters}
+        isTokenValid={false}
+      />
+    );
+
+    const status = screen.getByText(invalidTokenMessage);
+    const token = screen.queryByText(parameters.vercelAccessToken);
+
+    expect(status).toBeTruthy();
     expect(token).toBeFalsy();
   });
 });

--- a/apps/vercel/frontend/src/components/config-screen/AuthenticationSection/AuthenticationSection.spec.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/AuthenticationSection/AuthenticationSection.spec.tsx
@@ -5,7 +5,7 @@ import { AppInstallationParameters } from '@customTypes/configPage';
 import { AuthenticationSection } from './AuthenticationSection';
 import { copies } from '@constants/copies';
 
-const { input, statusMessages } = copies.configPage.authenticationSection;
+const { input, invalidTokenMessage } = copies.configPage.authenticationSection;
 
 describe('AuthenticationSection', () => {
   it('renders input when token is not yet inputed', () => {
@@ -21,7 +21,7 @@ describe('AuthenticationSection', () => {
       />
     );
 
-    const status = screen.getByText(statusMessages.invalid);
+    const status = screen.getByText(invalidTokenMessage);
     const tokenInput = screen.getByPlaceholderText(input.placeholder);
 
     expect(status).toBeTruthy();
@@ -37,10 +37,8 @@ describe('AuthenticationSection', () => {
       <AuthenticationSection handleTokenChange={vi.fn()} parameters={parameters} isTokenValid />
     );
 
-    const status = screen.getByText(statusMessages.valid);
     const token = screen.queryByText(parameters.vercelAccessToken);
 
-    expect(status).toBeTruthy();
     expect(token).toBeFalsy();
   });
 });

--- a/apps/vercel/frontend/src/components/config-screen/AuthenticationSection/AuthenticationSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/AuthenticationSection/AuthenticationSection.tsx
@@ -1,14 +1,12 @@
 import { ChangeEvent } from 'react';
 import {
   Box,
-  Flex,
   FormControl,
   Heading,
   HelpText,
   TextInput,
   TextLink,
-  Text,
-  Badge,
+  ValidationMessage,
 } from '@contentful/f36-components';
 import { ExternalLinkIcon } from '@contentful/f36-icons';
 
@@ -23,18 +21,11 @@ interface Props {
 }
 
 export const AuthenticationSection = ({ parameters, handleTokenChange, isTokenValid }: Props) => {
-  const { heading, subheading, input, link, statusMessages } =
+  const { heading, subheading, input, link, invalidTokenMessage } =
     copies.configPage.authenticationSection;
 
-  const renderStatusBadge = () => {
-    if (parameters.vercelAccessToken && isTokenValid) {
-      return <Badge variant="positive">{statusMessages.valid}</Badge>;
-    } else if (!isTokenValid) {
-      return <Badge variant="negative">{statusMessages.invalid}</Badge>;
-    } else {
-      return <Badge variant="secondary">{statusMessages.notConfigured}</Badge>;
-    }
-  };
+  const showError = Boolean(parameters.vercelAccessToken && !isTokenValid);
+
   return (
     <Box className={styles.box}>
       <Heading className={styles.heading}>{heading}</Heading>
@@ -50,6 +41,7 @@ export const AuthenticationSection = ({ parameters, handleTokenChange, isTokenVa
           placeholder={input.placeholder}
           value={parameters.vercelAccessToken}
           onChange={handleTokenChange}
+          isInvalid={showError}
         />
         <HelpText>
           Follow{' '}
@@ -63,14 +55,7 @@ export const AuthenticationSection = ({ parameters, handleTokenChange, isTokenVa
           </TextLink>{' '}
           to create an access token for your account.
         </HelpText>
-        <Box className={styles.badgeContainer}>
-          <Flex fullWidth flexDirection="column">
-            <Text fontWeight="fontWeightDemiBold" marginRight="spacing2Xs">
-              Status
-            </Text>
-            <Box>{renderStatusBadge()}</Box>
-          </Flex>
-        </Box>
+        {showError && <ValidationMessage>{invalidTokenMessage}</ValidationMessage>}
       </FormControl>
     </Box>
   );

--- a/apps/vercel/frontend/src/components/config-screen/AuthenticationSection/AuthenticationSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/AuthenticationSection/AuthenticationSection.tsx
@@ -21,17 +21,16 @@ interface Props {
 }
 
 export const AuthenticationSection = ({ parameters, handleTokenChange, isTokenValid }: Props) => {
-  const { heading, subheading, input, link, invalidTokenMessage } =
-    copies.configPage.authenticationSection;
+  const { title, input, link } = copies.configPage.authenticationSection;
 
   const showError = Boolean(parameters.vercelAccessToken && !isTokenValid);
 
   return (
     <Box className={styles.box}>
-      <Heading className={styles.heading}>{heading}</Heading>
+      <Heading className={styles.heading}>{title}</Heading>
       <FormControl id="accessToken" isRequired={true}>
         <FormControl.Label aria-label="accessToken" htmlFor="accessToken">
-          {subheading}
+          {input.label}
         </FormControl.Label>
         <TextInput
           data-testid="access-token"
@@ -55,7 +54,7 @@ export const AuthenticationSection = ({ parameters, handleTokenChange, isTokenVa
           </TextLink>{' '}
           to create an access token for your account.
         </HelpText>
-        {showError && <ValidationMessage>{invalidTokenMessage}</ValidationMessage>}
+        {showError && <ValidationMessage>{input.errorMessage}</ValidationMessage>}
       </FormControl>
     </Box>
   );

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSection.tsx
@@ -7,6 +7,7 @@ import { styles } from '@locations/ConfigScreen.styles';
 import { AppInstallationParameters } from '@customTypes/configPage';
 import { ContentTypePreviewPathSelectionList } from './ContentTypePreviewPathSelectionList/ContentTypePreviewPathSelectionList';
 import { PreviewPathInfoNote } from './PreviewPathInfoNote/PreviewPathInfoNote';
+import { copies } from '@constants/copies';
 
 interface Props {
   parameters: AppInstallationParameters;
@@ -15,17 +16,15 @@ interface Props {
 }
 
 export const ContentTypePreviewPathSection = ({ parameters, dispatch, contentTypes }: Props) => {
-  // TO DO: Adjust logic to limit content type duplication of preview path and token
   const { contentTypePreviewPathSelections } = parameters;
+  const { heading, subHeading } = copies.configPage.contentTypePreviewPathSection;
 
   return (
     <Box data-testid="content-type-preview-path-section" className={styles.box}>
       <Heading marginBottom="none" className={styles.heading}>
-        Content type and preview path and token
+        {heading}
       </Heading>
-      <Paragraph marginTop="spacingXs">
-        Select applicable content types and define corresponding preview paths and preview tokens.
-      </Paragraph>
+      <Paragraph marginTop="spacingXs">{subHeading}</Paragraph>
       <PreviewPathInfoNote />
       <ContentTypePreviewPathSelectionList
         contentTypes={contentTypes}

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSection.tsx
@@ -17,14 +17,14 @@ interface Props {
 
 export const ContentTypePreviewPathSection = ({ parameters, dispatch, contentTypes }: Props) => {
   const { contentTypePreviewPathSelections } = parameters;
-  const { heading, subHeading } = copies.configPage.contentTypePreviewPathSection;
+  const { title, description } = copies.configPage.contentTypePreviewPathSection;
 
   return (
     <Box data-testid="content-type-preview-path-section" className={styles.box}>
       <Heading marginBottom="none" className={styles.heading}>
-        {heading}
+        {title}
       </Heading>
-      <Paragraph marginTop="spacingXs">{subHeading}</Paragraph>
+      <Paragraph marginTop="spacingXs">{description}</Paragraph>
       <PreviewPathInfoNote />
       <ContentTypePreviewPathSelectionList
         contentTypes={contentTypes}

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.spec.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.spec.tsx
@@ -2,6 +2,9 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { ContentTypePreviewPathSelectionRow } from './ContentTypePreviewPathSelectionRow';
 import { mockContentTypes } from '@test/mocks/mockContentTypes';
+import { copies } from '@constants/copies';
+
+const { inputs } = copies.configPage.contentTypePreviewPathSection;
 
 vi.mock('lodash', () => ({
   debounce: (fn: { cancel: () => void }) => {
@@ -26,7 +29,7 @@ describe('ContentTypePreviewPathSelectionRow', () => {
 
     expect(mockOnUpdate).toHaveBeenCalled();
 
-    const previewPathInput = screen.getByPlaceholderText('Set preview path and token');
+    const previewPathInput = screen.getByPlaceholderText(inputs.previewPath.placeholder);
     fireEvent.change(previewPathInput, { target: { value: 'test-path' } });
 
     expect(mockOnUpdate).toHaveBeenCalled();
@@ -61,8 +64,8 @@ describe('ContentTypePreviewPathSelectionRow', () => {
       />
     );
 
-    expect(screen.getByText('Select content type...')).toBeTruthy();
-    expect(screen.getByPlaceholderText('Set preview path and token')).toBeTruthy();
+    expect(screen.getByText(inputs.contentType.placeholder)).toBeTruthy();
+    expect(screen.getByPlaceholderText(inputs.previewPath.placeholder)).toBeTruthy();
     unmount();
   });
 
@@ -92,7 +95,7 @@ describe('ContentTypePreviewPathSelectionRow', () => {
       />
     );
 
-    expect(screen.getByText('No Content Types currently configured.')).toBeTruthy();
+    expect(screen.getByText(inputs.contentType.emptyMessage)).toBeTruthy();
     unmount();
   });
 });

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.styles.ts
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.styles.ts
@@ -4,7 +4,7 @@ export const styles = {
   wrapper: css({
     width: '100%',
   }),
-  select: css({
+  inputWrapper: css({
     width: '100%',
   }),
 };

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.tsx
@@ -1,5 +1,5 @@
 import { ChangeEvent, useMemo } from 'react';
-import { Box, FormControl, Select, TextInput, Flex, IconButton } from '@contentful/f36-components';
+import { Box, FormControl, TextInput, Flex, IconButton } from '@contentful/f36-components';
 import { CloseIcon } from '@contentful/f36-icons';
 import { debounce } from 'lodash';
 import tokens from '@contentful/f36-tokens';
@@ -10,6 +10,8 @@ import {
   ContentTypePreviewPathSelection,
 } from '@customTypes/configPage';
 import { styles } from './ContentTypePreviewPathSelectionRow.styles';
+import { copies } from '@constants/copies';
+import { Select } from '@components/common/Select/Select';
 
 interface Props {
   contentTypes: ContentType[];
@@ -28,6 +30,8 @@ export const ContentTypePreviewPathSelectionRow = ({
 }: Props) => {
   const { contentType: configuredContentType, previewPath: configuredPreviewPath } =
     configuredContentTypePreviewPathSelection;
+
+  const { inputs } = copies.configPage.contentTypePreviewPathSection;
 
   const handlePreviewPathInput = (event: React.ChangeEvent<HTMLInputElement>) => {
     onParameterUpdate({
@@ -56,38 +60,32 @@ export const ContentTypePreviewPathSelectionRow = ({
 
   return (
     <Box className={styles.wrapper}>
-      <FormControl id="contentTypeSelect">
-        {renderLabel && (
-          <FormControl.Label isRequired>Content type and preview path</FormControl.Label>
-        )}
-        <Flex flexDirection="row" justifyContent="space-evenly" gap={tokens.spacingXs}>
-          <Select
-            id="contentTypeSelect"
-            name="contentTypeSelect"
-            className={styles.select}
-            defaultValue={configuredContentType}
-            onChange={handleContentTypeChange}>
-            {contentTypes && contentTypes.length ? (
-              <>
-                <Select.Option value="" isDisabled>
-                  Select content type...
-                </Select.Option>
-                {contentTypes.map((contentType) => (
-                  <Select.Option key={`option-${contentType.sys.id}`} value={contentType.sys.id}>
-                    {contentType.name}
-                  </Select.Option>
-                ))}
-              </>
-            ) : (
-              <Select.Option value="">No Content Types currently configured.</Select.Option>
+      <FormControl id="contentTypePreviewPathSelection">
+        <Flex
+          flexDirection="row"
+          justifyContent="space-evenly"
+          alignItems="flex-end"
+          gap={tokens.spacingXs}>
+          <Box className={styles.inputWrapper}>
+            <Select
+              placeholder={inputs.contentType.placeholder}
+              label={renderLabel ? inputs.contentType.label : undefined}
+              value={configuredContentType}
+              emptyMessage={inputs.contentType.emptyMessage}
+              options={contentTypes}
+              onChange={handleContentTypeChange}></Select>
+          </Box>
+          <Box className={styles.inputWrapper}>
+            {renderLabel && (
+              <FormControl.Label isRequired>{inputs.previewPath.label}</FormControl.Label>
             )}
-          </Select>
-          <TextInput
-            defaultValue={configuredPreviewPath}
-            isDisabled={!configuredContentType}
-            onChange={debouncedHandlePreviewPathInputChange}
-            placeholder="Set preview path and token"
-          />
+            <TextInput
+              defaultValue={configuredPreviewPath}
+              isDisabled={!configuredContentType}
+              onChange={debouncedHandlePreviewPathInputChange}
+              placeholder={inputs.previewPath.placeholder}
+            />
+          </Box>
           <IconButton onClick={handleRemoveRow} icon={<CloseIcon />} aria-label={'Delete row'} />
         </Flex>
       </FormControl>

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.tsx
@@ -69,7 +69,7 @@ export const ContentTypePreviewPathSelectionRow = ({
 
   return (
     <Box className={styles.wrapper}>
-      <FormControl id="contentTypePreviewPathSelection">
+      <FormControl marginBottom="spacingM" id="contentTypePreviewPathSelection">
         <Flex
           flexDirection="row"
           justifyContent="space-evenly"

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.tsx
@@ -58,6 +58,15 @@ export const ContentTypePreviewPathSelectionRow = ({
     []
   );
 
+  const contentTypeOptions = useMemo(
+    () =>
+      contentTypes.map((contentType) => ({
+        id: contentType.sys.id,
+        name: contentType.name,
+      })),
+    [contentTypes]
+  );
+
   return (
     <Box className={styles.wrapper}>
       <FormControl id="contentTypePreviewPathSelection">
@@ -72,7 +81,7 @@ export const ContentTypePreviewPathSelectionRow = ({
               label={renderLabel ? inputs.contentType.label : undefined}
               value={configuredContentType}
               emptyMessage={inputs.contentType.emptyMessage}
-              options={contentTypes}
+              options={contentTypeOptions}
               isRequired={true}
               onChange={handleContentTypeChange}></Select>
           </Box>

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.tsx
@@ -73,6 +73,7 @@ export const ContentTypePreviewPathSelectionRow = ({
               value={configuredContentType}
               emptyMessage={inputs.contentType.emptyMessage}
               options={contentTypes}
+              isRequired={true}
               onChange={handleContentTypeChange}></Select>
           </Box>
           <Box className={styles.inputWrapper}>

--- a/apps/vercel/frontend/src/components/config-screen/ProjectSelectionSection/ProjectSelect/ProjectSelect.spec.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ProjectSelectionSection/ProjectSelect/ProjectSelect.spec.tsx
@@ -3,8 +3,10 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { AppInstallationParameters } from '@customTypes/configPage';
 import { ProjectSelect } from './ProjectSelect';
+import { copies } from '@constants/copies';
 
 const parameters = { selectedProject: '' } as AppInstallationParameters;
+const { placeholder } = copies.configPage.projectSelectionSection.dropdown;
 
 describe('ProjectSelect', () => {
   it('renders list of projects to select', () => {
@@ -12,7 +14,7 @@ describe('ProjectSelect', () => {
       { id: 'project-1', name: 'Project 1', targets: { production: { id: 'project-1' } } },
     ];
     render(<ProjectSelect dispatch={vi.fn()} parameters={parameters} projects={projects} />);
-    const select = screen.getByText('Please select a project...');
+    const select = screen.getByText(placeholder);
     expect(select).toBeTruthy();
 
     select.click();

--- a/apps/vercel/frontend/src/components/config-screen/ProjectSelectionSection/ProjectSelect/ProjectSelect.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ProjectSelectionSection/ProjectSelect/ProjectSelect.tsx
@@ -4,6 +4,7 @@ import { ParameterAction, actions } from '@components/parameterReducer';
 import { AppInstallationParameters, Project } from '@customTypes/configPage';
 import { Select } from '@components/common/Select/Select';
 import { copies } from '@constants/copies';
+import { FormControl } from '@contentful/f36-components';
 
 interface Props {
   parameters: AppInstallationParameters;
@@ -23,13 +24,15 @@ export const ProjectSelect = ({ parameters, projects, dispatch }: Props) => {
   const { selectedProject } = parameters;
 
   return (
-    <Select
-      value={selectedProject}
-      onChange={handleProjectChange}
-      placeholder={placeholder}
-      emptyMessage={emptyMessage}
-      options={projects}
-      label={label}
-    />
+    <FormControl marginBottom="spacingS" id="projectSelect" isRequired={true}>
+      <Select
+        value={selectedProject}
+        onChange={handleProjectChange}
+        placeholder={placeholder}
+        emptyMessage={emptyMessage}
+        options={projects}
+        label={label}
+      />
+    </FormControl>
   );
 };

--- a/apps/vercel/frontend/src/constants/copies.ts
+++ b/apps/vercel/frontend/src/constants/copies.ts
@@ -9,11 +9,7 @@ export const copies = {
       link: {
         href: 'https://vercel.com/docs/rest-api#creating-an-access-token',
       },
-      statusMessages: {
-        valid: 'Valid access token',
-        invalid: 'Invalid access token',
-        notConfigured: 'Token not configured',
-      },
+      invalidTokenMessage: 'Invalid access token',
     },
     projectSelectionSection: {
       helpText: 'Select one of your Vercel projects.',

--- a/apps/vercel/frontend/src/constants/copies.ts
+++ b/apps/vercel/frontend/src/constants/copies.ts
@@ -1,17 +1,17 @@
 export const copies = {
   configPage: {
-    heading: 'Set up the Vercel App',
-    subHeading: 'Preview and edit content quickly and securely with the Vercel platform.',
+    title: 'Set up the Vercel App',
+    description: 'Preview and edit content quickly and securely with the Vercel platform.',
     authenticationSection: {
-      heading: 'Connect Vercel',
-      subheading: 'Vercel Access Token',
+      title: 'Connect Vercel',
       input: {
+        label: 'Vercel Access Token',
         placeholder: 'ex. atE2sdftcIp01O1isdfXc3QTdT4...',
+        errorMessage: 'Invalid access token',
       },
       link: {
         href: 'https://vercel.com/docs/rest-api#creating-an-access-token',
       },
-      invalidTokenMessage: 'Invalid access token',
     },
     projectSelectionSection: {
       helpText: 'Connect to a project associated with your website or experience.',
@@ -30,8 +30,8 @@ export const copies = {
       },
     },
     contentTypePreviewPathSection: {
-      heading: 'Preview settings',
-      subHeading:
+      title: 'Preview settings',
+      description:
         'Select a content type that you would like to preview. For each content type, add a preview path and optionally a token.',
       inputs: {
         contentType: {

--- a/apps/vercel/frontend/src/constants/copies.ts
+++ b/apps/vercel/frontend/src/constants/copies.ts
@@ -12,11 +12,11 @@ export const copies = {
       invalidTokenMessage: 'Invalid access token',
     },
     projectSelectionSection: {
-      helpText: 'Select one of your Vercel projects.',
+      helpText: 'Connect to a project associated with your website or experience.',
       dropdown: {
         label: 'Project',
         placeholder: 'Please select a project...',
-        emptyMessage: 'No Projects currently configured.',
+        emptyMessage: 'No Vercel projects are available',
       },
     },
     pathSelectionSection: {

--- a/apps/vercel/frontend/src/constants/copies.ts
+++ b/apps/vercel/frontend/src/constants/copies.ts
@@ -1,5 +1,7 @@
 export const copies = {
   configPage: {
+    heading: 'Set up the Vercel App',
+    subHeading: 'Preview and edit content quickly and securely with the Vercel platform.',
     authenticationSection: {
       heading: 'Connect Vercel',
       subheading: 'Vercel Access Token',
@@ -15,19 +17,33 @@ export const copies = {
       helpText: 'Connect to a project associated with your website or experience.',
       dropdown: {
         label: 'Project',
-        placeholder: 'Please select a project...',
+        placeholder: 'Select a project',
         emptyMessage: 'No Vercel projects are available',
       },
     },
     pathSelectionSection: {
-      helpText: 'Select one one of your Vercel routes.',
+      helpText: 'Select a Vercel route to render your preview.',
       dropdown: {
         label: 'API Path',
-        placeholder: 'Please select a path...',
+        placeholder: 'Select a path',
         emptyMessage: 'No paths currently configured.',
       },
     },
     contentTypePreviewPathSection: {
+      heading: 'Preview settings',
+      subHeading:
+        'Select a content type that you would like to preview. For each content type, add a preview path and optionally a token.',
+      inputs: {
+        contentType: {
+          label: 'Content type',
+          placeholder: 'Select content type',
+          emptyMessage: 'There are no content types available',
+        },
+        previewPath: {
+          label: 'Preview path',
+          placeholder: 'Set preview path and token',
+        },
+      },
       infoNote: {
         example: '/blogs/{entry.fields.slug}',
         description: 'Preview path and token example:',

--- a/apps/vercel/frontend/src/locations/ConfigScreen.tsx
+++ b/apps/vercel/frontend/src/locations/ConfigScreen.tsx
@@ -12,6 +12,7 @@ import VercelClient from '@clients/Vercel';
 import { ApiPath, Project } from '@customTypes/configPage';
 import { ApiPathSelectionSection } from '@components/config-screen/ApiPathSelectionSection/ApiPathSelectionSection';
 import { AuthenticationSection } from '@components/config-screen/AuthenticationSection/AuthenticationSection';
+import { copies } from '@constants/copies';
 
 const ConfigScreen = () => {
   const [isTokenValid, setIsTokenValid] = useState(false);
@@ -21,6 +22,8 @@ const ConfigScreen = () => {
 
   const [parameters, dispatchParameters] = useReducer(parameterReducer, initialParameters);
   const sdk = useSDK<ConfigAppSDK>();
+
+  const { heading, subHeading } = copies.configPage;
 
   useInitializeParameters(dispatchParameters);
 
@@ -112,10 +115,8 @@ const ConfigScreen = () => {
     <>
       <Box className={styles.body}>
         <Box>
-          <Heading>Set up the Vercel App</Heading>
-          <Paragraph>
-            Preview and deploy automatically and securely from the entry editor.
-          </Paragraph>
+          <Heading>{heading}</Heading>
+          <Paragraph>{subHeading}</Paragraph>
         </Box>
         <hr className={styles.splitter} />
         <Stack spacing="spacingS" flexDirection="column">

--- a/apps/vercel/frontend/src/locations/ConfigScreen.tsx
+++ b/apps/vercel/frontend/src/locations/ConfigScreen.tsx
@@ -23,7 +23,7 @@ const ConfigScreen = () => {
   const [parameters, dispatchParameters] = useReducer(parameterReducer, initialParameters);
   const sdk = useSDK<ConfigAppSDK>();
 
-  const { heading, subHeading } = copies.configPage;
+  const { title, description } = copies.configPage;
 
   useInitializeParameters(dispatchParameters);
 
@@ -115,8 +115,8 @@ const ConfigScreen = () => {
     <>
       <Box className={styles.body}>
         <Box>
-          <Heading>{heading}</Heading>
-          <Paragraph>{subHeading}</Paragraph>
+          <Heading>{title}</Heading>
+          <Paragraph>{description}</Paragraph>
         </Box>
         <hr className={styles.splitter} />
         <Stack spacing="spacingS" flexDirection="column">


### PR DESCRIPTION
## Purpose

With respect to the Vercel config page, the purpose of this PR is the following: 
1. Adjust the error state for an invalid authentication pasted token
2. Adjust the empty state for when projects do not exist
3. Update all of the page copies to align with designs
4. Update layout of Content type section

## Approach

The approach is fairly straightforward - removed the original "Status" badge that was used for the authentication section and instead placed the error message as per the [designs](https://www.figma.com/file/3zhaUVyNKPZOFjVPL7mG00/Vercel?type=design&node-id=857-15326&mode=design&t=8txI8tLGkelAsTuO-4). See below:

### New error state

![Screenshot 2024-04-12 at 8 21 23 AM](https://github.com/contentful/apps/assets/58186851/bdadc0fa-039b-435f-a9ba-32bcfa5d173b)

Additionally, ensured that the Content type field and Preview path field each have their own labels (previously it was one label per row- see below). 

### Before
![Screenshot 2024-04-12 at 8 22 37 AM](https://github.com/contentful/apps/assets/58186851/ec7354f0-c760-44e4-bc48-3de7b69f3d3d)

### After
![Screenshot 2024-04-12 at 8 20 42 AM](https://github.com/contentful/apps/assets/58186851/6c6dfacf-1c43-41d9-97b6-e0c3b0cab51e)

## Follow-up work
1. More error states and empty states to be added in follow-up work!
