### PR TITLE
chore(deps): add react 18 as a possible peer dependency

### DIFF
--- a/packages/dam-app-base/package.json
+++ b/packages/dam-app-base/package.json
@@ -38,8 +38,8 @@
     "emotion": "^10.0.0"
   },
   "peerDependencies": {
-    "react": "^16.3.0 || ^17.0.0",
-    "react-dom": "^16.3.0 || ^17.0.0"
+    "react": "^16.3.0 || ^17.0.0 || ^18.2.0",
+    "react-dom": "^16.3.0 || ^17.0.0 || ^18.2.0"
   },
   "scripts": {
     "build": "rimraf lib && tsc",


### PR DESCRIPTION
## Purpose
Add react 18 as a peer dependency, as apps that use DAM-app-base sometimes have react 18 installed.