### PR TITLE
chore(dropbox): update to dam-app-base v3.0.0 and update to react v18

### DIFF
--- a/apps/dropbox/package-lock.json
+++ b/apps/dropbox/package-lock.json
@@ -8,9 +8,9 @@
       "name": "@contentful/dropbox-assets",
       "version": "1.6.74",
       "dependencies": {
-        "@contentful/dam-app-base": "2.0.55",
-        "react": "16.12.0",
-        "react-dom": "16.12.0"
+        "@contentful/dam-app-base": "^3.0.0",
+        "react": "18.2.0",
+        "react-dom": "18.2.0"
       },
       "devDependencies": {
         "@contentful/app-scripts": "1.2.0",
@@ -173,9 +173,9 @@
       }
     },
     "node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -276,9 +276,9 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -339,9 +339,9 @@
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -1753,9 +1753,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-runtime/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -1975,9 +1975,9 @@
       }
     },
     "node_modules/@babel/preset-env/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -2133,41 +2133,41 @@
       }
     },
     "node_modules/@contentful/app-sdk": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.13.0.tgz",
-      "integrity": "sha512-jHQmks72qaW4Ge1k1Nk+3zVgCpfZYCJj0XqKfiHwAvXMBgqygOPYj717c3WsgAvwXm/CeTWVpRXg83ILI570LA==",
-      "peerDependencies": {
+      "version": "4.25.0",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/app-sdk/4.25.0/305d18a1809a5059a2abea9019bc8fcf6d854145",
+      "integrity": "sha512-Aw5Yq3zduwHonNJPQtBTNzZ4MC17UtH8zaSnq8cdbDLfyJOYiTgPDDh15AzgwAkfyOovoXCBcyajjra9Cm45Qg==",
+      "dependencies": {
         "contentful-management": ">=7.30.0"
       }
     },
     "node_modules/@contentful/dam-app-base": {
-      "version": "2.0.55",
-      "resolved": "https://registry.npmjs.org/@contentful/dam-app-base/-/dam-app-base-2.0.55.tgz",
-      "integrity": "sha512-sp+qWTbwV+msZnFrOEkrcJ9W62opZY2oEkYN5yKJJfVUVpohh15+0jP5zNxgBrc0e7UBjr6fQJHfB6gh0JexOQ==",
+      "version": "3.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/dam-app-base/3.0.0/8a6b0aef1674ddbf8845910e61f7f8380dc57595",
+      "integrity": "sha512-XuUq93wem0IMDuDzHnuEZkClFE3fYbdagAw6NIjo38ToKZEWS86WzYoKIJqm41R4jRRBF1tU3fmI48t93OTDmw==",
       "dependencies": {
-        "@contentful/app-sdk": "^4.0.0",
+        "@contentful/app-sdk": "^4.23.0",
         "@contentful/f36-components": "^4.0.42",
         "@contentful/f36-tokens": "^4.0.0",
-        "array-move": "^3.0.0",
+        "@dnd-kit/core": "^6.1.0",
+        "@dnd-kit/sortable": "^8.0.0",
         "contentful-management": "^10.0.0",
-        "emotion": "^10.0.0",
-        "react-sortable-hoc": "^2.0.0"
+        "emotion": "^10.0.0"
       },
       "peerDependencies": {
-        "react": "^16.3.0 || ^17.0.0",
-        "react-dom": "^16.3.0 || ^17.0.0"
+        "react": "18.2.0",
+        "react-dom": "18.2.0"
       }
     },
     "node_modules/@contentful/f36-accordion": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.23.2.tgz",
-      "integrity": "sha512-wUIK+19p18POfnL3NtFN9H29oEOwSeUldu4bhsAUNYsClXTgVweWcgEsbQAjJeG94Dnwzpua6pbskdMXBYTWnA==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-accordion/4.65.5/f5a8dff956f4a350ce3fd71b412fcfe3d5dc06cf",
+      "integrity": "sha512-2TIERDEQ3ChigDdiMimQl9FiDV8jIKqFil+a1smfPZrUway64NKQ9xo4fEHlFCe3N218zCvhZklzemmO3s2cQA==",
       "dependencies": {
-        "@contentful/f36-collapse": "^4.23.2",
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.23.2",
+        "@contentful/f36-collapse": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2176,15 +2176,15 @@
       }
     },
     "node_modules/@contentful/f36-asset": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.23.2.tgz",
-      "integrity": "sha512-ApXYb3DUCvTZwQ2LSR6BcfShgSbrCV0bGb7c2bnoJncGP9ai7YqpGmY8N+zD6/QxOjKQyCUsByxfYLUBcefojg==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-asset/4.65.5/c1e007b3ef2b341804783940da49545741db4017",
+      "integrity": "sha512-/SIKJ1RA8ZHkVIrgVzijDTQCAhos3eaDYnpcA1q2OCn7uBU5a4QMmCjC8U2vb0rmchSxK9Ddg1bASCdF2wjhuA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-icon": "^4.23.2",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.23.2",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-icon": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2193,19 +2193,19 @@
       }
     },
     "node_modules/@contentful/f36-autocomplete": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.23.2.tgz",
-      "integrity": "sha512-dvgr0z1HGMdh7OIzxVda83sHByinY2Xrgvn7i20pgqmQQAhvVop8nfe/XSFRqoWmUmJppxqot5+597HbQ9533A==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-autocomplete/4.65.5/1ace5c64fbaf7faee387a288abead6374efc61df",
+      "integrity": "sha512-QmTH8U3VWP/JIZVvLVis4UrHdjqvtFVFQP9q4XOCsjCHpI4QHx05pVD3vozBoWr0vAVeIAu2YQQYqDsqcLkg7w==",
       "dependencies": {
-        "@contentful/f36-button": "^4.23.2",
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-forms": "^4.23.2",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-popover": "^4.23.2",
-        "@contentful/f36-skeleton": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.23.2",
-        "@contentful/f36-utils": "^4.23.2",
+        "@contentful/f36-button": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-forms": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-popover": "^4.65.5",
+        "@contentful/f36-skeleton": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
+        "@contentful/f36-utils": "^4.24.3",
         "downshift": "^6.1.12",
         "emotion": "^10.0.17"
       },
@@ -2215,12 +2215,13 @@
       }
     },
     "node_modules/@contentful/f36-badge": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.23.2.tgz",
-      "integrity": "sha512-YXAT4pvpfSqqJ44Hwy3XZmb/j5EcNC4gaD4LAM8kOHuCFqUZwzjBOZVaYYHzfa2PhjgTJEKBjpTrPLgTMOJYLw==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-badge/4.65.5/9adf9e18b3b3387b99f604418d88b0498dd34bc2",
+      "integrity": "sha512-EEwf1ZGYQBeOxHnFdem0rCXDPWN1VgNxOpkJgpX8gWryb3xTBoa4/rf/ZQb2H/cQzWi7hVjStVgnUdEiIf2jAA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2229,13 +2230,14 @@
       }
     },
     "node_modules/@contentful/f36-button": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.23.2.tgz",
-      "integrity": "sha512-KPpSAyxIk8gcovhGFdtCMfKfRsqD/vUj7ioABFnytDTn+bcTdj4iVf1YvU/+4Er+ZD5L7+peAFh/vLVJsoPWZA==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-button/4.65.5/1ccdcef03cb7619da9aa4aec71e1227be37523f9",
+      "integrity": "sha512-+ja1Aba9kBOQNNmZ48esvj/gsR/S6lHT0ZRiR+oIue6eLowdWcurdEhUtv9jzpGiMlA3JOD36M9aalmuVYLA4Q==",
       "dependencies": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-spinner": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-spinner": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2244,22 +2246,22 @@
       }
     },
     "node_modules/@contentful/f36-card": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.23.2.tgz",
-      "integrity": "sha512-9gr0LufH+bLC9COJwnSogw9yBMuiSodf5z/UAFF3c2ZMvANHimiZZQ+viHurYIvXXdcRe9sdtEOxmlyTc2inNA==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-card/4.65.5/981bfc1651e30b07eaadd3e6513344edecdc7160",
+      "integrity": "sha512-4xg0Vm0gF/gzZfOsv4t1NHJ0lE5/QKHpJnoPmxgn4k5PiB6FtODjr29X+jF+m2Q5KB94aBhV3F0k7rX79GdL4Q==",
       "dependencies": {
-        "@contentful/f36-asset": "^4.23.2",
-        "@contentful/f36-badge": "^4.23.2",
-        "@contentful/f36-button": "^4.23.2",
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-drag-handle": "^4.23.2",
-        "@contentful/f36-icon": "^4.23.2",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-menu": "^4.23.2",
-        "@contentful/f36-skeleton": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-tooltip": "^4.23.2",
-        "@contentful/f36-typography": "^4.23.2",
+        "@contentful/f36-asset": "^4.65.5",
+        "@contentful/f36-badge": "^4.65.5",
+        "@contentful/f36-button": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-drag-handle": "^4.65.5",
+        "@contentful/f36-icon": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-menu": "^4.65.5",
+        "@contentful/f36-skeleton": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-tooltip": "^4.65.5",
+        "@contentful/f36-typography": "^4.65.5",
         "emotion": "^10.0.17",
         "truncate": "^3.0.0"
       },
@@ -2269,12 +2271,12 @@
       }
     },
     "node_modules/@contentful/f36-collapse": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.23.2.tgz",
-      "integrity": "sha512-Cy8cDv4JNFaw8BuDJWFx3ha/6NCJjzktobPUSqI/QJWUmXCWuMVb3N9n4LoZbxXjSBHm/4SAOPPstlsKsynrdA==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-collapse/4.65.5/67d2e87f52f03d30ee293f36e81d4150c66fc8ec",
+      "integrity": "sha512-aaVkGlPnEcV/reSbzegrRB8VRPiKWIfMgxrliOzA0uT8btTsKdgXySwFwyFiKyw81bfbLugZYan6jkWVcnVRrg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2283,62 +2285,64 @@
       }
     },
     "node_modules/@contentful/f36-components": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.23.2.tgz",
-      "integrity": "sha512-2VFHo8dYer0yKHlxZoAySR20K8FK89WKusn/pnPARKgzjMNc2XupmlMAjvzmfY4whMjNsSgPzSHOiRWzXoFW9w==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-components/4.65.5/03390a96972b36ac689bec292e38715940531fd6",
+      "integrity": "sha512-xQ6mi7+Rwj04lrF8O1PaAIvRXj6W8U16aYaJXQdc3MgNvUT9eUqEeN09LKTqwTpl/giuetrH/Zey6U+V2ikSkg==",
       "dependencies": {
-        "@contentful/f36-accordion": "^4.23.2",
-        "@contentful/f36-asset": "^4.23.2",
-        "@contentful/f36-autocomplete": "^4.23.2",
-        "@contentful/f36-badge": "^4.23.2",
-        "@contentful/f36-button": "^4.23.2",
-        "@contentful/f36-card": "^4.23.2",
-        "@contentful/f36-collapse": "^4.23.2",
-        "@contentful/f36-copybutton": "^4.23.2",
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-datepicker": "^4.23.2",
-        "@contentful/f36-datetime": "^4.23.2",
-        "@contentful/f36-drag-handle": "^4.23.2",
-        "@contentful/f36-entity-list": "^4.23.2",
-        "@contentful/f36-forms": "^4.23.2",
-        "@contentful/f36-icon": "^4.23.2",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-list": "^4.23.2",
-        "@contentful/f36-menu": "^4.23.2",
-        "@contentful/f36-modal": "^4.23.2",
-        "@contentful/f36-note": "^4.23.2",
-        "@contentful/f36-notification": "^4.23.2",
-        "@contentful/f36-pagination": "^4.23.2",
-        "@contentful/f36-pill": "^4.23.2",
-        "@contentful/f36-popover": "^4.23.2",
-        "@contentful/f36-skeleton": "^4.23.2",
-        "@contentful/f36-spinner": "^4.23.2",
-        "@contentful/f36-table": "^4.23.2",
-        "@contentful/f36-tabs": "^4.23.2",
-        "@contentful/f36-text-link": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-tooltip": "^4.23.2",
-        "@contentful/f36-typography": "^4.23.2",
-        "@contentful/f36-utils": "^4.23.2",
-        "@types/react": "16.14.22",
-        "@types/react-dom": "16.9.14"
+        "@contentful/f36-accordion": "^4.65.5",
+        "@contentful/f36-asset": "^4.65.5",
+        "@contentful/f36-autocomplete": "^4.65.5",
+        "@contentful/f36-badge": "^4.65.5",
+        "@contentful/f36-button": "^4.65.5",
+        "@contentful/f36-card": "^4.65.5",
+        "@contentful/f36-collapse": "^4.65.5",
+        "@contentful/f36-copybutton": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-datepicker": "^4.65.5",
+        "@contentful/f36-datetime": "^4.65.5",
+        "@contentful/f36-drag-handle": "^4.65.5",
+        "@contentful/f36-empty-state": "^4.65.5",
+        "@contentful/f36-entity-list": "^4.65.5",
+        "@contentful/f36-forms": "^4.65.5",
+        "@contentful/f36-icon": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-list": "^4.65.5",
+        "@contentful/f36-menu": "^4.65.5",
+        "@contentful/f36-modal": "^4.65.5",
+        "@contentful/f36-navbar": "^4.1.1",
+        "@contentful/f36-note": "^4.65.5",
+        "@contentful/f36-notification": "^4.65.5",
+        "@contentful/f36-pagination": "^4.65.5",
+        "@contentful/f36-pill": "^4.65.5",
+        "@contentful/f36-popover": "^4.65.5",
+        "@contentful/f36-skeleton": "^4.65.5",
+        "@contentful/f36-spinner": "^4.65.5",
+        "@contentful/f36-table": "^4.65.5",
+        "@contentful/f36-tabs": "^4.65.5",
+        "@contentful/f36-text-link": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-tooltip": "^4.65.5",
+        "@contentful/f36-typography": "^4.65.5",
+        "@contentful/f36-utils": "^4.24.3"
       },
       "peerDependencies": {
+        "@types/react": ">=16.8",
+        "@types/react-dom": ">=16.8",
         "react": ">=16.8",
         "react-dom": ">=16.8"
       }
     },
     "node_modules/@contentful/f36-copybutton": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.23.2.tgz",
