### PR TITLE
feat: add exact match search to category picker [INTEG-2018]

### DIFF
--- a/apps/commercetools/package-lock.json
+++ b/apps/commercetools/package-lock.json
@@ -12,7 +12,7 @@
         "@commercetools/sdk-client-v2": "1.4.2",
         "@contentful/app-scripts": "1.2.0",
         "@contentful/app-sdk": "4.23.0",
-        "@contentful/ecommerce-app-base": "3.5.1",
+        "@contentful/ecommerce-app-base": "^3.6.0",
         "@contentful/f36-components": "4.64.0",
         "@contentful/react-apps-toolkit": "1.2.16",
         "react": "17.0.1",
@@ -2207,9 +2207,10 @@
       }
     },
     "node_modules/@contentful/ecommerce-app-base": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@contentful/ecommerce-app-base/-/ecommerce-app-base-3.5.1.tgz",
-      "integrity": "sha512-AStRsVIAQg8xt9Pq8iOJbw9099mCTAL7njHv24gJRjQqmHCwyu/Og20aKK8P/Ue7cUdqJwPbsuopp8OLGRo/5g==",
+      "version": "3.6.0",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/ecommerce-app-base/3.6.0/a43599ed0c0a1c5f0f99d6ed789a11a49a4b7b02",
+      "integrity": "sha512-iuQFyC6nUevxQ38eEEq3zKu544zYq0pIlg77hd0uImen4373H6XsaDSuqY59gopgyH/u/mfpwL9TsR4oTnUxPQ==",
+      "license": "MIT",
       "dependencies": {
         "@contentful/app-sdk": "^4.23.0",
         "@contentful/f36-components": "^4.0.42",
@@ -21390,9 +21391,9 @@
       }
     },
     "@contentful/ecommerce-app-base": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@contentful/ecommerce-app-base/-/ecommerce-app-base-3.5.1.tgz",
-      "integrity": "sha512-AStRsVIAQg8xt9Pq8iOJbw9099mCTAL7njHv24gJRjQqmHCwyu/Og20aKK8P/Ue7cUdqJwPbsuopp8OLGRo/5g==",
+      "version": "3.6.0",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/ecommerce-app-base/3.6.0/a43599ed0c0a1c5f0f99d6ed789a11a49a4b7b02",
+      "integrity": "sha512-iuQFyC6nUevxQ38eEEq3zKu544zYq0pIlg77hd0uImen4373H6XsaDSuqY59gopgyH/u/mfpwL9TsR4oTnUxPQ==",
       "requires": {
         "@contentful/app-sdk": "^4.23.0",
         "@contentful/f36-components": "^4.0.42",

--- a/apps/commercetools/package.json
+++ b/apps/commercetools/package.json
@@ -13,7 +13,7 @@
     "@commercetools/sdk-client-v2": "1.4.2",
     "@contentful/app-scripts": "1.2.0",
     "@contentful/app-sdk": "4.23.0",
-    "@contentful/ecommerce-app-base": "3.5.1",
+    "@contentful/ecommerce-app-base": "^3.6.0",
     "@contentful/f36-components": "4.64.0",
     "@contentful/react-apps-toolkit": "1.2.16",
     "react": "17.0.1",

--- a/apps/commercetools/src/api/categories.ts
+++ b/apps/commercetools/src/api/categories.ts
@@ -80,22 +80,37 @@ export async function fetchCategoryPreviews(
 
 export async function fetchCategories(
   config: ConfigurationParameters,
-  _search: string,
+  search: string,
   pagination: { offset: number; limit: number }
 ): Promise<{
   pagination: Pagination;
   products: CommerceToolsProduct[];
 }> {
   const client = createClient(config);
-  const response = await client
-    .categories()
-    .get({
-      queryArgs: {
-        limit: pagination?.limit,
-        offset: pagination?.offset,
-      },
-    })
-    .execute();
+  let response;
+
+  if (search) {
+    response = await client
+      .categories()
+      .get({
+        queryArgs: {
+          limit: pagination?.limit,
+          offset: pagination?.offset,
+          where: `key="${search}" or name(${config.locale}="${search}") or slug(${config.locale}="${search}")`,
+        },
+      })
+      .execute();
+  } else {
+    response = await client
+      .categories()
+      .get({
+        queryArgs: {
+          limit: pagination?.limit,
+          offset: pagination?.offset,
+        },
+      })
+      .execute();
+  }
 
   if (response.statusCode === 200) {
     return {

--- a/apps/commercetools/src/dialog.ts
+++ b/apps/commercetools/src/dialog.ts
@@ -39,6 +39,14 @@ function makeSearchPlaceholderText(skuType: string | undefined): string {
   }
 }
 
+function makeSearchHelpText(skuType: string | undefined): string {
+  if (skuType === 'category') {
+    return 'Search value must be an exact match';
+  } else {
+    return '';
+  }
+}
+
 export async function renderDialog(sdk: DialogAppSDK) {
   const DIALOG_ID = 'dialog-root';
 
@@ -59,6 +67,7 @@ export async function renderDialog(sdk: DialogAppSDK) {
     skuType,
     makeSaveBtnText: makeSaveBtnText(skuType),
     makeSearchPlaceholderText,
+    makeSearchHelpText,
     hideSearch: false,
     showSearchBySkuOption: skuType === 'product',
   });

--- a/apps/commercetools/src/dialog.ts
+++ b/apps/commercetools/src/dialog.ts
@@ -31,6 +31,14 @@ function makeSaveBtnText(skuType: SkuType) {
   }
 }
 
+function makeSearchPlaceholderText(skuType: string | undefined): string {
+  if (skuType === 'category') {
+    return 'Search by category name, slug, or key...';
+  } else {
+    return 'Search for a product...';
+  }
+}
+
 export async function renderDialog(sdk: DialogAppSDK) {
   const DIALOG_ID = 'dialog-root';
 
@@ -50,6 +58,7 @@ export async function renderDialog(sdk: DialogAppSDK) {
     searchDelay: 750,
     skuType,
     makeSaveBtnText: makeSaveBtnText(skuType),
+    makeSearchPlaceholderText,
     hideSearch: false,
     showSearchBySkuOption: skuType === 'product',
   });

--- a/apps/commercetools/src/dialog.ts
+++ b/apps/commercetools/src/dialog.ts
@@ -50,8 +50,8 @@ export async function renderDialog(sdk: DialogAppSDK) {
     searchDelay: 750,
     skuType,
     makeSaveBtnText: makeSaveBtnText(skuType),
-    hideSearch: skuType === 'category',
-    showSearchBySkuOption: true,
+    hideSearch: false,
+    showSearchBySkuOption: skuType === 'product',
   });
 
   sdk.window.startAutoResizer();


### PR DESCRIPTION
## Purpose

This PR updates the category API call and implements the changes made in the ecommerce-app-base package (https://github.com/contentful/apps/pull/7337) in order to add category search to the commercetools app.

## Approach

I added the `where` query parameter and used their query predicate structure to query based on category name, key, and slug ([documentation here](https://docs.commercetools.com/api/projects/categories#query-categories)).

I bumped the `ecommerce-app-base` package and implemented the two new functions available to customize the search placeholder text and help text. I also updated the `hideSearch` and `showSearchBySkuOption` parameters accordingly

![Screenshot 2024-04-19 at 3 15 05 PM](https://github.com/contentful/apps/assets/62958907/12994cbf-947a-4f07-80c1-fab184808eba)

## Testing steps

I tested the changes with single and multiple products and categories to ensure everything still worked as expected. 

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
