### PR TITLE
Fallback to default API URL in useProducts hook []

### DIFF
--- a/examples/function-mock-shop/src/hooks/useProduct.ts
+++ b/examples/function-mock-shop/src/hooks/useProduct.ts
@@ -12,7 +12,7 @@ type HookResult = {
 };
 
 export function useProduct(productId: string = ''): HookResult {
-  const sdk = useSDK<ConfigAppSDK>();  
+  const sdk = useSDK<ConfigAppSDK>();
   const { apiEndpoint } = sdk.parameters.installation || 'https://mock.shop/api';
   const { isLoading, data: product } = useQuery<Product>({
     queryKey: ['product', productId],

--- a/examples/function-mock-shop/src/hooks/useProduct.ts
+++ b/examples/function-mock-shop/src/hooks/useProduct.ts
@@ -12,8 +12,8 @@ type HookResult = {
 };
 
 export function useProduct(productId: string = ''): HookResult {
-  const sdk = useSDK<ConfigAppSDK>();
-  const { apiEndpoint } = sdk.parameters.installation;
+  const sdk = useSDK<ConfigAppSDK>();  
+  const { apiEndpoint } = sdk.parameters.installation || 'https://mock.shop/api';
   const { isLoading, data: product } = useQuery<Product>({
     queryKey: ['product', productId],
     queryFn: () =>


### PR DESCRIPTION
## Purpose

There was no fallback url set for the `useProduct` hook

## Approach

<!-- Why did we do it the way we did? Did we consider alternatives? What other implementation details or artifacts (screenshots etc.) would help reviewers contextualize change? -->

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
