### PR TITLE
fix: use input event instead of change event to ensure input is captured [EXT-5237]

### DIFF
--- a/apps/ai-content-generator/src/components/config/api-key/APIKey.tsx
+++ b/apps/ai-content-generator/src/components/config/api-key/APIKey.tsx
@@ -60,7 +60,7 @@ const APIKey = (props: Props) => {
           type="text"
           name="apikey"
           placeholder="sk-...4svb"
-          onChange={(e: ChangeEvent<HTMLInputElement>) => setLocalApiKey(e.target.value)}
+          onInput={(e: ChangeEvent<HTMLInputElement>) => setLocalApiKey(e.target.value)}
           onBlur={handleBlur}
           isInvalid={displayInvalidMessage}
         />


### PR DESCRIPTION
## Purpose

<!-- Why are we introducing this change now? What problem does it solve? What is the story/background for it? -->

Since most users will paste in their api key, a common user path is to paste in the key and then immediately click save. The save happens before the text input change event fires since the text input is never unfocused. Switching to an input event instead of a change event ensures we capture the users input. 

## Approach

<!-- Why did we do it the way we did? Did we consider alternatives? What other implementation details or artifacts (screenshots etc.) would help reviewers contextualize change? -->

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

Install AICG, paste in your key and immediately click save. With these changes, refresh and the key should be preserved.

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->
n/a
## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->
n/a
## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
n/a