-      "integrity": "sha512-Je6NMxS+YZQ6FV261kYcnl2G4+agXWxWq4S+CUUGAiTXuSZyXouSlEzroq6dqVDgUQMmHoK5Mq5vAI5fZ79cgg==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-copybutton/4.65.5/3c564edf780231dd831bded291461baff8cd756d",
+      "integrity": "sha512-w4FQst+STqNi5sWQYgbW24eSWUyl2kCO40LK4YKO7Ugv2VUD5b6F25QqRrjs39bryTZWPO6g8ZLP6FEijdzv1g==",
       "dependencies": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-tooltip": "^4.23.2",
-        "emotion": "^10.0.17",
-        "react-copy-to-clipboard": "^5.1.0"
+        "@contentful/f36-button": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-tooltip": "^4.65.5",
+        "emotion": "^10.0.17"
       },
       "peerDependencies": {
         "react": ">=16.8",
@@ -2346,11 +2350,11 @@
       }
     },
     "node_modules/@contentful/f36-core": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.23.2.tgz",
-      "integrity": "sha512-kBSbDuVrA8ck2lAVvMzW5bJ/P2bwnpIb9ZZrqXt5aOYDV5iln7swdYnYlypMRS9w5PS4RAb2hnydQ1aUXOE93Q==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-core/4.65.5/76fea74e91d1c5cb54cffcc6715870a356789cff",
+      "integrity": "sha512-oGQGxRbdUlG6esKjV4NkPRYbIGUWTfwoT8T1CYz//bSGAi+K0Cvzf0oVpvjso1AYlVazXuByb0s1nOT48WlIug==",
       "dependencies": {
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-tokens": "^4.0.4",
         "@emotion/core": "^10.1.1",
         "@emotion/is-prop-valid": "^1.2.0",
         "csstype": "^3.1.1",
@@ -2362,20 +2366,20 @@
       }
     },
     "node_modules/@contentful/f36-datepicker": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.23.2.tgz",
-      "integrity": "sha512-arXVylfHRxI8VRrh4s1zfo5ha2LE+gKpzUtdoCfqQixyaVD5d2RwSjwXAx/9rWXhtVh9cvM7YF8mP5oTl/9KiA==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-datepicker/4.65.5/2862bdd5231f1c0157401839484a278d58bdcd1e",
+      "integrity": "sha512-ehA99+gV6i7IUcZopge+ElrVrO6ONQbfCEu9KqQRzrJ3Qg4m2k5HsTzmtkJi7DMKkplTy5Z4VIFDsx+yoNqwqg==",
       "dependencies": {
-        "@contentful/f36-button": "^4.23.2",
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-forms": "^4.23.2",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-popover": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-typography": "^4.23.2",
+        "@contentful/f36-button": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-forms": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-popover": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
         "date-fns": "^2.28.0",
         "emotion": "^10.0.17",
-        "react-day-picker": "^8.3.5",
+        "react-day-picker": "^8.7.1",
         "react-focus-lock": "^2.9.1"
       },
       "peerDependencies": {
@@ -2384,12 +2388,12 @@
       }
     },
     "node_modules/@contentful/f36-datetime": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.23.2.tgz",
-      "integrity": "sha512-bUTPIfvEdKjPVPVn4YH+eYCO8h7gLhfN+zKy5DrXlGIHmvk0IKhGfWq8ts82n96Fc4XRW3RrXkF4qO0eIQUVHQ==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-datetime/4.65.5/acfba66e0bd262d026c968ca87aa2a6edd64a7bc",
+      "integrity": "sha512-cs5A53ucqiX78S6wWmSATHo4BzccgUTrQ6Xzz9DLkXfNT/SLePTI9urIp8a/YChr0p76cYDcta4EjVt7ie+Ilw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
         "dayjs": "^1.11.5",
         "emotion": "^10.0.17"
       },
@@ -2399,13 +2403,28 @@
       }
     },
     "node_modules/@contentful/f36-drag-handle": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.23.2.tgz",
-      "integrity": "sha512-eR4nwtbiJSEvTACPVAe1a3ME70ge4H0/w7n+9U1p3GCF36KEl3j0VMweP0PXeH8hRvhAse3yRQTzIDOF5yKnMw==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-drag-handle/4.65.5/5ce7a2a700b9b9fe4a3e78ac06894f4be3756759",
+      "integrity": "sha512-QZXcWK8TrGYTaES1rWniJlOER673qHjnqiA1YD51Q53ACkDJ2OenzbNlHq7Rg65MLV9JognCXpXJqqjyMXCmxg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-utils": "^4.24.3",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-empty-state": {
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-empty-state/4.65.5/11c0ffb18bae1e8f06b4b38838eb61023e6d07eb",
+      "integrity": "sha512-ZnB+XtHe57JYBhqePLkp88Kn1xh41tLyJQec23nsz3k8EIyaTUy5tGVJ7JQoZOVYKfXlu6dqg9aKrzVhhgZG6A==",
+      "dependencies": {
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2414,20 +2433,20 @@
       }
     },
     "node_modules/@contentful/f36-entity-list": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.23.2.tgz",
-      "integrity": "sha512-OkgEgyRIG3u8ulIT6BBpUJ2cKr3pIRZEpZsQv80Tznls9cMeyq7z/IjYTWg7vOLeayTaciF0fGM1TkPnFw3Xfw==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-entity-list/4.65.5/c5393896e93eb59447f5a6ff5189ddc0fbb86b66",
+      "integrity": "sha512-oN+SGGsd215Kdu9FyVgoywPdpdGBP0yLQMs2iK51pdNfnCbxXQ/vqBsMk6IU9SgIPAKbnQvKXnd6cQIQ2VbSNA==",
       "dependencies": {
-        "@contentful/f36-badge": "^4.23.2",
-        "@contentful/f36-button": "^4.23.2",
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-drag-handle": "^4.23.2",
-        "@contentful/f36-icon": "^4.23.2",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-menu": "^4.23.2",
-        "@contentful/f36-skeleton": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.23.2",
+        "@contentful/f36-badge": "^4.65.5",
+        "@contentful/f36-button": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-drag-handle": "^4.65.5",
+        "@contentful/f36-icon": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-menu": "^4.65.5",
+        "@contentful/f36-skeleton": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2436,14 +2455,15 @@
       }
     },
     "node_modules/@contentful/f36-forms": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.23.2.tgz",
-      "integrity": "sha512-nIleirk2SiW8w86q3Y7M5ZJy7J2zFbq4f0PD/5d0O3bYGtobn8ZNzoY6oYSt48crmhwDMyntszTgOJfPNWH55w==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-forms/4.65.5/db51f3a74ec1335f6f6f2b8ebd28113fa584a2cd",
+      "integrity": "sha512-XkueX0CcF2ZdcwBBe/mD3GUSROsXcIwXmXdPSaQ1kgpCNVf9DS/GMgQPRCh7YCPOfT9jVDaeO8qg2JWRXsxrbg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.23.2",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2452,25 +2472,26 @@
       }
     },
     "node_modules/@contentful/f36-icon": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.23.2.tgz",
-      "integrity": "sha512-mWwYfcP20nK1+tmxdhrDoTI0Uo1YIMG3zKbNr20V0pC4de94K5u962CaBJaw3RosTnfCoikQmJbg7CY5OuKSVA==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-icon/4.65.5/a23dbdbcd977f5c0ed754a84127eb8b9020449ba",
+      "integrity": "sha512-ZdASqrHxSRhbOAzHdUqrdX/RrkAake6bjkkQ9/5LYNkM/Ru1hVcn4vgKSx65dA3+Eo6QzTA9zmETRyqn6awzeg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/@contentful/f36-icons": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-4.23.2.tgz",
-      "integrity": "sha512-1voQyaiMrQGAFUXRZiuP/9e1A2unp0IOGyXUUCaWaFRbivjxRTUd9Sq2jSA/DutCC5OJ+BDxMiIJJnQz1izGRQ==",
+      "version": "4.28.2",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-icons/4.28.2/8297da32e9d8e60e09550e365f24a74a8e12326c",
+      "integrity": "sha512-p7oWbQ5ITlMMuEl/6t/6JLVrCVhDE2nA8mv1VR4DHjXPm0y9w14533rCKxNIREZX8iVmyBoaqI3vdPsjUs1CAw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-icon": "^4.23.2",
+        "@contentful/f36-core": "^4.65.0",
+        "@contentful/f36-icon": "^4.65.0",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       },
@@ -2480,29 +2501,30 @@
       }
     },
     "node_modules/@contentful/f36-list": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.23.2.tgz",
-      "integrity": "sha512-hZ8bBIEpNF+G4XMQkEX1t4sFxmUr9/wcUAm1XEhWCC/AIipaYVgQoXNQFBO9IGZFAYonOZSqaT9mRrj5y2jegg==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-list/4.65.5/0aa877c124883e1af4434f72d9404de7c4a30575",
+      "integrity": "sha512-OH+odg2hjB9/9i6k71hqvmufNiFP0l/pob2+Yr2RtReM4+6gdULsNlZpo8SUv8L5ryX2/QdlEulIqk6Do9rYpg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/@contentful/f36-menu": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.23.2.tgz",
-      "integrity": "sha512-v5Txmv0mS9zQlq7b1aAmH4Q99TbnqkE2EbO37D04JyeB6DEbriVdlwhsIiW/LJcxC1ffQFaN2MTVGSJKNsiQ+A==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-menu/4.65.5/32ca0f66cdc3cef6b510e4aa236c54bb9f874e30",
+      "integrity": "sha512-XrCx3nWMbtl4KjobntUpzkccSdU/mmFHi3TSMV1VZ8aECIu3FuEx2RgBY5XRIQOSw4AfbA72RQO/HA4opsmJUQ==",
       "dependencies": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-popover": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.23.2",
-        "@contentful/f36-utils": "^4.23.2",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-popover": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2511,18 +2533,37 @@
       }
     },
     "node_modules/@contentful/f36-modal": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.23.2.tgz",
-      "integrity": "sha512-OVUoJp2LCMyIogxxyQFKfSKdQhFawDt0UWgire615VH5EZGVtd7y+qiB8oEelurdTGO6sozlA7FoZVBbH/SRnQ==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-modal/4.65.5/8eaffd5d0f531a960341857f68dc0473a09b2b78",
+      "integrity": "sha512-LoL948QiBUrRiWqQAmEIWtYb00Q2LDgvWwjL1LQDIpUx+Rvig657r5umypYUS31OKTYlOrkfo+J1JfpWi8/bMQ==",
       "dependencies": {
-        "@contentful/f36-button": "^4.23.2",
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.23.2",
-        "@types/react-modal": "^3.12.1",
+        "@contentful/f36-button": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
+        "@types/react-modal": "^3.13.1",
         "emotion": "^10.0.17",
-        "react-modal": "^3.14.3"
+        "react-modal": "^3.16.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-navbar": {
+      "version": "4.1.1",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-navbar/4.1.1/139c0280f14f3a923d40bfa7290984eb60486119",
+      "integrity": "sha512-nCLtZ7EgfKhmXWrGZYrZEQOoulOOVPOuZBk0CC4JgQRQmCYeYr2iAnM8zualISFaxX/O+GVvHPQf2hKeoeFRPA==",
+      "dependencies": {
+        "@contentful/f36-core": "^4.45.0",
+        "@contentful/f36-icon": "^4.45.0",
+        "@contentful/f36-icons": "^4.23.2",
+        "@contentful/f36-menu": "^4.45.0",
+        "@contentful/f36-skeleton": "^4.45.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-utils": "^4.23.2",
+        "emotion": "^10.0.17"
       },
       "peerDependencies": {
         "react": ">=16.8",
@@ -2530,16 +2571,16 @@
       }
     },
     "node_modules/@contentful/f36-note": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.23.2.tgz",
-      "integrity": "sha512-Sgi4lWhB357zz0VdqY1fQdH3EIMWoOMwhJqYtdhuo6AYfMWeVcJn/xoWEjhjiExtG5L4Q2CFt4lW9exeNgI1Rw==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-note/4.65.5/10652c0363f1437cfbdf65c76e192a69fc2bc29e",
+      "integrity": "sha512-TFd9p8Qg/Y+1Oq5aJEw5ybjaZs49CoBuhjxrybC8U4ODh0gpCUA0lJEVyWcaejyitTt2mSYJIhn9l/7CPrb+iw==",
       "dependencies": {
-        "@contentful/f36-button": "^4.23.2",
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-icon": "^4.23.2",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.23.2",
+        "@contentful/f36-button": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-icon": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2548,17 +2589,17 @@
       }
     },
     "node_modules/@contentful/f36-notification": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.23.2.tgz",
-      "integrity": "sha512-gzLAaYo8+kDj8MDJDMNR6JrvIQ3w+8z5A0VE95uzG1MKG3qp+S3jrXZBU0mzV2yVMcruYbpx7dIV+neeH4oS4Q==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-notification/4.65.5/0eb83df1926786423372f574859a267777104d5d",
+      "integrity": "sha512-jGtPKDc7mIHgNtSQQvN25c+L6JIf5mR9aXE8b7WPOc3vaFq8bln9OMMiivvD+iMDPbWf0bukNNn3NNP/bt+oZw==",
       "dependencies": {
-        "@contentful/f36-button": "^4.23.2",
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-text-link": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.23.2",
-        "@swc/helpers": "^0.4.2",
+        "@contentful/f36-button": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-text-link": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
+        "@swc/helpers": "^0.4.14",
         "emotion": "^10.0.17",
         "react-animate-height": "^3.0.4"
       },
@@ -2568,32 +2609,34 @@
       }
     },
     "node_modules/@contentful/f36-pagination": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.23.2.tgz",
