### PR TITLE
chore: reenable mux production deploys

### DIFF
--- a/apps/mux/package.json
+++ b/apps/mux/package.json
@@ -9,6 +9,7 @@
     "build-frontend": "cd frontend && npm ci --include=dev && BUILD_PATH=../build npm run build",
     "build:dev": "rimraf ./build && npm run build-frontend && npm run build-app-actions:dev",
     "build-app-actions:dev": "cd app-actions && npm ci && cd .. && NODE_ENV=development node build-actions.js",
+    "deploy": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEFINITIONS_ORG_ID} --definition-id 5l4WmuXdhJGcADHfCm1v4k --token ${CONTENTFUL_CMA_TOKEN}",
     "deploy:local": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEV_TESTING_ORG_ID} --definition-id 5ZIZdgWubBwSDCds1awbqE --token ${TEST_CMA_TOKEN}",
     "deploy:test": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEV_TESTING_ORG_ID} --definition-id 2Z5q0FnYZjRN79MjTE4ofn --token ${TEST_CMA_TOKEN}",
     "deploy:sandbox": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEV_TESTING_ORG_ID} --definition-id 1qaCyx8VYCtc5ij1wAdNbP --token ${TEST_CMA_TOKEN}",


### PR DESCRIPTION
## Purpose

Re-enable the Mux app deploy script, to start deploying Mux app to the production app definition. Currently, Mux is "pinned" to a build from Feb 5 while we rearchitected how tokens were being generated for signed URLs.

## Approach

* Add back the production deploy script to start deploying again

## Testing steps

For piece of mind I recorded a walkthrough of an end to end walkthrough of the Mux app, both with and without signed URLs. This was recorded from our sandbox space, which I built and deployed the current `master` too. So theoretically it's tested against the same artifact we will start deploying in this PR.

https://www.loom.com/share/d095b751fe1246829f6b6f4c1060f89a

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
