### PR TITLE
fix: update vite-react deps to fix build and security issues []

### DIFF
--- a/examples/vite-react/package-lock.json
+++ b/examples/vite-react/package-lock.json
@@ -8,22 +8,22 @@
       "name": "vite-react",
       "version": "0.1.0",
       "dependencies": {
-        "@contentful/app-sdk": "4.22.0",
-        "@contentful/f36-components": "4.45.0",
+        "@contentful/app-sdk": "4.25.0",
+        "@contentful/f36-components": "4.65.4",
         "@contentful/f36-tokens": "4.0.2",
         "@contentful/react-apps-toolkit": "1.2.16",
-        "contentful-management": "10.38.3",
+        "contentful-management": "10.46.4",
         "emotion": "10.0.27",
-        "react": "18.2.0",
-        "react-dom": "18.2.0"
+        "react": "18.3.1",
+        "react-dom": "18.3.1"
       },
       "devDependencies": {
-        "@contentful/app-scripts": "1.10.2",
+        "@contentful/app-scripts": "1.19.1",
         "@testing-library/react": "14.0.0",
         "@types/node": "16.18.38",
-        "@types/react": "18.2.14",
-        "@types/react-dom": "18.2.6",
-        "@vitejs/plugin-react": "4.0.1",
+        "@types/react": "18.3.1",
+        "@types/react-dom": "18.3.0",
+        "@vitejs/plugin-react": "4.2.1",
         "happy-dom": "9.20.3",
         "typescript": "5.1.6",
         "vite": "4.5.3",
@@ -31,60 +31,60 @@
       }
     },
     "node_modules/@ampproject/remapping": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
-      "integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
       "dev": true,
       "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.0",
-        "@jridgewell/trace-mapping": "^0.3.9"
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
       },
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.22.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
-      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+      "version": "7.24.2",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
+      "integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
       "dependencies": {
-        "@babel/highlight": "^7.22.13",
-        "chalk": "^2.4.2"
+        "@babel/highlight": "^7.24.2",
+        "picocolors": "^1.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.6.tgz",
-      "integrity": "sha512-29tfsWTq2Ftu7MXmimyC0C5FDZv5DYxOZkh3XD3+QW4V/BYuv/LyEsjj3c0hqedEaDt6DBfDvexMKU8YevdqFg==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.4.tgz",
+      "integrity": "sha512-vg8Gih2MLK+kOkHJp4gBEIkyaIi00jgWot2D9QOmmfLC8jINSOzmCLta6Bvz/JSBCqnegV0L80jhxkol5GWNfQ==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.6.tgz",
-      "integrity": "sha512-HPIyDa6n+HKw5dEuway3vVAhBboYCtREBMp+IWeseZy6TFtzn6MHkCH2KKYUOC/vKKwgSMHQW4htBOrmuRPXfw==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.5.tgz",
+      "integrity": "sha512-tVQRucExLQ02Boi4vdPp49svNGcfL2GhdTCT9aldhXgCJVAI21EtRfBettiuLUwce/7r6bFdgs6JFkcdTiFttA==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.22.5",
-        "@babel/generator": "^7.22.5",
-        "@babel/helper-compilation-targets": "^7.22.6",
-        "@babel/helper-module-transforms": "^7.22.5",
-        "@babel/helpers": "^7.22.6",
-        "@babel/parser": "^7.22.6",
-        "@babel/template": "^7.22.5",
-        "@babel/traverse": "^7.22.6",
-        "@babel/types": "^7.22.5",
-        "@nicolo-ribaudo/semver-v6": "^6.3.3",
-        "convert-source-map": "^1.7.0",
+        "@babel/code-frame": "^7.24.2",
+        "@babel/generator": "^7.24.5",
+        "@babel/helper-compilation-targets": "^7.23.6",
+        "@babel/helper-module-transforms": "^7.24.5",
+        "@babel/helpers": "^7.24.5",
+        "@babel/parser": "^7.24.5",
+        "@babel/template": "^7.24.0",
+        "@babel/traverse": "^7.24.5",
+        "@babel/types": "^7.24.5",
+        "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.2"
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -94,15 +94,21 @@
         "url": "https://opencollective.com/babel"
       }
     },
+    "node_modules/@babel/core/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true
+    },
     "node_modules/@babel/generator": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
-      "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.5.tgz",
+      "integrity": "sha512-x32i4hEXvr+iI0NEoEfDKzlemF8AmtOP8CcrRaEcpzysWuoEb1KknpcvMsHKPONoKZiDuItklgWhB18xEhr9PA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.23.0",
-        "@jridgewell/gen-mapping": "^0.3.2",
-        "@jridgewell/trace-mapping": "^0.3.17",
+        "@babel/types": "^7.24.5",
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^2.5.1"
       },
       "engines": {
@@ -110,22 +116,19 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.6.tgz",
-      "integrity": "sha512-534sYEqWD9VfUm3IPn2SLcH4Q3P86XL+QvqdC7ZsFrzyyPF3T4XGiVghF6PTYNdWg6pXuoqXxNQAhbYeEInTzA==",
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
+      "integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.22.6",
-        "@babel/helper-validator-option": "^7.22.5",
-        "@nicolo-ribaudo/semver-v6": "^6.3.3",
-        "browserslist": "^4.21.9",
-        "lru-cache": "^5.1.1"
+        "@babel/compat-data": "^7.23.5",
+        "@babel/helper-validator-option": "^7.23.5",
+        "browserslist": "^4.22.2",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
@@ -163,124 +166,125 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.5.tgz",
-      "integrity": "sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==",
+      "version": "7.24.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.3.tgz",
+      "integrity": "sha512-viKb0F9f2s0BCS22QSF308z/+1YWKV/76mwt61NBzS5izMzDPwdq1pTrzf+Li3npBWX9KdQbkeCt1jSAM7lZqg==",
       "dependencies": {
-        "@babel/types": "^7.22.5"
+        "@babel/types": "^7.24.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.5.tgz",
-      "integrity": "sha512-+hGKDt/Ze8GFExiVHno/2dvG5IdstpzCq0y4Qc9OJ25D4q3pKfiIP/4Vp3/JvhDkLKsDK2api3q3fpIgiIF5bw==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.24.5.tgz",
+      "integrity": "sha512-9GxeY8c2d2mdQUP1Dye0ks3VDyIMS98kt/llQ2nUId8IsWqTF0l1LkSX0/uP7l7MCDrzXS009Hyhe2gzTiGW8A==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-environment-visitor": "^7.22.5",
-        "@babel/helper-module-imports": "^7.22.5",
-        "@babel/helper-simple-access": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.5",
-        "@babel/helper-validator-identifier": "^7.22.5",
-        "@babel/template": "^7.22.5",
-        "@babel/traverse": "^7.22.5",
-        "@babel/types": "^7.22.5"
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-module-imports": "^7.24.3",
+        "@babel/helper-simple-access": "^7.24.5",
+        "@babel/helper-split-export-declaration": "^7.24.5",
+        "@babel/helper-validator-identifier": "^7.24.5"
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
-      "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.5.tgz",
+      "integrity": "sha512-xjNLDopRzW2o6ba0gKbkZq5YWEBaK3PCyTOY1K2P/O07LGMhMqlMXPxwN4S5/RhWuCobT8z0jrlKGlYmeR1OhQ==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-simple-access": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
-      "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.5.tgz",
+      "integrity": "sha512-uH3Hmf5q5n7n8mz7arjUlDOCbttY/DW4DYhE6FUsjKJ/oYC1kQQUvwEQWxRwUpX9qQKRXeqLwWxrqilMrf32sQ==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.22.5"
+        "@babel/types": "^7.24.5"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
-      "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.5.tgz",
+      "integrity": "sha512-5CHncttXohrHk8GWOFCcCl4oRD9fKosWlIRgWm4ql9VYioKm52Mk2xsmoohvm7f3JoiLSM5ZgJuRaf5QZZYd3Q==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.22.5"
+        "@babel/types": "^7.24.5"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+      "version": "7.24.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.1.tgz",
+      "integrity": "sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz",
+      "integrity": "sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.5.tgz",
-      "integrity": "sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
+      "integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.6.tgz",
-      "integrity": "sha512-YjDs6y/fVOYFV8hAf1rxd1QvR9wJe1pDBZ2AREKq/SDayfPzgk0PBnVuTCE5X1acEpMMNOVUqoe+OwiZGJ+OaA==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.5.tgz",
+      "integrity": "sha512-CiQmBMMpMQHwM5m01YnrM6imUG1ebgYJ+fAIW4FZe6m4qHTPaRHti+R8cggAwkdz4oXhtO4/K9JWlh+8hIfR2Q==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.22.5",
-        "@babel/traverse": "^7.22.6",
-        "@babel/types": "^7.22.5"
+        "@babel/template": "^7.24.0",
+        "@babel/traverse": "^7.24.5",
+        "@babel/types": "^7.24.5"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
-      "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.5.tgz",
+      "integrity": "sha512-8lLmua6AVh/8SLJRRVD6V8p73Hir9w5mJrhE+IPpILG31KKlI9iz5zmBYKcWPS59qSfgP9RaSBQSHHE81WKuEw==",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-validator-identifier": "^7.24.5",
         "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0"
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
-      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.5.tgz",
+      "integrity": "sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -290,12 +294,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx-self": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.22.5.tgz",
-      "integrity": "sha512-nTh2ogNUtxbiSbxaT4Ds6aXnXEipHweN9YRgOX/oNXdf0cCrGn/+2LozFa3lnPV5D90MkjhgckCPBrsoSc1a7g==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.24.5.tgz",
+      "integrity": "sha512-RtCJoUO2oYrYwFPtR1/jkoBEcFuI1ae9a9IMxeyAVa3a1Ap4AnxmyIKG2b2FaJKqkidw/0cxRbWN+HOs6ZWd1w==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.22.5"
+        "@babel/helper-plugin-utils": "^7.24.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -305,12 +309,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx-source": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.22.5.tgz",
-      "integrity": "sha512-yIiRO6yobeEIaI0RTbIr8iAK9FcBHLtZq0S89ZPjDLQXBA4xvghaKqI0etp/tF3htTM0sazJKKLz9oEiGRtu7w==",
+      "version": "7.24.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.24.1.tgz",
+      "integrity": "sha512-1v202n7aUq4uXAieRTKcwPzNyphlCuqHHDcdSNc+vdhoTEZcFMh+L5yZuCmGaIO7bs1nJUNfHB89TZyoL48xNA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.22.5"
+        "@babel/helper-plugin-utils": "^7.24.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -331,34 +335,34 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
-      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+      "version": "7.24.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.0.tgz",
+      "integrity": "sha512-Bkf2q8lMB0AFpX0NFEqSbx1OkTHf0f+0j82mkw+ZpzBnkk7e9Ql0891vlfgi+kHwOk8tQjiQHpqh4LaSa0fKEA==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/parser": "^7.22.15",
-        "@babel/types": "^7.22.15"
+        "@babel/code-frame": "^7.23.5",
+        "@babel/parser": "^7.24.0",
+        "@babel/types": "^7.24.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
-      "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.5.tgz",
+      "integrity": "sha512-7aaBLeDQ4zYcUFDUD41lJc1fG8+5IU9DaNSJAgal866FGvmD5EbWQgnEC6kO1gGLsX0esNkfnJSndbTXA3r7UA==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.23.0",
+        "@babel/code-frame": "^7.24.2",
+        "@babel/generator": "^7.24.5",
         "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-function-name": "^7.23.0",
         "@babel/helper-hoist-variables": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.23.0",
-        "@babel/types": "^7.23.0",
-        "debug": "^4.1.0",
+        "@babel/helper-split-export-declaration": "^7.24.5",
+        "@babel/parser": "^7.24.5",
+        "@babel/types": "^7.24.5",
+        "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
       "engines": {
@@ -366,12 +370,12 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
-      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
+      "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.22.5",
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-string-parser": "^7.24.1",
+        "@babel/helper-validator-identifier": "^7.24.5",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -379,26 +383,26 @@
       }
     },
     "node_modules/@contentful/app-scripts": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@contentful/app-scripts/-/app-scripts-1.10.2.tgz",
-      "integrity": "sha512-MPhzVXsw9TZMt3S5YVvFCO99ksFqGC8QqdcO3cYHn22CvtkUX9qJylnMwF9gUzLwUsFA0kAJG1NpB9bzaEN9sg==",
+      "version": "1.19.1",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/app-scripts/1.19.1/920a9d1352bb664af17d7c2d9dc0728f350d09f9",
+      "integrity": "sha512-pIqaIH99N6Fwf+rWI9Y9xb59TfYEd5PaNfBNECpFa/hoz+ow1rg+To+2dkhhh82W6hTmpnN7qBHlkLV1RU1p1g==",
       "dev": true,
       "dependencies": {
-        "adm-zip": "0.5.10",
-        "analytics-node": "^6.2.0",
+        "@segment/analytics-node": "^2.0.0",
+        "adm-zip": "0.5.12",
         "bottleneck": "2.19.5",
         "chalk": "4.1.2",
-        "commander": "10.0.1",
-        "contentful-management": "10.35.4",
-        "dotenv": "16.0.3",
-        "ignore": "5.2.4",
-        "inquirer": "8.2.5",
+        "commander": "12.0.0",
+        "contentful-management": "11.25.2",
+        "dotenv": "16.4.5",
+        "ignore": "5.3.1",
+        "inquirer": "8.2.6",
         "lodash": "4.17.21",
         "open": "8.4.2",
         "ora": "5.4.1"
       },
       "bin": {
-        "contentful-app-scripts": "bin/app-scripts"
+        "contentful-app-scripts": "lib/bin.js"
       },
       "engines": {
         "node": ">=14",
@@ -461,27 +465,27 @@
       "dev": true
     },
     "node_modules/@contentful/app-scripts/node_modules/contentful-management": {
-      "version": "10.35.4",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-10.35.4.tgz",
-      "integrity": "sha512-yAgnwzyyT3kqvxKkM6iky9UiWs8n1EQH5n52rcBrjHM44Ext+Kjagzz1gRQC3maYSgp5UR3FwyUj8gX9Kd7uDQ==",
+      "version": "11.25.2",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.25.2.tgz",
+      "integrity": "sha512-09KfIs3il8OFHzY+d2Vvq+2Jfgk8ISOKjTs3MFqqcc3Ae94T1pji8ZaHXZ6dlb9lLZT6kFYRE9aiDNUuL2Vjbg==",
       "dev": true,
       "dependencies": {
-        "@contentful/rich-text-types": "^16.0.3",
+        "@contentful/rich-text-types": "^16.3.0",
         "@types/json-patch": "0.0.30",
-        "axios": "^0.27.1",
-        "contentful-sdk-core": "^7.0.1",
+        "axios": "^1.6.2",
+        "contentful-sdk-core": "^8.1.0",
         "fast-copy": "^3.0.0",
         "lodash.isplainobject": "^4.0.6",
-        "type-fest": "^3.0.0"
+        "type-fest": "^4.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/@contentful/app-scripts/node_modules/fast-copy": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.1.tgz",
-      "integrity": "sha512-Knr7NOtK3HWRYGtHoJrjkaWepqT8thIVGAwt0p0aUs1zqkAzXZV4vo9fFNwyb5fcqK1GKYFYxldQdIDVKhUAfA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.2.tgz",
+      "integrity": "sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==",
       "dev": true
     },
     "node_modules/@contentful/app-scripts/node_modules/has-flag": {
@@ -506,40 +510,45 @@
       }
     },
     "node_modules/@contentful/app-sdk": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.22.0.tgz",
-      "integrity": "sha512-ljXNwqdCA1GCsD32SKGcUpLnuQAmAHSyW9ebHw185UBwNgqM02n20tODWftUYH94TlPiQnQmqDSDFX7TGRYW2g==",
+      "version": "4.25.0",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/app-sdk/4.25.0/305d18a1809a5059a2abea9019bc8fcf6d854145",
+      "integrity": "sha512-Aw5Yq3zduwHonNJPQtBTNzZ4MC17UtH8zaSnq8cdbDLfyJOYiTgPDDh15AzgwAkfyOovoXCBcyajjra9Cm45Qg==",
       "dependencies": {
         "contentful-management": ">=7.30.0"
       }
     },
     "node_modules/@contentful/f36-accordion": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.45.0.tgz",
-      "integrity": "sha512-7L78Xnu8VlZNdSgVEyVClMVBR96ktqhMSLjy7D6cOqwiro2HGz98VTWtlqv7unKgDzgbZYukcK+kmnaN6sTgGg==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-accordion/4.65.4/ac7bc3768e5b770321556604b3d65955a8fdd570",
+      "integrity": "sha512-gICRiYKaeHG6u1HFyzcHuelx311PRJwX4HDNwle+nkTBzho94qR1B0hNNAjh1Q9+7lpg+Rt0xNENBq9Od78/ww==",
       "dependencies": {
-        "@contentful/f36-collapse": "^4.45.0",
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.45.0",
+        "@contentful/f36-collapse": "^4.65.4",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.4",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
       }
+    },
+    "node_modules/@contentful/f36-accordion/node_modules/@contentful/f36-tokens": {
+      "version": "4.0.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+      "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
     },
     "node_modules/@contentful/f36-asset": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.45.0.tgz",
-      "integrity": "sha512-xMQc7MkH9j+/LXNbKREtqt8lN9fuh91JNdVXMkQNPavh0/C32xhJcyYztau9sr6BWB74PcfFvn7n1ceaW5pD6w==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-asset/4.65.4/8fc7135a5b83b4ce22dc0d8d9065dc9af12043f8",
+      "integrity": "sha512-MegkLloS9mAcp8e6gpPncumSAA4i6vYMPy1pW48WyfSQLGOQqPZB+0ULV/5FrCl8HRXqRdCkmiNODQsnyR5Yhw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-icon": "^4.45.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.45.0",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-icon": "^4.65.4",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.4",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -547,20 +556,25 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/@contentful/f36-asset/node_modules/@contentful/f36-tokens": {
+      "version": "4.0.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+      "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+    },
     "node_modules/@contentful/f36-autocomplete": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.45.0.tgz",
-      "integrity": "sha512-J+vU5+h9A0wt07xxKLw4U1EwkhL1HzF3B/LkUJwLDnWjidvWyiB6FU/Cmm9GxlPfAAEzHNwHLIe40S+3c3ourA==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-autocomplete/4.65.4/476b69439b766060e9948424d1f0efb7e833e821",
+      "integrity": "sha512-CCnBQy5vt5hBlKx6MiANo8TwIoquW25LJdilRqBbIX1tg9QTsBDbCFtY1ktZxoh802If/rnk7oNRFUFxe1k9cg==",
       "dependencies": {
-        "@contentful/f36-button": "^4.45.0",
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-forms": "^4.45.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-popover": "^4.45.0",
-        "@contentful/f36-skeleton": "^4.45.0",
-        "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.45.0",
-        "@contentful/f36-utils": "^4.23.2",
+        "@contentful/f36-button": "^4.65.4",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-forms": "^4.65.4",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-popover": "^4.65.4",
+        "@contentful/f36-skeleton": "^4.65.4",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.4",
+        "@contentful/f36-utils": "^4.24.3",
         "downshift": "^6.1.12",
         "emotion": "^10.0.17"
       },
@@ -569,30 +583,40 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/@contentful/f36-autocomplete/node_modules/@contentful/f36-tokens": {
+      "version": "4.0.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+      "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+    },
     "node_modules/@contentful/f36-badge": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.45.0.tgz",
-      "integrity": "sha512-g112nAiVevecTuCWuUad3GTII4qOaCtsnlmCG2YKqFZBQCI0tVTJdB2JTyFoHpJo1i6whZpqDyVqvosJgvI+RQ==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-badge/4.65.4/15b16e72f191485f8e2d2081d0c0576b064b8db1",
+      "integrity": "sha512-7MYdwOEIm+B95jBr1ISIHpSNDPfOXJHehsfZd6K12vJgjARhtFDWk3AEH8nW33oBuWysbsUKh3RVqMo7ro4mBg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-icons": "^4.25.0",
-        "@contentful/f36-tokens": "^4.0.2",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
       }
+    },
+    "node_modules/@contentful/f36-badge/node_modules/@contentful/f36-tokens": {
+      "version": "4.0.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+      "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
     },
     "node_modules/@contentful/f36-button": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.45.0.tgz",