-      "integrity": "sha512-+JW+qnwT+fu1LuvxZP6F7TWy6Qi0BFRvn+jJUVCCpvFLI4Ee5oIy7HaJwHUNVHp6/YrjIIR6K1tEQHBGC4eTNQ==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-pagination/4.65.5/c5ca04b4e514090aac2950ae89bcf341291c5905",
+      "integrity": "sha512-+UBNt5UbmPQElwhtzS6OLRWAbR/pi45HKSl3uGLlJ5V1HNhEcebLzqWGPeQuv7xkHMVUbTTJKwM0G2zD7b8dQA==",
       "dependencies": {
-        "@contentful/f36-button": "^4.23.2",
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-forms": "^4.23.2",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-typography": "^4.23.2",
+        "@contentful/f36-button": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-forms": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/@contentful/f36-pill": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.23.2.tgz",
-      "integrity": "sha512-qrNtbvcapPB6s8Bz1WtlBVVo+7zGN9b9ZABeDEvXJXGCeR0S5FP2fJou+9UCE5AD7579SdeEtbGU0JmjBb71ZQ==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-pill/4.65.5/9858608a30440b490c33908b71d18089d6e71a37",
+      "integrity": "sha512-mpK3StAaXmP/XpDDR6fVvM910RfY0C97VnVcbXA3ZZ9itb68jKzb7Y+gRfEJXGHza9oE/qgQEQuLHdNTqhuHEw==",
       "dependencies": {
-        "@contentful/f36-button": "^4.23.2",
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-tooltip": "^4.23.2",
+        "@contentful/f36-button": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-drag-handle": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-tooltip": "^4.65.5",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2602,29 +2645,30 @@
       }
     },
     "node_modules/@contentful/f36-popover": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.23.2.tgz",
-      "integrity": "sha512-SXZ9DkC9zjhW5TneZ0QmcfivK5cvlvPsjAFyJJoFLWWwbcLS6pynZhsa1do35xAIgmBKav2VNQKmmASc+mLJ/w==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-popover/4.65.5/83fba8d9336a1763a2148ecb0e05b9c637f37c54",
+      "integrity": "sha512-qZO0T8qyTg4FsSsgfPTk4/ZxQSFOWbajLI+LxpeC0UH95gb5xoTkb+jHBDRdJ+xQyIZqYAcycI2HK6IJZEfboQ==",
       "dependencies": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-utils": "^4.23.2",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
         "emotion": "^10.0.17",
         "react-popper": "^2.3.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/@contentful/f36-skeleton": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.23.2.tgz",
-      "integrity": "sha512-KkZlUl+QD1aVJK/yLUia6ew9lJ0Xt3ZDICkFCpSQQ0ZIg8tbd4tiGnBnM5CrcxP78Juwi8bseumYXksKexPYJg==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-skeleton/4.65.5/f11c1c0207c358f79274da8b81432e9808ad3d5f",
+      "integrity": "sha512-qb48ythK06bShtJh3VopNVygg9h3psjbo45weh1IlQrlMFZRXsGtn5sdvMAK/982QcUuUSvxjWhAyU3QYkpeMQ==",
       "dependencies": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-table": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-table": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2633,25 +2677,28 @@
       }
     },
     "node_modules/@contentful/f36-spinner": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.23.2.tgz",
-      "integrity": "sha512-QlP6CsnVGbVfdA+vFKEEM1YH/2TYHFBq8HxiRb9n69oSYvlzKsBH5gu3Jlsy/qH0vaT3a6N1hFi8zRIxkE5/2g==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-spinner/4.65.5/c6d35aff3638ed299b32abf3972a5ab07b4580e8",
+      "integrity": "sha512-nMn5ul1nrLcUOygzZ8LPavuFHnfPMZAo1BSarYhutz83CmEEVzlkAoGwM/cJCCrm6ylb3oXiQOZSUxmEJeqxiA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/@contentful/f36-table": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.23.2.tgz",
-      "integrity": "sha512-Q65a40FQfYhLFsGGdy+bM+0N4YLt2BQ8IdVk5FSknSHwb7rhGgg9hD11i9CAGoPuw6pIO/NuTeS62QKS2Bjuiw==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-table/4.65.5/d0f1c3706518570b3f2a6577e67c9a5f149f5e82",
+      "integrity": "sha512-HBp1yC7y8+/5fq46d0uPgYtGiKXEmUHFAvnJQfOQYdmQcnYHYoHvxII2d606cpfulBjydNDMha+HZV09jepQaA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2660,12 +2707,12 @@
       }
     },
     "node_modules/@contentful/f36-tabs": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.23.2.tgz",
-      "integrity": "sha512-Gd44MH2rtCidCGYbbtT65bQdxXX5THAXjtL3yxsgK3KfkkKGtEA91auVFhDqyxalHRv7qylgI/ZvlUiGK+vOBw==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tabs/4.65.5/741f176fbb609cb0208a90ba858bb7b8db00bf46",
+      "integrity": "sha512-7lEFs4IoYwIEOXqlEBQnO0dnKmGkASoKqeTP/lA6XS80Ymoled3XZLcc3ICZhjsZvtSRrXQ+3yIiDc1Y2EzIfg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
         "@radix-ui/react-tabs": "^1.0.1",
         "emotion": "^10.0.17"
       },
@@ -2675,31 +2722,32 @@
       }
     },
     "node_modules/@contentful/f36-text-link": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.23.2.tgz",
-      "integrity": "sha512-CBtNarrCE/ibjPynEVBEJYpbINfFO8dF+36TCCfe1Nk/bbLTcRfgy/3kTsM4Ee34aFVl6BgFUwjmrnfLmekE2g==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-text-link/4.65.5/9f25355a0b1f7d7ca60bea3056fa51ef5d703f2a",
+      "integrity": "sha512-1Jk/tebqIif+f4ef8QV+mxdzfA7g+YotAGRkkFjVCPjO1KX1GI6Ocyr0xI4h0fRjnUOJ4qqy7AU3a2DnbX07jw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/@contentful/f36-tokens": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-4.0.1.tgz",
-      "integrity": "sha512-NTyMAQcfvhPP8kJgOK5mtjKpErg799iglEb9B45ii4N7aMdph2GNqgv7KBgpogfbTEGBrlKIoH8MUDSV9YNREg=="
+      "version": "4.0.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+      "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
     },
     "node_modules/@contentful/f36-tooltip": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.23.2.tgz",
-      "integrity": "sha512-xqdkNg5HBPFTRn+J7q6gGWs5ugN1wyLJTSZm1uBYWXejUmfyWysLMRR8GYj7HxgoONKBtXujJF54PWQILRBiFw==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tooltip/4.65.5/f49f071595492d15f57f0b6b73a5c6a0d3329ab1",
+      "integrity": "sha512-12U5tYHIBEwK4WDXlt6riNWLEKLeatjtsz9H0zXp0ANANkNFSpVO32ED6fFHHDCtK6iekm/3EQ2QJ7Jua4y0iQ==",
       "dependencies": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-utils": "^4.23.2",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
         "csstype": "^3.1.1",
         "emotion": "^10.0.17",
@@ -2711,22 +2759,24 @@
       }
     },
     "node_modules/@contentful/f36-typography": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.23.2.tgz",
-      "integrity": "sha512-Js+jPfmiRbkgkztFf+wrLxv/fA9V+wU/zhyxTT3OcWHrLiVY92NjlfyEGXmWxJClH44hCw+p3jjSFVf3WsWG1Q==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-typography/4.65.5/42e3d72c44ceccdd450e9f2040728d15d1b4caa4",
+      "integrity": "sha512-hprmtdy0y661nxUYn2QddbKJyuHszG8j5p6Iz3CFEN2nCNaOe1OtCENrv1amZmDBHOj1x8ldWF7Bm/Nnqva45g==",
       "dependencies": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/@contentful/f36-utils": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-utils/-/f36-utils-4.23.2.tgz",
-      "integrity": "sha512-VCSjMMYgAPNPek2sz9EJT7mDD2S/I2F6JgyeIBczayDaZvp1sTq/elozEh7vfMsmfmkirOW6qFKwOBQkKCKgZA==",
+      "version": "4.24.3",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-utils/4.24.3/12868232fe068b7095d2db8ae1cfe296370d124a",
+      "integrity": "sha512-9+tyDOCjEhW7m4X7Sam0VYlmcgjhLVMiapCnv1EmRstlMaeI5ti9y0y/2aQ04Na2ScoHwrMTjveoZ6V62J62tA==",
       "dependencies": {
         "emotion": "^10.0.17"
       },
@@ -3021,6 +3071,55 @@
         "postcss-selector-parser": "^6.0.10"
       }
     },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.0.tgz",
+      "integrity": "sha512-ea7IkhKvlJUv9iSHJOnxinBcoOI3ppGnnL+VDJ75O45Nss6HtZd8IdN8touXPDtASfeI2T2LImb8VOZcL47wjQ==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.1.0.tgz",
+      "integrity": "sha512-J3cQBClB4TVxwGo3KEjssGEXNJqGVWx17aRTZ1ob0FliR5IjYgTxl5YJbKTzA6IzrtelotH19v6y7uoIRUZPSg==",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.0",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-8.0.0.tgz",
+      "integrity": "sha512-U3jk5ebVXe1Lr7c2wU7SBZjcWdQP+j7peHJfCspnA81enlu88Mgd7CC8Q+pub9ubP7eKVETzJW+IBAhsqbSu/g==",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.1.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
     "node_modules/@emotion/cache": {
       "version": "10.0.29",
       "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
@@ -3064,17 +3163,17 @@
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
     },
     "node_modules/@emotion/is-prop-valid": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz",
-      "integrity": "sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz",
+      "integrity": "sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==",
       "dependencies": {
-        "@emotion/memoize": "^0.8.0"
+        "@emotion/memoize": "^0.8.1"
       }
     },
     "node_modules/@emotion/memoize": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
-      "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
+      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
     },
     "node_modules/@emotion/serialize": {
       "version": "0.11.16",
@@ -3964,195 +4063,293 @@
       }
     },
     "node_modules/@popperjs/core": {
-      "version": "2.11.6",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
-      "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==",
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@radix-ui/primitive": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.0.tgz",
-      "integrity": "sha512-3e7rn8FDMin4CgeL7Z/49smCA3rFYY3Ha2rUQ7HRWFadS5iCRw08ZgVT1LaNTCNqgvrUiyczLflrVrF0SRQtNA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.1.tgz",
+      "integrity": "sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       }
     },
     "node_modules/@radix-ui/react-collection": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.0.1.tgz",
-      "integrity": "sha512-uuiFbs+YCKjn3X1DTSx9G7BHApu4GHbi3kgiwsnFUbOKCrwejAJv4eE4Vc8C0Oaxt9T0aV4ox0WCOdx+39Xo+g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.0.3.tgz",
+      "integrity": "sha512-3SzW+0PW7yBBoQlT8wNcGtaxaD0XSu0uLUFgrtHY08Acx05TaHaOmVLR73c0j/cqpDy53KBMO7s0dx2wmOIDIA==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-compose-refs": "1.0.0",
-        "@radix-ui/react-context": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.1",
-        "@radix-ui/react-slot": "1.0.1"
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2"
       },
       "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
         "react": "^16.8 || ^17.0 || ^18.0",
         "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@radix-ui/react-compose-refs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.0.tgz",
-      "integrity": "sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz",
+      "integrity": "sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       },
       "peerDependencies": {
+        "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@radix-ui/react-context": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.0.tgz",
-      "integrity": "sha512-1pVM9RfOQ+n/N5PJK33kRSKsr1glNxomxONs5c49MliinBY6Yw2Q995qfBUUo0/Mbg05B/sGA0gkgPI7kmSHBg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.1.tgz",
+      "integrity": "sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       },
       "peerDependencies": {
+        "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@radix-ui/react-direction": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.0.0.tgz",
-      "integrity": "sha512-2HV05lGUgYcA6xgLQ4BKPDmtL+QbIZYH5fCOTAOOcJ5O0QbWS3i9lKaurLzliYUDhORI2Qr3pyjhJh44lKA3rQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.0.1.tgz",
+      "integrity": "sha512-RXcvnXgyvYvBEOhCBuddKecVkoMiI10Jcm5cTI7abJRAHYfFxeu+FBQs/DvdxSYucxR5mna0dNsL6QFlds5TMA==",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       },
       "peerDependencies": {
+        "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@radix-ui/react-id": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.0.0.tgz",
-      "integrity": "sha512-Q6iAB/U7Tq3NTolBBQbHTgclPmGWE3OlktGGqrClPozSw4vkQ1DfQAOtzgRPecKsMdJINE05iaoDUG8tRzCBjw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.0.1.tgz",
+      "integrity": "sha512-tI7sT/kqYp8p96yGWY1OAnLHrqDgzHefRBKQ2YAkBS5ja7QLcZ9Z/uY7bEjPUatf8RomoXM8/1sMj1IJaE5UzQ==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-use-layout-effect": "1.0.0"
+        "@radix-ui/react-use-layout-effect": "1.0.1"
       },
       "peerDependencies": {
+        "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@radix-ui/react-presence": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.0.0.tgz",
-      "integrity": "sha512-A+6XEvN01NfVWiKu38ybawfHsBjWum42MRPnEuqPsBZ4eV7e/7K321B5VgYMPv3Xx5An6o1/l9ZuDBgmcmWK3w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.0.1.tgz",
+      "integrity": "sha512-UXLW4UAbIY5ZjcvzjfRFo5gxva8QirC9hF7wRE4U5gz+TP0DbRk+//qyuAQ1McDxBt1xNMBTaciFGvEmJvAZCg==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-compose-refs": "1.0.0",
-        "@radix-ui/react-use-layout-effect": "1.0.0"
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1"
       },
       "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
         "react": "^16.8 || ^17.0 || ^18.0",
         "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@radix-ui/react-primitive": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.1.tgz",
-      "integrity": "sha512-fHbmislWVkZaIdeF6GZxF0A/NH/3BjrGIYj+Ae6eTmTCr7EB0RQAAVEiqsXK6p3/JcRqVSBQoceZroj30Jj3XA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.3.tgz",
+      "integrity": "sha512-yi58uVyoAcK/Nq1inRY56ZSjKypBNKTa/1mcL8qdl6oJeEaDbOldlzrGn7P6Q3Id5d+SYNGc5AJgc4vGhjs5+g==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-slot": "1.0.1"
+        "@radix-ui/react-slot": "1.0.2"
       },
       "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
         "react": "^16.8 || ^17.0 || ^18.0",
         "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@radix-ui/react-roving-focus": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.0.1.tgz",
