### PR TITLE
feat: make SkuPicker search placeholder and help text configurable [INTEG-2017]

### DIFF
--- a/packages/ecommerce-app-base/docs/README.md
+++ b/packages/ecommerce-app-base/docs/README.md
@@ -14,6 +14,8 @@
 - [Integration](README.md#integration)
 - [MakeCTAFn](README.md#makectafn)
 - [MakeSaveBtnTextFn](README.md#makesavebtntextfn)
+- [MakeSearchHelpText](README.md#makesearchhelptext)
+- [MakeSearchPlaceholderText](README.md#makesearchplaceholdertext)
 - [OpenDialogFn](README.md#opendialogfn)
 - [Pagination](README.md#pagination)
 - [ParameterDefinition](README.md#parameterdefinition)
@@ -213,6 +215,50 @@ Returns the text that is used for confirming the dialog selection.
 Text that should be displayed on the button
 
 ___
+
+### MakeSearchHelpText
+
+Ƭ **MakeSearchHelpText**: (`skuType?`: `string`) => `string`
+
+Returns the text that is used as the help text for the SkuPicker search.
+
+#### Type declaration
+
+▸ (`skuType?`): `string`
+
+##### Parameters
+
+| Name       | Type     | Description                                                                                 |
+| :--------- | :------- | :------------------------------------------------------------------------------------------ |
+| `skuType?` | `string` | SKU type of the current field. Undefined if only a single SKU type is supported by the app. |
+
+##### Returns
+
+`string`
+
+---
+
+### MakeSearchPlaceholderText
+
+Ƭ **MakeSearchPlaceholderText**: (`skuType?`: `string`) => `string`
+
+Returns the text that is used as the placeholder for the SkuPicker search.
+
+#### Type declaration
+
+▸ (`skuType?`): `string`
+
+##### Parameters
+
+| Name       | Type     | Description                                                                                 |
+| :--------- | :------- | :------------------------------------------------------------------------------------------ |
+| `skuType?` | `string` | SKU type of the current field. Undefined if only a single SKU type is supported by the app. |
+
+##### Returns
+
+`string`
+
+---
 
 ### OpenDialogFn
 

--- a/packages/ecommerce-app-base/src/SkuPicker/SkuPicker.spec.tsx
+++ b/packages/ecommerce-app-base/src/SkuPicker/SkuPicker.spec.tsx
@@ -75,6 +75,24 @@ describe('SkuPicker', () => {
     expect(getByTestId('search-by-sku')).toBeInTheDocument();
   });
 
+  it('should render custom placeholder text in search box when makeSearchPlaceholderText exists', async () => {
+    const makeSearchPlaceholderText = jest.fn(() => 'My custom placeholder text');
+    const { getByPlaceholderText } = await renderComponent({
+      ...defaultProps,
+      makeSearchPlaceholderText,
+    });
+    expect(getByPlaceholderText('My custom placeholder text')).toBeInTheDocument();
+  });
+
+  it('should render custom help text under search box when makeSearchHelpText exists', async () => {
+    const makeSearchHelpText = jest.fn(() => 'My custom help text');
+    const { getByText } = await renderComponent({
+      ...defaultProps,
+      makeSearchHelpText,
+    });
+    expect(getByText('My custom help text')).toBeInTheDocument();
+  });
+
   describe('when it has infinite scrolling mode pagination', () => {
     it('should render the "Load more" text link if there is a next page', async () => {
       const { findByTestId } = await renderComponent({

--- a/packages/ecommerce-app-base/src/SkuPicker/SkuPicker.tsx
+++ b/packages/ecommerce-app-base/src/SkuPicker/SkuPicker.tsx
@@ -8,6 +8,7 @@ import { Paginator } from './Paginator';
 import {
   MakeSaveBtnTextFn,
   MakeSearchPlaceholderText,
+  MakeSearchHelpText,
   Pagination,
   Product,
   ProductPreviewsFn,
@@ -17,7 +18,7 @@ import { ProductSelectionList } from './ProductSelectionList';
 import { styles } from './styles';
 import { mapSort } from '../utils';
 
-import { Button, Checkbox, Text, TextInput } from '@contentful/f36-components';
+import { Button, Checkbox, Flex, Text, TextInput } from '@contentful/f36-components';
 
 import { SearchIcon } from '@contentful/f36-icons';
 
@@ -29,6 +30,7 @@ export interface Props {
   skuType?: string;
   makeSaveBtnText?: MakeSaveBtnTextFn;
   makeSearchPlaceholderText?: MakeSearchPlaceholderText;
+  makeSearchHelpText?: MakeSearchHelpText;
   hideSearch?: boolean;
   showSearchBySkuOption?: boolean;
 }
@@ -45,10 +47,6 @@ interface State {
 
 const DEFAULT_SEARCH_DELAY = 250;
 
-function defaultMakeSearchPlaceholderText(_skuType?: string): string {
-  return 'Search for a product...';
-}
-
 function defaultGetSaveBtnText(selectedSKUs: string[]): string {
   switch (selectedSKUs.length) {
     case 0:
@@ -58,6 +56,10 @@ function defaultGetSaveBtnText(selectedSKUs: string[]): string {
     default:
       return `Save ${selectedSKUs.length} products`;
   }
+}
+
+function defaultMakeSearchPlaceholderText(_skuType?: string): string {
+  return 'Search for a product...';
 }
 
 export class SkuPicker extends Component<Props, State> {
@@ -166,12 +168,37 @@ export class SkuPicker extends Component<Props, State> {
     }
   };
 
+  constructSearchAdditionalInfo = (
+    makeSearchHelpText: MakeSearchHelpText | undefined,
+    skuType: string | undefined,
+    paginationTotal: number
+  ) => {
+    const helpText = makeSearchHelpText ? makeSearchHelpText(skuType) : '';
+    const totalResults = !!paginationTotal
+      ? `${paginationTotal.toLocaleString()} total results`
+      : '';
+
+    if (helpText && totalResults) {
+      return (
+        <Flex justifyContent="space-between">
+          <Text marginRight="spacingXl" className={styles.helpText}>
+            {helpText}
+          </Text>
+          <Text className={styles.helpText}>{totalResults}</Text>
+        </Flex>
+      );
+    } else {
+      return <Text className={styles.helpText}>{helpText || totalResults}</Text>;
+    }
+  };
+
   render() {
     const { search, pagination, products, selectedProducts, selectedSKUs, searchBySku } =
       this.state;
     const {
       makeSaveBtnText = defaultGetSaveBtnText,
       makeSearchPlaceholderText = defaultMakeSearchPlaceholderText,
+      makeSearchHelpText,
       skuType,
       hideSearch = false,
       showSearchBySkuOption,
@@ -195,8 +222,12 @@ export class SkuPicker extends Component<Props, State> {
                     value={search}
                     onChange={(event) => this.setSearch((event.target as HTMLInputElement).value)}
                   />
-
                   <SearchIcon variant="muted" />
+                  {this.constructSearchAdditionalInfo(
+                    makeSearchHelpText,
+                    skuType,
+                    pagination.total
+                  )}
                 </div>
 
                 {showSearchBySkuOption && (
@@ -212,12 +243,6 @@ export class SkuPicker extends Component<Props, State> {
                   </div>
                 )}
               </div>
-            )}
-
-            {!!pagination.total && (
-              <Text className={styles.total}>
-                {pagination.total.toLocaleString()} total results
-              </Text>
             )}
           </div>
 

--- a/packages/ecommerce-app-base/src/SkuPicker/SkuPicker.tsx
+++ b/packages/ecommerce-app-base/src/SkuPicker/SkuPicker.tsx
@@ -5,7 +5,14 @@ import debounce from 'lodash/debounce';
 import { DialogAppSDK } from '@contentful/app-sdk';
 import { ProductList } from './ProductList';
 import { Paginator } from './Paginator';
-import { MakeSaveBtnTextFn, Pagination, Product, ProductPreviewsFn, ProductsFn } from '../types';
+import {
+  MakeSaveBtnTextFn,
+  MakeSearchPlaceholderText,
+  Pagination,
+  Product,
+  ProductPreviewsFn,
+  ProductsFn,
+} from '../types';
 import { ProductSelectionList } from './ProductSelectionList';
 import { styles } from './styles';
 import { mapSort } from '../utils';
@@ -21,6 +28,7 @@ export interface Props {
   searchDelay?: number;
   skuType?: string;
   makeSaveBtnText?: MakeSaveBtnTextFn;
+  makeSearchPlaceholderText?: MakeSearchPlaceholderText;
   hideSearch?: boolean;
   showSearchBySkuOption?: boolean;
 }
@@ -36,6 +44,10 @@ interface State {
 }
 
 const DEFAULT_SEARCH_DELAY = 250;
+
+function defaultMakeSearchPlaceholderText(_skuType?: string): string {
+  return 'Search for a product...';
+}
 
 function defaultGetSaveBtnText(selectedSKUs: string[]): string {
   switch (selectedSKUs.length) {
@@ -159,6 +171,7 @@ export class SkuPicker extends Component<Props, State> {
       this.state;
     const {
       makeSaveBtnText = defaultGetSaveBtnText,
+      makeSearchPlaceholderText = defaultMakeSearchPlaceholderText,
       skuType,
       hideSearch = false,
       showSearchBySkuOption,
@@ -174,7 +187,7 @@ export class SkuPicker extends Component<Props, State> {
               <div className={styles.searchWrapper}>
                 <div className={styles.leftSideControls}>
                   <TextInput
-                    placeholder="Search for a product..."
+                    placeholder={makeSearchPlaceholderText(skuType)}
                     type="search"
                     name="sku-search"
                     id="sku-search"

--- a/packages/ecommerce-app-base/src/SkuPicker/SkuPicker.tsx
+++ b/packages/ecommerce-app-base/src/SkuPicker/SkuPicker.tsx
@@ -58,9 +58,9 @@ function defaultGetSaveBtnText(selectedSKUs: string[]): string {
   }
 }
 
-function defaultMakeSearchPlaceholderText(_skuType?: string): string {
+const defaultMakeSearchPlaceholderText: MakeSearchPlaceholderText = (_skuType) => {
   return 'Search for a product...';
-}
+};
 
 export class SkuPicker extends Component<Props, State> {
   state: State = {

--- a/packages/ecommerce-app-base/src/SkuPicker/renderSkuPicker.tsx
+++ b/packages/ecommerce-app-base/src/SkuPicker/renderSkuPicker.tsx
@@ -2,7 +2,12 @@ import * as React from 'react';
 import { DialogAppSDK } from '@contentful/app-sdk';
 import { render } from 'react-dom';
 import { SkuPicker } from './SkuPicker';
-import { MakeSaveBtnTextFn, ProductPreviewsFn, ProductsFn } from '../types';
+import {
+  MakeSaveBtnTextFn,
+  MakeSearchPlaceholderText,
+  ProductPreviewsFn,
+  ProductsFn,
+} from '../types';
 
 interface Props<> {
   sdk: DialogAppSDK;
@@ -11,6 +16,7 @@ interface Props<> {
   searchDelay?: number;
   skuType?: string;
   makeSaveBtnText?: MakeSaveBtnTextFn;
+  makeSearchPlaceholderText?: MakeSearchPlaceholderText;
   hideSearch?: boolean;
   showSearchBySkuOption?: boolean;
 }
@@ -24,6 +30,7 @@ export function renderSkuPicker(
     searchDelay,
     skuType,
     makeSaveBtnText,
+    makeSearchPlaceholderText,
     hideSearch,
     showSearchBySkuOption,
   }: Props
@@ -38,6 +45,7 @@ export function renderSkuPicker(
       searchDelay={searchDelay}
       skuType={skuType}
       makeSaveBtnText={makeSaveBtnText}
+      makeSearchPlaceholderText={makeSearchPlaceholderText}
       hideSearch={hideSearch}
       showSearchBySkuOption={showSearchBySkuOption}
     />,

--- a/packages/ecommerce-app-base/src/SkuPicker/renderSkuPicker.tsx
+++ b/packages/ecommerce-app-base/src/SkuPicker/renderSkuPicker.tsx
@@ -5,6 +5,7 @@ import { SkuPicker } from './SkuPicker';
 import {
   MakeSaveBtnTextFn,
   MakeSearchPlaceholderText,
+  MakeSearchHelpText,
   ProductPreviewsFn,
   ProductsFn,
 } from '../types';
@@ -17,6 +18,7 @@ interface Props<> {
   skuType?: string;
   makeSaveBtnText?: MakeSaveBtnTextFn;
   makeSearchPlaceholderText?: MakeSearchPlaceholderText;
+  makeSearchHelpText?: MakeSearchHelpText;
   hideSearch?: boolean;
   showSearchBySkuOption?: boolean;
 }
@@ -31,6 +33,7 @@ export function renderSkuPicker(
     skuType,
     makeSaveBtnText,
     makeSearchPlaceholderText,
+    makeSearchHelpText,
     hideSearch,
     showSearchBySkuOption,
   }: Props
@@ -46,6 +49,7 @@ export function renderSkuPicker(
       skuType={skuType}
       makeSaveBtnText={makeSaveBtnText}
       makeSearchPlaceholderText={makeSearchPlaceholderText}
+      makeSearchHelpText={makeSearchHelpText}
       hideSearch={hideSearch}
       showSearchBySkuOption={showSearchBySkuOption}
     />,

--- a/packages/ecommerce-app-base/src/SkuPicker/styles.ts
+++ b/packages/ecommerce-app-base/src/SkuPicker/styles.ts
@@ -39,11 +39,10 @@ export const styles = {
     },
   }),
   body: makeBodyStyle(),
-  total: css({
-    fontSize: tokens.fontSizeS,
-    color: tokens.gray600,
+  helpText: css({
+    color: tokens.gray500,
     display: 'block',
-    marginTop: tokens.spacingS,
+    marginTop: tokens.spacingXs,
   }),
   saveBtn: css({
     marginRight: tokens.spacingM,
@@ -55,6 +54,7 @@ export const styles = {
   leftSideControls: css({
     position: 'relative',
     zIndex: 0,
+    minWidth: '320px',
     svg: css({
       zIndex: 1,
       position: 'absolute',
@@ -80,7 +80,8 @@ export const styles = {
   }),
   skuSearch: css({
     display: 'flex',
-    alignItems: 'center',
+    alignSelf: 'flex-start',
+    marginTop: tokens.spacingXs,
     marginLeft: tokens.spacingM,
     marginRight: tokens.spacingXs,
   }),

--- a/packages/ecommerce-app-base/src/types/ui.ts
+++ b/packages/ecommerce-app-base/src/types/ui.ts
@@ -28,6 +28,14 @@ export type MakeSaveBtnTextFn = (selectedSKUs: string[], skuType?: string) => st
 export type MakeSearchPlaceholderText = (skuType?: string) => string;
 
 /**
+ * Returns the text that is used as the help text for the SkuPicker search.
+ *
+ * @param skuType SKU type of the current field. Undefined if only a single SKU type is supported by the app.
+ * @returns Text that should be displayed as the help text
+ */
+export type MakeSearchHelpText = (skuType?: string) => string;
+
+/**
  * Custom code that validates installation parameters that is run before saving.
  *
  * @param parameters Object containg the entered parameters.

--- a/packages/ecommerce-app-base/src/types/ui.ts
+++ b/packages/ecommerce-app-base/src/types/ui.ts
@@ -20,6 +20,14 @@ export type MakeCTAFn = (fieldType: string, skuType?: string) => string;
 export type MakeSaveBtnTextFn = (selectedSKUs: string[], skuType?: string) => string;
 
 /**
+ * Returns the text that is used as the placeholder for the SkuPicker search.
+ *
+ * @param skuType SKU type of the current field. Undefined if only a single SKU type is supported by the app.
+ * @returns Text that should be displayed as the placeholder
+ */
+export type MakeSearchPlaceholderText = (skuType?: string) => string;
+
+/**
  * Custom code that validates installation parameters that is run before saving.
  *
  * @param parameters Object containg the entered parameters.


### PR DESCRIPTION
## Purpose

The SkuPicker component had the placeholder text hardcoded to "Search for a Product...", which is not helpful if your ecommerce app supports multiple sku types (e.g. categories). Also, this PR adds the ability to create help text under the search box. This is the first step in adding in category search functionality in the commercetools app, and also addresses bugs in apps with multiple sku types, since the placeholder text was incorrect.

## Approach

I added two new functions: `MakeSearchHelpText` and `MakeSearchPlaceholderText`. I ensured that these were backwards compatible if the app doesn't pass in these functions. Otherwise, the app consuming this library will need to pass in these functions in order to have configured placeholder and help text. Here's a branch where I am testing these changes with the commercetools app: https://github.com/contentful/apps/compare/master...feat/commercetools-category-search

I also made some small UI improvements, like making the search box wider and making the help text and total count the same font.

Here are the various states now supported:

Default placeholder with no help text or total results:
![Screenshot 2024-04-17 at 2 42 45 PM](https://github.com/contentful/apps/assets/62958907/cae49b74-48ae-46fb-b2e2-351afeefc00a)

Default placeholder with total results:
![Screenshot 2024-04-17 at 2 43 32 PM](https://github.com/contentful/apps/assets/62958907/f3c9f576-8da8-4322-897e-dc9943ccd7b1)

Custom placeholder with help text:
![Screenshot 2024-04-17 at 2 43 06 PM](https://github.com/contentful/apps/assets/62958907/0861ef9e-0482-409f-98b4-f54387546512)

Custom placeholder with help text and total results:
![Screenshot 2024-04-17 at 2 36 06 PM](https://github.com/contentful/apps/assets/62958907/f3603c71-acec-44d2-b9a5-dee85ea6e186)

I also ensured that this works with the "Search only by SKU option" in the commercetools app:
![Screenshot 2024-04-17 at 3 45 48 PM](https://github.com/contentful/apps/assets/62958907/29e8f131-a939-4bad-ab8e-1c87f4df9a1d)


## Testing steps

I tested this in Storybook and also locally by linking the package in the commercetools app.

## Breaking Changes

There should not be any breaking changes introduced here

## Dependencies and/or References

## Deployment

