### PR TITLE
feat: add deeplink to install MS Teams app [INTEG-1819]

### DIFF
--- a/apps/microsoft-teams/frontend/src/constants/configCopy.ts
+++ b/apps/microsoft-teams/frontend/src/constants/configCopy.ts
@@ -1,13 +1,13 @@
 import { AppEventKey } from '@customTypes/configPage';
+import { MS_TEAMS_APP_ID } from './msTeamsAppId';
 
 const headerSection = {
   title: 'Set up the Microsoft Teams App',
   description: 'Get notifications about Contentful content updates directly in Microsoft Teams.',
 };
 
-// TODO: Update to deep link with Teams app id
 // https://learn.microsoft.com/en-us/microsoftteams/platform/concepts/build-and-test/deep-link-application?tabs=teamsjs-v2#deep-link-to-open-application-install-dialog
-const appDeepLink = 'https://teams.microsoft.com/';
+const appDeepLink = `https://teams.microsoft.com/l/app/${MS_TEAMS_APP_ID}`;
 
 const accessSection = {
   title: 'Access',

--- a/apps/microsoft-teams/frontend/src/constants/msTeamsAppId.ts
+++ b/apps/microsoft-teams/frontend/src/constants/msTeamsAppId.ts
@@ -1,0 +1,5 @@
+/**
+ * @description - This is the App Id from our app manifest for our
+ * Microsoft Teams app that is published in the Teams App Store.
+ */
+export const MS_TEAMS_APP_ID = 'e4e4e40e-18a1-48e7-becf-49bb3f348e13';


### PR DESCRIPTION
## Purpose

This PR updates the "Add the App" link in the channel selection modal so that it is now a deep link directly to the Contentful app within MS Teams.

## Approach

Followed this documentation: https://learn.microsoft.com/en-us/microsoftteams/platform/concepts/build-and-test/deep-link-application?tabs=teamsjs-v2#deep-link-to-open-application-install-dialog

Link in modal:
![Screenshot 2024-04-23 at 12 51 40 PM](https://github.com/contentful/apps/assets/62958907/4057c962-af3d-4f0f-99c1-12cecfff56df)

![Screenshot 2024-04-23 at 12 51 24 PM](https://github.com/contentful/apps/assets/62958907/e84bf5a7-7f81-4afe-bfc2-babc59e44723)


Where the deeplink takes you in Teams:
![Screenshot 2024-04-23 at 12 54 10 PM](https://github.com/contentful/apps/assets/62958907/c4f0e8f2-9ffb-4f3f-baaa-a1cf21dffe22)


## Testing steps

Tested in our sandbox.

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
