### PR TITLE
chore: bump react and react-dom in commercetools []

### DIFF
--- a/apps/commercetools/package-lock.json
+++ b/apps/commercetools/package-lock.json
@@ -15,8 +15,8 @@
         "@contentful/ecommerce-app-base": "3.5.1",
         "@contentful/f36-components": "4.64.0",
         "@contentful/react-apps-toolkit": "1.2.16",
-        "react": "17.0.1",
-        "react-dom": "17.0.1",
+        "react": "17.0.2",
+        "react-dom": "17.0.2",
         "react-scripts": "5.0.1"
       },
       "devDependencies": {
@@ -2445,15 +2445,15 @@
       }
     },
     "node_modules/@contentful/f36-accordion": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.64.0.tgz",
-      "integrity": "sha512-XXH+ioAHeQmCfhylb3y8qSHaLnNBiohCxaibBk1bxgsLHIGxgUoRbqkO9itXH4XcGSw2jCjFZRvtEwUu6uX3qQ==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.65.3.tgz",
+      "integrity": "sha512-J7xAwHIVDxFMBy7VODDXBKdI52T93e2VMCaOsOiGTye1ZkCKOepL0m+1KsL79bG+jobuzfQ9j9q3IHpBKI+wlg==",
       "dependencies": {
-        "@contentful/f36-collapse": "^4.64.0",
-        "@contentful/f36-core": "^4.64.0",
-        "@contentful/f36-icons": "^4.28.0",
+        "@contentful/f36-collapse": "^4.65.3",
+        "@contentful/f36-core": "^4.65.3",
+        "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.64.0",
+        "@contentful/f36-typography": "^4.65.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2462,15 +2462,15 @@
       }
     },
     "node_modules/@contentful/f36-asset": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.64.0.tgz",
-      "integrity": "sha512-ZN3G9s/j90SGwlgXDTuUDkd7m5JoLQSJFf66KOoIvYP6+Nk24bC2taGwFmywiLVa7/TZ5nq/Wq9lZCFxDTMurA==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.65.3.tgz",
+      "integrity": "sha512-mXziWPxKZ88/eYb7dyroXo7o44fEqY4ABzaSuz4UnmnxtTyLpAefly8vjQ5V9KTf8kUKv6HcaVkYw942hL0AwQ==",
       "dependencies": {
-        "@contentful/f36-core": "^4.64.0",
-        "@contentful/f36-icon": "^4.64.0",
-        "@contentful/f36-icons": "^4.28.0",
+        "@contentful/f36-core": "^4.65.3",
+        "@contentful/f36-icon": "^4.65.3",
+        "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.64.0",
+        "@contentful/f36-typography": "^4.65.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2479,18 +2479,18 @@
       }
     },
     "node_modules/@contentful/f36-autocomplete": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.64.0.tgz",
-      "integrity": "sha512-LvD0EQYqpFx/kAbpQFsuwRPQh26FPPq2WH9d8A9EY8xCLJA4Lv2KY5GfwGEWjWTiIo06hyOYzD8k1/F6kjdznA==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.65.3.tgz",
+      "integrity": "sha512-4GrcUKOI5XwZFmj0qquL5v7cRgjXCubGq2Ad19+Bv7xt4ndxwIbkTiZnaxDRav9PE7yJVVr+M1wh2f2DZBR0fg==",
       "dependencies": {
-        "@contentful/f36-button": "^4.64.0",
-        "@contentful/f36-core": "^4.64.0",
-        "@contentful/f36-forms": "^4.64.0",
-        "@contentful/f36-icons": "^4.28.0",
-        "@contentful/f36-popover": "^4.64.0",
-        "@contentful/f36-skeleton": "^4.64.0",
+        "@contentful/f36-button": "^4.65.3",
+        "@contentful/f36-core": "^4.65.3",
+        "@contentful/f36-forms": "^4.65.3",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-popover": "^4.65.3",
+        "@contentful/f36-skeleton": "^4.65.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.64.0",
+        "@contentful/f36-typography": "^4.65.3",
         "@contentful/f36-utils": "^4.24.3",
         "downshift": "^6.1.12",
         "emotion": "^10.0.17"
@@ -2501,12 +2501,12 @@
       }
     },
     "node_modules/@contentful/f36-badge": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.64.0.tgz",
-      "integrity": "sha512-VwrYdLT9zN4fIsGtlCC14Da5ygPK1z/JLAQS2UgZBIs7mSdLmyJUP0kJnfEPRgZGIOCkRz3r3xU1JfxK6fTZIA==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.65.3.tgz",
+      "integrity": "sha512-cY7GY8g/KdzcCL0ApB0OG1sOZyzllyWTglYBdnMEbKHXnGk0SNLQQlELet35th2d7BBTweJC811p5QDlp8IhHg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.64.0",
-        "@contentful/f36-icons": "^4.28.0",
+        "@contentful/f36-core": "^4.65.3",
+        "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2516,12 +2516,12 @@
       }
     },
     "node_modules/@contentful/f36-button": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.64.0.tgz",
-      "integrity": "sha512-DaJ7z4mVRk1Ft0hcTpzprnDvC2QoKq1C5YXsNO4y6AZv26jLKn5Jr+kxn4DmeI+H/Qe6bbrg3jEBNaFO7bU02Q==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.65.3.tgz",
+      "integrity": "sha512-bsfJPcGPr6zjeR0nmKbeKSTTGh/o6dOXKNurlJrFGrSr+i9rqprmhCDpBCrv2Zb/xPByS3n/ADYE0+CMG6v1BQ==",
       "dependencies": {
-        "@contentful/f36-core": "^4.64.0",
-        "@contentful/f36-spinner": "^4.64.0",
+        "@contentful/f36-core": "^4.65.3",
+        "@contentful/f36-spinner": "^4.65.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
@@ -2532,22 +2532,22 @@
       }
     },
     "node_modules/@contentful/f36-card": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.64.0.tgz",
-      "integrity": "sha512-M6Xj3NXFVV0e9/Kb/g6vxkKylZVd3J0XB5bFN0yxC851zz9sf0FOkPM0NQeFZbGYR6mkCe6Yv4zB0Z9BsU+VWw==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.65.3.tgz",
+      "integrity": "sha512-igsdDKQlgmPmo3Qgm4hn4szj7OXHI0lAiS0YXRW1LyvZfMQjdSnmtJRDbfZIQi7uxJNeFqlX9YGGOoa/WofheQ==",
       "dependencies": {
-        "@contentful/f36-asset": "^4.64.0",
-        "@contentful/f36-badge": "^4.64.0",
-        "@contentful/f36-button": "^4.64.0",
-        "@contentful/f36-core": "^4.64.0",
-        "@contentful/f36-drag-handle": "^4.64.0",
-        "@contentful/f36-icon": "^4.64.0",
-        "@contentful/f36-icons": "^4.28.0",
-        "@contentful/f36-menu": "^4.64.0",
-        "@contentful/f36-skeleton": "^4.64.0",
+        "@contentful/f36-asset": "^4.65.3",
+        "@contentful/f36-badge": "^4.65.3",
+        "@contentful/f36-button": "^4.65.3",
+        "@contentful/f36-core": "^4.65.3",
+        "@contentful/f36-drag-handle": "^4.65.3",
+        "@contentful/f36-icon": "^4.65.3",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-menu": "^4.65.3",
+        "@contentful/f36-skeleton": "^4.65.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.64.0",
-        "@contentful/f36-typography": "^4.64.0",
+        "@contentful/f36-tooltip": "^4.65.3",
+        "@contentful/f36-typography": "^4.65.3",
         "emotion": "^10.0.17",
         "truncate": "^3.0.0"
       },
@@ -2557,11 +2557,11 @@
       }
     },
     "node_modules/@contentful/f36-collapse": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.64.0.tgz",
-      "integrity": "sha512-R5he8izDIHW2QlMem4adJfkISLaCO/xFSu7QxQGGzh8mfbAqmi3dpGYGCZYgekThSfox6gHUFkaLpBQqnjTVqA==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.65.3.tgz",
+      "integrity": "sha512-lW2l1pDxPb4wRN5daAxhsxCj3POzZdru8mqCbgFJpW7tNdbGqSo1oUy2q35iCbrfNkukkMdYt4aT+Mxyhjbq9w==",
       "dependencies": {
-        "@contentful/f36-core": "^4.64.0",
+        "@contentful/f36-core": "^4.65.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2627,15 +2627,15 @@
       }
     },
     "node_modules/@contentful/f36-copybutton": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.64.0.tgz",
