### PR TITLE
feat: add fallback component for an API path

### DIFF
--- a/apps/vercel/frontend/src/clients/Vercel.ts
+++ b/apps/vercel/frontend/src/clients/Vercel.ts
@@ -52,24 +52,36 @@ export default class VercelClient implements VercelAPIClient {
     projectId: string,
     deploymentId?: string
   ): Promise<ListDeploymentSummaryResponse> {
-    const latestDeploymentId = deploymentId || (await this.getLatestDeploymentId(projectId));
-    const res = await fetch(
-      `${this.baseEndpoint}/v6/deployments/${latestDeploymentId}/files/outputs?file=..%2Fdeploy_metadata.json`,
-      {
-        headers: this.buildHeaders(),
-        method: 'GET',
-      }
-    );
+    let data: ListDeploymentSummaryResponse = { serverlessFunctions: [] };
+    try {
+      const latestDeploymentId = deploymentId || (await this.getLatestDeploymentId(projectId));
+      const res = await fetch(
+        `${this.baseEndpoint}/v6/deployments/${latestDeploymentId}/fil/outputs?file=..%2Fdeploy_metadata.json`,
+        {
+          headers: this.buildHeaders(),
+          method: 'GET',
+        }
+      );
 
-    const data = await res.json();
+      data = await res.json();
+    } catch (e) {
+      console.error(e);
+      throw new Error('Failed to fetch deployment summary.');
+    }
 
     return data;
   }
 
   async listApiPaths(projectId: string): Promise<ApiPath[]> {
-    const data = await this.listDeploymentSummary(projectId);
+    let deploymentData: ListDeploymentSummaryResponse = { serverlessFunctions: [] };
+    try {
+      deploymentData = await this.listDeploymentSummary(projectId);
+    } catch (e) {
+      console.error(e);
+      throw new Error('Failed to fetch API paths.');
+    }
 
-    const apiPaths = this.filterServerlessFunctions(data.serverlessFunctions);
+    const apiPaths = this.filterServerlessFunctions(deploymentData.serverlessFunctions);
     const formattedApiPaths = this.formatApiPaths(apiPaths);
 
     return formattedApiPaths;

--- a/apps/vercel/frontend/src/clients/Vercel.ts
+++ b/apps/vercel/frontend/src/clients/Vercel.ts
@@ -123,7 +123,6 @@ export default class VercelClient implements VercelAPIClient {
   private formatApiPaths(data: ServerlessFunction[]): ApiPath[] {
     return data.map((file: ServerlessFunction) => {
       const filePath = file.path;
-      // TO DO: Add compound key for ID property
       return {
         name: filePath,
         id: filePath,

--- a/apps/vercel/frontend/src/clients/Vercel.ts
+++ b/apps/vercel/frontend/src/clients/Vercel.ts
@@ -56,7 +56,7 @@ export default class VercelClient implements VercelAPIClient {
     try {
       const latestDeploymentId = deploymentId || (await this.getLatestDeploymentId(projectId));
       const res = await fetch(
-        `${this.baseEndpoint}/v6/deployments/${latestDeploymentId}/fil/outputs?file=..%2Fdeploy_metadata.json`,
+        `${this.baseEndpoint}/v6/deployments/${latestDeploymentId}/files/outputs?file=..%2Fdeploy_metadata.json`,
         {
           headers: this.buildHeaders(),
           method: 'GET',

--- a/apps/vercel/frontend/src/components/common/Select/Select.tsx
+++ b/apps/vercel/frontend/src/components/common/Select/Select.tsx
@@ -1,11 +1,6 @@
 import { ChangeEvent } from 'react';
-import {
-  Box,
-  FormControl,
-  Select as F36Select,
-  HelpText,
-  ValidationMessage,
-} from '@contentful/f36-components';
+import { Select as F36Select } from '@contentful/f36-components';
+import { SelectionWrapper } from '../SelectionWrapper/SelectionWrapper';
 
 interface Props {
   options: { id: string; name: string }[];
@@ -35,8 +30,12 @@ export const Select = ({
   const optionsExist = Boolean(options && options.length);
 
   return (
-    <Box>
-      {label && <FormControl.Label isRequired={isRequired}>{label}</FormControl.Label>}
+    <SelectionWrapper
+      label={label}
+      isLoading={isLoading}
+      isRequired={isRequired}
+      helpText={helpText}
+      errorMessage={errorMessage}>
       <F36Select
         isDisabled={!optionsExist}
         id="optionsSelect"
@@ -59,8 +58,6 @@ export const Select = ({
           <F36Select.Option value="">{emptyMessage}</F36Select.Option>
         )}
       </F36Select>
-      {helpText && <HelpText marginBottom="spacingXs">{helpText}</HelpText>}
-      {errorMessage && !isLoading && <ValidationMessage>{errorMessage}</ValidationMessage>}
-    </Box>
+    </SelectionWrapper>
   );
 };

--- a/apps/vercel/frontend/src/components/common/Select/Select.tsx
+++ b/apps/vercel/frontend/src/components/common/Select/Select.tsx
@@ -39,6 +39,7 @@ export const Select = ({
       <F36Select
         isDisabled={!optionsExist}
         id="optionsSelect"
+        data-testid="optionsSelect"
         name="optionsSelect"
         isInvalid={Boolean(errorMessage)}
         value={value}

--- a/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.spec.tsx
+++ b/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { AppInstallationParameters } from '@customTypes/configPage';
 import { SelectSection } from './SelectSection';

--- a/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.spec.tsx
+++ b/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.spec.tsx
@@ -1,10 +1,12 @@
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
 
 import { AppInstallationParameters } from '@customTypes/configPage';
 import { SelectSection } from './SelectSection';
 import { copies } from '@constants/copies';
 import { actions, singleSelectionSections } from '@constants/enums';
+import { renderConfigPageComponent } from '@test/helpers/renderConfigPageComponent';
 
 const parameters = { selectedApiPath: '', selectedProject: '' } as AppInstallationParameters;
 const paths = [{ id: 'path-1', name: 'Path/1' }];
@@ -16,7 +18,7 @@ describe('SelectSection', () => {
   it('renders list of api paths to select', () => {
     const ID = singleSelectionSections.API_PATH_SELECTION_SECTION;
     const { placeholder, helpText, errorMessage } = copies.configPage.pathSelectionSection;
-    render(
+    const { unmount } = render(
       <SelectSection
         options={paths}
         section={ID}
@@ -33,34 +35,42 @@ describe('SelectSection', () => {
     expect(screen.getByText(paths[0].name)).toBeTruthy();
     expect(screen.getByText(helpText)).toBeTruthy();
     expect(screen.queryByText(errorMessage)).toBeFalsy();
+    unmount();
   });
 
-  it('renders list of projects to select', () => {
+  it('renders list of projects to select', async () => {
+    const user = userEvent.setup();
+
+    const mockHandleAppConfigurationChange = vi.fn();
     const ID = singleSelectionSections.PROJECT_SELECTION_SECTION;
     const { placeholder, helpText, errorMessage } = copies.configPage.projectSelectionSection;
-    render(
+    const { unmount } = renderConfigPageComponent(
       <SelectSection
         options={projects}
         section={ID}
         id={ID}
         action={actions.APPLY_API_PATH}
         selectedOption={parameters.selectedApiPath}
-      />
+      />,
+      { handleAppConfigurationChange: mockHandleAppConfigurationChange }
     );
     const select = screen.getByText(placeholder);
     expect(select).toBeTruthy();
-
-    select.click();
-
-    expect(screen.getByText(projects[0].name)).toBeTruthy();
     expect(screen.getByText(helpText)).toBeTruthy();
     expect(screen.queryByText(errorMessage)).toBeFalsy();
+
+    user.click(select);
+    expect(screen.getByText(projects[0].name)).toBeTruthy();
+
+    user.selectOptions(screen.getByTestId('optionsSelect'), projects[0].name);
+    await waitFor(() => expect(mockHandleAppConfigurationChange).not.toBeCalled());
+    unmount();
   });
 
   it('renders error message when selected option no longer exists', () => {
     const ID = singleSelectionSections.PROJECT_SELECTION_SECTION;
     const { errorMessage } = copies.configPage.projectSelectionSection;
-    render(
+    const { unmount } = render(
       <SelectSection
         options={projects}
         section={ID}
@@ -71,5 +81,6 @@ describe('SelectSection', () => {
     );
 
     expect(screen.getByText(errorMessage)).toBeTruthy();
+    unmount();
   });
 });

--- a/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.spec.tsx
+++ b/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.spec.tsx
@@ -18,7 +18,6 @@ describe('SelectSection', () => {
     const { placeholder, helpText, errorMessage } = copies.configPage.pathSelectionSection;
     render(
       <SelectSection
-        dispatch={vi.fn()}
         options={paths}
         section={ID}
         id={ID}
@@ -41,7 +40,6 @@ describe('SelectSection', () => {
     const { placeholder, helpText, errorMessage } = copies.configPage.projectSelectionSection;
     render(
       <SelectSection
-        dispatch={vi.fn()}
         options={projects}
         section={ID}
         id={ID}
@@ -64,7 +62,6 @@ describe('SelectSection', () => {
     const { errorMessage } = copies.configPage.projectSelectionSection;
     render(
       <SelectSection
-        dispatch={vi.fn()}
         options={projects}
         section={ID}
         id={ID}

--- a/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.tsx
+++ b/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.tsx
@@ -1,6 +1,5 @@
-import { ChangeEvent, Dispatch, useContext, useEffect, useState } from 'react';
+import { ChangeEvent, useContext, useEffect, useState } from 'react';
 
-import { ParameterAction } from '@components/parameterReducer';
 import { Select } from '@components/common/Select/Select';
 import { Path, Project } from '@customTypes/configPage';
 import { copies } from '@constants/copies';

--- a/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.tsx
+++ b/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.tsx
@@ -4,7 +4,7 @@ import { Select } from '@components/common/Select/Select';
 import { Path, Project } from '@customTypes/configPage';
 import { copies } from '@constants/copies';
 import { FormControl } from '@contentful/f36-components';
-import { actions } from '@constants/enums';
+import { actions, singleSelectionSections } from '@constants/enums';
 import { ConfigPageContext } from '@contexts/ConfigPageProvider';
 
 type CopySection = Extract<
@@ -25,7 +25,10 @@ export const SelectSection = ({ selectedOption, options, action, section, id }: 
   const { placeholder, label, emptyMessage, helpText, errorMessage } = copies.configPage[section];
   const { isLoading, dispatch, handleAppConfigurationChange } = useContext(ConfigPageContext);
   const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
-    handleAppConfigurationChange();
+    // indicate app config change when project has been re-selected
+    if (section === singleSelectionSections.PROJECT_SELECTION_SECTION)
+      handleAppConfigurationChange();
+
     dispatch({
       type: action,
       payload: event.target.value,

--- a/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.tsx
+++ b/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.tsx
@@ -23,8 +23,9 @@ interface Props {
 export const SelectSection = ({ selectedOption, options, action, section, id }: Props) => {
   const [isSelectionInvalid, setIsSelectionInvalid] = useState<boolean>(false);
   const { placeholder, label, emptyMessage, helpText, errorMessage } = copies.configPage[section];
-  const { isLoading, dispatch } = useContext(ConfigPageContext);
+  const { isLoading, dispatch, handleAppConfigurationChange } = useContext(ConfigPageContext);
   const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    handleAppConfigurationChange();
     dispatch({
       type: action,
       payload: event.target.value,

--- a/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.tsx
+++ b/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.tsx
@@ -16,23 +16,15 @@ type CopySection = Extract<
 interface Props {
   selectedOption: string;
   options: Path[] | Project[];
-  dispatch: Dispatch<ParameterAction>;
   action: actions.APPLY_API_PATH | actions.APPLY_SELECTED_PROJECT;
   section: CopySection;
   id: string;
 }
 
-export const SelectSection = ({
-  selectedOption,
-  options,
-  dispatch,
-  action,
-  section,
-  id,
-}: Props) => {
+export const SelectSection = ({ selectedOption, options, action, section, id }: Props) => {
   const [isSelectionInvalid, setIsSelectionInvalid] = useState<boolean>(false);
   const { placeholder, label, emptyMessage, helpText, errorMessage } = copies.configPage[section];
-  const { isLoading } = useContext(ConfigPageContext);
+  const { isLoading, dispatch } = useContext(ConfigPageContext);
   const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
     dispatch({
       type: action,

--- a/apps/vercel/frontend/src/components/common/SelectionWrapper/SelectionWrapper.spec.tsx
+++ b/apps/vercel/frontend/src/components/common/SelectionWrapper/SelectionWrapper.spec.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { SelectionWrapper } from './SelectionWrapper';
+import { copies } from '@constants/copies';
+
+describe('SelectionWrapper', () => {
+  it('renders content', () => {
+    const { label, helpText, errorMessage } = copies.configPage.pathSelectionSection;
+    render(
+      <SelectionWrapper
+        label={label}
+        helpText={helpText}
+        errorMessage={errorMessage}
+        isLoading={false}>
+        <div>Test Child</div>
+      </SelectionWrapper>
+    );
+    const labelElement = screen.getByText(label);
+    const helpTextElement = screen.getByText(helpText);
+    const errorMessageElement = screen.getByText(errorMessage);
+
+    expect(labelElement).toBeTruthy();
+    expect(helpTextElement).toBeTruthy();
+    expect(errorMessageElement).toBeTruthy();
+  });
+});

--- a/apps/vercel/frontend/src/components/common/SelectionWrapper/SelectionWrapper.tsx
+++ b/apps/vercel/frontend/src/components/common/SelectionWrapper/SelectionWrapper.tsx
@@ -1,0 +1,29 @@
+import { Box, FormControl, HelpText, ValidationMessage } from '@contentful/f36-components';
+import React from 'react';
+
+interface Props {
+  isLoading: boolean;
+  children: React.ReactNode;
+  label?: string;
+  isRequired?: boolean;
+  helpText?: string;
+  errorMessage?: string;
+}
+
+export const SelectionWrapper = ({
+  label,
+  isLoading,
+  isRequired,
+  helpText,
+  errorMessage,
+  children,
+}: Props) => {
+  return (
+    <Box>
+      {label && <FormControl.Label isRequired={isRequired}>{label}</FormControl.Label>}
+      {children}
+      {helpText && <HelpText marginBottom="spacingXs">{helpText}</HelpText>}
+      {errorMessage && !isLoading && <ValidationMessage>{errorMessage}</ValidationMessage>}
+    </Box>
+  );
+};

--- a/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/ApiPathSelectionSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/ApiPathSelectionSection.tsx
@@ -1,29 +1,38 @@
-import { useContext } from 'react';
+import { useContext, useState, useEffect } from 'react';
 
 import { Path } from '@customTypes/configPage';
 import { SectionWrapper } from '@components/common/SectionWrapper/SectionWrapper';
 import { SelectSection } from '@components/common/SelectSection/SelectSection';
 import { actions, singleSelectionSections } from '@constants/enums';
 import { ConfigPageContext } from '@contexts/ConfigPageProvider';
+import { TextFieldSection } from './TextFieldSection/TextFieldSection';
 
 interface Props {
   paths: Path[];
 }
 
 export const ApiPathSelectionSection = ({ paths }: Props) => {
+  const [renderSelect, setRenderSelect] = useState(false);
   const sectionId = singleSelectionSections.API_PATH_SELECTION_SECTION;
-  const { dispatch, parameters } = useContext(ConfigPageContext);
+  const { parameters, isLoading } = useContext(ConfigPageContext);
+
+  useEffect(() => {
+    setRenderSelect(paths.length > 0 || isLoading);
+  }, [paths, isLoading]);
 
   return (
     <SectionWrapper testId={sectionId}>
-      <SelectSection
-        selectedOption={parameters.selectedApiPath}
-        options={paths}
-        action={actions.APPLY_API_PATH}
-        dispatch={dispatch}
-        section={sectionId}
-        id={sectionId}
-      />
+      {renderSelect ? (
+        <SelectSection
+          selectedOption={parameters.selectedApiPath}
+          options={paths}
+          action={actions.APPLY_API_PATH}
+          section={sectionId}
+          id={sectionId}
+        />
+      ) : (
+        <TextFieldSection value={parameters.selectedApiPath} />
+      )}
     </SectionWrapper>
   );
 };

--- a/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/TextFieldSection/TextFieldSection.spec.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/TextFieldSection/TextFieldSection.spec.tsx
@@ -1,0 +1,18 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { TextFieldSection } from './TextFieldSection';
+import { copies } from '@constants/copies';
+
+describe('TextFieldSection', () => {
+  it('renders text field with value', () => {
+    const value = 'api/disable-path';
+    const { textInputPlaceholder } = copies.configPage.pathSelectionSection;
+    render(<TextFieldSection value={value} />);
+
+    const input = document.querySelector('input');
+    expect(input).toBeTruthy();
+    expect(input).toHaveProperty('value', value);
+    expect(input).toHaveProperty('placeholder', textInputPlaceholder);
+  });
+});

--- a/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/TextFieldSection/TextFieldSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/TextFieldSection/TextFieldSection.tsx
@@ -1,0 +1,44 @@
+import { useContext, useMemo } from 'react';
+
+import { copies } from '@constants/copies';
+import { FormControl, TextInput } from '@contentful/f36-components';
+import { actions, singleSelectionSections } from '@constants/enums';
+import { ConfigPageContext } from '@contexts/ConfigPageProvider';
+import { SelectionWrapper } from '@components/common/SelectionWrapper/SelectionWrapper';
+import { debounce } from 'lodash';
+
+interface Props {
+  value: string;
+}
+
+export const TextFieldSection = ({ value }: Props) => {
+  const { textInputPlaceholder, label, textInputHelpText } = copies.configPage.pathSelectionSection;
+  const { isLoading, dispatch } = useContext(ConfigPageContext);
+  const handleApiPathInput = (event: React.ChangeEvent<HTMLInputElement>) => {
+    dispatch({
+      type: actions.APPLY_API_PATH,
+      payload: event.target.value,
+    });
+  };
+
+  const debouncedHandleApiPathInputChange = useMemo(() => debounce(handleApiPathInput, 700), []);
+
+  return (
+    <FormControl
+      marginBottom="spacingS"
+      id={singleSelectionSections.API_PATH_SELECTION_SECTION}
+      isRequired={true}>
+      <SelectionWrapper
+        label={label}
+        isLoading={isLoading}
+        isRequired={true}
+        helpText={textInputHelpText}>
+        <TextInput
+          defaultValue={value}
+          onChange={debouncedHandleApiPathInputChange}
+          placeholder={textInputPlaceholder}
+        />
+      </SelectionWrapper>
+    </FormControl>
+  );
+};

--- a/apps/vercel/frontend/src/components/config-screen/ProjectSelectionSection/ProjectSelectionSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ProjectSelectionSection/ProjectSelectionSection.tsx
@@ -12,7 +12,7 @@ interface Props {
 
 export const ProjectSelectionSection = ({ projects }: Props) => {
   const sectionId = singleSelectionSections.PROJECT_SELECTION_SECTION;
-  const { dispatch, parameters } = useContext(ConfigPageContext);
+  const { parameters } = useContext(ConfigPageContext);
 
   return (
     <SectionWrapper testId={sectionId}>
@@ -20,7 +20,6 @@ export const ProjectSelectionSection = ({ projects }: Props) => {
         selectedOption={parameters.selectedProject}
         options={projects}
         action={actions.APPLY_SELECTED_PROJECT}
-        dispatch={dispatch}
         section={sectionId}
         id={sectionId}
       />

--- a/apps/vercel/frontend/src/constants/copies.ts
+++ b/apps/vercel/frontend/src/constants/copies.ts
@@ -24,10 +24,12 @@ export const copies = {
     pathSelectionSection: {
       label: 'API Path',
       placeholder: 'Select a path',
+      textInputPlaceholder: 'Ex: api/enable-draft',
       emptyMessage: 'No paths currently configured.',
       errorMessage:
         'The path you have configured is no longer available. Please select another one.',
       helpText: 'Select a Vercel route to enable your draft mode.',
+      textInputHelpText: 'Set a Vercel route to enable your draft mode.',
     },
     contentTypePreviewPathSection: {
       title: 'Preview settings',

--- a/apps/vercel/frontend/src/locations/ConfigScreen.tsx
+++ b/apps/vercel/frontend/src/locations/ConfigScreen.tsx
@@ -117,17 +117,19 @@ const ConfigScreen = () => {
     }
 
     if (parameters.selectedProject) {
-      // reset the selected api path only when the project changes
-      if (apiPaths.length) {
-        dispatchParameters({
-          type: actions.APPLY_API_PATH,
-          payload: '',
-        });
-      }
-
       getApiPaths();
     }
   }, [parameters.selectedProject, vercelClient]);
+
+  useEffect(() => {
+    if (parameters.selectedProject && !isLoading && !isAppConfigurationSaved) {
+      // reset the selected api path only when the project changes
+      dispatchParameters({
+        type: actions.APPLY_API_PATH,
+        payload: '',
+      });
+    }
+  }, [parameters.selectedProject, isLoading, isAppConfigurationSaved]);
 
   const updateTokenValidityState = (tokenValidity: boolean) => {
     setIsLoading(false);

--- a/apps/vercel/frontend/src/locations/ConfigScreen.tsx
+++ b/apps/vercel/frontend/src/locations/ConfigScreen.tsx
@@ -110,8 +110,13 @@ const ConfigScreen = () => {
     async function getApiPaths() {
       setIsLoading(true);
       if (vercelClient) {
-        const data = await vercelClient.listApiPaths(parameters.selectedProject);
-        setApiPaths(validateApiPathData(data) ? data : []);
+        try {
+          const data = await vercelClient.listApiPaths(parameters.selectedProject);
+          setApiPaths(validateApiPathData(data) ? data : []);
+        } catch (e) {
+          console.error(e);
+          setApiPaths([]);
+        }
       }
 
       setIsLoading(false);

--- a/apps/vercel/frontend/src/locations/ConfigScreen.tsx
+++ b/apps/vercel/frontend/src/locations/ConfigScreen.tsx
@@ -16,6 +16,7 @@ import { copies } from '@constants/copies';
 import { actions } from '@constants/enums';
 import { ConfigPageProvider } from '@contexts/ConfigPageProvider';
 import { GettingStartedSection } from '@components/config-screen/GettingStartedSection/GettingStartedSection';
+import { validateApiPathData } from '@utils/validateApiPathData/validateApiPathData';
 
 const ConfigScreen = () => {
   const [isTokenValid, setIsTokenValid] = useState(false);
@@ -110,7 +111,7 @@ const ConfigScreen = () => {
       setIsLoading(true);
       if (vercelClient) {
         const data = await vercelClient.listApiPaths(parameters.selectedProject);
-        setApiPaths(data || []);
+        setApiPaths(validateApiPathData(data) ? data : []);
       }
 
       setIsLoading(false);

--- a/apps/vercel/frontend/src/utils/validateApiPathData/validateApiPathData.spec.ts
+++ b/apps/vercel/frontend/src/utils/validateApiPathData/validateApiPathData.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { validateApiPathData } from './validateApiPathData';
+import { ApiPath } from '@customTypes/configPage';
+
+describe('validateApiPathData', () => {
+  it('should validate correct data', () => {
+    const result = validateApiPathData([{ id: '1', name: 'test' }]);
+
+    expect(result).toBe(true);
+  });
+
+  it('should invalidate data that is not an array', () => {
+    const result = validateApiPathData({ id: '1', name: 'test' } as unknown as ApiPath[]);
+
+    expect(result).toBe(false);
+  });
+
+  it('should invalidate data that is an empty array', () => {
+    const result = validateApiPathData([]);
+
+    expect(result).toBe(false);
+  });
+});

--- a/apps/vercel/frontend/src/utils/validateApiPathData/validateApiPathData.ts
+++ b/apps/vercel/frontend/src/utils/validateApiPathData/validateApiPathData.ts
@@ -1,0 +1,4 @@
+import { ApiPath } from '@customTypes/configPage';
+
+export const validateApiPathData = (apiPathData: ApiPath[]) =>
+  Array.isArray(apiPathData) && apiPathData.length > 0;


### PR DESCRIPTION
## Purpose

The purpose of this PR is to add the fallback component that will render if the fetched API paths are 1. not feasibly fetched or 2. if the results are empty.

## Approach

If there is an error with the API path endpoint or if the results are empty, this fallback input is rendered. 

Rendering this fallback component when the results are empty is something I am wavering on, as it seems to me that if the results are empty, their application is not configured correctly in the first place, so should we evens support this? But I also could perhaps since this API path endpoint is potentially unreliable, the endpoint just may at some point not return anything or return differing data, even if the user has set-up their application appropriately. 

The error handling I have added also denotes the data as "invalid" if there is any presence of an empty array with the `apiPaths` state on the `ConfigScreen`. 

I scope this PR to just work on handling edge cases with this API path and no other endpoints or functionality. 

![Screenshot 2024-04-23 at 12 07 55 PM](https://github.com/contentful/apps/assets/58186851/78501b02-e715-4814-a3cb-cd5dbec239b3)

## Testing steps

Select a project on the Vercel config page that does not have any of these routes configured (there is at least one). Notice how the API path Select field is actually an input instead. You should be able to save and update as before. 