-      "integrity": "sha512-KRRgjqDzm5Ta3QEWTyx2H/m7d0HyPBMgex5T7RL6BK/Alu/4tJqAEN5VciRumfOKG0rXKwxsiseP9O5tdVjy9w==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-button/4.65.4/4b8bf5952b01d298f66e72ca7b5910e08772493d",
+      "integrity": "sha512-YpQMw24TvTc9Z9P7Em/0aO/xjD7TLHxIiR26oa5/UGuY7/8nuzBEiC4L4dFbgtVSXpLYDyj4uxcOZc/o7sul5Q==",
       "dependencies": {
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-spinner": "^4.45.0",
-        "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-utils": "^4.24.1",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-spinner": "^4.65.4",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -600,23 +624,28 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/@contentful/f36-button/node_modules/@contentful/f36-tokens": {
+      "version": "4.0.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+      "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+    },
     "node_modules/@contentful/f36-card": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.45.0.tgz",
-      "integrity": "sha512-JAu20JpUkwabm2ODxxsGu0mRuiIvDjAp4ACcAWNmrIWpA57lRCZbxI+OWDa4mp2tJFCf3AxfaiQ0pP6Z//vTIA==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-card/4.65.4/57805f81d2c9fa2c1a8e41f70791a3111b261234",
+      "integrity": "sha512-AiUYpGxnn0KJWHoyuhy6YpAaGFPhBhRgq2yr3iXTeDDxJvHKwtFtw/80SRIUeKIy9NaxZWB6EW13NBtyZZ+QAw==",
       "dependencies": {
-        "@contentful/f36-asset": "^4.45.0",
-        "@contentful/f36-badge": "^4.45.0",
-        "@contentful/f36-button": "^4.45.0",
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-drag-handle": "^4.45.0",
-        "@contentful/f36-icon": "^4.45.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-menu": "^4.45.0",
-        "@contentful/f36-skeleton": "^4.45.0",
-        "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-tooltip": "^4.45.0",
-        "@contentful/f36-typography": "^4.45.0",
+        "@contentful/f36-asset": "^4.65.4",
+        "@contentful/f36-badge": "^4.65.4",
+        "@contentful/f36-button": "^4.65.4",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-drag-handle": "^4.65.4",
+        "@contentful/f36-icon": "^4.65.4",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-menu": "^4.65.4",
+        "@contentful/f36-skeleton": "^4.65.4",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-tooltip": "^4.65.4",
+        "@contentful/f36-typography": "^4.65.4",
         "emotion": "^10.0.17",
         "truncate": "^3.0.0"
       },
@@ -625,101 +654,93 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/@contentful/f36-card/node_modules/@contentful/f36-tokens": {
+      "version": "4.0.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+      "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+    },
     "node_modules/@contentful/f36-collapse": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.45.0.tgz",
-      "integrity": "sha512-wCAm+lR9HSQ/IEsnheSSNW0UT6B9SJEnutzJnh16Xk1trZWqRhdUmys69mOAleKq/lqwfODKl8CfzGUVxPcEmw==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-collapse/4.65.4/1f9635a99385728a33d2feb391e8406ab6ca0cb0",
+      "integrity": "sha512-S/niEGAxXWYWuTj8z4+QdqWqfqM+uulaOIwsA9GG3B5/t73TrE1tb/SGJzWYcCenb6zGUrUeeJVMLU1V4J517g==",
       "dependencies": {
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-tokens": "^4.0.2",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
       }
+    },
+    "node_modules/@contentful/f36-collapse/node_modules/@contentful/f36-tokens": {
+      "version": "4.0.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+      "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
     },
     "node_modules/@contentful/f36-components": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.45.0.tgz",
-      "integrity": "sha512-vxEWAHlcbfSmhHh5wfjNY3NsdN3vpTxK2pg1MvqECFBFxwTVfA2UxYwioM0cgd1W/rLRNTf+sCLSryKr2F3JCg==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-components/4.65.4/8f269a62337b3302798cbbe4b2074c17d57a291b",
+      "integrity": "sha512-NgnOKH63CEGAROqL71slZagqS6eG144vY/p8P1psE/AACoFq2VrlGITA9uGsdcO88jt1icFUiUdZHwkwkoamcw==",
       "dependencies": {
-        "@contentful/f36-accordion": "^4.45.0",
-        "@contentful/f36-asset": "^4.45.0",
-        "@contentful/f36-autocomplete": "^4.45.0",
-        "@contentful/f36-badge": "^4.45.0",
-        "@contentful/f36-button": "^4.45.0",
-        "@contentful/f36-card": "^4.45.0",
-        "@contentful/f36-collapse": "^4.45.0",
-        "@contentful/f36-copybutton": "^4.45.0",
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-datepicker": "^4.45.0",
-        "@contentful/f36-datetime": "^4.45.0",
-        "@contentful/f36-drag-handle": "^4.45.0",
-        "@contentful/f36-empty-state": "^4.45.0",
-        "@contentful/f36-entity-list": "^4.45.0",
-        "@contentful/f36-forms": "^4.45.0",
-        "@contentful/f36-icon": "^4.45.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-list": "^4.45.0",
-        "@contentful/f36-menu": "^4.45.0",
-        "@contentful/f36-modal": "^4.45.0",
-        "@contentful/f36-navbar": "^4.1.0",
-        "@contentful/f36-note": "^4.45.0",
-        "@contentful/f36-notification": "^4.45.0",
-        "@contentful/f36-pagination": "^4.45.0",
-        "@contentful/f36-pill": "^4.45.0",
-        "@contentful/f36-popover": "^4.45.0",
-        "@contentful/f36-skeleton": "^4.45.0",
-        "@contentful/f36-spinner": "^4.45.0",
-        "@contentful/f36-table": "^4.45.0",
-        "@contentful/f36-tabs": "^4.45.0",
-        "@contentful/f36-text-link": "^4.45.0",
-        "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-tooltip": "^4.45.0",
-        "@contentful/f36-typography": "^4.45.0",
-        "@contentful/f36-utils": "^4.23.2",
-        "@types/react": "16.14.22",
-        "@types/react-dom": "16.9.14"
+        "@contentful/f36-accordion": "^4.65.4",
+        "@contentful/f36-asset": "^4.65.4",
+        "@contentful/f36-autocomplete": "^4.65.4",
+        "@contentful/f36-badge": "^4.65.4",
+        "@contentful/f36-button": "^4.65.4",
+        "@contentful/f36-card": "^4.65.4",
+        "@contentful/f36-collapse": "^4.65.4",
+        "@contentful/f36-copybutton": "^4.65.4",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-datepicker": "^4.65.4",
+        "@contentful/f36-datetime": "^4.65.4",
+        "@contentful/f36-drag-handle": "^4.65.4",
+        "@contentful/f36-empty-state": "^4.65.4",
+        "@contentful/f36-entity-list": "^4.65.4",
+        "@contentful/f36-forms": "^4.65.4",
+        "@contentful/f36-icon": "^4.65.4",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-list": "^4.65.4",
+        "@contentful/f36-menu": "^4.65.4",
+        "@contentful/f36-modal": "^4.65.4",
+        "@contentful/f36-navbar": "^4.1.1",
+        "@contentful/f36-note": "^4.65.4",
+        "@contentful/f36-notification": "^4.65.4",
+        "@contentful/f36-pagination": "^4.65.4",
+        "@contentful/f36-pill": "^4.65.4",
+        "@contentful/f36-popover": "^4.65.4",
+        "@contentful/f36-skeleton": "^4.65.4",
+        "@contentful/f36-spinner": "^4.65.4",
+        "@contentful/f36-table": "^4.65.4",
+        "@contentful/f36-tabs": "^4.65.4",
+        "@contentful/f36-text-link": "^4.65.4",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-tooltip": "^4.65.4",
+        "@contentful/f36-typography": "^4.65.4",
+        "@contentful/f36-utils": "^4.24.3"
       },
       "peerDependencies": {
+        "@types/react": ">=16.8",
+        "@types/react-dom": ">=16.8",
         "react": ">=16.8",
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/@contentful/f36-components/node_modules/@types/react": {
-      "version": "16.14.22",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.22.tgz",
-      "integrity": "sha512-4NnkxKDd2UO9SiCckuhCQOCzdO+RtE4Epf1D6eGz3f9jZjiIXOVo+Bk3jqSad+8EOT+LBXwKdkFX0V0F+NFzDQ==",
-      "dependencies": {
-        "@types/prop-types": "*",
-        "@types/scheduler": "*",
-        "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@contentful/f36-components/node_modules/@types/react-dom": {
-      "version": "16.9.14",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.14.tgz",
-      "integrity": "sha512-FIX2AVmPTGP30OUJ+0vadeIFJJ07Mh1m+U0rxfgyW34p3rTlXI+nlenvAxNn4BP36YyI9IJ/+UJ7Wu22N1pI7A==",
-      "dependencies": {
-        "@types/react": "^16"
-      }
-    },
-    "node_modules/@contentful/f36-components/node_modules/csstype": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
-      "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA=="
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-tokens": {
+      "version": "4.0.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+      "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
     },
     "node_modules/@contentful/f36-copybutton": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.45.0.tgz",
-      "integrity": "sha512-cEjy8xb5r0WDW8G690l/rV3pwwne9NoFkEVRi2lQaJ9XquU0y4Fl81M0Adm2/7nv9GPFJULZwTCCHNYoElTL9g==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-copybutton/4.65.4/4c435eb442f593cb6e3dc851678b467eb99dd1dd",
+      "integrity": "sha512-mz5NeUfrafSBkXhGDHl4CUXBjDY//ueBURtfA9wROF7ixKRYHb3TtBxzipzzLm4i77n+b5Rt02kl9jkPZPKyWQ==",
       "dependencies": {
-        "@contentful/f36-button": "^4.45.0",
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-tooltip": "^4.45.0",
+        "@contentful/f36-button": "^4.65.4",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-tooltip": "^4.65.4",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -727,12 +748,17 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/@contentful/f36-copybutton/node_modules/@contentful/f36-tokens": {
+      "version": "4.0.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+      "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+    },
     "node_modules/@contentful/f36-core": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.45.0.tgz",
-      "integrity": "sha512-UvFfwj8os0VyUFk7KVw4+LVItAiweASxWmiKgwvxM4B8O74DBcu3/OqwQbgJk01ufnPC4i2p+cSt0SZ1Z+cOkg==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-core/4.65.4/7baeab61593b31508c3947e3404229cdd445e6db",
+      "integrity": "sha512-VepF58IpC/xcT49RKPm/ri7bHmgNkvd0dtlJvvcoGifz/Yb+VuSwOXFUEIav1htIitG8wnfYPFJBur5FYCBu6A==",
       "dependencies": {
-        "@contentful/f36-tokens": "^4.0.2",
+        "@contentful/f36-tokens": "^4.0.4",
         "@emotion/core": "^10.1.1",
         "@emotion/is-prop-valid": "^1.2.0",
         "csstype": "^3.1.1",
@@ -743,23 +769,28 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/@contentful/f36-core/node_modules/@contentful/f36-tokens": {
+      "version": "4.0.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+      "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+    },
     "node_modules/@contentful/f36-core/node_modules/csstype": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/@contentful/f36-datepicker": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.45.0.tgz",
-      "integrity": "sha512-ZTHuBphRsTDoXdpLn1J1lxZJk1D1X9KR95pgDXOV4Aq4fg+4YLY/8PiqrgT/N6RmAMBjUgwr1eFCzDTtWVnybQ==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-datepicker/4.65.4/0afea77c09b6ae580a3a9961d2f3963e93a34b41",
+      "integrity": "sha512-JUdmCgBJuZ9khUY+MtDH1xSwh6ob1k9mH1tIjKeRkF292GZGkJMw51PAoWyU95CTyL42pVt2dXUhr0mtBI93pQ==",
       "dependencies": {
-        "@contentful/f36-button": "^4.45.0",
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-forms": "^4.45.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-popover": "^4.45.0",
-        "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.45.0",
+        "@contentful/f36-button": "^4.65.4",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-forms": "^4.65.4",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-popover": "^4.65.4",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.4",
         "date-fns": "^2.28.0",
         "emotion": "^10.0.17",
         "react-day-picker": "^8.7.1",
@@ -770,13 +801,18 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/@contentful/f36-datepicker/node_modules/@contentful/f36-tokens": {
+      "version": "4.0.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+      "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+    },
     "node_modules/@contentful/f36-datetime": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.45.0.tgz",
-      "integrity": "sha512-2jGOzRTzknMngjv2MclQg+SyVt11uhjFrsCaRNa3oau1DGAjOOtglwkGwD1uO6KIzkjA5DDevHMAKRgJ4fCv0Q==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-datetime/4.65.4/ef2e8b99fb92c22d3a56b1e00600cc7aca68d818",
+      "integrity": "sha512-vGARpWxr+wzjEBgi/V1YnPvutEZdOw+uMVcLSPIAYv8aQ+w1bu7K7wimBOtIBA8D4Qk4v1/Km/YLf2r2q8JNvg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-tokens": "^4.0.2",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-tokens": "^4.0.4",
         "dayjs": "^1.11.5",
         "emotion": "^10.0.17"
       },
@@ -785,67 +821,88 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/@contentful/f36-datetime/node_modules/@contentful/f36-tokens": {
+      "version": "4.0.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+      "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+    },
     "node_modules/@contentful/f36-drag-handle": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.45.0.tgz",
-      "integrity": "sha512-LJ2aUPXr+1tlCe28NdhZFBEhFw+25NRsKMSLln5hHRU+pDbeBQFPwHhgglVXYIpxSRBWFXtXtOGb8tWxSue2OA==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-drag-handle/4.65.4/c605ca420ae0f3e02b4ed39bf2702c38f4468a28",
+      "integrity": "sha512-ZuowEbXCEmhU/n8hgEcdGtWjy7rBKkuf3zqGV4wDZLOzBsCP7d0Y2TeRvuNhA8tXX/ng/TQxcUH57GylGqVB9A==",
       "dependencies": {
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-utils": "^4.24.1",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
       }
+    },
+    "node_modules/@contentful/f36-drag-handle/node_modules/@contentful/f36-tokens": {
+      "version": "4.0.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+      "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
     },
     "node_modules/@contentful/f36-empty-state": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.45.0.tgz",
-      "integrity": "sha512-pshErnTpBgZO6zllIHQ8YtJ+nuM9UL55bUFFg+XuZUbOAIzxY1kmJWG4aSWai8Z3CtWnQOeccOOpRWO796jFkw==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-empty-state/4.65.4/13c01ad2ff42ed150443d7b873911b91c948c35f",
+      "integrity": "sha512-d3zirN3KUKIm9BRIvLBRudF7veva2jojUci4MzG51uTrufKPkDh6LqxJVItF+ktZKqm0on1wFMaMzz+h6pi5sw==",
       "dependencies": {
-        "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.45.0",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.4",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
       }
+    },
+    "node_modules/@contentful/f36-empty-state/node_modules/@contentful/f36-tokens": {
+      "version": "4.0.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+      "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
     },
     "node_modules/@contentful/f36-entity-list": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.45.0.tgz",
-      "integrity": "sha512-/WyhSuzHuoJjAdosmBxmsUgnzwcMYi9WvonuKXJTn3S/qy7VGSofzd4zy964Bmu/Abkq6mgoDvZxIt7RoebEDw==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-entity-list/4.65.4/d6297dcff6ec9c4627465a981cd60cf26f2ea55d",
+      "integrity": "sha512-gS/LsUH5hv9Fx8c2t1QOdL2S5Uuy3lnpNm9TNMy87zNaQQ0YS9rNGKKBEUIcAo2ngzvqf/7DsGIxdzQrzada2w==",
       "dependencies": {
-        "@contentful/f36-badge": "^4.45.0",
-        "@contentful/f36-button": "^4.45.0",
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-drag-handle": "^4.45.0",
-        "@contentful/f36-icon": "^4.45.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-menu": "^4.45.0",
-        "@contentful/f36-skeleton": "^4.45.0",
-        "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.45.0",
+        "@contentful/f36-badge": "^4.65.4",
+        "@contentful/f36-button": "^4.65.4",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-drag-handle": "^4.65.4",
+        "@contentful/f36-icon": "^4.65.4",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-menu": "^4.65.4",
+        "@contentful/f36-skeleton": "^4.65.4",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.4",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
       }
+    },
+    "node_modules/@contentful/f36-entity-list/node_modules/@contentful/f36-tokens": {
+      "version": "4.0.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+      "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
     },
     "node_modules/@contentful/f36-forms": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.45.0.tgz",
-      "integrity": "sha512-1rKMY02LUVWzr2TDkzk6a/1GwQNjxNfMH9Y5vVQ8q+lojTl5ppDXrcLdKC4Fk8dLWLjEIvfvCA1vC9sPDUptug==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-forms/4.65.4/e1397cb35bbe82fc57630d10c194a97ce37209c2",
+      "integrity": "sha512-pA5S3x44s2vG/2u1UmlMN5M8CWU1KbW2ec9qj/yiFkAH7uLzpmTbCUrk1EXpHKruN5RhgadlnMiBJFnq4QHAnA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.45.0",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.4",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -853,26 +910,37 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/@contentful/f36-forms/node_modules/@contentful/f36-tokens": {
+      "version": "4.0.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+      "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+    },
     "node_modules/@contentful/f36-icon": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.45.0.tgz",
-      "integrity": "sha512-6vs0iP2y9IsmIC/YwiE7bOAl1jqyk28J4dqJLZsk3T63i5uXrJCnb8NPDOJCJkIRZQRFCbZd4XVfXPKz1F2EjQ==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-icon/4.65.4/4d12f054e6df73d48a16c6c7797b1ee689a43b56",
+      "integrity": "sha512-y/hT/3cxTA+Nr4ezbpVmQirVzRv9NPvg5Q8wdF68PgHfKyhYVgNXD+AnRcbN9aHeESFzoDWvgv1bca76GCWpYg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-tokens": "^4.0.2",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
+    "node_modules/@contentful/f36-icon/node_modules/@contentful/f36-tokens": {
+      "version": "4.0.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+      "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+    },
     "node_modules/@contentful/f36-icons": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-4.25.0.tgz",
-      "integrity": "sha512-PDEvCtoAfP3FF7K+slhOb+LP2MxlUSKQXmRUmtBPXIFz+usZC4FOGQAMWKF9kdnDEq9C/kaYiCzPkZ6BJC4hmg==",
+      "version": "4.28.2",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-icons/4.28.2/8297da32e9d8e60e09550e365f24a74a8e12326c",
+      "integrity": "sha512-p7oWbQ5ITlMMuEl/6t/6JLVrCVhDE2nA8mv1VR4DHjXPm0y9w14533rCKxNIREZX8iVmyBoaqI3vdPsjUs1CAw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-icon": "^4.23.2",
+        "@contentful/f36-core": "^4.65.0",
+        "@contentful/f36-icon": "^4.65.0",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
@@ -882,29 +950,12 @@
       }
     },
     "node_modules/@contentful/f36-list": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.45.0.tgz",
