### PR TITLE
feat: handle warning messages when API paths are missing

### DIFF
--- a/apps/vercel/frontend/src/clients/Vercel.ts
+++ b/apps/vercel/frontend/src/clients/Vercel.ts
@@ -84,6 +84,7 @@ export default class VercelClient implements VercelAPIClient {
     }
 
     const apiPaths = this.filterServerlessFunctions(deploymentData.serverlessFunctions);
+    if (!apiPaths.length) throw new Error(errorTypes.API_PATHS_EMPTY);
     const formattedApiPaths = this.formatApiPaths(apiPaths);
 
     return formattedApiPaths;

--- a/apps/vercel/frontend/src/clients/Vercel.ts
+++ b/apps/vercel/frontend/src/clients/Vercel.ts
@@ -83,8 +83,17 @@ export default class VercelClient implements VercelAPIClient {
       throw new Error(errorTypes.CANNOT_FETCH_API_PATHS);
     }
 
+    if (
+      !deploymentData?.serverlessFunctions ||
+      !Array.isArray(deploymentData.serverlessFunctions)
+    ) {
+      throw new Error(errorTypes.INVALID_DEPLOYMENT_DATA);
+    }
+
     const apiPaths = this.filterServerlessFunctions(deploymentData.serverlessFunctions);
+
     if (!apiPaths.length) throw new Error(errorTypes.API_PATHS_EMPTY);
+
     const formattedApiPaths = this.formatApiPaths(apiPaths);
 
     return formattedApiPaths;

--- a/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.spec.tsx
+++ b/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.spec.tsx
@@ -5,7 +5,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { AppInstallationParameters } from '@customTypes/configPage';
 import { SelectSection } from './SelectSection';
 import { copies } from '@constants/copies';
-import { parametersActions, singleSelectionSections } from '@constants/enums';
+import { singleSelectionSections } from '@constants/enums';
 import { renderConfigPageComponent } from '@test/helpers/renderConfigPageComponent';
 import { errorMessages } from '@constants/errorMessages';
 
