### PR TITLE
fix: fix flashing bug of components when clicking on Content type selection

### DIFF
--- a/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.tsx
+++ b/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.tsx
@@ -40,8 +40,14 @@ export const SelectSection = ({
   const { isLoading, dispatch, handleAppConfigurationChange } = useContext(ConfigPageContext);
   const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
     // indicate app config change when project has been re-selected
-    if (section === singleSelectionSections.PROJECT_SELECTION_SECTION)
+    if (section === singleSelectionSections.PROJECT_SELECTION_SECTION) {
+      // reset the selected api path only when the project changes
+      dispatch({
+        type: actions.APPLY_API_PATH,
+        payload: '',
+      });
       handleAppConfigurationChange();
+    }
 
     dispatch({
       type: action,

--- a/apps/vercel/frontend/src/locations/ConfigScreen.tsx
+++ b/apps/vercel/frontend/src/locations/ConfigScreen.tsx
@@ -127,16 +127,6 @@ const ConfigScreen = () => {
     }
   }, [parameters.selectedProject, vercelClient]);
 
-  useEffect(() => {
-    if (parameters.selectedProject && !isLoading && !isAppConfigurationSaved) {
-      // reset the selected api path only when the project changes
-      dispatchParameters({
-        type: actions.APPLY_API_PATH,
-        payload: '',
-      });
-    }
-  }, [parameters.selectedProject, isLoading, isAppConfigurationSaved]);
-
   const updateTokenValidityState = (tokenValidity: boolean) => {
     setIsLoading(false);
     setIsTokenValid(tokenValidity);


### PR DESCRIPTION
## Purpose

The purpose of this PR is to quickly resolve a bug that is occurring on the Vercel config page, when a user interacts with the content type/preview path selection section, the component itself umounts and Draft mode path selection is cleared. This unmounting should not be happening. 

## Approach

I simply removed the problem `useEffect` on the Config page and moved it to the logic where the project is being changed. This logic is to essentially clear the API path parameter when the project is changed, so it has just been moved closer to that logic. 