-      "integrity": "sha512-TB76u5TIxKpqMpUAuYH2VqMhHYKa+4Vs1NHygo/llLvlffN6mLVsFhz0AnSFlSBAvTBYVHYAkHAyEt7x1gPJOA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.0.4.tgz",
+      "integrity": "sha512-2mUg5Mgcu001VkGy+FfzZyzbmuUWzgWkj3rvv4yu+mLw03+mTzbxZHvfcGyFp2b8EkQeMkpRQ5FiA2Vr2O6TeQ==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/primitive": "1.0.0",
-        "@radix-ui/react-collection": "1.0.1",
-        "@radix-ui/react-compose-refs": "1.0.0",
-        "@radix-ui/react-context": "1.0.0",
-        "@radix-ui/react-direction": "1.0.0",
-        "@radix-ui/react-id": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.1",
-        "@radix-ui/react-use-callback-ref": "1.0.0",
-        "@radix-ui/react-use-controllable-state": "1.0.0"
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-collection": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@radix-ui/react-use-controllable-state": "1.0.1"
       },
       "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
         "react": "^16.8 || ^17.0 || ^18.0",
         "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@radix-ui/react-slot": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.1.tgz",
-      "integrity": "sha512-avutXAFL1ehGvAXtPquu0YK5oz6ctS474iM3vNGQIkswrVhdrS52e3uoMQBzZhNRAIE0jBnUyXWNmSjGHhCFcw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.2.tgz",
+      "integrity": "sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-compose-refs": "1.0.0"
+        "@radix-ui/react-compose-refs": "1.0.1"
       },
       "peerDependencies": {
+        "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@radix-ui/react-tabs": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.0.1.tgz",
-      "integrity": "sha512-mVNEwHwgjy2G9F7b39f9VY+jF0QUZykTm0Sdv+Uz6KC4KOEIa4HLDiHU8MeEZluRtZE3aqGYDhl93O7QbJDwhg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.0.4.tgz",
+      "integrity": "sha512-egZfYY/+wRNCflXNHx+dePvnz9FbmssDTJBtgRfDY7e8SE5oIo3Py2eCB1ckAbh1Q7cQ/6yJZThJ++sgbxibog==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/primitive": "1.0.0",
-        "@radix-ui/react-context": "1.0.0",
-        "@radix-ui/react-direction": "1.0.0",
-        "@radix-ui/react-id": "1.0.0",
-        "@radix-ui/react-presence": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.1",
-        "@radix-ui/react-roving-focus": "1.0.1",
-        "@radix-ui/react-use-controllable-state": "1.0.0"
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-presence": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-roving-focus": "1.0.4",
+        "@radix-ui/react-use-controllable-state": "1.0.1"
       },
       "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
         "react": "^16.8 || ^17.0 || ^18.0",
         "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@radix-ui/react-use-callback-ref": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.0.tgz",
-      "integrity": "sha512-GZtyzoHz95Rhs6S63D2t/eqvdFCm7I+yHMLVQheKM7nBD8mbZIt+ct1jz4536MDnaOGKIxynJ8eHTkVGVVkoTg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.1.tgz",
+      "integrity": "sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ==",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       },
       "peerDependencies": {
+        "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@radix-ui/react-use-controllable-state": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.0.tgz",
-      "integrity": "sha512-FohDoZvk3mEXh9AWAVyRTYR4Sq7/gavuofglmiXB2g1aKyboUD4YtgWxKj8O5n+Uak52gXQ4wKz5IFST4vtJHg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.1.tgz",
+      "integrity": "sha512-Svl5GY5FQeN758fWKrjM6Qb7asvXeiZltlT4U2gVfl8Gx5UAv2sMR0LWo8yhsIZh2oQ0eFdZ59aoOOMV7b47VA==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-use-callback-ref": "1.0.0"
+        "@radix-ui/react-use-callback-ref": "1.0.1"
       },
       "peerDependencies": {
+        "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@radix-ui/react-use-layout-effect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.0.tgz",
-      "integrity": "sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.1.tgz",
+      "integrity": "sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==",
       "dependencies": {
         "@babel/runtime": "^7.13.10"
       },
       "peerDependencies": {
+        "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -4530,10 +4727,11 @@
       }
     },
     "node_modules/@swc/helpers": {
-      "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
-      "integrity": "sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.36.tgz",
+      "integrity": "sha512-5lxnyLEYFskErRPenYItLRSge5DjrJngYKdVjRSrWfza9G6KkgHEXi0vUZiyUeMU5JfXH1YnvXZzSp8ul88o2Q==",
       "dependencies": {
+        "legacy-swc-helpers": "npm:@swc/helpers@=0.4.14",
         "tslib": "^2.4.0"
       }
     },
@@ -4791,9 +4989,9 @@
       "dev": true
     },
     "node_modules/@types/prop-types": {
-      "version": "15.7.5",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
+      "version": "15.7.12",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
+      "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q=="
     },
     "node_modules/@types/q": {
       "version": "1.5.5",
@@ -4814,27 +5012,27 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "16.14.22",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.22.tgz",
-      "integrity": "sha512-4NnkxKDd2UO9SiCckuhCQOCzdO+RtE4Epf1D6eGz3f9jZjiIXOVo+Bk3jqSad+8EOT+LBXwKdkFX0V0F+NFzDQ==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-V0kuGBX3+prX+DQ/7r2qsv1NsdfnCLnTgnRJ1pYnxykBhGMz+qj+box5lq7XsO5mtZsBqpjwwTu/7wszPfMBcw==",
       "dependencies": {
         "@types/prop-types": "*",
-        "@types/scheduler": "*",
         "csstype": "^3.0.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "16.9.14",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.14.tgz",
-      "integrity": "sha512-FIX2AVmPTGP30OUJ+0vadeIFJJ07Mh1m+U0rxfgyW34p3rTlXI+nlenvAxNn4BP36YyI9IJ/+UJ7Wu22N1pI7A==",
+      "version": "18.3.0",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
+      "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
+      "peer": true,
       "dependencies": {
-        "@types/react": "^16"
+        "@types/react": "*"
       }
     },
     "node_modules/@types/react-modal": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/@types/react-modal/-/react-modal-3.13.1.tgz",
-      "integrity": "sha512-iY/gPvTDIy6Z+37l+ibmrY+GTV4KQTHcCyR5FIytm182RQS69G5ps4PH2FxtC7bAQ2QRHXMevsBgck7IQruHNg==",
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/@types/react-modal/-/react-modal-3.16.3.tgz",
+      "integrity": "sha512-xXuGavyEGaFQDgBv4UVm8/ZsG+qxeQ7f77yNrW3n+1J6XAstUy5rYHeIHPh1KzsGc6IkCIdu6lQ2xWzu1jBTLg==",
       "dependencies": {
         "@types/react": "*"
       }
@@ -4853,11 +5051,6 @@
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "dev": true
-    },
-    "node_modules/@types/scheduler": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "node_modules/@types/semver": {
       "version": "7.5.8",
@@ -5657,17 +5850,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/array-move": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/array-move/-/array-move-3.0.1.tgz",
-      "integrity": "sha512-H3Of6NIn2nNU1gsVDqDnYKY/LCdWvCMMOWifNGhKcVQgiZ6nOek39aESOvro6zmueP07exSl93YLvkN4fZOkSg==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -6076,9 +6258,9 @@
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -7075,14 +7257,6 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "dev": true
     },
-    "node_modules/copy-to-clipboard": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
-      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
-      "dependencies": {
-        "toggle-selection": "^1.0.6"
-      }
-    },
     "node_modules/core-js": {
       "version": "3.36.1",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.36.1.tgz",
@@ -7579,9 +7753,9 @@
       "dev": true
     },
     "node_modules/csstype": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -7655,9 +7829,12 @@
       }
     },
     "node_modules/date-fns": {
-      "version": "2.29.3",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
-      "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==",
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
       "engines": {
         "node": ">=0.11"
       },
@@ -7667,9 +7844,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.6.tgz",
-      "integrity": "sha512-zZbY5giJAinCG+7AGaw0wIhNZ6J8AhWuSXKvuc1KAyMiRsvGQWqh4L+MomvhdAYjN+lqvVCMq1I41e3YHvXkyQ=="
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.11.tgz",
+      "integrity": "sha512-okzr3f11N6WuqYtZSvm+F776mB41wRZMhKP+hc34YdW+KmtYYK9iqvHSwo2k9FEH3fhGXvOPV6yz2IcSrfRUDg=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -9444,9 +9621,9 @@
       "dev": true
     },
     "node_modules/focus-lock": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.11.4.tgz",
-      "integrity": "sha512-LzZWJcOBIcHslQ46N3SUu/760iLPSrUtp8omM4gh9du438V2CQdks8TcOu1yvmu2C68nVOBnl1WFiKGPbQ8L6g==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-1.3.5.tgz",
+      "integrity": "sha512-QFaHbhv9WPUeLYBDe/PAuLKJ4Dd9OPvKs9xZBr3yLXnUrDNaVXKu2baDBXe3naPY30hgHYSsf2JW4jzas2mDEQ==",
       "dependencies": {
         "tslib": "^2.0.3"
       },
@@ -10472,14 +10649,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/invariant": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/ipaddr.js": {
@@ -12174,9 +12343,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "bin": {
         "json5": "lib/cli.js"
@@ -12283,6 +12452,15 @@
       "dependencies": {
         "picocolors": "^1.0.0",
         "shell-quote": "^1.8.1"
+      }
+    },
+    "node_modules/legacy-swc-helpers": {
+      "name": "@swc/helpers",
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
+      "integrity": "sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==",
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/leven": {
@@ -15019,22 +15197,20 @@
       }
     },
     "node_modules/react": {
-      "version": "16.12.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.12.0.tgz",
-      "integrity": "sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
+        "loose-envify": "^1.1.0"
       },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-animate-height": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/react-animate-height/-/react-animate-height-3.1.0.tgz",
-      "integrity": "sha512-+0pW2OzB8PzVn10dpTB9q5jFI+GwQTnCDLbzyqPBUzKXJfpBrlWW954uud/59Mreo+laRN/fPzvckuA+WTptXA==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/react-animate-height/-/react-animate-height-3.2.3.tgz",
+      "integrity": "sha512-R6DSvr7ud07oeCixScyvXWEMJY/Mt2+GyOWC1KMaRc69gOBw+SsCg4TJmrp4rKUM1hyd6p+YKw90brjPH93Y2A==",
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -15071,28 +15247,16 @@
         "react": "^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
-    "node_modules/react-copy-to-clipboard": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/react-copy-to-clipboard/-/react-copy-to-clipboard-5.1.0.tgz",
-      "integrity": "sha512-k61RsNgAayIJNoy9yDsYzDe/yAZAzEbEgcz3DZMhF686LEyukcE1hzurxe85JandPUG+yTfGVFzuEw3xt8WP/A==",
-      "dependencies": {
-        "copy-to-clipboard": "^3.3.1",
-        "prop-types": "^15.8.1"
-      },
-      "peerDependencies": {
-        "react": "^15.3.0 || 16 || 17 || 18"
-      }
-    },
     "node_modules/react-day-picker": {
-      "version": "8.3.7",
-      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.3.7.tgz",
-      "integrity": "sha512-sQvyJde6OKsXIB0ZFwUBmaDNb4IyKypv/uSyauQ6AUw4F6vmPijJsQNEVsxrxXQ4L3GZKIpcCD/7Pftz/sLegA==",
+      "version": "8.10.1",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.10.1.tgz",
+      "integrity": "sha512-TMx7fNbhLk15eqcMt+7Z7S2KF7mfTId/XJDjKE8f+IUcFn0l08/kI4FiYTL/0yuOLmEcbR4Fwe3GJf/NiiMnPA==",
       "funding": {
         "type": "individual",
         "url": "https://github.com/sponsors/gpbl"
       },
       "peerDependencies": {
-        "date-fns": "^2.28.0",
+        "date-fns": "^2.28.0 || ^3.0.0",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
@@ -15153,17 +15317,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "16.12.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.12.0.tgz",
-      "integrity": "sha512-LMxFfAGrcS3kETtQaCkTKjMiifahaMySFDn71fZUNpPHZQEzmk/GiAeIT8JSOrHB23fnuCOMruL2a8NYlw+8Gw==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
       "dependencies": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.18.0"
+        "scheduler": "^0.23.0"
       },
       "peerDependencies": {
-        "react": "^16.0.0"
+        "react": "^18.2.0"
       }
     },
     "node_modules/react-error-overlay": {
@@ -15173,20 +15335,20 @@
       "dev": true
     },
     "node_modules/react-fast-compare": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
-      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
     },
     "node_modules/react-focus-lock": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.2.tgz",
-      "integrity": "sha512-5JfrsOKyA5Zn3h958mk7bAcfphr24jPoMoznJ8vaJF6fUrPQ8zrtEd3ILLOK8P5jvGxdMd96OxWNjDzATfR2qw==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.12.1.tgz",
+      "integrity": "sha512-lfp8Dve4yJagkHiFrC1bGtib3mF2ktqwPJw4/WGcgPW+pJ/AVQA5X2vI7xgp13FcxFEpYBBHpXai/N2DBNC0Jw==",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
-        "focus-lock": "^0.11.2",
+        "focus-lock": "^1.3.5",
         "prop-types": "^15.6.2",
         "react-clientside-effect": "^1.2.6",
-        "use-callback-ref": "^1.3.0",
+        "use-callback-ref": "^1.3.2",
         "use-sidecar": "^1.1.2"
       },
       "peerDependencies": {
@@ -15397,21 +15559,6 @@
         "webpack": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-sortable-hoc": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/react-sortable-hoc/-/react-sortable-hoc-2.0.0.tgz",
-      "integrity": "sha512-JZUw7hBsAHXK7PTyErJyI7SopSBFRcFHDjWW5SWjcugY0i6iH7f+eJkY8cJmGMlZ1C9xz1J3Vjz0plFpavVeRg==",
-      "dependencies": {
-        "@babel/runtime": "^7.2.0",
-        "invariant": "^2.2.4",
-        "prop-types": "^15.5.7"
-      },
-      "peerDependencies": {
-        "prop-types": "^15.5.7",
-        "react": "^16.3.0 || ^17.0.0",
-        "react-dom": "^16.3.0 || ^17.0.0"
       }
     },
     "node_modules/read-cache": {
@@ -16009,12 +16156,11 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.18.0.tgz",
-      "integrity": "sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/schema-utils": {
@@ -17336,11 +17482,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/toggle-selection": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
-      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
-    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -17764,9 +17905,9 @@
       }
     },
     "node_modules/use-callback-ref": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.0.tgz",
