### PR TITLE
chore: update sidenotes packages

### DIFF
--- a/apps/side-notes-app/package-lock.json
+++ b/apps/side-notes-app/package-lock.json
@@ -23,7 +23,7 @@
         "@contentful/field-editor-rating": "^1.2.0",
         "@contentful/field-editor-reference": "5.27.0",
         "@contentful/field-editor-rich-text": "^3.3.2",
-        "@contentful/field-editor-single-line": "^1.1.7",
+        "@contentful/field-editor-single-line": "^1.3.9",
         "@contentful/field-editor-slug": "^1.2.0",
         "@contentful/field-editor-tags": "^1.2.0",
         "@contentful/field-editor-url": "^1.2.0",
@@ -1857,16 +1857,15 @@
       }
     },
     "node_modules/@contentful/field-editor-single-line": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-single-line/-/field-editor-single-line-1.1.7.tgz",
-      "integrity": "sha512-B2zALG2RSl6GKH5WF7Z7bLCSlKXmsaa7zt4gEXdxWFKrUaPm6lzOHeQ0BIwEoVVaKTsRrPws1Pk4R82P8SPEXQ==",
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-single-line/-/field-editor-single-line-1.3.9.tgz",
+      "integrity": "sha512-YQ+mGOndR+WtJ3gpso/JRyrwbo42suiRIPeSRq7twt5qOev9jyhczbbUDANCjwucfn8oPnl5H39w58lCgumq1Q==",
       "dependencies": {
         "@contentful/f36-components": "^4.0.27",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/field-editor-shared": "^1.1.4",
+        "@contentful/field-editor-shared": "^1.4.7",
         "emotion": "^10.0.17",
-        "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15"
+        "lodash": "^4.17.15"
       },
       "peerDependencies": {
         "react": ">=16.8.0"
@@ -9111,11 +9110,6 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
-    "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
-    },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
@@ -13672,16 +13666,15 @@
       }
     },
     "@contentful/field-editor-single-line": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-single-line/-/field-editor-single-line-1.1.7.tgz",
-      "integrity": "sha512-B2zALG2RSl6GKH5WF7Z7bLCSlKXmsaa7zt4gEXdxWFKrUaPm6lzOHeQ0BIwEoVVaKTsRrPws1Pk4R82P8SPEXQ==",
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-single-line/-/field-editor-single-line-1.3.9.tgz",
+      "integrity": "sha512-YQ+mGOndR+WtJ3gpso/JRyrwbo42suiRIPeSRq7twt5qOev9jyhczbbUDANCjwucfn8oPnl5H39w58lCgumq1Q==",
       "requires": {
         "@contentful/f36-components": "^4.0.27",
         "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/field-editor-shared": "^1.1.4",
+        "@contentful/field-editor-shared": "^1.4.7",
         "emotion": "^10.0.17",
-        "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15"
+        "lodash": "^4.17.15"
       }
     },
     "@contentful/field-editor-slug": {
@@ -17526,11 +17519,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
-    "lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "lodash.isplainobject": {
       "version": "4.0.6",

--- a/apps/side-notes-app/package.json
+++ b/apps/side-notes-app/package.json
@@ -18,7 +18,7 @@
     "@contentful/field-editor-rating": "^1.2.0",
     "@contentful/field-editor-reference": "5.27.0",
     "@contentful/field-editor-rich-text": "^3.3.2",
-    "@contentful/field-editor-single-line": "^1.1.7",
+    "@contentful/field-editor-single-line": "^1.3.9",
     "@contentful/field-editor-slug": "^1.2.0",
     "@contentful/field-editor-tags": "^1.2.0",
     "@contentful/field-editor-url": "^1.2.0",


### PR DESCRIPTION
## Purpose

Single line fields in sidenotes crash the app. This updates the package to a version that supports our current version of react