-      "integrity": "sha512-dCwCXKr+uFAyyeEOWTX+rgrmZ8TGwUGPWHvoUHKcwecvyMyzGncgZUqe7K7VeZSg+Xjf8Qqu1MXrfRFfJ8CgAA==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-list/4.65.4/ad6613ff5a1fd838bc7f64dcad5a9004d3fa8421",
+      "integrity": "sha512-7MhF4wAFFZIDSF7DX80C5TDkEhuWYAkGNTSnfX+HZpDd53bfJNZpC0gJT7g5wXoGWoKS58GBj3fjze0Cqw9yPA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-tokens": "^4.0.2",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-menu": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.45.0.tgz",
-      "integrity": "sha512-eH2UfWhhGc4VwAUXMHfBiQLPUkxxN+T3/6OQUekAxf8Pa0jRGPfi6IP0lyxeTIHMSUNaoZ5gxw/2ifV4sn0v2A==",
-      "dependencies": {
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-popover": "^4.45.0",
-        "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.45.0",
-        "@contentful/f36-utils": "^4.23.2",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -912,16 +963,44 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/@contentful/f36-modal": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.45.0.tgz",
-      "integrity": "sha512-oFuA5J5f8bKdI74Wb1y/P7CUapzLjSfNTbEekK6TBFnUJabQXItJdxHHwH5bXFZa4BKFeZ6sGr/9xohvI8Nv2Q==",
+    "node_modules/@contentful/f36-list/node_modules/@contentful/f36-tokens": {
+      "version": "4.0.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+      "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+    },
+    "node_modules/@contentful/f36-menu": {
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-menu/4.65.4/8a8724f828161ba3b92ef2c9d5656c4be95c3a55",
+      "integrity": "sha512-FAm7InhFr2V7S4yv02VuOf/XE5afTOJ57ueGW6eVO7BVL2HovZookyRD61tX3IFrBc27VomfxB9rIFUhT5J0kg==",
       "dependencies": {
-        "@contentful/f36-button": "^4.45.0",
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.45.0",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-popover": "^4.65.4",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.4",
+        "@contentful/f36-utils": "^4.24.3",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-menu/node_modules/@contentful/f36-tokens": {
+      "version": "4.0.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+      "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+    },
+    "node_modules/@contentful/f36-modal": {
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-modal/4.65.4/c7948a4436c98ac01b91722987e51be99abe6882",
+      "integrity": "sha512-/oPt/GFYncqkQG7FLVy3UARWv59jA0TRCbytovWZQPcBvd4RgQUMQNasZeN77DlyaQKoUWiET3y06rBaQxW7+w==",
+      "dependencies": {
+        "@contentful/f36-button": "^4.65.4",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.4",
         "@types/react-modal": "^3.13.1",
         "emotion": "^10.0.17",
         "react-modal": "^3.16.1"
@@ -931,10 +1010,15 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/@contentful/f36-modal/node_modules/@contentful/f36-tokens": {
+      "version": "4.0.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+      "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+    },
     "node_modules/@contentful/f36-navbar": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-navbar/-/f36-navbar-4.1.0.tgz",
-      "integrity": "sha512-tFzg4px28dGq2zD+/rKsVmZ684WItZ+xNGI7et6QeAmevwIzifE1JGblJr/BC1Nn2nWLlF0LZn4URekIf7ijkA==",
+      "version": "4.1.1",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-navbar/4.1.1/139c0280f14f3a923d40bfa7290984eb60486119",
+      "integrity": "sha512-nCLtZ7EgfKhmXWrGZYrZEQOoulOOVPOuZBk0CC4JgQRQmCYeYr2iAnM8zualISFaxX/O+GVvHPQf2hKeoeFRPA==",
       "dependencies": {
         "@contentful/f36-core": "^4.45.0",
         "@contentful/f36-icon": "^4.45.0",
@@ -951,16 +1035,16 @@
       }
     },
     "node_modules/@contentful/f36-note": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.45.0.tgz",
-      "integrity": "sha512-+yPOlZtFe4vmLZiZjCBTG8wUikqLcaliikUKEs68Qk6/sLTsAL8vTmCG7B8addDv1kmY5rpWA2D8x7/v/TGNuQ==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-note/4.65.4/eb649736ef20960836121c6269664a49dcc2f0a7",
+      "integrity": "sha512-njpLgLEKEH2TJFpDIEABziM6KRYWWfVe/5b9ixSk1d3q0OuBatd1Wd4fg71ZBfPJQa5d+i/C5n0auwR0/C+SgA==",
       "dependencies": {
-        "@contentful/f36-button": "^4.45.0",
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-icon": "^4.45.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.45.0",
+        "@contentful/f36-button": "^4.65.4",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-icon": "^4.65.4",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.4",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -968,17 +1052,22 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/@contentful/f36-note/node_modules/@contentful/f36-tokens": {
+      "version": "4.0.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+      "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+    },
     "node_modules/@contentful/f36-notification": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.45.0.tgz",
-      "integrity": "sha512-qByB39m9x1NCnXc1Ult/SYJftXLsRbJ1VAoDSWiKpz4dKUkuLq34dujNyml3nQr7Hhh2l6qzTIsspHO2yaBbUA==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-notification/4.65.4/581b0db345575d11e61ebc887df01e8b4bff79be",
+      "integrity": "sha512-USO9c3GifvvCZZjrraeDxSEuvS4hTPT6iLmqWw2E21qOoeJRxz1iRLyhNpWxQHyvjnINcuEgcXbGQD5EDk3sZA==",
       "dependencies": {
-        "@contentful/f36-button": "^4.45.0",
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-text-link": "^4.45.0",
-        "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.45.0",
+        "@contentful/f36-button": "^4.65.4",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-text-link": "^4.65.4",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.4",
         "@swc/helpers": "^0.4.14",
         "emotion": "^10.0.17",
         "react-animate-height": "^3.0.4"
@@ -988,34 +1077,22 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/@contentful/f36-pagination": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.45.0.tgz",
-      "integrity": "sha512-SQ7GeFa+m63mwN/6vW4uJBlk9C2Iv0wOQjr88bBIyzSbYQBvZYp+yAT+n3Wk2gTfKK6Ph3W/K2bIijTKN+cDkA==",
-      "dependencies": {
-        "@contentful/f36-button": "^4.45.0",
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-forms": "^4.45.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.45.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8"
-      }
+    "node_modules/@contentful/f36-notification/node_modules/@contentful/f36-tokens": {
+      "version": "4.0.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+      "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
     },
-    "node_modules/@contentful/f36-pill": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.45.0.tgz",
-      "integrity": "sha512-pksZOGj4Sq0Sl4tAackZgAQCGDOXCUtR3ldoEvsrHSlbuyZTkBNc40TRuz+Ky83icO2XaBuepl06IGxmecxcUw==",
+    "node_modules/@contentful/f36-pagination": {
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-pagination/4.65.4/3f931cbcc1bbf1c8c299f9c43b97b78388958759",
+      "integrity": "sha512-juv5gmqaDFBuus/iNhuTwcrpBw+wm0gjHa2sv8q07okb8ztTbxFMxg8g7QsR59TWjNnSq5KuTWREHS6djxiyNw==",
       "dependencies": {
-        "@contentful/f36-button": "^4.45.0",
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-drag-handle": "^4.45.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-tooltip": "^4.45.0",
+        "@contentful/f36-button": "^4.65.4",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-forms": "^4.65.4",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.4",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -1023,59 +1100,83 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/@contentful/f36-popover": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.45.0.tgz",
-      "integrity": "sha512-MuXd8xCJFhDFSlq+uY1dpHk5A5jtgVR1RblleCDZSkquwMfEuEOHCM9z9BFyLpxQK6jKerSoyogsY3v9W694qg==",
+    "node_modules/@contentful/f36-pagination/node_modules/@contentful/f36-tokens": {
+      "version": "4.0.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+      "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+    },
+    "node_modules/@contentful/f36-pill": {
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-pill/4.65.4/caaa09af078bacce456088181bf85071d59b0e37",
+      "integrity": "sha512-oK5Qk1vH3vlKFSWsG5mZHRSI25AWRYKwKzNFePOfv6V824815oLgpfSB9wJwyDtSbNThORLr6+9u9T9JiNgmJQ==",
       "dependencies": {
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-utils": "^4.23.2",
+        "@contentful/f36-button": "^4.65.4",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-drag-handle": "^4.65.4",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-tooltip": "^4.65.4",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-pill/node_modules/@contentful/f36-tokens": {
+      "version": "4.0.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+      "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+    },
+    "node_modules/@contentful/f36-popover": {
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-popover/4.65.4/77eec4ec7f8f27fb55e520582d05782eca200e4c",
+      "integrity": "sha512-z6fqpoqOANvMl2ygGgGItQ12njWV5jDxrfBwv2QK6ZO5YGBGohq51qzoOLwRC7njCFPFbrdBs2a9Y6C7qRbx9Q==",
+      "dependencies": {
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
         "emotion": "^10.0.17",
         "react-popper": "^2.3.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
+    },
+    "node_modules/@contentful/f36-popover/node_modules/@contentful/f36-tokens": {
+      "version": "4.0.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+      "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
     },
     "node_modules/@contentful/f36-skeleton": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.45.0.tgz",
-      "integrity": "sha512-OL0JOzW9dUt9p81w6382o/mObGUdIRKoETI6564eEtzrLHfqpBZOmENA/7b9QILhPMC4qCM1UvipixcejyVRVg==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-skeleton/4.65.4/9d347d10603433ba7ea8108ac986a7006d5318d6",
+      "integrity": "sha512-96ArmHTrXF3zjbMkuE5lSn5qXX9h/NzWRJo7kjfKu6GcfL9ajIcpB1ft26vjygP3ZzVdy37NXmVvYijKqTUeYw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-table": "^4.45.0",
-        "@contentful/f36-tokens": "^4.0.2",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-table": "^4.65.4",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
       }
+    },
+    "node_modules/@contentful/f36-skeleton/node_modules/@contentful/f36-tokens": {
+      "version": "4.0.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+      "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
     },
     "node_modules/@contentful/f36-spinner": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.45.0.tgz",
-      "integrity": "sha512-2WdQ3IAanLP8pN+tqrTvYsTeZUkKx+O91TzfM5HOYCdi3EorV5BcXXxv2uXTHvzNUUxjGJG7E8WSR6HxpWWQRw==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-spinner/4.65.4/e0bbe2bb8147f964a47628eb1d658d9ac04d09dd",
+      "integrity": "sha512-heO40qyNQY8N9hoMz5LDxPnJlpltLGVPEdvjKVAGU46eUEgc0PF0BgEJcziX/kZWONnyMJ5XMJBLfspmbFM7Pg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-tokens": "^4.0.2",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-table": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.45.0.tgz",
-      "integrity": "sha512-deF/IGNAhetfn+5t8myYMO5jO75ZtY+kshUWmOKaiNolCix2ReRWGxxWVDDLwsokukm6McnF0uLIix1ivvI/YQ==",
-      "dependencies": {
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-icons": "^4.25.0",
-        "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.45.0",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -1083,13 +1184,39 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/@contentful/f36-tabs": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.45.0.tgz",
-      "integrity": "sha512-rTsxdbcQQPiEgLKbLyUHflitt1GAdboTrvjdGV48tGfF0tJm3oxksJuavcQwVy0Bd+9GdKFh16mqHlMosR+h5g==",
+    "node_modules/@contentful/f36-spinner/node_modules/@contentful/f36-tokens": {
+      "version": "4.0.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+      "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+    },
+    "node_modules/@contentful/f36-table": {
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-table/4.65.4/de4b330cc7abd0afc61d1e27199980d95e8878a8",
+      "integrity": "sha512-nP2AaYTzC8ujuykvq1E/L+2uE9OGiPClY8tEWvzVB1Kn0T8FcDw2GKezB5HQBwbpntUT5u6oMmui6GC7POMc4A==",
       "dependencies": {
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-tokens": "^4.0.2",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.4",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-table/node_modules/@contentful/f36-tokens": {
+      "version": "4.0.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+      "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+    },
+    "node_modules/@contentful/f36-tabs": {
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tabs/4.65.4/7071236298846f5f421dcce9e79c1d4568781385",
+      "integrity": "sha512-OG3eqrgr8Jc/Elvjw0CNGhenjRiTIBiE55BN2do9+1HYgRrZSAfA0rjauvOGlo9FJfu07YzggnSIjh8pW7tT1g==",
+      "dependencies": {
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-tokens": "^4.0.4",
         "@radix-ui/react-tabs": "^1.0.1",
         "emotion": "^10.0.17"
       },
@@ -1098,18 +1225,29 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/@contentful/f36-tabs/node_modules/@contentful/f36-tokens": {
+      "version": "4.0.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+      "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+    },
     "node_modules/@contentful/f36-text-link": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.45.0.tgz",
-      "integrity": "sha512-Bm3ZD7TELaeafR7AemkqvpsupRSQQI+UyfXUFFI3PO3wGJIIWp0A3T6uJGTc1yBc3JWC7YhRIgpp3UAn5fUDNg==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-text-link/4.65.4/b0be7010e3dfc1a97e97f8ea057901c9e7a8e2c6",
+      "integrity": "sha512-IkBs1Q8XCEm4XfSjowfNQDXIdpxqAamH23afhovS2OVWavBDTYqsGdfREbFt3o2sDEVd0Zlfr+rnjFw6Lufa3Q==",
       "dependencies": {
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-tokens": "^4.0.2",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
+    },
+    "node_modules/@contentful/f36-text-link/node_modules/@contentful/f36-tokens": {
+      "version": "4.0.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+      "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
     },
     "node_modules/@contentful/f36-tokens": {
       "version": "4.0.2",
@@ -1117,13 +1255,13 @@
       "integrity": "sha512-sM2AM/8Qn4K0mm2H14nDJMIYoAUv7+tHGUyGqnXEyOVD/5O9lzLTkELEA9R0UgtPPcTywCYC6aZCCggy/Ezd/g=="
     },
     "node_modules/@contentful/f36-tooltip": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.45.0.tgz",
-      "integrity": "sha512-eJzxqDxzzrnO4fSzq3umE4iwsnUj5YGvq+Q4oERVZm2CZm1w4cgDZa4EHbegj1w9iF4OX7vC58kCZztOuhbPHA==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tooltip/4.65.4/c72367404eb9b38a05ccdf07ca87bb791f282166",
+      "integrity": "sha512-atXRcn3uWuzBRWQcBlIU6dpt5tTe2HmDEvcp7LO0quNWY7+jnu9kiJDz0Axfs1/WDA5h5QmSMoyVGXrssKNvMQ==",
       "dependencies": {
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-utils": "^4.23.2",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
         "csstype": "^3.1.1",
         "emotion": "^10.0.17",
@@ -1134,28 +1272,40 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/@contentful/f36-tooltip/node_modules/@contentful/f36-tokens": {
+      "version": "4.0.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+      "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+    },
     "node_modules/@contentful/f36-tooltip/node_modules/csstype": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/@contentful/f36-typography": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.45.0.tgz",
-      "integrity": "sha512-aIuv2gsUWaezsnm/6g/HfrgK3iJWSfOWONDE4r6+glpLwiZ7twBVZFAObLHcBBI8WB4AACgs4vN3FrQiH7ZTIA==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-typography/4.65.4/7b57a3e06c90debb5ef1edc39ae1123904c59d41",
+      "integrity": "sha512-bHBmDWnOSO29xX/0aBhZy2WIw7UvsKvqhfuw8XilWky3rt8zvoUgCcatbWh9/TQ7cjJjpHf8B+g1+azeldpVBw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-tokens": "^4.0.2",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
+    "node_modules/@contentful/f36-typography/node_modules/@contentful/f36-tokens": {
+      "version": "4.0.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+      "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+    },
     "node_modules/@contentful/f36-utils": {
-      "version": "4.24.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-utils/-/f36-utils-4.24.1.tgz",
-      "integrity": "sha512-jr+61KiKn7oA38WXgAJoqVNdr6gXzmJSA+MCl7Djapxxf+jsC1vsi8j8okISCm4a/ZcPncKekDYzzWu+kkI7VQ==",
+      "version": "4.24.3",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-utils/4.24.3/12868232fe068b7095d2db8ae1cfe296370d124a",
+      "integrity": "sha512-9+tyDOCjEhW7m4X7Sam0VYlmcgjhLVMiapCnv1EmRstlMaeI5ti9y0y/2aQ04Na2ScoHwrMTjveoZ6V62J62tA==",
       "dependencies": {
         "emotion": "^10.0.17"
       },
@@ -1177,9 +1327,9 @@
       }
     },
     "node_modules/@contentful/rich-text-types": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.2.0.tgz",
-      "integrity": "sha512-4BHC+mfa50JB70epzpnas4EkiuB3mGdBZ5Rp8w7R5wXvswEf8TLg5yGau2FxmZeEjrAkDrt4vzBLVQ8v3Y//Jw==",
+      "version": "16.3.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/rich-text-types/16.3.5/927433a84416101ba3dbf19bd0924e755f5e6d65",
+      "integrity": "sha512-ZLq6p5uyQXg+i1XGDFu4tAc2VYS12S1KA/jIOyyZjNgC1DvDajsi1JzuiBuOuMEhi1sKEUy6Ry3Yr9jsQtOKuQ==",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1227,9 +1377,9 @@
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
     },
     "node_modules/@emotion/is-prop-valid": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
-      "integrity": "sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz",
+      "integrity": "sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==",
       "dependencies": {
         "@emotion/memoize": "^0.8.1"
       }
@@ -1646,32 +1796,32 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
       "dev": true,
       "dependencies": {
-        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/set-array": "^1.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.9"
+        "@jridgewell/trace-mapping": "^0.3.24"
       },
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/set-array": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
       "dev": true,
       "engines": {
         "node": ">=6.0.0"
@@ -1684,28 +1834,34 @@
       "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.18",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
-      "integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
       "dev": true,
       "dependencies": {
-        "@jridgewell/resolve-uri": "3.1.0",
-        "@jridgewell/sourcemap-codec": "1.4.14"
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@jridgewell/trace-mapping/node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-      "dev": true
-    },
-    "node_modules/@nicolo-ribaudo/semver-v6": {
-      "version": "6.3.3",
-      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/semver-v6/-/semver-v6-6.3.3.tgz",
-      "integrity": "sha512-3Yc1fUTs69MG/uZbJlLSI3JISMn2UV2rg+1D/vROUqZyh3l6iYHCs7GMp+M40ZD7yOdDbYjJcU1oTJhrc+dGKg==",
+    "node_modules/@lukeed/csprng": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
+      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
       "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@lukeed/uuid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@lukeed/uuid/-/uuid-2.0.1.tgz",
+      "integrity": "sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==",
+      "dev": true,
+      "dependencies": {
+        "@lukeed/csprng": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@popperjs/core": {
@@ -1998,14 +2154,43 @@
         }
       }
     },
-    "node_modules/@segment/loosely-validate-event": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@segment/loosely-validate-event/-/loosely-validate-event-2.0.0.tgz",
-      "integrity": "sha512-ZMCSfztDBqwotkl848ODgVcAmN4OItEWDCkshcKz0/W6gGSQayuuCtWV/MlodFivAZD793d6UgANd6wCXUfrIw==",
+    "node_modules/@segment/analytics-core": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-core/-/analytics-core-1.6.0.tgz",
+      "integrity": "sha512-bn9X++IScUfpT7aJGjKU/yJAu/Ko2sYD6HsKA70Z2560E89x30pqgqboVKY8kootvQnT4UKCJiUr5NDMgjmWdQ==",
       "dev": true,
       "dependencies": {
-        "component-type": "^1.2.1",
-        "join-component": "^1.1.0"
+        "@lukeed/uuid": "^2.0.0",
+        "@segment/analytics-generic-utils": "1.2.0",
+        "dset": "^3.1.2",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@segment/analytics-generic-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-generic-utils/-/analytics-generic-utils-1.2.0.tgz",
+      "integrity": "sha512-DfnW6mW3YQOLlDQQdR89k4EqfHb0g/3XvBXkovH1FstUN93eL1kfW9CsDcVQyH3bAC5ZsFyjA/o/1Q2j0QeoWw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@segment/analytics-node": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-node/-/analytics-node-2.1.2.tgz",
+      "integrity": "sha512-CIqWH5G0pB/LAFAZEZtntAxujiYIpdk0F+YGhfM6N/qt4/VLWjFcd4VZXVLW7xqaxig64UKWGQhe8bszXDRXXw==",
+      "dev": true,
+      "dependencies": {
+        "@lukeed/uuid": "^2.0.0",
+        "@segment/analytics-core": "1.6.0",
+        "@segment/analytics-generic-utils": "1.2.0",
+        "buffer": "^6.0.3",
+        "jose": "^5.1.0",
+        "node-fetch": "^2.6.7",
+        "tslib": "^2.4.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -2015,10 +2200,11 @@
       "dev": true
     },
     "node_modules/@swc/helpers": {
-      "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
-      "integrity": "sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.36.tgz",
+      "integrity": "sha512-5lxnyLEYFskErRPenYItLRSge5DjrJngYKdVjRSrWfza9G6KkgHEXi0vUZiyUeMU5JfXH1YnvXZzSp8ul88o2Q==",
       "dependencies": {
+        "legacy-swc-helpers": "npm:@swc/helpers@=0.4.14",
         "tslib": "^2.4.0"
       }
     },
@@ -2135,6 +2321,47 @@
       "integrity": "sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==",
       "dev": true
     },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.6.8",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.8.tgz",
+      "integrity": "sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.5.tgz",
+      "integrity": "sha512-WXCyOcRtH37HAUkpXhUduaxdm82b4GSlyTqajXviN4EfiuPgNYR109xMCKvpl6zPIpua0DGlMEDCq+g8EdoheQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.20.7"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "4.3.5",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.5.tgz",
@@ -2172,28 +2399,26 @@
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
     "node_modules/@types/react": {
-      "version": "18.2.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.14.tgz",
-      "integrity": "sha512-A0zjq+QN/O0Kpe30hA1GidzyFjatVvrpIvWLxD+xv67Vt91TWWgco9IvrJBkeyHm1trGaFS/FSGqPlhyeZRm0g==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-V0kuGBX3+prX+DQ/7r2qsv1NsdfnCLnTgnRJ1pYnxykBhGMz+qj+box5lq7XsO5mtZsBqpjwwTu/7wszPfMBcw==",
       "dependencies": {
         "@types/prop-types": "*",
-        "@types/scheduler": "*",
         "csstype": "^3.0.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.2.6",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.6.tgz",
-      "integrity": "sha512-2et4PDvg6PVCyS7fuTc4gPoksV58bW0RwSxWKcPRcHZf0PRUGq03TKcD/rUHe3azfV6/5/biUBJw+HhCQjaP0A==",
-      "devOptional": true,
+      "version": "18.3.0",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
+      "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
       "dependencies": {
         "@types/react": "*"
       }
     },
     "node_modules/@types/react-modal": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@types/react-modal/-/react-modal-3.16.0.tgz",
-      "integrity": "sha512-iphdqXAyUfByLbxJn5j6d+yh93dbMgshqGP0IuBeaKbZXx0aO+OXsvEkt6QctRdxjeM9/bR+Gp3h9F9djVWTQQ==",
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/@types/react-modal/-/react-modal-3.16.3.tgz",
+      "integrity": "sha512-xXuGavyEGaFQDgBv4UVm8/ZsG+qxeQ7f77yNrW3n+1J6XAstUy5rYHeIHPh1KzsGc6IkCIdu6lQ2xWzu1jBTLg==",
       "dependencies": {
         "@types/react": "*"
       }
@@ -2203,27 +2428,23 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
       "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA=="
     },
-    "node_modules/@types/scheduler": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
-    },
     "node_modules/@vitejs/plugin-react": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.0.1.tgz",
-      "integrity": "sha512-g25lL98essfeSj43HJ0o4DMp0325XK0ITkxpgChzJU/CyemgyChtlxfnRbjfwxDGCTRxTiXtQAsdebQXKMRSOA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.2.1.tgz",
+      "integrity": "sha512-oojO9IDc4nCUUi8qIR11KoQm0XFFLIwsRBwHRR4d/88IWghn1y6ckz/bJ8GHDCsYEJee8mDzqtJxh15/cisJNQ==",
       "dev": true,
       "dependencies": {
-        "@babel/core": "^7.22.5",
-        "@babel/plugin-transform-react-jsx-self": "^7.22.5",
-        "@babel/plugin-transform-react-jsx-source": "^7.22.5",
+        "@babel/core": "^7.23.5",
+        "@babel/plugin-transform-react-jsx-self": "^7.23.3",
+        "@babel/plugin-transform-react-jsx-source": "^7.23.3",
+        "@types/babel__core": "^7.20.5",
         "react-refresh": "^0.14.0"
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
       },
       "peerDependencies": {
-        "vite": "^4.2.0"
+        "vite": "^4.2.0 || ^5.0.0"
       }
     },
     "node_modules/@vitest/expect": {
@@ -2380,31 +2601,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
-      "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==",
+      "version": "0.5.12",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.12.tgz",
+      "integrity": "sha512-6TVU49mK6KZb4qG6xWaaM4C7sA/sgUMLy/JYMOzkcp3BvVLpW0fXDFQiIzAuxFCt/2+xD7fNIiPFAoLZPhVNLQ==",
       "dev": true,
       "engines": {
         "node": ">=6.0"
-      }
-    },
-    "node_modules/analytics-node": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/analytics-node/-/analytics-node-6.2.0.tgz",
-      "integrity": "sha512-NLU4tCHlWt0tzEaFQL7NIoWhq2KmQSmz0JvyS2lYn6fc4fEjTMSabhJUx8H1r5995FX8fE3rZ15uIHU6u+ovlQ==",
-      "dev": true,
-      "dependencies": {
-        "@segment/loosely-validate-event": "^2.0.0",
-        "axios": "^0.27.2",
-        "axios-retry": "3.2.0",
-        "lodash.isstring": "^4.0.1",
-        "md5": "^2.2.1",
-        "ms": "^2.0.0",
-        "remove-trailing-slash": "^0.1.0",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/ansi-escapes": {
@@ -2503,21 +2705,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
       "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
-      }
-    },
-    "node_modules/axios-retry": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.2.0.tgz",
-      "integrity": "sha512-RK2cLMgIsAQBDhlIsJR5dOhODPigvel18XUv1dDXW+4k1FzebyfRk+C+orot6WPZOYFKSfhLwHPwVmTVOODQ5w==",
-      "dev": true,
-      "dependencies": {
-        "is-retry-allowed": "^1.1.0"
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/babel-plugin-emotion": {
@@ -2583,39 +2777,7 @@
         "readable-stream": "^3.4.0"
       }
     },
-    "node_modules/browserslist": {
-      "version": "4.21.9",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
-      "integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "dependencies": {
-        "caniuse-lite": "^1.0.30001503",
-        "electron-to-chromium": "^1.4.431",
-        "node-releases": "^2.0.12",
-        "update-browserslist-db": "^1.0.11"
-      },
-      "bin": {
-        "browserslist": "cli.js"
-      },
-      "engines": {
-        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/buffer": {
+    "node_modules/bl/node_modules/buffer": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
@@ -2639,6 +2801,62 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/browserslist": {
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
+      "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001587",
+        "electron-to-chromium": "^1.4.668",
+        "node-releases": "^2.0.14",
+        "update-browserslist-db": "^1.0.13"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -2649,12 +2867,18 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2669,9 +2893,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001512",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001512.tgz",
-      "integrity": "sha512-2S9nK0G/mE+jasCUsMPlARhRCts1ebcp2Ji8Y8PWi4NDE1iRdLCnEPHkEfeBrGC45L4isBx5ur3IQ6yTE2mRZw==",
+      "version": "1.0.30001615",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001615.tgz",
+      "integrity": "sha512-1IpazM5G3r38meiae0bHRnPhz+CBQ3ZLqbQMtrg+AsTPKAXgW38JNsXkyZ+v8waCsDmPq87lmfun5Q2AGysNEQ==",
       "dev": true,
       "funding": [
         {
@@ -2725,15 +2949,6 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
-    "node_modules/charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
@@ -2756,9 +2971,9 @@
       }
     },
     "node_modules/cli-spinners": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.0.tgz",
-      "integrity": "sha512-4/aL9X3Wh0yiMQlE+eeRhWP6vclO3QRtw1JHKIT0FFUs5FjpFmESqtMvYZ0+lbzBw900b95mS0hohy+qn2VK/g==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -2810,19 +3025,13 @@
       }
     },
     "node_modules/commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.0.0.tgz",
