### PR TITLE
chore: bump ecommerce-app-base in ct []

### DIFF
--- a/apps/commercetools/package-lock.json
+++ b/apps/commercetools/package-lock.json
@@ -12,7 +12,7 @@
         "@commercetools/sdk-client-v2": "1.4.2",
         "@contentful/app-scripts": "1.2.0",
         "@contentful/app-sdk": "4.23.0",
-        "@contentful/ecommerce-app-base": "3.5.1",
+        "@contentful/ecommerce-app-base": "3.6.0",
         "@contentful/f36-components": "4.64.0",
         "@contentful/react-apps-toolkit": "1.2.16",
         "react": "17.0.2",
@@ -2207,9 +2207,9 @@
       }
     },
     "node_modules/@contentful/ecommerce-app-base": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@contentful/ecommerce-app-base/-/ecommerce-app-base-3.5.1.tgz",
-      "integrity": "sha512-AStRsVIAQg8xt9Pq8iOJbw9099mCTAL7njHv24gJRjQqmHCwyu/Og20aKK8P/Ue7cUdqJwPbsuopp8OLGRo/5g==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@contentful/ecommerce-app-base/-/ecommerce-app-base-3.6.0.tgz",
+      "integrity": "sha512-iuQFyC6nUevxQ38eEEq3zKu544zYq0pIlg77hd0uImen4373H6XsaDSuqY59gopgyH/u/mfpwL9TsR4oTnUxPQ==",
       "dependencies": {
         "@contentful/app-sdk": "^4.23.0",
         "@contentful/f36-components": "^4.0.42",
@@ -21391,9 +21391,9 @@
       }
     },
     "@contentful/ecommerce-app-base": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@contentful/ecommerce-app-base/-/ecommerce-app-base-3.5.1.tgz",
-      "integrity": "sha512-AStRsVIAQg8xt9Pq8iOJbw9099mCTAL7njHv24gJRjQqmHCwyu/Og20aKK8P/Ue7cUdqJwPbsuopp8OLGRo/5g==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@contentful/ecommerce-app-base/-/ecommerce-app-base-3.6.0.tgz",
+      "integrity": "sha512-iuQFyC6nUevxQ38eEEq3zKu544zYq0pIlg77hd0uImen4373H6XsaDSuqY59gopgyH/u/mfpwL9TsR4oTnUxPQ==",
       "requires": {
         "@contentful/app-sdk": "^4.23.0",
         "@contentful/f36-components": "^4.0.42",

--- a/apps/commercetools/package.json
+++ b/apps/commercetools/package.json
@@ -13,7 +13,7 @@
     "@commercetools/sdk-client-v2": "1.4.2",
     "@contentful/app-scripts": "1.2.0",
     "@contentful/app-sdk": "4.23.0",
-    "@contentful/ecommerce-app-base": "3.5.1",
+    "@contentful/ecommerce-app-base": "3.6.0",
     "@contentful/f36-components": "4.64.0",
     "@contentful/react-apps-toolkit": "1.2.16",
     "react": "17.0.2",


### PR DESCRIPTION
## Purpose

Bump the ecommerce-base-app in commercetools after bumping the react version.

## Approach

<!-- Why did we do it the way we did? Did we consider alternatives? What other implementation details or artifacts (screenshots etc.) would help reviewers contextualize change? -->

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
