### PR TITLE
chore: add some polish improvements for Vercel config page

### DIFF
--- a/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.spec.tsx
+++ b/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.spec.tsx
@@ -8,6 +8,11 @@ import { copies } from '@constants/copies';
 import { singleSelectionSections } from '@constants/enums';
 import { renderConfigPageComponent } from '@test/helpers/renderConfigPageComponent';
 import { errorMessages } from '@constants/errorMessages';
+import { mockSdk } from '@test/mocks';
+
+vi.mock('@contentful/react-apps-toolkit', () => ({
+  useSDK: () => mockSdk,
+}));
 
 const parameters = { selectedApiPath: '', selectedProject: '' } as AppInstallationParameters;
 const paths = [{ id: 'path-1', name: 'Path/1' }];

--- a/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/ApiPathSelectionSection.spec.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/ApiPathSelectionSection.spec.tsx
@@ -6,6 +6,11 @@ import { renderConfigPageComponent } from '@test/helpers/renderConfigPageCompone
 import { ApiPath, AppInstallationParameters } from '@customTypes/configPage';
 import { copies } from '@constants/copies';
 import userEvent from '@testing-library/user-event';
+import { mockSdk } from '@test/mocks';
+
+vi.mock('@contentful/react-apps-toolkit', () => ({
+  useSDK: () => mockSdk,
+}));
 
 describe('ApiPathSelectionSection', () => {
   it('renders dropdown when paths are present and no errors are present', () => {

--- a/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/TextFieldSection/TextFieldSection.spec.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ApiPathSelectionSection/TextFieldSection/TextFieldSection.spec.tsx
@@ -5,6 +5,11 @@ import { TextFieldSection } from './TextFieldSection';
 import { copies } from '@constants/copies';
 import { renderConfigPageComponent } from '@test/helpers/renderConfigPageComponent';
 import { errorMessages } from '@constants/errorMessages';
+import { mockSdk } from '@test/mocks';
+
+vi.mock('@contentful/react-apps-toolkit', () => ({
+  useSDK: () => mockSdk,
+}));
 
 describe('TextFieldSection', () => {
   it('renders text field with value', () => {

--- a/apps/vercel/frontend/src/components/config-screen/AuthenticationSection/AuthenticationSection.spec.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/AuthenticationSection/AuthenticationSection.spec.tsx
@@ -7,8 +7,13 @@ import { copies } from '@constants/copies';
 import { renderConfigPageComponent } from '@test/helpers/renderConfigPageComponent';
 import { errorMessages } from '@constants/errorMessages';
 import { initialErrors } from '@constants/defaultParams';
+import { mockSdk } from '@test/mocks';
 
 const { input } = copies.configPage.authenticationSection;
+
+vi.mock('@contentful/react-apps-toolkit', () => ({
+  useSDK: () => mockSdk,
+}));
 
 describe('AuthenticationSection', () => {
   it('renders input when token is not yet inputed', () => {

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionList/ContentTypePreviewPathSelectionList.spec.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionList/ContentTypePreviewPathSelectionList.spec.tsx
@@ -1,9 +1,14 @@
 import { screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { ContentTypePreviewPathSelectionList } from './ContentTypePreviewPathSelectionList';
 import { mockContentTypePreviewPathSelections } from '@test/mocks/mockContentTypePreviewPathSelections';
 import { renderConfigPageComponent } from '@test/helpers/renderConfigPageComponent';
 import { AppInstallationParameters } from '@customTypes/configPage';
+import { mockSdk } from '@test/mocks';
+
+vi.mock('@contentful/react-apps-toolkit', () => ({
+  useSDK: () => mockSdk,
+}));
 
 describe('ContentTypePreviewPathSelectionList', () => {
   it('renders list of selections', () => {

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.spec.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.spec.tsx
@@ -6,6 +6,11 @@ import { copies } from '@constants/copies';
 import { renderConfigPageComponent } from '@test/helpers/renderConfigPageComponent';
 import { errorMessages } from '@constants/errorMessages';
 import lodash from 'lodash';
+import { mockSdk } from '@test/mocks';
+
+vi.mock('@contentful/react-apps-toolkit', () => ({
+  useSDK: () => mockSdk,
+}));
 
 const { inputs } = copies.configPage.contentTypePreviewPathSection;
 

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.tsx
@@ -126,7 +126,7 @@ export const ContentTypePreviewPathSelectionRow = ({
 
   const itemAlignment = useMemo(() => {
     if (isError) {
-      return !renderLabel ? 'baseline' : 'normal';
+      return renderLabel ? 'normal' : 'baseline';
     }
     return 'flex-end';
   }, [isError, renderLabel]);
@@ -154,16 +154,23 @@ export const ContentTypePreviewPathSelectionRow = ({
             {renderLabel && (
               <FormControl.Label isRequired>{inputs.previewPath.label}</FormControl.Label>
             )}
-            <TextInput
-              defaultValue={configuredPreviewPath}
-              isDisabled={!configuredContentType || !contentTypes.length}
-              onChange={debouncedHandlePreviewPathInputChange}
-              placeholder={inputs.previewPath.placeholder}
-              isInvalid={isError}
-            />
+            <Flex gap={tokens.spacing2Xs}>
+              <TextInput
+                defaultValue={configuredPreviewPath}
+                isDisabled={!configuredContentType || !contentTypes.length}
+                onChange={debouncedHandlePreviewPathInputChange}
+                placeholder={inputs.previewPath.placeholder}
+                isInvalid={isError}
+              />
+              <IconButton
+                onClick={handleRemoveRow}
+                icon={<CloseIcon />}
+                aria-label={'Delete row'}
+              />
+            </Flex>
+
             {isError && <ValidationMessage>{message}</ValidationMessage>}
           </Box>
-          <IconButton onClick={handleRemoveRow} icon={<CloseIcon />} aria-label={'Delete row'} />
         </Flex>
       </FormControl>
     </Box>

--- a/apps/vercel/frontend/src/components/config-screen/ProjectSelectionSection/ProjectSelectionSection.spec.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ProjectSelectionSection/ProjectSelectionSection.spec.tsx
@@ -7,6 +7,11 @@ import { copies } from '@constants/copies';
 import { renderConfigPageComponent } from '@test/helpers/renderConfigPageComponent';
 import userEvent from '@testing-library/user-event';
 import * as fetchData from '@hooks/useFetchData/useFetchData';
+import { mockSdk } from '@test/mocks';
+
+vi.mock('@contentful/react-apps-toolkit', () => ({
+  useSDK: () => mockSdk,
+}));
 
 const projects = [
   { id: 'project-1', name: 'Project 1', targets: { production: { id: 'project-1' } }, env: [] },

--- a/apps/vercel/frontend/src/constants/errorMessages.ts
+++ b/apps/vercel/frontend/src/constants/errorMessages.ts
@@ -12,6 +12,6 @@ export const errorMessages = {
   invalidPreviewPathFormat: 'Path must start with a "/", and include a {token}.',
   emptyPreviewPathInput: 'Field is empty.',
   invalidDeploymentData: 'We had trouble fetching routes for this Vercel project.',
-  invalidSpaceId:
-    'It looks like you’ve configured an environment variable, CONTENTFUL_SPACE_ID, in the selected Vercel project that doesn’t match the id of the space where this app is installed.',
+  invalidSpaceId: (spaceId: string) =>
+    `It looks like you’ve configured an environment variable, CONTENTFUL_SPACE_ID, in the selected Vercel project that doesn’t match the current id of the space, ${spaceId}, where this app is installed.`,
 };

--- a/apps/vercel/frontend/src/hooks/useError/useError.spec.tsx
+++ b/apps/vercel/frontend/src/hooks/useError/useError.spec.tsx
@@ -1,8 +1,13 @@
 import { renderHook } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { useError } from './useError';
 import { errorMessages } from '@constants/errorMessages';
 import { renderConfigPageHook as wrapper } from '@test/helpers/renderConfigPageHook';
+import { mockSdk, SPACE_ID } from '@test/mocks';
+
+vi.mock('@contentful/react-apps-toolkit', () => ({
+  useSDK: () => mockSdk,
+}));
 
 describe('useError', () => {
   it('should return correct error message and error status when error exists', async () => {
@@ -44,6 +49,24 @@ describe('useError', () => {
           contentType: previewPathError.contentType,
         });
         expect(message).toBe(errorMessages.emptyPreviewPathInput);
+      },
+      { wrapper }
+    );
+  });
+
+  it('should return error message with dynamic spaceId when error is invalidSpaceId', async () => {
+    const projectSelectionerror = {
+      invalidSpaceId: true,
+      projectNotFound: false,
+      cannotFetchProjects: false,
+    };
+
+    renderHook(
+      () => {
+        const { message } = useError({
+          error: projectSelectionerror,
+        });
+        expect(message).toBe(errorMessages.invalidSpaceId(SPACE_ID));
       },
       { wrapper }
     );

--- a/apps/vercel/frontend/src/hooks/useFetchData/useFetchData.tsx
+++ b/apps/vercel/frontend/src/hooks/useFetchData/useFetchData.tsx
@@ -20,6 +20,11 @@ export const useFetchData = ({
 }: FetchData) => {
   const validateToken = async (onComplete: () => void, newVercelClient?: VercelClient) => {
     if (vercelClient) {
+      // reset all authentication errors before validating again
+      dispatchErrors({
+        type: errorsActions.RESET_AUTHENTICATION_ERRORS,
+      });
+
       try {
         const client = newVercelClient || vercelClient;
         const response = await client.checkToken();
@@ -31,10 +36,6 @@ export const useFetchData = ({
               payload: response.data?.teamId,
             });
           }
-
-          dispatchErrors({
-            type: errorsActions.RESET_AUTHENTICATION_ERRORS,
-          });
         }
       } catch (e) {
         const err = e as Error;

--- a/apps/vercel/frontend/src/locations/ConfigScreen.tsx
+++ b/apps/vercel/frontend/src/locations/ConfigScreen.tsx
@@ -150,7 +150,7 @@ const ConfigScreen = () => {
 
   const renderPostAuthComponents =
     !isAuthenticationError && hasTokenBeenValidated && parameters.teamId;
-  const renderPostProjectComponents =
+  const renderPostProjectSelectionComponents =
     renderPostAuthComponents &&
     !errors.projectSelection.projectNotFound &&
     !errors.projectSelection.cannotFetchProjects &&
@@ -180,9 +180,9 @@ const ConfigScreen = () => {
 
           {renderPostAuthComponents && <ProjectSelectionSection projects={projects} />}
 
-          {renderPostProjectComponents && <ApiPathSelectionSection paths={apiPaths} />}
+          {renderPostProjectSelectionComponents && <ApiPathSelectionSection paths={apiPaths} />}
 
-          {renderPostProjectComponents && parameters.selectedApiPath && (
+          {renderPostProjectSelectionComponents && parameters.selectedApiPath && (
             <>
               <ContentTypePreviewPathSection />
               <hr className={styles.splitter} />

--- a/apps/vercel/frontend/src/locations/ConfigScreen.tsx
+++ b/apps/vercel/frontend/src/locations/ConfigScreen.tsx
@@ -76,7 +76,7 @@ const ConfigScreen = () => {
 
     async function checkToken() {
       if (vercelClient) {
-        validateToken(updateTokenValidityState);
+        await validateToken(updateTokenValidityState);
       }
     }
 
@@ -103,25 +103,19 @@ const ConfigScreen = () => {
   useEffect(() => {
     async function getProjects() {
       setIsLoading(true);
-      fetchProjects(setProjects);
+      await fetchProjects(setProjects);
       setIsLoading(false);
     }
 
-    if (parameters.vercelAccessToken && hasTokenBeenValidated && !isAuthenticationError) {
+    if (parameters.teamId) {
       getProjects();
     }
-  }, [
-    parameters.vercelAccessToken,
-    hasTokenBeenValidated,
-    isAuthenticationError,
-    vercelClient,
-    parameters.teamId,
-  ]);
+  }, [vercelClient, parameters.teamId]);
 
   useEffect(() => {
     async function getApiPaths() {
       setIsLoading(true);
-      fetchApiPaths(setApiPaths, parameters.selectedProject);
+      await fetchApiPaths(setApiPaths, parameters.selectedProject);
       setIsLoading(false);
     }
 
@@ -154,7 +148,14 @@ const ConfigScreen = () => {
     setIsAppConfigurationSaved(false);
   };
 
-  const renderPostAuthComponents = !isAuthenticationError && parameters.vercelAccessToken;
+  const renderPostAuthComponents =
+    !isAuthenticationError && hasTokenBeenValidated && parameters.teamId;
+  const renderPostProjectComponents =
+    renderPostAuthComponents &&
+    !errors.projectSelection.projectNotFound &&
+    !errors.projectSelection.cannotFetchProjects &&
+    parameters.selectedProject &&
+    projects.length;
 
   return (
     <ConfigPageProvider
@@ -179,11 +180,9 @@ const ConfigScreen = () => {
 
           {renderPostAuthComponents && <ProjectSelectionSection projects={projects} />}
 
-          {renderPostAuthComponents && parameters.selectedProject && (
-            <ApiPathSelectionSection paths={apiPaths} />
-          )}
+          {renderPostProjectComponents && <ApiPathSelectionSection paths={apiPaths} />}
 
-          {renderPostAuthComponents && parameters.selectedProject && parameters.selectedApiPath && (
+          {renderPostProjectComponents && parameters.selectedApiPath && (
             <>
               <ContentTypePreviewPathSection />
               <hr className={styles.splitter} />

--- a/apps/vercel/frontend/test/mocks/index.ts
+++ b/apps/vercel/frontend/test/mocks/index.ts
@@ -1,5 +1,5 @@
 export { mockCma } from './mockCma';
-export { mockSdk } from './mockSdk';
+export { mockSdk, SPACE_ID } from './mockSdk';
 export { mockContentTypes } from './mockContentTypes';
 export { mockContentTypePreviewPathSelections } from './mockContentTypePreviewPathSelections';
 export { mockDeploymentSummary } from './mockDeploymentSummary';

--- a/apps/vercel/frontend/test/mocks/mockSdk.ts
+++ b/apps/vercel/frontend/test/mocks/mockSdk.ts
@@ -1,7 +1,7 @@
 import { AppInstallationParameters } from '@customTypes/configPage';
 import { vi } from 'vitest';
 
-const SPACE_ID = '1234';
+export const SPACE_ID = '1234';
 
 export const mockParameters: AppInstallationParameters = {
   vercelAccessToken: 'abc-123',


### PR DESCRIPTION
## Purpose

The purpose of this PR is to accomplish the following: 
1. Adjust the 'X' button height mis-alignment in the Content type/preview path selection section. 
2. Fine tune general loading of the config page
3. Add [spaceId](url) to error message when selected project `spaceId` is not aligned with current `spaceId`. 
## Approach

1. 'X' button: 
### Before
![Screenshot 2024-05-07 at 12 54 12 PM](https://github.com/contentful/apps/assets/58186851/9960e059-9597-4151-8709-731b85d7e0a9)

### After
![Screenshot 2024-05-08 at 3 03 43 PM](https://github.com/contentful/apps/assets/58186851/fc7983fe-6489-4289-9470-1f6758219f6e)

2. Config page loading. This is a bit more difficult to visualize, but when reloading the page the components flashed a bit more before, and now with some adjustments of the conditional rendering and the `useEffect` dependencies, the loading is a bit more seamless. 

3. Error message with `spaceId`: 
![Screenshot 2024-05-08 at 2 36 00 PM](https://github.com/contentful/apps/assets/58186851/6921054c-6299-457c-a84d-479875b5359f)

