### PR TITLE
fix: ensure authentication token logic is handled consistently 

### DIFF
--- a/apps/vercel/frontend/src/clients/Vercel.spec.ts
+++ b/apps/vercel/frontend/src/clients/Vercel.spec.ts
@@ -27,7 +27,7 @@ describe('VercelClient', () => {
       it('returns true for valid token', async () => {
         const res = await client.checkToken();
 
-        expect(res).toBe(true);
+        expect(res.ok).toBe(true);
       });
     });
 
@@ -42,7 +42,7 @@ describe('VercelClient', () => {
       it('returns false for invalid token', async () => {
         const res = await client.checkToken();
 
-        expect(res).toBe(false);
+        expect(res.ok).toBe(false);
       });
     });
   });

--- a/apps/vercel/frontend/src/clients/Vercel.ts
+++ b/apps/vercel/frontend/src/clients/Vercel.ts
@@ -7,8 +7,12 @@ import {
   ServerlessFunction,
 } from '@customTypes/configPage';
 
+interface CheckTokenResponse {
+  ok: boolean;
+}
+
 interface VercelAPIClient {
-  checkToken: () => Promise<boolean>;
+  checkToken: () => Promise<CheckTokenResponse>;
   listProjects: () => Promise<ListProjectsResponse>;
   createDeployment: (input: CreateDeploymentInput) => Promise<Deployment>;
   getDeploymentById: (deploymentId: string) => Promise<Deployment>;
@@ -24,13 +28,13 @@ export default class VercelClient implements VercelAPIClient {
     });
   }
 
