### PR TITLE
chore(ai-image-tagging): bump lambda runtime to node to v18 [INTEG-1959]

### DIFF
--- a/apps/ai-image-tagging/lambda/serverless.yml
+++ b/apps/ai-image-tagging/lambda/serverless.yml
@@ -16,7 +16,7 @@ custom:
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs18.x
   stage: ${opt:stage, 'test'}
   region: 'us-east-1'
   deploymentBucket:


### PR DESCRIPTION
## Purpose

Update AI Image Tagging Lambda runtime from node v16 to node v18.

## Approach

<!-- Why did we do it the way we did? Did we consider alternatives? What other implementation details or artifacts (screenshots etc.) would help reviewers contextualize change? -->

## Testing steps

Tested deploying to lambda staging environment.

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