+      "integrity": "sha512-MwVNWlYjDTtOjX5PiD7o5pK0UrFU/OYgcJfjjK4RaHZETNtjJqrZa9Y9ds88+A+f+d5lv+561eZ+yCKoS3gbAA==",
       "dev": true,
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
-    },
-    "node_modules/component-type": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/component-type/-/component-type-1.2.1.tgz",
-      "integrity": "sha512-Kgy+2+Uwr75vAi6ChWXgHuLvd+QLD7ssgpaRq2zCvt80ptvAfMc/hijcJxXkBa2wMlEZcJvC2H8Ubo+A9ATHIg==",
-      "dev": true
     },
     "node_modules/compute-scroll-into-view": {
       "version": "1.0.20",
@@ -2830,17 +3039,17 @@
       "integrity": "sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg=="
     },
     "node_modules/contentful-management": {
-      "version": "10.38.3",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-10.38.3.tgz",
-      "integrity": "sha512-hAuUSEfPYMQ6aplaENkZM5Zvhg9q+yiCsbm++pyHadUr5x+XKC9D85fASXuA4vI0hB/K66YHaqBiJ7CwAHT9bQ==",
+      "version": "10.46.4",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-10.46.4.tgz",
+      "integrity": "sha512-swOTlKO6AeCRnD5w237ey6wKDXty8shFVm0AisKO2w5seQINlFytgCkZd89E0lxjg4zgjb9maa7AScUtyQUd5w==",
       "dependencies": {
-        "@contentful/rich-text-types": "^16.0.3",
+        "@contentful/rich-text-types": "^16.3.0",
         "@types/json-patch": "0.0.30",
-        "axios": "^0.27.1",
-        "contentful-sdk-core": "^7.0.1",
+        "axios": "^1.4.0",
+        "contentful-sdk-core": "^8.1.0",
         "fast-copy": "^3.0.0",
         "lodash.isplainobject": "^4.0.6",
-        "type-fest": "^3.0.0"
+        "type-fest": "^4.0.0"
       },
       "engines": {
         "node": ">=14"
@@ -2852,15 +3061,15 @@
       "integrity": "sha512-Knr7NOtK3HWRYGtHoJrjkaWepqT8thIVGAwt0p0aUs1zqkAzXZV4vo9fFNwyb5fcqK1GKYFYxldQdIDVKhUAfA=="
     },
     "node_modules/contentful-sdk-core": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-7.0.2.tgz",
-      "integrity": "sha512-HkBzzzJ3UGqOIJiTd4qMEMvn44ccrN7a75gEej28X1srGn05myRgJ/pWbmXJhtgpq/5gU7IURnynyKx/ecsOfg==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-8.1.2.tgz",
+      "integrity": "sha512-XZvX2JMJF4YiICXLrHFv59KBHaQJ6ElqAP8gSNgnCu4x+pPG7Y1bC2JMNOiyAgJuGQGVUOcNZ5PmK+tsNEayYw==",
       "dependencies": {
-        "fast-copy": "^2.1.3",
+        "fast-copy": "^2.1.7",
         "lodash.isplainobject": "^4.0.6",
         "lodash.isstring": "^4.0.1",
         "p-throttle": "^4.1.1",
-        "qs": "^6.9.4"
+        "qs": "^6.11.2"
       },
       "engines": {
         "node": ">=12"
@@ -2900,15 +3109,6 @@
         "@emotion/utils": "0.11.3"
       }
     },
-    "node_modules/crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/css.escape": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
@@ -2936,9 +3136,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.9",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.9.tgz",
-      "integrity": "sha512-QvzAURSbQ0pKdIye2txOzNaHmxtUBXerpY0FJsFXUMKbIZeFm5ht1LS/jFsrncjnmtv8HsG0W2g6c0zUjZWmpA=="
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.11.tgz",
+      "integrity": "sha512-okzr3f11N6WuqYtZSvm+F776mB41wRZMhKP+hc34YdW+KmtYYK9iqvHSwo2k9FEH3fhGXvOPV6yz2IcSrfRUDg=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -3016,6 +3216,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/define-lazy-prop": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
@@ -3070,12 +3286,15 @@
       "dev": true
     },
     "node_modules/dotenv": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
-      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
       "dev": true,
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/downshift": {
@@ -3093,10 +3312,19 @@
         "react": ">=16.12.0"
       }
     },
+    "node_modules/dset": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.3.tgz",
+      "integrity": "sha512-20TuZZHCEZ2O71q9/+8BwKwZ0QtD9D8ObhrihJPr+vLLYlSuAU3/zL4cSlgbfeoGHTjCSJBa7NGcrF9/Bx/WJQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.449",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.449.tgz",
-      "integrity": "sha512-TxLRpRUj/107ATefeP8VIUWNOv90xJxZZbCW/eIbSZQiuiFANCx2b7u+GbVc9X4gU+xnbvypNMYVM/WArE1DNQ==",
+      "version": "1.4.754",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.754.tgz",
+      "integrity": "sha512-7Kr5jUdns5rL/M9wFFmMZAgFDuL2YOnanFH4OI4iFzUqyh3XOL7nAGbSlSMZdzKMIyyTpNSbqZsWG9odwLeKvA==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -3132,6 +3360,25 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "dependencies": {
+        "get-intrinsic": "^1.2.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/es-get-iterator": {
@@ -3198,9 +3445,9 @@
       }
     },
     "node_modules/escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -3234,9 +3481,9 @@
       }
     },
     "node_modules/fast-copy": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-2.1.3.tgz",
-      "integrity": "sha512-LDzYKNTHhD+XOp8wGMuCkY4eTxFZOOycmpwLBiuF3r3OjOmZnURRD8t2dUAbmKuXGbo/MGggwbSjcBdp8QT0+g=="
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-2.1.7.tgz",
+      "integrity": "sha512-ozrGwyuCTAy7YgFCua8rmqmytECYk/JYAMXcswOcm0qvGoE3tPb7ivBeIHTOK2DiapBhDZgacIhzhQIKU5TCfA=="
     },
     "node_modules/figures": {
       "version": "3.2.0",
@@ -3259,9 +3506,9 @@
       "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
     },
     "node_modules/focus-lock": {
-      "version": "0.11.6",
-      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.11.6.tgz",
-      "integrity": "sha512-KSuV3ur4gf2KqMNoZx3nXNVhqCkn42GuTYCX4tXPEwf0MjpFQmNMiN6m7dXaUXgIoivL6/65agoUMg4RLS0Vbg==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-1.3.5.tgz",
+      "integrity": "sha512-QFaHbhv9WPUeLYBDe/PAuLKJ4Dd9OPvKs9xZBr3yLXnUrDNaVXKu2baDBXe3naPY30hgHYSsf2JW4jzas2mDEQ==",
       "dependencies": {
         "tslib": "^2.0.3"
       },
@@ -3325,9 +3572,12 @@
       }
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/functions-have-names": {
       "version": "1.2.3",
@@ -3348,23 +3598,27 @@
       }
     },
     "node_modules/get-func-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
       "dev": true,
       "engines": {
         "node": "*"
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
-      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
         "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3"
+        "has-symbols": "^1.0.3",
+        "hasown": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3383,7 +3637,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
       "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "dev": true,
       "dependencies": {
         "get-intrinsic": "^1.1.3"
       },
@@ -3476,12 +3729,11 @@
       }
     },
     "node_modules/has-property-descriptors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
-      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
-      "dev": true,
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "dependencies": {
-        "get-intrinsic": "^1.1.1"
+        "es-define-property": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3524,6 +3776,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -3557,9 +3820,9 @@
       ]
     },
     "node_modules/ignore": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
+      "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
       "dev": true,
       "engines": {
         "node": ">= 4"
@@ -3587,9 +3850,9 @@
       "dev": true
     },
     "node_modules/inquirer": {
-      "version": "8.2.5",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.5.tgz",
-      "integrity": "sha512-QAgPDQMEgrDssk1XiwwHoOGYF9BAbUcc1+j+FhEvaOt8/cKRqyLn0U5qA6F74fGhTMGxf92pOvPBeh29jQJDTQ==",
+      "version": "8.2.6",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.6.tgz",
+      "integrity": "sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==",
       "dev": true,
       "dependencies": {
         "ansi-escapes": "^4.2.1",
@@ -3606,7 +3869,7 @@
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0",
         "through": "^2.3.6",
-        "wrap-ansi": "^7.0.0"
+        "wrap-ansi": "^6.0.1"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -3759,12 +4022,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
-    },
     "node_modules/is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -3874,15 +4131,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-retry-allowed": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
-      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/is-set": {
@@ -4001,11 +4249,14 @@
         "node": ">=8"
       }
     },
-    "node_modules/join-component": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/join-component/-/join-component-1.1.0.tgz",
-      "integrity": "sha512-bF7vcQxbODoGK1imE2P9GS9aw4zD0Sd+Hni68IMZLj7zRnquH7dXUmMw9hDI5S/Jzt7q+IyTXN0rSg2GI0IKhQ==",
-      "dev": true
+    "node_modules/jose": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.2.4.tgz",
+      "integrity": "sha512-6ScbIk2WWCeXkmzF6bRPmEuaqy1m8SbsRFMa/FLrSCkGIhj8OLVG/IH+XHVmNMx/KUo8cVWEE6oKR4dJ+S0Rkg==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -4046,6 +4297,15 @@
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
       "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
       "dev": true
+    },
+    "node_modules/legacy-swc-helpers": {
+      "name": "@swc/helpers",
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
+      "integrity": "sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
@@ -4216,17 +4476,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/md5": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-      "dev": true,
-      "dependencies": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "~1.1.6"
-      }
-    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -4297,10 +4546,30 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-releases": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.12.tgz",
-      "integrity": "sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
       "dev": true
     },
     "node_modules/object-assign": {
@@ -4312,9 +4581,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
+      "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -4581,8 +4850,7 @@
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "node_modules/pkg-types": {
       "version": "1.0.3",
@@ -4664,12 +4932,17 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "node_modules/qs": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.1.tgz",
+      "integrity": "sha512-zWmv4RSuB9r2mYQw3zxQuHWeU+42aKi1wWig/j4ele4ygELZ7PEO6MM7rim9oAQH2A5MWfsAVf/jPvTPgCbvUQ==",
       "dependencies": {
-        "side-channel": "^1.0.4"
+        "side-channel": "^1.0.6"
       },
       "engines": {
         "node": ">=0.6"
@@ -4679,9 +4952,9 @@
       }
     },
     "node_modules/react": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4690,9 +4963,9 @@
       }
     },
     "node_modules/react-animate-height": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/react-animate-height/-/react-animate-height-3.1.1.tgz",
-      "integrity": "sha512-UkC6+V3ZlCneBRaSM7aUctDJ+PRP6ztcGtxvU7MTeoMMWPhz8BQNaX7QWaZrkzp1ih1G8uZZ+DI9nfLvtD6OdQ==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/react-animate-height/-/react-animate-height-3.2.3.tgz",
+      "integrity": "sha512-R6DSvr7ud07oeCixScyvXWEMJY/Mt2+GyOWC1KMaRc69gOBw+SsCg4TJmrp4rKUM1hyd6p+YKw90brjPH93Y2A==",
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4713,28 +4986,28 @@
       }
     },
     "node_modules/react-day-picker": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.8.0.tgz",
-      "integrity": "sha512-QIC3uOuyGGbtypbd5QEggsCSqVaPNu8kzUWquZ7JjW9fuWB9yv7WyixKmnaFelTLXFdq7h7zU6n/aBleBqe/dA==",
+      "version": "8.10.1",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.10.1.tgz",
+      "integrity": "sha512-TMx7fNbhLk15eqcMt+7Z7S2KF7mfTId/XJDjKE8f+IUcFn0l08/kI4FiYTL/0yuOLmEcbR4Fwe3GJf/NiiMnPA==",
       "funding": {
         "type": "individual",
         "url": "https://github.com/sponsors/gpbl"
       },
       "peerDependencies": {
-        "date-fns": "^2.28.0",
+        "date-fns": "^2.28.0 || ^3.0.0",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
-      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "dependencies": {
         "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.0"
+        "scheduler": "^0.23.2"
       },
       "peerDependencies": {
-        "react": "^18.2.0"
+        "react": "^18.3.1"
       }
     },
     "node_modules/react-fast-compare": {
@@ -4743,15 +5016,15 @@
       "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
     },
     "node_modules/react-focus-lock": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.4.tgz",
-      "integrity": "sha512-7pEdXyMseqm3kVjhdVH18sovparAzLg5h6WvIx7/Ck3ekjhrrDMEegHSa3swwC8wgfdd7DIdUVRGeiHT9/7Sgg==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.12.1.tgz",
+      "integrity": "sha512-lfp8Dve4yJagkHiFrC1bGtib3mF2ktqwPJw4/WGcgPW+pJ/AVQA5X2vI7xgp13FcxFEpYBBHpXai/N2DBNC0Jw==",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
-        "focus-lock": "^0.11.6",
+        "focus-lock": "^1.3.5",
         "prop-types": "^15.6.2",
         "react-clientside-effect": "^1.2.6",
-        "use-callback-ref": "^1.3.0",
+        "use-callback-ref": "^1.3.2",
         "use-sidecar": "^1.1.2"
       },
       "peerDependencies": {
@@ -4851,12 +5124,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/remove-trailing-slash": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/remove-trailing-slash/-/remove-trailing-slash-0.1.1.tgz",
-      "integrity": "sha512-o4S4Qh6L2jpnCy83ysZDau+VORNvnFw07CKSAymkd6ICNVEPisMyzlc00KlvvicsxKck94SEwhDnMNdICzO+tA==",
-      "dev": true
-    },
     "node_modules/resolve": {
       "version": "1.22.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
@@ -4940,21 +5207,50 @@
       "dev": true
     },
     "node_modules/scheduler": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
-      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
     },
-    "node_modules/side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
       "dependencies": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
+      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.4",
+        "object-inspect": "^1.13.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5152,6 +5448,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
+    },
     "node_modules/truncate": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/truncate/-/truncate-3.0.0.tgz",
@@ -5175,11 +5477,11 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.12.0.tgz",
-      "integrity": "sha512-qj9wWsnFvVEMUDbESiilKeXeHL7FwwiFcogfhfyjmvT968RXSvnl23f1JOClTHYItsi7o501C/7qVllscUP3oA==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.18.1.tgz",
+      "integrity": "sha512-qXhgeNsX15bM63h5aapNFcQid9jRF/l3ojDoDFmekDQEUufZ9U4ErVt6SjDxnHp48Ltrw616R8yNc3giJ3KvVQ==",
       "engines": {
-        "node": ">=14.16"
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5205,9 +5507,9 @@
       "dev": true
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
-      "integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.14.tgz",
+      "integrity": "sha512-JixKH8GR2pWYshIPUg/NujK3JO7JiqEEUiNArE86NQyrgUuZeTlZQN3xuS/yiV5Kb48ev9K6RqNkaJjXsdg7Jw==",
       "dev": true,
       "funding": [
         {
@@ -5224,7 +5526,7 @@
         }
       ],
       "dependencies": {
-        "escalade": "^3.1.1",
+        "escalade": "^3.1.2",
         "picocolors": "^1.0.0"
       },
       "bin": {
@@ -5235,9 +5537,9 @@
       }
     },
     "node_modules/use-callback-ref": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.0.tgz",
-      "integrity": "sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.2.tgz",
+      "integrity": "sha512-elOQwe6Q8gqZgDA8mrh44qRTQqpIHDcZ3hXTLjBe1i4ph8XpNJnO+aQf3NaG+lriLopI4HMx9VjQLfPQ6vhnoA==",
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -5280,15 +5582,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
-    },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/vite": {
       "version": "4.5.3",
@@ -5462,6 +5755,22 @@
         "defaults": "^1.0.3"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which-boxed-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