-      "integrity": "sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.2.tgz",
+      "integrity": "sha512-elOQwe6Q8gqZgDA8mrh44qRTQqpIHDcZ3hXTLjBe1i4ph8XpNJnO+aQf3NaG+lriLopI4HMx9VjQLfPQ6vhnoA==",
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -19024,9 +19165,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -19100,9 +19241,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -19147,9 +19288,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -20094,9 +20235,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -20261,9 +20402,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -20386,182 +20527,186 @@
       }
     },
     "@contentful/app-sdk": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.13.0.tgz",
-      "integrity": "sha512-jHQmks72qaW4Ge1k1Nk+3zVgCpfZYCJj0XqKfiHwAvXMBgqygOPYj717c3WsgAvwXm/CeTWVpRXg83ILI570LA==",
-      "requires": {}
+      "version": "4.25.0",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/app-sdk/4.25.0/305d18a1809a5059a2abea9019bc8fcf6d854145",
+      "integrity": "sha512-Aw5Yq3zduwHonNJPQtBTNzZ4MC17UtH8zaSnq8cdbDLfyJOYiTgPDDh15AzgwAkfyOovoXCBcyajjra9Cm45Qg==",
+      "requires": {
+        "contentful-management": ">=7.30.0"
+      }
     },
     "@contentful/dam-app-base": {
-      "version": "2.0.55",
-      "resolved": "https://registry.npmjs.org/@contentful/dam-app-base/-/dam-app-base-2.0.55.tgz",
-      "integrity": "sha512-sp+qWTbwV+msZnFrOEkrcJ9W62opZY2oEkYN5yKJJfVUVpohh15+0jP5zNxgBrc0e7UBjr6fQJHfB6gh0JexOQ==",
+      "version": "3.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/dam-app-base/3.0.0/8a6b0aef1674ddbf8845910e61f7f8380dc57595",
+      "integrity": "sha512-XuUq93wem0IMDuDzHnuEZkClFE3fYbdagAw6NIjo38ToKZEWS86WzYoKIJqm41R4jRRBF1tU3fmI48t93OTDmw==",
       "requires": {
-        "@contentful/app-sdk": "^4.0.0",
+        "@contentful/app-sdk": "^4.23.0",
         "@contentful/f36-components": "^4.0.42",
         "@contentful/f36-tokens": "^4.0.0",
-        "array-move": "^3.0.0",
+        "@dnd-kit/core": "^6.1.0",
+        "@dnd-kit/sortable": "^8.0.0",
         "contentful-management": "^10.0.0",
-        "emotion": "^10.0.0",
-        "react-sortable-hoc": "^2.0.0"
+        "emotion": "^10.0.0"
       }
     },
     "@contentful/f36-accordion": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.23.2.tgz",
-      "integrity": "sha512-wUIK+19p18POfnL3NtFN9H29oEOwSeUldu4bhsAUNYsClXTgVweWcgEsbQAjJeG94Dnwzpua6pbskdMXBYTWnA==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-accordion/4.65.5/f5a8dff956f4a350ce3fd71b412fcfe3d5dc06cf",
+      "integrity": "sha512-2TIERDEQ3ChigDdiMimQl9FiDV8jIKqFil+a1smfPZrUway64NKQ9xo4fEHlFCe3N218zCvhZklzemmO3s2cQA==",
       "requires": {
-        "@contentful/f36-collapse": "^4.23.2",
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.23.2",
+        "@contentful/f36-collapse": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-asset": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.23.2.tgz",
-      "integrity": "sha512-ApXYb3DUCvTZwQ2LSR6BcfShgSbrCV0bGb7c2bnoJncGP9ai7YqpGmY8N+zD6/QxOjKQyCUsByxfYLUBcefojg==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-asset/4.65.5/c1e007b3ef2b341804783940da49545741db4017",
+      "integrity": "sha512-/SIKJ1RA8ZHkVIrgVzijDTQCAhos3eaDYnpcA1q2OCn7uBU5a4QMmCjC8U2vb0rmchSxK9Ddg1bASCdF2wjhuA==",
       "requires": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-icon": "^4.23.2",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.23.2",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-icon": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-autocomplete": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.23.2.tgz",
-      "integrity": "sha512-dvgr0z1HGMdh7OIzxVda83sHByinY2Xrgvn7i20pgqmQQAhvVop8nfe/XSFRqoWmUmJppxqot5+597HbQ9533A==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-autocomplete/4.65.5/1ace5c64fbaf7faee387a288abead6374efc61df",
+      "integrity": "sha512-QmTH8U3VWP/JIZVvLVis4UrHdjqvtFVFQP9q4XOCsjCHpI4QHx05pVD3vozBoWr0vAVeIAu2YQQYqDsqcLkg7w==",
       "requires": {
-        "@contentful/f36-button": "^4.23.2",
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-forms": "^4.23.2",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-popover": "^4.23.2",
-        "@contentful/f36-skeleton": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.23.2",
-        "@contentful/f36-utils": "^4.23.2",
+        "@contentful/f36-button": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-forms": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-popover": "^4.65.5",
+        "@contentful/f36-skeleton": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
+        "@contentful/f36-utils": "^4.24.3",
         "downshift": "^6.1.12",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-badge": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.23.2.tgz",
-      "integrity": "sha512-YXAT4pvpfSqqJ44Hwy3XZmb/j5EcNC4gaD4LAM8kOHuCFqUZwzjBOZVaYYHzfa2PhjgTJEKBjpTrPLgTMOJYLw==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-badge/4.65.5/9adf9e18b3b3387b99f604418d88b0498dd34bc2",
+      "integrity": "sha512-EEwf1ZGYQBeOxHnFdem0rCXDPWN1VgNxOpkJgpX8gWryb3xTBoa4/rf/ZQb2H/cQzWi7hVjStVgnUdEiIf2jAA==",
       "requires": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-button": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.23.2.tgz",
-      "integrity": "sha512-KPpSAyxIk8gcovhGFdtCMfKfRsqD/vUj7ioABFnytDTn+bcTdj4iVf1YvU/+4Er+ZD5L7+peAFh/vLVJsoPWZA==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-button/4.65.5/1ccdcef03cb7619da9aa4aec71e1227be37523f9",
+      "integrity": "sha512-+ja1Aba9kBOQNNmZ48esvj/gsR/S6lHT0ZRiR+oIue6eLowdWcurdEhUtv9jzpGiMlA3JOD36M9aalmuVYLA4Q==",
       "requires": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-spinner": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-spinner": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-card": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.23.2.tgz",
-      "integrity": "sha512-9gr0LufH+bLC9COJwnSogw9yBMuiSodf5z/UAFF3c2ZMvANHimiZZQ+viHurYIvXXdcRe9sdtEOxmlyTc2inNA==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-card/4.65.5/981bfc1651e30b07eaadd3e6513344edecdc7160",
+      "integrity": "sha512-4xg0Vm0gF/gzZfOsv4t1NHJ0lE5/QKHpJnoPmxgn4k5PiB6FtODjr29X+jF+m2Q5KB94aBhV3F0k7rX79GdL4Q==",
       "requires": {
-        "@contentful/f36-asset": "^4.23.2",
-        "@contentful/f36-badge": "^4.23.2",
-        "@contentful/f36-button": "^4.23.2",
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-drag-handle": "^4.23.2",
-        "@contentful/f36-icon": "^4.23.2",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-menu": "^4.23.2",
-        "@contentful/f36-skeleton": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-tooltip": "^4.23.2",
-        "@contentful/f36-typography": "^4.23.2",
+        "@contentful/f36-asset": "^4.65.5",
+        "@contentful/f36-badge": "^4.65.5",
+        "@contentful/f36-button": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-drag-handle": "^4.65.5",
+        "@contentful/f36-icon": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-menu": "^4.65.5",
+        "@contentful/f36-skeleton": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-tooltip": "^4.65.5",
+        "@contentful/f36-typography": "^4.65.5",
         "emotion": "^10.0.17",
         "truncate": "^3.0.0"
       }
     },
     "@contentful/f36-collapse": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.23.2.tgz",
-      "integrity": "sha512-Cy8cDv4JNFaw8BuDJWFx3ha/6NCJjzktobPUSqI/QJWUmXCWuMVb3N9n4LoZbxXjSBHm/4SAOPPstlsKsynrdA==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-collapse/4.65.5/67d2e87f52f03d30ee293f36e81d4150c66fc8ec",
+      "integrity": "sha512-aaVkGlPnEcV/reSbzegrRB8VRPiKWIfMgxrliOzA0uT8btTsKdgXySwFwyFiKyw81bfbLugZYan6jkWVcnVRrg==",
       "requires": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-components": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.23.2.tgz",
-      "integrity": "sha512-2VFHo8dYer0yKHlxZoAySR20K8FK89WKusn/pnPARKgzjMNc2XupmlMAjvzmfY4whMjNsSgPzSHOiRWzXoFW9w==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-components/4.65.5/03390a96972b36ac689bec292e38715940531fd6",
+      "integrity": "sha512-xQ6mi7+Rwj04lrF8O1PaAIvRXj6W8U16aYaJXQdc3MgNvUT9eUqEeN09LKTqwTpl/giuetrH/Zey6U+V2ikSkg==",
       "requires": {
-        "@contentful/f36-accordion": "^4.23.2",
-        "@contentful/f36-asset": "^4.23.2",
-        "@contentful/f36-autocomplete": "^4.23.2",
-        "@contentful/f36-badge": "^4.23.2",
-        "@contentful/f36-button": "^4.23.2",
-        "@contentful/f36-card": "^4.23.2",
-        "@contentful/f36-collapse": "^4.23.2",
-        "@contentful/f36-copybutton": "^4.23.2",
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-datepicker": "^4.23.2",
-        "@contentful/f36-datetime": "^4.23.2",
-        "@contentful/f36-drag-handle": "^4.23.2",
-        "@contentful/f36-entity-list": "^4.23.2",
-        "@contentful/f36-forms": "^4.23.2",
-        "@contentful/f36-icon": "^4.23.2",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-list": "^4.23.2",
-        "@contentful/f36-menu": "^4.23.2",
-        "@contentful/f36-modal": "^4.23.2",
-        "@contentful/f36-note": "^4.23.2",
-        "@contentful/f36-notification": "^4.23.2",
-        "@contentful/f36-pagination": "^4.23.2",
-        "@contentful/f36-pill": "^4.23.2",
-        "@contentful/f36-popover": "^4.23.2",
-        "@contentful/f36-skeleton": "^4.23.2",
-        "@contentful/f36-spinner": "^4.23.2",
-        "@contentful/f36-table": "^4.23.2",
-        "@contentful/f36-tabs": "^4.23.2",
-        "@contentful/f36-text-link": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-tooltip": "^4.23.2",
-        "@contentful/f36-typography": "^4.23.2",
-        "@contentful/f36-utils": "^4.23.2",
-        "@types/react": "16.14.22",
-        "@types/react-dom": "16.9.14"
+        "@contentful/f36-accordion": "^4.65.5",
+        "@contentful/f36-asset": "^4.65.5",
+        "@contentful/f36-autocomplete": "^4.65.5",
+        "@contentful/f36-badge": "^4.65.5",
+        "@contentful/f36-button": "^4.65.5",
+        "@contentful/f36-card": "^4.65.5",
+        "@contentful/f36-collapse": "^4.65.5",
+        "@contentful/f36-copybutton": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-datepicker": "^4.65.5",
+        "@contentful/f36-datetime": "^4.65.5",
+        "@contentful/f36-drag-handle": "^4.65.5",
+        "@contentful/f36-empty-state": "^4.65.5",
+        "@contentful/f36-entity-list": "^4.65.5",
+        "@contentful/f36-forms": "^4.65.5",
+        "@contentful/f36-icon": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-list": "^4.65.5",
+        "@contentful/f36-menu": "^4.65.5",
+        "@contentful/f36-modal": "^4.65.5",
+        "@contentful/f36-navbar": "^4.1.1",
+        "@contentful/f36-note": "^4.65.5",
+        "@contentful/f36-notification": "^4.65.5",
+        "@contentful/f36-pagination": "^4.65.5",
+        "@contentful/f36-pill": "^4.65.5",
+        "@contentful/f36-popover": "^4.65.5",
+        "@contentful/f36-skeleton": "^4.65.5",
+        "@contentful/f36-spinner": "^4.65.5",
+        "@contentful/f36-table": "^4.65.5",
+        "@contentful/f36-tabs": "^4.65.5",
+        "@contentful/f36-text-link": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-tooltip": "^4.65.5",
+        "@contentful/f36-typography": "^4.65.5",
+        "@contentful/f36-utils": "^4.24.3"
       }
     },
     "@contentful/f36-copybutton": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.23.2.tgz",
-      "integrity": "sha512-Je6NMxS+YZQ6FV261kYcnl2G4+agXWxWq4S+CUUGAiTXuSZyXouSlEzroq6dqVDgUQMmHoK5Mq5vAI5fZ79cgg==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-copybutton/4.65.5/3c564edf780231dd831bded291461baff8cd756d",
+      "integrity": "sha512-w4FQst+STqNi5sWQYgbW24eSWUyl2kCO40LK4YKO7Ugv2VUD5b6F25QqRrjs39bryTZWPO6g8ZLP6FEijdzv1g==",
       "requires": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-tooltip": "^4.23.2",
