### PR TITLE
Account for empty content type and empty preview path

### DIFF
--- a/apps/vercel/frontend/src/components/common/Select/Select.tsx
+++ b/apps/vercel/frontend/src/components/common/Select/Select.tsx
@@ -38,6 +38,7 @@ export const Select = ({
         isDisabled={!optionsExist}
         id="optionsSelect"
         name="optionsSelect"
+        isInvalid={Boolean(errorMessage)}
         value={value}
         onChange={onChange}>
         {optionsExist ? (

--- a/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.tsx
+++ b/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.tsx
@@ -29,7 +29,7 @@ export const SelectSection = ({
   section,
   id,
 }: Props) => {
-  const [isSelectionValid, setIsSelectionValid] = useState<boolean>(false);
+  const [isSelectionInvalid, setIsSelectionInvalid] = useState<boolean>(false);
   const { placeholder, label, emptyMessage, helpText, errorMessage } = copies.configPage[section];
   const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
     dispatch({
@@ -39,9 +39,9 @@ export const SelectSection = ({
   };
 
   useEffect(() => {
-    const isValidSelection =
-      options.some((item) => item.id === selectedOption) || selectedOption === '';
-    setIsSelectionValid(!isValidSelection);
+    const isValidSelection = options.some((item) => item.id === selectedOption) || !selectedOption;
+    const areOptionsAvailable = options.length === 0;
+    setIsSelectionInvalid(!isValidSelection && !areOptionsAvailable);
   }, [selectedOption, options]);
 
   return (
@@ -54,7 +54,7 @@ export const SelectSection = ({
         options={options}
         label={label}
         helpText={helpText}
-        errorMessage={isSelectionValid ? errorMessage : undefined}
+        errorMessage={isSelectionInvalid ? errorMessage : undefined}
       />
     </FormControl>
   );

--- a/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/ApiPathSelectionSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/ApiPathSelectionSection.tsx
@@ -1,19 +1,19 @@
-import { Dispatch } from 'react';
+import { useContext } from 'react';
 
-import { ParameterAction } from '@components/parameterReducer';
-import { AppInstallationParameters, Path } from '@customTypes/configPage';
+import { Path } from '@customTypes/configPage';
 import { SectionWrapper } from '@components/common/SectionWrapper/SectionWrapper';
 import { SelectSection } from '@components/common/SelectSection/SelectSection';
 import { actions, singleSelectionSections } from '@constants/enums';
+import { ConfigPageContext } from '@contexts/ConfigPageProvider';
 
 interface Props {
-  parameters: AppInstallationParameters;
   paths: Path[];
-  dispatch: Dispatch<ParameterAction>;
 }
 
-export const ApiPathSelectionSection = ({ parameters, dispatch, paths }: Props) => {
+export const ApiPathSelectionSection = ({ paths }: Props) => {
   const sectionId = singleSelectionSections.API_PATH_SELECTION_SECTION;
+  const { dispatch, parameters } = useContext(ConfigPageContext);
+
   return (
     <SectionWrapper testId={sectionId}>
       <SelectSection

--- a/apps/vercel/frontend/src/components/config-screen/AuthenticationSection/AuthenticationSection.spec.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/AuthenticationSection/AuthenticationSection.spec.tsx
@@ -1,9 +1,10 @@
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import { AppInstallationParameters } from '@customTypes/configPage';
 import { AuthenticationSection } from './AuthenticationSection';
 import { copies } from '@constants/copies';
+import { renderConfigPageComponent } from '@test/helpers/renderConfigPageComponent';
 
 const { input } = copies.configPage.authenticationSection;
 
@@ -11,14 +12,10 @@ describe('AuthenticationSection', () => {
   it('renders input when token is not yet inputed', () => {
     const parameters = {
       vercelAccessToken: '',
-      vercelAccessTokenStatus: '',
     } as unknown as AppInstallationParameters;
-    render(
-      <AuthenticationSection
-        handleTokenChange={vi.fn()}
-        parameters={parameters}
-        isTokenValid={false}
-      />
+    renderConfigPageComponent(
+      <AuthenticationSection handleTokenChange={vi.fn()} isTokenValid={false} />,
+      { parameters }
     );
 
     const tokenInput = screen.getByPlaceholderText(input.placeholder);
@@ -29,11 +26,10 @@ describe('AuthenticationSection', () => {
   it('renders hidden token and valid content when token is valid', () => {
     const parameters = {
       vercelAccessToken: '12345',
-      vercelAccessTokenStatus: 'valid',
     } as unknown as AppInstallationParameters;
-    render(
-      <AuthenticationSection handleTokenChange={vi.fn()} parameters={parameters} isTokenValid />
-    );
+    renderConfigPageComponent(<AuthenticationSection handleTokenChange={vi.fn()} isTokenValid />, {
+      parameters,
+    });
 
     const token = screen.queryByText(parameters.vercelAccessToken);
 
@@ -43,14 +39,10 @@ describe('AuthenticationSection', () => {
   it('renders hidden token and invalid content when token is invalid', () => {
     const parameters = {
       vercelAccessToken: '12345',
-      vercelAccessTokenStatus: 'valid',
     } as unknown as AppInstallationParameters;
-    render(
-      <AuthenticationSection
-        handleTokenChange={vi.fn()}
-        parameters={parameters}
-        isTokenValid={false}
-      />
+    renderConfigPageComponent(
+      <AuthenticationSection handleTokenChange={vi.fn()} isTokenValid={false} />,
+      { parameters }
     );
 
     const status = screen.getByText(input.errorMessage);

--- a/apps/vercel/frontend/src/components/config-screen/AuthenticationSection/AuthenticationSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/AuthenticationSection/AuthenticationSection.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent } from 'react';
+import { ChangeEvent, useContext } from 'react';
 import {
   Box,
   FormControl,
@@ -11,17 +11,17 @@ import {
 import { ExternalLinkIcon } from '@contentful/f36-icons';
 
 import { styles } from './AuthenticationSection.styles';
-import { AppInstallationParameters } from '@customTypes/configPage';
 import { copies } from '@constants/copies';
+import { ConfigPageContext } from '@contexts/ConfigPageProvider';
 
 interface Props {
-  parameters: AppInstallationParameters;
   isTokenValid: boolean;
   handleTokenChange: (e: ChangeEvent<HTMLInputElement>) => void;
 }
 
-export const AuthenticationSection = ({ parameters, handleTokenChange, isTokenValid }: Props) => {
+export const AuthenticationSection = ({ handleTokenChange, isTokenValid }: Props) => {
   const { title, input, link } = copies.configPage.authenticationSection;
+  const { parameters } = useContext(ConfigPageContext);
 
   const showError = Boolean(parameters.vercelAccessToken && !isTokenValid);
 

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSection.tsx
@@ -1,36 +1,27 @@
 import { Box, Heading, Paragraph } from '@contentful/f36-components';
-import { ContentType } from '@contentful/app-sdk';
-import { Dispatch } from 'react';
 
-import { ParameterAction } from '@components/parameterReducer';
 import { styles } from '@locations/ConfigScreen.styles';
-import { AppInstallationParameters } from '@customTypes/configPage';
 import { ContentTypePreviewPathSelectionList } from './ContentTypePreviewPathSelectionList/ContentTypePreviewPathSelectionList';
 import { PreviewPathInfoNote } from './PreviewPathInfoNote/PreviewPathInfoNote';
 import { copies } from '@constants/copies';
+import { useContext } from 'react';
+import { ConfigPageContext } from '@contexts/ConfigPageProvider';
 
-interface Props {
-  parameters: AppInstallationParameters;
-  dispatch: Dispatch<ParameterAction>;
-  contentTypes: ContentType[];
-}
-
-export const ContentTypePreviewPathSection = ({ parameters, dispatch, contentTypes }: Props) => {
-  const { contentTypePreviewPathSelections } = parameters;
+export const ContentTypePreviewPathSection = () => {
   const { title, description } = copies.configPage.contentTypePreviewPathSection;
+  const { clearIsAppConfigureCalled } = useContext(ConfigPageContext);
 
   return (
-    <Box data-testid="content-type-preview-path-section" className={styles.box}>
+    <Box
+      onClick={clearIsAppConfigureCalled}
+      data-testid="content-type-preview-path-section"
+      className={styles.box}>
       <Heading marginBottom="none" className={styles.heading}>
         {title}
       </Heading>
       <Paragraph marginTop="spacingXs">{description}</Paragraph>
       <PreviewPathInfoNote />
-      <ContentTypePreviewPathSelectionList
-        contentTypes={contentTypes}
-        contentTypePreviewPathSelections={contentTypePreviewPathSelections}
-        dispatch={dispatch}
-      />
+      <ContentTypePreviewPathSelectionList />
     </Box>
   );
 };

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSection.tsx
@@ -9,11 +9,11 @@ import { ConfigPageContext } from '@contexts/ConfigPageProvider';
 
 export const ContentTypePreviewPathSection = () => {
   const { title, description } = copies.configPage.contentTypePreviewPathSection;
-  const { clearIsAppConfigureCalled } = useContext(ConfigPageContext);
+  const { handleAppConfigurationChange } = useContext(ConfigPageContext);
 
   return (
     <Box
-      onClick={clearIsAppConfigureCalled}
+      onClick={handleAppConfigurationChange}
       data-testid="content-type-preview-path-section"
       className={styles.box}>
       <Heading marginBottom="none" className={styles.heading}>

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionList/ContentTypePreviewPathSelectionList.spec.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionList/ContentTypePreviewPathSelectionList.spec.tsx
@@ -1,18 +1,13 @@
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { ContentTypePreviewPathSelectionList } from './ContentTypePreviewPathSelectionList';
-import { mockContentTypes } from '@test/mocks/mockContentTypes';
 import { mockContentTypePreviewPathSelections } from '@test/mocks/mockContentTypePreviewPathSelections';
+import { renderConfigPageComponent } from '@test/helpers/renderConfigPageComponent';
+import { AppInstallationParameters } from '@customTypes/configPage';
 
 describe('ContentTypePreviewPathSelectionList', () => {
   it('renders list of selections', () => {
-    const { unmount } = render(
-      <ContentTypePreviewPathSelectionList
-        contentTypes={mockContentTypes}
-        contentTypePreviewPathSelections={mockContentTypePreviewPathSelections}
-        dispatch={() => null}
-      />
-    );
+    const { unmount } = renderConfigPageComponent(<ContentTypePreviewPathSelectionList />);
 
     expect(screen.getAllByText('Blog')).toBeTruthy();
     expect(
@@ -28,16 +23,13 @@ describe('ContentTypePreviewPathSelectionList', () => {
   });
 
   it('disables add button if all content types have been configured', () => {
-    const { unmount } = render(
-      <ContentTypePreviewPathSelectionList
-        contentTypes={mockContentTypes}
-        contentTypePreviewPathSelections={[
-          ...mockContentTypePreviewPathSelections,
-          { contentType: 'article', previewPath: 'test-article-path' },
-        ]}
-        dispatch={() => null}
-      />
-    );
+    const contentTypePreviewPathSelections = [
+      ...mockContentTypePreviewPathSelections,
+      { contentType: 'article', previewPath: 'test-article-path' },
+    ];
+    const { unmount } = renderConfigPageComponent(<ContentTypePreviewPathSelectionList />, {
+      parameters: { contentTypePreviewPathSelections } as unknown as AppInstallationParameters,
+    });
 
     expect(screen.getAllByText('Blog')).toBeTruthy();
     expect(
@@ -47,6 +39,22 @@ describe('ContentTypePreviewPathSelectionList', () => {
     expect(
       screen.getByDisplayValue(mockContentTypePreviewPathSelections[1].previewPath)
     ).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Add Content Type' })).toHaveProperty(
+      'disabled',
+      true
+    );
+
+    unmount();
+  });
+
+  it('disables add button if no content types exist', () => {
+    const { unmount } = renderConfigPageComponent(<ContentTypePreviewPathSelectionList />, {
+      parameters: {
+        contentTypePreviewPathSelections: mockContentTypePreviewPathSelections,
+      } as unknown as AppInstallationParameters,
+      contentTypes: [],
+    });
+
     expect(screen.getByRole('button', { name: 'Add Content Type' })).toHaveProperty(
       'disabled',
       true

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionList/ContentTypePreviewPathSelectionList.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionList/ContentTypePreviewPathSelectionList.tsx
@@ -1,9 +1,7 @@
-import { ContentType } from '@contentful/app-sdk';
 import { PlusIcon } from '@contentful/f36-icons';
-import { Button } from '@contentful/f36-components';
-import { useState, Dispatch } from 'react';
+import { Button, Tooltip } from '@contentful/f36-components';
+import { useState, useContext } from 'react';
 
-import { ParameterAction } from '@components/parameterReducer';
 import {
   ApplyContentTypePreviewPathSelectionPayload,
   ContentTypePreviewPathSelection,
@@ -11,19 +9,16 @@ import {
 import { ContentTypePreviewPathSelectionRow } from '../ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow';
 import { getAvailableContentTypes } from '@utils/getAvailableContentTypes';
 import { actions } from '@constants/enums';
+import { ConfigPageContext } from '@contexts/ConfigPageProvider';
+import { copies } from '@constants/copies';
 
-interface Props {
-  contentTypes: ContentType[];
-  dispatch: Dispatch<ParameterAction>;
-  contentTypePreviewPathSelections: ContentTypePreviewPathSelection[];
-}
-
-export const ContentTypePreviewPathSelectionList = ({
-  contentTypes,
-  dispatch,
-  contentTypePreviewPathSelections = [],
-}: Props) => {
+export const ContentTypePreviewPathSelectionList = () => {
   const [addRow, setAddRow] = useState<boolean>(false);
+
+  const { dispatch, parameters, contentTypes } = useContext(ConfigPageContext);
+  const { contentTypePreviewPathSelections } = parameters;
+
+  const { button } = copies.configPage.contentTypePreviewPathSection;
 
   const filterContentTypes = getAvailableContentTypes(
     contentTypes,
@@ -51,20 +46,18 @@ export const ContentTypePreviewPathSelectionList = ({
     setAddRow(true);
   };
 
-  // disable add button if there is a row with empty fields present or when all content types are already selected
+  // disable add button if there is a row with empty fields present, when all content types are already selected, or no content types exist
   const isAddButtonDisabled =
     addRow ||
     contentTypePreviewPathSelections.length === 0 ||
-    contentTypePreviewPathSelections.length === contentTypes.length;
+    contentTypePreviewPathSelections.length === contentTypes.length ||
+    contentTypes.length === 0;
 
   const renderSelectionRow = () => {
     const selectionsWithBlankRow =
       addRow || !contentTypePreviewPathSelections?.length
         ? contentTypePreviewPathSelections.concat({ contentType: '', previewPath: '' })
         : contentTypePreviewPathSelections;
-
-    // TO DO: Handle case where contentTypes are not present - do not render add button etc.
-    if (!contentTypes?.length) return;
 
     return selectionsWithBlankRow.map((contentTypePreviewPathSelection, index) => (
       <ContentTypePreviewPathSelectionRow
@@ -82,9 +75,14 @@ export const ContentTypePreviewPathSelectionList = ({
     <>
       {renderSelectionRow()}
 
-      <Button isDisabled={isAddButtonDisabled} onClick={handleAddRow} startIcon={<PlusIcon />}>
-        Add Content Type
-      </Button>
+      <Tooltip
+        content={
+          contentTypePreviewPathSelections.length === contentTypes.length ? button.tooltip : ''
+        }>
+        <Button isDisabled={isAddButtonDisabled} onClick={handleAddRow} startIcon={<PlusIcon />}>
+          {button.copy}
+        </Button>
+      </Tooltip>
     </>
   );
 };

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.tsx
@@ -81,13 +81,20 @@ export const ContentTypePreviewPathSelectionRow = ({
     return isAppConfigurationSaved && !configuredPreviewPath && !!configuredContentType;
   }, [isAppConfigurationSaved, configuredPreviewPath, configuredContentType]);
 
+  const itemAlignment = useMemo(() => {
+    if (isPreviewPathInvalid) {
+      return !renderLabel ? 'baseline' : 'normal';
+    }
+    return 'flex-end';
+  }, [isPreviewPathInvalid, renderLabel]);
+
   return (
     <Box className={styles.wrapper}>
       <FormControl marginBottom="spacingM" id="contentTypePreviewPathSelection">
         <Flex
           flexDirection="row"
           justifyContent="space-evenly"
-          alignItems={isPreviewPathInvalid ? 'normal' : 'flex-end'}
+          alignItems={itemAlignment}
           gap={tokens.spacingXs}>
           <Box className={styles.inputWrapper}>
             <Select

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.tsx
@@ -41,7 +41,7 @@ export const ContentTypePreviewPathSelectionRow = ({
 
   const { inputs } = copies.configPage.contentTypePreviewPathSection;
 
-  const { isAppConfigurationSaved, parameters } = useContext(ConfigPageContext);
+  const { isAppConfigurationSaved } = useContext(ConfigPageContext);
 
   const handlePreviewPathInput = (event: React.ChangeEvent<HTMLInputElement>) => {
     onParameterUpdate({
@@ -78,8 +78,8 @@ export const ContentTypePreviewPathSelectionRow = ({
   );
 
   const isPreviewPathInvalid = useMemo(() => {
-    return isAppConfigurationSaved && !configuredPreviewPath;
-  }, [isAppConfigurationSaved, configuredPreviewPath]);
+    return isAppConfigurationSaved && !configuredPreviewPath && !!configuredContentType;
+  }, [isAppConfigurationSaved, configuredPreviewPath, configuredContentType]);
 
   return (
     <Box className={styles.wrapper}>
@@ -87,7 +87,7 @@ export const ContentTypePreviewPathSelectionRow = ({
         <Flex
           flexDirection="row"
           justifyContent="space-evenly"
-          alignItems={isPreviewPathInvalid ? 'flex-start' : 'flex-end'}
+          alignItems={isPreviewPathInvalid ? 'normal' : 'flex-end'}
           gap={tokens.spacingXs}>
           <Box className={styles.inputWrapper}>
             <Select

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.tsx
@@ -78,7 +78,7 @@ export const ContentTypePreviewPathSelectionRow = ({
   );
 
   const isPreviewPathInvalid = useMemo(() => {
-    return Boolean(isAppConfigureCalled && !configuredPreviewPath && configuredContentType);
+    return isAppConfigureCalled && !configuredPreviewPath && !!configuredContentType;
   }, [isAppConfigureCalled, configuredPreviewPath, configuredContentType]);
 
   return (
@@ -87,7 +87,7 @@ export const ContentTypePreviewPathSelectionRow = ({
         <Flex
           flexDirection="row"
           justifyContent="space-evenly"
-          alignItems={isPreviewPathInvalid ? 'flex-start' : 'flex-end'}
+          alignItems={isPreviewPathInvalid ? 'normal' : 'flex-end'}
           gap={tokens.spacingXs}>
           <Box className={styles.inputWrapper}>
             <Select

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.tsx
@@ -1,5 +1,12 @@
-import { ChangeEvent, useMemo } from 'react';
-import { Box, FormControl, TextInput, Flex, IconButton } from '@contentful/f36-components';
+import { ChangeEvent, useContext, useMemo } from 'react';
+import {
+  Box,
+  FormControl,
+  TextInput,
+  Flex,
+  IconButton,
+  ValidationMessage,
+} from '@contentful/f36-components';
 import { CloseIcon } from '@contentful/f36-icons';
 import { debounce } from 'lodash';
 import tokens from '@contentful/f36-tokens';
@@ -12,6 +19,7 @@ import {
 import { styles } from './ContentTypePreviewPathSelectionRow.styles';
 import { copies } from '@constants/copies';
 import { Select } from '@components/common/Select/Select';
+import { ConfigPageContext } from '@contexts/ConfigPageProvider';
 
 interface Props {
   contentTypes: ContentType[];
@@ -32,6 +40,8 @@ export const ContentTypePreviewPathSelectionRow = ({
     configuredContentTypePreviewPathSelection;
 
   const { inputs } = copies.configPage.contentTypePreviewPathSection;
+
+  const { isAppConfigureCalled } = useContext(ConfigPageContext);
 
   const handlePreviewPathInput = (event: React.ChangeEvent<HTMLInputElement>) => {
     onParameterUpdate({
@@ -67,13 +77,17 @@ export const ContentTypePreviewPathSelectionRow = ({
     [contentTypes]
   );
 
+  const isPreviewPathInvalid = useMemo(() => {
+    return Boolean(isAppConfigureCalled && !configuredPreviewPath && configuredContentType);
+  }, [isAppConfigureCalled, configuredPreviewPath, configuredContentType]);
+
   return (
     <Box className={styles.wrapper}>
       <FormControl marginBottom="spacingM" id="contentTypePreviewPathSelection">
         <Flex
           flexDirection="row"
           justifyContent="space-evenly"
-          alignItems="flex-end"
+          alignItems={isPreviewPathInvalid ? 'flex-start' : 'flex-end'}
           gap={tokens.spacingXs}>
           <Box className={styles.inputWrapper}>
             <Select
@@ -91,10 +105,14 @@ export const ContentTypePreviewPathSelectionRow = ({
             )}
             <TextInput
               defaultValue={configuredPreviewPath}
-              isDisabled={!configuredContentType}
+              isDisabled={!configuredContentType || !contentTypes.length}
               onChange={debouncedHandlePreviewPathInputChange}
               placeholder={inputs.previewPath.placeholder}
+              isInvalid={isPreviewPathInvalid}
             />
+            {isPreviewPathInvalid && (
+              <ValidationMessage>{inputs.previewPath.errorMessage}</ValidationMessage>
+            )}
           </Box>
           <IconButton onClick={handleRemoveRow} icon={<CloseIcon />} aria-label={'Delete row'} />
         </Flex>

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.tsx
@@ -41,7 +41,7 @@ export const ContentTypePreviewPathSelectionRow = ({
 
   const { inputs } = copies.configPage.contentTypePreviewPathSection;
 
-  const { isAppConfigureCalled } = useContext(ConfigPageContext);
+  const { isAppConfigurationSaved, parameters } = useContext(ConfigPageContext);
 
   const handlePreviewPathInput = (event: React.ChangeEvent<HTMLInputElement>) => {
     onParameterUpdate({
@@ -78,8 +78,8 @@ export const ContentTypePreviewPathSelectionRow = ({
   );
 
   const isPreviewPathInvalid = useMemo(() => {
-    return isAppConfigureCalled && !configuredPreviewPath && !!configuredContentType;
-  }, [isAppConfigureCalled, configuredPreviewPath, configuredContentType]);
+    return isAppConfigurationSaved && !configuredPreviewPath;
+  }, [isAppConfigurationSaved, configuredPreviewPath]);
 
   return (
     <Box className={styles.wrapper}>
@@ -87,7 +87,7 @@ export const ContentTypePreviewPathSelectionRow = ({
         <Flex
           flexDirection="row"
           justifyContent="space-evenly"
-          alignItems={isPreviewPathInvalid ? 'normal' : 'flex-end'}
+          alignItems={isPreviewPathInvalid ? 'flex-start' : 'flex-end'}
           gap={tokens.spacingXs}>
           <Box className={styles.inputWrapper}>
             <Select

--- a/apps/vercel/frontend/src/components/config-screen/ProjectSelectionSection/ProjectSelectionSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ProjectSelectionSection/ProjectSelectionSection.tsx
@@ -1,19 +1,19 @@
-import { Dispatch } from 'react';
+import { useContext } from 'react';
 
-import { ParameterAction } from '@components/parameterReducer';
-import { AppInstallationParameters, Project } from '@customTypes/configPage';
+import { Project } from '@customTypes/configPage';
 import { SectionWrapper } from '@components/common/SectionWrapper/SectionWrapper';
 import { SelectSection } from '@components/common/SelectSection/SelectSection';
 import { actions, singleSelectionSections } from '@constants/enums';
+import { ConfigPageContext } from '@contexts/ConfigPageProvider';
 
 interface Props {
-  parameters: AppInstallationParameters;
   projects: Project[];
-  dispatch: Dispatch<ParameterAction>;
 }
 
-export const ProjectSelectionSection = ({ parameters, dispatch, projects }: Props) => {
+export const ProjectSelectionSection = ({ projects }: Props) => {
   const sectionId = singleSelectionSections.PROJECT_SELECTION_SECTION;
+  const { dispatch, parameters } = useContext(ConfigPageContext);
+
   return (
     <SectionWrapper testId={sectionId}>
       <SelectSection

--- a/apps/vercel/frontend/src/components/parameterReducer.ts
+++ b/apps/vercel/frontend/src/components/parameterReducer.ts
@@ -1,17 +1,9 @@
+import { actions } from '@constants/enums';
 import {
   AppInstallationParameters,
   ApplyContentTypePreviewPathSelectionPayload,
   ContentTypePreviewPathSelection,
 } from '@customTypes/configPage';
-
-export enum actions {
-  UPDATE_VERCEL_ACCESS_TOKEN = 'updateVercelAccessToken',
-  APPLY_CONTENTFUL_PARAMETERS = 'applyContentfulParameters',
-  APPLY_SELECTED_PROJECT = 'applySelectedProject',
-  ADD_CONTENT_TYPE_PREVIEW_PATH_SELECTION = 'addContentTypePreviewPathSelection',
-  REMOVE_CONTENT_TYPE_PREVIEW_PATH_SELECTION = 'removeContentTypePreviewPathSelection',
-  APPLY_API_PATH = 'applyApiPath',
-}
 
 type VercelAccessTokenAction = {
   type: actions.UPDATE_VERCEL_ACCESS_TOKEN;

--- a/apps/vercel/frontend/src/constants/copies.ts
+++ b/apps/vercel/frontend/src/constants/copies.ts
@@ -29,6 +29,10 @@ export const copies = {
     },
     contentTypePreviewPathSection: {
       title: 'Preview settings',
+      button: {
+        copy: 'Add Content Type',
+        tooltip: 'All content types have been configured',
+      },
       description:
         'Select a content type that you would like to preview. For each content type, add a preview path and optionally a token.',
       inputs: {

--- a/apps/vercel/frontend/src/constants/copies.ts
+++ b/apps/vercel/frontend/src/constants/copies.ts
@@ -40,6 +40,7 @@ export const copies = {
         previewPath: {
           label: 'Preview path',
           placeholder: 'Set preview path and token',
+          errorMessage: 'This field is empty and not saved',
         },
       },
       infoNote: {

--- a/apps/vercel/frontend/src/contexts/ConfigPageProvider.tsx
+++ b/apps/vercel/frontend/src/contexts/ConfigPageProvider.tsx
@@ -1,0 +1,47 @@
+import { createContext, Dispatch } from 'react';
+import { ContentType } from '@contentful/app-sdk';
+import { ParameterAction } from '@components/parameterReducer';
+import { AppInstallationParameters } from '@customTypes/configPage';
+
+interface ConfigPageContextValue {
+  isAppConfigureCalled: boolean;
+  contentTypes: ContentType[];
+  parameters: AppInstallationParameters;
+  dispatch: Dispatch<ParameterAction>;
+  clearIsAppConfigureCalled: () => void;
+}
+
+export interface ChannelContextProviderProps {
+  children: React.ReactNode;
+  isAppConfigureCalled: boolean;
+  contentTypes: ContentType[];
+  parameters: AppInstallationParameters;
+  dispatch: Dispatch<ParameterAction>;
+  clearIsAppConfigureCalled: () => void;
+}
+
+export const ConfigPageContext = createContext({} as ConfigPageContextValue);
+
+export const ConfigPageProvider = (props: ChannelContextProviderProps) => {
+  const {
+    children,
+    isAppConfigureCalled,
+    contentTypes,
+    dispatch,
+    parameters,
+    clearIsAppConfigureCalled,
+  } = props;
+
+  return (
+    <ConfigPageContext.Provider
+      value={{
+        isAppConfigureCalled,
+        contentTypes,
+        dispatch,
+        parameters,
+        clearIsAppConfigureCalled,
+      }}>
+      {children}
+    </ConfigPageContext.Provider>
+  );
+};

--- a/apps/vercel/frontend/src/contexts/ConfigPageProvider.tsx
+++ b/apps/vercel/frontend/src/contexts/ConfigPageProvider.tsx
@@ -4,20 +4,15 @@ import { ParameterAction } from '@components/parameterReducer';
 import { AppInstallationParameters } from '@customTypes/configPage';
 
 interface ConfigPageContextValue {
-  isAppConfigureCalled: boolean;
+  isAppConfigurationSaved: boolean;
   contentTypes: ContentType[];
   parameters: AppInstallationParameters;
   dispatch: Dispatch<ParameterAction>;
-  clearIsAppConfigureCalled: () => void;
+  handleAppConfigurationChange: () => void;
 }
 
-export interface ChannelContextProviderProps {
+export interface ChannelContextProviderProps extends ConfigPageContextValue {
   children: React.ReactNode;
-  isAppConfigureCalled: boolean;
-  contentTypes: ContentType[];
-  parameters: AppInstallationParameters;
-  dispatch: Dispatch<ParameterAction>;
-  clearIsAppConfigureCalled: () => void;
 }
 
 export const ConfigPageContext = createContext({} as ConfigPageContextValue);
@@ -25,21 +20,21 @@ export const ConfigPageContext = createContext({} as ConfigPageContextValue);
 export const ConfigPageProvider = (props: ChannelContextProviderProps) => {
   const {
     children,
-    isAppConfigureCalled,
+    isAppConfigurationSaved,
     contentTypes,
     dispatch,
     parameters,
-    clearIsAppConfigureCalled,
+    handleAppConfigurationChange,
   } = props;
 
   return (
     <ConfigPageContext.Provider
       value={{
-        isAppConfigureCalled,
+        isAppConfigurationSaved,
         contentTypes,
         dispatch,
         parameters,
-        clearIsAppConfigureCalled,
+        handleAppConfigurationChange,
       }}>
       {children}
     </ConfigPageContext.Provider>

--- a/apps/vercel/frontend/src/hooks/useInitializeParameters/useInitializeParameters.tsx
+++ b/apps/vercel/frontend/src/hooks/useInitializeParameters/useInitializeParameters.tsx
@@ -2,7 +2,8 @@ import { Dispatch, useEffect, useCallback } from 'react';
 import { useSDK } from '@contentful/react-apps-toolkit';
 import type { ConfigAppSDK } from '@contentful/app-sdk';
 import { AppInstallationParameters } from '@customTypes/configPage';
-import { ParameterAction, actions } from '@components/parameterReducer';
+import { ParameterAction } from '@components/parameterReducer';
+import { actions } from '@constants/enums';
 
 /**
  * This hook is used to initialize the parameters of the app.

--- a/apps/vercel/frontend/src/hooks/useInitializeParameters/uzeInitializeParameters.spec.tsx
+++ b/apps/vercel/frontend/src/hooks/useInitializeParameters/uzeInitializeParameters.spec.tsx
@@ -1,8 +1,8 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { mockSdk } from '@test/mocks';
-import { actions } from '@components/parameterReducer';
 import { mockParameters } from '@test/mocks/mockSdk';
+import { actions } from '@constants/enums';
 import useInitializeParameters from './useInitializeParameters';
 
 vi.mock('@contentful/react-apps-toolkit', () => ({

--- a/apps/vercel/frontend/src/locations/ConfigScreen.tsx
+++ b/apps/vercel/frontend/src/locations/ConfigScreen.tsx
@@ -21,7 +21,7 @@ const ConfigScreen = () => {
   const [contentTypes, setContentTypes] = useState<ContentType[]>([]);
   const [projects, setProjects] = useState<Project[]>([]);
   const [apiPaths, setApiPaths] = useState<ApiPath[]>([]);
-  const [isAppConfigureCalled, setIsAppConfigureCalled] = useState(false);
+  const [isAppConfigurationSaved, setIsAppConfigurationSaved] = useState(true);
 
   const [parameters, dispatchParameters] = useReducer(parameterReducer, initialParameters);
   const sdk = useSDK<ConfigAppSDK>();
@@ -38,7 +38,7 @@ const ConfigScreen = () => {
       return false;
     }
 
-    setIsAppConfigureCalled(true);
+    setIsAppConfigurationSaved(true);
 
     return {
       parameters,
@@ -116,15 +116,15 @@ const ConfigScreen = () => {
     });
   };
 
-  const clearIsAppConfigureCalled = () => {
-    setIsAppConfigureCalled(false);
+  const handleAppConfigurationChange = () => {
+    setIsAppConfigurationSaved(false);
   };
 
   return (
     <ConfigPageProvider
       contentTypes={contentTypes}
-      isAppConfigureCalled={isAppConfigureCalled}
-      clearIsAppConfigureCalled={clearIsAppConfigureCalled}
+      isAppConfigurationSaved={isAppConfigurationSaved}
+      handleAppConfigurationChange={handleAppConfigurationChange}
       dispatch={dispatchParameters}
       parameters={parameters}>
       <Box className={styles.body}>

--- a/apps/vercel/frontend/src/locations/ConfigScreen.tsx
+++ b/apps/vercel/frontend/src/locations/ConfigScreen.tsx
@@ -14,12 +14,14 @@ import { ApiPathSelectionSection } from '@components/config-screen/ApiPathSelect
 import { AuthenticationSection } from '@components/config-screen/AuthenticationSection/AuthenticationSection';
 import { copies } from '@constants/copies';
 import { actions } from '@constants/enums';
+import { ConfigPageProvider } from '@contexts/ConfigPageProvider';
 
 const ConfigScreen = () => {
   const [isTokenValid, setIsTokenValid] = useState(false);
   const [contentTypes, setContentTypes] = useState<ContentType[]>([]);
   const [projects, setProjects] = useState<Project[]>([]);
   const [apiPaths, setApiPaths] = useState<ApiPath[]>([]);
+  const [isAppConfigureCalled, setIsAppConfigureCalled] = useState(false);
 
   const [parameters, dispatchParameters] = useReducer(parameterReducer, initialParameters);
   const sdk = useSDK<ConfigAppSDK>();
@@ -35,6 +37,8 @@ const ConfigScreen = () => {
       sdk.notifier.error('A valid Vercel access token is required');
       return false;
     }
+
+    setIsAppConfigureCalled(true);
 
     return {
       parameters,
@@ -112,8 +116,17 @@ const ConfigScreen = () => {
     });
   };
 
+  const clearIsAppConfigureCalled = () => {
+    setIsAppConfigureCalled(false);
+  };
+
   return (
-    <>
+    <ConfigPageProvider
+      contentTypes={contentTypes}
+      isAppConfigureCalled={isAppConfigureCalled}
+      clearIsAppConfigureCalled={clearIsAppConfigureCalled}
+      dispatch={dispatchParameters}
+      parameters={parameters}>
       <Box className={styles.body}>
         <Box>
           <Heading>{title}</Heading>
@@ -122,37 +135,22 @@ const ConfigScreen = () => {
         <hr className={styles.splitter} />
         <Stack spacing="spacingS" flexDirection="column">
           <AuthenticationSection
-            parameters={parameters}
             handleTokenChange={handleTokenChange}
             isTokenValid={isTokenValid}
           />
 
-          {isTokenValid && (
-            <ProjectSelectionSection
-              parameters={parameters}
-              dispatch={dispatchParameters}
-              projects={projects}
-            />
-          )}
+          {isTokenValid && <ProjectSelectionSection projects={projects} />}
 
           {isTokenValid && parameters.selectedProject && (
-            <ApiPathSelectionSection
-              parameters={parameters}
-              dispatch={dispatchParameters}
-              paths={apiPaths}
-            />
+            <ApiPathSelectionSection paths={apiPaths} />
           )}
 
           {isTokenValid && parameters.selectedProject && parameters.selectedApiPath && (
-            <ContentTypePreviewPathSection
-              parameters={parameters}
-              dispatch={dispatchParameters}
-              contentTypes={contentTypes}
-            />
+            <ContentTypePreviewPathSection />
           )}
         </Stack>
       </Box>
-    </>
+    </ConfigPageProvider>
   );
 };
 

--- a/apps/vercel/frontend/test/helpers/renderConfigPageComponent.tsx
+++ b/apps/vercel/frontend/test/helpers/renderConfigPageComponent.tsx
@@ -20,8 +20,8 @@ export const renderConfigPageComponent = (
           contentTypePreviewPathSelections: mockContentTypePreviewPathSelections,
         } as AppInstallationParameters,
         dispatch: () => null,
-        isAppConfigureCalled: false,
-        clearIsAppConfigureCalled: () => null,
+        isAppConfigurationSaved: false,
+        handleAppConfigurationChange: () => null,
         ...overrides,
       }}>
       {children}

--- a/apps/vercel/frontend/test/helpers/renderConfigPageComponent.tsx
+++ b/apps/vercel/frontend/test/helpers/renderConfigPageComponent.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { mockContentTypes } from '../mocks/mockContentTypes';
+import { mockContentTypePreviewPathSelections } from '../mocks/mockContentTypePreviewPathSelections';
+import {
+  ConfigPageContext,
+  ChannelContextProviderProps,
+} from '../../src/contexts/ConfigPageProvider';
+import { AppInstallationParameters } from '../../src/customTypes/configPage';
+
+export const renderConfigPageComponent = (
+  children: React.ReactNode,
+  overrides?: Partial<ChannelContextProviderProps>
+) =>
+  render(
+    <ConfigPageContext.Provider
+      value={{
+        contentTypes: mockContentTypes,
+        parameters: {
+          contentTypePreviewPathSelections: mockContentTypePreviewPathSelections,
+        } as AppInstallationParameters,
+        dispatch: () => null,
+        isAppConfigureCalled: false,
+        clearIsAppConfigureCalled: () => null,
+        ...overrides,
+      }}>
+      {children}
+    </ConfigPageContext.Provider>
+  );

--- a/apps/vercel/frontend/tsconfig.json
+++ b/apps/vercel/frontend/tsconfig.json
@@ -23,6 +23,7 @@
       "@customTypes/*": ["./src/customTypes/*"],
       "@utils/*": ["./src/utils/*"],
       "@test/*": ["./test/*"],
+      "@contexts/*": ["./src/contexts/*"],
     },
     "jsx": "react-jsx"
   },

--- a/apps/vercel/frontend/vite.config.ts
+++ b/apps/vercel/frontend/vite.config.ts
@@ -23,6 +23,7 @@ export default defineConfig(() => ({
       '@utils': path.resolve(__dirname, './src/utils'),
       '@test': path.resolve(__dirname, './test'),
       '@locations': path.resolve(__dirname, './src/locations'),
+      '@contexts': path.resolve(__dirname, './src/contexts'),
     },
   },
 


### PR DESCRIPTION
## Purpose

This PR accomplishes the following: 
1. Updates the Select error state to also include the red outline of the field (follow-up from last PR)
2. Adds a tooltip to the Add Content Type button when all content types have been configured.
3. Adds an error state to the preview path input that appears when the field is empty and the user has saved/installed the page. This error message disappears when the user interacts with that section once again. 
4. Creates a context that can be used to manage props being passed from the Config page to child components. 
5. Fixes a few imports that were not compiling correctly. 

## Approach

### Updated invalid state on Project and API path select component:

<img width="852" alt="Screenshot 2024-04-15 at 4 22 00 PM" src="https://github.com/contentful/apps/assets/58186851/a5b01a9f-f4f7-42f1-9757-0a8e938caa49">

### Error state for preview path: 

<img width="839" alt="Screenshot 2024-04-15 at 4 21 16 PM" src="https://github.com/contentful/apps/assets/58186851/a6257dab-b9ae-46c5-a5f3-227be9754ed9">

### Tooltip for Add Content Type button: 

![Screenshot 2024-04-15 at 1 11 53 PM](https://github.com/contentful/apps/assets/58186851/4eae1e4b-e286-49fc-9352-506ce09e794a)