@@ -5530,9 +5839,9 @@
       }
     },
     "node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
       "dev": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -5540,10 +5849,7 @@
         "strip-ansi": "^6.0.0"
       },
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+        "node": ">=8"
       }
     },
     "node_modules/wrap-ansi/node_modules/ansi-styles": {
@@ -5608,76 +5914,84 @@
   },
   "dependencies": {
     "@ampproject/remapping": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
-      "integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
       "dev": true,
       "requires": {
-        "@jridgewell/gen-mapping": "^0.3.0",
-        "@jridgewell/trace-mapping": "^0.3.9"
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
     "@babel/code-frame": {
-      "version": "7.22.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
-      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+      "version": "7.24.2",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
+      "integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
       "requires": {
-        "@babel/highlight": "^7.22.13",
-        "chalk": "^2.4.2"
+        "@babel/highlight": "^7.24.2",
+        "picocolors": "^1.0.0"
       }
     },
     "@babel/compat-data": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.6.tgz",
-      "integrity": "sha512-29tfsWTq2Ftu7MXmimyC0C5FDZv5DYxOZkh3XD3+QW4V/BYuv/LyEsjj3c0hqedEaDt6DBfDvexMKU8YevdqFg==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.4.tgz",
+      "integrity": "sha512-vg8Gih2MLK+kOkHJp4gBEIkyaIi00jgWot2D9QOmmfLC8jINSOzmCLta6Bvz/JSBCqnegV0L80jhxkol5GWNfQ==",
       "dev": true
     },
     "@babel/core": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.6.tgz",
-      "integrity": "sha512-HPIyDa6n+HKw5dEuway3vVAhBboYCtREBMp+IWeseZy6TFtzn6MHkCH2KKYUOC/vKKwgSMHQW4htBOrmuRPXfw==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.5.tgz",
+      "integrity": "sha512-tVQRucExLQ02Boi4vdPp49svNGcfL2GhdTCT9aldhXgCJVAI21EtRfBettiuLUwce/7r6bFdgs6JFkcdTiFttA==",
       "dev": true,
       "requires": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.22.5",
-        "@babel/generator": "^7.22.5",
-        "@babel/helper-compilation-targets": "^7.22.6",
-        "@babel/helper-module-transforms": "^7.22.5",
-        "@babel/helpers": "^7.22.6",
-        "@babel/parser": "^7.22.6",
-        "@babel/template": "^7.22.5",
-        "@babel/traverse": "^7.22.6",
-        "@babel/types": "^7.22.5",
-        "@nicolo-ribaudo/semver-v6": "^6.3.3",
-        "convert-source-map": "^1.7.0",
+        "@babel/code-frame": "^7.24.2",
+        "@babel/generator": "^7.24.5",
+        "@babel/helper-compilation-targets": "^7.23.6",
+        "@babel/helper-module-transforms": "^7.24.5",
+        "@babel/helpers": "^7.24.5",
+        "@babel/parser": "^7.24.5",
+        "@babel/template": "^7.24.0",
+        "@babel/traverse": "^7.24.5",
+        "@babel/types": "^7.24.5",
+        "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.2"
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "dependencies": {
+        "convert-source-map": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+          "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+          "dev": true
+        }
       }
     },
     "@babel/generator": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
-      "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.5.tgz",
+      "integrity": "sha512-x32i4hEXvr+iI0NEoEfDKzlemF8AmtOP8CcrRaEcpzysWuoEb1KknpcvMsHKPONoKZiDuItklgWhB18xEhr9PA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.23.0",
-        "@jridgewell/gen-mapping": "^0.3.2",
-        "@jridgewell/trace-mapping": "^0.3.17",
+        "@babel/types": "^7.24.5",
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^2.5.1"
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.6.tgz",
-      "integrity": "sha512-534sYEqWD9VfUm3IPn2SLcH4Q3P86XL+QvqdC7ZsFrzyyPF3T4XGiVghF6PTYNdWg6pXuoqXxNQAhbYeEInTzA==",
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
+      "integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.22.6",
-        "@babel/helper-validator-option": "^7.22.5",
-        "@nicolo-ribaudo/semver-v6": "^6.3.3",
-        "browserslist": "^4.21.9",
-        "lru-cache": "^5.1.1"
+        "@babel/compat-data": "^7.23.5",
+        "@babel/helper-validator-option": "^7.23.5",
+        "browserslist": "^4.22.2",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
       }
     },
     "@babel/helper-environment-visitor": {
@@ -5706,112 +6020,110 @@
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.5.tgz",
-      "integrity": "sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==",
+      "version": "7.24.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.3.tgz",
+      "integrity": "sha512-viKb0F9f2s0BCS22QSF308z/+1YWKV/76mwt61NBzS5izMzDPwdq1pTrzf+Li3npBWX9KdQbkeCt1jSAM7lZqg==",
       "requires": {
-        "@babel/types": "^7.22.5"
+        "@babel/types": "^7.24.0"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.5.tgz",
-      "integrity": "sha512-+hGKDt/Ze8GFExiVHno/2dvG5IdstpzCq0y4Qc9OJ25D4q3pKfiIP/4Vp3/JvhDkLKsDK2api3q3fpIgiIF5bw==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.24.5.tgz",
+      "integrity": "sha512-9GxeY8c2d2mdQUP1Dye0ks3VDyIMS98kt/llQ2nUId8IsWqTF0l1LkSX0/uP7l7MCDrzXS009Hyhe2gzTiGW8A==",
       "dev": true,
       "requires": {
-        "@babel/helper-environment-visitor": "^7.22.5",
-        "@babel/helper-module-imports": "^7.22.5",
-        "@babel/helper-simple-access": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.5",
-        "@babel/helper-validator-identifier": "^7.22.5",
-        "@babel/template": "^7.22.5",
-        "@babel/traverse": "^7.22.5",
-        "@babel/types": "^7.22.5"
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-module-imports": "^7.24.3",
+        "@babel/helper-simple-access": "^7.24.5",
+        "@babel/helper-split-export-declaration": "^7.24.5",
+        "@babel/helper-validator-identifier": "^7.24.5"
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
-      "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.5.tgz",
+      "integrity": "sha512-xjNLDopRzW2o6ba0gKbkZq5YWEBaK3PCyTOY1K2P/O07LGMhMqlMXPxwN4S5/RhWuCobT8z0jrlKGlYmeR1OhQ==",
       "dev": true
     },
     "@babel/helper-simple-access": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
-      "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.5.tgz",
+      "integrity": "sha512-uH3Hmf5q5n7n8mz7arjUlDOCbttY/DW4DYhE6FUsjKJ/oYC1kQQUvwEQWxRwUpX9qQKRXeqLwWxrqilMrf32sQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.22.5"
+        "@babel/types": "^7.24.5"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
-      "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.5.tgz",
+      "integrity": "sha512-5CHncttXohrHk8GWOFCcCl4oRD9fKosWlIRgWm4ql9VYioKm52Mk2xsmoohvm7f3JoiLSM5ZgJuRaf5QZZYd3Q==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.22.5"
+        "@babel/types": "^7.24.5"
       }
     },
     "@babel/helper-string-parser": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw=="
+      "version": "7.24.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.1.tgz",
+      "integrity": "sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ=="
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A=="
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz",
+      "integrity": "sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA=="
     },
     "@babel/helper-validator-option": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.5.tgz",
-      "integrity": "sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
+      "integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
       "dev": true
     },
     "@babel/helpers": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.6.tgz",
-      "integrity": "sha512-YjDs6y/fVOYFV8hAf1rxd1QvR9wJe1pDBZ2AREKq/SDayfPzgk0PBnVuTCE5X1acEpMMNOVUqoe+OwiZGJ+OaA==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.5.tgz",
+      "integrity": "sha512-CiQmBMMpMQHwM5m01YnrM6imUG1ebgYJ+fAIW4FZe6m4qHTPaRHti+R8cggAwkdz4oXhtO4/K9JWlh+8hIfR2Q==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.22.5",
-        "@babel/traverse": "^7.22.6",
-        "@babel/types": "^7.22.5"
+        "@babel/template": "^7.24.0",
+        "@babel/traverse": "^7.24.5",
+        "@babel/types": "^7.24.5"
       }
     },
     "@babel/highlight": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
-      "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.5.tgz",
+      "integrity": "sha512-8lLmua6AVh/8SLJRRVD6V8p73Hir9w5mJrhE+IPpILG31KKlI9iz5zmBYKcWPS59qSfgP9RaSBQSHHE81WKuEw==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-validator-identifier": "^7.24.5",
         "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0"
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
       }
     },
     "@babel/parser": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
-      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.5.tgz",
+      "integrity": "sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==",
       "dev": true
     },
     "@babel/plugin-transform-react-jsx-self": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.22.5.tgz",
-      "integrity": "sha512-nTh2ogNUtxbiSbxaT4Ds6aXnXEipHweN9YRgOX/oNXdf0cCrGn/+2LozFa3lnPV5D90MkjhgckCPBrsoSc1a7g==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.24.5.tgz",
+      "integrity": "sha512-RtCJoUO2oYrYwFPtR1/jkoBEcFuI1ae9a9IMxeyAVa3a1Ap4AnxmyIKG2b2FaJKqkidw/0cxRbWN+HOs6ZWd1w==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.22.5"
+        "@babel/helper-plugin-utils": "^7.24.5"
       }
     },
     "@babel/plugin-transform-react-jsx-source": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.22.5.tgz",
-      "integrity": "sha512-yIiRO6yobeEIaI0RTbIr8iAK9FcBHLtZq0S89ZPjDLQXBA4xvghaKqI0etp/tF3htTM0sazJKKLz9oEiGRtu7w==",
+      "version": "7.24.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.24.1.tgz",
+      "integrity": "sha512-1v202n7aUq4uXAieRTKcwPzNyphlCuqHHDcdSNc+vdhoTEZcFMh+L5yZuCmGaIO7bs1nJUNfHB89TZyoL48xNA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.22.5"
+        "@babel/helper-plugin-utils": "^7.24.0"
       }
     },
     "@babel/runtime": {
@@ -5823,59 +6135,59 @@
       }
     },
     "@babel/template": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
-      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+      "version": "7.24.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.0.tgz",
+      "integrity": "sha512-Bkf2q8lMB0AFpX0NFEqSbx1OkTHf0f+0j82mkw+ZpzBnkk7e9Ql0891vlfgi+kHwOk8tQjiQHpqh4LaSa0fKEA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/parser": "^7.22.15",
-        "@babel/types": "^7.22.15"
+        "@babel/code-frame": "^7.23.5",
+        "@babel/parser": "^7.24.0",
+        "@babel/types": "^7.24.0"
       }
     },
     "@babel/traverse": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
-      "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.5.tgz",
+      "integrity": "sha512-7aaBLeDQ4zYcUFDUD41lJc1fG8+5IU9DaNSJAgal866FGvmD5EbWQgnEC6kO1gGLsX0esNkfnJSndbTXA3r7UA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.23.0",
+        "@babel/code-frame": "^7.24.2",
+        "@babel/generator": "^7.24.5",
         "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-function-name": "^7.23.0",
         "@babel/helper-hoist-variables": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.23.0",
-        "@babel/types": "^7.23.0",
-        "debug": "^4.1.0",
+        "@babel/helper-split-export-declaration": "^7.24.5",
+        "@babel/parser": "^7.24.5",
+        "@babel/types": "^7.24.5",
+        "debug": "^4.3.1",
         "globals": "^11.1.0"
       }
     },
     "@babel/types": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
-      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
+      "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
       "requires": {
-        "@babel/helper-string-parser": "^7.22.5",
-        "@babel/helper-validator-identifier": "^7.22.20",
+        "@babel/helper-string-parser": "^7.24.1",
+        "@babel/helper-validator-identifier": "^7.24.5",
         "to-fast-properties": "^2.0.0"
       }
     },
     "@contentful/app-scripts": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@contentful/app-scripts/-/app-scripts-1.10.2.tgz",
-      "integrity": "sha512-MPhzVXsw9TZMt3S5YVvFCO99ksFqGC8QqdcO3cYHn22CvtkUX9qJylnMwF9gUzLwUsFA0kAJG1NpB9bzaEN9sg==",
+      "version": "1.19.1",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/app-scripts/1.19.1/920a9d1352bb664af17d7c2d9dc0728f350d09f9",
+      "integrity": "sha512-pIqaIH99N6Fwf+rWI9Y9xb59TfYEd5PaNfBNECpFa/hoz+ow1rg+To+2dkhhh82W6hTmpnN7qBHlkLV1RU1p1g==",
       "dev": true,
       "requires": {
-        "adm-zip": "0.5.10",
-        "analytics-node": "^6.2.0",
+        "@segment/analytics-node": "^2.0.0",
+        "adm-zip": "0.5.12",
         "bottleneck": "2.19.5",
         "chalk": "4.1.2",
-        "commander": "10.0.1",
-        "contentful-management": "10.35.4",
-        "dotenv": "16.0.3",
-        "ignore": "5.2.4",
-        "inquirer": "8.2.5",
+        "commander": "12.0.0",
+        "contentful-management": "11.25.2",
+        "dotenv": "16.4.5",
+        "ignore": "5.3.1",
+        "inquirer": "8.2.6",
         "lodash": "4.17.21",
         "open": "8.4.2",
         "ora": "5.4.1"
@@ -5922,24 +6234,24 @@
           "dev": true
         },
         "contentful-management": {
-          "version": "10.35.4",
-          "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-10.35.4.tgz",
-          "integrity": "sha512-yAgnwzyyT3kqvxKkM6iky9UiWs8n1EQH5n52rcBrjHM44Ext+Kjagzz1gRQC3maYSgp5UR3FwyUj8gX9Kd7uDQ==",
+          "version": "11.25.2",
+          "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.25.2.tgz",
+          "integrity": "sha512-09KfIs3il8OFHzY+d2Vvq+2Jfgk8ISOKjTs3MFqqcc3Ae94T1pji8ZaHXZ6dlb9lLZT6kFYRE9aiDNUuL2Vjbg==",
           "dev": true,
           "requires": {
-            "@contentful/rich-text-types": "^16.0.3",
+            "@contentful/rich-text-types": "^16.3.0",
             "@types/json-patch": "0.0.30",
-            "axios": "^0.27.1",
-            "contentful-sdk-core": "^7.0.1",
+            "axios": "^1.6.2",
+            "contentful-sdk-core": "^8.1.0",
             "fast-copy": "^3.0.0",
             "lodash.isplainobject": "^4.0.6",
-            "type-fest": "^3.0.0"
+            "type-fest": "^4.0.0"
           }
         },
         "fast-copy": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.1.tgz",
-          "integrity": "sha512-Knr7NOtK3HWRYGtHoJrjkaWepqT8thIVGAwt0p0aUs1zqkAzXZV4vo9fFNwyb5fcqK1GKYFYxldQdIDVKhUAfA==",
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.2.tgz",
+          "integrity": "sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==",
           "dev": true
         },
         "has-flag": {
@@ -5960,357 +6272,469 @@
       }
     },
     "@contentful/app-sdk": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.22.0.tgz",
-      "integrity": "sha512-ljXNwqdCA1GCsD32SKGcUpLnuQAmAHSyW9ebHw185UBwNgqM02n20tODWftUYH94TlPiQnQmqDSDFX7TGRYW2g==",
+      "version": "4.25.0",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/app-sdk/4.25.0/305d18a1809a5059a2abea9019bc8fcf6d854145",
+      "integrity": "sha512-Aw5Yq3zduwHonNJPQtBTNzZ4MC17UtH8zaSnq8cdbDLfyJOYiTgPDDh15AzgwAkfyOovoXCBcyajjra9Cm45Qg==",
       "requires": {
         "contentful-management": ">=7.30.0"
       }
     },
     "@contentful/f36-accordion": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.45.0.tgz",
-      "integrity": "sha512-7L78Xnu8VlZNdSgVEyVClMVBR96ktqhMSLjy7D6cOqwiro2HGz98VTWtlqv7unKgDzgbZYukcK+kmnaN6sTgGg==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-accordion/4.65.4/ac7bc3768e5b770321556604b3d65955a8fdd570",
+      "integrity": "sha512-gICRiYKaeHG6u1HFyzcHuelx311PRJwX4HDNwle+nkTBzho94qR1B0hNNAjh1Q9+7lpg+Rt0xNENBq9Od78/ww==",
       "requires": {
-        "@contentful/f36-collapse": "^4.45.0",
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.45.0",
+        "@contentful/f36-collapse": "^4.65.4",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.4",
         "emotion": "^10.0.17"
+      },
+      "dependencies": {
+        "@contentful/f36-tokens": {
+          "version": "4.0.5",
+          "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+          "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+        }
       }
     },
     "@contentful/f36-asset": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.45.0.tgz",
-      "integrity": "sha512-xMQc7MkH9j+/LXNbKREtqt8lN9fuh91JNdVXMkQNPavh0/C32xhJcyYztau9sr6BWB74PcfFvn7n1ceaW5pD6w==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-asset/4.65.4/8fc7135a5b83b4ce22dc0d8d9065dc9af12043f8",
+      "integrity": "sha512-MegkLloS9mAcp8e6gpPncumSAA4i6vYMPy1pW48WyfSQLGOQqPZB+0ULV/5FrCl8HRXqRdCkmiNODQsnyR5Yhw==",
       "requires": {
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-icon": "^4.45.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.45.0",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-icon": "^4.65.4",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.4",
         "emotion": "^10.0.17"
+      },
+      "dependencies": {
+        "@contentful/f36-tokens": {
+          "version": "4.0.5",
+          "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+          "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+        }
       }
     },
     "@contentful/f36-autocomplete": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.45.0.tgz",
-      "integrity": "sha512-J+vU5+h9A0wt07xxKLw4U1EwkhL1HzF3B/LkUJwLDnWjidvWyiB6FU/Cmm9GxlPfAAEzHNwHLIe40S+3c3ourA==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-autocomplete/4.65.4/476b69439b766060e9948424d1f0efb7e833e821",
+      "integrity": "sha512-CCnBQy5vt5hBlKx6MiANo8TwIoquW25LJdilRqBbIX1tg9QTsBDbCFtY1ktZxoh802If/rnk7oNRFUFxe1k9cg==",
       "requires": {
-        "@contentful/f36-button": "^4.45.0",
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-forms": "^4.45.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-popover": "^4.45.0",
-        "@contentful/f36-skeleton": "^4.45.0",
-        "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.45.0",
-        "@contentful/f36-utils": "^4.23.2",
+        "@contentful/f36-button": "^4.65.4",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-forms": "^4.65.4",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-popover": "^4.65.4",
+        "@contentful/f36-skeleton": "^4.65.4",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.4",
+        "@contentful/f36-utils": "^4.24.3",
         "downshift": "^6.1.12",
         "emotion": "^10.0.17"
+      },
+      "dependencies": {
+        "@contentful/f36-tokens": {
+          "version": "4.0.5",
+          "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+          "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+        }
       }
     },
     "@contentful/f36-badge": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.45.0.tgz",
-      "integrity": "sha512-g112nAiVevecTuCWuUad3GTII4qOaCtsnlmCG2YKqFZBQCI0tVTJdB2JTyFoHpJo1i6whZpqDyVqvosJgvI+RQ==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-badge/4.65.4/15b16e72f191485f8e2d2081d0c0576b064b8db1",
+      "integrity": "sha512-7MYdwOEIm+B95jBr1ISIHpSNDPfOXJHehsfZd6K12vJgjARhtFDWk3AEH8nW33oBuWysbsUKh3RVqMo7ro4mBg==",
       "requires": {
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-icons": "^4.25.0",
-        "@contentful/f36-tokens": "^4.0.2",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
+      },
+      "dependencies": {
+        "@contentful/f36-tokens": {
+          "version": "4.0.5",
+          "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+          "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+        }
       }
     },
     "@contentful/f36-button": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.45.0.tgz",
-      "integrity": "sha512-KRRgjqDzm5Ta3QEWTyx2H/m7d0HyPBMgex5T7RL6BK/Alu/4tJqAEN5VciRumfOKG0rXKwxsiseP9O5tdVjy9w==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-button/4.65.4/4b8bf5952b01d298f66e72ca7b5910e08772493d",
+      "integrity": "sha512-YpQMw24TvTc9Z9P7Em/0aO/xjD7TLHxIiR26oa5/UGuY7/8nuzBEiC4L4dFbgtVSXpLYDyj4uxcOZc/o7sul5Q==",
       "requires": {
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-spinner": "^4.45.0",
-        "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-utils": "^4.24.1",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-spinner": "^4.65.4",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
+      },
+      "dependencies": {
+        "@contentful/f36-tokens": {
+          "version": "4.0.5",
+          "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+          "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+        }
       }
     },
     "@contentful/f36-card": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.45.0.tgz",
-      "integrity": "sha512-JAu20JpUkwabm2ODxxsGu0mRuiIvDjAp4ACcAWNmrIWpA57lRCZbxI+OWDa4mp2tJFCf3AxfaiQ0pP6Z//vTIA==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-card/4.65.4/57805f81d2c9fa2c1a8e41f70791a3111b261234",
+      "integrity": "sha512-AiUYpGxnn0KJWHoyuhy6YpAaGFPhBhRgq2yr3iXTeDDxJvHKwtFtw/80SRIUeKIy9NaxZWB6EW13NBtyZZ+QAw==",
       "requires": {
-        "@contentful/f36-asset": "^4.45.0",
-        "@contentful/f36-badge": "^4.45.0",
-        "@contentful/f36-button": "^4.45.0",
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-drag-handle": "^4.45.0",
-        "@contentful/f36-icon": "^4.45.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-menu": "^4.45.0",
-        "@contentful/f36-skeleton": "^4.45.0",
-        "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-tooltip": "^4.45.0",
-        "@contentful/f36-typography": "^4.45.0",
+        "@contentful/f36-asset": "^4.65.4",
+        "@contentful/f36-badge": "^4.65.4",
+        "@contentful/f36-button": "^4.65.4",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-drag-handle": "^4.65.4",
+        "@contentful/f36-icon": "^4.65.4",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-menu": "^4.65.4",
+        "@contentful/f36-skeleton": "^4.65.4",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-tooltip": "^4.65.4",
+        "@contentful/f36-typography": "^4.65.4",
         "emotion": "^10.0.17",
         "truncate": "^3.0.0"
+      },
+      "dependencies": {
+        "@contentful/f36-tokens": {
+          "version": "4.0.5",
+          "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+          "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+        }
       }
     },
     "@contentful/f36-collapse": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.45.0.tgz",
