### PR TITLE
fix: remove unused usehooks-ts dependency []

### DIFF
--- a/packages/ecommerce-app-base/package-lock.json
+++ b/packages/ecommerce-app-base/package-lock.json
@@ -19,8 +19,7 @@
         "contentful-management": "^10.0.0",
         "emotion": "^10.0.0",
         "lodash": "^4.0.0",
-        "react-sortable-hoc": "^2.0.0",
-        "usehooks-ts": "^2.9.1"
+        "react-sortable-hoc": "^2.0.0"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.22.10",
@@ -22312,20 +22311,6 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/usehooks-ts": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-2.16.0.tgz",
-      "integrity": "sha512-bez95WqYujxp6hFdM/CpRDiVPirZPxlMzOH2QB8yopoKQMXpscyZoxOjpEdaxvV+CAWUDSM62cWnqHE0E/MZ7w==",
-      "dependencies": {
-        "lodash.debounce": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=16.15.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0  || ^17 || ^18"
       }
     },
     "node_modules/util": {

--- a/packages/ecommerce-app-base/package.json
+++ b/packages/ecommerce-app-base/package.json
@@ -64,8 +64,7 @@
     "contentful-management": "^10.0.0",
     "emotion": "^10.0.0",
     "lodash": "^4.0.0",
-    "react-sortable-hoc": "^2.0.0",
-    "usehooks-ts": "^2.9.1"
+    "react-sortable-hoc": "^2.0.0"
   },
   "peerDependencies": {
     "react": "^16.3.0 || ^17.0.0",


### PR DESCRIPTION
## Purpose

Remove unused dependency from the ecommerce-app-base package.

## Approach

<!-- Why did we do it the way we did? Did we consider alternatives? What other implementation details or artifacts (screenshots etc.) would help reviewers contextualize change? -->

## Testing steps

Testing locally and in staging using npm pack.

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
