### PR TITLE
fix: resolve issue when project no longer exists

### DIFF
--- a/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.tsx
+++ b/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.tsx
@@ -49,7 +49,7 @@ export const SelectSection = ({
   return (
     <FormControl marginBottom="spacingS" id={id} isRequired={true}>
       <Select
-        value={selectedOption}
+        value={isSelectionInvalid ? '' : selectedOption}
         onChange={handleChange}
         placeholder={placeholder}
         emptyMessage={emptyMessage}

--- a/apps/vercel/frontend/src/constants/copies.ts
+++ b/apps/vercel/frontend/src/constants/copies.ts
@@ -17,14 +17,16 @@ export const copies = {
       label: 'Project',
       placeholder: 'Select a project',
       emptyMessage: 'No Vercel projects are available',
-      errorMessage: 'This project is no longer available. Please select another one.',
+      errorMessage:
+        'The project you have configured is no longer available. Please select another one.',
       helpText: 'Connect to a project associated with your website or experience.',
     },
     pathSelectionSection: {
       label: 'API Path',
       placeholder: 'Select a path',
       emptyMessage: 'No paths currently configured.',
-      errorMessage: 'This path is no longer available. Please select another one.',
+      errorMessage:
+        'The path you have configured is no longer available. Please select another one.',
       helpText: 'Select a Vercel route to enable your draft mode.',
     },
     contentTypePreviewPathSection: {


### PR DESCRIPTION
## Purpose

The purpose of this PR is to ensure a user is not confused by the wording of the error message, as well as the default selection of another new project, when a project they had configured is no longer available in the list of projects. 

## Approach

Originally, when a configured project value no longer existed, a different project was selected AND the error was shown, causing confusion to the user.

I have adjusted the copy and logic to ensure that when there is in incompatible configured project or path  with the current list of projects or paths, that the user understands clearly how to resolve it. 

### Before 
<img width="850" alt="Screenshot 2024-04-18 at 9 23 30 AM" src="https://github.com/contentful/apps/assets/58186851/07d4ddfb-b37e-4c9c-b5c0-fafc291a327d">

### After

<img width="859" alt="Screenshot 2024-04-18 at 11 23 49 AM" src="https://github.com/contentful/apps/assets/58186851/22efc70a-108a-4e70-8ae9-30be74dcde63">