-      "integrity": "sha512-wCAm+lR9HSQ/IEsnheSSNW0UT6B9SJEnutzJnh16Xk1trZWqRhdUmys69mOAleKq/lqwfODKl8CfzGUVxPcEmw==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-collapse/4.65.4/1f9635a99385728a33d2feb391e8406ab6ca0cb0",
+      "integrity": "sha512-S/niEGAxXWYWuTj8z4+QdqWqfqM+uulaOIwsA9GG3B5/t73TrE1tb/SGJzWYcCenb6zGUrUeeJVMLU1V4J517g==",
       "requires": {
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-tokens": "^4.0.2",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
+      },
+      "dependencies": {
+        "@contentful/f36-tokens": {
+          "version": "4.0.5",
+          "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+          "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+        }
       }
     },
     "@contentful/f36-components": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.45.0.tgz",
-      "integrity": "sha512-vxEWAHlcbfSmhHh5wfjNY3NsdN3vpTxK2pg1MvqECFBFxwTVfA2UxYwioM0cgd1W/rLRNTf+sCLSryKr2F3JCg==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-components/4.65.4/8f269a62337b3302798cbbe4b2074c17d57a291b",
+      "integrity": "sha512-NgnOKH63CEGAROqL71slZagqS6eG144vY/p8P1psE/AACoFq2VrlGITA9uGsdcO88jt1icFUiUdZHwkwkoamcw==",
       "requires": {
-        "@contentful/f36-accordion": "^4.45.0",
-        "@contentful/f36-asset": "^4.45.0",
-        "@contentful/f36-autocomplete": "^4.45.0",
-        "@contentful/f36-badge": "^4.45.0",
-        "@contentful/f36-button": "^4.45.0",
-        "@contentful/f36-card": "^4.45.0",
-        "@contentful/f36-collapse": "^4.45.0",
-        "@contentful/f36-copybutton": "^4.45.0",
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-datepicker": "^4.45.0",
-        "@contentful/f36-datetime": "^4.45.0",
-        "@contentful/f36-drag-handle": "^4.45.0",
-        "@contentful/f36-empty-state": "^4.45.0",
-        "@contentful/f36-entity-list": "^4.45.0",
-        "@contentful/f36-forms": "^4.45.0",
-        "@contentful/f36-icon": "^4.45.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-list": "^4.45.0",
-        "@contentful/f36-menu": "^4.45.0",
-        "@contentful/f36-modal": "^4.45.0",
-        "@contentful/f36-navbar": "^4.1.0",
-        "@contentful/f36-note": "^4.45.0",
-        "@contentful/f36-notification": "^4.45.0",
-        "@contentful/f36-pagination": "^4.45.0",
-        "@contentful/f36-pill": "^4.45.0",
-        "@contentful/f36-popover": "^4.45.0",
-        "@contentful/f36-skeleton": "^4.45.0",
-        "@contentful/f36-spinner": "^4.45.0",
-        "@contentful/f36-table": "^4.45.0",
-        "@contentful/f36-tabs": "^4.45.0",
-        "@contentful/f36-text-link": "^4.45.0",
-        "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-tooltip": "^4.45.0",
-        "@contentful/f36-typography": "^4.45.0",
-        "@contentful/f36-utils": "^4.23.2",
-        "@types/react": "16.14.22",
-        "@types/react-dom": "16.9.14"
+        "@contentful/f36-accordion": "^4.65.4",
+        "@contentful/f36-asset": "^4.65.4",
+        "@contentful/f36-autocomplete": "^4.65.4",
+        "@contentful/f36-badge": "^4.65.4",
+        "@contentful/f36-button": "^4.65.4",
+        "@contentful/f36-card": "^4.65.4",
+        "@contentful/f36-collapse": "^4.65.4",
+        "@contentful/f36-copybutton": "^4.65.4",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-datepicker": "^4.65.4",
+        "@contentful/f36-datetime": "^4.65.4",
+        "@contentful/f36-drag-handle": "^4.65.4",
+        "@contentful/f36-empty-state": "^4.65.4",
+        "@contentful/f36-entity-list": "^4.65.4",
+        "@contentful/f36-forms": "^4.65.4",
+        "@contentful/f36-icon": "^4.65.4",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-list": "^4.65.4",
+        "@contentful/f36-menu": "^4.65.4",
+        "@contentful/f36-modal": "^4.65.4",
+        "@contentful/f36-navbar": "^4.1.1",
+        "@contentful/f36-note": "^4.65.4",
+        "@contentful/f36-notification": "^4.65.4",
+        "@contentful/f36-pagination": "^4.65.4",
+        "@contentful/f36-pill": "^4.65.4",
+        "@contentful/f36-popover": "^4.65.4",
+        "@contentful/f36-skeleton": "^4.65.4",
+        "@contentful/f36-spinner": "^4.65.4",
+        "@contentful/f36-table": "^4.65.4",
+        "@contentful/f36-tabs": "^4.65.4",
+        "@contentful/f36-text-link": "^4.65.4",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-tooltip": "^4.65.4",
+        "@contentful/f36-typography": "^4.65.4",
+        "@contentful/f36-utils": "^4.24.3"
       },
       "dependencies": {
-        "@types/react": {
-          "version": "16.14.22",
-          "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.22.tgz",
-          "integrity": "sha512-4NnkxKDd2UO9SiCckuhCQOCzdO+RtE4Epf1D6eGz3f9jZjiIXOVo+Bk3jqSad+8EOT+LBXwKdkFX0V0F+NFzDQ==",
-          "requires": {
-            "@types/prop-types": "*",
-            "@types/scheduler": "*",
-            "csstype": "^3.0.2"
-          }
-        },
-        "@types/react-dom": {
-          "version": "16.9.14",
-          "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.14.tgz",
-          "integrity": "sha512-FIX2AVmPTGP30OUJ+0vadeIFJJ07Mh1m+U0rxfgyW34p3rTlXI+nlenvAxNn4BP36YyI9IJ/+UJ7Wu22N1pI7A==",
-          "requires": {
-            "@types/react": "^16"
-          }
-        },
-        "csstype": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
-          "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA=="
+        "@contentful/f36-tokens": {
+          "version": "4.0.5",
+          "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+          "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
         }
       }
     },
     "@contentful/f36-copybutton": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.45.0.tgz",
-      "integrity": "sha512-cEjy8xb5r0WDW8G690l/rV3pwwne9NoFkEVRi2lQaJ9XquU0y4Fl81M0Adm2/7nv9GPFJULZwTCCHNYoElTL9g==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-copybutton/4.65.4/4c435eb442f593cb6e3dc851678b467eb99dd1dd",
+      "integrity": "sha512-mz5NeUfrafSBkXhGDHl4CUXBjDY//ueBURtfA9wROF7ixKRYHb3TtBxzipzzLm4i77n+b5Rt02kl9jkPZPKyWQ==",
       "requires": {
-        "@contentful/f36-button": "^4.45.0",
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-tooltip": "^4.45.0",
+        "@contentful/f36-button": "^4.65.4",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-tooltip": "^4.65.4",
         "emotion": "^10.0.17"
+      },
+      "dependencies": {
+        "@contentful/f36-tokens": {
+          "version": "4.0.5",
+          "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+          "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+        }
       }
     },
     "@contentful/f36-core": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.45.0.tgz",
-      "integrity": "sha512-UvFfwj8os0VyUFk7KVw4+LVItAiweASxWmiKgwvxM4B8O74DBcu3/OqwQbgJk01ufnPC4i2p+cSt0SZ1Z+cOkg==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-core/4.65.4/7baeab61593b31508c3947e3404229cdd445e6db",
+      "integrity": "sha512-VepF58IpC/xcT49RKPm/ri7bHmgNkvd0dtlJvvcoGifz/Yb+VuSwOXFUEIav1htIitG8wnfYPFJBur5FYCBu6A==",
       "requires": {
-        "@contentful/f36-tokens": "^4.0.2",
+        "@contentful/f36-tokens": "^4.0.4",
         "@emotion/core": "^10.1.1",
         "@emotion/is-prop-valid": "^1.2.0",
         "csstype": "^3.1.1",
         "emotion": "^10.0.17"
       },
       "dependencies": {
+        "@contentful/f36-tokens": {
+          "version": "4.0.5",
+          "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+          "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+        },
         "csstype": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-          "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
         }
       }
     },
     "@contentful/f36-datepicker": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.45.0.tgz",
-      "integrity": "sha512-ZTHuBphRsTDoXdpLn1J1lxZJk1D1X9KR95pgDXOV4Aq4fg+4YLY/8PiqrgT/N6RmAMBjUgwr1eFCzDTtWVnybQ==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-datepicker/4.65.4/0afea77c09b6ae580a3a9961d2f3963e93a34b41",
+      "integrity": "sha512-JUdmCgBJuZ9khUY+MtDH1xSwh6ob1k9mH1tIjKeRkF292GZGkJMw51PAoWyU95CTyL42pVt2dXUhr0mtBI93pQ==",
       "requires": {
-        "@contentful/f36-button": "^4.45.0",
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-forms": "^4.45.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-popover": "^4.45.0",
-        "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.45.0",
+        "@contentful/f36-button": "^4.65.4",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-forms": "^4.65.4",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-popover": "^4.65.4",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.4",
         "date-fns": "^2.28.0",
         "emotion": "^10.0.17",
         "react-day-picker": "^8.7.1",
         "react-focus-lock": "^2.9.1"
+      },
+      "dependencies": {
+        "@contentful/f36-tokens": {
+          "version": "4.0.5",
+          "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+          "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+        }
       }
     },
     "@contentful/f36-datetime": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.45.0.tgz",
-      "integrity": "sha512-2jGOzRTzknMngjv2MclQg+SyVt11uhjFrsCaRNa3oau1DGAjOOtglwkGwD1uO6KIzkjA5DDevHMAKRgJ4fCv0Q==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-datetime/4.65.4/ef2e8b99fb92c22d3a56b1e00600cc7aca68d818",
+      "integrity": "sha512-vGARpWxr+wzjEBgi/V1YnPvutEZdOw+uMVcLSPIAYv8aQ+w1bu7K7wimBOtIBA8D4Qk4v1/Km/YLf2r2q8JNvg==",
       "requires": {
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-tokens": "^4.0.2",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-tokens": "^4.0.4",
         "dayjs": "^1.11.5",
         "emotion": "^10.0.17"
+      },
+      "dependencies": {
+        "@contentful/f36-tokens": {
+          "version": "4.0.5",
+          "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+          "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+        }
       }
     },
     "@contentful/f36-drag-handle": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.45.0.tgz",
-      "integrity": "sha512-LJ2aUPXr+1tlCe28NdhZFBEhFw+25NRsKMSLln5hHRU+pDbeBQFPwHhgglVXYIpxSRBWFXtXtOGb8tWxSue2OA==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-drag-handle/4.65.4/c605ca420ae0f3e02b4ed39bf2702c38f4468a28",
+      "integrity": "sha512-ZuowEbXCEmhU/n8hgEcdGtWjy7rBKkuf3zqGV4wDZLOzBsCP7d0Y2TeRvuNhA8tXX/ng/TQxcUH57GylGqVB9A==",
       "requires": {
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-utils": "^4.24.1",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
+      },
+      "dependencies": {
+        "@contentful/f36-tokens": {
+          "version": "4.0.5",
+          "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+          "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+        }
       }
     },
     "@contentful/f36-empty-state": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.45.0.tgz",
-      "integrity": "sha512-pshErnTpBgZO6zllIHQ8YtJ+nuM9UL55bUFFg+XuZUbOAIzxY1kmJWG4aSWai8Z3CtWnQOeccOOpRWO796jFkw==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-empty-state/4.65.4/13c01ad2ff42ed150443d7b873911b91c948c35f",
+      "integrity": "sha512-d3zirN3KUKIm9BRIvLBRudF7veva2jojUci4MzG51uTrufKPkDh6LqxJVItF+ktZKqm0on1wFMaMzz+h6pi5sw==",
       "requires": {
-        "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.45.0",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.4",
         "emotion": "^10.0.17"
+      },
+      "dependencies": {
+        "@contentful/f36-tokens": {
+          "version": "4.0.5",
+          "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+          "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+        }
       }
     },
     "@contentful/f36-entity-list": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.45.0.tgz",
-      "integrity": "sha512-/WyhSuzHuoJjAdosmBxmsUgnzwcMYi9WvonuKXJTn3S/qy7VGSofzd4zy964Bmu/Abkq6mgoDvZxIt7RoebEDw==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-entity-list/4.65.4/d6297dcff6ec9c4627465a981cd60cf26f2ea55d",
+      "integrity": "sha512-gS/LsUH5hv9Fx8c2t1QOdL2S5Uuy3lnpNm9TNMy87zNaQQ0YS9rNGKKBEUIcAo2ngzvqf/7DsGIxdzQrzada2w==",
       "requires": {
-        "@contentful/f36-badge": "^4.45.0",
-        "@contentful/f36-button": "^4.45.0",
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-drag-handle": "^4.45.0",
-        "@contentful/f36-icon": "^4.45.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-menu": "^4.45.0",
-        "@contentful/f36-skeleton": "^4.45.0",
-        "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.45.0",
+        "@contentful/f36-badge": "^4.65.4",
+        "@contentful/f36-button": "^4.65.4",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-drag-handle": "^4.65.4",
+        "@contentful/f36-icon": "^4.65.4",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-menu": "^4.65.4",
+        "@contentful/f36-skeleton": "^4.65.4",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.4",
         "emotion": "^10.0.17"
+      },
+      "dependencies": {
+        "@contentful/f36-tokens": {
+          "version": "4.0.5",
+          "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+          "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+        }
       }
     },
     "@contentful/f36-forms": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.45.0.tgz",
-      "integrity": "sha512-1rKMY02LUVWzr2TDkzk6a/1GwQNjxNfMH9Y5vVQ8q+lojTl5ppDXrcLdKC4Fk8dLWLjEIvfvCA1vC9sPDUptug==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-forms/4.65.4/e1397cb35bbe82fc57630d10c194a97ce37209c2",
+      "integrity": "sha512-pA5S3x44s2vG/2u1UmlMN5M8CWU1KbW2ec9qj/yiFkAH7uLzpmTbCUrk1EXpHKruN5RhgadlnMiBJFnq4QHAnA==",
       "requires": {
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.45.0",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.4",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
+      },
+      "dependencies": {
+        "@contentful/f36-tokens": {
+          "version": "4.0.5",
+          "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+          "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+        }
       }
     },
     "@contentful/f36-icon": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.45.0.tgz",
-      "integrity": "sha512-6vs0iP2y9IsmIC/YwiE7bOAl1jqyk28J4dqJLZsk3T63i5uXrJCnb8NPDOJCJkIRZQRFCbZd4XVfXPKz1F2EjQ==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-icon/4.65.4/4d12f054e6df73d48a16c6c7797b1ee689a43b56",
+      "integrity": "sha512-y/hT/3cxTA+Nr4ezbpVmQirVzRv9NPvg5Q8wdF68PgHfKyhYVgNXD+AnRcbN9aHeESFzoDWvgv1bca76GCWpYg==",
       "requires": {
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-tokens": "^4.0.2",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
+      },
+      "dependencies": {
+        "@contentful/f36-tokens": {
+          "version": "4.0.5",
+          "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+          "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+        }
       }
     },
     "@contentful/f36-icons": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-4.25.0.tgz",
-      "integrity": "sha512-PDEvCtoAfP3FF7K+slhOb+LP2MxlUSKQXmRUmtBPXIFz+usZC4FOGQAMWKF9kdnDEq9C/kaYiCzPkZ6BJC4hmg==",
+      "version": "4.28.2",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-icons/4.28.2/8297da32e9d8e60e09550e365f24a74a8e12326c",
+      "integrity": "sha512-p7oWbQ5ITlMMuEl/6t/6JLVrCVhDE2nA8mv1VR4DHjXPm0y9w14533rCKxNIREZX8iVmyBoaqI3vdPsjUs1CAw==",
       "requires": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-icon": "^4.23.2",
+        "@contentful/f36-core": "^4.65.0",
+        "@contentful/f36-icon": "^4.65.0",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-list": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.45.0.tgz",
-      "integrity": "sha512-dCwCXKr+uFAyyeEOWTX+rgrmZ8TGwUGPWHvoUHKcwecvyMyzGncgZUqe7K7VeZSg+Xjf8Qqu1MXrfRFfJ8CgAA==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-list/4.65.4/ad6613ff5a1fd838bc7f64dcad5a9004d3fa8421",
+      "integrity": "sha512-7MhF4wAFFZIDSF7DX80C5TDkEhuWYAkGNTSnfX+HZpDd53bfJNZpC0gJT7g5wXoGWoKS58GBj3fjze0Cqw9yPA==",
       "requires": {
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-tokens": "^4.0.2",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
+      },
+      "dependencies": {
+        "@contentful/f36-tokens": {
+          "version": "4.0.5",
+          "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+          "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+        }
       }
     },
     "@contentful/f36-menu": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.45.0.tgz",
-      "integrity": "sha512-eH2UfWhhGc4VwAUXMHfBiQLPUkxxN+T3/6OQUekAxf8Pa0jRGPfi6IP0lyxeTIHMSUNaoZ5gxw/2ifV4sn0v2A==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-menu/4.65.4/8a8724f828161ba3b92ef2c9d5656c4be95c3a55",
+      "integrity": "sha512-FAm7InhFr2V7S4yv02VuOf/XE5afTOJ57ueGW6eVO7BVL2HovZookyRD61tX3IFrBc27VomfxB9rIFUhT5J0kg==",
       "requires": {
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-popover": "^4.45.0",
-        "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.45.0",
-        "@contentful/f36-utils": "^4.23.2",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-popover": "^4.65.4",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.4",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
+      },
+      "dependencies": {
+        "@contentful/f36-tokens": {
+          "version": "4.0.5",
+          "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+          "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+        }
       }
     },
     "@contentful/f36-modal": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.45.0.tgz",
-      "integrity": "sha512-oFuA5J5f8bKdI74Wb1y/P7CUapzLjSfNTbEekK6TBFnUJabQXItJdxHHwH5bXFZa4BKFeZ6sGr/9xohvI8Nv2Q==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-modal/4.65.4/c7948a4436c98ac01b91722987e51be99abe6882",
+      "integrity": "sha512-/oPt/GFYncqkQG7FLVy3UARWv59jA0TRCbytovWZQPcBvd4RgQUMQNasZeN77DlyaQKoUWiET3y06rBaQxW7+w==",
       "requires": {
-        "@contentful/f36-button": "^4.45.0",
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.45.0",
+        "@contentful/f36-button": "^4.65.4",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.4",
         "@types/react-modal": "^3.13.1",
         "emotion": "^10.0.17",
         "react-modal": "^3.16.1"
+      },
+      "dependencies": {
+        "@contentful/f36-tokens": {
+          "version": "4.0.5",
+          "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+          "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+        }
       }
     },
     "@contentful/f36-navbar": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-navbar/-/f36-navbar-4.1.0.tgz",
-      "integrity": "sha512-tFzg4px28dGq2zD+/rKsVmZ684WItZ+xNGI7et6QeAmevwIzifE1JGblJr/BC1Nn2nWLlF0LZn4URekIf7ijkA==",
+      "version": "4.1.1",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-navbar/4.1.1/139c0280f14f3a923d40bfa7290984eb60486119",
+      "integrity": "sha512-nCLtZ7EgfKhmXWrGZYrZEQOoulOOVPOuZBk0CC4JgQRQmCYeYr2iAnM8zualISFaxX/O+GVvHPQf2hKeoeFRPA==",
       "requires": {
         "@contentful/f36-core": "^4.45.0",
         "@contentful/f36-icon": "^4.45.0",
@@ -6323,128 +6747,198 @@
       }
     },
     "@contentful/f36-note": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.45.0.tgz",
-      "integrity": "sha512-+yPOlZtFe4vmLZiZjCBTG8wUikqLcaliikUKEs68Qk6/sLTsAL8vTmCG7B8addDv1kmY5rpWA2D8x7/v/TGNuQ==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-note/4.65.4/eb649736ef20960836121c6269664a49dcc2f0a7",
+      "integrity": "sha512-njpLgLEKEH2TJFpDIEABziM6KRYWWfVe/5b9ixSk1d3q0OuBatd1Wd4fg71ZBfPJQa5d+i/C5n0auwR0/C+SgA==",
       "requires": {
-        "@contentful/f36-button": "^4.45.0",
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-icon": "^4.45.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.45.0",
+        "@contentful/f36-button": "^4.65.4",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-icon": "^4.65.4",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.4",
         "emotion": "^10.0.17"
+      },
+      "dependencies": {
+        "@contentful/f36-tokens": {
+          "version": "4.0.5",
+          "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+          "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+        }
       }
     },
     "@contentful/f36-notification": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.45.0.tgz",