-      "integrity": "sha512-ptNOmQpTNAc3d2lIaKlBdAH+H+rhrp61TauZ7Ca+w5nPNQdyb0ZyKPnppwWWy89+yTdV69wlE7oCsX8dD/yTkw==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.65.3.tgz",
+      "integrity": "sha512-d2NXIzxHb8LMM64UGpun3yoOqhwGFH+6Q8OtxhvOxUrB4Ky3w2EWqXCqL9rimvx19pIstbN+2JoCVCSQy1j8Zg==",
       "dependencies": {
-        "@contentful/f36-button": "^4.64.0",
-        "@contentful/f36-core": "^4.64.0",
-        "@contentful/f36-icons": "^4.28.0",
+        "@contentful/f36-button": "^4.65.3",
+        "@contentful/f36-core": "^4.65.3",
+        "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.64.0",
+        "@contentful/f36-tooltip": "^4.65.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2644,9 +2644,9 @@
       }
     },
     "node_modules/@contentful/f36-core": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.64.0.tgz",
-      "integrity": "sha512-H7jbIk7BuGZzTD5Xc3vAn8EXYWsMmTncPDwImtvr1eOgtox++7Wll+aw8ZYn+hoftQuOtbXXy9DJFCBhSbfGoQ==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.65.3.tgz",
+      "integrity": "sha512-16tC0M57/h/T7rIq9ZvLAmXHKchB7f/iZxZOIZy40zaHLTOX8nIW3Lgha2fPEeQR4AaiS7+qwbN2Y815hgCx2Q==",
       "dependencies": {
         "@contentful/f36-tokens": "^4.0.4",
         "@emotion/core": "^10.1.1",
@@ -2660,22 +2660,22 @@
       }
     },
     "node_modules/@contentful/f36-core/node_modules/csstype": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/@contentful/f36-datepicker": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.64.0.tgz",
-      "integrity": "sha512-JCyxdEK+Rw94DCEPmG6kAx6vEhx9fQYP+tjXzFDSy2OHMfGKZz/zkdfudPbGWUn3vQ1pTxMhViLVWd6Lxkscbw==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.65.3.tgz",
+      "integrity": "sha512-kF/o3zDwzMnuREzQf/1fNzdTa0JxtULHUlLHBc2h+FLYl9mi7fgScaH6fCLkR6p3Yd7e3bn0JLZTfO0JmEYUhw==",
       "dependencies": {
-        "@contentful/f36-button": "^4.64.0",
-        "@contentful/f36-core": "^4.64.0",
-        "@contentful/f36-forms": "^4.64.0",
-        "@contentful/f36-icons": "^4.28.0",
-        "@contentful/f36-popover": "^4.64.0",
+        "@contentful/f36-button": "^4.65.3",
+        "@contentful/f36-core": "^4.65.3",
+        "@contentful/f36-forms": "^4.65.3",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-popover": "^4.65.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.64.0",
+        "@contentful/f36-typography": "^4.65.3",
         "date-fns": "^2.28.0",
         "emotion": "^10.0.17",
         "react-day-picker": "^8.7.1",
@@ -2687,11 +2687,11 @@
       }
     },
     "node_modules/@contentful/f36-datetime": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.64.0.tgz",
-      "integrity": "sha512-BKoyFfH8lXWemQ+svmYVdz4jNgPrJSg6fgzP7k20yI/KF8u4/HLeWTL/FR+mWu92jrhLNdUiIgOh3zMAETkAGg==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.65.3.tgz",
+      "integrity": "sha512-MSrk+dMMFOwCft2kezzwhIq9vdvKE05T1JFAKhmP3qYcCvxpkcukqSs5QnZUlRs3BP4E76myO7zG1upAE6V6dw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.64.0",
+        "@contentful/f36-core": "^4.65.3",
         "@contentful/f36-tokens": "^4.0.4",
         "dayjs": "^1.11.5",
         "emotion": "^10.0.17"
@@ -2702,12 +2702,12 @@
       }
     },
     "node_modules/@contentful/f36-drag-handle": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.64.0.tgz",
-      "integrity": "sha512-cmvOt29J862bNIMFednMSIO2kfcpzRi7LPY2iskHAsae7L9mc5+NfHIyAdd0hbYY4ZoYZ6Jts+uDnP/G2djDHg==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.65.3.tgz",
+      "integrity": "sha512-1HmbIY7wWp7bAC9qnRgTM04HWb175Bz4rWA9lwVtfSvsCBLiMbS6dUiqwHOVWusQw1MroB5OywusLyjjdyLGqw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.64.0",
-        "@contentful/f36-icons": "^4.28.0",
+        "@contentful/f36-core": "^4.65.3",
+        "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
@@ -2718,12 +2718,12 @@
       }
     },
     "node_modules/@contentful/f36-empty-state": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.64.0.tgz",
-      "integrity": "sha512-7SVyevYGKyeFAkYQrXlylN4SRasfrWTicZxVzGQY1Uh+/JAAmEHgHY6bpBosmFjRzV870WoFBbBuBWZasljEbQ==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.65.3.tgz",
+      "integrity": "sha512-2Cv8YmiXKCryUAdl9nwKV3y8nUtf/l1++xvbIAZwT+M5kYRD7gzEDCmhlZ9IGAOiS/DwiRLV82yx94AE8zipUw==",
       "dependencies": {
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.64.0",
+        "@contentful/f36-typography": "^4.65.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2732,20 +2732,20 @@
       }
     },
     "node_modules/@contentful/f36-entity-list": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.64.0.tgz",
-      "integrity": "sha512-7861feXWhD+yBAHhhbIXq9Bq3t74IYm9i5QGx0vnD2CyPMWFwDgSc60rFfOE6Cu+uTRa70iCc4t1gqBTpdgRmg==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.65.3.tgz",
+      "integrity": "sha512-rKFFkVwtj6RO06ShaPevoMyP0vXNHX0u13GaL6aWP5A+devQeNq7Lvb22rM4hXEW+qERyDjcjhY9mHuG55jRjw==",
       "dependencies": {
-        "@contentful/f36-badge": "^4.64.0",
-        "@contentful/f36-button": "^4.64.0",
-        "@contentful/f36-core": "^4.64.0",
-        "@contentful/f36-drag-handle": "^4.64.0",
-        "@contentful/f36-icon": "^4.64.0",
-        "@contentful/f36-icons": "^4.28.0",
-        "@contentful/f36-menu": "^4.64.0",
-        "@contentful/f36-skeleton": "^4.64.0",
+        "@contentful/f36-badge": "^4.65.3",
+        "@contentful/f36-button": "^4.65.3",
+        "@contentful/f36-core": "^4.65.3",
+        "@contentful/f36-drag-handle": "^4.65.3",
+        "@contentful/f36-icon": "^4.65.3",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-menu": "^4.65.3",
+        "@contentful/f36-skeleton": "^4.65.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.64.0",
+        "@contentful/f36-typography": "^4.65.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2754,14 +2754,14 @@
       }
     },
     "node_modules/@contentful/f36-forms": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.64.0.tgz",
-      "integrity": "sha512-x9fMYEJvn2aEgDgLBT2mhzsCWFLCckYxCQC0FSskk/Bpx7iwBUejCsN3WLKsTjYxCg4cWGlJMzeMe7I3t8DTig==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.65.3.tgz",
+      "integrity": "sha512-g8vYzhmBNzIvLK0ClAHN4akJIdaGsYVlopGPuYpfFh0lP+AePGCHoG945wxIRvTcMFsIYiHWJZUpDul/idfzvg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.64.0",
-        "@contentful/f36-icons": "^4.28.0",
+        "@contentful/f36-core": "^4.65.3",
+        "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.64.0",
+        "@contentful/f36-typography": "^4.65.3",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
@@ -2771,11 +2771,11 @@
       }
     },
     "node_modules/@contentful/f36-icon": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.64.0.tgz",
-      "integrity": "sha512-m+27GQZoza0M0jjJMboThu8CDBXusXOrlbq8tap6EzvRZ/tRGS313C0mQ+oe2N7I1E7GNAg9vt0MQUt2pGZy5w==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.65.3.tgz",
+      "integrity": "sha512-qeT8Es0cScXtQ6wLXY4E7CXxvA0fpZM5Udw7AQjmDU1u/uX5LrOD3fxCF64mM53ARM/WkIh9CyMePQkiJMylhA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.64.0",
+        "@contentful/f36-core": "^4.65.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2785,12 +2785,12 @@
       }
     },
     "node_modules/@contentful/f36-icons": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-4.28.0.tgz",
