### PR TITLE
feat: add preview path input validation on save

### DIFF
--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.spec.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.spec.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { ContentTypePreviewPathSelectionRow } from './ContentTypePreviewPathSelectionRow';
 import { mockContentTypes } from '@test/mocks/mockContentTypes';
 import { copies } from '@constants/copies';
+import { renderConfigPageComponent } from '@test/helpers/renderConfigPageComponent';
 
 const { inputs } = copies.configPage.contentTypePreviewPathSection;
 
@@ -12,6 +13,8 @@ vi.mock('lodash', () => ({
     return fn;
   },
 }));
+
+const selection = { contentType: 'blog', previewPath: 'test-blog-path-1' };
 
 describe('ContentTypePreviewPathSelectionRow', () => {
   it('calls handler to update parameters when each input is provided', () => {
@@ -37,7 +40,6 @@ describe('ContentTypePreviewPathSelectionRow', () => {
   });
 
   it('calls handler to remove row when remove button is clicked', () => {
-    const selection = { contentType: 'blog', previewPath: 'test-blog-path-1' };
     const mockOnRemoveRow = vi.fn();
     const { unmount } = render(
       <ContentTypePreviewPathSelectionRow
@@ -70,7 +72,6 @@ describe('ContentTypePreviewPathSelectionRow', () => {
   });
 
   it('renders selection row with configured selection provided', () => {
-    const selection = { contentType: 'blog', previewPath: 'test-blog-path-2' };
     const { unmount } = render(
       <ContentTypePreviewPathSelectionRow
         contentTypes={mockContentTypes}
@@ -85,7 +86,6 @@ describe('ContentTypePreviewPathSelectionRow', () => {
   });
 
   it('renders message when no content types exist', () => {
-    const selection = { contentType: 'blog', previewPath: 'test-blog-path-3' };
     const { unmount } = render(
       <ContentTypePreviewPathSelectionRow
         contentTypes={[]}
@@ -96,6 +96,37 @@ describe('ContentTypePreviewPathSelectionRow', () => {
     );
 
     expect(screen.getByText(inputs.contentType.emptyMessage)).toBeTruthy();
+    unmount();
+  });
+
+  it('renders message when preview path is empty and user has saved config', () => {
+    const selection = { contentType: 'blog', previewPath: '' };
+    const { unmount } = renderConfigPageComponent(
+      <ContentTypePreviewPathSelectionRow
+        contentTypes={mockContentTypes}
+        onParameterUpdate={vi.fn()}
+        onRemoveRow={() => null}
+        configuredContentTypePreviewPathSelection={selection}
+      />,
+      { isAppConfigurationSaved: true }
+    );
+
+    expect(screen.getByText(inputs.previewPath.emptyErrorMessage)).toBeTruthy();
+    unmount();
+  });
+
+  it('renders error message when preview path is invalid and user has saved config', () => {
+    const { unmount } = renderConfigPageComponent(
+      <ContentTypePreviewPathSelectionRow
+        contentTypes={mockContentTypes}
+        onParameterUpdate={vi.fn()}
+        onRemoveRow={() => null}
+        configuredContentTypePreviewPathSelection={selection}
+      />,
+      { isAppConfigurationSaved: true }
+    );
+
+    expect(screen.getByText(inputs.previewPath.invalidFormattingMessage)).toBeTruthy();
     unmount();
   });
 });

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.tsx
@@ -88,7 +88,8 @@ export const ContentTypePreviewPathSelectionRow = ({
   }, [isAppConfigurationSaved, configuredPreviewPath, configuredContentType]);
 
   useEffect(() => {
-    if (configuredPreviewPath && isAppConfigurationSaved) {
+    if (!isAppConfigurationSaved) setIsPreviewPathInvalid(false);
+    else if (configuredPreviewPath) {
       const isPreviewPathValid = validatePreviewPath(configuredPreviewPath);
       setIsPreviewPathInvalid(!isPreviewPathValid);
     }

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.tsx
@@ -38,12 +38,11 @@ export const ContentTypePreviewPathSelectionRow = ({
 }: Props) => {
   const [isPreviewPathInvalid, setIsPreviewPathInvalid] = useState(false);
   const [isPreviewPathEmpty, setIsPreviewPathEmpty] = useState(false);
+  const { isAppConfigurationSaved, isLoading } = useContext(ConfigPageContext);
+
   const { contentType: configuredContentType, previewPath: configuredPreviewPath } =
     configuredContentTypePreviewPathSelection;
-
   const { inputs } = copies.configPage.contentTypePreviewPathSection;
-
-  const { isAppConfigurationSaved, isLoading } = useContext(ConfigPageContext);
 
   const handlePreviewPathInput = (event: React.ChangeEvent<HTMLInputElement>) => {
     onParameterUpdate({
@@ -64,6 +63,9 @@ export const ContentTypePreviewPathSelectionRow = ({
   const handleRemoveRow = () => {
     onRemoveRow(configuredContentTypePreviewPathSelection);
   };
+
+  const validatePreviewPath = (previewPath: string) =>
+    [/^\/.*{([^}]+)}.*$/].some((regex) => regex.test(previewPath));
 
   const debouncedHandlePreviewPathInputChange = useMemo(
     () => debounce(handlePreviewPathInput, 700),
@@ -91,9 +93,6 @@ export const ContentTypePreviewPathSelectionRow = ({
       setIsPreviewPathInvalid(!isPreviewPathValid);
     }
   }, [isAppConfigurationSaved, configuredPreviewPath]);
-
-  const validatePreviewPath = (previewPath: string) =>
-    [/^\/.*{([^}]+)}.*$/].some((regex) => regex.test(previewPath));
 
   const itemAlignment = useMemo(() => {
     if (isPreviewPathEmpty || isPreviewPathInvalid) {

--- a/apps/vercel/frontend/src/constants/copies.ts
+++ b/apps/vercel/frontend/src/constants/copies.ts
@@ -46,8 +46,8 @@ export const copies = {
         previewPath: {
           label: 'Preview path',
           placeholder: 'Set preview path and token',
-          emptyErrorMessage: 'Field is empty and omitted from configuration',
-          invalidFormattingMessage: 'Formatting is invalid and omitted from configuration',
+          emptyErrorMessage: 'Field is empty',
+          invalidFormattingMessage: 'Path must start with a "/", and include a {token}',
         },
       },
       infoNote: {

--- a/apps/vercel/frontend/src/constants/copies.ts
+++ b/apps/vercel/frontend/src/constants/copies.ts
@@ -46,7 +46,8 @@ export const copies = {
         previewPath: {
           label: 'Preview path',
           placeholder: 'Set preview path and token',
-          errorMessage: 'This field is empty and not saved',
+          emptyErrorMessage: 'Field is empty and omitted from configuration',
+          invalidFormattingMessage: 'Formatting is invalid and omitted from configuration',
         },
       },
       infoNote: {


### PR DESCRIPTION
## Purpose

The purpose of this PR is to provide validation within the preview path input when a user saves the configuration. 

## Approach

The following rules apply for the validation: 
1. The input must start with a '/' and must contain at least one set of closed curly braces i.e '{}' somewhere within the string. 
The validation of the preview path input will only run when the user has saved the configuration.

I also adjusted the messages that appear for preview path error messages (either empty or invalid). Would love input on those!

<img width="838" alt="Screenshot 2024-04-18 at 7 31 34 AM" src="https://github.com/contentful/apps/assets/58186851/90cb833b-6f35-45d3-817a-7231627998c2">

## Testing steps

Input an invalid preview path, save the config, and notice the error message that appears. The error message should then clear once you interact with the section. 