-      "integrity": "sha512-qByB39m9x1NCnXc1Ult/SYJftXLsRbJ1VAoDSWiKpz4dKUkuLq34dujNyml3nQr7Hhh2l6qzTIsspHO2yaBbUA==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-notification/4.65.4/581b0db345575d11e61ebc887df01e8b4bff79be",
+      "integrity": "sha512-USO9c3GifvvCZZjrraeDxSEuvS4hTPT6iLmqWw2E21qOoeJRxz1iRLyhNpWxQHyvjnINcuEgcXbGQD5EDk3sZA==",
       "requires": {
-        "@contentful/f36-button": "^4.45.0",
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-text-link": "^4.45.0",
-        "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.45.0",
+        "@contentful/f36-button": "^4.65.4",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-text-link": "^4.65.4",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.4",
         "@swc/helpers": "^0.4.14",
         "emotion": "^10.0.17",
         "react-animate-height": "^3.0.4"
+      },
+      "dependencies": {
+        "@contentful/f36-tokens": {
+          "version": "4.0.5",
+          "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+          "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+        }
       }
     },
     "@contentful/f36-pagination": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.45.0.tgz",
-      "integrity": "sha512-SQ7GeFa+m63mwN/6vW4uJBlk9C2Iv0wOQjr88bBIyzSbYQBvZYp+yAT+n3Wk2gTfKK6Ph3W/K2bIijTKN+cDkA==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-pagination/4.65.4/3f931cbcc1bbf1c8c299f9c43b97b78388958759",
+      "integrity": "sha512-juv5gmqaDFBuus/iNhuTwcrpBw+wm0gjHa2sv8q07okb8ztTbxFMxg8g7QsR59TWjNnSq5KuTWREHS6djxiyNw==",
       "requires": {
-        "@contentful/f36-button": "^4.45.0",
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-forms": "^4.45.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.45.0",
+        "@contentful/f36-button": "^4.65.4",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-forms": "^4.65.4",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.4",
         "emotion": "^10.0.17"
+      },
+      "dependencies": {
+        "@contentful/f36-tokens": {
+          "version": "4.0.5",
+          "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+          "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+        }
       }
     },
     "@contentful/f36-pill": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.45.0.tgz",
-      "integrity": "sha512-pksZOGj4Sq0Sl4tAackZgAQCGDOXCUtR3ldoEvsrHSlbuyZTkBNc40TRuz+Ky83icO2XaBuepl06IGxmecxcUw==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-pill/4.65.4/caaa09af078bacce456088181bf85071d59b0e37",
+      "integrity": "sha512-oK5Qk1vH3vlKFSWsG5mZHRSI25AWRYKwKzNFePOfv6V824815oLgpfSB9wJwyDtSbNThORLr6+9u9T9JiNgmJQ==",
       "requires": {
-        "@contentful/f36-button": "^4.45.0",
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-drag-handle": "^4.45.0",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-tooltip": "^4.45.0",
+        "@contentful/f36-button": "^4.65.4",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-drag-handle": "^4.65.4",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-tooltip": "^4.65.4",
         "emotion": "^10.0.17"
+      },
+      "dependencies": {
+        "@contentful/f36-tokens": {
+          "version": "4.0.5",
+          "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+          "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+        }
       }
     },
     "@contentful/f36-popover": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.45.0.tgz",
-      "integrity": "sha512-MuXd8xCJFhDFSlq+uY1dpHk5A5jtgVR1RblleCDZSkquwMfEuEOHCM9z9BFyLpxQK6jKerSoyogsY3v9W694qg==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-popover/4.65.4/77eec4ec7f8f27fb55e520582d05782eca200e4c",
+      "integrity": "sha512-z6fqpoqOANvMl2ygGgGItQ12njWV5jDxrfBwv2QK6ZO5YGBGohq51qzoOLwRC7njCFPFbrdBs2a9Y6C7qRbx9Q==",
       "requires": {
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-utils": "^4.23.2",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
         "emotion": "^10.0.17",
         "react-popper": "^2.3.0"
+      },
+      "dependencies": {
+        "@contentful/f36-tokens": {
+          "version": "4.0.5",
+          "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+          "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+        }
       }
     },
     "@contentful/f36-skeleton": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.45.0.tgz",
-      "integrity": "sha512-OL0JOzW9dUt9p81w6382o/mObGUdIRKoETI6564eEtzrLHfqpBZOmENA/7b9QILhPMC4qCM1UvipixcejyVRVg==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-skeleton/4.65.4/9d347d10603433ba7ea8108ac986a7006d5318d6",
+      "integrity": "sha512-96ArmHTrXF3zjbMkuE5lSn5qXX9h/NzWRJo7kjfKu6GcfL9ajIcpB1ft26vjygP3ZzVdy37NXmVvYijKqTUeYw==",
       "requires": {
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-table": "^4.45.0",
-        "@contentful/f36-tokens": "^4.0.2",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-table": "^4.65.4",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
+      },
+      "dependencies": {
+        "@contentful/f36-tokens": {
+          "version": "4.0.5",
+          "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+          "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+        }
       }
     },
     "@contentful/f36-spinner": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.45.0.tgz",
-      "integrity": "sha512-2WdQ3IAanLP8pN+tqrTvYsTeZUkKx+O91TzfM5HOYCdi3EorV5BcXXxv2uXTHvzNUUxjGJG7E8WSR6HxpWWQRw==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-spinner/4.65.4/e0bbe2bb8147f964a47628eb1d658d9ac04d09dd",
+      "integrity": "sha512-heO40qyNQY8N9hoMz5LDxPnJlpltLGVPEdvjKVAGU46eUEgc0PF0BgEJcziX/kZWONnyMJ5XMJBLfspmbFM7Pg==",
       "requires": {
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-tokens": "^4.0.2",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
+      },
+      "dependencies": {
+        "@contentful/f36-tokens": {
+          "version": "4.0.5",
+          "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+          "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+        }
       }
     },
     "@contentful/f36-table": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.45.0.tgz",
-      "integrity": "sha512-deF/IGNAhetfn+5t8myYMO5jO75ZtY+kshUWmOKaiNolCix2ReRWGxxWVDDLwsokukm6McnF0uLIix1ivvI/YQ==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-table/4.65.4/de4b330cc7abd0afc61d1e27199980d95e8878a8",
+      "integrity": "sha512-nP2AaYTzC8ujuykvq1E/L+2uE9OGiPClY8tEWvzVB1Kn0T8FcDw2GKezB5HQBwbpntUT5u6oMmui6GC7POMc4A==",
       "requires": {
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-icons": "^4.25.0",
-        "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-typography": "^4.45.0",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.4",
         "emotion": "^10.0.17"
+      },
+      "dependencies": {
+        "@contentful/f36-tokens": {
+          "version": "4.0.5",
+          "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+          "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+        }
       }
     },
     "@contentful/f36-tabs": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.45.0.tgz",
-      "integrity": "sha512-rTsxdbcQQPiEgLKbLyUHflitt1GAdboTrvjdGV48tGfF0tJm3oxksJuavcQwVy0Bd+9GdKFh16mqHlMosR+h5g==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tabs/4.65.4/7071236298846f5f421dcce9e79c1d4568781385",
+      "integrity": "sha512-OG3eqrgr8Jc/Elvjw0CNGhenjRiTIBiE55BN2do9+1HYgRrZSAfA0rjauvOGlo9FJfu07YzggnSIjh8pW7tT1g==",
       "requires": {
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-tokens": "^4.0.2",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-tokens": "^4.0.4",
         "@radix-ui/react-tabs": "^1.0.1",
         "emotion": "^10.0.17"
+      },
+      "dependencies": {
+        "@contentful/f36-tokens": {
+          "version": "4.0.5",
+          "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+          "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+        }
       }
     },
     "@contentful/f36-text-link": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.45.0.tgz",
-      "integrity": "sha512-Bm3ZD7TELaeafR7AemkqvpsupRSQQI+UyfXUFFI3PO3wGJIIWp0A3T6uJGTc1yBc3JWC7YhRIgpp3UAn5fUDNg==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-text-link/4.65.4/b0be7010e3dfc1a97e97f8ea057901c9e7a8e2c6",
+      "integrity": "sha512-IkBs1Q8XCEm4XfSjowfNQDXIdpxqAamH23afhovS2OVWavBDTYqsGdfREbFt3o2sDEVd0Zlfr+rnjFw6Lufa3Q==",
       "requires": {
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-tokens": "^4.0.2",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
+      },
+      "dependencies": {
+        "@contentful/f36-tokens": {
+          "version": "4.0.5",
+          "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+          "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+        }
       }
     },
     "@contentful/f36-tokens": {
@@ -6453,40 +6947,53 @@
       "integrity": "sha512-sM2AM/8Qn4K0mm2H14nDJMIYoAUv7+tHGUyGqnXEyOVD/5O9lzLTkELEA9R0UgtPPcTywCYC6aZCCggy/Ezd/g=="
     },
     "@contentful/f36-tooltip": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.45.0.tgz",
-      "integrity": "sha512-eJzxqDxzzrnO4fSzq3umE4iwsnUj5YGvq+Q4oERVZm2CZm1w4cgDZa4EHbegj1w9iF4OX7vC58kCZztOuhbPHA==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tooltip/4.65.4/c72367404eb9b38a05ccdf07ca87bb791f282166",
+      "integrity": "sha512-atXRcn3uWuzBRWQcBlIU6dpt5tTe2HmDEvcp7LO0quNWY7+jnu9kiJDz0Axfs1/WDA5h5QmSMoyVGXrssKNvMQ==",
       "requires": {
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-tokens": "^4.0.2",
-        "@contentful/f36-utils": "^4.23.2",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
         "csstype": "^3.1.1",
         "emotion": "^10.0.17",
         "react-popper": "^2.3.0"
       },
       "dependencies": {
+        "@contentful/f36-tokens": {
+          "version": "4.0.5",
+          "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+          "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+        },
         "csstype": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-          "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+          "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
         }
       }
     },
     "@contentful/f36-typography": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.45.0.tgz",
-      "integrity": "sha512-aIuv2gsUWaezsnm/6g/HfrgK3iJWSfOWONDE4r6+glpLwiZ7twBVZFAObLHcBBI8WB4AACgs4vN3FrQiH7ZTIA==",
+      "version": "4.65.4",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-typography/4.65.4/7b57a3e06c90debb5ef1edc39ae1123904c59d41",
+      "integrity": "sha512-bHBmDWnOSO29xX/0aBhZy2WIw7UvsKvqhfuw8XilWky3rt8zvoUgCcatbWh9/TQ7cjJjpHf8B+g1+azeldpVBw==",
       "requires": {
-        "@contentful/f36-core": "^4.45.0",
-        "@contentful/f36-tokens": "^4.0.2",
+        "@contentful/f36-core": "^4.65.4",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
+      },
+      "dependencies": {
+        "@contentful/f36-tokens": {
+          "version": "4.0.5",
+          "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+          "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
+        }
       }
     },
     "@contentful/f36-utils": {
-      "version": "4.24.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-utils/-/f36-utils-4.24.1.tgz",
-      "integrity": "sha512-jr+61KiKn7oA38WXgAJoqVNdr6gXzmJSA+MCl7Djapxxf+jsC1vsi8j8okISCm4a/ZcPncKekDYzzWu+kkI7VQ==",
+      "version": "4.24.3",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-utils/4.24.3/12868232fe068b7095d2db8ae1cfe296370d124a",
+      "integrity": "sha512-9+tyDOCjEhW7m4X7Sam0VYlmcgjhLVMiapCnv1EmRstlMaeI5ti9y0y/2aQ04Na2ScoHwrMTjveoZ6V62J62tA==",
       "requires": {
         "emotion": "^10.0.17"
       }
@@ -6500,9 +7007,9 @@
       }
     },
     "@contentful/rich-text-types": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.2.0.tgz",
-      "integrity": "sha512-4BHC+mfa50JB70epzpnas4EkiuB3mGdBZ5Rp8w7R5wXvswEf8TLg5yGau2FxmZeEjrAkDrt4vzBLVQ8v3Y//Jw=="
+      "version": "16.3.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/rich-text-types/16.3.5/927433a84416101ba3dbf19bd0924e755f5e6d65",
+      "integrity": "sha512-ZLq6p5uyQXg+i1XGDFu4tAc2VYS12S1KA/jIOyyZjNgC1DvDajsi1JzuiBuOuMEhi1sKEUy6Ry3Yr9jsQtOKuQ=="
     },
     "@emotion/cache": {
       "version": "10.0.29",
@@ -6544,9 +7051,9 @@
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
     },
     "@emotion/is-prop-valid": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
-      "integrity": "sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz",
+      "integrity": "sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==",
       "requires": {
         "@emotion/memoize": "^0.8.1"
       },
@@ -6764,26 +7271,26 @@
       }
     },
     "@jridgewell/gen-mapping": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
       "dev": true,
       "requires": {
-        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/set-array": "^1.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.9"
+        "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
     "@jridgewell/resolve-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "dev": true
     },
     "@jridgewell/set-array": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
       "dev": true
     },
     "@jridgewell/sourcemap-codec": {
@@ -6793,28 +7300,29 @@
       "dev": true
     },
     "@jridgewell/trace-mapping": {
-      "version": "0.3.18",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
-      "integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
       "dev": true,
       "requires": {
-        "@jridgewell/resolve-uri": "3.1.0",
-        "@jridgewell/sourcemap-codec": "1.4.14"
-      },
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": {
-          "version": "1.4.14",
-          "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-          "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-          "dev": true
-        }
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "@nicolo-ribaudo/semver-v6": {
-      "version": "6.3.3",
-      "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/semver-v6/-/semver-v6-6.3.3.tgz",
-      "integrity": "sha512-3Yc1fUTs69MG/uZbJlLSI3JISMn2UV2rg+1D/vROUqZyh3l6iYHCs7GMp+M40ZD7yOdDbYjJcU1oTJhrc+dGKg==",
+    "@lukeed/csprng": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
+      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
       "dev": true
+    },
+    "@lukeed/uuid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@lukeed/uuid/-/uuid-2.0.1.tgz",
+      "integrity": "sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==",
+      "dev": true,
+      "requires": {
+        "@lukeed/csprng": "^1.1.0"
+      }
     },
     "@popperjs/core": {
       "version": "2.11.8",
@@ -6960,14 +7468,40 @@
         "@babel/runtime": "^7.13.10"
       }
     },
-    "@segment/loosely-validate-event": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@segment/loosely-validate-event/-/loosely-validate-event-2.0.0.tgz",
-      "integrity": "sha512-ZMCSfztDBqwotkl848ODgVcAmN4OItEWDCkshcKz0/W6gGSQayuuCtWV/MlodFivAZD793d6UgANd6wCXUfrIw==",
+    "@segment/analytics-core": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-core/-/analytics-core-1.6.0.tgz",
+      "integrity": "sha512-bn9X++IScUfpT7aJGjKU/yJAu/Ko2sYD6HsKA70Z2560E89x30pqgqboVKY8kootvQnT4UKCJiUr5NDMgjmWdQ==",
       "dev": true,
       "requires": {
-        "component-type": "^1.2.1",
-        "join-component": "^1.1.0"
+        "@lukeed/uuid": "^2.0.0",
+        "@segment/analytics-generic-utils": "1.2.0",
+        "dset": "^3.1.2",
+        "tslib": "^2.4.1"
+      }
+    },
+    "@segment/analytics-generic-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-generic-utils/-/analytics-generic-utils-1.2.0.tgz",
+      "integrity": "sha512-DfnW6mW3YQOLlDQQdR89k4EqfHb0g/3XvBXkovH1FstUN93eL1kfW9CsDcVQyH3bAC5ZsFyjA/o/1Q2j0QeoWw==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.4.1"
+      }
+    },
+    "@segment/analytics-node": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-node/-/analytics-node-2.1.2.tgz",
+      "integrity": "sha512-CIqWH5G0pB/LAFAZEZtntAxujiYIpdk0F+YGhfM6N/qt4/VLWjFcd4VZXVLW7xqaxig64UKWGQhe8bszXDRXXw==",
+      "dev": true,
+      "requires": {
+        "@lukeed/uuid": "^2.0.0",
+        "@segment/analytics-core": "1.6.0",
+        "@segment/analytics-generic-utils": "1.2.0",
+        "buffer": "^6.0.3",
+        "jose": "^5.1.0",
+        "node-fetch": "^2.6.7",
+        "tslib": "^2.4.1"
       }
     },
     "@sinclair/typebox": {
@@ -6977,10 +7511,11 @@
       "dev": true
     },
     "@swc/helpers": {
-      "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
-      "integrity": "sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.36.tgz",
+      "integrity": "sha512-5lxnyLEYFskErRPenYItLRSge5DjrJngYKdVjRSrWfza9G6KkgHEXi0vUZiyUeMU5JfXH1YnvXZzSp8ul88o2Q==",
       "requires": {
+        "legacy-swc-helpers": "npm:@swc/helpers@=0.4.14",
         "tslib": "^2.4.0"
       }
     },
@@ -7068,6 +7603,47 @@
       "integrity": "sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==",
       "dev": true
     },
+    "@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "@types/babel__generator": {
+      "version": "7.6.8",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.8.tgz",
+      "integrity": "sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@types/babel__traverse": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.5.tgz",
+      "integrity": "sha512-WXCyOcRtH37HAUkpXhUduaxdm82b4GSlyTqajXviN4EfiuPgNYR109xMCKvpl6zPIpua0DGlMEDCq+g8EdoheQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.20.7"
+      }
+    },
     "@types/chai": {
       "version": "4.3.5",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.5.tgz",
@@ -7105,12 +7681,11 @@
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
     "@types/react": {
-      "version": "18.2.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.14.tgz",
-      "integrity": "sha512-A0zjq+QN/O0Kpe30hA1GidzyFjatVvrpIvWLxD+xv67Vt91TWWgco9IvrJBkeyHm1trGaFS/FSGqPlhyeZRm0g==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-V0kuGBX3+prX+DQ/7r2qsv1NsdfnCLnTgnRJ1pYnxykBhGMz+qj+box5lq7XsO5mtZsBqpjwwTu/7wszPfMBcw==",
       "requires": {
         "@types/prop-types": "*",
-        "@types/scheduler": "*",
         "csstype": "^3.0.2"
       },
       "dependencies": {
@@ -7122,36 +7697,31 @@
       }
     },
     "@types/react-dom": {
-      "version": "18.2.6",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.6.tgz",
-      "integrity": "sha512-2et4PDvg6PVCyS7fuTc4gPoksV58bW0RwSxWKcPRcHZf0PRUGq03TKcD/rUHe3azfV6/5/biUBJw+HhCQjaP0A==",
-      "devOptional": true,
+      "version": "18.3.0",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
+      "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
       "requires": {
         "@types/react": "*"
       }
     },
     "@types/react-modal": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/@types/react-modal/-/react-modal-3.16.0.tgz",
-      "integrity": "sha512-iphdqXAyUfByLbxJn5j6d+yh93dbMgshqGP0IuBeaKbZXx0aO+OXsvEkt6QctRdxjeM9/bR+Gp3h9F9djVWTQQ==",
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/@types/react-modal/-/react-modal-3.16.3.tgz",
+      "integrity": "sha512-xXuGavyEGaFQDgBv4UVm8/ZsG+qxeQ7f77yNrW3n+1J6XAstUy5rYHeIHPh1KzsGc6IkCIdu6lQ2xWzu1jBTLg==",
       "requires": {
         "@types/react": "*"
       }
     },
-    "@types/scheduler": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
-    },
     "@vitejs/plugin-react": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.0.1.tgz",
-      "integrity": "sha512-g25lL98essfeSj43HJ0o4DMp0325XK0ITkxpgChzJU/CyemgyChtlxfnRbjfwxDGCTRxTiXtQAsdebQXKMRSOA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.2.1.tgz",
+      "integrity": "sha512-oojO9IDc4nCUUi8qIR11KoQm0XFFLIwsRBwHRR4d/88IWghn1y6ckz/bJ8GHDCsYEJee8mDzqtJxh15/cisJNQ==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.22.5",
-        "@babel/plugin-transform-react-jsx-self": "^7.22.5",
-        "@babel/plugin-transform-react-jsx-source": "^7.22.5",
+        "@babel/core": "^7.23.5",
+        "@babel/plugin-transform-react-jsx-self": "^7.23.3",
+        "@babel/plugin-transform-react-jsx-source": "^7.23.3",
+        "@types/babel__core": "^7.20.5",
         "react-refresh": "^0.14.0"
       }
     },
@@ -7271,26 +7841,10 @@
       "dev": true
     },
     "adm-zip": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
-      "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==",
+      "version": "0.5.12",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.12.tgz",
+      "integrity": "sha512-6TVU49mK6KZb4qG6xWaaM4C7sA/sgUMLy/JYMOzkcp3BvVLpW0fXDFQiIzAuxFCt/2+xD7fNIiPFAoLZPhVNLQ==",
       "dev": true
-    },
-    "analytics-node": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/analytics-node/-/analytics-node-6.2.0.tgz",
-      "integrity": "sha512-NLU4tCHlWt0tzEaFQL7NIoWhq2KmQSmz0JvyS2lYn6fc4fEjTMSabhJUx8H1r5995FX8fE3rZ15uIHU6u+ovlQ==",
-      "dev": true,
-      "requires": {
-        "@segment/loosely-validate-event": "^2.0.0",
-        "axios": "^0.27.2",
-        "axios-retry": "3.2.0",
-        "lodash.isstring": "^4.0.1",
-        "md5": "^2.2.1",
-        "ms": "^2.0.0",
-        "remove-trailing-slash": "^0.1.0",
-        "uuid": "^8.3.2"
-      }
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -7360,21 +7914,13 @@
       "dev": true
     },
     "axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
       "requires": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