-      "integrity": "sha512-N5rZxEJ2/NOl4PCJD7hWZRVGovXGxR7v7Lbm9px6YTNdgiCM3iPSvjG99XmxhOR/U0oy90ctaNOaUrbq1vPJCA==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-4.28.2.tgz",
+      "integrity": "sha512-p7oWbQ5ITlMMuEl/6t/6JLVrCVhDE2nA8mv1VR4DHjXPm0y9w14533rCKxNIREZX8iVmyBoaqI3vdPsjUs1CAw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.63.0",
-        "@contentful/f36-icon": "^4.63.0",
+        "@contentful/f36-core": "^4.65.0",
+        "@contentful/f36-icon": "^4.65.0",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
@@ -2800,11 +2800,11 @@
       }
     },
     "node_modules/@contentful/f36-list": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.64.0.tgz",
-      "integrity": "sha512-DRss0R4VFQYS6c9Fl3VY0i3T63knzZtG1VvH5JTqC70GGNhtHRgjnvIs1TVLvNGNSMtyev+hoDlDaFVT0uVGtg==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.65.3.tgz",
+      "integrity": "sha512-HT2MbyVFCpQJ/vSy0k+WLnqVBqlONN7kX1P/6hA8xr9iu0gZwGZsFAAr+1t5J41vqv2HB83zYf6DIIeC+9njhA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.64.0",
+        "@contentful/f36-core": "^4.65.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2814,15 +2814,15 @@
       }
     },
     "node_modules/@contentful/f36-menu": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.64.0.tgz",
-      "integrity": "sha512-KOxM7mskGjSDKLaGvJTMNYkyzj1C1j+8ftL+qhB2slrmmDY7oAlItLqoRL/N9VCZPJazOEdWZoCfbhZ7YXySTw==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.65.3.tgz",
+      "integrity": "sha512-652sjkM+oHCyRi2RWSARLRvzQWIxManMBzR/FcDLAiTy0hQDxCIWFuniPQUFyExXAMlmDWzWY2zMDMHs5jRCQQ==",
       "dependencies": {
-        "@contentful/f36-core": "^4.64.0",
-        "@contentful/f36-icons": "^4.28.0",
-        "@contentful/f36-popover": "^4.64.0",
+        "@contentful/f36-core": "^4.65.3",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-popover": "^4.65.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.64.0",
+        "@contentful/f36-typography": "^4.65.3",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
@@ -2832,15 +2832,15 @@
       }
     },
     "node_modules/@contentful/f36-modal": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.64.0.tgz",
-      "integrity": "sha512-uKLAleibMv3xth0JZ1EFkq31Vb7gOYiKHYM64YkzFZYB1whwO97UKKUF3/6i2rA31T0q2XHHNW9YMkGkKAxs5g==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.65.3.tgz",
+      "integrity": "sha512-7AthnhPpTA/2cVZZaLV8ntc6AHTeR9i5Qm0vb0cwRfyf1mHBNmUl0b7TqiFOb/3Xnt/zMcEtVqJG6IJfXU/Enw==",
       "dependencies": {
-        "@contentful/f36-button": "^4.64.0",
-        "@contentful/f36-core": "^4.64.0",
-        "@contentful/f36-icons": "^4.28.0",
+        "@contentful/f36-button": "^4.65.3",
+        "@contentful/f36-core": "^4.65.3",
+        "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.64.0",
+        "@contentful/f36-typography": "^4.65.3",
         "@types/react-modal": "^3.13.1",
         "emotion": "^10.0.17",
         "react-modal": "^3.16.1"
@@ -2870,16 +2870,16 @@
       }
     },
     "node_modules/@contentful/f36-note": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.64.0.tgz",
-      "integrity": "sha512-Kuo8rrcAJJZ3NmIzAFY5/Re2eIQX/6xrTfIZgDvZFuJB+MvglQrSfow01Mpcus3yqcyt5/LPNI4dty5hnCRLCQ==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.65.3.tgz",
+      "integrity": "sha512-gMnkfloIkBFsGYNSPjVPmwNn7CeCfeuqhOK0Mwl/4C25NpmaaiyA6WgDMWJ1j+TR/AfJqxw0ncsMhKNnLG4LTQ==",
       "dependencies": {
-        "@contentful/f36-button": "^4.64.0",
-        "@contentful/f36-core": "^4.64.0",
-        "@contentful/f36-icon": "^4.64.0",
-        "@contentful/f36-icons": "^4.28.0",
+        "@contentful/f36-button": "^4.65.3",
+        "@contentful/f36-core": "^4.65.3",
+        "@contentful/f36-icon": "^4.65.3",
+        "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.64.0",
+        "@contentful/f36-typography": "^4.65.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2888,16 +2888,16 @@
       }
     },
     "node_modules/@contentful/f36-notification": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.64.0.tgz",
-      "integrity": "sha512-BqybNFhQ3AzZv8pT+fGtcO0wzzygiclxe78vYGEyymXmj5vL1A7sAtFJLvi09/xTdlDUDPiRz7WjmBHivmuRzA==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.65.3.tgz",
+      "integrity": "sha512-3viQhfhUksnL4oEQSRHV07JesjhVDESNgOD/tbCSPVbqbu4vYhS9Qr3n3TYJ4HWkRsJnRw6qiyTQ4qS98Lo93g==",
       "dependencies": {
-        "@contentful/f36-button": "^4.64.0",
-        "@contentful/f36-core": "^4.64.0",
-        "@contentful/f36-icons": "^4.28.0",
-        "@contentful/f36-text-link": "^4.64.0",
+        "@contentful/f36-button": "^4.65.3",
+        "@contentful/f36-core": "^4.65.3",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-text-link": "^4.65.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.64.0",
+        "@contentful/f36-typography": "^4.65.3",
         "@swc/helpers": "^0.4.14",
         "emotion": "^10.0.17",
         "react-animate-height": "^3.0.4"
@@ -2908,16 +2908,16 @@
       }
     },
     "node_modules/@contentful/f36-pagination": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.64.0.tgz",
-      "integrity": "sha512-eT+RhRCz7Asoi7M9UfLv2dIqqIAVNumiFcWYHiBNVX61qYssq+ddgbYIePXUTVPwSJIO3LGD+qNGlmwZnQ6h8A==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.65.3.tgz",
+      "integrity": "sha512-/WoTrsuJ2CeuGIPG/OsV1n7GykZsfZqXPMK/1QSnWLrgbafKnVx3vWqX1h3u9iIRMUTvSIg9HYRvrWi+t8wXSw==",
       "dependencies": {
-        "@contentful/f36-button": "^4.64.0",
-        "@contentful/f36-core": "^4.64.0",
-        "@contentful/f36-forms": "^4.64.0",
-        "@contentful/f36-icons": "^4.28.0",
+        "@contentful/f36-button": "^4.65.3",
+        "@contentful/f36-core": "^4.65.3",
+        "@contentful/f36-forms": "^4.65.3",
+        "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.64.0",
+        "@contentful/f36-typography": "^4.65.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2926,16 +2926,16 @@
       }
     },
     "node_modules/@contentful/f36-pill": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.64.0.tgz",
-      "integrity": "sha512-bzqNE7q/ldp3S2Aov2z1oQCPc//mVlmFtzZLEfY1WSXWr/c/fA7pwqH80w703DV4ji8WLpFJJCZxrMsc77u/Sw==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.65.3.tgz",
+      "integrity": "sha512-ZbD+MHVNozPlqXuqK1/wyjeHrTHeMDQkiZsyz/eeSxXZXABfUD1WPz9dZMpeJ+nz2mbeWDjjIlBFFamFso7lJg==",
       "dependencies": {
-        "@contentful/f36-button": "^4.64.0",
-        "@contentful/f36-core": "^4.64.0",
-        "@contentful/f36-drag-handle": "^4.64.0",
-        "@contentful/f36-icons": "^4.28.0",
+        "@contentful/f36-button": "^4.65.3",
+        "@contentful/f36-core": "^4.65.3",
+        "@contentful/f36-drag-handle": "^4.65.3",
+        "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.64.0",
+        "@contentful/f36-tooltip": "^4.65.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2944,11 +2944,11 @@
       }
     },
     "node_modules/@contentful/f36-popover": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.64.0.tgz",