-        "emotion": "^10.0.17",
-        "react-copy-to-clipboard": "^5.1.0"
+        "@contentful/f36-button": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-tooltip": "^4.65.5",
+        "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-core": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.23.2.tgz",
-      "integrity": "sha512-kBSbDuVrA8ck2lAVvMzW5bJ/P2bwnpIb9ZZrqXt5aOYDV5iln7swdYnYlypMRS9w5PS4RAb2hnydQ1aUXOE93Q==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-core/4.65.5/76fea74e91d1c5cb54cffcc6715870a356789cff",
+      "integrity": "sha512-oGQGxRbdUlG6esKjV4NkPRYbIGUWTfwoT8T1CYz//bSGAi+K0Cvzf0oVpvjso1AYlVazXuByb0s1nOT48WlIug==",
       "requires": {
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-tokens": "^4.0.4",
         "@emotion/core": "^10.1.1",
         "@emotion/is-prop-valid": "^1.2.0",
         "csstype": "^3.1.1",
@@ -20569,270 +20714,300 @@
       }
     },
     "@contentful/f36-datepicker": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.23.2.tgz",
-      "integrity": "sha512-arXVylfHRxI8VRrh4s1zfo5ha2LE+gKpzUtdoCfqQixyaVD5d2RwSjwXAx/9rWXhtVh9cvM7YF8mP5oTl/9KiA==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-datepicker/4.65.5/2862bdd5231f1c0157401839484a278d58bdcd1e",
+      "integrity": "sha512-ehA99+gV6i7IUcZopge+ElrVrO6ONQbfCEu9KqQRzrJ3Qg4m2k5HsTzmtkJi7DMKkplTy5Z4VIFDsx+yoNqwqg==",
       "requires": {
-        "@contentful/f36-button": "^4.23.2",
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-forms": "^4.23.2",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-popover": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-typography": "^4.23.2",
+        "@contentful/f36-button": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-forms": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-popover": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
         "date-fns": "^2.28.0",
         "emotion": "^10.0.17",
-        "react-day-picker": "^8.3.5",
+        "react-day-picker": "^8.7.1",
         "react-focus-lock": "^2.9.1"
       }
     },
     "@contentful/f36-datetime": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.23.2.tgz",
-      "integrity": "sha512-bUTPIfvEdKjPVPVn4YH+eYCO8h7gLhfN+zKy5DrXlGIHmvk0IKhGfWq8ts82n96Fc4XRW3RrXkF4qO0eIQUVHQ==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-datetime/4.65.5/acfba66e0bd262d026c968ca87aa2a6edd64a7bc",
+      "integrity": "sha512-cs5A53ucqiX78S6wWmSATHo4BzccgUTrQ6Xzz9DLkXfNT/SLePTI9urIp8a/YChr0p76cYDcta4EjVt7ie+Ilw==",
       "requires": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
         "dayjs": "^1.11.5",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-drag-handle": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.23.2.tgz",
-      "integrity": "sha512-eR4nwtbiJSEvTACPVAe1a3ME70ge4H0/w7n+9U1p3GCF36KEl3j0VMweP0PXeH8hRvhAse3yRQTzIDOF5yKnMw==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-drag-handle/4.65.5/5ce7a2a700b9b9fe4a3e78ac06894f4be3756759",
+      "integrity": "sha512-QZXcWK8TrGYTaES1rWniJlOER673qHjnqiA1YD51Q53ACkDJ2OenzbNlHq7Rg65MLV9JognCXpXJqqjyMXCmxg==",
       "requires": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-utils": "^4.24.3",
+        "emotion": "^10.0.17"
+      }
+    },
+    "@contentful/f36-empty-state": {
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-empty-state/4.65.5/11c0ffb18bae1e8f06b4b38838eb61023e6d07eb",
+      "integrity": "sha512-ZnB+XtHe57JYBhqePLkp88Kn1xh41tLyJQec23nsz3k8EIyaTUy5tGVJ7JQoZOVYKfXlu6dqg9aKrzVhhgZG6A==",
+      "requires": {
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-entity-list": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.23.2.tgz",
-      "integrity": "sha512-OkgEgyRIG3u8ulIT6BBpUJ2cKr3pIRZEpZsQv80Tznls9cMeyq7z/IjYTWg7vOLeayTaciF0fGM1TkPnFw3Xfw==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-entity-list/4.65.5/c5393896e93eb59447f5a6ff5189ddc0fbb86b66",
+      "integrity": "sha512-oN+SGGsd215Kdu9FyVgoywPdpdGBP0yLQMs2iK51pdNfnCbxXQ/vqBsMk6IU9SgIPAKbnQvKXnd6cQIQ2VbSNA==",
       "requires": {
-        "@contentful/f36-badge": "^4.23.2",
-        "@contentful/f36-button": "^4.23.2",
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-drag-handle": "^4.23.2",
-        "@contentful/f36-icon": "^4.23.2",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-menu": "^4.23.2",
-        "@contentful/f36-skeleton": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.23.2",
+        "@contentful/f36-badge": "^4.65.5",
+        "@contentful/f36-button": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-drag-handle": "^4.65.5",
+        "@contentful/f36-icon": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-menu": "^4.65.5",
+        "@contentful/f36-skeleton": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-forms": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.23.2.tgz",
-      "integrity": "sha512-nIleirk2SiW8w86q3Y7M5ZJy7J2zFbq4f0PD/5d0O3bYGtobn8ZNzoY6oYSt48crmhwDMyntszTgOJfPNWH55w==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-forms/4.65.5/db51f3a74ec1335f6f6f2b8ebd28113fa584a2cd",
+      "integrity": "sha512-XkueX0CcF2ZdcwBBe/mD3GUSROsXcIwXmXdPSaQ1kgpCNVf9DS/GMgQPRCh7YCPOfT9jVDaeO8qg2JWRXsxrbg==",
       "requires": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.23.2",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-icon": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.23.2.tgz",
-      "integrity": "sha512-mWwYfcP20nK1+tmxdhrDoTI0Uo1YIMG3zKbNr20V0pC4de94K5u962CaBJaw3RosTnfCoikQmJbg7CY5OuKSVA==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-icon/4.65.5/a23dbdbcd977f5c0ed754a84127eb8b9020449ba",
+      "integrity": "sha512-ZdASqrHxSRhbOAzHdUqrdX/RrkAake6bjkkQ9/5LYNkM/Ru1hVcn4vgKSx65dA3+Eo6QzTA9zmETRyqn6awzeg==",
       "requires": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-icons": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-4.23.2.tgz",
-      "integrity": "sha512-1voQyaiMrQGAFUXRZiuP/9e1A2unp0IOGyXUUCaWaFRbivjxRTUd9Sq2jSA/DutCC5OJ+BDxMiIJJnQz1izGRQ==",
+      "version": "4.28.2",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-icons/4.28.2/8297da32e9d8e60e09550e365f24a74a8e12326c",
+      "integrity": "sha512-p7oWbQ5ITlMMuEl/6t/6JLVrCVhDE2nA8mv1VR4DHjXPm0y9w14533rCKxNIREZX8iVmyBoaqI3vdPsjUs1CAw==",
       "requires": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-icon": "^4.23.2",
+        "@contentful/f36-core": "^4.65.0",
+        "@contentful/f36-icon": "^4.65.0",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-list": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.23.2.tgz",
-      "integrity": "sha512-hZ8bBIEpNF+G4XMQkEX1t4sFxmUr9/wcUAm1XEhWCC/AIipaYVgQoXNQFBO9IGZFAYonOZSqaT9mRrj5y2jegg==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-list/4.65.5/0aa877c124883e1af4434f72d9404de7c4a30575",
+      "integrity": "sha512-OH+odg2hjB9/9i6k71hqvmufNiFP0l/pob2+Yr2RtReM4+6gdULsNlZpo8SUv8L5ryX2/QdlEulIqk6Do9rYpg==",
       "requires": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-menu": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.23.2.tgz",
-      "integrity": "sha512-v5Txmv0mS9zQlq7b1aAmH4Q99TbnqkE2EbO37D04JyeB6DEbriVdlwhsIiW/LJcxC1ffQFaN2MTVGSJKNsiQ+A==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-menu/4.65.5/32ca0f66cdc3cef6b510e4aa236c54bb9f874e30",
+      "integrity": "sha512-XrCx3nWMbtl4KjobntUpzkccSdU/mmFHi3TSMV1VZ8aECIu3FuEx2RgBY5XRIQOSw4AfbA72RQO/HA4opsmJUQ==",
       "requires": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-popover": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.23.2",
-        "@contentful/f36-utils": "^4.23.2",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-popover": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-modal": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.23.2.tgz",
-      "integrity": "sha512-OVUoJp2LCMyIogxxyQFKfSKdQhFawDt0UWgire615VH5EZGVtd7y+qiB8oEelurdTGO6sozlA7FoZVBbH/SRnQ==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-modal/4.65.5/8eaffd5d0f531a960341857f68dc0473a09b2b78",
+      "integrity": "sha512-LoL948QiBUrRiWqQAmEIWtYb00Q2LDgvWwjL1LQDIpUx+Rvig657r5umypYUS31OKTYlOrkfo+J1JfpWi8/bMQ==",
       "requires": {
-        "@contentful/f36-button": "^4.23.2",
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.23.2",
-        "@types/react-modal": "^3.12.1",
+        "@contentful/f36-button": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
+        "@types/react-modal": "^3.13.1",
         "emotion": "^10.0.17",
-        "react-modal": "^3.14.3"
+        "react-modal": "^3.16.1"
+      }
+    },
+    "@contentful/f36-navbar": {
+      "version": "4.1.1",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-navbar/4.1.1/139c0280f14f3a923d40bfa7290984eb60486119",
+      "integrity": "sha512-nCLtZ7EgfKhmXWrGZYrZEQOoulOOVPOuZBk0CC4JgQRQmCYeYr2iAnM8zualISFaxX/O+GVvHPQf2hKeoeFRPA==",
+      "requires": {
+        "@contentful/f36-core": "^4.45.0",
+        "@contentful/f36-icon": "^4.45.0",
+        "@contentful/f36-icons": "^4.23.2",
+        "@contentful/f36-menu": "^4.45.0",
+        "@contentful/f36-skeleton": "^4.45.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-utils": "^4.23.2",
+        "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-note": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.23.2.tgz",
-      "integrity": "sha512-Sgi4lWhB357zz0VdqY1fQdH3EIMWoOMwhJqYtdhuo6AYfMWeVcJn/xoWEjhjiExtG5L4Q2CFt4lW9exeNgI1Rw==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-note/4.65.5/10652c0363f1437cfbdf65c76e192a69fc2bc29e",
+      "integrity": "sha512-TFd9p8Qg/Y+1Oq5aJEw5ybjaZs49CoBuhjxrybC8U4ODh0gpCUA0lJEVyWcaejyitTt2mSYJIhn9l/7CPrb+iw==",
       "requires": {
-        "@contentful/f36-button": "^4.23.2",
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-icon": "^4.23.2",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.23.2",
+        "@contentful/f36-button": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-icon": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-notification": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.23.2.tgz",
-      "integrity": "sha512-gzLAaYo8+kDj8MDJDMNR6JrvIQ3w+8z5A0VE95uzG1MKG3qp+S3jrXZBU0mzV2yVMcruYbpx7dIV+neeH4oS4Q==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-notification/4.65.5/0eb83df1926786423372f574859a267777104d5d",
+      "integrity": "sha512-jGtPKDc7mIHgNtSQQvN25c+L6JIf5mR9aXE8b7WPOc3vaFq8bln9OMMiivvD+iMDPbWf0bukNNn3NNP/bt+oZw==",
       "requires": {
-        "@contentful/f36-button": "^4.23.2",
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-text-link": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-typography": "^4.23.2",
-        "@swc/helpers": "^0.4.2",
+        "@contentful/f36-button": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-text-link": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
+        "@swc/helpers": "^0.4.14",
         "emotion": "^10.0.17",
         "react-animate-height": "^3.0.4"
       }
     },
     "@contentful/f36-pagination": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.23.2.tgz",
-      "integrity": "sha512-+JW+qnwT+fu1LuvxZP6F7TWy6Qi0BFRvn+jJUVCCpvFLI4Ee5oIy7HaJwHUNVHp6/YrjIIR6K1tEQHBGC4eTNQ==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-pagination/4.65.5/c5ca04b4e514090aac2950ae89bcf341291c5905",
+      "integrity": "sha512-+UBNt5UbmPQElwhtzS6OLRWAbR/pi45HKSl3uGLlJ5V1HNhEcebLzqWGPeQuv7xkHMVUbTTJKwM0G2zD7b8dQA==",
       "requires": {
-        "@contentful/f36-button": "^4.23.2",
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-forms": "^4.23.2",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-typography": "^4.23.2",
+        "@contentful/f36-button": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-forms": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-pill": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.23.2.tgz",
-      "integrity": "sha512-qrNtbvcapPB6s8Bz1WtlBVVo+7zGN9b9ZABeDEvXJXGCeR0S5FP2fJou+9UCE5AD7579SdeEtbGU0JmjBb71ZQ==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-pill/4.65.5/9858608a30440b490c33908b71d18089d6e71a37",
+      "integrity": "sha512-mpK3StAaXmP/XpDDR6fVvM910RfY0C97VnVcbXA3ZZ9itb68jKzb7Y+gRfEJXGHza9oE/qgQEQuLHdNTqhuHEw==",
       "requires": {
-        "@contentful/f36-button": "^4.23.2",
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-tooltip": "^4.23.2",
+        "@contentful/f36-button": "^4.65.5",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-drag-handle": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-tooltip": "^4.65.5",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-popover": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.23.2.tgz",
-      "integrity": "sha512-SXZ9DkC9zjhW5TneZ0QmcfivK5cvlvPsjAFyJJoFLWWwbcLS6pynZhsa1do35xAIgmBKav2VNQKmmASc+mLJ/w==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-popover/4.65.5/83fba8d9336a1763a2148ecb0e05b9c637f37c54",
+      "integrity": "sha512-qZO0T8qyTg4FsSsgfPTk4/ZxQSFOWbajLI+LxpeC0UH95gb5xoTkb+jHBDRdJ+xQyIZqYAcycI2HK6IJZEfboQ==",
       "requires": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-utils": "^4.23.2",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
         "emotion": "^10.0.17",
         "react-popper": "^2.3.0"
       }
     },
     "@contentful/f36-skeleton": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.23.2.tgz",
-      "integrity": "sha512-KkZlUl+QD1aVJK/yLUia6ew9lJ0Xt3ZDICkFCpSQQ0ZIg8tbd4tiGnBnM5CrcxP78Juwi8bseumYXksKexPYJg==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-skeleton/4.65.5/f11c1c0207c358f79274da8b81432e9808ad3d5f",
+      "integrity": "sha512-qb48ythK06bShtJh3VopNVygg9h3psjbo45weh1IlQrlMFZRXsGtn5sdvMAK/982QcUuUSvxjWhAyU3QYkpeMQ==",
       "requires": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-table": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-table": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-spinner": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.23.2.tgz",
-      "integrity": "sha512-QlP6CsnVGbVfdA+vFKEEM1YH/2TYHFBq8HxiRb9n69oSYvlzKsBH5gu3Jlsy/qH0vaT3a6N1hFi8zRIxkE5/2g==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-spinner/4.65.5/c6d35aff3638ed299b32abf3972a5ab07b4580e8",
+      "integrity": "sha512-nMn5ul1nrLcUOygzZ8LPavuFHnfPMZAo1BSarYhutz83CmEEVzlkAoGwM/cJCCrm6ylb3oXiQOZSUxmEJeqxiA==",
       "requires": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-table": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.23.2.tgz",
-      "integrity": "sha512-Q65a40FQfYhLFsGGdy+bM+0N4YLt2BQ8IdVk5FSknSHwb7rhGgg9hD11i9CAGoPuw6pIO/NuTeS62QKS2Bjuiw==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-table/4.65.5/d0f1c3706518570b3f2a6577e67c9a5f149f5e82",
+      "integrity": "sha512-HBp1yC7y8+/5fq46d0uPgYtGiKXEmUHFAvnJQfOQYdmQcnYHYoHvxII2d606cpfulBjydNDMha+HZV09jepQaA==",
       "requires": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-typography": "^4.65.5",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-tabs": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.23.2.tgz",
-      "integrity": "sha512-Gd44MH2rtCidCGYbbtT65bQdxXX5THAXjtL3yxsgK3KfkkKGtEA91auVFhDqyxalHRv7qylgI/ZvlUiGK+vOBw==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tabs/4.65.5/741f176fbb609cb0208a90ba858bb7b8db00bf46",
+      "integrity": "sha512-7lEFs4IoYwIEOXqlEBQnO0dnKmGkASoKqeTP/lA6XS80Ymoled3XZLcc3ICZhjsZvtSRrXQ+3yIiDc1Y2EzIfg==",
       "requires": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
         "@radix-ui/react-tabs": "^1.0.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-text-link": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.23.2.tgz",
-      "integrity": "sha512-CBtNarrCE/ibjPynEVBEJYpbINfFO8dF+36TCCfe1Nk/bbLTcRfgy/3kTsM4Ee34aFVl6BgFUwjmrnfLmekE2g==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-text-link/4.65.5/9f25355a0b1f7d7ca60bea3056fa51ef5d703f2a",
+      "integrity": "sha512-1Jk/tebqIif+f4ef8QV+mxdzfA7g+YotAGRkkFjVCPjO1KX1GI6Ocyr0xI4h0fRjnUOJ4qqy7AU3a2DnbX07jw==",
       "requires": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-tokens": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-4.0.1.tgz",
-      "integrity": "sha512-NTyMAQcfvhPP8kJgOK5mtjKpErg799iglEb9B45ii4N7aMdph2GNqgv7KBgpogfbTEGBrlKIoH8MUDSV9YNREg=="
+      "version": "4.0.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tokens/4.0.5/20fbaa7f58115be7b31998fb1af618c3bb85bfbe",
+      "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
     },
     "@contentful/f36-tooltip": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.23.2.tgz",
-      "integrity": "sha512-xqdkNg5HBPFTRn+J7q6gGWs5ugN1wyLJTSZm1uBYWXejUmfyWysLMRR8GYj7HxgoONKBtXujJF54PWQILRBiFw==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-tooltip/4.65.5/f49f071595492d15f57f0b6b73a5c6a0d3329ab1",
+      "integrity": "sha512-12U5tYHIBEwK4WDXlt6riNWLEKLeatjtsz9H0zXp0ANANkNFSpVO32ED6fFHHDCtK6iekm/3EQ2QJ7Jua4y0iQ==",
       "requires": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-utils": "^4.23.2",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
         "csstype": "^3.1.1",
         "emotion": "^10.0.17",
@@ -20840,19 +21015,20 @@
       }
     },
     "@contentful/f36-typography": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.23.2.tgz",
-      "integrity": "sha512-Js+jPfmiRbkgkztFf+wrLxv/fA9V+wU/zhyxTT3OcWHrLiVY92NjlfyEGXmWxJClH44hCw+p3jjSFVf3WsWG1Q==",
+      "version": "4.65.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-typography/4.65.5/42e3d72c44ceccdd450e9f2040728d15d1b4caa4",
+      "integrity": "sha512-hprmtdy0y661nxUYn2QddbKJyuHszG8j5p6Iz3CFEN2nCNaOe1OtCENrv1amZmDBHOj1x8ldWF7Bm/Nnqva45g==",
       "requires": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-core": "^4.65.5",
+        "@contentful/f36-tokens": "^4.0.4",
+        "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-utils": {
-      "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-utils/-/f36-utils-4.23.2.tgz",
-      "integrity": "sha512-VCSjMMYgAPNPek2sz9EJT7mDD2S/I2F6JgyeIBczayDaZvp1sTq/elozEh7vfMsmfmkirOW6qFKwOBQkKCKgZA==",
+      "version": "4.24.3",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/f36-utils/4.24.3/12868232fe068b7095d2db8ae1cfe296370d124a",
+      "integrity": "sha512-9+tyDOCjEhW7m4X7Sam0VYlmcgjhLVMiapCnv1EmRstlMaeI5ti9y0y/2aQ04Na2ScoHwrMTjveoZ6V62J62tA==",
       "requires": {
         "emotion": "^10.0.17"
       }
@@ -20999,6 +21175,41 @@
       "dev": true,
       "requires": {}
     },
+    "@dnd-kit/accessibility": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.0.tgz",
+      "integrity": "sha512-ea7IkhKvlJUv9iSHJOnxinBcoOI3ppGnnL+VDJ75O45Nss6HtZd8IdN8touXPDtASfeI2T2LImb8VOZcL47wjQ==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@dnd-kit/core": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.1.0.tgz",
+      "integrity": "sha512-J3cQBClB4TVxwGo3KEjssGEXNJqGVWx17aRTZ1ob0FliR5IjYgTxl5YJbKTzA6IzrtelotH19v6y7uoIRUZPSg==",
+      "requires": {
+        "@dnd-kit/accessibility": "^3.1.0",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@dnd-kit/sortable": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-8.0.0.tgz",
+      "integrity": "sha512-U3jk5ebVXe1Lr7c2wU7SBZjcWdQP+j7peHJfCspnA81enlu88Mgd7CC8Q+pub9ubP7eKVETzJW+IBAhsqbSu/g==",
+      "requires": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
     "@emotion/cache": {
       "version": "10.0.29",
       "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
@@ -21039,17 +21250,17 @@
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
     },
     "@emotion/is-prop-valid": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz",
-      "integrity": "sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz",
+      "integrity": "sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==",
       "requires": {
-        "@emotion/memoize": "^0.8.0"
+        "@emotion/memoize": "^0.8.1"
       }
     },
     "@emotion/memoize": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
-      "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA=="
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
+      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
     },
     "@emotion/serialize": {
       "version": "0.11.16",
@@ -21721,145 +21932,145 @@
       }
     },
     "@popperjs/core": {
-      "version": "2.11.6",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
-      "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw=="
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
     },
     "@radix-ui/primitive": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.0.tgz",
