### PR TITLE
chore: upgrade mux player to 2.4.1

### DIFF
--- a/apps/mux/frontend/package-lock.json
+++ b/apps/mux/frontend/package-lock.json
@@ -12,7 +12,7 @@
         "@contentful/dam-app-base": "2.0.46",
         "@contentful/f36-components": "4.62.0",
         "@contentful/react-apps-toolkit": "1.2.16",
-        "@mux/mux-player-react": "2.3.2",
+        "@mux/mux-player-react": "2.4.1",
         "@mux/mux-uploader-react": "1.0.0-beta.15",
         "crypto-browserify": "^3.12.0",
         "react": "17.0.2",
@@ -4335,22 +4335,22 @@
       }
     },
     "node_modules/@mux/mux-player": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@mux/mux-player/-/mux-player-2.3.2.tgz",
-      "integrity": "sha512-ar58+vNGHCytUDM9+Q+yasFCRayqvw5UwyqUVibPR4k0yRML7PTqejAZNzi9obqgUW/yKsZEbV7foKDYcJL6uw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@mux/mux-player/-/mux-player-2.4.1.tgz",
+      "integrity": "sha512-Lm7KkG/lD1tqqqtL1nacZsCll9JY4gVNGxUw/MPYmgIevYACYtQ/76iaEtaN67DmHYYxep1QUpYEDZPXallkEg==",
       "dependencies": {
-        "@mux/mux-video": "0.17.2",
-        "@mux/playback-core": "0.22.1",
-        "media-chrome": "~2.1.0"
+        "@mux/mux-video": "0.17.5",
+        "@mux/playback-core": "0.22.4",
+        "media-chrome": "~3.1.1"
       }
     },
     "node_modules/@mux/mux-player-react": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@mux/mux-player-react/-/mux-player-react-2.3.2.tgz",
-      "integrity": "sha512-WpxFRM6C617sOw4MdyjtPP2GXl2QISCKaYuFTBps9E6E8pSdGeg4sVybPESMfPPTnelUWbcYPf4DpIb8OQOeEA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@mux/mux-player-react/-/mux-player-react-2.4.1.tgz",
+      "integrity": "sha512-grM6T847fKnzlK786NG1AxhNS+6A78pEPc5zG4yYvKe3ayGNTOpq/Hnm9pDVkOx5/uMI/yCdSsfiNyytYaw8qA==",
       "dependencies": {
-        "@mux/mux-player": "2.3.2",
-        "@mux/playback-core": "0.22.1",
+        "@mux/mux-player": "2.4.1",
+        "@mux/playback-core": "0.22.4",
         "prop-types": "^15.7.2"
       },
       "peerDependencies": {
@@ -4398,20 +4398,20 @@
       }
     },
     "node_modules/@mux/mux-video": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/@mux/mux-video/-/mux-video-0.17.2.tgz",
-      "integrity": "sha512-IIGZhUYPClUIOQ/VZZ7kjYcxTcSSSvm+yiv/+c4hHlreO1XLly8Oe1Dzq2xx12t1b+UUupIzx2Cnc8bzVEQTKA==",
+      "version": "0.17.5",
+      "resolved": "https://registry.npmjs.org/@mux/mux-video/-/mux-video-0.17.5.tgz",
+      "integrity": "sha512-EMLflDnr/o7XQiWKfwnq9BJmj30kpSszzXwpXE4hmBIgc9JAuF3Hl94qv1kyWQAUhrO5hnnOxwGHgv0FvkJ1GQ==",
       "dependencies": {
-        "@mux/playback-core": "0.22.1",
+        "@mux/playback-core": "0.22.4",
         "castable-video": "~1.0.6",
-        "custom-media-element": "~1.2.2",
+        "custom-media-element": "~1.2.3",
         "media-tracks": "~0.3.0"
       }
     },
     "node_modules/@mux/playback-core": {
-      "version": "0.22.1",
-      "resolved": "https://registry.npmjs.org/@mux/playback-core/-/playback-core-0.22.1.tgz",
-      "integrity": "sha512-tsPMpcu/xYHQtO6USZwg80CDaXyc7UbyJGoqMU9P1o0e15X/KDcz179nhr6k0CXafg/yiwAlxPNGXnpwToWJ4w==",
+      "version": "0.22.4",
+      "resolved": "https://registry.npmjs.org/@mux/playback-core/-/playback-core-0.22.4.tgz",
+      "integrity": "sha512-f/jWcYbFRjXjdFRNq3MK79D1YHTqvwcfchRLYukE384P3cb027dru+bSxMKESrfkhAhnWFy7fdq/llawl7SU9g==",
       "dependencies": {
         "hls.js": "~1.4.13",
         "mux-embed": "~4.30.0"
@@ -8461,9 +8461,9 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/custom-media-element": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/custom-media-element/-/custom-media-element-1.2.2.tgz",
-      "integrity": "sha512-tI+NjVRS485QlSxHeM3JIjdEZSJMLOZVp41/vvWukDmIkZSoYG9gLYl9GFZGBpY42UbRVo1eMlF7XkI/IiDHzQ=="
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/custom-media-element/-/custom-media-element-1.2.3.tgz",
+      "integrity": "sha512-xr9Hbrslkjm1fapJP5hL98pySeZmNepBSefQS/XTxynamqPTfRBK5MnhReMOiAj8xvJApVPrVnlYxIrknay8jg=="
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -14267,9 +14267,9 @@
       "integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA=="
     },
     "node_modules/media-chrome": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/media-chrome/-/media-chrome-2.1.0.tgz",
-      "integrity": "sha512-ceUEE9tHVIe7KNmjtWq4oCOx1oYq09VyL3A9EP1MDGnFot0eOoLuDfaye/koe8+4tzhB4/yGyn8pIGuvzF85lg=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/media-chrome/-/media-chrome-3.1.1.tgz",
+      "integrity": "sha512-EqofPNX7Eq1dv9ixuRo51Wv/Wo3P4PIPjY4iM1jGqu/Jyond8BqdigQKdhxPM2rH9SohdUXZvUWS1OJ1xMO6Ww=="
     },
     "node_modules/media-tracks": {
       "version": "0.3.0",

--- a/apps/mux/frontend/package.json
+++ b/apps/mux/frontend/package.json
@@ -23,7 +23,7 @@
     "@contentful/dam-app-base": "2.0.46",
     "@contentful/f36-components": "4.62.0",
     "@contentful/react-apps-toolkit": "1.2.16",
-    "@mux/mux-player-react": "2.3.2",
+    "@mux/mux-player-react": "2.4.1",
     "@mux/mux-uploader-react": "1.0.0-beta.15",
     "crypto-browserify": "^3.12.0",
     "react": "17.0.2",

--- a/apps/mux/frontend/src/setupTests.ts
+++ b/apps/mux/frontend/src/setupTests.ts
@@ -5,3 +5,18 @@
 import '@testing-library/jest-dom';
 
 global.ResizeObserver = require('resize-observer-polyfill');
+
+// See https://jestjs.io/docs/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // deprecated
+    removeListener: jest.fn(), // deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});


### PR DESCRIPTION
## Purpose

Unblock upgrade of mux player (see https://github.com/contentful/apps/pull/7123). There was a test failure because `matchMedia` is not supported in the Jest test environment.

## Approach

* Mock `matchMedia` per the handy guidance [from the docs](https://jestjs.io/docs/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom).

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