-      "integrity": "sha512-A0wn/uBSl2kufJdpyiSfszJL3RoVKEPispdda/eYpAt8eEO5D7E0S5fvFc/J4DdJSoUeycJ1ewhD8tA5+sVlqQ==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.65.3.tgz",
+      "integrity": "sha512-lDwfbIaPS+d2TZ0p6rfBu5zjeDOCOXOmf6lNCwzqv4fev9k8c28mtPCKtNMhFQ/Ztf1bsJCUGDsK5pZMdw6B/Q==",
       "dependencies": {
-        "@contentful/f36-core": "^4.64.0",
+        "@contentful/f36-core": "^4.65.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -2961,12 +2961,12 @@
       }
     },
     "node_modules/@contentful/f36-skeleton": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.64.0.tgz",
-      "integrity": "sha512-/zSdX7LuX0OxznfJ1CwxtnCHwDpiRmwjjIwt2yrN0ro2LxY1dihJ/BTsnsDb55O2RG0tY5hdTV4rBKZ60xvf1g==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.65.3.tgz",
+      "integrity": "sha512-SCmEHwGlkD3J3GiobGbC09W5YwyQtt2CBVL96piTrOWt8FZYngmCP6xvynG8qe/pRXsWfm/rmJEp+hRUSeN0jw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.64.0",
-        "@contentful/f36-table": "^4.64.0",
+        "@contentful/f36-core": "^4.65.3",
+        "@contentful/f36-table": "^4.65.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2976,11 +2976,11 @@
       }
     },
     "node_modules/@contentful/f36-spinner": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.64.0.tgz",
-      "integrity": "sha512-PRXYneDvIMt0Wcw6R1Y3gaqkJ+XzSF/FAoyIc6rFtschuhYkzeaonYhzDJUVJlaMphPrSK7i7MAeouPiJ6GS3Q==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.65.3.tgz",
+      "integrity": "sha512-/lYEFxM1UWGDE/zkOxWJrNtmZ8zJRv23KzWrtCKT2QYH/R9Zp4SAQSFfXL2YizZ1i181Z/ZPik/jbE4GVxLimg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.64.0",
+        "@contentful/f36-core": "^4.65.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2990,14 +2990,14 @@
       }
     },
     "node_modules/@contentful/f36-table": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.64.0.tgz",
-      "integrity": "sha512-hIdFBBPPmTJlDTmYzFUqR38e5qtG1C5m5f0qXryPU/5kxRU9QYmHit8BeBv4HgmYK31TVw5xHQLQ2dpOgfqouA==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.65.3.tgz",
+      "integrity": "sha512-q6Q+/FeUQ8TkAT3IiLfQPjvo/5Y49hL7hQY0m99B/bWJwFavIUcy5b2a5lLwXFoiPuwM7SZulct7dOVWzA7ozg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.64.0",
-        "@contentful/f36-icons": "^4.28.0",
+        "@contentful/f36-core": "^4.65.3",
+        "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.64.0",
+        "@contentful/f36-typography": "^4.65.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -3006,11 +3006,11 @@
       }
     },
     "node_modules/@contentful/f36-tabs": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.64.0.tgz",
-      "integrity": "sha512-u7pPK/CWaq53PrLee1I/TdT5PXkD2ukJVkF9gClli7dUH0ivbJwLthj2shY2/KYA0UpaUpzkH+GWlwii+r22Yg==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.65.3.tgz",
+      "integrity": "sha512-mKG11Lotk7jMUZMzODYFnWHPY1t7DNOIE1przFiHcjivUboDxo7uS5Okx6RaCNlG54L+T9QvMadyEGSaMVXjKA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.64.0",
+        "@contentful/f36-core": "^4.65.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@radix-ui/react-tabs": "^1.0.1",
         "emotion": "^10.0.17"
@@ -3021,11 +3021,11 @@
       }
     },
     "node_modules/@contentful/f36-text-link": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.64.0.tgz",
-      "integrity": "sha512-+sJJ7hIBTfSNkHnSJjXTicDFMMBtbCHEbq7ofUp15XXlp7RGmbGZXp8r1XXqK9x/JUzmrmNfmi0wXOSDfFMDAg==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.65.3.tgz",
+      "integrity": "sha512-MWXzv8DmWaORS86YXstGDfswj8DqlY6/uSrb+Xz/M0waIQ0eCt32vXOeMkzxE2bAVyZVtiJP6OGvcqd2k7Ny6Q==",
       "dependencies": {
-        "@contentful/f36-core": "^4.64.0",
+        "@contentful/f36-core": "^4.65.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -3040,11 +3040,11 @@
       "integrity": "sha512-yPHNQjHVEuO+5nUoX3EbrQvLoU7ZjNc/w3RyCmYR3F/NWZCy/3n0Knhq5Jfow+CcXkVY6Ch526VlA3+ayEN2kA=="
     },
     "node_modules/@contentful/f36-tooltip": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.64.0.tgz",
-      "integrity": "sha512-jjMQvPU0ljb1PZ4xuysUmfWjncqQOzWekrq9GB5YTsu6x7lRHnHF1aiGUxhYplmRQopu4YT6cJ0kGjhJfTaK0w==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.65.3.tgz",
+      "integrity": "sha512-Xeo5YW0ix3pFB1IXeiGPKoGrDFD+4b2FD83/F2ar6Z60ewg8Rz4z8+RiQti/A/2M/88cZJVOdG2NfesJiXUDtg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.64.0",
+        "@contentful/f36-core": "^4.65.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -3063,11 +3063,11 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/@contentful/f36-typography": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.64.0.tgz",
-      "integrity": "sha512-X1T+MugozF/RK5w/ci3WZadCpdpXJHOvTbVM3HSD7jsDuiyXFq7uByynlp4i7QY4czovjy2XQ+LahvP0rNDeHw==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.65.3.tgz",
+      "integrity": "sha512-cr9UJLbLcB9S22/L601nIrLshRAERLw1+hUE6FpxOwkk4MOeSL3WWFusIa2oVlMJqb5BbOsCCVVcpsigHEqIqw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.64.0",
+        "@contentful/f36-core": "^4.65.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
@@ -3414,9 +3414,9 @@
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
     },
     "node_modules/@emotion/is-prop-valid": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
-      "integrity": "sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz",
+      "integrity": "sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==",
       "dependencies": {
         "@emotion/memoize": "^0.8.1"
       }
@@ -8020,9 +8020,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.10",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
-      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.11.tgz",
+      "integrity": "sha512-okzr3f11N6WuqYtZSvm+F776mB41wRZMhKP+hc34YdW+KmtYYK9iqvHSwo2k9FEH3fhGXvOPV6yz2IcSrfRUDg=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -16408,9 +16408,9 @@
       }
     },
     "node_modules/react": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.1.tgz",
-      "integrity": "sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -16648,16 +16648,16 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.1.tgz",
-      "integrity": "sha512-6eV150oJZ9U2t9svnsspTMrWNyHc6chX0KzDeAOXftRa8bNeOKTTfCJ7KorIwenkHd2xqVTBTCZd79yk/lx/Ug==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
+      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "scheduler": "^0.20.1"
+        "scheduler": "^0.20.2"
       },
       "peerDependencies": {
-        "react": "17.0.1"
+        "react": "17.0.2"
       }
     },
     "node_modules/react-error-overlay": {
@@ -16671,9 +16671,9 @@
       "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
     },
     "node_modules/react-focus-lock": {
-      "version": "2.11.3",
-      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.11.3.tgz",
-      "integrity": "sha512-CfWYS86y6KvAIGxYzO1/HlWI2zGON9Fa3L2xfREDGMNFAtYj3m/ZRvnsMH4H75dj5FpgDy2LWA1Vyx+twV80vw==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.12.1.tgz",
+      "integrity": "sha512-lfp8Dve4yJagkHiFrC1bGtib3mF2ktqwPJw4/WGcgPW+pJ/AVQA5X2vI7xgp13FcxFEpYBBHpXai/N2DBNC0Jw==",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
         "focus-lock": "^1.3.5",
@@ -18907,16 +18907,17 @@
       }
     },
     "node_modules/usehooks-ts": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-2.9.1.tgz",