@@ -24,8 +24,8 @@ describe('SelectSection', () => {
         options={paths}
         section={ID}
         id={ID}
-        parameterAction={parametersActions.APPLY_API_PATH}
         handleInvalidSelectionError={vi.fn()}
+        handleChange={vi.fn()}
         selectedOption={parameters.selectedApiPath}
       />
     );
@@ -41,8 +41,8 @@ describe('SelectSection', () => {
 
   it('renders list of projects to select', async () => {
     const user = userEvent.setup();
-
     const mockHandleAppConfigurationChange = vi.fn();
+    const mockHandleChange = vi.fn();
     const ID = singleSelectionSections.PROJECT_SELECTION_SECTION;
     const { placeholder, helpText } = copies.configPage.projectSelectionSection;
     const { unmount } = renderConfigPageComponent(
@@ -50,7 +50,7 @@ describe('SelectSection', () => {
         options={projects}
         section={ID}
         id={ID}
-        parameterAction={parametersActions.APPLY_API_PATH}
+        handleChange={mockHandleChange}
         handleInvalidSelectionError={vi.fn()}
         selectedOption={parameters.selectedApiPath}
       />,
@@ -65,6 +65,7 @@ describe('SelectSection', () => {
     expect(screen.getByText(projects[0].name)).toBeTruthy();
 
     user.selectOptions(screen.getByTestId('optionsSelect'), projects[0].name);
+    await waitFor(() => expect(mockHandleChange).toBeCalled());
     await waitFor(() => expect(mockHandleAppConfigurationChange).not.toBeCalled());
     unmount();
   });
@@ -78,8 +79,8 @@ describe('SelectSection', () => {
         options={projects}
         section={ID}
         id={ID}
-        parameterAction={parametersActions.APPLY_API_PATH}
         selectedOption={'non-existent-id'}
+        handleChange={vi.fn()}
         handleInvalidSelectionError={mockHandleInvalidSelectionError}
         error={projectSelectionError}
       />

--- a/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.tsx
+++ b/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.tsx
@@ -4,7 +4,6 @@ import { Select } from '@components/common/Select/Select';
 import { Errors, Path, Project } from '@customTypes/configPage';
 import { copies } from '@constants/copies';
 import { FormControl } from '@contentful/f36-components';
-import { errorsActions, parametersActions, singleSelectionSections } from '@constants/enums';
 import { ConfigPageContext } from '@contexts/ConfigPageProvider';
 import { useError } from '@hooks/useError/useError';
 
@@ -12,14 +11,13 @@ type CopySection = Extract<
   keyof typeof copies.configPage,
   'projectSelectionSection' | 'pathSelectionSection'
 >;
-
 interface Props {
   selectedOption: string;
   options: Path[] | Project[];
-  parameterAction: parametersActions.APPLY_API_PATH | parametersActions.APPLY_SELECTED_PROJECT;
   section: CopySection;
   id: string;
   handleInvalidSelectionError: () => void;
+  handleChange: (event: ChangeEvent<HTMLSelectElement>) => void;
   helpText?: string | React.ReactNode;
   error?: Errors['projectSelection'] | Errors['apiPathSelection'];
 }
@@ -27,42 +25,16 @@ interface Props {
 export const SelectSection = ({
   selectedOption,
   options,
-  parameterAction,
   section,
   id,
   helpText,
   error,
   handleInvalidSelectionError,
+  handleChange,
 }: Props) => {
   const { placeholder, label, emptyMessage, helpText: helpTextCopy } = copies.configPage[section];
-  const { isLoading, dispatchParameters, handleAppConfigurationChange, dispatchErrors } =
-    useContext(ConfigPageContext);
+  const { isLoading } = useContext(ConfigPageContext);
   const { isError, message } = useError({ error });
-
-  const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
-    if (section === singleSelectionSections.PROJECT_SELECTION_SECTION) {
-      // indicate app config change when project has been re-selected
-      handleAppConfigurationChange();
-      // reset the selected api path only when the project changes
-      dispatchParameters({
-        type: parametersActions.APPLY_API_PATH,
-        payload: '',
-      });
-
-      dispatchErrors({
-        type: errorsActions.RESET_PROJECT_SELECTION_ERRORS,
-      });
-    } else if (section === singleSelectionSections.API_PATH_SELECTION_SECTION) {
-      dispatchErrors({
-        type: errorsActions.RESET_API_PATH_SELECTION_ERRORS,
-      });
-    }
-
-    dispatchParameters({
-      type: parameterAction,
-      payload: event.target.value,
-    });
-  };
 
   useEffect(() => {
     if (!isLoading) {

--- a/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/ApiPathSelectionSection.spec.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/ApiPathSelectionSection.spec.tsx
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { screen } from '@testing-library/react';
+
+import { ApiPathSelectionSection } from './ApiPathSelectionSection';
+import { renderConfigPageComponent } from '@test/helpers/renderConfigPageComponent';
+import { ApiPath } from '@customTypes/configPage';
+
+describe('ApiPathSelectionSection', () => {
+  it('renders dropdown when paths are present and no errors are present', () => {
+    const paths = [{ id: 'path-1', name: 'Path/1' }];
+    const { unmount } = renderConfigPageComponent(<ApiPathSelectionSection paths={paths} />);
+
+    const select = screen.getByTestId('optionsSelect');
+    expect(select).toBeTruthy();
+    unmount();
+  });
+
+  it('renders dropdown when apiPathNotFound error is present', () => {
+    const paths = [{ id: 'path-1', name: 'Path/1' }];
+    const errors = { apiPathSelection: { apiPathNotFound: true } };
+    const { unmount } = renderConfigPageComponent(
+      <ApiPathSelectionSection paths={paths} />,
+      errors
+    );
+
+    const select = screen.getByTestId('optionsSelect');
+    expect(select).toBeTruthy();
+    unmount();
+  });
+
+  it('renders textfield when no paths', () => {
+    const paths: ApiPath[] = [];
+    const { unmount } = renderConfigPageComponent(<ApiPathSelectionSection paths={paths} />);
+
+    const input = screen.getByTestId('apiPathInput');
+    expect(input).toBeTruthy();
+    unmount();
+  });
+
+  it('renders textfield when invalidDeploymentData error', () => {
+    const paths: ApiPath[] = [];
+    const errors = { apiPathSelection: { invalidDeploymentData: true } };
+    const { unmount } = renderConfigPageComponent(
+      <ApiPathSelectionSection paths={paths} />,
+      errors
+    );
+
+    const input = screen.getByTestId('apiPathInput');
+    expect(input).toBeTruthy();
+    unmount();
+  });
+
+  it('renders textfield when cannotFetchApiPaths error', () => {
+    const paths: ApiPath[] = [];
+    const errors = { apiPathSelection: { cannotFetchApiPaths: true } };
+    const { unmount } = renderConfigPageComponent(
+      <ApiPathSelectionSection paths={paths} />,
+      errors
+    );
+
+    const input = screen.getByTestId('apiPathInput');
+    expect(input).toBeTruthy();
+    unmount();
+  });
+});

--- a/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/ApiPathSelectionSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/ApiPathSelectionSection.tsx
@@ -10,8 +10,7 @@ import {
 } from '@constants/enums';
 import { ConfigPageContext } from '@contexts/ConfigPageProvider';
 import { TextFieldSection } from './TextFieldSection/TextFieldSection';
-import { HelpText, TextLink } from '@contentful/f36-components';
-import { ExternalLinkIcon } from '@contentful/f36-icons';
+import { DraftModeHelpText } from './HelpText/HelpText';
 
 interface Props {
   paths: Path[];
@@ -40,21 +39,6 @@ export const ApiPathSelectionSection = ({ paths }: Props) => {
     });
   };
 
-  const helpText = (
-    <HelpText>
-      Select the route from your application that enables Draft Mode. See our{' '}
-      <TextLink
-        icon={<ExternalLinkIcon />}
-        alignIcon="end"
-        href="http://www.example.com"
-        target="_blank"
-        rel="noopener noreferrer">
-        Vercel developer guide
-      </TextLink>{' '}
-      for instructions on setting up a Draft Mode route handler. UPDATE LINK
-    </HelpText>
-  );
-
   const renderInput = () => {
     if (paths.length === 0 && !isLoading) {
       return <TextFieldSection />;
@@ -68,7 +52,7 @@ export const ApiPathSelectionSection = ({ paths }: Props) => {
         handleChange={handleChange}
         section={sectionId}
         id={sectionId}
-        helpText={helpText}
+        helpText={<DraftModeHelpText />}
         error={errors.apiPathSelection}
       />
     );

--- a/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/ApiPathSelectionSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/ApiPathSelectionSection.tsx
@@ -20,6 +20,7 @@ export const ApiPathSelectionSection = ({ paths }: Props) => {
   const sectionId = singleSelectionSections.API_PATH_SELECTION_SECTION;
   const { parameters, isLoading, dispatchErrors, errors, dispatchParameters } =
     useContext(ConfigPageContext);
+  const { invalidDeploymentData, cannotFetchApiPaths } = errors.apiPathSelection;
 
   const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
     dispatchParameters({
@@ -40,7 +41,7 @@ export const ApiPathSelectionSection = ({ paths }: Props) => {
   };
 
   const renderInput = () => {
-    if (paths.length === 0 && !isLoading) {
+    if ((paths.length === 0 && !isLoading) || invalidDeploymentData || cannotFetchApiPaths) {
       return <TextFieldSection />;
     }
 

--- a/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/ApiPathSelectionSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/ApiPathSelectionSection.tsx
@@ -1,4 +1,4 @@
-import { useContext, useState, useEffect } from 'react';
+import { useContext, useState, useEffect, ChangeEvent } from 'react';
 import { Path } from '@customTypes/configPage';
 import { SectionWrapper } from '@components/common/SectionWrapper/SectionWrapper';
 import { SelectSection } from '@components/common/SelectSection/SelectSection';
@@ -20,7 +20,19 @@ interface Props {
 export const ApiPathSelectionSection = ({ paths }: Props) => {
   const [renderSelect, setRenderSelect] = useState(false);
   const sectionId = singleSelectionSections.API_PATH_SELECTION_SECTION;
-  const { parameters, isLoading, dispatchErrors, errors } = useContext(ConfigPageContext);
+  const { parameters, isLoading, dispatchErrors, errors, dispatchParameters } =
+    useContext(ConfigPageContext);
+
+  const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    dispatchParameters({
+      type: parametersActions.APPLY_API_PATH,
+      payload: event.target.value,
+    });
+
+    dispatchErrors({
+      type: errorsActions.RESET_API_PATH_SELECTION_ERRORS,
+    });
+  };
 
   const handleInvalidSelectionError = () => {
     dispatchErrors({
@@ -54,15 +66,15 @@ export const ApiPathSelectionSection = ({ paths }: Props) => {
         <SelectSection
           selectedOption={parameters.selectedApiPath}
           options={paths}
-          parameterAction={parametersActions.APPLY_API_PATH}
           handleInvalidSelectionError={handleInvalidSelectionError}
+          handleChange={handleChange}
           section={sectionId}
           id={sectionId}
           helpText={helpText}
           error={errors.apiPathSelection}
         />
       ) : (
-        <TextFieldSection value={parameters.selectedApiPath} />
+        <TextFieldSection error={errors.apiPathSelection} value={parameters.selectedApiPath} />
       )}
     </SectionWrapper>
   );

--- a/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/ApiPathSelectionSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/ApiPathSelectionSection.tsx
@@ -1,4 +1,4 @@
-import { useContext, useState, useEffect, ChangeEvent } from 'react';
+import { useContext, ChangeEvent } from 'react';
 import { Path } from '@customTypes/configPage';
 import { SectionWrapper } from '@components/common/SectionWrapper/SectionWrapper';
 import { SelectSection } from '@components/common/SelectSection/SelectSection';
@@ -18,7 +18,6 @@ interface Props {
 }
 
 export const ApiPathSelectionSection = ({ paths }: Props) => {
-  const [renderSelect, setRenderSelect] = useState(false);
   const sectionId = singleSelectionSections.API_PATH_SELECTION_SECTION;
   const { parameters, isLoading, dispatchErrors, errors, dispatchParameters } =
     useContext(ConfigPageContext);
@@ -41,10 +40,6 @@ export const ApiPathSelectionSection = ({ paths }: Props) => {
     });
   };
 
-  useEffect(() => {
-    setRenderSelect(paths.length > 0 || isLoading);
-  }, [paths, isLoading]);
-
   const helpText = (
     <HelpText>
       Select the route from your application that enables Draft Mode. See our{' '}
@@ -60,22 +55,24 @@ export const ApiPathSelectionSection = ({ paths }: Props) => {
     </HelpText>
   );
 
-  return (
-    <SectionWrapper testId={sectionId}>
-      {renderSelect ? (
-        <SelectSection
-          selectedOption={parameters.selectedApiPath}
-          options={paths}
-          handleInvalidSelectionError={handleInvalidSelectionError}
-          handleChange={handleChange}
-          section={sectionId}
-          id={sectionId}
-          helpText={helpText}
-          error={errors.apiPathSelection}
-        />
-      ) : (
-        <TextFieldSection error={errors.apiPathSelection} value={parameters.selectedApiPath} />
-      )}
-    </SectionWrapper>
-  );
+  const renderInput = () => {
+    if (paths.length === 0 && !isLoading) {
+      return <TextFieldSection />;
+    }
+
+    return (
+      <SelectSection
+        selectedOption={parameters.selectedApiPath}
+        options={paths}
+        handleInvalidSelectionError={handleInvalidSelectionError}
+        handleChange={handleChange}
+        section={sectionId}
+        id={sectionId}
+        helpText={helpText}
+        error={errors.apiPathSelection}
+      />
+    );
+  };
+
+  return <SectionWrapper testId={sectionId}>{renderInput()}</SectionWrapper>;
 };

--- a/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/HelpText/HelpText.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/HelpText/HelpText.tsx
@@ -1,0 +1,17 @@
+import { HelpText, TextLink } from '@contentful/f36-components';
+import { ExternalLinkIcon } from '@contentful/f36-icons';
+
+export const DraftModeHelpText = () => (
+  <HelpText>
+    Select the route from your application that enables Draft Mode. See our{' '}
+    <TextLink
+      icon={<ExternalLinkIcon />}
+      alignIcon="end"
+      href="http://www.example.com"
+      target="_blank"
+      rel="noopener noreferrer">
+      Vercel developer guide
+    </TextLink>{' '}
+    for instructions on setting up a Draft Mode route handler. UPDATE LINK
+  </HelpText>
+);

--- a/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/TextFieldSection/TextFieldSection.spec.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/TextFieldSection/TextFieldSection.spec.tsx
@@ -1,18 +1,45 @@
-import { render } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { screen } from '@testing-library/react';
 
 import { TextFieldSection } from './TextFieldSection';
 import { copies } from '@constants/copies';
+import { renderConfigPageComponent } from '@test/helpers/renderConfigPageComponent';
+import { errorMessages } from '@constants/errorMessages';
 
 describe('TextFieldSection', () => {
   it('renders text field with value', () => {
-    const value = 'api/disable-path';
+    const apiPath = 'api/disable-path';
     const { textInputPlaceholder } = copies.configPage.pathSelectionSection;
-    render(<TextFieldSection value={value} />);
+    renderConfigPageComponent(<TextFieldSection />, { parameters: { selectedApiPath: apiPath } });
 
     const input = document.querySelector('input');
     expect(input).toBeTruthy();
-    expect(input).toHaveProperty('value', value);
+    expect(input).toHaveProperty('value', apiPath);
     expect(input).toHaveProperty('placeholder', textInputPlaceholder);
+  });
+
+  it('renders error if api paths are empty and there is no saved value', () => {
+    const mockDispatchErrors = vi.fn();
+    renderConfigPageComponent(<TextFieldSection />, {
+      parameters: { selectedApiPath: '' },
+      errors: { apiPathSelection: { apiPathsEmpty: true } },
+      isLoading: false,
+      dispatchErrors: mockDispatchErrors,
+    });
+
+    expect(screen.getByText(errorMessages.apiPathsEmpty)).toBeTruthy();
+  });
+
+  it('clears any associated errors if there are no paths, but a saved value', () => {
+    const apiPath = 'api/disable-path';
+    const mockDispatchErrors = vi.fn();
+    renderConfigPageComponent(<TextFieldSection />, {
+      parameters: { selectedApiPath: apiPath },
+      errors: { apiPathSelection: { apiPathsEmpty: true } },
+      isLoading: false,
+      dispatchErrors: mockDispatchErrors,
+    });
+
+    expect(mockDispatchErrors).toHaveBeenCalled();
   });
 });

--- a/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/TextFieldSection/TextFieldSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/TextFieldSection/TextFieldSection.tsx
@@ -53,6 +53,7 @@ export const TextFieldSection = () => {
           onChange={debouncedHandleApiPathInputChange}
           placeholder={textInputPlaceholder}
           isInvalid={isError}
+          data-testid="apiPathInput"
         />
       </SelectionWrapper>
     </FormControl>

--- a/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/TextFieldSection/TextFieldSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/TextFieldSection/TextFieldSection.tsx
@@ -7,9 +7,10 @@ import { ConfigPageContext } from '@contexts/ConfigPageProvider';
 import { SelectionWrapper } from '@components/common/SelectionWrapper/SelectionWrapper';
 import { debounce } from 'lodash';
 import { useError } from '@hooks/useError/useError';
+import { DraftModeHelpText } from '../HelpText/HelpText';
 
 export const TextFieldSection = () => {
-  const { textInputPlaceholder, label, textInputHelpText } = copies.configPage.pathSelectionSection;
+  const { textInputPlaceholder, label } = copies.configPage.pathSelectionSection;
   const { isLoading, dispatchParameters, dispatchErrors, parameters, errors } =
     useContext(ConfigPageContext);
   const { isError, message } = useError({ error: errors.apiPathSelection });
@@ -46,7 +47,7 @@ export const TextFieldSection = () => {
         isLoading={isLoading}
         isRequired={true}
         errorMessage={message}
-        helpText={textInputHelpText}>
+        helpText={<DraftModeHelpText />}>
         <TextInput
           defaultValue={parameters.selectedApiPath}
           onChange={debouncedHandleApiPathInputChange}

--- a/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/TextFieldSection/TextFieldSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/TextFieldSection/TextFieldSection.tsx
@@ -1,31 +1,40 @@
-import { useContext, useMemo } from 'react';
+import { useContext, useEffect, useMemo } from 'react';
 
 import { copies } from '@constants/copies';
 import { FormControl, TextInput } from '@contentful/f36-components';
-import { parametersActions, singleSelectionSections } from '@constants/enums';
+import { errorsActions, parametersActions, singleSelectionSections } from '@constants/enums';
 import { ConfigPageContext } from '@contexts/ConfigPageProvider';
 import { SelectionWrapper } from '@components/common/SelectionWrapper/SelectionWrapper';
 import { debounce } from 'lodash';
 import { useError } from '@hooks/useError/useError';
-import { Errors } from '@customTypes/configPage';
 
-interface Props {
-  value: string;
-  error: Errors['apiPathSelection'];
-}
-
-export const TextFieldSection = ({ value, error }: Props) => {
+export const TextFieldSection = () => {
   const { textInputPlaceholder, label, textInputHelpText } = copies.configPage.pathSelectionSection;
-  const { isLoading, dispatchParameters } = useContext(ConfigPageContext);
-  const { isError, message } = useError({ error });
+  const { isLoading, dispatchParameters, dispatchErrors, parameters, errors } =
+    useContext(ConfigPageContext);
+  const { isError, message } = useError({ error: errors.apiPathSelection });
+
+  const resetApiPathSelectionErrors = () => {
+    dispatchErrors({
+      type: errorsActions.RESET_API_PATH_SELECTION_ERRORS,
+    });
+  };
+
   const handleApiPathInput = (event: React.ChangeEvent<HTMLInputElement>) => {
     dispatchParameters({
       type: parametersActions.APPLY_API_PATH,
       payload: event.target.value,
     });
+
+    resetApiPathSelectionErrors();
   };
 
   const debouncedHandleApiPathInputChange = useMemo(() => debounce(handleApiPathInput, 700), []);
+
+  useEffect(() => {
+    if (parameters.selectedApiPath && errors.apiPathSelection.apiPathsEmpty)
+      resetApiPathSelectionErrors();
+  }, [parameters.selectedApiPath, errors.apiPathSelection.apiPathsEmpty]);
 
   return (
     <FormControl
@@ -39,7 +48,7 @@ export const TextFieldSection = ({ value, error }: Props) => {
         errorMessage={message}
         helpText={textInputHelpText}>
         <TextInput
-          defaultValue={value}
+          defaultValue={parameters.selectedApiPath}
           onChange={debouncedHandleApiPathInputChange}
           placeholder={textInputPlaceholder}
           isInvalid={isError}

--- a/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/TextFieldSection/TextFieldSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/TextFieldSection/TextFieldSection.tsx
@@ -6,14 +6,18 @@ import { parametersActions, singleSelectionSections } from '@constants/enums';
 import { ConfigPageContext } from '@contexts/ConfigPageProvider';
 import { SelectionWrapper } from '@components/common/SelectionWrapper/SelectionWrapper';
 import { debounce } from 'lodash';
+import { useError } from '@hooks/useError/useError';
+import { Errors } from '@customTypes/configPage';
 
 interface Props {
   value: string;
+  error: Errors['apiPathSelection'];
 }
 
-export const TextFieldSection = ({ value }: Props) => {
+export const TextFieldSection = ({ value, error }: Props) => {
   const { textInputPlaceholder, label, textInputHelpText } = copies.configPage.pathSelectionSection;
   const { isLoading, dispatchParameters } = useContext(ConfigPageContext);
+  const { isError, message } = useError({ error });
   const handleApiPathInput = (event: React.ChangeEvent<HTMLInputElement>) => {
     dispatchParameters({
       type: parametersActions.APPLY_API_PATH,
@@ -32,11 +36,13 @@ export const TextFieldSection = ({ value }: Props) => {
         label={label}
         isLoading={isLoading}
         isRequired={true}
+        errorMessage={message}
         helpText={textInputHelpText}>
         <TextInput
           defaultValue={value}
           onChange={debouncedHandleApiPathInputChange}
           placeholder={textInputPlaceholder}
+          isInvalid={isError}
         />
       </SelectionWrapper>
     </FormControl>

--- a/apps/vercel/frontend/src/components/config-screen/ProjectSelectionSection/ProjectSelectionSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ProjectSelectionSection/ProjectSelectionSection.tsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import { ChangeEvent, useContext } from 'react';
 
 import { Project } from '@customTypes/configPage';
 import { SectionWrapper } from '@components/common/SectionWrapper/SectionWrapper';
@@ -17,7 +17,28 @@ interface Props {
 
 export const ProjectSelectionSection = ({ projects }: Props) => {
   const sectionId = singleSelectionSections.PROJECT_SELECTION_SECTION;
-  const { parameters, errors, dispatchErrors } = useContext(ConfigPageContext);
+  const { parameters, errors, dispatchErrors, dispatchParameters, handleAppConfigurationChange } =
+    useContext(ConfigPageContext);
+
+  const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    // indicate app config change when project has been re-selected
+    handleAppConfigurationChange();
+
+    // reset the selected api path only when the project changes
+    dispatchParameters({
+      type: parametersActions.APPLY_API_PATH,
+      payload: '',
+    });
+
+    dispatchParameters({
+      type: parametersActions.APPLY_SELECTED_PROJECT,
+      payload: event.target.value,
+    });
+
+    dispatchErrors({
+      type: errorsActions.RESET_PROJECT_SELECTION_ERRORS,
+    });
+  };
 
   const handleInvalidSelectionError = () => {
     dispatchErrors({
@@ -31,11 +52,11 @@ export const ProjectSelectionSection = ({ projects }: Props) => {
       <SelectSection
         selectedOption={parameters.selectedProject}
         options={projects}
-        parameterAction={parametersActions.APPLY_SELECTED_PROJECT}
         handleInvalidSelectionError={handleInvalidSelectionError}
         section={sectionId}
         id={sectionId}
         error={errors.projectSelection}
+        handleChange={handleChange}
       />
     </SectionWrapper>
   );

--- a/apps/vercel/frontend/src/constants/defaultParams.ts
+++ b/apps/vercel/frontend/src/constants/defaultParams.ts
@@ -22,6 +22,7 @@ export const initialErrors: Errors = {
     apiPathNotFound: false,
     apiPathsEmpty: false,
     cannotFetchApiPaths: false,
+    invalidDeploymentData: false,
   },
   previewPathSelection: [],
 };

--- a/apps/vercel/frontend/src/constants/enums.ts
+++ b/apps/vercel/frontend/src/constants/enums.ts
@@ -34,4 +34,5 @@ export enum errorTypes {
   CANNOT_FETCH_API_PATHS = 'cannotFetchApiPaths',
   INVALID_PREVIEW_PATH_FORMAT = 'invalidPreviewPathFormat',
   EMPTY_PREVIEW_PATH_INPUT = 'emptyPreviewPathInput',
+  API_PATHS_EMPTY = 'apiPathsEmpty',
 }

--- a/apps/vercel/frontend/src/constants/enums.ts
+++ b/apps/vercel/frontend/src/constants/enums.ts
@@ -35,4 +35,5 @@ export enum errorTypes {
   INVALID_PREVIEW_PATH_FORMAT = 'invalidPreviewPathFormat',
   EMPTY_PREVIEW_PATH_INPUT = 'emptyPreviewPathInput',
   API_PATHS_EMPTY = 'apiPathsEmpty',
+  INVALID_DEPLOYMENT_DATA = 'invalidDeploymentData',
 }

--- a/apps/vercel/frontend/src/constants/errorMessages.ts
+++ b/apps/vercel/frontend/src/constants/errorMessages.ts
@@ -4,11 +4,11 @@ export const errorMessages = {
   expiredToken: 'Token has expired.',
   projectNotFound:
     'The project you have configured is no longer available. Please select another one.',
-  cannotFetchProjects: 'Cannot retrieve Vercel projects.',
+  cannotFetchProjects: 'We had trouble fetching your Vercel projects.',
   apiPathNotFound:
     'The path you have configured is no longer available. Please select another one.',
-  apiPathsEmpty: 'No paths currently configured in selected project.',
-  cannotFetchApiPaths: 'Cannot retrieve paths.',
+  apiPathsEmpty: "It looks like you haven't configured any routes yet.",
+  cannotFetchApiPaths: 'We had trouble fetching routes for this Vercel project.',
   invalidPreviewPathFormat: 'Path must start with a "/", and include a {token}.',
   emptyPreviewPathInput: 'Field is empty.',
 };

--- a/apps/vercel/frontend/src/constants/errorMessages.ts
+++ b/apps/vercel/frontend/src/constants/errorMessages.ts
@@ -6,9 +6,10 @@ export const errorMessages = {
     'The project you have configured is no longer available. Please select another one.',
   cannotFetchProjects: 'We had trouble fetching your Vercel projects.',
   apiPathNotFound:
-    'The path you have configured is no longer available. Please select another one.',
-  apiPathsEmpty: "It looks like you haven't configured any routes yet.",
+    'The route you previously selected is no longer available. Please select another one.',
+  apiPathsEmpty: "It looks like your Vercel project doesn't have any routes configured yet.",
   cannotFetchApiPaths: 'We had trouble fetching routes for this Vercel project.',
   invalidPreviewPathFormat: 'Path must start with a "/", and include a {token}.',
   emptyPreviewPathInput: 'Field is empty.',
+  invalidDeploymentData: 'We had trouble fetching routes for this Vercel project.',
 };

--- a/apps/vercel/frontend/src/customTypes/configPage.ts
+++ b/apps/vercel/frontend/src/customTypes/configPage.ts
@@ -91,6 +91,7 @@ export type Errors = {
     apiPathNotFound: boolean;
     apiPathsEmpty: boolean;
     cannotFetchApiPaths: boolean;
+    invalidDeploymentData: boolean;
   };
   previewPathSelection: PreviewPathError[];
 };

--- a/apps/vercel/frontend/src/hooks/useFetchAndValidateData/useFetchAndValidateData.tsx
+++ b/apps/vercel/frontend/src/hooks/useFetchAndValidateData/useFetchAndValidateData.tsx
@@ -78,11 +78,21 @@ export const useFetchAndValidateData = ({
           type: errorsActions.RESET_API_PATH_SELECTION_ERRORS,
         });
       } catch (e) {
+        const err = e as Error;
         console.error(e);
-        dispatchErrors({
-          type: errorsActions.UPDATE_API_PATH_SELECTION_ERRORS,
-          payload: errorTypes.CANNOT_FETCH_API_PATHS,
-        });
+        const errorAction = errorsActions.UPDATE_API_PATH_SELECTION_ERRORS;
+
+        if (err.message === errorTypes.API_PATHS_EMPTY) {
+          dispatchErrors({
+            type: errorAction,
+            payload: errorTypes.API_PATHS_EMPTY,
+          });
+        } else {
+          dispatchErrors({
+            type: errorAction,
+            payload: errorTypes.CANNOT_FETCH_API_PATHS,
+          });
+        }
         setApiPaths([]);
       }
     }

--- a/apps/vercel/frontend/src/hooks/useFetchAndValidateData/useFetchAndValidateData.tsx
+++ b/apps/vercel/frontend/src/hooks/useFetchAndValidateData/useFetchAndValidateData.tsx
@@ -79,7 +79,6 @@ export const useFetchAndValidateData = ({
         });
       } catch (e) {
         const err = e as Error;
-        console.error(e);
         const errorAction = errorsActions.UPDATE_API_PATH_SELECTION_ERRORS;
 
         if (err.message === errorTypes.API_PATHS_EMPTY) {
@@ -88,6 +87,7 @@ export const useFetchAndValidateData = ({
             payload: errorTypes.API_PATHS_EMPTY,
           });
         } else {
+          console.error(e);
           dispatchErrors({
             type: errorAction,
             payload: errorTypes.CANNOT_FETCH_API_PATHS,

--- a/apps/vercel/frontend/src/hooks/useFetchData/useFetchData.tsx
+++ b/apps/vercel/frontend/src/hooks/useFetchData/useFetchData.tsx
@@ -3,22 +3,21 @@ import { ErrorAction } from '@reducers/errorsReducer';
 import { Dispatch } from 'react';
 import { errorTypes, errorsActions, parametersActions } from '@constants/enums';
 import { ApiPath, Errors, Project } from '@customTypes/configPage';
-import { validateApiPathData } from '@utils/validateApiPathData/validateApiPathData';
 import { ParameterAction } from '@reducers/parameterReducer';
 
-interface FetchAndValidateData {
+interface FetchData {
   dispatchParameters: Dispatch<ParameterAction>;
   dispatchErrors: Dispatch<ErrorAction>;
   vercelClient: VercelClient | null;
   teamId: string | undefined;
 }
 
-export const useFetchAndValidateData = ({
+export const useFetchData = ({
   dispatchErrors,
   dispatchParameters,
   vercelClient,
   teamId,
-}: FetchAndValidateData) => {
+}: FetchData) => {
   const validateToken = async (onComplete: () => void, newVercelClient?: VercelClient) => {
     if (vercelClient) {
       try {
@@ -73,7 +72,7 @@ export const useFetchAndValidateData = ({
     if (vercelClient && teamId) {
       try {
         const data = await vercelClient.listApiPaths(selectedProject, teamId);
-        setApiPaths(validateApiPathData(data) ? data : []);
+        setApiPaths(data);
         dispatchErrors({
           type: errorsActions.RESET_API_PATH_SELECTION_ERRORS,
         });
@@ -85,6 +84,11 @@ export const useFetchAndValidateData = ({
           dispatchErrors({
             type: errorAction,
             payload: errorTypes.API_PATHS_EMPTY,
+          });
+        } else if (err.message === errorTypes.INVALID_DEPLOYMENT_DATA) {
+          dispatchErrors({
+            type: errorAction,
+            payload: errorTypes.INVALID_DEPLOYMENT_DATA,
           });
         } else {
           console.error(e);

--- a/apps/vercel/frontend/src/locations/ConfigScreen.tsx
+++ b/apps/vercel/frontend/src/locations/ConfigScreen.tsx
@@ -18,7 +18,7 @@ import { ConfigPageProvider } from '@contexts/ConfigPageProvider';
 import { GettingStartedSection } from '@components/config-screen/GettingStartedSection/GettingStartedSection';
 import errorsReducer from '@reducers/errorsReducer';
 import { useError } from '@hooks/useError/useError';
-import { useFetchAndValidateData } from '@hooks/useFetchAndValidateData/useFetchAndValidateData';
+import { useFetchData } from '@hooks/useFetchData/useFetchData';
 
 const ConfigScreen = () => {
   const [isLoading, setIsLoading] = useState(false);
@@ -32,7 +32,7 @@ const ConfigScreen = () => {
   const [parameters, dispatchParameters] = useReducer(parameterReducer, initialParameters);
   const [errors, dispatchErrors] = useReducer(errorsReducer, initialErrors);
   const { isError: isAuthenticationError } = useError({ error: errors.authentication });
-  const { validateToken, fetchProjects, fetchApiPaths } = useFetchAndValidateData({
+  const { validateToken, fetchProjects, fetchApiPaths } = useFetchData({
     dispatchErrors,
     dispatchParameters,
     vercelClient,

--- a/apps/vercel/frontend/src/locations/ConfigScreen.tsx
+++ b/apps/vercel/frontend/src/locations/ConfigScreen.tsx
@@ -128,7 +128,7 @@ const ConfigScreen = () => {
     if (parameters.selectedProject) {
       getApiPaths();
     }
-  }, [parameters.selectedProject, vercelClient]);
+  }, [parameters.selectedProject, vercelClient, parameters.teamId]);
 
   const updateTokenValidityState = () => {
     setIsLoading(false);


### PR DESCRIPTION
## Purpose

The purpose of this PR is to effectively communicate to the user that we are either unable to fetch the API paths or there do not exist API paths within their Vercel setup to render. 

## Approach

1. When there are no errors thrown on retrieval of the data, but there are no API paths to render. I am most curious around opinions for this. Does this make it clear enough to the user that they have not configured routes correctly?
![Screenshot 2024-05-01 at 8 22 47 AM](https://github.com/contentful/apps/assets/58186851/b6bf85b3-9262-417d-a673-426412812f28)

2. When there is an error on retrieval of the data (particularly important if this endpoint goes down). 
![Screenshot 2024-05-01 at 8 30 24 AM](https://github.com/contentful/apps/assets/58186851/0d5be503-0dff-4be3-a2f3-231017ea512e)

3. When the API path they have selected previously no longer exists within the current list (this logic already existed and exists for the projects as well). 
![Screenshot 2024-05-01 at 8 29 52 AM](https://github.com/contentful/apps/assets/58186851/a45dd8f6-f9d0-4cde-8abc-ee4a299d3f3f)

<!-- Why did we do it the way we did? Did we consider alternatives? What other implementation details or artifacts (screenshots etc.) would help reviewers contextualize change? -->
