### PR TITLE
feat: add category search commercetools [INTEG-2018]

### DIFF
--- a/apps/commercetools/src/api/categories.ts
+++ b/apps/commercetools/src/api/categories.ts
@@ -80,22 +80,37 @@ export async function fetchCategoryPreviews(
 
 export async function fetchCategories(
   config: ConfigurationParameters,
-  _search: string,
+  search: string,
   pagination: { offset: number; limit: number }
 ): Promise<{
   pagination: Pagination;
   products: CommerceToolsProduct[];
 }> {
   const client = createClient(config);
-  const response = await client
-    .categories()
-    .get({
-      queryArgs: {
-        limit: pagination?.limit,
-        offset: pagination?.offset,
-      },
-    })
-    .execute();
+  let response;
+
+  if (search) {
+    response = await client
+      .categories()
+      .get({
+        queryArgs: {
+          limit: pagination?.limit,
+          offset: pagination?.offset,
+          where: `key="${search}" or name(${config.locale}="${search}") or slug(${config.locale}="${search}")`,
+        },
+      })
+      .execute();
+  } else {
+    response = await client
+      .categories()
+      .get({
+        queryArgs: {
+          limit: pagination?.limit,
+          offset: pagination?.offset,
+        },
+      })
+      .execute();
+  }
 
   if (response.statusCode === 200) {
     return {

--- a/apps/commercetools/src/dialog.ts
+++ b/apps/commercetools/src/dialog.ts
@@ -39,6 +39,14 @@ function makeSearchPlaceholderText(skuType: string | undefined): string {
   }
 }
 
+function makeSearchHelpText(skuType: string | undefined): string {
+  if (skuType === 'category') {
+    return 'Search value must be an exact match';
+  } else {
+    return '';
+  }
+}
+
 export async function renderDialog(sdk: DialogAppSDK) {
   const DIALOG_ID = 'dialog-root';
 
@@ -59,6 +67,7 @@ export async function renderDialog(sdk: DialogAppSDK) {
     skuType,
     makeSaveBtnText: makeSaveBtnText(skuType),
     makeSearchPlaceholderText,
+    makeSearchHelpText,
     hideSearch: false,
     showSearchBySkuOption: skuType === 'product',
   });

--- a/apps/commercetools/src/dialog.ts
+++ b/apps/commercetools/src/dialog.ts
@@ -31,6 +31,14 @@ function makeSaveBtnText(skuType: SkuType) {
   }
 }
 
+function makeSearchPlaceholderText(skuType: string | undefined): string {
+  if (skuType === 'category') {
+    return 'Search by category name, slug, or key...';
+  } else {
+    return 'Search for a product...';
+  }
+}
+
 export async function renderDialog(sdk: DialogAppSDK) {
   const DIALOG_ID = 'dialog-root';
 
@@ -50,6 +58,7 @@ export async function renderDialog(sdk: DialogAppSDK) {
     searchDelay: 750,
     skuType,
     makeSaveBtnText: makeSaveBtnText(skuType),
+    makeSearchPlaceholderText,
     hideSearch: false,
     showSearchBySkuOption: skuType === 'product',
   });

--- a/apps/commercetools/src/dialog.ts
+++ b/apps/commercetools/src/dialog.ts
@@ -50,8 +50,8 @@ export async function renderDialog(sdk: DialogAppSDK) {
     searchDelay: 750,
     skuType,
     makeSaveBtnText: makeSaveBtnText(skuType),
-    hideSearch: skuType === 'category',
-    showSearchBySkuOption: true,
+    hideSearch: false,
+    showSearchBySkuOption: skuType === 'product',
   });
 
   sdk.window.startAutoResizer();


### PR DESCRIPTION
## Purpose

This PR updates the category API call and implements the changes made in the ecommerce-app-base package (https://github.com/contentful/apps/pull/7337) in order to add category search to the commercetools app. The ecommerce-app-base was bumped to version 3.6.0 in a previous PR (https://github.com/contentful/apps/pull/7474). This implements the changes previously approved in this PR (https://github.com/contentful/apps/pull/7357) that had to be reverted due to an issue with the ecommerce-app-base.

## Approach

I added the `where` query parameter and used their query predicate structure to query based on category name, key, and slug ([documentation here](https://docs.commercetools.com/api/projects/categories#query-categories)).

I bumped the `ecommerce-app-base` package and implemented the two new functions available to customize the search placeholder text and help text. I also updated the `hideSearch` and `showSearchBySkuOption` parameters accordingly

![Screenshot 2024-04-19 at 3 15 05 PM](https://github.com/contentful/apps/assets/62958907/12994cbf-947a-4f07-80c1-fab184808eba)

## Testing steps

I tested the changes with single and multiple products and categories to ensure everything still worked as expected. I tested it in staging as well.

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