-  async checkToken(): Promise<boolean> {
+  async checkToken(): Promise<CheckTokenResponse> {
     const res = await fetch(`${this.baseEndpoint}/v5/user/tokens`, {
       headers: this.buildHeaders(),
       method: 'GET',
     });
 
-    return res.ok;
+    return { ok: res.ok };
   }
 
   async listProjects(): Promise<ListProjectsResponse> {

--- a/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.tsx
+++ b/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.tsx
@@ -41,10 +41,13 @@ export const SelectSection = ({
   };
 
   useEffect(() => {
-    const isValidSelection = options.some((item) => item.id === selectedOption) || !selectedOption;
-    const areOptionsAvailable = options.length === 0;
-    setIsSelectionInvalid(!isValidSelection && !areOptionsAvailable);
-  }, [selectedOption, options]);
+    if (!isLoading) {
+      const isValidSelection =
+        options.some((item) => item.id === selectedOption) || !selectedOption;
+      const areOptionsAvailable = options.length === 0;
+      setIsSelectionInvalid(!isValidSelection && !areOptionsAvailable);
+    }
+  }, [selectedOption, options, isLoading]);
 
   return (
     <FormControl marginBottom="spacingS" id={id} isRequired={true}>

--- a/apps/vercel/frontend/src/locations/ConfigScreen.spec.tsx
+++ b/apps/vercel/frontend/src/locations/ConfigScreen.spec.tsx
@@ -30,7 +30,7 @@ describe('ConfigScreen', () => {
   });
 
   it('renders the project sections once there is a valid token', async () => {
-    vi.spyOn(VercelClient.prototype, 'checkToken').mockResolvedValue(true);
+    vi.spyOn(VercelClient.prototype, 'checkToken').mockResolvedValue({ ok: true });
     const { unmount } = render(<ConfigScreen />);
 
     expect(await screen.findByText('Connect Vercel')).toBeTruthy();

--- a/apps/vercel/frontend/src/locations/ConfigScreen.tsx
+++ b/apps/vercel/frontend/src/locations/ConfigScreen.tsx
@@ -71,8 +71,8 @@ const ConfigScreen = () => {
     }
 
     if (!parameters.vercelAccessToken) {
-      const isTokenEmpty = true;
-      updateTokenValidityState(isTokenEmpty);
+      // if there is no value set for the access token we will consider it valid
+      updateTokenValidityState(true);
     } else if (!hasTokenBeenValidated) {
       checkToken();
     }

--- a/apps/vercel/frontend/src/locations/ConfigScreen.tsx
+++ b/apps/vercel/frontend/src/locations/ConfigScreen.tsx
@@ -66,20 +66,15 @@ const ConfigScreen = () => {
     async function checkToken() {
       if (vercelClient) {
         const response = await vercelClient.checkToken();
-        if (response) {
-          setIsLoading(false);
-          setIsTokenValid(response.ok);
-          setHasTokenBeenValidated(true);
-        }
+        if (response) updateTokenValidityState(response.ok);
       }
     }
 
-    if (!hasTokenBeenValidated && parameters.vercelAccessToken) {
+    if (!parameters.vercelAccessToken) {
+      const isTokenEmpty = true;
+      updateTokenValidityState(isTokenEmpty);
+    } else if (!hasTokenBeenValidated) {
       checkToken();
-    } else if (!parameters.vercelAccessToken) {
-      setHasTokenBeenValidated(true);
-      setIsLoading(false);
-      setIsTokenValid(true);
     }
   }, [parameters.vercelAccessToken]);
 
@@ -134,6 +129,12 @@ const ConfigScreen = () => {
     }
   }, [parameters.selectedProject, vercelClient]);
 
+  const updateTokenValidityState = (tokenValidity: boolean) => {
+    setIsLoading(false);
+    setIsTokenValid(tokenValidity);
+    setHasTokenBeenValidated(true);
+  };
+
   const handleTokenChange = (e: ChangeEvent<HTMLInputElement>) => {
     setIsLoading(true);
 
@@ -144,9 +145,7 @@ const ConfigScreen = () => {
 
     async function checkToken() {
       const response = await new VercelClient(e.target.value).checkToken();
-      setIsTokenValid(response.ok);
-      setIsLoading(false);
-      setHasTokenBeenValidated(true);
+      updateTokenValidityState(response.ok);
     }
 
     checkToken();

--- a/apps/vercel/frontend/src/locations/ConfigScreen.tsx
+++ b/apps/vercel/frontend/src/locations/ConfigScreen.tsx
@@ -83,7 +83,7 @@ const ConfigScreen = () => {
       const contentTypesResponse = await sdk.cma.contentType.getMany({});
 
       if (contentTypesResponse.items && contentTypesResponse.items.length) {
-        setContentTypes(contentTypesResponse.items);
+        setContentTypes(contentTypesResponse.items || []);
       }
     }
 
@@ -95,7 +95,7 @@ const ConfigScreen = () => {
       setIsLoading(true);
       if (vercelClient) {
         const data = await vercelClient.listProjects();
-        setProjects(data.projects);
+        setProjects(data.projects || []);
       }
       setIsLoading(false);
     }
@@ -110,7 +110,7 @@ const ConfigScreen = () => {
       setIsLoading(true);
       if (vercelClient) {
         const data = await vercelClient.listApiPaths(parameters.selectedProject);
-        setApiPaths(data);
+        setApiPaths(data || []);
       }
 
       setIsLoading(false);

--- a/apps/vercel/frontend/src/locations/ConfigScreen.tsx
+++ b/apps/vercel/frontend/src/locations/ConfigScreen.tsx
@@ -105,7 +105,9 @@ const ConfigScreen = () => {
       setIsLoading(false);
     }
 
-    if (parameters.vercelAccessToken && hasTokenBeenValidated && isTokenValid) getProjects();
+    if (parameters.vercelAccessToken && hasTokenBeenValidated && isTokenValid) {
+      getProjects();
+    }
   }, [parameters.vercelAccessToken, hasTokenBeenValidated, isTokenValid, vercelClient]);
 
   useEffect(() => {


### PR DESCRIPTION
## Purpose

The purpose of this PR is to do the following: 
1. Ensure that the VercelClient is never instantiated without the applied access token. 
2. Ensure that the loading and "validity" states that are dictating the rendering and error states on the Config page are being adjusted based on valid calls and responses from API communication. 
3. Ensure you cannot save an invalid token. 

## Approach

You will notice comments throughout the code, but I have made a few conditional adjustments within the ConfigPage code. Transparently, I am not excited by the ever-increasing complexity of our loading states and conditional statements, so I have a follow-up task to really abstract some of this, but feel its higher priority to work on other things at this time. 

## Testing steps

Work through the following testing flows: 
1. Clean install the Vercel app, and iterate on adding an invalid as well as a valid token. Play around with reloading the frame for the various states and observe there shouldn't be flashing of any error state, and notice that you cannot install when the token is invalid. You may notice a small flash of a component that renders and then unmounts when the token being applied is invalid, but I feel this is a small price to pay when everything else is working great right now. Not letting good get in the way of perfect at the moment 😅 . 
2. Also play around in the same way as above, but with an already installed app. 

