### PR TITLE
feat: add app setup guide link to vercel config page

### DIFF
--- a/apps/vercel/frontend/src/components/config-screen/GettingStartedSection/GettingStartedSection.spec.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/GettingStartedSection/GettingStartedSection.spec.tsx
@@ -13,9 +13,11 @@ describe('GettingStartedSection', () => {
     const titleText = screen.getByText(title);
     const stepOneText = screen.getByText(contentPreviewSidebar.copy);
     const stepTwoText = screen.getByText(contentPreviewSettings.copy);
+    const helpCenterLink = screen.getByText('app setup guide');
 
     expect(titleText).toBeTruthy();
     expect(stepOneText).toBeTruthy();
     expect(stepTwoText).toBeTruthy();
+    expect(helpCenterLink).toBeTruthy();
   });
 });

--- a/apps/vercel/frontend/src/components/config-screen/GettingStartedSection/GettingStartedSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/GettingStartedSection/GettingStartedSection.tsx
@@ -1,9 +1,11 @@
-import { copies } from '@constants/copies';
-import { Flex, Heading, Paragraph, Box } from '@contentful/f36-components';
+import { Flex, Heading, Paragraph, Box, TextLink } from '@contentful/f36-components';
+import { ExternalLinkIcon } from '@contentful/f36-icons';
+import tokens from '@contentful/f36-tokens';
 import { styles } from '@locations/ConfigScreen.styles';
+import { copies } from '@constants/copies';
 
 export const GettingStartedSection = () => {
-  const { contentPreviewSidebar, contentPreviewSettings, title } =
+  const { contentPreviewSidebar, contentPreviewSettings, title, link } =
     copies.configPage.gettingStartedSection;
   return (
     <Box>
@@ -15,6 +17,17 @@ export const GettingStartedSection = () => {
       <Flex>
         <Paragraph>{contentPreviewSettings.copy}</Paragraph>
         <img src={contentPreviewSettings.src} alt="Content preview settings screen capture" />
+      </Flex>
+      <Flex marginTop="spacingM" gap={tokens.spacing2Xs} alignItems="center">
+        <Paragraph marginBottom="none">Need help with app setup? Follow this</Paragraph>
+        <TextLink
+          icon={<ExternalLinkIcon />}
+          alignIcon="end"
+          href={link.href}
+          target="_blank"
+          rel="noopener noreferrer">
+          app setup guide
+        </TextLink>{' '}
       </Flex>
     </Box>
   );

--- a/apps/vercel/frontend/src/components/config-screen/GettingStartedSection/GettingStartedSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/GettingStartedSection/GettingStartedSection.tsx
@@ -19,7 +19,7 @@ export const GettingStartedSection = () => {
         <img src={contentPreviewSettings.src} alt="Content preview settings screen capture" />
       </Flex>
       <Flex marginTop="spacingM" gap={tokens.spacing2Xs} alignItems="center">
-        <Paragraph marginBottom="none">Need help with app setup? Follow this</Paragraph>
+        Need help with app setup? Follow this
         <TextLink
           icon={<ExternalLinkIcon />}
           alignIcon="end"

--- a/apps/vercel/frontend/src/constants/copies.ts
+++ b/apps/vercel/frontend/src/constants/copies.ts
@@ -149,6 +149,9 @@ export const copies = {
         copy: 'Within the content preview settings, you will see Vercel as an option.',
         src: './images/content-preview-settings-screen-capture.png',
       },
+      link: {
+        href: 'https://www.contentful.com/help/vercel-app/',
+      },
     },
   },
 };


### PR DESCRIPTION
## Purpose

The purpose of this PR is to add a link to the App setup guide to the bottom of the Vercel config page, to further support the user with their app setup experience. 

## Approach
As you see below, the link is added to the bottom of the page =>` 'Need help with app setup?....'.`. 

The link also directs to [this](https://www.contentful.com/help/vercel-app/) app setup guide page. Open to any and all suggestions here :) 

![Screenshot 2024-05-13 at 11 18 54 AM](https://github.com/contentful/apps/assets/58186851/5c072a7a-e8db-4b4f-8db9-20ac31818a87)


