### PR TITLE
feat: add link to help text for api path

### DIFF
--- a/apps/vercel/frontend/src/components/common/Select/Select.tsx
+++ b/apps/vercel/frontend/src/components/common/Select/Select.tsx
@@ -10,7 +10,7 @@ interface Props {
   isLoading: boolean;
   label?: string;
   isRequired?: boolean;
-  helpText?: string;
+  helpText?: string | React.ReactNode;
   errorMessage?: string;
   emptyMessage?: string;
 }

--- a/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.spec.tsx
+++ b/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.spec.tsx
@@ -14,10 +14,10 @@ const projects = [
   { id: 'project-1', name: 'Project 1', targets: { production: { id: 'project-1' } } },
 ];
 
-describe('SelectSection', () => {
+describe.only('SelectSection', () => {
   it('renders list of api paths to select', () => {
     const ID = singleSelectionSections.API_PATH_SELECTION_SECTION;
-    const { placeholder, helpText, errorMessage } = copies.configPage.pathSelectionSection;
+    const { placeholder, errorMessage } = copies.configPage.pathSelectionSection;
     const { unmount } = render(
       <SelectSection
         options={paths}
@@ -33,7 +33,6 @@ describe('SelectSection', () => {
     select.click();
 
     expect(screen.getByText(paths[0].name)).toBeTruthy();
-    expect(screen.getByText(helpText)).toBeTruthy();
     expect(screen.queryByText(errorMessage)).toBeFalsy();
     unmount();
   });

--- a/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.spec.tsx
+++ b/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.spec.tsx
@@ -14,7 +14,7 @@ const projects = [
   { id: 'project-1', name: 'Project 1', targets: { production: { id: 'project-1' } } },
 ];
 
-describe.only('SelectSection', () => {
+describe('SelectSection', () => {
   it('renders list of api paths to select', () => {
     const ID = singleSelectionSections.API_PATH_SELECTION_SECTION;
     const { placeholder, errorMessage } = copies.configPage.pathSelectionSection;

--- a/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.tsx
+++ b/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.tsx
@@ -18,11 +18,25 @@ interface Props {
   action: actions.APPLY_API_PATH | actions.APPLY_SELECTED_PROJECT;
   section: CopySection;
   id: string;
+  helpText?: string | React.ReactNode;
 }
 
-export const SelectSection = ({ selectedOption, options, action, section, id }: Props) => {
+export const SelectSection = ({
+  selectedOption,
+  options,
+  action,
+  section,
+  id,
+  helpText,
+}: Props) => {
   const [isSelectionInvalid, setIsSelectionInvalid] = useState<boolean>(false);
-  const { placeholder, label, emptyMessage, helpText, errorMessage } = copies.configPage[section];
+  const {
+    placeholder,
+    label,
+    emptyMessage,
+    helpText: helpTextCopy,
+    errorMessage,
+  } = copies.configPage[section];
   const { isLoading, dispatch, handleAppConfigurationChange } = useContext(ConfigPageContext);
   const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
     // indicate app config change when project has been re-selected
@@ -53,7 +67,7 @@ export const SelectSection = ({ selectedOption, options, action, section, id }: 
         emptyMessage={emptyMessage}
         options={options}
         label={label}
-        helpText={helpText}
+        helpText={helpText || helpTextCopy}
         errorMessage={isSelectionInvalid && !isLoading ? errorMessage : undefined}
         isLoading={isLoading}
       />

--- a/apps/vercel/frontend/src/components/common/SelectionWrapper/SelectionWrapper.spec.tsx
+++ b/apps/vercel/frontend/src/components/common/SelectionWrapper/SelectionWrapper.spec.tsx
@@ -1,13 +1,19 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { SelectionWrapper } from './SelectionWrapper';
 import { copies } from '@constants/copies';
 
 describe('SelectionWrapper', () => {
+  let helpText: string | React.ReactNode;
+
+  beforeEach(() => {
+    helpText = 'help text';
+  });
+
   it('renders content', () => {
-    const { label, helpText, errorMessage } = copies.configPage.pathSelectionSection;
-    render(
+    const { label, errorMessage } = copies.configPage.pathSelectionSection;
+    const { unmount } = render(
       <SelectionWrapper
         label={label}
         helpText={helpText}
@@ -17,11 +23,41 @@ describe('SelectionWrapper', () => {
       </SelectionWrapper>
     );
     const labelElement = screen.getByText(label);
-    const helpTextElement = screen.getByText(helpText);
+    const helpTextElement = screen.getByText(helpText as string);
     const errorMessageElement = screen.getByText(errorMessage);
 
     expect(labelElement).toBeTruthy();
     expect(helpTextElement).toBeTruthy();
     expect(errorMessageElement).toBeTruthy();
+
+    unmount();
+  });
+
+  describe('when helpText is a React node', () => {
+    beforeEach(() => {
+      helpText = <div data-testid="help-text">help div</div>;
+    });
+
+    it('renders content', () => {
+      const { label, errorMessage } = copies.configPage.pathSelectionSection;
+      const { unmount } = render(
+        <SelectionWrapper
+          label={label}
+          helpText={helpText}
+          errorMessage={errorMessage}
+          isLoading={false}>
+          <div>Test Child</div>
+        </SelectionWrapper>
+      );
+      const labelElement = screen.getByText(label);
+      const helpTextElement = screen.getByTestId('help-text');
+      const errorMessageElement = screen.getByText(errorMessage);
+
+      expect(labelElement).toBeTruthy();
+      expect(helpTextElement).toBeTruthy();
+      expect(errorMessageElement).toBeTruthy();
+
+      unmount();
+    });
   });
 });

--- a/apps/vercel/frontend/src/components/common/SelectionWrapper/SelectionWrapper.tsx
+++ b/apps/vercel/frontend/src/components/common/SelectionWrapper/SelectionWrapper.tsx
@@ -6,7 +6,7 @@ interface Props {
   children: React.ReactNode;
   label?: string;
   isRequired?: boolean;
-  helpText?: string;
+  helpText?: string | React.ReactNode;
   errorMessage?: string;
 }
 
@@ -18,12 +18,19 @@ export const SelectionWrapper = ({
   errorMessage,
   children,
 }: Props) => {
+  const helpTextComponent = helpTextCompontentFor(helpText);
   return (
     <Box>
       {label && <FormControl.Label isRequired={isRequired}>{label}</FormControl.Label>}
       {children}
-      {helpText && <HelpText marginBottom="spacingXs">{helpText}</HelpText>}
+      {helpTextComponent}
       {errorMessage && !isLoading && <ValidationMessage>{errorMessage}</ValidationMessage>}
     </Box>
   );
+};
+
+const helpTextCompontentFor = (helpText: Props['helpText']): React.ReactNode | undefined => {
+  if (!helpText) return;
+  if (typeof helpText === 'string') return <HelpText marginBottom="spacingXs">{helpText}</HelpText>;
+  return helpText;
 };

--- a/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/ApiPathSelectionSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/ApiPathSelectionSection.tsx
@@ -6,6 +6,8 @@ import { SelectSection } from '@components/common/SelectSection/SelectSection';
 import { actions, singleSelectionSections } from '@constants/enums';
 import { ConfigPageContext } from '@contexts/ConfigPageProvider';
 import { TextFieldSection } from './TextFieldSection/TextFieldSection';
+import { HelpText, TextLink } from '@contentful/f36-components';
+import { ExternalLinkIcon } from '@contentful/f36-icons';
 
 interface Props {
   paths: Path[];
@@ -20,6 +22,21 @@ export const ApiPathSelectionSection = ({ paths }: Props) => {
     setRenderSelect(paths.length > 0 || isLoading);
   }, [paths, isLoading]);
 
+  const helpText = (
+    <HelpText>
+      Select the route from your application that enables Draft Mode. See our{' '}
+      <TextLink
+        icon={<ExternalLinkIcon />}
+        alignIcon="end"
+        href="http://www.example.com"
+        target="_blank"
+        rel="noopener noreferrer">
+        Vercel developer guide
+      </TextLink>{' '}
+      for instructions on setting up a Draft Mode route handler. UPDATE LINK
+    </HelpText>
+  );
+
   return (
     <SectionWrapper testId={sectionId}>
       {renderSelect ? (
@@ -29,6 +46,7 @@ export const ApiPathSelectionSection = ({ paths }: Props) => {
           action={actions.APPLY_API_PATH}
           section={sectionId}
           id={sectionId}
+          helpText={helpText}
         />
       ) : (
         <TextFieldSection value={parameters.selectedApiPath} />

--- a/apps/vercel/frontend/src/constants/copies.ts
+++ b/apps/vercel/frontend/src/constants/copies.ts
@@ -22,13 +22,13 @@ export const copies = {
       helpText: 'Connect to a project associated with your website or experience.',
     },
     pathSelectionSection: {
-      label: 'API Path',
-      placeholder: 'Select a path',
+      label: 'Draft Mode route handler',
+      placeholder: 'Select a route',
       textInputPlaceholder: 'Ex: api/enable-draft',
       emptyMessage: 'No paths currently configured.',
       errorMessage:
         'The path you have configured is no longer available. Please select another one.',
-      helpText: 'Select a Vercel route to enable your draft mode.',
+      helpText: undefined, // defined as React component
       textInputHelpText: 'Set a Vercel route to enable your draft mode.',
     },
     contentTypePreviewPathSection: {


### PR DESCRIPTION
## Purpose

The naming and help text for choosing your draft mode route handler are confusing at the moment.

## Approach

* Update the copy and provide a link to the guide
* Refactor components a bit to support providing a react node and not just a string for help text
* UPDATE LINK is intentionally there and ugly, to remind us that we need to update it with the real link once we publish the guide

## Testing steps

Before:

<img width="867" alt="image" src="https://github.com/contentful/apps/assets/235836/864de158-0bbe-4bf7-9835-7f283237f7b4">

After:

<img width="871" alt="image" src="https://github.com/contentful/apps/assets/235836/58e1c6da-9cde-4a7e-8aef-471e59606ddf">


## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
