### PR TITLE
ci(side-notes): disable deployments

### DIFF
--- a/apps/side-notes-app/package.json
+++ b/apps/side-notes-app/package.json
@@ -41,8 +41,7 @@
     "preview": "vite preview",
     "build": "tsc && vite build",
     "test": "vitest",
-    "test:ci": "vitest",
-    "deploy": "contentful-app-scripts upload --ci --bundle-dir ./build  --organization-id ${DEFINITIONS_ORG_ID} --definition-id 6KyvAKw1VPdABdmocRB6NH --token ${CONTENTFUL_CMA_TOKEN}"
+    "test:ci": "vitest"
   },
   "devDependencies": {
     "@contentful/app-scripts": "1.1.11",


### PR DESCRIPTION
## Purpose
Disable deployments in the side notes app, because the app is broken in production.

[zendesk](https://contentful.atlassian.net/browse/ZEND-4890)
[discord](https://discord.com/channels/1030176999471321129/1111352040413724712/1234496414843928677)