-      }
-    },
-    "axios-retry": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.2.0.tgz",
-      "integrity": "sha512-RK2cLMgIsAQBDhlIsJR5dOhODPigvel18XUv1dDXW+4k1FzebyfRk+C+orot6WPZOYFKSfhLwHPwVmTVOODQ5w==",
-      "dev": true,
-      "requires": {
-        "is-retry-allowed": "^1.1.0"
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "babel-plugin-emotion": {
@@ -7424,28 +7970,40 @@
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        }
       }
     },
     "browserslist": {
-      "version": "4.21.9",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
-      "integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
+      "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001503",
-        "electron-to-chromium": "^1.4.431",
-        "node-releases": "^2.0.12",
-        "update-browserslist-db": "^1.0.11"
+        "caniuse-lite": "^1.0.30001587",
+        "electron-to-chromium": "^1.4.668",
+        "node-releases": "^2.0.14",
+        "update-browserslist-db": "^1.0.13"
       }
     },
     "buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
       "dev": true,
       "requires": {
         "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
+        "ieee754": "^1.2.1"
       }
     },
     "cac": {
@@ -7455,12 +8013,15 @@
       "dev": true
     },
     "call-bind": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
       "requires": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.1"
       }
     },
     "callsites": {
@@ -7469,9 +8030,9 @@
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
     },
     "caniuse-lite": {
-      "version": "1.0.30001512",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001512.tgz",
-      "integrity": "sha512-2S9nK0G/mE+jasCUsMPlARhRCts1ebcp2Ji8Y8PWi4NDE1iRdLCnEPHkEfeBrGC45L4isBx5ur3IQ6yTE2mRZw==",
+      "version": "1.0.30001615",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001615.tgz",
+      "integrity": "sha512-1IpazM5G3r38meiae0bHRnPhz+CBQ3ZLqbQMtrg+AsTPKAXgW38JNsXkyZ+v8waCsDmPq87lmfun5Q2AGysNEQ==",
       "dev": true
     },
     "chai": {
@@ -7505,12 +8066,6 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
-    "charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
-      "dev": true
-    },
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
@@ -7527,9 +8082,9 @@
       }
     },
     "cli-spinners": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.0.tgz",
-      "integrity": "sha512-4/aL9X3Wh0yiMQlE+eeRhWP6vclO3QRtw1JHKIT0FFUs5FjpFmESqtMvYZ0+lbzBw900b95mS0hohy+qn2VK/g==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
       "dev": true
     },
     "cli-width": {
@@ -7566,15 +8121,9 @@
       }
     },
     "commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
-      "dev": true
-    },
-    "component-type": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/component-type/-/component-type-1.2.1.tgz",
-      "integrity": "sha512-Kgy+2+Uwr75vAi6ChWXgHuLvd+QLD7ssgpaRq2zCvt80ptvAfMc/hijcJxXkBa2wMlEZcJvC2H8Ubo+A9ATHIg==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.0.0.tgz",
+      "integrity": "sha512-MwVNWlYjDTtOjX5PiD7o5pK0UrFU/OYgcJfjjK4RaHZETNtjJqrZa9Y9ds88+A+f+d5lv+561eZ+yCKoS3gbAA==",
       "dev": true
     },
     "compute-scroll-into-view": {
@@ -7583,17 +8132,17 @@
       "integrity": "sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg=="
     },
     "contentful-management": {
-      "version": "10.38.3",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-10.38.3.tgz",
-      "integrity": "sha512-hAuUSEfPYMQ6aplaENkZM5Zvhg9q+yiCsbm++pyHadUr5x+XKC9D85fASXuA4vI0hB/K66YHaqBiJ7CwAHT9bQ==",
+      "version": "10.46.4",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-10.46.4.tgz",
+      "integrity": "sha512-swOTlKO6AeCRnD5w237ey6wKDXty8shFVm0AisKO2w5seQINlFytgCkZd89E0lxjg4zgjb9maa7AScUtyQUd5w==",
       "requires": {
-        "@contentful/rich-text-types": "^16.0.3",
+        "@contentful/rich-text-types": "^16.3.0",
         "@types/json-patch": "0.0.30",
-        "axios": "^0.27.1",
-        "contentful-sdk-core": "^7.0.1",
+        "axios": "^1.4.0",
+        "contentful-sdk-core": "^8.1.0",
         "fast-copy": "^3.0.0",
         "lodash.isplainobject": "^4.0.6",
-        "type-fest": "^3.0.0"
+        "type-fest": "^4.0.0"
       },
       "dependencies": {
         "fast-copy": {
@@ -7604,15 +8153,15 @@
       }
     },
     "contentful-sdk-core": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-7.0.2.tgz",
-      "integrity": "sha512-HkBzzzJ3UGqOIJiTd4qMEMvn44ccrN7a75gEej28X1srGn05myRgJ/pWbmXJhtgpq/5gU7IURnynyKx/ecsOfg==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-8.1.2.tgz",
+      "integrity": "sha512-XZvX2JMJF4YiICXLrHFv59KBHaQJ6ElqAP8gSNgnCu4x+pPG7Y1bC2JMNOiyAgJuGQGVUOcNZ5PmK+tsNEayYw==",
       "requires": {
-        "fast-copy": "^2.1.3",
+        "fast-copy": "^2.1.7",
         "lodash.isplainobject": "^4.0.6",
         "lodash.isstring": "^4.0.1",
         "p-throttle": "^4.1.1",
-        "qs": "^6.9.4"
+        "qs": "^6.11.2"
       }
     },
     "convert-source-map": {
@@ -7646,12 +8195,6 @@
         "@emotion/utils": "0.11.3"
       }
     },
-    "crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
-      "dev": true
-    },
     "css.escape": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
@@ -7672,9 +8215,9 @@
       }
     },
     "dayjs": {
-      "version": "1.11.9",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.9.tgz",
-      "integrity": "sha512-QvzAURSbQ0pKdIye2txOzNaHmxtUBXerpY0FJsFXUMKbIZeFm5ht1LS/jFsrncjnmtv8HsG0W2g6c0zUjZWmpA=="
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.11.tgz",
+      "integrity": "sha512-okzr3f11N6WuqYtZSvm+F776mB41wRZMhKP+hc34YdW+KmtYYK9iqvHSwo2k9FEH3fhGXvOPV6yz2IcSrfRUDg=="
     },
     "debug": {
       "version": "4.3.4",
@@ -7737,6 +8280,16 @@
         "clone": "^1.0.2"
       }
     },
+    "define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "requires": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      }
+    },
     "define-lazy-prop": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
@@ -7776,9 +8329,9 @@
       "dev": true
     },
     "dotenv": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
-      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
       "dev": true
     },
     "downshift": {
@@ -7793,10 +8346,16 @@
         "tslib": "^2.3.0"
       }
     },
+    "dset": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.3.tgz",
+      "integrity": "sha512-20TuZZHCEZ2O71q9/+8BwKwZ0QtD9D8ObhrihJPr+vLLYlSuAU3/zL4cSlgbfeoGHTjCSJBa7NGcrF9/Bx/WJQ==",
+      "dev": true
+    },
     "electron-to-chromium": {
-      "version": "1.4.449",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.449.tgz",
-      "integrity": "sha512-TxLRpRUj/107ATefeP8VIUWNOv90xJxZZbCW/eIbSZQiuiFANCx2b7u+GbVc9X4gU+xnbvypNMYVM/WArE1DNQ==",
+      "version": "1.4.754",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.754.tgz",
+      "integrity": "sha512-7Kr5jUdns5rL/M9wFFmMZAgFDuL2YOnanFH4OI4iFzUqyh3XOL7nAGbSlSMZdzKMIyyTpNSbqZsWG9odwLeKvA==",
       "dev": true
     },
     "emoji-regex": {
@@ -7827,6 +8386,19 @@
       "requires": {
         "is-arrayish": "^0.2.1"
       }
+    },
+    "es-define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "requires": {
+        "get-intrinsic": "^1.2.4"
+      }
+    },
+    "es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
     },
     "es-get-iterator": {
       "version": "1.1.3",
@@ -7884,9 +8456,9 @@
       }
     },
     "escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
       "dev": true
     },
     "escape-string-regexp": {
@@ -7911,9 +8483,9 @@
       }
     },
     "fast-copy": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-2.1.3.tgz",
-      "integrity": "sha512-LDzYKNTHhD+XOp8wGMuCkY4eTxFZOOycmpwLBiuF3r3OjOmZnURRD8t2dUAbmKuXGbo/MGggwbSjcBdp8QT0+g=="
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-2.1.7.tgz",
+      "integrity": "sha512-ozrGwyuCTAy7YgFCua8rmqmytECYk/JYAMXcswOcm0qvGoE3tPb7ivBeIHTOK2DiapBhDZgacIhzhQIKU5TCfA=="
     },
     "figures": {
       "version": "3.2.0",
@@ -7930,9 +8502,9 @@
       "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
     },
     "focus-lock": {
-      "version": "0.11.6",
-      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.11.6.tgz",
-      "integrity": "sha512-KSuV3ur4gf2KqMNoZx3nXNVhqCkn42GuTYCX4tXPEwf0MjpFQmNMiN6m7dXaUXgIoivL6/65agoUMg4RLS0Vbg==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-1.3.5.tgz",
+      "integrity": "sha512-QFaHbhv9WPUeLYBDe/PAuLKJ4Dd9OPvKs9xZBr3yLXnUrDNaVXKu2baDBXe3naPY30hgHYSsf2JW4jzas2mDEQ==",
       "requires": {
         "tslib": "^2.0.3"
       }
@@ -7969,9 +8541,9 @@
       "optional": true
     },
     "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
     },
     "functions-have-names": {
       "version": "1.2.3",
@@ -7986,20 +8558,21 @@
       "dev": true
     },
     "get-func-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
       "dev": true
     },
     "get-intrinsic": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
-      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
       "requires": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
         "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3"
+        "has-symbols": "^1.0.3",
+        "hasown": "^2.0.0"
       }
     },
     "globals": {
@@ -8012,7 +8585,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
       "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "dev": true,
       "requires": {
         "get-intrinsic": "^1.1.3"
       }
@@ -8083,12 +8655,11 @@
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
     },
     "has-property-descriptors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
-      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
-      "dev": true,
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "requires": {
-        "get-intrinsic": "^1.1.1"
+        "es-define-property": "^1.0.0"
       }
     },
     "has-proto": {
@@ -8110,6 +8681,14 @@
         "has-symbols": "^1.0.2"
       }
     },
+    "hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "requires": {
+        "function-bind": "^1.1.2"
+      }
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -8126,9 +8705,9 @@
       "dev": true
     },
     "ignore": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
+      "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
       "dev": true
     },
     "import-fresh": {
@@ -8147,9 +8726,9 @@
       "dev": true
     },
     "inquirer": {
-      "version": "8.2.5",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.5.tgz",
-      "integrity": "sha512-QAgPDQMEgrDssk1XiwwHoOGYF9BAbUcc1+j+FhEvaOt8/cKRqyLn0U5qA6F74fGhTMGxf92pOvPBeh29jQJDTQ==",
+      "version": "8.2.6",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.6.tgz",
+      "integrity": "sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^4.2.1",
@@ -8166,7 +8745,7 @@
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0",
         "through": "^2.3.6",
-        "wrap-ansi": "^7.0.0"
+        "wrap-ansi": "^6.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -8276,12 +8855,6 @@
         "has-tostringtag": "^1.0.0"
       }
     },
-    "is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
-    },
     "is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -8347,12 +8920,6 @@
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
       }
-    },
-    "is-retry-allowed": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
-      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
-      "dev": true
     },
     "is-set": {
       "version": "2.0.2",
@@ -8431,10 +8998,10 @@
         "is-docker": "^2.0.0"
       }
     },
-    "join-component": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/join-component/-/join-component-1.1.0.tgz",
-      "integrity": "sha512-bF7vcQxbODoGK1imE2P9GS9aw4zD0Sd+Hni68IMZLj7zRnquH7dXUmMw9hDI5S/Jzt7q+IyTXN0rSg2GI0IKhQ==",
+    "jose": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.2.4.tgz",
+      "integrity": "sha512-6ScbIk2WWCeXkmzF6bRPmEuaqy1m8SbsRFMa/FLrSCkGIhj8OLVG/IH+XHVmNMx/KUo8cVWEE6oKR4dJ+S0Rkg==",
       "dev": true
     },
     "js-tokens": {
@@ -8464,6 +9031,14 @@
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
       "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
       "dev": true
+    },
+    "legacy-swc-helpers": {
+      "version": "npm:@swc/helpers@0.4.14",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
+      "integrity": "sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==",
+      "requires": {
+        "tslib": "^2.4.0"
+      }
     },
     "lines-and-columns": {
       "version": "1.2.4",
@@ -8594,17 +9169,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.15"
       }
     },
-    "md5": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-      "dev": true,
-      "requires": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "~1.1.6"
-      }
-    },
     "mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -8654,10 +9218,19 @@
       "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
       "dev": true
     },
+    "node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
+    },
     "node-releases": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.12.tgz",
-      "integrity": "sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
       "dev": true
     },
     "object-assign": {
@@ -8666,9 +9239,9 @@
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
     },
     "object-inspect": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ=="
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
+      "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ=="
     },
     "object-is": {
       "version": "1.1.5",
@@ -8850,8 +9423,7 @@
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "pkg-types": {
       "version": "1.0.3",
@@ -8911,26 +9483,31 @@
         }
       }
     },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "qs": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "version": "6.12.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.1.tgz",
+      "integrity": "sha512-zWmv4RSuB9r2mYQw3zxQuHWeU+42aKi1wWig/j4ele4ygELZ7PEO6MM7rim9oAQH2A5MWfsAVf/jPvTPgCbvUQ==",
       "requires": {
-        "side-channel": "^1.0.4"
+        "side-channel": "^1.0.6"
       }
     },
     "react": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "requires": {
         "loose-envify": "^1.1.0"
       }
     },
     "react-animate-height": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/react-animate-height/-/react-animate-height-3.1.1.tgz",
-      "integrity": "sha512-UkC6+V3ZlCneBRaSM7aUctDJ+PRP6ztcGtxvU7MTeoMMWPhz8BQNaX7QWaZrkzp1ih1G8uZZ+DI9nfLvtD6OdQ==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/react-animate-height/-/react-animate-height-3.2.3.tgz",
+      "integrity": "sha512-R6DSvr7ud07oeCixScyvXWEMJY/Mt2+GyOWC1KMaRc69gOBw+SsCg4TJmrp4rKUM1hyd6p+YKw90brjPH93Y2A==",
       "requires": {}
     },
     "react-clientside-effect": {
@@ -8942,18 +9519,18 @@
       }
     },
     "react-day-picker": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.8.0.tgz",
-      "integrity": "sha512-QIC3uOuyGGbtypbd5QEggsCSqVaPNu8kzUWquZ7JjW9fuWB9yv7WyixKmnaFelTLXFdq7h7zU6n/aBleBqe/dA==",
+      "version": "8.10.1",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.10.1.tgz",
+      "integrity": "sha512-TMx7fNbhLk15eqcMt+7Z7S2KF7mfTId/XJDjKE8f+IUcFn0l08/kI4FiYTL/0yuOLmEcbR4Fwe3GJf/NiiMnPA==",
       "requires": {}
     },
     "react-dom": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
-      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "requires": {
         "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.0"
+        "scheduler": "^0.23.2"
       }
     },
     "react-fast-compare": {
@@ -8962,15 +9539,15 @@
       "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
     },
     "react-focus-lock": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.4.tgz",
-      "integrity": "sha512-7pEdXyMseqm3kVjhdVH18sovparAzLg5h6WvIx7/Ck3ekjhrrDMEegHSa3swwC8wgfdd7DIdUVRGeiHT9/7Sgg==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.12.1.tgz",
+      "integrity": "sha512-lfp8Dve4yJagkHiFrC1bGtib3mF2ktqwPJw4/WGcgPW+pJ/AVQA5X2vI7xgp13FcxFEpYBBHpXai/N2DBNC0Jw==",
       "requires": {
         "@babel/runtime": "^7.0.0",
-        "focus-lock": "^0.11.6",
+        "focus-lock": "^1.3.5",
         "prop-types": "^15.6.2",
         "react-clientside-effect": "^1.2.6",
-        "use-callback-ref": "^1.3.0",
+        "use-callback-ref": "^1.3.2",
         "use-sidecar": "^1.1.2"
       }
     },
@@ -9037,12 +9614,6 @@
         "functions-have-names": "^1.2.3"
       }
     },
-    "remove-trailing-slash": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/remove-trailing-slash/-/remove-trailing-slash-0.1.1.tgz",
-      "integrity": "sha512-o4S4Qh6L2jpnCy83ysZDau+VORNvnFw07CKSAymkd6ICNVEPisMyzlc00KlvvicsxKck94SEwhDnMNdICzO+tA==",
-      "dev": true
-    },
     "resolve": {
       "version": "1.22.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
@@ -9104,21 +9675,41 @@
       "dev": true
     },
     "scheduler": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
-      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "requires": {
         "loose-envify": "^1.1.0"
       }
     },
-    "side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+    "semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true
+    },
+    "set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
       "requires": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      }
+    },
+    "side-channel": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
+      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+      "requires": {
+        "call-bind": "^1.0.7",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.4",
+        "object-inspect": "^1.13.1"
       }
     },
     "siginfo": {
@@ -9262,6 +9853,12 @@
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog=="
     },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
+    },
     "truncate": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/truncate/-/truncate-3.0.0.tgz",
@@ -9279,9 +9876,9 @@
       "dev": true
     },
     "type-fest": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.12.0.tgz",
-      "integrity": "sha512-qj9wWsnFvVEMUDbESiilKeXeHL7FwwiFcogfhfyjmvT968RXSvnl23f1JOClTHYItsi7o501C/7qVllscUP3oA=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.18.1.tgz",
+      "integrity": "sha512-qXhgeNsX15bM63h5aapNFcQid9jRF/l3ojDoDFmekDQEUufZ9U4ErVt6SjDxnHp48Ltrw616R8yNc3giJ3KvVQ=="
     },
     "typescript": {
       "version": "5.1.6",
@@ -9296,19 +9893,19 @@
       "dev": true
     },
     "update-browserslist-db": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
-      "integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.14.tgz",
+      "integrity": "sha512-JixKH8GR2pWYshIPUg/NujK3JO7JiqEEUiNArE86NQyrgUuZeTlZQN3xuS/yiV5Kb48ev9K6RqNkaJjXsdg7Jw==",
       "dev": true,
       "requires": {
-        "escalade": "^3.1.1",
+        "escalade": "^3.1.2",
         "picocolors": "^1.0.0"
       }
     },
     "use-callback-ref": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.0.tgz",
-      "integrity": "sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.2.tgz",
+      "integrity": "sha512-elOQwe6Q8gqZgDA8mrh44qRTQqpIHDcZ3hXTLjBe1i4ph8XpNJnO+aQf3NaG+lriLopI4HMx9VjQLfPQ6vhnoA==",
       "requires": {
         "tslib": "^2.0.0"
       }
@@ -9326,12 +9923,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
-    },
-    "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "dev": true
     },
     "vite": {
@@ -9409,6 +10000,22 @@
         "defaults": "^1.0.3"
       }
     },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "which-boxed-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
@@ -9459,9 +10066,9 @@
       }
     },
     "wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
       "dev": true,
       "requires": {
         "ansi-styles": "^4.0.0",

--- a/examples/vite-react/package.json
+++ b/examples/vite-react/package.json
@@ -3,14 +3,14 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@contentful/app-sdk": "4.22.0",
-    "@contentful/f36-components": "4.45.0",
+    "@contentful/app-sdk": "4.25.0",
+    "@contentful/f36-components": "4.65.4",
     "@contentful/f36-tokens": "4.0.2",
     "@contentful/react-apps-toolkit": "1.2.16",
-    "contentful-management": "10.38.3",
+    "contentful-management": "10.46.4",
     "emotion": "10.0.27",
-    "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
   },
   "scripts": {
     "start": "vite",
@@ -21,12 +21,12 @@
     "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./dist  --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN"
   },
   "devDependencies": {
-    "@contentful/app-scripts": "1.10.2",
+    "@contentful/app-scripts": "1.19.1",
     "@testing-library/react": "14.0.0",
     "@types/node": "16.18.38",
-    "@types/react": "18.2.14",
-    "@types/react-dom": "18.2.6",
-    "@vitejs/plugin-react": "4.0.1",
+    "@types/react": "18.3.1",
+    "@types/react-dom": "18.3.0",
+    "@vitejs/plugin-react": "4.2.1",
     "happy-dom": "9.20.3",
     "typescript": "5.1.6",
     "vite": "4.5.3",


### PR DESCRIPTION
## Purpose

<!-- Why are we introducing this change now? What problem does it solve? What is the story/background for it? -->

vite-react template needs these new react versions in order to build properly 

## Approach

<!-- Why did we do it the way we did? Did we consider alternatives? What other implementation details or artifacts (screenshots etc.) would help reviewers contextualize change? -->

also went ahead and safely bumped other deps to resolve all security issues from audit

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

See https://github.com/contentful/apps/issues/7538

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

These upgrades should not introduce any breaking changes

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

See https://github.com/remix-run/remix/issues/7514 
