### PR TITLE
chore(dam-app-base): remove react v18 peer dependency.

### DIFF
--- a/packages/dam-app-base/package.json
+++ b/packages/dam-app-base/package.json
@@ -38,8 +38,8 @@
     "emotion": "^10.0.0"
   },
   "peerDependencies": {
-    "react": "^16.3.0 || ^17.0.0 || ^18.2.0",
-    "react-dom": "^16.3.0 || ^17.0.0 || ^18.2.0"
+    "react": "^16.3.0 || ^17.0.0",
+    "react-dom": "^16.3.0 || ^17.0.0"
   },
   "scripts": {
     "build": "rimraf lib && tsc",


### PR DESCRIPTION
## Purpose
As a team, it was decided to create new major versions of the `dam-app-base` and `ecommerce-app-base` for any consumers that are running react v18+.

This PR **removes** the peer dependency definition of react 18, i.e. this current major version is expected to only work with consumers running react v16 or v17.

Going forward, if a consumer is running react v18+ they will need to use dam-app-base v3+

