### PR TITLE
fix(dam-app-base): sortable images should have min height

### DIFF
--- a/packages/dam-app-base/src/Editor/SortableComponent.tsx
+++ b/packages/dam-app-base/src/Editor/SortableComponent.tsx
@@ -71,6 +71,7 @@ const styles = {
       margin: '10px',
       position: 'relative',
       cursor: disabled ? 'move' : 'pointer',
+      minHeight: '130px',
       img: {
         display: 'block',
         maxWidth: '150px',
@@ -81,11 +82,12 @@ const styles = {
     }),
   remove: css({
     position: 'absolute',
-    top: '-10px',
-    right: '-10px',
+    top: '-5px',
+    right: '-5px',
     backgroundColor: 'white',
     padding: 0,
     minHeight: 'initial',
+    minWidth: '25px',
   }),
   altTextContainer: css({
     display: 'flex',


### PR DESCRIPTION
## Purpose
**Bug:** A minor CSS bug was discovered with the new version of dndkit that replaced react-sortable-hoc for sortable components in dam-app-base.  When dragging/sorting components, if the heights of the components vary, it creates a jarring UX.  See video:

**Broken**
![borked-sort](https://github.com/contentful/apps/assets/158083968/deb235b4-394b-45fe-85fd-7a3c7e7aa73d)


Resolution is a quick style fix to sortable cards.  Something must have changed when migrating from react-sortable-hoc to dndkit.  just a few lines of CSS.

**Fixed**
![fixed-sort](https://github.com/contentful/apps/assets/158083968/00ebe08d-7c37-460b-9374-3b273cb59371)





## Testing steps
Tested locally, see videos.