-      "integrity": "sha512-3e7rn8FDMin4CgeL7Z/49smCA3rFYY3Ha2rUQ7HRWFadS5iCRw08ZgVT1LaNTCNqgvrUiyczLflrVrF0SRQtNA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.1.tgz",
+      "integrity": "sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==",
       "requires": {
         "@babel/runtime": "^7.13.10"
       }
     },
     "@radix-ui/react-collection": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.0.1.tgz",
-      "integrity": "sha512-uuiFbs+YCKjn3X1DTSx9G7BHApu4GHbi3kgiwsnFUbOKCrwejAJv4eE4Vc8C0Oaxt9T0aV4ox0WCOdx+39Xo+g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.0.3.tgz",
+      "integrity": "sha512-3SzW+0PW7yBBoQlT8wNcGtaxaD0XSu0uLUFgrtHY08Acx05TaHaOmVLR73c0j/cqpDy53KBMO7s0dx2wmOIDIA==",
       "requires": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-compose-refs": "1.0.0",
-        "@radix-ui/react-context": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.1",
-        "@radix-ui/react-slot": "1.0.1"
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2"
       }
     },
     "@radix-ui/react-compose-refs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.0.tgz",
-      "integrity": "sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz",
+      "integrity": "sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==",
       "requires": {
         "@babel/runtime": "^7.13.10"
       }
     },
     "@radix-ui/react-context": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.0.tgz",
-      "integrity": "sha512-1pVM9RfOQ+n/N5PJK33kRSKsr1glNxomxONs5c49MliinBY6Yw2Q995qfBUUo0/Mbg05B/sGA0gkgPI7kmSHBg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.1.tgz",
+      "integrity": "sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==",
       "requires": {
         "@babel/runtime": "^7.13.10"
       }
     },
     "@radix-ui/react-direction": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.0.0.tgz",
-      "integrity": "sha512-2HV05lGUgYcA6xgLQ4BKPDmtL+QbIZYH5fCOTAOOcJ5O0QbWS3i9lKaurLzliYUDhORI2Qr3pyjhJh44lKA3rQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.0.1.tgz",
+      "integrity": "sha512-RXcvnXgyvYvBEOhCBuddKecVkoMiI10Jcm5cTI7abJRAHYfFxeu+FBQs/DvdxSYucxR5mna0dNsL6QFlds5TMA==",
       "requires": {
         "@babel/runtime": "^7.13.10"
       }
     },
     "@radix-ui/react-id": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.0.0.tgz",
-      "integrity": "sha512-Q6iAB/U7Tq3NTolBBQbHTgclPmGWE3OlktGGqrClPozSw4vkQ1DfQAOtzgRPecKsMdJINE05iaoDUG8tRzCBjw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.0.1.tgz",
+      "integrity": "sha512-tI7sT/kqYp8p96yGWY1OAnLHrqDgzHefRBKQ2YAkBS5ja7QLcZ9Z/uY7bEjPUatf8RomoXM8/1sMj1IJaE5UzQ==",
       "requires": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-use-layout-effect": "1.0.0"
+        "@radix-ui/react-use-layout-effect": "1.0.1"
       }
     },
     "@radix-ui/react-presence": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.0.0.tgz",
-      "integrity": "sha512-A+6XEvN01NfVWiKu38ybawfHsBjWum42MRPnEuqPsBZ4eV7e/7K321B5VgYMPv3Xx5An6o1/l9ZuDBgmcmWK3w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.0.1.tgz",
+      "integrity": "sha512-UXLW4UAbIY5ZjcvzjfRFo5gxva8QirC9hF7wRE4U5gz+TP0DbRk+//qyuAQ1McDxBt1xNMBTaciFGvEmJvAZCg==",
       "requires": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-compose-refs": "1.0.0",
-        "@radix-ui/react-use-layout-effect": "1.0.0"
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1"
       }
     },
     "@radix-ui/react-primitive": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.1.tgz",
-      "integrity": "sha512-fHbmislWVkZaIdeF6GZxF0A/NH/3BjrGIYj+Ae6eTmTCr7EB0RQAAVEiqsXK6p3/JcRqVSBQoceZroj30Jj3XA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.3.tgz",
+      "integrity": "sha512-yi58uVyoAcK/Nq1inRY56ZSjKypBNKTa/1mcL8qdl6oJeEaDbOldlzrGn7P6Q3Id5d+SYNGc5AJgc4vGhjs5+g==",
       "requires": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-slot": "1.0.1"
+        "@radix-ui/react-slot": "1.0.2"
       }
     },
     "@radix-ui/react-roving-focus": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.0.1.tgz",
-      "integrity": "sha512-TB76u5TIxKpqMpUAuYH2VqMhHYKa+4Vs1NHygo/llLvlffN6mLVsFhz0AnSFlSBAvTBYVHYAkHAyEt7x1gPJOA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.0.4.tgz",
+      "integrity": "sha512-2mUg5Mgcu001VkGy+FfzZyzbmuUWzgWkj3rvv4yu+mLw03+mTzbxZHvfcGyFp2b8EkQeMkpRQ5FiA2Vr2O6TeQ==",
       "requires": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/primitive": "1.0.0",
-        "@radix-ui/react-collection": "1.0.1",
-        "@radix-ui/react-compose-refs": "1.0.0",
-        "@radix-ui/react-context": "1.0.0",
-        "@radix-ui/react-direction": "1.0.0",
-        "@radix-ui/react-id": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.1",
-        "@radix-ui/react-use-callback-ref": "1.0.0",
-        "@radix-ui/react-use-controllable-state": "1.0.0"
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-collection": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@radix-ui/react-use-controllable-state": "1.0.1"
       }
     },
     "@radix-ui/react-slot": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.1.tgz",
-      "integrity": "sha512-avutXAFL1ehGvAXtPquu0YK5oz6ctS474iM3vNGQIkswrVhdrS52e3uoMQBzZhNRAIE0jBnUyXWNmSjGHhCFcw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.2.tgz",
+      "integrity": "sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==",
       "requires": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-compose-refs": "1.0.0"
+        "@radix-ui/react-compose-refs": "1.0.1"
       }
     },
     "@radix-ui/react-tabs": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.0.1.tgz",
-      "integrity": "sha512-mVNEwHwgjy2G9F7b39f9VY+jF0QUZykTm0Sdv+Uz6KC4KOEIa4HLDiHU8MeEZluRtZE3aqGYDhl93O7QbJDwhg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.0.4.tgz",
+      "integrity": "sha512-egZfYY/+wRNCflXNHx+dePvnz9FbmssDTJBtgRfDY7e8SE5oIo3Py2eCB1ckAbh1Q7cQ/6yJZThJ++sgbxibog==",
       "requires": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/primitive": "1.0.0",
