### PR TITLE
fix: update search icon for channel and content type selection [INTEG-1840]

### DIFF
--- a/apps/microsoft-teams/frontend/src/components/config/DebouncedSearchInput/DebouncedSearchInput.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/DebouncedSearchInput/DebouncedSearchInput.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { Box, IconButton, TextInput } from '@contentful/f36-components';
+import { Box, TextInput } from '@contentful/f36-components';
 import { SearchIcon } from '@contentful/f36-icons';
 import { debounce } from 'lodash';
 
@@ -19,12 +19,7 @@ const DebouncedSearchInput = ({ onChange = () => {}, placeholder, disabled = fal
           placeholder={placeholder}
           onChange={debouncedHandleChange}
           isDisabled={disabled}
-        />
-        <IconButton
-          icon={<SearchIcon variant="muted" />}
-          aria-label="magnifying glass icon"
-          aria-hidden={true}
-          isDisabled={true}
+          icon={<SearchIcon />}
         />
       </TextInput.Group>
     </Box>


### PR DESCRIPTION
## Purpose

Our original design had the search icon on the right side of the text input for the channel and content type selection modals. However, it was rendering as a button which was confusing for users since it wasn't actionable.

## Approach

Utilize the icon prop for the TextInput Forma36 component rather than the action button (https://f36.contentful.com/components/text-input). This moves the icon from the right to the left, but checked with design and we are good to make this change since it aligns with our design system. This changes the look for both the content type and channel selection modals.

Before
![Screenshot 2024-05-01 at 11 53 57 AM](https://github.com/contentful/apps/assets/62958907/21e09748-a081-4e45-88f2-d98946f15b53)

![Screenshot 2024-05-01 at 11 54 07 AM](https://github.com/contentful/apps/assets/62958907/cfbb45f8-131e-4ad2-abe5-42d77b3131e6)

After
![Screenshot 2024-05-01 at 11 53 41 AM](https://github.com/contentful/apps/assets/62958907/efde96e2-c564-4f71-b066-82309e347b2f)

![Screenshot 2024-05-01 at 11 53 49 AM](https://github.com/contentful/apps/assets/62958907/d6e6cd98-6fe3-4128-b16b-6ddeec7a3408)

## Testing steps

Run the app locally and use the channel and content type selection modals

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
