### PR TITLE
docs: add more testing to config page and add basic frontend README

### DIFF
--- a/apps/vercel/frontend/README.md
+++ b/apps/vercel/frontend/README.md
@@ -1,3 +1,8 @@
+## Overview
+
+This frontend module for the Vercel marketplace app was created using the Contentful App Framework.
+To make the app look and feel like Contentful, Contentful's design system, [Forma 36](https://f36.contentful.com/), was leveraged.
+
 ## Available Scripts
 
 In the project directory, you can run:
@@ -18,27 +23,10 @@ It correctly bundles React in production mode and optimizes the build for the be
 The build is minified and the filenames include the hashes.
 Your app is ready to be deployed!
 
-## Libraries to use
+#### `npm run test`
 
-To make your app look and feel like Contentful use the following libraries:
+Runs the spec files within the module, and remains in watch mode.
 
-- [Forma 36](https://f36.contentful.com/) – Contentful's design system
-- [Contentful Field Editors](https://www.contentful.com/developers/docs/extensibility/field-editors/) – Contentful's field editor React components
-
-## Using the `contentful-management` SDK
-
-In the default create contentful app output, a contentful management client is
-passed into each location. This can be used to interact with Contentful's
-management API. For example
-
-```js
-// Use the client
-cma.locale.getMany({}).then((locales) => console.log(locales));
-```
-
-Visit the [`contentful-management` documentation](https://www.contentful.com/developers/docs/extensibility/app-framework/sdk/#using-the-contentful-management-library)
-to find out more.
-
-## Learn More
+## Learn more about the app framework
 
 [Read more](https://www.contentful.com/developers/docs/extensibility/app-framework/create-contentful-app/) and check out the video on how to use the CLI.

--- a/apps/vercel/frontend/README.md
+++ b/apps/vercel/frontend/README.md
@@ -1,1 +1,44 @@
-# Vercel
+## Available Scripts
+
+In the project directory, you can run:
+
+#### `npm start`
+
+Creates or updates your app definition in Contentful, and runs the app in development mode.
+Open your app to view it in the browser.
+
+The page will reload if you make edits.
+You will also see any lint errors in the console.
+
+#### `npm run build`
+
+Builds the app for production to the `dist` folder.
+It correctly bundles React in production mode and optimizes the build for the best performance.
+
+The build is minified and the filenames include the hashes.
+Your app is ready to be deployed!
+
+## Libraries to use
+
+To make your app look and feel like Contentful use the following libraries:
+
+- [Forma 36](https://f36.contentful.com/) – Contentful's design system
+- [Contentful Field Editors](https://www.contentful.com/developers/docs/extensibility/field-editors/) – Contentful's field editor React components
+
+## Using the `contentful-management` SDK
+
+In the default create contentful app output, a contentful management client is
+passed into each location. This can be used to interact with Contentful's
+management API. For example
+
+```js
+// Use the client
+cma.locale.getMany({}).then((locales) => console.log(locales));
+```
+
+Visit the [`contentful-management` documentation](https://www.contentful.com/developers/docs/extensibility/app-framework/sdk/#using-the-contentful-management-library)
+to find out more.
+
+## Learn More
+
+[Read more](https://www.contentful.com/developers/docs/extensibility/app-framework/create-contentful-app/) and check out the video on how to use the CLI.

--- a/apps/vercel/frontend/src/components/common/Select/Select.tsx
+++ b/apps/vercel/frontend/src/components/common/Select/Select.tsx
@@ -41,7 +41,6 @@ export const Select = ({
         id="optionsSelect"
         data-testid="optionsSelect"
         name="optionsSelect"
-        data-testid="optionsSelect"
         isInvalid={Boolean(errorMessage)}
         value={value}
         onChange={onChange}>

--- a/apps/vercel/frontend/src/components/common/Select/Select.tsx
+++ b/apps/vercel/frontend/src/components/common/Select/Select.tsx
@@ -41,6 +41,7 @@ export const Select = ({
         id="optionsSelect"
         data-testid="optionsSelect"
         name="optionsSelect"
+        data-testid="optionsSelect"
         isInvalid={Boolean(errorMessage)}
         value={value}
         onChange={onChange}>

--- a/apps/vercel/frontend/src/locations/ConfigScreen.spec.tsx
+++ b/apps/vercel/frontend/src/locations/ConfigScreen.spec.tsx
@@ -5,6 +5,7 @@ import { mockCma, mockSdk } from '../../test/mocks';
 import ConfigScreen from './ConfigScreen';
 import VercelClient from '@clients/Vercel';
 import { singleSelectionSections } from '@constants/enums';
+import { copies } from '@constants/copies';
 
 const projectSelectionSectionTestId = singleSelectionSections.PROJECT_SELECTION_SECTION;
 const pathSelectionSectionTestId = singleSelectionSections.API_PATH_SELECTION_SECTION;
@@ -66,6 +67,10 @@ describe('ConfigScreen', () => {
     expect(screen.queryByTestId('content-type-preview-path-section')).toBeFalsy();
 
     const selectDropdowns = await screen.findAllByTestId('optionsSelect');
+    const dropdownPlaceholder = await screen.findByText(
+      copies.configPage.projectSelectionSection.placeholder
+    );
+    expect(dropdownPlaceholder).toBeTruthy();
 
     user.selectOptions(selectDropdowns[0], 'Project 1');
 

--- a/apps/vercel/frontend/src/locations/ConfigScreen.spec.tsx
+++ b/apps/vercel/frontend/src/locations/ConfigScreen.spec.tsx
@@ -1,5 +1,5 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { describe, expect, it, vi, beforeAll, afterEach, afterAll } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi, beforeAll } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import { mockCma, mockSdk } from '../../test/mocks';
 import ConfigScreen from './ConfigScreen';


### PR DESCRIPTION
## Purpose

The purpose of this PR is to add a very basic README to the Vercel frontend module and to add a bit more testing to the functionality of the overall Vercel config page. 

README => This adds a very basic frontend README for how to interact with that module as a developer. 
Testing => wanted to make sure a lot of the conditional logic paths of the Config page were accounted for in testing. 
