### PR TITLE
fix: remove useContext call from handleLogout function [INTEG-2085]

### DIFF
--- a/apps/microsoft-teams/frontend/src/components/config/AccessSection/AccessSection.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/AccessSection/AccessSection.tsx
@@ -134,8 +134,6 @@ const AccessSection = (props: Props) => {
 
   const handleLogout = () => {
     ModalLauncher.open(({ isShown, onClose }) => {
-      const { trackEvent } = useContext(SegmentAnalyticsContext);
-
       return (
         <DisconnectModal
           isShown={isShown}


### PR DESCRIPTION
## Purpose

There was a regression in the MS Teams app when a user clicks the "Disconnect" button on the app config page, it wasn't working.

## Approach

The error that occurred was an invalid hook call. Our `handleLogout` function was calling `useContext` to get the `trackEvent` so we removed this.

## Testing steps

Tested locally and it fixes the issue.

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
