### PR TITLE
chore: bump ecom-app-base to 3.6.0 in commercetools [INTEG-2055]

### DIFF
--- a/apps/commercetools/package-lock.json
+++ b/apps/commercetools/package-lock.json
@@ -12,7 +12,7 @@
         "@commercetools/sdk-client-v2": "1.4.2",
         "@contentful/app-scripts": "1.2.0",
         "@contentful/app-sdk": "4.23.0",
-        "@contentful/ecommerce-app-base": "3.5.1",
+        "@contentful/ecommerce-app-base": "3.6.0",
         "@contentful/f36-components": "4.64.0",
         "@contentful/react-apps-toolkit": "1.2.16",
         "react": "17.0.1",
@@ -2207,9 +2207,9 @@
       }
     },
     "node_modules/@contentful/ecommerce-app-base": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@contentful/ecommerce-app-base/-/ecommerce-app-base-3.5.1.tgz",
-      "integrity": "sha512-AStRsVIAQg8xt9Pq8iOJbw9099mCTAL7njHv24gJRjQqmHCwyu/Og20aKK8P/Ue7cUdqJwPbsuopp8OLGRo/5g==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@contentful/ecommerce-app-base/-/ecommerce-app-base-3.6.0.tgz",
+      "integrity": "sha512-iuQFyC6nUevxQ38eEEq3zKu544zYq0pIlg77hd0uImen4373H6XsaDSuqY59gopgyH/u/mfpwL9TsR4oTnUxPQ==",
       "dependencies": {
         "@contentful/app-sdk": "^4.23.0",
         "@contentful/f36-components": "^4.0.42",
@@ -21390,9 +21390,9 @@
       }
     },
     "@contentful/ecommerce-app-base": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@contentful/ecommerce-app-base/-/ecommerce-app-base-3.5.1.tgz",
-      "integrity": "sha512-AStRsVIAQg8xt9Pq8iOJbw9099mCTAL7njHv24gJRjQqmHCwyu/Og20aKK8P/Ue7cUdqJwPbsuopp8OLGRo/5g==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@contentful/ecommerce-app-base/-/ecommerce-app-base-3.6.0.tgz",
+      "integrity": "sha512-iuQFyC6nUevxQ38eEEq3zKu544zYq0pIlg77hd0uImen4373H6XsaDSuqY59gopgyH/u/mfpwL9TsR4oTnUxPQ==",
       "requires": {
         "@contentful/app-sdk": "^4.23.0",
         "@contentful/f36-components": "^4.0.42",

--- a/apps/commercetools/package.json
+++ b/apps/commercetools/package.json
@@ -13,7 +13,7 @@
     "@commercetools/sdk-client-v2": "1.4.2",
     "@contentful/app-scripts": "1.2.0",
     "@contentful/app-sdk": "4.23.0",
-    "@contentful/ecommerce-app-base": "3.5.1",
+    "@contentful/ecommerce-app-base": "3.6.0",
     "@contentful/f36-components": "4.64.0",
     "@contentful/react-apps-toolkit": "1.2.16",
     "react": "17.0.1",


### PR DESCRIPTION
## Purpose

Bumps ecommerce-app-base to version 3.6.0 in commercetools app. 

## Approach

Trying this again after the ecommerce-app-base has incremented to a new version so 3.6.0 is no longer the current version of that package.

## Testing steps

Tested on staging branch and there are no errors.

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
