### PR TITLE
fix: improve loading experience of vercel config page

### DIFF
--- a/apps/vercel/frontend/src/clients/Vercel.ts
+++ b/apps/vercel/frontend/src/clients/Vercel.ts
@@ -25,15 +25,10 @@ export default class VercelClient implements VercelAPIClient {
   }
 
   async checkToken(): Promise<boolean> {
-    let res: { ok: boolean } = { ok: false };
-    try {
-      res = await fetch(`${this.baseEndpoint}/v5/user/tokens`, {
-        headers: this.buildHeaders(),
-        method: 'GET',
-      });
-    } catch (e) {
-      console.error(e);
-    }
+    const res = await fetch(`${this.baseEndpoint}/v5/user/tokens`, {
+      headers: this.buildHeaders(),
+      method: 'GET',
+    });
 
     return res.ok;
   }

--- a/apps/vercel/frontend/src/clients/Vercel.ts
+++ b/apps/vercel/frontend/src/clients/Vercel.ts
@@ -25,10 +25,15 @@ export default class VercelClient implements VercelAPIClient {
   }
 
   async checkToken(): Promise<boolean> {
-    const res = await fetch(`${this.baseEndpoint}/v5/user/tokens`, {
-      headers: this.buildHeaders(),
-      method: 'GET',
-    });
+    let res: { ok: boolean } = { ok: false };
+    try {
+      res = await fetch(`${this.baseEndpoint}/v5/user/tokens`, {
+        headers: this.buildHeaders(),
+        method: 'GET',
+      });
+    } catch (e) {
+      console.error(e);
+    }
 
     return res.ok;
   }