-        "@radix-ui/react-context": "1.0.0",
-        "@radix-ui/react-direction": "1.0.0",
-        "@radix-ui/react-id": "1.0.0",
-        "@radix-ui/react-presence": "1.0.0",
-        "@radix-ui/react-primitive": "1.0.1",
-        "@radix-ui/react-roving-focus": "1.0.1",
-        "@radix-ui/react-use-controllable-state": "1.0.0"
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-presence": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-roving-focus": "1.0.4",
+        "@radix-ui/react-use-controllable-state": "1.0.1"
       }
     },
     "@radix-ui/react-use-callback-ref": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.0.tgz",
-      "integrity": "sha512-GZtyzoHz95Rhs6S63D2t/eqvdFCm7I+yHMLVQheKM7nBD8mbZIt+ct1jz4536MDnaOGKIxynJ8eHTkVGVVkoTg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.1.tgz",
+      "integrity": "sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ==",
       "requires": {
         "@babel/runtime": "^7.13.10"
       }
     },
     "@radix-ui/react-use-controllable-state": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.0.tgz",
-      "integrity": "sha512-FohDoZvk3mEXh9AWAVyRTYR4Sq7/gavuofglmiXB2g1aKyboUD4YtgWxKj8O5n+Uak52gXQ4wKz5IFST4vtJHg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.1.tgz",
+      "integrity": "sha512-Svl5GY5FQeN758fWKrjM6Qb7asvXeiZltlT4U2gVfl8Gx5UAv2sMR0LWo8yhsIZh2oQ0eFdZ59aoOOMV7b47VA==",
       "requires": {
         "@babel/runtime": "^7.13.10",
-        "@radix-ui/react-use-callback-ref": "1.0.0"
+        "@radix-ui/react-use-callback-ref": "1.0.1"
       }
     },
     "@radix-ui/react-use-layout-effect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.0.tgz",
-      "integrity": "sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.1.tgz",
+      "integrity": "sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==",
       "requires": {
         "@babel/runtime": "^7.13.10"
       }
@@ -22113,10 +22324,11 @@
       }
     },
     "@swc/helpers": {
-      "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
-      "integrity": "sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.36.tgz",
+      "integrity": "sha512-5lxnyLEYFskErRPenYItLRSge5DjrJngYKdVjRSrWfza9G6KkgHEXi0vUZiyUeMU5JfXH1YnvXZzSp8ul88o2Q==",
       "requires": {
+        "legacy-swc-helpers": "npm:@swc/helpers@=0.4.14",
         "tslib": "^2.4.0"
       }
     },
@@ -22368,9 +22580,9 @@
       "dev": true
     },
     "@types/prop-types": {
-      "version": "15.7.5",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
+      "version": "15.7.12",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
+      "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q=="
     },
     "@types/q": {
       "version": "1.5.5",
@@ -22391,27 +22603,27 @@
       "dev": true
     },
     "@types/react": {
-      "version": "16.14.22",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.22.tgz",
-      "integrity": "sha512-4NnkxKDd2UO9SiCckuhCQOCzdO+RtE4Epf1D6eGz3f9jZjiIXOVo+Bk3jqSad+8EOT+LBXwKdkFX0V0F+NFzDQ==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-V0kuGBX3+prX+DQ/7r2qsv1NsdfnCLnTgnRJ1pYnxykBhGMz+qj+box5lq7XsO5mtZsBqpjwwTu/7wszPfMBcw==",
       "requires": {
         "@types/prop-types": "*",
-        "@types/scheduler": "*",
         "csstype": "^3.0.2"
       }
     },
     "@types/react-dom": {
-      "version": "16.9.14",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.14.tgz",
-      "integrity": "sha512-FIX2AVmPTGP30OUJ+0vadeIFJJ07Mh1m+U0rxfgyW34p3rTlXI+nlenvAxNn4BP36YyI9IJ/+UJ7Wu22N1pI7A==",
+      "version": "18.3.0",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
+      "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
+      "peer": true,
       "requires": {
-        "@types/react": "^16"
+        "@types/react": "*"
       }
     },
     "@types/react-modal": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/@types/react-modal/-/react-modal-3.13.1.tgz",
-      "integrity": "sha512-iY/gPvTDIy6Z+37l+ibmrY+GTV4KQTHcCyR5FIytm182RQS69G5ps4PH2FxtC7bAQ2QRHXMevsBgck7IQruHNg==",
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/@types/react-modal/-/react-modal-3.16.3.tgz",
+      "integrity": "sha512-xXuGavyEGaFQDgBv4UVm8/ZsG+qxeQ7f77yNrW3n+1J6XAstUy5rYHeIHPh1KzsGc6IkCIdu6lQ2xWzu1jBTLg==",
       "requires": {
         "@types/react": "*"
       }
@@ -22430,11 +22642,6 @@
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "dev": true
-    },
-    "@types/scheduler": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "@types/semver": {
       "version": "7.5.8",
@@ -23046,11 +23253,6 @@
         "is-string": "^1.0.7"
       }
     },
-    "array-move": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/array-move/-/array-move-3.0.1.tgz",
-      "integrity": "sha512-H3Of6NIn2nNU1gsVDqDnYKY/LCdWvCMMOWifNGhKcVQgiZ6nOek39aESOvro6zmueP07exSl93YLvkN4fZOkSg=="
-    },
     "array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -23358,9 +23560,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -24124,14 +24326,6 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "dev": true
     },
-    "copy-to-clipboard": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
-      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
-      "requires": {
-        "toggle-selection": "^1.0.6"
-      }
-    },
     "core-js": {
       "version": "3.36.1",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.36.1.tgz",
@@ -24468,9 +24662,9 @@
       }
     },
     "csstype": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "damerau-levenshtein": {
       "version": "1.0.8",
@@ -24523,14 +24717,17 @@
       }
     },
     "date-fns": {
-      "version": "2.29.3",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
-      "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA=="
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "requires": {
+        "@babel/runtime": "^7.21.0"
+      }
     },
     "dayjs": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.6.tgz",
-      "integrity": "sha512-zZbY5giJAinCG+7AGaw0wIhNZ6J8AhWuSXKvuc1KAyMiRsvGQWqh4L+MomvhdAYjN+lqvVCMq1I41e3YHvXkyQ=="
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.11.tgz",
+      "integrity": "sha512-okzr3f11N6WuqYtZSvm+F776mB41wRZMhKP+hc34YdW+KmtYYK9iqvHSwo2k9FEH3fhGXvOPV6yz2IcSrfRUDg=="
     },
     "debug": {
       "version": "4.3.4",
@@ -25899,9 +26096,9 @@
       "dev": true
     },
     "focus-lock": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.11.4.tgz",
-      "integrity": "sha512-LzZWJcOBIcHslQ46N3SUu/760iLPSrUtp8omM4gh9du438V2CQdks8TcOu1yvmu2C68nVOBnl1WFiKGPbQ8L6g==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-1.3.5.tgz",
+      "integrity": "sha512-QFaHbhv9WPUeLYBDe/PAuLKJ4Dd9OPvKs9xZBr3yLXnUrDNaVXKu2baDBXe3naPY30hgHYSsf2JW4jzas2mDEQ==",
       "requires": {
         "tslib": "^2.0.3"
       }
@@ -26623,14 +26820,6 @@
         "es-errors": "^1.3.0",
         "hasown": "^2.0.0",
         "side-channel": "^1.0.4"
-      }
-    },
-    "invariant": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "requires": {
-        "loose-envify": "^1.0.0"
       }
     },
     "ipaddr.js": {
@@ -27883,9 +28072,9 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true
     },
     "jsonfile": {
@@ -27966,6 +28155,14 @@
       "requires": {
         "picocolors": "^1.0.0",
         "shell-quote": "^1.8.1"
+      }
+    },
+    "legacy-swc-helpers": {
+      "version": "npm:@swc/helpers@0.4.14",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
+      "integrity": "sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==",
+      "requires": {
+        "tslib": "^2.4.0"
       }
     },
     "leven": {
@@ -29825,19 +30022,17 @@
       }
     },
     "react": {
-      "version": "16.12.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.12.0.tgz",
-      "integrity": "sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
+        "loose-envify": "^1.1.0"
       }
     },
     "react-animate-height": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/react-animate-height/-/react-animate-height-3.1.0.tgz",
-      "integrity": "sha512-+0pW2OzB8PzVn10dpTB9q5jFI+GwQTnCDLbzyqPBUzKXJfpBrlWW954uud/59Mreo+laRN/fPzvckuA+WTptXA==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/react-animate-height/-/react-animate-height-3.2.3.tgz",
+      "integrity": "sha512-R6DSvr7ud07oeCixScyvXWEMJY/Mt2+GyOWC1KMaRc69gOBw+SsCg4TJmrp4rKUM1hyd6p+YKw90brjPH93Y2A==",
       "requires": {}
     },
     "react-app-polyfill": {
@@ -29862,19 +30057,10 @@
         "@babel/runtime": "^7.12.13"
       }
     },
-    "react-copy-to-clipboard": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/react-copy-to-clipboard/-/react-copy-to-clipboard-5.1.0.tgz",
-      "integrity": "sha512-k61RsNgAayIJNoy9yDsYzDe/yAZAzEbEgcz3DZMhF686LEyukcE1hzurxe85JandPUG+yTfGVFzuEw3xt8WP/A==",
-      "requires": {
-        "copy-to-clipboard": "^3.3.1",
-        "prop-types": "^15.8.1"
-      }
-    },
     "react-day-picker": {
-      "version": "8.3.7",
-      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.3.7.tgz",
-      "integrity": "sha512-sQvyJde6OKsXIB0ZFwUBmaDNb4IyKypv/uSyauQ6AUw4F6vmPijJsQNEVsxrxXQ4L3GZKIpcCD/7Pftz/sLegA==",
+      "version": "8.10.1",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.10.1.tgz",
+      "integrity": "sha512-TMx7fNbhLk15eqcMt+7Z7S2KF7mfTId/XJDjKE8f+IUcFn0l08/kI4FiYTL/0yuOLmEcbR4Fwe3GJf/NiiMnPA==",
       "requires": {}
     },
     "react-dev-utils": {
@@ -29924,14 +30110,12 @@
       }
     },
     "react-dom": {
-      "version": "16.12.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.12.0.tgz",
-      "integrity": "sha512-LMxFfAGrcS3kETtQaCkTKjMiifahaMySFDn71fZUNpPHZQEzmk/GiAeIT8JSOrHB23fnuCOMruL2a8NYlw+8Gw==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
       "requires": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.18.0"
+        "scheduler": "^0.23.0"
       }
     },
     "react-error-overlay": {
@@ -29941,20 +30125,20 @@
       "dev": true
     },
     "react-fast-compare": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
-      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
     },
     "react-focus-lock": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.2.tgz",
-      "integrity": "sha512-5JfrsOKyA5Zn3h958mk7bAcfphr24jPoMoznJ8vaJF6fUrPQ8zrtEd3ILLOK8P5jvGxdMd96OxWNjDzATfR2qw==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.12.1.tgz",
+      "integrity": "sha512-lfp8Dve4yJagkHiFrC1bGtib3mF2ktqwPJw4/WGcgPW+pJ/AVQA5X2vI7xgp13FcxFEpYBBHpXai/N2DBNC0Jw==",
       "requires": {
         "@babel/runtime": "^7.0.0",
-        "focus-lock": "^0.11.2",
+        "focus-lock": "^1.3.5",
         "prop-types": "^15.6.2",
         "react-clientside-effect": "^1.2.6",
-        "use-callback-ref": "^1.3.0",
+        "use-callback-ref": "^1.3.2",
         "use-sidecar": "^1.1.2"
       }
     },
@@ -30085,16 +30269,6 @@
             "tapable": "^2.0.0"
           }
         }
-      }
-    },
-    "react-sortable-hoc": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/react-sortable-hoc/-/react-sortable-hoc-2.0.0.tgz",
-      "integrity": "sha512-JZUw7hBsAHXK7PTyErJyI7SopSBFRcFHDjWW5SWjcugY0i6iH7f+eJkY8cJmGMlZ1C9xz1J3Vjz0plFpavVeRg==",
-      "requires": {
-        "@babel/runtime": "^7.2.0",
-        "invariant": "^2.2.4",
-        "prop-types": "^15.5.7"
       }
     },
     "read-cache": {
@@ -30512,12 +30686,11 @@
       }
     },
     "scheduler": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.18.0.tgz",
-      "integrity": "sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "schema-utils": {
@@ -31532,11 +31705,6 @@
         "is-number": "^7.0.0"
       }
     },
-    "toggle-selection": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
-      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
-    },
     "toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -31848,9 +32016,9 @@
       }
     },
     "use-callback-ref": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.0.tgz",
-      "integrity": "sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.2.tgz",
+      "integrity": "sha512-elOQwe6Q8gqZgDA8mrh44qRTQqpIHDcZ3hXTLjBe1i4ph8XpNJnO+aQf3NaG+lriLopI4HMx9VjQLfPQ6vhnoA==",
       "requires": {
         "tslib": "^2.0.0"
       }

--- a/apps/dropbox/package.json
+++ b/apps/dropbox/package.json
@@ -8,9 +8,9 @@
     "react-scripts": "5.0.1"
   },
   "dependencies": {
-    "@contentful/dam-app-base": "2.0.55",
-    "react": "16.12.0",
-    "react-dom": "16.12.0"
+    "@contentful/dam-app-base": "^3.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
   },
   "scripts": {
     "start": "cross-env BROWSER=none react-scripts --openssl-legacy-provider start",


### PR DESCRIPTION
## Purpose
Update the Dropbox app's version of react to 18, as well as update dam-app-base to v3.0.0

## Breaking Changes
v3 of the dam-app-base is a breaking change for consumers that are on a version of react less than 18.0.0.  Fortunately for the dropbox app, we don't render any actual react code, instead depending on dam-app-base to render react code.  So no changes to the dropbox app necessary.

See [dam-app-base changelog](https://github.com/contentful/apps/blob/master/packages/dam-app-base/CHANGELOG.md#300-2024-05-07)