### PR TITLE
feat: add error message when project not aligned to spaceId

### DIFF
--- a/apps/vercel/frontend/src/clients/Vercel.ts
+++ b/apps/vercel/frontend/src/clients/Vercel.ts
@@ -162,7 +162,7 @@ export default class VercelClient implements VercelAPIClient {
     teamId: string
   ) {
     try {
-      const data = await this.listProject(projectId, teamId);
+      const data = await this.getProject(projectId, teamId);
       const envs = data.env;
       const contentfulSpaceIdEnv = envs.find((env) => env.key === CONTENTFUL_SPACE_ID);
       if (contentfulSpaceIdEnv) {
@@ -187,7 +187,7 @@ export default class VercelClient implements VercelAPIClient {
     return false;
   }
 
-  private async listProject(projectId: string, teamId: string): Promise<Project> {
+  private async getProject(projectId: string, teamId: string): Promise<Project> {
     let projectData: Response;
     try {
       projectData = await fetch(

--- a/apps/vercel/frontend/src/clients/Vercel.ts
+++ b/apps/vercel/frontend/src/clients/Vercel.ts
@@ -167,7 +167,9 @@ export default class VercelClient implements VercelAPIClient {
       const contentfulSpaceIdEnv = envs.find((env) => env.key === CONTENTFUL_SPACE_ID);
       if (contentfulSpaceIdEnv) {
         const res = await fetch(
-          `${this.baseEndpoint}/v1/projects/${projectId}/env/${contentfulSpaceIdEnv.id}`,
+          `${this.baseEndpoint}/v1/projects/${projectId}/env/${
+            contentfulSpaceIdEnv.id
+          }?${this.buildTeamIdQueryParam(teamId)}`,
           {
             headers: this.buildHeaders(),
             method: 'GET',

--- a/apps/vercel/frontend/src/clients/Vercel.ts
+++ b/apps/vercel/frontend/src/clients/Vercel.ts
@@ -180,7 +180,7 @@ export default class VercelClient implements VercelAPIClient {
         return data.value === currentSpaceId;
       }
     } catch (e) {
-      // let user continue if there is an validating env value
+      // let user continue if there is an error validating env value
       console.error(e);
     }
 

--- a/apps/vercel/frontend/src/clients/Vercel.ts
+++ b/apps/vercel/frontend/src/clients/Vercel.ts
@@ -207,8 +207,10 @@ export default class VercelClient implements VercelAPIClient {
   }
 
   private filterServerlessFunctions(data: ServerlessFunction[]) {
+    const irrelevantServerlessFunctionType = 'ISR';
     return data.filter(
-      (file: ServerlessFunction) => file.type === 'Page' && file.path.includes('api')
+      (file: ServerlessFunction) =>
+        file.type != irrelevantServerlessFunctionType && file.path.includes('api')
     );
   }
 

--- a/apps/vercel/frontend/src/clients/Vercel.ts
+++ b/apps/vercel/frontend/src/clients/Vercel.ts
@@ -6,7 +6,11 @@ import {
   ServerlessFunction,
   AccessToken,
   Deployment,
+  ProjectEnv,
+  Project,
 } from '@customTypes/configPage';
+
+const CONTENTFUL_SPACE_ID = 'CONTENTFUL_SPACE_ID';
 
 interface GetToken {
   ok: boolean;
@@ -18,6 +22,12 @@ interface VercelAPIClient {
   getToken: () => Promise<Response>;
   listProjects: (teamId?: string) => Promise<ListProjectsResponse>;
   listApiPaths: (projectId: string, teamId?: string) => Promise<ApiPath[]>;
+  validateProjectContentfulSpaceId: (
+    currentSpaceId: string,
+    projectId: string,
+    teamId: string,
+    envs: ProjectEnv[]
+  ) => Promise<boolean>;
 }
 
 export default class VercelClient implements VercelAPIClient {
@@ -144,6 +154,54 @@ export default class VercelClient implements VercelAPIClient {
 
     // Vercel returns deployments sorted by date in descending order
     return data.deployments[0];
+  }
+
+  async validateProjectContentfulSpaceId(
+    currentSpaceId: string,
+    projectId: string,
+    teamId: string
+  ) {
+    try {
+      const data = await this.listProject(projectId, teamId);
+      const envs = data.env;
+      const contentfulSpaceIdEnv = envs.find((env) => env.key === CONTENTFUL_SPACE_ID);
+      if (contentfulSpaceIdEnv) {
+        const res = await fetch(
+          `${this.baseEndpoint}/v1/projects/${projectId}/env/${contentfulSpaceIdEnv.id}`,
+          {
+            headers: this.buildHeaders(),
+            method: 'GET',
+          }
+        );
+
+        const data = await res.json();
+        return data.value === currentSpaceId;
+      }
+    } catch (e) {
+      // let user continue if there is an validating env value
+      console.error(e);
+    }
+
+    return false;
+  }
+
+  private async listProject(projectId: string, teamId: string): Promise<Project> {
+    let projectData: Response;
+    try {
+      projectData = await fetch(
+        `${this.baseEndpoint}/v9/projects/${projectId}?${this.buildTeamIdQueryParam(teamId)}`,
+        {
+          headers: this.buildHeaders(),
+          method: 'GET',
+        }
+      );
+    } catch (e) {
+      console.error(e);
+      throw new Error('Cannot fetch project data.');
+    }
+
+    const data = await projectData.json();
+    return data;
   }
 
   private filterServerlessFunctions(data: ServerlessFunction[]) {

--- a/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.spec.tsx
+++ b/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.spec.tsx
@@ -24,7 +24,7 @@ describe('SelectSection', () => {
         options={paths}
         section={ID}
         id={ID}
-        handleInvalidSelectionError={vi.fn()}
+        handleNotFoundError={vi.fn()}
         handleChange={vi.fn()}
         selectedOption={parameters.selectedApiPath}
       />
@@ -51,7 +51,7 @@ describe('SelectSection', () => {
         section={ID}
         id={ID}
         handleChange={mockHandleChange}
-        handleInvalidSelectionError={vi.fn()}
+        handleNotFoundError={vi.fn()}
         selectedOption={parameters.selectedApiPath}
       />,
       { handleAppConfigurationChange: mockHandleAppConfigurationChange }
@@ -85,7 +85,7 @@ describe('SelectSection', () => {
         id={ID}
         selectedOption={'non-existent-id'}
         handleChange={vi.fn()}
-        handleInvalidSelectionError={mockHandleInvalidSelectionError}
+        handleNotFoundError={mockHandleInvalidSelectionError}
         error={projectSelectionError}
       />
     );

--- a/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.spec.tsx
+++ b/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.spec.tsx
@@ -72,7 +72,11 @@ describe('SelectSection', () => {
 
   it('renders error message when selected option no longer exists', () => {
     const ID = singleSelectionSections.PROJECT_SELECTION_SECTION;
-    const projectSelectionError = { projectNotFound: true, cannotFetchProjects: false };
+    const projectSelectionError = {
+      projectNotFound: true,
+      cannotFetchProjects: false,
+      invalidSpaceId: false,
+    };
     const mockHandleInvalidSelectionError = vi.fn(() => {});
     const { unmount } = render(
       <SelectSection

--- a/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.tsx
+++ b/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.tsx
@@ -34,7 +34,7 @@ export const SelectSection = ({
 }: Props) => {
   const { placeholder, label, emptyMessage, helpText: helpTextCopy } = copies.configPage[section];
   const { isLoading } = useContext(ConfigPageContext);
-  const { isError, message } = useError({ error });
+  const { message } = useError({ error });
 
   useEffect(() => {
     if (!isLoading) {
@@ -51,7 +51,7 @@ export const SelectSection = ({
   return (
     <FormControl marginBottom="spacingS" id={id} isRequired={true}>
       <Select
-        value={isError ? '' : selectedOption}
+        value={selectedOption}
         onChange={handleChange}
         placeholder={placeholder}
         emptyMessage={emptyMessage}

--- a/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.tsx
+++ b/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.tsx
@@ -16,7 +16,7 @@ interface Props {
   options: Path[] | Project[];
   section: CopySection;
   id: string;
-  handleInvalidSelectionError: () => void;
+  handleNotFoundError: () => void;
   handleChange: (event: ChangeEvent<HTMLSelectElement>) => void;
   helpText?: string | React.ReactNode;
   error?: Errors['projectSelection'] | Errors['apiPathSelection'];
@@ -29,7 +29,7 @@ export const SelectSection = ({
   id,
   helpText,
   error,
-  handleInvalidSelectionError,
+  handleNotFoundError,
   handleChange,
 }: Props) => {
   const { placeholder, label, emptyMessage, helpText: helpTextCopy } = copies.configPage[section];
@@ -43,7 +43,7 @@ export const SelectSection = ({
       const areOptionsAvailable = options.length === 0;
 
       if (!isValidSelection && !areOptionsAvailable) {
-        handleInvalidSelectionError();
+        handleNotFoundError();
       }
     }
   }, [selectedOption, options, isLoading]);

--- a/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/ApiPathSelectionSection.spec.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/ApiPathSelectionSection.spec.tsx
@@ -4,6 +4,7 @@ import { screen } from '@testing-library/react';
 import { ApiPathSelectionSection } from './ApiPathSelectionSection';
 import { renderConfigPageComponent } from '@test/helpers/renderConfigPageComponent';
 import { ApiPath } from '@customTypes/configPage';
+import { copies } from '@constants/copies';
 
 describe('ApiPathSelectionSection', () => {
   it('renders dropdown when paths are present and no errors are present', () => {
@@ -60,6 +61,19 @@ describe('ApiPathSelectionSection', () => {
 
     const input = screen.getByTestId('apiPathInput');
     expect(input).toBeTruthy();
+    unmount();
+  });
+
+  it('renders no selected value in dropdown when apiPathNotFound error', () => {
+    const paths = [{ id: 'path-1', name: 'Path/1' }];
+    const errors = { apiPathSelection: { apiPathNotFound: true }, selectedApiPath: 'path-1' };
+    const { unmount } = renderConfigPageComponent(
+      <ApiPathSelectionSection paths={paths} />,
+      errors
+    );
+
+    const emptyInput = screen.getByText(copies.configPage.pathSelectionSection.placeholder);
+    expect(emptyInput).toBeTruthy();
     unmount();
   });
 });

--- a/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/ApiPathSelectionSection.spec.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/ApiPathSelectionSection.spec.tsx
@@ -1,10 +1,11 @@
-import { describe, expect, it } from 'vitest';
-import { screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
 
 import { ApiPathSelectionSection } from './ApiPathSelectionSection';
 import { renderConfigPageComponent } from '@test/helpers/renderConfigPageComponent';
-import { ApiPath } from '@customTypes/configPage';
+import { ApiPath, AppInstallationParameters } from '@customTypes/configPage';
 import { copies } from '@constants/copies';
+import userEvent from '@testing-library/user-event';
 
 describe('ApiPathSelectionSection', () => {
   it('renders dropdown when paths are present and no errors are present', () => {
@@ -74,6 +75,27 @@ describe('ApiPathSelectionSection', () => {
 
     const emptyInput = screen.getByText(copies.configPage.pathSelectionSection.placeholder);
     expect(emptyInput).toBeTruthy();
+    unmount();
+  });
+
+  it('handles path selection', async () => {
+    const user = userEvent.setup();
+
+    const paths = [{ id: 'path-1', name: 'Path/1' }];
+    const mockDispatchParameters = vi.fn();
+    const parameters = {
+      dispatchParameters: mockDispatchParameters,
+    } as unknown as AppInstallationParameters;
+    const { unmount } = renderConfigPageComponent(
+      <ApiPathSelectionSection paths={paths} />,
+      parameters
+    );
+
+    const selectDropdown = screen.getByTestId('optionsSelect');
+
+    user.selectOptions(selectDropdown, paths[0].name);
+
+    await waitFor(() => expect(mockDispatchParameters).toHaveBeenCalled());
     unmount();
   });
 });

--- a/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/ApiPathSelectionSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/ApiPathSelectionSection.tsx
@@ -22,6 +22,8 @@ export const ApiPathSelectionSection = ({ paths }: Props) => {
     useContext(ConfigPageContext);
   const { invalidDeploymentData, cannotFetchApiPaths } = errors.apiPathSelection;
 
+  const selectedOption = errors.apiPathSelection ? '' : parameters.selectedApiPath;
+
   const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
     dispatchParameters({
       type: parametersActions.APPLY_API_PATH,
@@ -47,7 +49,7 @@ export const ApiPathSelectionSection = ({ paths }: Props) => {
 
     return (
       <SelectSection
-        selectedOption={parameters.selectedApiPath}
+        selectedOption={selectedOption}
         options={paths}
         handleInvalidSelectionError={handleInvalidSelectionError}
         handleChange={handleChange}

--- a/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/ApiPathSelectionSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/ApiPathSelectionSection.tsx
@@ -35,7 +35,7 @@ export const ApiPathSelectionSection = ({ paths }: Props) => {
     });
   };
 
-  const handleInvalidSelectionError = () => {
+  const handlePathNotFoundError = () => {
     dispatchErrors({
       type: errorsActions.UPDATE_API_PATH_SELECTION_ERRORS,
       payload: errorTypes.API_PATH_NOT_FOUND,
@@ -51,7 +51,7 @@ export const ApiPathSelectionSection = ({ paths }: Props) => {
       <SelectSection
         selectedOption={selectedOption}
         options={paths}
-        handleInvalidSelectionError={handleInvalidSelectionError}
+        handleNotFoundError={handlePathNotFoundError}
         handleChange={handleChange}
         section={sectionId}
         id={sectionId}

--- a/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/ApiPathSelectionSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/ApiPathSelectionSection.tsx
@@ -20,9 +20,9 @@ export const ApiPathSelectionSection = ({ paths }: Props) => {
   const sectionId = singleSelectionSections.API_PATH_SELECTION_SECTION;
   const { parameters, isLoading, dispatchErrors, errors, dispatchParameters } =
     useContext(ConfigPageContext);
-  const { invalidDeploymentData, cannotFetchApiPaths } = errors.apiPathSelection;
+  const { invalidDeploymentData, cannotFetchApiPaths, apiPathNotFound } = errors.apiPathSelection;
 
-  const selectedOption = errors.apiPathSelection ? '' : parameters.selectedApiPath;
+  const selectedOption = apiPathNotFound ? '' : parameters.selectedApiPath;
 
   const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
     dispatchParameters({

--- a/apps/vercel/frontend/src/components/config-screen/ProjectSelectionSection/ProjectSelectionSection.spec.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ProjectSelectionSection/ProjectSelectionSection.spec.tsx
@@ -37,6 +37,7 @@ describe('ProjectSelectionSection', () => {
   });
 
   it('handles project selection', async () => {
+    const user = userEvent.setup();
     const mockValidation = vi.fn().mockImplementationOnce(() => Promise.resolve());
     vi.spyOn(fetchData, 'useFetchData').mockReturnValue({
       validateProjectEnv: mockValidation,
@@ -44,20 +45,17 @@ describe('ProjectSelectionSection', () => {
       fetchProjects: vi.fn(),
       fetchApiPaths: vi.fn(),
     });
-    const user = userEvent.setup();
     const mockHandleAppConfigurationChange = vi.fn();
     const mockDispatchParameters = vi.fn();
-    const parameters = {
+    const overrides = {
       dispatchParameters: mockDispatchParameters,
       handleAppConfigurationChange: mockHandleAppConfigurationChange,
+      parameters: { teamId: '1234', selectedProject: projects[0].id },
     } as unknown as AppInstallationParameters;
-    const projects = [
-      { id: 'project-1', name: 'Project 1', targets: { production: { id: 'project-1' } }, env: [] },
-    ];
-    const { unmount } = renderConfigPageComponent(
-      <ProjectSelectionSection projects={projects} />,
-      parameters
-    );
+
+    const { unmount } = renderConfigPageComponent(<ProjectSelectionSection projects={projects} />, {
+      ...overrides,
+    });
 
     const selectDropdown = screen.getByTestId('optionsSelect');
 

--- a/apps/vercel/frontend/src/components/config-screen/ProjectSelectionSection/ProjectSelectionSection.spec.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ProjectSelectionSection/ProjectSelectionSection.spec.tsx
@@ -1,0 +1,71 @@
+import { screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { AppInstallationParameters } from '@customTypes/configPage';
+import { ProjectSelectionSection } from './ProjectSelectionSection';
+import { copies } from '@constants/copies';
+import { renderConfigPageComponent } from '@test/helpers/renderConfigPageComponent';
+import userEvent from '@testing-library/user-event';
+import * as fetchData from '@hooks/useFetchData/useFetchData';
+
+const projects = [
+  { id: 'project-1', name: 'Project 1', targets: { production: { id: 'project-1' } }, env: [] },
+];
+
+describe('ProjectSelectionSection', () => {
+  it('renders dropdown when paths are present and no errors are present', () => {
+    const { unmount } = renderConfigPageComponent(<ProjectSelectionSection projects={projects} />);
+
+    const select = screen.getByTestId('optionsSelect');
+    expect(select).toBeTruthy();
+    unmount();
+  });
+
+  it('renders no selected value in dropdown when projectNotFound error', () => {
+    const mockDispatchParameters = vi.fn();
+    const parameters = {
+      dispatchParameters: mockDispatchParameters,
+    } as unknown as AppInstallationParameters;
+    const { unmount } = renderConfigPageComponent(
+      <ProjectSelectionSection projects={projects} />,
+      parameters
+    );
+
+    const emptyInput = screen.getByText(copies.configPage.projectSelectionSection.placeholder);
+    expect(emptyInput).toBeTruthy();
+    unmount();
+  });
+
+  it('handles project selection', async () => {
+    const mockValidation = vi.fn().mockImplementationOnce(() => Promise.resolve());
+    vi.spyOn(fetchData, 'useFetchData').mockReturnValue({
+      validateProjectEnv: mockValidation,
+      validateToken: vi.fn(),
+      fetchProjects: vi.fn(),
+      fetchApiPaths: vi.fn(),
+    });
+    const user = userEvent.setup();
+    const mockHandleAppConfigurationChange = vi.fn();
+    const mockDispatchParameters = vi.fn();
+    const parameters = {
+      dispatchParameters: mockDispatchParameters,
+      handleAppConfigurationChange: mockHandleAppConfigurationChange,
+    } as unknown as AppInstallationParameters;
+    const projects = [
+      { id: 'project-1', name: 'Project 1', targets: { production: { id: 'project-1' } }, env: [] },
+    ];
+    const { unmount } = renderConfigPageComponent(
+      <ProjectSelectionSection projects={projects} />,
+      parameters
+    );
+
+    const selectDropdown = screen.getByTestId('optionsSelect');
+
+    user.selectOptions(selectDropdown, projects[0].name);
+
+    await waitFor(() => expect(mockHandleAppConfigurationChange).toBeCalled());
+    await waitFor(() => expect(mockDispatchParameters).toBeCalled());
+    await waitFor(() => expect(mockValidation).toBeCalled());
+    unmount();
+  });
+});

--- a/apps/vercel/frontend/src/components/config-screen/ProjectSelectionSection/ProjectSelectionSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ProjectSelectionSection/ProjectSelectionSection.tsx
@@ -34,7 +34,7 @@ export const ProjectSelectionSection = ({ projects }: Props) => {
     teamId: parameters.teamId,
   });
 
-  const handleChange = async (event: ChangeEvent<HTMLSelectElement>) => {
+  const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
     // indicate app config change when project has been re-selected
     handleAppConfigurationChange();
 

--- a/apps/vercel/frontend/src/components/config-screen/ProjectSelectionSection/ProjectSelectionSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ProjectSelectionSection/ProjectSelectionSection.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useContext } from 'react';
+import { ChangeEvent, useContext, useEffect } from 'react';
 
 import { Project } from '@customTypes/configPage';
 import { SectionWrapper } from '@components/common/SectionWrapper/SectionWrapper';
@@ -48,12 +48,17 @@ export const ProjectSelectionSection = ({ projects }: Props) => {
       type: parametersActions.APPLY_SELECTED_PROJECT,
       payload: event.target.value,
     });
-
-    const currentSpaceId = sdk.ids.space;
-    await validateProjectEnv(currentSpaceId, event.target.value);
   };
 
-  const handleInvalidSelectionError = () => {
+  useEffect(() => {
+    const currentSpaceId = sdk.ids.space;
+    const validateProjectSelectionEnv = async () => {
+      await validateProjectEnv(currentSpaceId, parameters.selectedProject);
+    };
+    if (parameters.selectedProject) validateProjectSelectionEnv();
+  }, [parameters.selectedProject, vercelClient, parameters.teamId]);
+
+  const handleProjectNotFoundError = () => {
     dispatchErrors({
       type: errorsActions.UPDATE_PROJECT_SELECTION_ERRORS,
       payload: errorTypes.PROJECT_NOT_FOUND,
@@ -67,7 +72,7 @@ export const ProjectSelectionSection = ({ projects }: Props) => {
       <SelectSection
         selectedOption={selectedOption}
         options={projects}
-        handleInvalidSelectionError={handleInvalidSelectionError}
+        handleNotFoundError={handleProjectNotFoundError}
         section={sectionId}
         id={sectionId}
         error={errors.projectSelection}

--- a/apps/vercel/frontend/src/constants/defaultParams.ts
+++ b/apps/vercel/frontend/src/constants/defaultParams.ts
@@ -17,6 +17,7 @@ export const initialErrors: Errors = {
   projectSelection: {
     projectNotFound: false,
     cannotFetchProjects: false,
+    invalidSpaceId: false,
   },
   apiPathSelection: {
     apiPathNotFound: false,

--- a/apps/vercel/frontend/src/constants/enums.ts
+++ b/apps/vercel/frontend/src/constants/enums.ts
@@ -36,4 +36,5 @@ export enum errorTypes {
   EMPTY_PREVIEW_PATH_INPUT = 'emptyPreviewPathInput',
   API_PATHS_EMPTY = 'apiPathsEmpty',
   INVALID_DEPLOYMENT_DATA = 'invalidDeploymentData',
+  INVALID_SPACE_ID = 'invalidSpaceId',
 }

--- a/apps/vercel/frontend/src/constants/errorMessages.ts
+++ b/apps/vercel/frontend/src/constants/errorMessages.ts
@@ -12,4 +12,6 @@ export const errorMessages = {
   invalidPreviewPathFormat: 'Path must start with a "/", and include a {token}.',
   emptyPreviewPathInput: 'Field is empty.',
   invalidDeploymentData: 'We had trouble fetching routes for this Vercel project.',
+  invalidSpaceId:
+    'It looks like you’ve configured an environment variable, CONTENTFUL_SPACE_ID, in the selected Vercel project that doesn’t match the id of the space where this app is installed.',
 };

--- a/apps/vercel/frontend/src/contexts/ConfigPageProvider.tsx
+++ b/apps/vercel/frontend/src/contexts/ConfigPageProvider.tsx
@@ -1,8 +1,9 @@
 import { createContext, Dispatch } from 'react';
-import { ContentType } from '@contentful/app-sdk';
+import { ConfigAppSDK, ContentType } from '@contentful/app-sdk';
 import { ParameterAction } from '@reducers/parameterReducer';
 import { AppInstallationParameters, Errors } from '@customTypes/configPage';
 import { ErrorAction } from '@reducers/errorsReducer';
+import VercelClient from '@clients/Vercel';
 
 interface ConfigPageContextValue {
   isAppConfigurationSaved: boolean;
@@ -13,6 +14,8 @@ interface ConfigPageContextValue {
   dispatchErrors: Dispatch<ErrorAction>;
   handleAppConfigurationChange: () => void;
   isLoading: boolean;
+  sdk: ConfigAppSDK;
+  vercelClient: VercelClient | null;
 }
 
 export interface ChannelContextProviderProps extends ConfigPageContextValue {
@@ -32,6 +35,8 @@ export const ConfigPageProvider = (props: ChannelContextProviderProps) => {
     errors,
     handleAppConfigurationChange,
     isLoading,
+    sdk,
+    vercelClient,
   } = props;
 
   return (
@@ -45,6 +50,8 @@ export const ConfigPageProvider = (props: ChannelContextProviderProps) => {
         errors,
         handleAppConfigurationChange,
         isLoading,
+        sdk,
+        vercelClient,
       }}>
       {children}
     </ConfigPageContext.Provider>

--- a/apps/vercel/frontend/src/customTypes/configPage.ts
+++ b/apps/vercel/frontend/src/customTypes/configPage.ts
@@ -17,6 +17,11 @@ export interface AppInstallationParameters {
   teamId?: string;
 }
 
+export type ProjectEnv = {
+  key: string;
+  id: string;
+  value: string;
+};
 export interface Project {
   id: string;
   name: string;
@@ -25,6 +30,7 @@ export interface Project {
       id: string;
     };
   };
+  env: ProjectEnv[];
 }
 
 export interface Deployment {
@@ -86,6 +92,7 @@ export type Errors = {
   projectSelection: {
     projectNotFound: boolean;
     cannotFetchProjects: boolean;
+    invalidSpaceId: boolean;
   };
   apiPathSelection: {
     apiPathNotFound: boolean;

--- a/apps/vercel/frontend/src/hooks/useFetchData/useFetchData.tsx
+++ b/apps/vercel/frontend/src/hooks/useFetchData/useFetchData.tsx
@@ -102,5 +102,30 @@ export const useFetchData = ({
     }
   };
 
-  return { validateToken, fetchProjects, fetchApiPaths };
+  const validateProjectEnv = async (currentSpaceId: string, projectId: string) => {
+    if (vercelClient && teamId)
+      try {
+        const isProjectSelectionValid = await vercelClient.validateProjectContentfulSpaceId(
+          currentSpaceId,
+          projectId,
+          teamId
+        );
+        if (!isProjectSelectionValid) throw new Error(errorTypes.INVALID_SPACE_ID);
+        else {
+          dispatchErrors({
+            type: errorsActions.RESET_PROJECT_SELECTION_ERRORS,
+          });
+        }
+      } catch (e) {
+        const err = e as Error;
+        if (err.message === errorTypes.INVALID_SPACE_ID) {
+          dispatchErrors({
+            type: errorsActions.UPDATE_PROJECT_SELECTION_ERRORS,
+            payload: errorTypes.INVALID_SPACE_ID,
+          });
+        }
+      }
+  };
+
+  return { validateToken, fetchProjects, fetchApiPaths, validateProjectEnv };
 };

--- a/apps/vercel/frontend/src/locations/ConfigScreen.spec.tsx
+++ b/apps/vercel/frontend/src/locations/ConfigScreen.spec.tsx
@@ -33,6 +33,7 @@ describe('ConfigScreen', () => {
               id: '',
             },
           },
+          env: [],
         },
       ],
     });

--- a/apps/vercel/frontend/src/locations/ConfigScreen.tsx
+++ b/apps/vercel/frontend/src/locations/ConfigScreen.tsx
@@ -165,6 +165,8 @@ const ConfigScreen = () => {
       dispatchErrors={dispatchErrors}
       isLoading={isLoading}
       parameters={parameters}
+      sdk={sdk}
+      vercelClient={vercelClient}
       errors={errors}>
       <Box className={styles.body}>
         <Box>

--- a/apps/vercel/frontend/test/helpers/renderConfigPageComponent.tsx
+++ b/apps/vercel/frontend/test/helpers/renderConfigPageComponent.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { mockContentTypes } from '../mocks/mockContentTypes';
 import { mockContentTypePreviewPathSelections } from '../mocks/mockContentTypePreviewPathSelections';
-import { ConfigPageContext } from '../../src/contexts/ConfigPageProvider';
-import { AppInstallationParameters, Errors } from '../../src/customTypes/configPage';
+import { ConfigPageContext } from '@contexts/ConfigPageProvider';
+import { AppInstallationParameters, Errors } from '@customTypes/configPage';
 import { initialErrors } from '@constants/defaultParams';
+import { mockSdk } from '@test/mocks';
 
 export const renderConfigPageComponent = (
   children: React.ReactNode,
@@ -26,6 +27,8 @@ export const renderConfigPageComponent = (
         isAppConfigurationSaved: false,
         handleAppConfigurationChange: () => null,
         isLoading: false,
+        sdk: mockSdk,
+        vercelClient: null,
         ...overrides,
       }}>
       {children}

--- a/apps/vercel/frontend/test/helpers/renderConfigPageHook.tsx
+++ b/apps/vercel/frontend/test/helpers/renderConfigPageHook.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { mockContentTypes } from '../mocks/mockContentTypes';
 import { mockContentTypePreviewPathSelections } from '../mocks/mockContentTypePreviewPathSelections';
-import { ConfigPageContext } from '../../src/contexts/ConfigPageProvider';
-import { AppInstallationParameters, Errors } from '../../src/customTypes/configPage';
+import { ConfigPageContext } from '@contexts/ConfigPageProvider';
+import { AppInstallationParameters, Errors } from '@customTypes/configPage';
 import { initialErrors } from '@constants/defaultParams';
+import { mockSdk } from '@test/mocks';
 
 export const renderConfigPageHook = ({ children }: { children: React.ReactNode }) => (
   <ConfigPageContext.Provider
@@ -20,6 +21,8 @@ export const renderConfigPageHook = ({ children }: { children: React.ReactNode }
       isAppConfigurationSaved: false,
       handleAppConfigurationChange: () => null,
       isLoading: false,
+      sdk: mockSdk,
+      vercelClient: null,
     }}>
     {children}
   </ConfigPageContext.Provider>

--- a/apps/vercel/frontend/test/mocks/mockSdk.ts
+++ b/apps/vercel/frontend/test/mocks/mockSdk.ts
@@ -1,13 +1,14 @@
+import { AppInstallationParameters } from '@customTypes/configPage';
 import { vi } from 'vitest';
 
-export const mockParameters = {
+const SPACE_ID = '1234';
+
+export const mockParameters: AppInstallationParameters = {
   vercelAccessToken: 'abc-123',
   selectedProject: 'test-project-id',
-  projects: [
-    {
-      id: 'test-project-id',
-      name: 'test project',
-    },
+  selectedApiPath: 'test-api-path',
+  contentTypePreviewPathSelections: [
+    { contentType: 'test-content-type', previewPath: 'test-preview-path' },
   ],
 };
 
@@ -26,12 +27,11 @@ const mockSdk: any = {
     installation: {
       vercelAccessToken: mockParameters.vercelAccessToken,
       selectedProject: mockParameters.selectedProject,
-      projects: mockParameters.projects,
     },
   },
   ids: {
     app: 'test-app',
-    space: '1234',
+    space: SPACE_ID,
   },
   cma: {
     contentType: {

--- a/apps/vercel/frontend/test/mocks/mockSdk.ts
+++ b/apps/vercel/frontend/test/mocks/mockSdk.ts
@@ -31,6 +31,7 @@ const mockSdk: any = {
   },
   ids: {
     app: 'test-app',
+    space: '1234',
   },
   cma: {
     contentType: {


### PR DESCRIPTION
## Purpose

The purpose of this PR is to add an error message when the user selects a project that is not configured to be in the space where the current app is installed/being installed. 

## Approach

I added the below error message on render of the page AND when the user changes project, and the selected project contains an incompatible `CONTENTFUL_SPACE_ID` variable. The error lingers until the user changes to a valid project, but they are still able to install and save changes. 

![Screenshot 2024-05-07 at 7 07 56 AM](https://github.com/contentful/apps/assets/58186851/630bda9b-ec3d-4a89-b712-cf66737bf047)


## Testing steps

Within [this](https://app.contentful.com/spaces/5rotc6q2lcs7/apps/656HN4kwcFsgd1lmZ5BhvP) space, I have created one Vercel project that is compatible with the space:` nextjs-lb-4`. The rest of the projects are not compatible, so you should see warnings for all other project selections.  