--- a/apps/vercel/frontend/src/components/common/Select/Select.spec.tsx
+++ b/apps/vercel/frontend/src/components/common/Select/Select.spec.tsx
@@ -14,19 +14,29 @@ const defaultProps = {
 
 describe('Select', () => {
   it('renders list of options to select', () => {
-    render(<Select options={options} {...defaultProps} />);
+    const { unmount } = render(<Select options={options} isLoading={false} {...defaultProps} />);
     const select = screen.getByText(defaultProps.placeholder);
     expect(select).toBeTruthy();
 
     select.click();
 
     expect(screen.getByText(options[0].name)).toBeTruthy();
+    unmount();
   });
 
   it('renders message when no options exist', () => {
-    render(<Select options={[]} {...defaultProps} />);
+    const { unmount } = render(<Select options={[]} isLoading={false} {...defaultProps} />);
     const emptyMessage = screen.getByText(defaultProps.emptyMessage);
 
     expect(emptyMessage).toBeTruthy();
+    unmount();
+  });
+
+  it('does not render empty message when in loading state', () => {
+    const { unmount } = render(<Select options={[]} isLoading={true} {...defaultProps} />);
+    const emptyMessage = screen.queryByText(defaultProps.emptyMessage);
+
+    expect(emptyMessage).toBeFalsy();
+    unmount();
   });
 });

--- a/apps/vercel/frontend/src/components/common/Select/Select.tsx
+++ b/apps/vercel/frontend/src/components/common/Select/Select.tsx
@@ -33,7 +33,7 @@ export const Select = ({
   errorMessage,
 }: Props) => {
   const optionsExist = Boolean(options && options.length);
-  console.log('isLoading', isLoading);
+
   return (
     <Box>
       {label && <FormControl.Label isRequired={isRequired}>{label}</FormControl.Label>}

--- a/apps/vercel/frontend/src/components/common/Select/Select.tsx
+++ b/apps/vercel/frontend/src/components/common/Select/Select.tsx
@@ -12,6 +12,7 @@ interface Props {
   placeholder: string;
   value: string;
   onChange: (event: ChangeEvent<HTMLSelectElement>) => void;
+  isLoading: boolean;
   label?: string;
   isRequired?: boolean;
   helpText?: string;
@@ -25,12 +26,14 @@ export const Select = ({
   placeholder,
   value,
   onChange,
+  isLoading,
   emptyMessage = 'No options to select',
   isRequired,
   helpText,
   errorMessage,
 }: Props) => {
   const optionsExist = Boolean(options && options.length);
+  console.log('isLoading', isLoading);
   return (
     <Box>
       {label && <FormControl.Label isRequired={isRequired}>{label}</FormControl.Label>}
@@ -41,7 +44,7 @@ export const Select = ({
         isInvalid={Boolean(errorMessage)}
         value={value}
         onChange={onChange}>
-        {optionsExist ? (
+        {optionsExist || isLoading ? (
           <>
             <F36Select.Option value="" isDisabled>
               {placeholder}
@@ -57,7 +60,7 @@ export const Select = ({
         )}
       </F36Select>
       {helpText && <HelpText marginBottom="spacingXs">{helpText}</HelpText>}
-      {errorMessage && <ValidationMessage>{errorMessage}</ValidationMessage>}
+      {errorMessage && !isLoading && <ValidationMessage>{errorMessage}</ValidationMessage>}
     </Box>
   );
 };

--- a/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.tsx
+++ b/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, Dispatch, useEffect, useState } from 'react';
+import { ChangeEvent, Dispatch, useContext, useEffect, useState } from 'react';
 
 import { ParameterAction } from '@components/parameterReducer';
 import { Select } from '@components/common/Select/Select';
@@ -6,6 +6,7 @@ import { Path, Project } from '@customTypes/configPage';
 import { copies } from '@constants/copies';
 import { FormControl } from '@contentful/f36-components';
 import { actions } from '@constants/enums';
+import { ConfigPageContext } from '@contexts/ConfigPageProvider';
 
 type CopySection = Extract<
   keyof typeof copies.configPage,
@@ -31,6 +32,7 @@ export const SelectSection = ({
 }: Props) => {
   const [isSelectionInvalid, setIsSelectionInvalid] = useState<boolean>(false);
   const { placeholder, label, emptyMessage, helpText, errorMessage } = copies.configPage[section];
+  const { isLoading } = useContext(ConfigPageContext);
   const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
     dispatch({
       type: action,
@@ -54,7 +56,8 @@ export const SelectSection = ({
         options={options}
         label={label}
         helpText={helpText}
-        errorMessage={isSelectionInvalid ? errorMessage : undefined}
+        errorMessage={isSelectionInvalid && !isLoading ? errorMessage : undefined}
+        isLoading={isLoading}
       />
     </FormControl>
   );

--- a/apps/vercel/frontend/src/components/config-screen/AuthenticationSection/AuthenticationSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/AuthenticationSection/AuthenticationSection.tsx
@@ -21,9 +21,9 @@ interface Props {
 
 export const AuthenticationSection = ({ handleTokenChange, isTokenValid }: Props) => {
   const { title, input, link } = copies.configPage.authenticationSection;
-  const { parameters } = useContext(ConfigPageContext);
+  const { parameters, isLoading } = useContext(ConfigPageContext);
 
-  const showError = Boolean(parameters.vercelAccessToken && !isTokenValid);
+  const showError = Boolean(parameters.vercelAccessToken && !isTokenValid && !isLoading);
 
   return (
     <Box className={styles.box}>

--- a/apps/vercel/frontend/src/components/config-screen/AuthenticationSection/AuthenticationSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/AuthenticationSection/AuthenticationSection.tsx
@@ -50,7 +50,7 @@ export const AuthenticationSection = ({ handleTokenChange, isTokenValid }: Props
             href={link.href}
             target="_blank"
             rel="noopener noreferrer">
-            Vercel's instructions
+            Vercel&apos;s instructions
           </TextLink>{' '}
           to create an access token for your account.
         </HelpText>

--- a/apps/vercel/frontend/src/components/config-screen/AuthenticationSection/AuthenticationSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/AuthenticationSection/AuthenticationSection.tsx
@@ -50,7 +50,7 @@ export const AuthenticationSection = ({ handleTokenChange, isTokenValid }: Props
             href={link.href}
             target="_blank"
             rel="noopener noreferrer">
-            Vercel instructions
+            Vercel's instructions
           </TextLink>{' '}
           to create an access token for your account.
         </HelpText>

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.tsx
@@ -41,7 +41,7 @@ export const ContentTypePreviewPathSelectionRow = ({
 
   const { inputs } = copies.configPage.contentTypePreviewPathSection;
 
-  const { isAppConfigurationSaved } = useContext(ConfigPageContext);
+  const { isAppConfigurationSaved, isLoading } = useContext(ConfigPageContext);
 
   const handlePreviewPathInput = (event: React.ChangeEvent<HTMLInputElement>) => {
     onParameterUpdate({
@@ -104,6 +104,7 @@ export const ContentTypePreviewPathSelectionRow = ({
               emptyMessage={inputs.contentType.emptyMessage}
               options={contentTypeOptions}
               isRequired={true}
+              isLoading={isLoading}
               onChange={handleContentTypeChange}></Select>
           </Box>
           <Box className={styles.inputWrapper}>

--- a/apps/vercel/frontend/src/constants/copies.ts
+++ b/apps/vercel/frontend/src/constants/copies.ts
@@ -25,7 +25,7 @@ export const copies = {
       placeholder: 'Select a path',
       emptyMessage: 'No paths currently configured.',
       errorMessage: 'This path is no longer available. Please select another one.',
-      helpText: 'Select a Vercel route to render your preview.',
+      helpText: 'Select a Vercel route to enable your draft mode.',
     },
     contentTypePreviewPathSection: {
       title: 'Preview settings',

--- a/apps/vercel/frontend/src/contexts/ConfigPageProvider.tsx
+++ b/apps/vercel/frontend/src/contexts/ConfigPageProvider.tsx
@@ -9,6 +9,7 @@ interface ConfigPageContextValue {
   parameters: AppInstallationParameters;
   dispatch: Dispatch<ParameterAction>;
   handleAppConfigurationChange: () => void;
+  isLoading: boolean;
 }
 
 export interface ChannelContextProviderProps extends ConfigPageContextValue {
@@ -25,6 +26,7 @@ export const ConfigPageProvider = (props: ChannelContextProviderProps) => {
     dispatch,
     parameters,
     handleAppConfigurationChange,
+    isLoading,
   } = props;
 
   return (
@@ -35,6 +37,7 @@ export const ConfigPageProvider = (props: ChannelContextProviderProps) => {
         dispatch,
         parameters,
         handleAppConfigurationChange,
+        isLoading,
       }}>
       {children}
     </ConfigPageContext.Provider>

--- a/apps/vercel/frontend/src/locations/ConfigScreen.spec.tsx
+++ b/apps/vercel/frontend/src/locations/ConfigScreen.spec.tsx
@@ -21,7 +21,7 @@ describe('ConfigScreen', () => {
   it('renders only authentication section on mount', async () => {
     const { unmount } = render(<ConfigScreen />);
 
-    expect(screen.getByText('Connect Vercel')).toBeTruthy();
+    expect(await screen.findByText('Connect Vercel')).toBeTruthy();
     expect(screen.getByText('Vercel Access Token')).toBeTruthy();
     expect(screen.queryByTestId(projectSelectionSectionTestId)).toBeFalsy();
     expect(screen.queryByTestId(pathSelectionSectionTestId)).toBeFalsy();
@@ -33,7 +33,7 @@ describe('ConfigScreen', () => {
     vi.spyOn(VercelClient.prototype, 'checkToken').mockResolvedValue(true);
     const { unmount } = render(<ConfigScreen />);
 
-    expect(screen.getByText('Connect Vercel')).toBeTruthy();
+    expect(await screen.findByText('Connect Vercel')).toBeTruthy();
     expect(screen.getByText('Vercel Access Token')).toBeTruthy();
 
     const input = screen.getByTestId('access-token');

--- a/apps/vercel/frontend/src/locations/ConfigScreen.tsx
+++ b/apps/vercel/frontend/src/locations/ConfigScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, useEffect, useReducer, ChangeEvent, isValidElement } from 'react';
+import { useCallback, useState, useEffect, useReducer, ChangeEvent } from 'react';
 import { ConfigAppSDK, ContentType } from '@contentful/app-sdk';
 import { Box, Heading, Paragraph, Stack } from '@contentful/f36-components';
 import { useSDK } from '@contentful/react-apps-toolkit';
@@ -58,30 +58,17 @@ const ConfigScreen = () => {
     setIsLoading(true);
 
     async function checkToken() {
-      console.log('not hitting here>>>');
-      const tokenValid = await vercelClient.checkToken();
+      const response = await vercelClient.checkToken();
+      if (response) setIsLoading(false);
 
-      setIsTokenValid(tokenValid);
-      console.log('tokenValid>>>>', tokenValid);
-
-      setIsLoading(false);
+      setIsTokenValid(response);
       setHasTokenBeenValidated(true);
     }
 
     if (!hasTokenBeenValidated) {
       checkToken();
-      // setHasTokenBeenValidated(true)
     }
-
-    // setHasTokenBeenValidated(true)
-
-    // if (parameters.vercelAccessToken === '') {
-    //   setHasTokenBeenValidated(true);
-    //   setIsLoading(false)
-    // }
   }, [parameters.vercelAccessToken]);
-
-  console.log('hasTokenBeenValidated', hasTokenBeenValidated, 'isTokenValid>>', isTokenValid);
 
   useEffect(() => {
     async function getContentTypes() {
@@ -97,14 +84,13 @@ const ConfigScreen = () => {
 
   useEffect(() => {
     async function getProjects() {
-      // setIsLoading(true)
+      setIsLoading(true);
       const data = await vercelClient.listProjects();
 
       if (parameters.vercelAccessToken && hasTokenBeenValidated && isTokenValid) {
         setProjects(data.projects);
+        setIsLoading(false);
       }
-
-      // setIsLoading(false);
     }
 
     getProjects();
@@ -144,7 +130,6 @@ const ConfigScreen = () => {
     });
 
     async function checkToken() {
-      console.log('only hitting here>>>>>>');
       const tokenValid = await new VercelClient(e.target.value).checkToken();
       setIsTokenValid(tokenValid);
       setIsLoading(false);

--- a/apps/vercel/frontend/src/locations/ConfigScreen.tsx
+++ b/apps/vercel/frontend/src/locations/ConfigScreen.tsx
@@ -86,14 +86,11 @@ const ConfigScreen = () => {
     async function getProjects() {
       setIsLoading(true);
       const data = await vercelClient.listProjects();
-
-      if (parameters.vercelAccessToken && hasTokenBeenValidated && isTokenValid) {
-        setProjects(data.projects);
-        setIsLoading(false);
-      }
+      setProjects(data.projects);
+      setIsLoading(false);
     }
 
-    getProjects();
+    if (parameters.vercelAccessToken && hasTokenBeenValidated && isTokenValid) getProjects();
   }, [parameters.vercelAccessToken, hasTokenBeenValidated, isTokenValid]);
 
   useEffect(() => {

--- a/apps/vercel/frontend/test/helpers/renderConfigPageComponent.tsx
+++ b/apps/vercel/frontend/test/helpers/renderConfigPageComponent.tsx
@@ -22,6 +22,7 @@ export const renderConfigPageComponent = (
         dispatch: () => null,
         isAppConfigurationSaved: false,
         handleAppConfigurationChange: () => null,
+        isLoading: false,
         ...overrides,
       }}>
       {children}


### PR DESCRIPTION
## Purpose

The purpose of this PR is to resolve the flashing error messages that may occur when the Vercel config page originally renders. This is really an optimization of state and data fetching management on the page itself, mostly with respect to validating the authentication token. 

## Approach

1. I created a loading state that reflects API loading when checking the token, fetching projects, and fetching API paths. This ensures we can not prematurely render error messages or empty messages in any of these sections.
2. I also separated the logic of validating the token when it is updated and also validating it on render of the page. Also this introduces some duplicate code, this ensures that we are not just relying on useEffect updates to validate this logic, which tends to introduce complexity with various variables updating at various times, which ultimately causes the flashing behavior. I created the `hasTokenBeenUpdated` state to support the relationship between these two functions, to ensure we only validate the token once. 
3. I also updates some copies per Mob QA feedback. 

### Before: 


https://github.com/contentful/apps/assets/58186851/ca96cf87-d1b3-43ae-9f5e-79917b354368



### After: 

https://github.com/contentful/apps/assets/58186851/6973c920-a88a-487e-9769-841f719a59a2

## Testing steps

Render the loading page, with either information already persisted, or from the start. Ensure that updating the access token does not cause unwanted side effects of error messages or empty states rendering for a flash of a second. 

