### PR TITLE
fix: update link to help center app guide [INTEG-2062]

### DIFF
--- a/apps/microsoft-teams/frontend/src/components/config/AccessSection/AccessSection.tsx
+++ b/apps/microsoft-teams/frontend/src/components/config/AccessSection/AccessSection.tsx
@@ -237,8 +237,7 @@ const AccessSection = (props: Props) => {
             <HyperLink
               body={teamsAppInfo}
               substring={teamsAppLink}
-              // TODO: update link to app documentation
-              href={'https://www.contentful.com/help/apps-at-contentful/'}
+              href={'https://www.contentful.com/help/microsoft-teams-app'}
             />
           </Box>
         </Flex>


### PR DESCRIPTION
## Purpose

Update link on the app config page to point to the new help center app guide.

## Approach

Note: page is not live on the help center yet, but the updated link reflects the slug of the help article I just created.

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