-      "integrity": "sha512-2FAuSIGHlY+apM9FVlj8/oNhd+1y+Uwv5QNkMQz1oSfdHk4PXo1qoCw9I5M7j0vpH8CSWFJwXbVPeYDjLCx9PA==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-2.16.0.tgz",
+      "integrity": "sha512-bez95WqYujxp6hFdM/CpRDiVPirZPxlMzOH2QB8yopoKQMXpscyZoxOjpEdaxvV+CAWUDSM62cWnqHE0E/MZ7w==",
+      "dependencies": {
+        "lodash.debounce": "^4.0.8"
+      },
       "engines": {
-        "node": ">=16.15.0",
-        "npm": ">=8"
+        "node": ">=16.15.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0  || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0  || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0  || ^17 || ^18"
       }
     },
     "node_modules/util-deprecate": {
@@ -21525,99 +21526,99 @@
       }
     },
     "@contentful/f36-accordion": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.64.0.tgz",
-      "integrity": "sha512-XXH+ioAHeQmCfhylb3y8qSHaLnNBiohCxaibBk1bxgsLHIGxgUoRbqkO9itXH4XcGSw2jCjFZRvtEwUu6uX3qQ==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.65.3.tgz",
+      "integrity": "sha512-J7xAwHIVDxFMBy7VODDXBKdI52T93e2VMCaOsOiGTye1ZkCKOepL0m+1KsL79bG+jobuzfQ9j9q3IHpBKI+wlg==",
       "requires": {
-        "@contentful/f36-collapse": "^4.64.0",
-        "@contentful/f36-core": "^4.64.0",
-        "@contentful/f36-icons": "^4.28.0",
+        "@contentful/f36-collapse": "^4.65.3",
+        "@contentful/f36-core": "^4.65.3",
+        "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.64.0",
+        "@contentful/f36-typography": "^4.65.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-asset": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.64.0.tgz",
-      "integrity": "sha512-ZN3G9s/j90SGwlgXDTuUDkd7m5JoLQSJFf66KOoIvYP6+Nk24bC2taGwFmywiLVa7/TZ5nq/Wq9lZCFxDTMurA==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.65.3.tgz",
+      "integrity": "sha512-mXziWPxKZ88/eYb7dyroXo7o44fEqY4ABzaSuz4UnmnxtTyLpAefly8vjQ5V9KTf8kUKv6HcaVkYw942hL0AwQ==",
       "requires": {
-        "@contentful/f36-core": "^4.64.0",
-        "@contentful/f36-icon": "^4.64.0",
-        "@contentful/f36-icons": "^4.28.0",
+        "@contentful/f36-core": "^4.65.3",
+        "@contentful/f36-icon": "^4.65.3",
+        "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.64.0",
+        "@contentful/f36-typography": "^4.65.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-autocomplete": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.64.0.tgz",
-      "integrity": "sha512-LvD0EQYqpFx/kAbpQFsuwRPQh26FPPq2WH9d8A9EY8xCLJA4Lv2KY5GfwGEWjWTiIo06hyOYzD8k1/F6kjdznA==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.65.3.tgz",
+      "integrity": "sha512-4GrcUKOI5XwZFmj0qquL5v7cRgjXCubGq2Ad19+Bv7xt4ndxwIbkTiZnaxDRav9PE7yJVVr+M1wh2f2DZBR0fg==",
       "requires": {
-        "@contentful/f36-button": "^4.64.0",
-        "@contentful/f36-core": "^4.64.0",
-        "@contentful/f36-forms": "^4.64.0",
-        "@contentful/f36-icons": "^4.28.0",
-        "@contentful/f36-popover": "^4.64.0",
-        "@contentful/f36-skeleton": "^4.64.0",
+        "@contentful/f36-button": "^4.65.3",
+        "@contentful/f36-core": "^4.65.3",
+        "@contentful/f36-forms": "^4.65.3",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-popover": "^4.65.3",
+        "@contentful/f36-skeleton": "^4.65.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.64.0",
+        "@contentful/f36-typography": "^4.65.3",
         "@contentful/f36-utils": "^4.24.3",
         "downshift": "^6.1.12",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-badge": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.64.0.tgz",
-      "integrity": "sha512-VwrYdLT9zN4fIsGtlCC14Da5ygPK1z/JLAQS2UgZBIs7mSdLmyJUP0kJnfEPRgZGIOCkRz3r3xU1JfxK6fTZIA==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.65.3.tgz",
+      "integrity": "sha512-cY7GY8g/KdzcCL0ApB0OG1sOZyzllyWTglYBdnMEbKHXnGk0SNLQQlELet35th2d7BBTweJC811p5QDlp8IhHg==",
       "requires": {
-        "@contentful/f36-core": "^4.64.0",
-        "@contentful/f36-icons": "^4.28.0",
+        "@contentful/f36-core": "^4.65.3",
+        "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-button": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.64.0.tgz",
-      "integrity": "sha512-DaJ7z4mVRk1Ft0hcTpzprnDvC2QoKq1C5YXsNO4y6AZv26jLKn5Jr+kxn4DmeI+H/Qe6bbrg3jEBNaFO7bU02Q==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.65.3.tgz",
+      "integrity": "sha512-bsfJPcGPr6zjeR0nmKbeKSTTGh/o6dOXKNurlJrFGrSr+i9rqprmhCDpBCrv2Zb/xPByS3n/ADYE0+CMG6v1BQ==",
       "requires": {
-        "@contentful/f36-core": "^4.64.0",
-        "@contentful/f36-spinner": "^4.64.0",
+        "@contentful/f36-core": "^4.65.3",
+        "@contentful/f36-spinner": "^4.65.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-card": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.64.0.tgz",
-      "integrity": "sha512-M6Xj3NXFVV0e9/Kb/g6vxkKylZVd3J0XB5bFN0yxC851zz9sf0FOkPM0NQeFZbGYR6mkCe6Yv4zB0Z9BsU+VWw==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.65.3.tgz",
+      "integrity": "sha512-igsdDKQlgmPmo3Qgm4hn4szj7OXHI0lAiS0YXRW1LyvZfMQjdSnmtJRDbfZIQi7uxJNeFqlX9YGGOoa/WofheQ==",
       "requires": {
-        "@contentful/f36-asset": "^4.64.0",
-        "@contentful/f36-badge": "^4.64.0",
-        "@contentful/f36-button": "^4.64.0",
-        "@contentful/f36-core": "^4.64.0",
-        "@contentful/f36-drag-handle": "^4.64.0",
-        "@contentful/f36-icon": "^4.64.0",
-        "@contentful/f36-icons": "^4.28.0",
-        "@contentful/f36-menu": "^4.64.0",
-        "@contentful/f36-skeleton": "^4.64.0",
+        "@contentful/f36-asset": "^4.65.3",
+        "@contentful/f36-badge": "^4.65.3",
+        "@contentful/f36-button": "^4.65.3",
+        "@contentful/f36-core": "^4.65.3",
+        "@contentful/f36-drag-handle": "^4.65.3",
+        "@contentful/f36-icon": "^4.65.3",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-menu": "^4.65.3",
+        "@contentful/f36-skeleton": "^4.65.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.64.0",
-        "@contentful/f36-typography": "^4.64.0",
+        "@contentful/f36-tooltip": "^4.65.3",
+        "@contentful/f36-typography": "^4.65.3",
         "emotion": "^10.0.17",
         "truncate": "^3.0.0"
       }
     },
     "@contentful/f36-collapse": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.64.0.tgz",
-      "integrity": "sha512-R5he8izDIHW2QlMem4adJfkISLaCO/xFSu7QxQGGzh8mfbAqmi3dpGYGCZYgekThSfox6gHUFkaLpBQqnjTVqA==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.65.3.tgz",
+      "integrity": "sha512-lW2l1pDxPb4wRN5daAxhsxCj3POzZdru8mqCbgFJpW7tNdbGqSo1oUy2q35iCbrfNkukkMdYt4aT+Mxyhjbq9w==",
       "requires": {
-        "@contentful/f36-core": "^4.64.0",
+        "@contentful/f36-core": "^4.65.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
@@ -21665,22 +21666,22 @@
       }
     },
     "@contentful/f36-copybutton": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.64.0.tgz",
-      "integrity": "sha512-ptNOmQpTNAc3d2lIaKlBdAH+H+rhrp61TauZ7Ca+w5nPNQdyb0ZyKPnppwWWy89+yTdV69wlE7oCsX8dD/yTkw==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.65.3.tgz",
+      "integrity": "sha512-d2NXIzxHb8LMM64UGpun3yoOqhwGFH+6Q8OtxhvOxUrB4Ky3w2EWqXCqL9rimvx19pIstbN+2JoCVCSQy1j8Zg==",
       "requires": {
-        "@contentful/f36-button": "^4.64.0",
-        "@contentful/f36-core": "^4.64.0",
-        "@contentful/f36-icons": "^4.28.0",
+        "@contentful/f36-button": "^4.65.3",
+        "@contentful/f36-core": "^4.65.3",
+        "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.64.0",
+        "@contentful/f36-tooltip": "^4.65.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-core": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.64.0.tgz",
-      "integrity": "sha512-H7jbIk7BuGZzTD5Xc3vAn8EXYWsMmTncPDwImtvr1eOgtox++7Wll+aw8ZYn+hoftQuOtbXXy9DJFCBhSbfGoQ==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.65.3.tgz",
+      "integrity": "sha512-16tC0M57/h/T7rIq9ZvLAmXHKchB7f/iZxZOIZy40zaHLTOX8nIW3Lgha2fPEeQR4AaiS7+qwbN2Y815hgCx2Q==",
       "requires": {
         "@contentful/f36-tokens": "^4.0.4",
         "@emotion/core": "^10.1.1",
@@ -21690,24 +21691,24 @@
       },
       "dependencies": {
         "csstype": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-          "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
         }
       }
     },
     "@contentful/f36-datepicker": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.64.0.tgz",
-      "integrity": "sha512-JCyxdEK+Rw94DCEPmG6kAx6vEhx9fQYP+tjXzFDSy2OHMfGKZz/zkdfudPbGWUn3vQ1pTxMhViLVWd6Lxkscbw==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.65.3.tgz",
+      "integrity": "sha512-kF/o3zDwzMnuREzQf/1fNzdTa0JxtULHUlLHBc2h+FLYl9mi7fgScaH6fCLkR6p3Yd7e3bn0JLZTfO0JmEYUhw==",
       "requires": {
-        "@contentful/f36-button": "^4.64.0",
-        "@contentful/f36-core": "^4.64.0",
-        "@contentful/f36-forms": "^4.64.0",
-        "@contentful/f36-icons": "^4.28.0",
-        "@contentful/f36-popover": "^4.64.0",
+        "@contentful/f36-button": "^4.65.3",
+        "@contentful/f36-core": "^4.65.3",
+        "@contentful/f36-forms": "^4.65.3",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-popover": "^4.65.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.64.0",
+        "@contentful/f36-typography": "^4.65.3",
         "date-fns": "^2.28.0",
         "emotion": "^10.0.17",
         "react-day-picker": "^8.7.1",
@@ -21715,124 +21716,124 @@
       }
     },
     "@contentful/f36-datetime": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.64.0.tgz",
-      "integrity": "sha512-BKoyFfH8lXWemQ+svmYVdz4jNgPrJSg6fgzP7k20yI/KF8u4/HLeWTL/FR+mWu92jrhLNdUiIgOh3zMAETkAGg==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.65.3.tgz",
+      "integrity": "sha512-MSrk+dMMFOwCft2kezzwhIq9vdvKE05T1JFAKhmP3qYcCvxpkcukqSs5QnZUlRs3BP4E76myO7zG1upAE6V6dw==",
       "requires": {
-        "@contentful/f36-core": "^4.64.0",
+        "@contentful/f36-core": "^4.65.3",
         "@contentful/f36-tokens": "^4.0.4",
         "dayjs": "^1.11.5",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-drag-handle": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.64.0.tgz",
-      "integrity": "sha512-cmvOt29J862bNIMFednMSIO2kfcpzRi7LPY2iskHAsae7L9mc5+NfHIyAdd0hbYY4ZoYZ6Jts+uDnP/G2djDHg==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.65.3.tgz",
+      "integrity": "sha512-1HmbIY7wWp7bAC9qnRgTM04HWb175Bz4rWA9lwVtfSvsCBLiMbS6dUiqwHOVWusQw1MroB5OywusLyjjdyLGqw==",
       "requires": {
-        "@contentful/f36-core": "^4.64.0",
-        "@contentful/f36-icons": "^4.28.0",
+        "@contentful/f36-core": "^4.65.3",
+        "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-empty-state": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.64.0.tgz",
-      "integrity": "sha512-7SVyevYGKyeFAkYQrXlylN4SRasfrWTicZxVzGQY1Uh+/JAAmEHgHY6bpBosmFjRzV870WoFBbBuBWZasljEbQ==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.65.3.tgz",
+      "integrity": "sha512-2Cv8YmiXKCryUAdl9nwKV3y8nUtf/l1++xvbIAZwT+M5kYRD7gzEDCmhlZ9IGAOiS/DwiRLV82yx94AE8zipUw==",
       "requires": {
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.64.0",
+        "@contentful/f36-typography": "^4.65.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-entity-list": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.64.0.tgz",
-      "integrity": "sha512-7861feXWhD+yBAHhhbIXq9Bq3t74IYm9i5QGx0vnD2CyPMWFwDgSc60rFfOE6Cu+uTRa70iCc4t1gqBTpdgRmg==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.65.3.tgz",
+      "integrity": "sha512-rKFFkVwtj6RO06ShaPevoMyP0vXNHX0u13GaL6aWP5A+devQeNq7Lvb22rM4hXEW+qERyDjcjhY9mHuG55jRjw==",
       "requires": {
-        "@contentful/f36-badge": "^4.64.0",
-        "@contentful/f36-button": "^4.64.0",
-        "@contentful/f36-core": "^4.64.0",
-        "@contentful/f36-drag-handle": "^4.64.0",
-        "@contentful/f36-icon": "^4.64.0",
-        "@contentful/f36-icons": "^4.28.0",
-        "@contentful/f36-menu": "^4.64.0",
-        "@contentful/f36-skeleton": "^4.64.0",
+        "@contentful/f36-badge": "^4.65.3",
+        "@contentful/f36-button": "^4.65.3",
+        "@contentful/f36-core": "^4.65.3",
+        "@contentful/f36-drag-handle": "^4.65.3",
+        "@contentful/f36-icon": "^4.65.3",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-menu": "^4.65.3",
+        "@contentful/f36-skeleton": "^4.65.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.64.0",
+        "@contentful/f36-typography": "^4.65.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-forms": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.64.0.tgz",
-      "integrity": "sha512-x9fMYEJvn2aEgDgLBT2mhzsCWFLCckYxCQC0FSskk/Bpx7iwBUejCsN3WLKsTjYxCg4cWGlJMzeMe7I3t8DTig==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.65.3.tgz",
+      "integrity": "sha512-g8vYzhmBNzIvLK0ClAHN4akJIdaGsYVlopGPuYpfFh0lP+AePGCHoG945wxIRvTcMFsIYiHWJZUpDul/idfzvg==",
       "requires": {
-        "@contentful/f36-core": "^4.64.0",
-        "@contentful/f36-icons": "^4.28.0",
+        "@contentful/f36-core": "^4.65.3",
+        "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.64.0",
+        "@contentful/f36-typography": "^4.65.3",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-icon": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.64.0.tgz",
-      "integrity": "sha512-m+27GQZoza0M0jjJMboThu8CDBXusXOrlbq8tap6EzvRZ/tRGS313C0mQ+oe2N7I1E7GNAg9vt0MQUt2pGZy5w==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.65.3.tgz",
+      "integrity": "sha512-qeT8Es0cScXtQ6wLXY4E7CXxvA0fpZM5Udw7AQjmDU1u/uX5LrOD3fxCF64mM53ARM/WkIh9CyMePQkiJMylhA==",
       "requires": {
-        "@contentful/f36-core": "^4.64.0",
+        "@contentful/f36-core": "^4.65.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-icons": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-4.28.0.tgz",
-      "integrity": "sha512-N5rZxEJ2/NOl4PCJD7hWZRVGovXGxR7v7Lbm9px6YTNdgiCM3iPSvjG99XmxhOR/U0oy90ctaNOaUrbq1vPJCA==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-4.28.2.tgz",
+      "integrity": "sha512-p7oWbQ5ITlMMuEl/6t/6JLVrCVhDE2nA8mv1VR4DHjXPm0y9w14533rCKxNIREZX8iVmyBoaqI3vdPsjUs1CAw==",
       "requires": {
-        "@contentful/f36-core": "^4.63.0",
-        "@contentful/f36-icon": "^4.63.0",
+        "@contentful/f36-core": "^4.65.0",
+        "@contentful/f36-icon": "^4.65.0",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-list": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.64.0.tgz",
-      "integrity": "sha512-DRss0R4VFQYS6c9Fl3VY0i3T63knzZtG1VvH5JTqC70GGNhtHRgjnvIs1TVLvNGNSMtyev+hoDlDaFVT0uVGtg==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.65.3.tgz",
+      "integrity": "sha512-HT2MbyVFCpQJ/vSy0k+WLnqVBqlONN7kX1P/6hA8xr9iu0gZwGZsFAAr+1t5J41vqv2HB83zYf6DIIeC+9njhA==",
       "requires": {
-        "@contentful/f36-core": "^4.64.0",
+        "@contentful/f36-core": "^4.65.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-menu": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.64.0.tgz",
-      "integrity": "sha512-KOxM7mskGjSDKLaGvJTMNYkyzj1C1j+8ftL+qhB2slrmmDY7oAlItLqoRL/N9VCZPJazOEdWZoCfbhZ7YXySTw==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.65.3.tgz",
+      "integrity": "sha512-652sjkM+oHCyRi2RWSARLRvzQWIxManMBzR/FcDLAiTy0hQDxCIWFuniPQUFyExXAMlmDWzWY2zMDMHs5jRCQQ==",
       "requires": {
-        "@contentful/f36-core": "^4.64.0",
-        "@contentful/f36-icons": "^4.28.0",
-        "@contentful/f36-popover": "^4.64.0",
+        "@contentful/f36-core": "^4.65.3",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-popover": "^4.65.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.64.0",
+        "@contentful/f36-typography": "^4.65.3",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-modal": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.64.0.tgz",
-      "integrity": "sha512-uKLAleibMv3xth0JZ1EFkq31Vb7gOYiKHYM64YkzFZYB1whwO97UKKUF3/6i2rA31T0q2XHHNW9YMkGkKAxs5g==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.65.3.tgz",
+      "integrity": "sha512-7AthnhPpTA/2cVZZaLV8ntc6AHTeR9i5Qm0vb0cwRfyf1mHBNmUl0b7TqiFOb/3Xnt/zMcEtVqJG6IJfXU/Enw==",
       "requires": {
-        "@contentful/f36-button": "^4.64.0",
-        "@contentful/f36-core": "^4.64.0",
-        "@contentful/f36-icons": "^4.28.0",
+        "@contentful/f36-button": "^4.65.3",
+        "@contentful/f36-core": "^4.65.3",
+        "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.64.0",
+        "@contentful/f36-typography": "^4.65.3",
         "@types/react-modal": "^3.13.1",
         "emotion": "^10.0.17",
         "react-modal": "^3.16.1"
@@ -21854,69 +21855,69 @@
       }
     },
     "@contentful/f36-note": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.64.0.tgz",
-      "integrity": "sha512-Kuo8rrcAJJZ3NmIzAFY5/Re2eIQX/6xrTfIZgDvZFuJB+MvglQrSfow01Mpcus3yqcyt5/LPNI4dty5hnCRLCQ==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.65.3.tgz",
+      "integrity": "sha512-gMnkfloIkBFsGYNSPjVPmwNn7CeCfeuqhOK0Mwl/4C25NpmaaiyA6WgDMWJ1j+TR/AfJqxw0ncsMhKNnLG4LTQ==",
       "requires": {
-        "@contentful/f36-button": "^4.64.0",
-        "@contentful/f36-core": "^4.64.0",
-        "@contentful/f36-icon": "^4.64.0",
-        "@contentful/f36-icons": "^4.28.0",
+        "@contentful/f36-button": "^4.65.3",
+        "@contentful/f36-core": "^4.65.3",
+        "@contentful/f36-icon": "^4.65.3",
+        "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.64.0",
+        "@contentful/f36-typography": "^4.65.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-notification": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.64.0.tgz",
-      "integrity": "sha512-BqybNFhQ3AzZv8pT+fGtcO0wzzygiclxe78vYGEyymXmj5vL1A7sAtFJLvi09/xTdlDUDPiRz7WjmBHivmuRzA==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.65.3.tgz",
+      "integrity": "sha512-3viQhfhUksnL4oEQSRHV07JesjhVDESNgOD/tbCSPVbqbu4vYhS9Qr3n3TYJ4HWkRsJnRw6qiyTQ4qS98Lo93g==",
       "requires": {
-        "@contentful/f36-button": "^4.64.0",
-        "@contentful/f36-core": "^4.64.0",
-        "@contentful/f36-icons": "^4.28.0",
-        "@contentful/f36-text-link": "^4.64.0",
+        "@contentful/f36-button": "^4.65.3",
+        "@contentful/f36-core": "^4.65.3",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-text-link": "^4.65.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.64.0",
+        "@contentful/f36-typography": "^4.65.3",
         "@swc/helpers": "^0.4.14",
         "emotion": "^10.0.17",
         "react-animate-height": "^3.0.4"
       }
     },
     "@contentful/f36-pagination": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.64.0.tgz",
-      "integrity": "sha512-eT+RhRCz7Asoi7M9UfLv2dIqqIAVNumiFcWYHiBNVX61qYssq+ddgbYIePXUTVPwSJIO3LGD+qNGlmwZnQ6h8A==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.65.3.tgz",
+      "integrity": "sha512-/WoTrsuJ2CeuGIPG/OsV1n7GykZsfZqXPMK/1QSnWLrgbafKnVx3vWqX1h3u9iIRMUTvSIg9HYRvrWi+t8wXSw==",
       "requires": {
-        "@contentful/f36-button": "^4.64.0",
-        "@contentful/f36-core": "^4.64.0",
-        "@contentful/f36-forms": "^4.64.0",
-        "@contentful/f36-icons": "^4.28.0",
+        "@contentful/f36-button": "^4.65.3",
+        "@contentful/f36-core": "^4.65.3",
+        "@contentful/f36-forms": "^4.65.3",
+        "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.64.0",
+        "@contentful/f36-typography": "^4.65.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-pill": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.64.0.tgz",
-      "integrity": "sha512-bzqNE7q/ldp3S2Aov2z1oQCPc//mVlmFtzZLEfY1WSXWr/c/fA7pwqH80w703DV4ji8WLpFJJCZxrMsc77u/Sw==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.65.3.tgz",
+      "integrity": "sha512-ZbD+MHVNozPlqXuqK1/wyjeHrTHeMDQkiZsyz/eeSxXZXABfUD1WPz9dZMpeJ+nz2mbeWDjjIlBFFamFso7lJg==",
       "requires": {
-        "@contentful/f36-button": "^4.64.0",
-        "@contentful/f36-core": "^4.64.0",
-        "@contentful/f36-drag-handle": "^4.64.0",
-        "@contentful/f36-icons": "^4.28.0",
+        "@contentful/f36-button": "^4.65.3",
+        "@contentful/f36-core": "^4.65.3",
+        "@contentful/f36-drag-handle": "^4.65.3",
+        "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.64.0",
+        "@contentful/f36-tooltip": "^4.65.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-popover": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.64.0.tgz",
-      "integrity": "sha512-A0wn/uBSl2kufJdpyiSfszJL3RoVKEPispdda/eYpAt8eEO5D7E0S5fvFc/J4DdJSoUeycJ1ewhD8tA5+sVlqQ==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.65.3.tgz",
+      "integrity": "sha512-lDwfbIaPS+d2TZ0p6rfBu5zjeDOCOXOmf6lNCwzqv4fev9k8c28mtPCKtNMhFQ/Ztf1bsJCUGDsK5pZMdw6B/Q==",
       "requires": {
-        "@contentful/f36-core": "^4.64.0",
+        "@contentful/f36-core": "^4.65.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -21925,55 +21926,55 @@
       }
     },
     "@contentful/f36-skeleton": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.64.0.tgz",
-      "integrity": "sha512-/zSdX7LuX0OxznfJ1CwxtnCHwDpiRmwjjIwt2yrN0ro2LxY1dihJ/BTsnsDb55O2RG0tY5hdTV4rBKZ60xvf1g==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.65.3.tgz",
+      "integrity": "sha512-SCmEHwGlkD3J3GiobGbC09W5YwyQtt2CBVL96piTrOWt8FZYngmCP6xvynG8qe/pRXsWfm/rmJEp+hRUSeN0jw==",
       "requires": {
-        "@contentful/f36-core": "^4.64.0",
-        "@contentful/f36-table": "^4.64.0",
+        "@contentful/f36-core": "^4.65.3",
+        "@contentful/f36-table": "^4.65.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-spinner": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.64.0.tgz",
-      "integrity": "sha512-PRXYneDvIMt0Wcw6R1Y3gaqkJ+XzSF/FAoyIc6rFtschuhYkzeaonYhzDJUVJlaMphPrSK7i7MAeouPiJ6GS3Q==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.65.3.tgz",
+      "integrity": "sha512-/lYEFxM1UWGDE/zkOxWJrNtmZ8zJRv23KzWrtCKT2QYH/R9Zp4SAQSFfXL2YizZ1i181Z/ZPik/jbE4GVxLimg==",
       "requires": {
-        "@contentful/f36-core": "^4.64.0",
+        "@contentful/f36-core": "^4.65.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-table": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.64.0.tgz",
-      "integrity": "sha512-hIdFBBPPmTJlDTmYzFUqR38e5qtG1C5m5f0qXryPU/5kxRU9QYmHit8BeBv4HgmYK31TVw5xHQLQ2dpOgfqouA==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.65.3.tgz",
+      "integrity": "sha512-q6Q+/FeUQ8TkAT3IiLfQPjvo/5Y49hL7hQY0m99B/bWJwFavIUcy5b2a5lLwXFoiPuwM7SZulct7dOVWzA7ozg==",
       "requires": {
-        "@contentful/f36-core": "^4.64.0",
-        "@contentful/f36-icons": "^4.28.0",
+        "@contentful/f36-core": "^4.65.3",
+        "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.64.0",
+        "@contentful/f36-typography": "^4.65.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-tabs": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.64.0.tgz",
-      "integrity": "sha512-u7pPK/CWaq53PrLee1I/TdT5PXkD2ukJVkF9gClli7dUH0ivbJwLthj2shY2/KYA0UpaUpzkH+GWlwii+r22Yg==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.65.3.tgz",
+      "integrity": "sha512-mKG11Lotk7jMUZMzODYFnWHPY1t7DNOIE1przFiHcjivUboDxo7uS5Okx6RaCNlG54L+T9QvMadyEGSaMVXjKA==",
       "requires": {
-        "@contentful/f36-core": "^4.64.0",
+        "@contentful/f36-core": "^4.65.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@radix-ui/react-tabs": "^1.0.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-text-link": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.64.0.tgz",
-      "integrity": "sha512-+sJJ7hIBTfSNkHnSJjXTicDFMMBtbCHEbq7ofUp15XXlp7RGmbGZXp8r1XXqK9x/JUzmrmNfmi0wXOSDfFMDAg==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.65.3.tgz",
+      "integrity": "sha512-MWXzv8DmWaORS86YXstGDfswj8DqlY6/uSrb+Xz/M0waIQ0eCt32vXOeMkzxE2bAVyZVtiJP6OGvcqd2k7Ny6Q==",
       "requires": {
-        "@contentful/f36-core": "^4.64.0",
+        "@contentful/f36-core": "^4.65.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
@@ -21984,11 +21985,11 @@
       "integrity": "sha512-yPHNQjHVEuO+5nUoX3EbrQvLoU7ZjNc/w3RyCmYR3F/NWZCy/3n0Knhq5Jfow+CcXkVY6Ch526VlA3+ayEN2kA=="
     },
     "@contentful/f36-tooltip": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.64.0.tgz",
-      "integrity": "sha512-jjMQvPU0ljb1PZ4xuysUmfWjncqQOzWekrq9GB5YTsu6x7lRHnHF1aiGUxhYplmRQopu4YT6cJ0kGjhJfTaK0w==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.65.3.tgz",
+      "integrity": "sha512-Xeo5YW0ix3pFB1IXeiGPKoGrDFD+4b2FD83/F2ar6Z60ewg8Rz4z8+RiQti/A/2M/88cZJVOdG2NfesJiXUDtg==",
       "requires": {
-        "@contentful/f36-core": "^4.64.0",
+        "@contentful/f36-core": "^4.65.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -22005,11 +22006,11 @@
       }
     },
     "@contentful/f36-typography": {
-      "version": "4.64.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.64.0.tgz",
-      "integrity": "sha512-X1T+MugozF/RK5w/ci3WZadCpdpXJHOvTbVM3HSD7jsDuiyXFq7uByynlp4i7QY4czovjy2XQ+LahvP0rNDeHw==",
+      "version": "4.65.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.65.3.tgz",
+      "integrity": "sha512-cr9UJLbLcB9S22/L601nIrLshRAERLw1+hUE6FpxOwkk4MOeSL3WWFusIa2oVlMJqb5BbOsCCVVcpsigHEqIqw==",
       "requires": {
-        "@contentful/f36-core": "^4.64.0",
+        "@contentful/f36-core": "^4.65.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
@@ -22197,9 +22198,9 @@
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
     },
     "@emotion/is-prop-valid": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
-      "integrity": "sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz",
+      "integrity": "sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==",
       "requires": {
         "@emotion/memoize": "^0.8.1"
       },
@@ -25539,9 +25540,9 @@
       }
     },
     "dayjs": {
-      "version": "1.11.10",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
-      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.11.tgz",
+      "integrity": "sha512-okzr3f11N6WuqYtZSvm+F776mB41wRZMhKP+hc34YdW+KmtYYK9iqvHSwo2k9FEH3fhGXvOPV6yz2IcSrfRUDg=="
     },
     "debug": {
       "version": "4.3.4",
@@ -31439,9 +31440,9 @@
       }
     },
     "react": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.1.tgz",
-      "integrity": "sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -31610,13 +31611,13 @@
       }
     },
     "react-dom": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.1.tgz",
-      "integrity": "sha512-6eV150oJZ9U2t9svnsspTMrWNyHc6chX0KzDeAOXftRa8bNeOKTTfCJ7KorIwenkHd2xqVTBTCZd79yk/lx/Ug==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
+      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "scheduler": "^0.20.1"
+        "scheduler": "^0.20.2"
       }
     },
     "react-error-overlay": {
@@ -31630,9 +31631,9 @@
       "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
     },
     "react-focus-lock": {
-      "version": "2.11.3",
-      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.11.3.tgz",
-      "integrity": "sha512-CfWYS86y6KvAIGxYzO1/HlWI2zGON9Fa3L2xfREDGMNFAtYj3m/ZRvnsMH4H75dj5FpgDy2LWA1Vyx+twV80vw==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.12.1.tgz",
+      "integrity": "sha512-lfp8Dve4yJagkHiFrC1bGtib3mF2ktqwPJw4/WGcgPW+pJ/AVQA5X2vI7xgp13FcxFEpYBBHpXai/N2DBNC0Jw==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "focus-lock": "^1.3.5",
@@ -33224,10 +33225,12 @@
       }
     },
     "usehooks-ts": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-2.9.1.tgz",
-      "integrity": "sha512-2FAuSIGHlY+apM9FVlj8/oNhd+1y+Uwv5QNkMQz1oSfdHk4PXo1qoCw9I5M7j0vpH8CSWFJwXbVPeYDjLCx9PA==",
-      "requires": {}
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-2.16.0.tgz",
+      "integrity": "sha512-bez95WqYujxp6hFdM/CpRDiVPirZPxlMzOH2QB8yopoKQMXpscyZoxOjpEdaxvV+CAWUDSM62cWnqHE0E/MZ7w==",
+      "requires": {
+        "lodash.debounce": "^4.0.8"
+      }
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/apps/commercetools/package.json
+++ b/apps/commercetools/package.json
@@ -16,8 +16,8 @@
     "@contentful/ecommerce-app-base": "3.5.1",
     "@contentful/f36-components": "4.64.0",
     "@contentful/react-apps-toolkit": "1.2.16",
-    "react": "17.0.1",
-    "react-dom": "17.0.1",
+    "react": "17.0.2",
+    "react-dom": "17.0.2",
     "react-scripts": "5.0.1"
   },
   "scripts": {


### PR DESCRIPTION
## Purpose

Continuing to troubleshoot why the commercetools app isn't compatible with ecommerce-app-base ^3.5.1, bumping the `react` and `react-dom` versions.

## Approach

<!-- Why did we do it the way we did? Did we consider alternatives? What other implementation details or artifacts (screenshots etc.) would help reviewers contextualize change? -->

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
