### PR TITLE
feat: add contentful preview secret input

### DIFF
--- a/apps/vercel/frontend/src/clients/Vercel.ts
+++ b/apps/vercel/frontend/src/clients/Vercel.ts
@@ -30,7 +30,11 @@ interface ListEnvironmentVariables {
 interface VercelAPIClient {
   checkToken: () => Promise<GetToken>;
   getToken: () => Promise<Response>;
-  updateEnvironmentVariable: (variable: string, variableName: string, projectId: string) => Promise<UpdateEnvironmentVariable>;
+  updateEnvironmentVariable: (
+    variable: string,
+    variableName: string,
+    projectId: string
+  ) => Promise<UpdateEnvironmentVariable>;
   listProjects: (teamId?: string) => Promise<ListProjectsResponse>;
   listApiPaths: (projectId: string, teamId?: string) => Promise<ApiPath[]>;
   validateProjectContentfulSpaceId: (
@@ -42,7 +46,7 @@ interface VercelAPIClient {
 }
 
 export default class VercelClient implements VercelAPIClient {
-  constructor(public accessToken = '', private baseEndpoint = 'https://api.vercel.com') { }
+  constructor(public accessToken = '', private baseEndpoint = 'https://api.vercel.com') {}
 
   private buildHeaders(overrides: Headers = new Headers({})): Headers {
     return new Headers({
@@ -76,7 +80,11 @@ export default class VercelClient implements VercelAPIClient {
     return res;
   }
 
-  async updateEnvironmentVariable(variable: string, variableName: string, projectId: string): Promise<UpdateEnvironmentVariable> {
+  async updateEnvironmentVariable(
+    variable: string,
+    variableName: string,
+    projectId: string
+  ): Promise<UpdateEnvironmentVariable> {
     const res = await fetch(`${this.baseEndpoint}/v10/projects/${projectId}/env`, {
       headers: this.buildHeaders(),
       method: 'POST',
@@ -87,7 +95,7 @@ export default class VercelClient implements VercelAPIClient {
 
         // TODO: Add checkbox support for target selection.
         target: ['production', 'development', 'preview'],
-      })
+      }),
     });
 
     if (!res.ok) throw new Error(errorTypes.INVALID_CONTENTFUL_PREVIEW_SECRET);
@@ -100,7 +108,6 @@ export default class VercelClient implements VercelAPIClient {
       headers: this.buildHeaders(),
       method: 'GET',
     });
-
 
     if (!res.ok) throw new Error(errorTypes.CANNOT_FETCH_VERCEL_ENV_VARS);
 
@@ -163,7 +170,8 @@ export default class VercelClient implements VercelAPIClient {
       const latestDeployment = await this.getLatestProjectDeployment(projectId, teamId);
       const latestDeploymentId = deploymentId || latestDeployment.uid;
       const res = await fetch(
-        `${this.baseEndpoint
+        `${
+          this.baseEndpoint
         }/v6/deployments/${latestDeploymentId}/files/outputs?file=..%2Fdeploy_metadata.json&${this.buildTeamIdQueryParam(
           teamId
         )}`,
@@ -210,7 +218,8 @@ export default class VercelClient implements VercelAPIClient {
       const contentfulSpaceIdEnv = envs.find((env) => env.key === CONTENTFUL_SPACE_ID);
       if (contentfulSpaceIdEnv) {
         const res = await fetch(
-          `${this.baseEndpoint}/v1/projects/${projectId}/env/${contentfulSpaceIdEnv.id
+          `${this.baseEndpoint}/v1/projects/${projectId}/env/${
+            contentfulSpaceIdEnv.id
           }?${this.buildTeamIdQueryParam(teamId)}`,
           {
             headers: this.buildHeaders(),

--- a/apps/vercel/frontend/src/clients/Vercel.ts
+++ b/apps/vercel/frontend/src/clients/Vercel.ts
@@ -30,7 +30,7 @@ interface ListEnvironmentVariables {
 interface VercelAPIClient {
   checkToken: () => Promise<GetToken>;
   getToken: () => Promise<Response>;
-  updateEnvironmentVariable: (variable: string, projectId: string) => Promise<UpdateEnvironmentVariable>;
+  updateEnvironmentVariable: (variable: string, variableName: string, projectId: string) => Promise<UpdateEnvironmentVariable>;
   listProjects: (teamId?: string) => Promise<ListProjectsResponse>;
   listApiPaths: (projectId: string, teamId?: string) => Promise<ApiPath[]>;
   validateProjectContentfulSpaceId: (
@@ -76,12 +76,12 @@ export default class VercelClient implements VercelAPIClient {
     return res;
   }
 
-  async updateEnvironmentVariable(variable: string, projectId: string): Promise<UpdateEnvironmentVariable> {
+  async updateEnvironmentVariable(variable: string, variableName: string, projectId: string): Promise<UpdateEnvironmentVariable> {
     const res = await fetch(`${this.baseEndpoint}/v10/projects/${projectId}/env`, {
       headers: this.buildHeaders(),
       method: 'POST',
       body: JSON.stringify({
-        key: 'CONTENTFUL_PREVIEW_SECRET',
+        key: variableName,
         value: variable,
         type: 'encrypted',
 

--- a/apps/vercel/frontend/src/components/config-screen/ContentfulPreviewSecretSection/ContentfulPreviewSecretSection.spec.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentfulPreviewSecretSection/ContentfulPreviewSecretSection.spec.tsx
@@ -1,0 +1,83 @@
+import { screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { AppInstallationParameters } from '@customTypes/configPage';
+import { ContentfulPreviewSecretSection } from './ContentfulPreviewSecretSection';
+import { copies } from '@constants/copies';
+import { renderConfigPageComponent } from '@test/helpers/renderConfigPageComponent';
+import { mockSdk } from '@test/mocks';
+
+const { input } = copies.configPage.contentfulPreviewSecretSection;
+
+vi.mock('@contentful/react-apps-toolkit', () => ({
+  useSDK: () => mockSdk,
+}));
+
+describe('ContentfulPreviewSecretSection', () => {
+  it('renders input with placeholder when secret is not yet inputed', () => {
+    const parameters = {
+      contentfulPreviewSecret: '',
+    } as unknown as AppInstallationParameters;
+    renderConfigPageComponent(
+      <ContentfulPreviewSecretSection
+        handleBlur={vi.fn()}
+        handleChange={vi.fn()}
+        handleRetry={vi.fn()}
+      />,
+      {
+        parameters,
+      }
+    );
+
+    const tokenInput = screen.getByPlaceholderText(input.placeholder);
+
+    expect(tokenInput).toBeTruthy();
+  });
+
+  it('renders hidden secret and valid content when secret is valid', () => {
+    const parameters = {
+      contentfulPreviewSecret: '12345',
+    } as unknown as AppInstallationParameters;
+    renderConfigPageComponent(
+      <ContentfulPreviewSecretSection
+        handleBlur={vi.fn()}
+        handleChange={vi.fn()}
+        handleRetry={vi.fn()}
+      />,
+      {
+        parameters,
+      }
+    );
+
+    const secret = screen.queryByText(parameters.contentfulPreviewSecret);
+
+    expect(secret).toBeFalsy();
+  });
+
+  // it('renders hidden token and invalid content when token is invalid', () => {
+  //   const parameters = {
+  //     vercelAccessToken: '12345',
+  //   } as unknown as AppInstallationParameters;
+  //   const errors = {
+  //     ...initialErrors,
+  //     authentication: {
+  //       invalidToken: true,
+  //       invalidTeamScope: false,
+  //       expiredToken: false,
+  //     },
+  //   };
+  //   renderConfigPageComponent(
+  //     <AuthenticationSection handleTokenChange={vi.fn()} />,
+  //     {
+  //       parameters,
+  //       errors,
+  //     }
+  //   );
+
+  //   const status = screen.getByText(errorMessages.invalidToken);
+  //   const token = screen.queryByText(parameters.vercelAccessToken);
+
+  //   expect(status).toBeTruthy();
+  //   expect(token).toBeFalsy();
+  // });
+});

--- a/apps/vercel/frontend/src/components/config-screen/ContentfulPreviewSecretSection/ContentfulPreviewSecretSection.styles.ts
+++ b/apps/vercel/frontend/src/components/config-screen/ContentfulPreviewSecretSection/ContentfulPreviewSecretSection.styles.ts
@@ -1,14 +1,14 @@
 import { css } from 'emotion';
 
 export const styles = {
-    box: css({
-        width: '100%',
-    }),
-    badgeContainer: css({
-        marginTop: '10px',
-        width: '100%',
-    }),
-    heading: css({
-        fontSize: '1rem',
-    }),
+  box: css({
+    width: '100%',
+  }),
+  badgeContainer: css({
+    marginTop: '10px',
+    width: '100%',
+  }),
+  heading: css({
+    fontSize: '1rem',
+  }),
 };

--- a/apps/vercel/frontend/src/components/config-screen/ContentfulPreviewSecretSection/ContentfulPreviewSecretSection.styles.ts
+++ b/apps/vercel/frontend/src/components/config-screen/ContentfulPreviewSecretSection/ContentfulPreviewSecretSection.styles.ts
@@ -1,0 +1,14 @@
+import { css } from 'emotion';
+
+export const styles = {
+    box: css({
+        width: '100%',
+    }),
+    badgeContainer: css({
+        marginTop: '10px',
+        width: '100%',
+    }),
+    heading: css({
+        fontSize: '1rem',
+    }),
+};

--- a/apps/vercel/frontend/src/components/config-screen/ContentfulPreviewSecretSection/ContentfulPreviewSecretSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentfulPreviewSecretSection/ContentfulPreviewSecretSection.tsx
@@ -1,0 +1,86 @@
+import { ChangeEvent, FocusEvent, useContext } from 'react';
+import {
+  Box,
+  FormControl,
+  HelpText,
+  TextInput,
+  TextLink,
+  ValidationMessage,
+} from '@contentful/f36-components';
+import { ExternalLinkIcon } from '@contentful/f36-icons';
+import { styles } from './ContentfulPreviewSecretSection.styles';
+import { copies } from '@constants/copies';
+import { ConfigPageContext } from '@contexts/ConfigPageProvider';
+import { useError } from '@hooks/useError/useError';
+
+interface Props {
+  handleChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  handleBlur: (e: FocusEvent<HTMLInputElement>) => void;
+  handleRetry: () => void;
+}
+
+export const ContentfulPreviewSecretSection = ({
+  handleChange,
+  handleBlur,
+  handleRetry,
+}: Props) => {
+  const { input, docs } = copies.configPage.contentfulPreviewSecretSection;
+  const { parameters, isLoading, errors } = useContext(ConfigPageContext);
+  const error = errors.contentfulPreviewSecret;
+  const { message, isError } = useError({ error });
+
+  const alreadyExistsInVercel =
+    error.environmentVariableAlreadyExists && !isLoading && isError;
+
+  const showError = Boolean(
+    parameters.vercelAccessToken &&
+      isError &&
+      !isLoading &&
+      !error.environmentVariableAlreadyExists
+  );
+
+  return (
+    <Box className={styles.box}>
+      <FormControl id='previewToken' isRequired={true}>
+        <FormControl.Label aria-label='previewToken' htmlFor='previewToken'>
+          {input.label}
+        </FormControl.Label>
+        <TextInput
+          data-testid='preview-token'
+          spellCheck={false}
+          name='previewToken'
+          type='text'
+          placeholder={input.placeholder}
+          value={
+            alreadyExistsInVercel ? message : parameters.contentfulPreviewSecret
+          }
+          onChange={handleChange}
+          onBlur={handleBlur}
+          isInvalid={showError}
+          isDisabled={isLoading || error.environmentVariableAlreadyExists}
+        />
+        <HelpText>
+          This is used to validate requests from Contentful to your Vercel app.
+        </HelpText>
+        {alreadyExistsInVercel && !parameters.contentfulPreviewSecret && (
+          <ValidationMessage>
+            Follow{' '}
+            <TextLink
+              icon={<ExternalLinkIcon />}
+              alignIcon='end'
+              href={docs.href}
+              target='_blank'
+              rel='noopener noreferrer'
+            >
+              Vercel&apos;s instructions
+            </TextLink>{' '}
+            to remove this environment variable before continuing.{' '}
+            <TextLink onClick={handleRetry}>Click to Retry</TextLink>
+          </ValidationMessage>
+        )}
+
+        {showError && <ValidationMessage>{message}</ValidationMessage>}
+      </FormControl>
+    </Box>
+  );
+};

--- a/apps/vercel/frontend/src/components/config-screen/ContentfulPreviewSecretSection/ContentfulPreviewSecretSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentfulPreviewSecretSection/ContentfulPreviewSecretSection.tsx
@@ -29,49 +29,40 @@ export const ContentfulPreviewSecretSection = ({
   const error = errors.contentfulPreviewSecret;
   const { message, isError } = useError({ error });
 
-  const alreadyExistsInVercel =
-    error.environmentVariableAlreadyExists && !isLoading && isError;
+  const alreadyExistsInVercel = error.environmentVariableAlreadyExists && !isLoading && isError;
 
   const showError = Boolean(
-    parameters.vercelAccessToken &&
-      isError &&
-      !isLoading &&
-      !error.environmentVariableAlreadyExists
+    parameters.vercelAccessToken && isError && !isLoading && !error.environmentVariableAlreadyExists
   );
 
   return (
     <Box className={styles.box}>
-      <FormControl id='previewToken' isRequired={true}>
-        <FormControl.Label aria-label='previewToken' htmlFor='previewToken'>
+      <FormControl id="previewToken" isRequired={true}>
+        <FormControl.Label aria-label="previewToken" htmlFor="previewToken">
           {input.label}
         </FormControl.Label>
         <TextInput
-          data-testid='preview-token'
+          data-testid="preview-token"
           spellCheck={false}
-          name='previewToken'
-          type='text'
+          name="previewToken"
+          type="text"
           placeholder={input.placeholder}
-          value={
-            alreadyExistsInVercel ? message : parameters.contentfulPreviewSecret
-          }
+          value={alreadyExistsInVercel ? message : parameters.contentfulPreviewSecret}
           onChange={handleChange}
           onBlur={handleBlur}
           isInvalid={showError}
           isDisabled={isLoading || error.environmentVariableAlreadyExists}
         />
-        <HelpText>
-          This is used to validate requests from Contentful to your Vercel app.
-        </HelpText>
+        <HelpText>This is used to validate requests from Contentful to your Vercel app.</HelpText>
         {alreadyExistsInVercel && !parameters.contentfulPreviewSecret && (
           <ValidationMessage>
             Follow{' '}
             <TextLink
               icon={<ExternalLinkIcon />}
-              alignIcon='end'
+              alignIcon="end"
               href={docs.href}
-              target='_blank'
-              rel='noopener noreferrer'
-            >
+              target="_blank"
+              rel="noopener noreferrer">
               Vercel&apos;s instructions
             </TextLink>{' '}
             to remove this environment variable before continuing.{' '}

--- a/apps/vercel/frontend/src/components/config-screen/ProjectSelectionSection/ProjectSelectionSection.spec.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ProjectSelectionSection/ProjectSelectionSection.spec.tsx
@@ -24,9 +24,7 @@ const projects = [
 
 describe('ProjectSelectionSection', () => {
   it('renders dropdown when paths are present and no errors are present', () => {
-    const { unmount } = renderConfigPageComponent(
-      <ProjectSelectionSection projects={projects} />
-    );
+    const { unmount } = renderConfigPageComponent(<ProjectSelectionSection projects={projects} />);
 
     const select = screen.getByTestId('optionsSelect');
     expect(select).toBeTruthy();
@@ -43,18 +41,14 @@ describe('ProjectSelectionSection', () => {
       parameters
     );
 
-    const emptyInput = screen.getByText(
-      copies.configPage.projectSelectionSection.placeholder
-    );
+    const emptyInput = screen.getByText(copies.configPage.projectSelectionSection.placeholder);
     expect(emptyInput).toBeTruthy();
     unmount();
   });
 
   it('handles project selection', async () => {
     const user = userEvent.setup();
-    const mockValidation = vi
-      .fn()
-      .mockImplementationOnce(() => Promise.resolve());
+    const mockValidation = vi.fn().mockImplementationOnce(() => Promise.resolve());
     vi.spyOn(fetchData, 'useFetchData').mockReturnValue({
       validateProjectEnv: mockValidation,
       validateToken: vi.fn(),
@@ -70,12 +64,9 @@ describe('ProjectSelectionSection', () => {
       parameters: { teamId: '1234', selectedProject: projects[0].id },
     } as unknown as AppInstallationParameters;
 
-    const { unmount } = renderConfigPageComponent(
-      <ProjectSelectionSection projects={projects} />,
-      {
-        ...overrides,
-      }
-    );
+    const { unmount } = renderConfigPageComponent(<ProjectSelectionSection projects={projects} />, {
+      ...overrides,
+    });
 
     const selectDropdown = screen.getByTestId('optionsSelect');
 

--- a/apps/vercel/frontend/src/components/config-screen/ProjectSelectionSection/ProjectSelectionSection.spec.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ProjectSelectionSection/ProjectSelectionSection.spec.tsx
@@ -14,12 +14,19 @@ vi.mock('@contentful/react-apps-toolkit', () => ({
 }));
 
 const projects = [
-  { id: 'project-1', name: 'Project 1', targets: { production: { id: 'project-1' } }, env: [] },
+  {
+    id: 'project-1',
+    name: 'Project 1',
+    targets: { production: { id: 'project-1' } },
+    env: [],
+  },
 ];
 
 describe('ProjectSelectionSection', () => {
   it('renders dropdown when paths are present and no errors are present', () => {
-    const { unmount } = renderConfigPageComponent(<ProjectSelectionSection projects={projects} />);
+    const { unmount } = renderConfigPageComponent(
+      <ProjectSelectionSection projects={projects} />
+    );
 
     const select = screen.getByTestId('optionsSelect');
     expect(select).toBeTruthy();
@@ -36,18 +43,23 @@ describe('ProjectSelectionSection', () => {
       parameters
     );
 
-    const emptyInput = screen.getByText(copies.configPage.projectSelectionSection.placeholder);
+    const emptyInput = screen.getByText(
+      copies.configPage.projectSelectionSection.placeholder
+    );
     expect(emptyInput).toBeTruthy();
     unmount();
   });
 
   it('handles project selection', async () => {
     const user = userEvent.setup();
-    const mockValidation = vi.fn().mockImplementationOnce(() => Promise.resolve());
+    const mockValidation = vi
+      .fn()
+      .mockImplementationOnce(() => Promise.resolve());
     vi.spyOn(fetchData, 'useFetchData').mockReturnValue({
       validateProjectEnv: mockValidation,
       validateToken: vi.fn(),
       fetchProjects: vi.fn(),
+      validateContentfulPreviewSecret: vi.fn(),
       fetchApiPaths: vi.fn(),
     });
     const mockHandleAppConfigurationChange = vi.fn();
@@ -58,9 +70,12 @@ describe('ProjectSelectionSection', () => {
       parameters: { teamId: '1234', selectedProject: projects[0].id },
     } as unknown as AppInstallationParameters;
 
-    const { unmount } = renderConfigPageComponent(<ProjectSelectionSection projects={projects} />, {
-      ...overrides,
-    });
+    const { unmount } = renderConfigPageComponent(
+      <ProjectSelectionSection projects={projects} />,
+      {
+        ...overrides,
+      }
+    );
 
     const selectDropdown = screen.getByTestId('optionsSelect');
 

--- a/apps/vercel/frontend/src/components/config-screen/ProjectSelectionSection/ProjectSelectionSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ProjectSelectionSection/ProjectSelectionSection.tsx
@@ -65,7 +65,9 @@ export const ProjectSelectionSection = ({ projects }: Props) => {
     });
   };
 
-  const selectedOption = errors.projectSelection.projectNotFound ? '' : parameters.selectedProject;
+  const selectedOption = errors.projectSelection.projectNotFound
+    ? ''
+    : parameters.selectedProject;
 
   return (
     <SectionWrapper testId={sectionId}>

--- a/apps/vercel/frontend/src/components/config-screen/ProjectSelectionSection/ProjectSelectionSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ProjectSelectionSection/ProjectSelectionSection.tsx
@@ -65,9 +65,7 @@ export const ProjectSelectionSection = ({ projects }: Props) => {
     });
   };
 
-  const selectedOption = errors.projectSelection.projectNotFound
-    ? ''
-    : parameters.selectedProject;
+  const selectedOption = errors.projectSelection.projectNotFound ? '' : parameters.selectedProject;
 
   return (
     <SectionWrapper testId={sectionId}>

--- a/apps/vercel/frontend/src/constants/copies.ts
+++ b/apps/vercel/frontend/src/constants/copies.ts
@@ -20,6 +20,18 @@ export const copies = {
         copy: 'Connect to a project associated with your website or experience.',
       },
     },
+    contentfulPreviewSecretSection: {
+      input: {
+        label: 'Contentful Preview Secret',
+        placeholder: 'ex. atE2sdftcIp01O1isdfXc3QTdT4...',
+      },
+      token: {
+        href: 'https://vercel.com/account/tokens',
+      },
+      docs: {
+        href: 'https://vercel.com/docs/projects/environment-variables',
+      },
+    },
     pathSelectionSection: {
       label: 'Draft Mode route handler',
       placeholder: 'Select a route',

--- a/apps/vercel/frontend/src/constants/defaultParams.ts
+++ b/apps/vercel/frontend/src/constants/defaultParams.ts
@@ -2,6 +2,7 @@ import { AppInstallationParameters, Errors } from '@customTypes/configPage';
 
 export const initialParameters: AppInstallationParameters = {
   vercelAccessToken: '',
+  contentfulPreviewSecret: '',
   selectedProject: '',
   contentTypePreviewPathSelections: [],
   selectedApiPath: '',
@@ -13,6 +14,11 @@ export const initialErrors: Errors = {
     invalidToken: false,
     invalidTeamScope: false,
     expiredToken: false,
+  },
+  contentfulPreviewSecret: {
+    invalidContentfulPreviewSecret: false,
+    environmentVariableAlreadyExists: false,
+    cannotFetchVercelEnvVars: false,
   },
   projectSelection: {
     projectNotFound: false,

--- a/apps/vercel/frontend/src/constants/enums.ts
+++ b/apps/vercel/frontend/src/constants/enums.ts
@@ -1,5 +1,6 @@
 export enum parametersActions {
   UPDATE_VERCEL_ACCESS_TOKEN = 'updateVercelAccessToken',
+  UPDATE_CONTENTFUL_PREVIEW_SECRET = 'updateContentfulPreviewSecret',
   APPLY_CONTENTFUL_PARAMETERS = 'applyContentfulParameters',
   APPLY_SELECTED_PROJECT = 'applySelectedProject',
   ADD_CONTENT_TYPE_PREVIEW_PATH_SELECTION = 'addContentTypePreviewPathSelection',
@@ -15,7 +16,9 @@ export enum singleSelectionSections {
 
 export enum errorsActions {
   UPDATE_AUTHENTICATION_ERRORS = 'updateAuthenticationErrors',
-  RESET_AUTHENTICATION_ERRORS = 'restAuthenticationErrors',
+  RESET_AUTHENTICATION_ERRORS = 'resetAuthenticationErrors',
+  UPDATE_CONTENTFUL_PREVIEW_SECRET_ERRORS = 'updateContentfulPreviewSecretErrors',
+  RESET_CONTENTFUL_PREVIEW_SECRET_ERRORS = 'resetContentfulPreviewSecretErrors',
   UPDATE_PROJECT_SELECTION_ERRORS = 'updateProjectSelectionErrors',
   RESET_PROJECT_SELECTION_ERRORS = 'resetProjectSelectionErrors',
   UPDATE_API_PATH_SELECTION_ERRORS = 'updateApiPathSelectionErrors',
@@ -26,9 +29,12 @@ export enum errorsActions {
 
 export enum errorTypes {
   INVALID_TOKEN = 'invalidToken',
+  INVALID_CONTENTFUL_PREVIEW_SECRET = 'invalidContentfulPreviewSecret',
+  ENVIRONMENT_VARIABLE_ALREADY_EXISTS = 'environmentVariableAlreadyExists',
   INVALID_TEAM_SCOPE = 'invalidTeamScope',
   EXPIRED_TOKEN = 'expiredToken',
   PROJECT_NOT_FOUND = 'projectNotFound',
+  CANNOT_FETCH_VERCEL_ENV_VARS = 'cannotFetchVercelEnvVars',
   CANNOT_FETCH_PROJECTS = 'cannotFetchProjects',
   API_PATH_NOT_FOUND = 'apiPathNotFound',
   CANNOT_FETCH_API_PATHS = 'cannotFetchApiPaths',

--- a/apps/vercel/frontend/src/constants/errorMessages.ts
+++ b/apps/vercel/frontend/src/constants/errorMessages.ts
@@ -1,8 +1,10 @@
 export const errorMessages = {
   invalidToken: 'Invalid access token.',
   invalidContentfulPreviewSecret: 'Invalid Contentful preview secret.',
-  environmentVariableAlreadyExists: (key: string) => `An environment variable with key of ${key} already exists.`,
-  cannotFetchVercelEnvVars: 'We had trouble fetching environment variables for this Vercel project.',
+  environmentVariableAlreadyExists: (key: string) =>
+    `An environment variable with key of ${key} already exists.`,
+  cannotFetchVercelEnvVars:
+    'We had trouble fetching environment variables for this Vercel project.',
   invalidTeamScope: 'Token is not scoped to a team.',
   expiredToken: 'Token has expired.',
   projectNotFound:

--- a/apps/vercel/frontend/src/constants/errorMessages.ts
+++ b/apps/vercel/frontend/src/constants/errorMessages.ts
@@ -1,5 +1,8 @@
 export const errorMessages = {
   invalidToken: 'Invalid access token.',
+  invalidContentfulPreviewSecret: 'Invalid Contentful preview secret.',
+  environmentVariableAlreadyExists: (key: string) => `An environment variable with key of ${key} already exists.`,
+  cannotFetchVercelEnvVars: 'We had trouble fetching environment variables for this Vercel project.',
   invalidTeamScope: 'Token is not scoped to a team.',
   expiredToken: 'Token has expired.',
   projectNotFound:

--- a/apps/vercel/frontend/src/contexts/ConfigPageProvider.tsx
+++ b/apps/vercel/frontend/src/contexts/ConfigPageProvider.tsx
@@ -24,6 +24,8 @@ export interface ChannelContextProviderProps extends ConfigPageContextValue {
 
 export const ConfigPageContext = createContext({} as ConfigPageContextValue);
 
+ConfigPageContext.displayName = 'ConfigPageContext';
+
 export const ConfigPageProvider = (props: ChannelContextProviderProps) => {
   const {
     children,
@@ -52,7 +54,8 @@ export const ConfigPageProvider = (props: ChannelContextProviderProps) => {
         isLoading,
         sdk,
         vercelClient,
-      }}>
+      }}
+    >
       {children}
     </ConfigPageContext.Provider>
   );

--- a/apps/vercel/frontend/src/contexts/ConfigPageProvider.tsx
+++ b/apps/vercel/frontend/src/contexts/ConfigPageProvider.tsx
@@ -54,8 +54,7 @@ export const ConfigPageProvider = (props: ChannelContextProviderProps) => {
         isLoading,
         sdk,
         vercelClient,
-      }}
-    >
+      }}>
       {children}
     </ConfigPageContext.Provider>
   );

--- a/apps/vercel/frontend/src/customTypes/configPage.ts
+++ b/apps/vercel/frontend/src/customTypes/configPage.ts
@@ -11,6 +11,7 @@ export type ApplyContentTypePreviewPathSelectionPayload = {
 
 export interface AppInstallationParameters {
   vercelAccessToken: string;
+  contentfulPreviewSecret: string;
   selectedProject: string;
   contentTypePreviewPathSelections: ContentTypePreviewPathSelection[];
   selectedApiPath: string;
@@ -77,6 +78,69 @@ export type AccessToken = {
   expiresAt: string;
 };
 
+export type VercelEnvironmentVariable = {
+  /**
+   * Unique identifier for the configuration
+   */
+  configurationId: string | null;
+
+  /**
+   * Timestamp when the configuration was created (in milliseconds since epoch)
+   */
+  createdAt: number;
+
+  /**
+   * Identifier of the user who created the configuration
+   */
+  createdBy: string;
+
+  /**
+   * Indicates whether the configuration is decrypted
+   */
+  decrypted: boolean;
+
+  /**
+   * Unique identifier for the configuration entry
+   */
+  id: string;
+
+  /**
+   * The key associated with the configuration
+   */
+  key: string;
+
+  /**
+   * Display name of the last user who edited the configuration
+   */
+  lastEditedByDisplayName: string;
+
+  /**
+   * An array of target environments for the configuration
+   */
+  target: Array<'production' | 'development' | 'preview'>;
+
+  /**
+   * Type of the configuration (in this case, 'encrypted')
+   */
+  type: 'encrypted' | 'sensitive' | 'plain' | 'secret';
+
+  /**
+   * Timestamp when the configuration was last updated (in milliseconds since epoch)
+   */
+  updatedAt: number;
+
+  /**
+   * Identifier of the user who last updated the configuration
+   */
+  updatedBy: string | null;
+
+  /**
+   * The encrypted value of the configuration
+   */
+  value: string;
+}
+
+
 export type PreviewPathError = {
   contentType: string;
   invalidPreviewPathFormat: boolean;
@@ -88,6 +152,11 @@ export type Errors = {
     invalidToken: boolean;
     expiredToken: boolean;
     invalidTeamScope: boolean;
+  };
+  contentfulPreviewSecret: {
+    invalidContentfulPreviewSecret: boolean;
+    cannotFetchVercelEnvVars: boolean;
+    environmentVariableAlreadyExists: boolean;
   };
   projectSelection: {
     projectNotFound: boolean;

--- a/apps/vercel/frontend/src/customTypes/configPage.ts
+++ b/apps/vercel/frontend/src/customTypes/configPage.ts
@@ -138,8 +138,7 @@ export type VercelEnvironmentVariable = {
    * The encrypted value of the configuration
    */
   value: string;
-}
-
+};
 
 export type PreviewPathError = {
   contentType: string;

--- a/apps/vercel/frontend/src/hooks/useError/useError.tsx
+++ b/apps/vercel/frontend/src/hooks/useError/useError.tsx
@@ -41,11 +41,7 @@ export const getErrorMessage = (
   return message;
 };
 
-const determineErrorPresence = (
-  errors: Errors,
-  currentError?: Error,
-  contentType?: string
-) => {
+const determineErrorPresence = (errors: Errors, currentError?: Error, contentType?: string) => {
   if (!contentType) return !isEmpty(pickBy(currentError));
   return errors.previewPathSelection.some(
     (error) =>
@@ -66,12 +62,7 @@ export const useError = ({
   const sdk = useSDK<ConfigAppSDK>();
 
   const errorMessage = error
-    ? getErrorMessage(
-        error,
-        sdk.ids.space,
-        'CONTENTFUL_PREVIEW_SECRET',
-        contentType
-      )
+    ? getErrorMessage(error, sdk.ids.space, 'CONTENTFUL_PREVIEW_SECRET', contentType)
     : '';
   const isError = determineErrorPresence(errors, error, contentType);
   return { message: errorMessage, isError: isError };

--- a/apps/vercel/frontend/src/hooks/useFetchData/useFetchData.tsx
+++ b/apps/vercel/frontend/src/hooks/useFetchData/useFetchData.tsx
@@ -18,10 +18,7 @@ export const useFetchData = ({
   vercelClient,
   teamId,
 }: FetchData) => {
-  const validateToken = async (
-    onComplete: () => void,
-    newVercelClient?: VercelClient
-  ) => {
+  const validateToken = async (onComplete: () => void, newVercelClient?: VercelClient) => {
     if (vercelClient) {
       // reset all authentication errors before validating again
       dispatchErrors({
@@ -44,8 +41,7 @@ export const useFetchData = ({
         const err = e as Error;
         dispatchErrors({
           type: errorsActions.UPDATE_AUTHENTICATION_ERRORS,
-          payload:
-            (err.message as keyof Errors['authentication']) || 'invalidToken',
+          payload: (err.message as keyof Errors['authentication']) || 'invalidToken',
         });
       }
       onComplete();
@@ -60,9 +56,7 @@ export const useFetchData = ({
       try {
         console.log('selected project', selectedProject);
         // Check if the environment variable already exists
-        const envVars = await vercelClient.listEnvironmentVariables(
-          selectedProject
-        );
+        const envVars = await vercelClient.listEnvironmentVariables(selectedProject);
 
         const existingEnvVar = envVars.data.find(
           (envVar) => envVar.key === 'CONTENTFUL_PREVIEW_SECRET'
@@ -76,9 +70,7 @@ export const useFetchData = ({
         const err = e as Error;
         dispatchErrors({
           type: errorsActions.UPDATE_CONTENTFUL_PREVIEW_SECRET_ERRORS,
-          payload:
-            (err.message as keyof Errors['contentfulPreviewSecret']) ||
-            'invalidSecret',
+          payload: (err.message as keyof Errors['contentfulPreviewSecret']) || 'invalidSecret',
         });
       }
       onComplete();
@@ -140,20 +132,15 @@ export const useFetchData = ({
     }
   };
 
-  const validateProjectEnv = async (
-    currentSpaceId: string,
-    projectId: string
-  ) => {
+  const validateProjectEnv = async (currentSpaceId: string, projectId: string) => {
     if (vercelClient && teamId)
       try {
-        const isProjectSelectionValid =
-          await vercelClient.validateProjectContentfulSpaceId(
-            currentSpaceId,
-            projectId,
-            teamId
-          );
-        if (!isProjectSelectionValid)
-          throw new Error(errorTypes.INVALID_SPACE_ID);
+        const isProjectSelectionValid = await vercelClient.validateProjectContentfulSpaceId(
+          currentSpaceId,
+          projectId,
+          teamId
+        );
+        if (!isProjectSelectionValid) throw new Error(errorTypes.INVALID_SPACE_ID);
         else {
           dispatchErrors({
             type: errorsActions.RESET_PROJECT_SELECTION_ERRORS,

--- a/apps/vercel/frontend/src/locations/ConfigScreen.spec.tsx
+++ b/apps/vercel/frontend/src/locations/ConfigScreen.spec.tsx
@@ -7,8 +7,11 @@ import VercelClient from '@clients/Vercel';
 import { singleSelectionSections } from '@constants/enums';
 import { copies } from '@constants/copies';
 
-const projectSelectionSectionTestId = singleSelectionSections.PROJECT_SELECTION_SECTION;
-const pathSelectionSectionTestId = singleSelectionSections.API_PATH_SELECTION_SECTION;
+const projectSelectionSectionTestId =
+  singleSelectionSections.PROJECT_SELECTION_SECTION;
+const pathSelectionSectionTestId =
+  singleSelectionSections.API_PATH_SELECTION_SECTION;
+const previewTokenTestId = 'preview-token';
 
 vi.mock('@contentful/react-apps-toolkit', () => ({
   useSDK: () => mockSdk,
@@ -21,7 +24,12 @@ describe('ConfigScreen', () => {
     mockSdk.cma.contentType.getMany = vi.fn().mockResolvedValue({ items: [] });
     vi.spyOn(VercelClient.prototype, 'checkToken').mockResolvedValue({
       ok: true,
-      data: { id: 'team-id', name: 'token-name', expiresAt: '', teamId: '12345' },
+      data: {
+        id: 'team-id',
+        name: 'token-name',
+        expiresAt: '',
+        teamId: '12345',
+      },
     });
     vi.spyOn(VercelClient.prototype, 'listProjects').mockResolvedValue({
       projects: [
@@ -47,8 +55,11 @@ describe('ConfigScreen', () => {
     expect(await screen.findByText('Connect Vercel')).toBeTruthy();
     expect(screen.getByText('Vercel Access Token')).toBeTruthy();
     expect(screen.queryByTestId(projectSelectionSectionTestId)).toBeFalsy();
+    expect(screen.queryByTestId(previewTokenTestId)).toBeFalsy();
     expect(screen.queryByTestId(pathSelectionSectionTestId)).toBeFalsy();
-    expect(screen.queryByTestId('content-type-preview-path-section')).toBeFalsy();
+    expect(
+      screen.queryByTestId('content-type-preview-path-section')
+    ).toBeFalsy();
     unmount();
   });
 
@@ -62,10 +73,15 @@ describe('ConfigScreen', () => {
     const input = screen.getByTestId('access-token');
     fireEvent.change(input, { target: { value: '12345' } });
 
-    const projectSection = await screen.findByTestId(projectSelectionSectionTestId);
+    const projectSection = await screen.findByTestId(
+      projectSelectionSectionTestId
+    );
     expect(projectSection).toBeTruthy();
+    expect(screen.queryByTestId(previewTokenTestId)).toBeFalsy();
     expect(screen.queryByTestId(pathSelectionSectionTestId)).toBeFalsy();
-    expect(screen.queryByTestId('content-type-preview-path-section')).toBeFalsy();
+    expect(
+      screen.queryByTestId('content-type-preview-path-section')
+    ).toBeFalsy();
 
     const selectDropdowns = await screen.findAllByTestId('optionsSelect');
     const dropdownPlaceholder = await screen.findByText(
@@ -75,13 +91,20 @@ describe('ConfigScreen', () => {
 
     user.selectOptions(selectDropdowns[0], 'Project 1');
 
-    const apiPathSection = await screen.findByTestId(pathSelectionSectionTestId);
+    const apiPathSection = await screen.findByTestId(
+      pathSelectionSectionTestId
+    );
     expect(apiPathSection).toBeTruthy();
+    expect(screen.queryByTestId(previewTokenTestId)).toBeTruthy();
 
-    const updatedSelectDropdowns = await screen.findAllByTestId('optionsSelect');
+    const updatedSelectDropdowns = await screen.findAllByTestId(
+      'optionsSelect'
+    );
     user.selectOptions(updatedSelectDropdowns[1], 'Api Path 1');
 
-    expect(await screen.findByTestId('content-type-preview-path-section')).toBeTruthy();
+    expect(
+      await screen.findByTestId('content-type-preview-path-section')
+    ).toBeTruthy();
     unmount();
   });
 });

--- a/apps/vercel/frontend/src/locations/ConfigScreen.spec.tsx
+++ b/apps/vercel/frontend/src/locations/ConfigScreen.spec.tsx
@@ -7,10 +7,8 @@ import VercelClient from '@clients/Vercel';
 import { singleSelectionSections } from '@constants/enums';
 import { copies } from '@constants/copies';
 
-const projectSelectionSectionTestId =
-  singleSelectionSections.PROJECT_SELECTION_SECTION;
-const pathSelectionSectionTestId =
-  singleSelectionSections.API_PATH_SELECTION_SECTION;
+const projectSelectionSectionTestId = singleSelectionSections.PROJECT_SELECTION_SECTION;
+const pathSelectionSectionTestId = singleSelectionSections.API_PATH_SELECTION_SECTION;
 const previewTokenTestId = 'preview-token';
 
 vi.mock('@contentful/react-apps-toolkit', () => ({
@@ -57,9 +55,7 @@ describe('ConfigScreen', () => {
     expect(screen.queryByTestId(projectSelectionSectionTestId)).toBeFalsy();
     expect(screen.queryByTestId(previewTokenTestId)).toBeFalsy();
     expect(screen.queryByTestId(pathSelectionSectionTestId)).toBeFalsy();
-    expect(
-      screen.queryByTestId('content-type-preview-path-section')
-    ).toBeFalsy();
+    expect(screen.queryByTestId('content-type-preview-path-section')).toBeFalsy();
     unmount();
   });
 
@@ -73,15 +69,11 @@ describe('ConfigScreen', () => {
     const input = screen.getByTestId('access-token');
     fireEvent.change(input, { target: { value: '12345' } });
 
-    const projectSection = await screen.findByTestId(
-      projectSelectionSectionTestId
-    );
+    const projectSection = await screen.findByTestId(projectSelectionSectionTestId);
     expect(projectSection).toBeTruthy();
     expect(screen.queryByTestId(previewTokenTestId)).toBeFalsy();
     expect(screen.queryByTestId(pathSelectionSectionTestId)).toBeFalsy();
-    expect(
-      screen.queryByTestId('content-type-preview-path-section')
-    ).toBeFalsy();
+    expect(screen.queryByTestId('content-type-preview-path-section')).toBeFalsy();
 
     const selectDropdowns = await screen.findAllByTestId('optionsSelect');
     const dropdownPlaceholder = await screen.findByText(
@@ -91,20 +83,14 @@ describe('ConfigScreen', () => {
 
     user.selectOptions(selectDropdowns[0], 'Project 1');
 
-    const apiPathSection = await screen.findByTestId(
-      pathSelectionSectionTestId
-    );
+    const apiPathSection = await screen.findByTestId(pathSelectionSectionTestId);
     expect(apiPathSection).toBeTruthy();
     expect(screen.queryByTestId(previewTokenTestId)).toBeTruthy();
 
-    const updatedSelectDropdowns = await screen.findAllByTestId(
-      'optionsSelect'
-    );
+    const updatedSelectDropdowns = await screen.findAllByTestId('optionsSelect');
     user.selectOptions(updatedSelectDropdowns[1], 'Api Path 1');
 
-    expect(
-      await screen.findByTestId('content-type-preview-path-section')
-    ).toBeTruthy();
+    expect(await screen.findByTestId('content-type-preview-path-section')).toBeTruthy();
     unmount();
   });
 });

--- a/apps/vercel/frontend/src/locations/ConfigScreen.tsx
+++ b/apps/vercel/frontend/src/locations/ConfigScreen.tsx
@@ -1,11 +1,4 @@
-import {
-  useCallback,
-  useState,
-  useEffect,
-  useReducer,
-  ChangeEvent,
-  FocusEvent,
-} from 'react';
+import { useCallback, useState, useEffect, useReducer, ChangeEvent, FocusEvent } from 'react';
 import { ConfigAppSDK, ContentType } from '@contentful/app-sdk';
 import { Box, Heading, Paragraph, Stack } from '@contentful/f36-components';
 import { useSDK } from '@contentful/react-apps-toolkit';
@@ -37,10 +30,7 @@ const ConfigScreen = () => {
   const [isAppConfigurationSaved, setIsAppConfigurationSaved] = useState(true);
   const [vercelClient, setVercelClient] = useState<VercelClient | null>(null);
 
-  const [parameters, dispatchParameters] = useReducer(
-    parameterReducer,
-    initialParameters
-  );
+  const [parameters, dispatchParameters] = useReducer(parameterReducer, initialParameters);
   const [errors, dispatchErrors] = useReducer(errorsReducer, initialErrors);
 
   const { isError: isAuthenticationError } = useError({
@@ -51,17 +41,13 @@ const ConfigScreen = () => {
     error: errors.contentfulPreviewSecret,
   });
 
-  const {
-    validateToken,
-    validateContentfulPreviewSecret,
-    fetchProjects,
-    fetchApiPaths,
-  } = useFetchData({
-    dispatchErrors,
-    dispatchParameters,
-    vercelClient,
-    teamId: parameters.teamId,
-  });
+  const { validateToken, validateContentfulPreviewSecret, fetchProjects, fetchApiPaths } =
+    useFetchData({
+      dispatchErrors,
+      dispatchParameters,
+      vercelClient,
+      teamId: parameters.teamId,
+    });
 
   const sdk = useSDK<ConfigAppSDK>();
 
@@ -83,16 +69,11 @@ const ConfigScreen = () => {
     }
 
     if (!vercelClient) {
-      sdk.notifier.error(
-        'An error occurred while trying to authenticate with Vercel'
-      );
+      sdk.notifier.error('An error occurred while trying to authenticate with Vercel');
       return false;
     }
 
-    if (
-      !parameters.contentfulPreviewSecret ||
-      !isContentfulPreviewSecretError
-    ) {
+    if (!parameters.contentfulPreviewSecret || !isContentfulPreviewSecretError) {
       await vercelClient.updateEnvironmentVariable(
         parameters.contentfulPreviewSecret,
         'CONTENTFUL_PREVIEW_SECRET',
@@ -119,14 +100,11 @@ const ConfigScreen = () => {
   const validateEnvironmentExistence = useCallback(async () => {
     if (vercelClient && parameters.selectedProject) {
       try {
-        const res = await vercelClient.listEnvironmentVariables(
-          parameters.selectedProject
-        );
+        const res = await vercelClient.listEnvironmentVariables(parameters.selectedProject);
 
         if (res.ok) {
           const contentfulPreviewSecret = res.data.find(
-            (envVar: { key: string }) =>
-              envVar.key === 'CONTENTFUL_PREVIEW_SECRET'
+            (envVar: { key: string }) => envVar.key === 'CONTENTFUL_PREVIEW_SECRET'
           );
 
           if (contentfulPreviewSecret) {
@@ -228,10 +206,7 @@ const ConfigScreen = () => {
           type: errorsActions.RESET_AUTHENTICATION_ERRORS,
         });
       } else {
-        await validateToken(
-          updateTokenValidityState,
-          new VercelClient(e.target.value)
-        );
+        await validateToken(updateTokenValidityState, new VercelClient(e.target.value));
       }
     }
 
@@ -288,19 +263,16 @@ const ConfigScreen = () => {
       parameters={parameters}
       sdk={sdk}
       vercelClient={vercelClient}
-      errors={errors}
-    >
+      errors={errors}>
       <Box className={styles.body}>
         <Box>
           <Heading>{title}</Heading>
           <Paragraph>{description}</Paragraph>
         </Box>
         <hr className={styles.splitter} />
-        <Stack spacing='spacingS' flexDirection='column'>
+        <Stack spacing="spacingS" flexDirection="column">
           <AuthenticationSection handleTokenChange={handleTokenChange} />
-          {renderPostAuthComponents && (
-            <ProjectSelectionSection projects={projects} />
-          )}
+          {renderPostAuthComponents && <ProjectSelectionSection projects={projects} />}
 
           {renderPostProjectSelectionComponents && (
             <>
@@ -313,14 +285,13 @@ const ConfigScreen = () => {
             </>
           )}
 
-          {renderPostProjectSelectionComponents &&
-            parameters.selectedApiPath && (
-              <>
-                <ContentTypePreviewPathSection />
-                <hr className={styles.splitter} />
-                <GettingStartedSection />
-              </>
-            )}
+          {renderPostProjectSelectionComponents && parameters.selectedApiPath && (
+            <>
+              <ContentTypePreviewPathSection />
+              <hr className={styles.splitter} />
+              <GettingStartedSection />
+            </>
+          )}
         </Stack>
       </Box>
     </ConfigPageProvider>

--- a/apps/vercel/frontend/src/locations/ConfigScreen.tsx
+++ b/apps/vercel/frontend/src/locations/ConfigScreen.tsx
@@ -95,6 +95,7 @@ const ConfigScreen = () => {
     ) {
       await vercelClient.updateEnvironmentVariable(
         parameters.contentfulPreviewSecret,
+        'CONTENTFUL_PREVIEW_SECRET',
         parameters.selectedProject
       );
 

--- a/apps/vercel/frontend/src/reducers/errorsReducer.ts
+++ b/apps/vercel/frontend/src/reducers/errorsReducer.ts
@@ -7,8 +7,18 @@ type UpdateAuthenticationError = {
   payload: keyof Errors['authentication'];
 };
 
+
 type ResetAuthenticationErrors = {
   type: errorsActions.RESET_AUTHENTICATION_ERRORS;
+};
+
+type UpdateContentfulPreviewSecretError = {
+  type: errorsActions.UPDATE_CONTENTFUL_PREVIEW_SECRET_ERRORS;
+  payload: keyof Errors['contentfulPreviewSecret'];
+};
+
+type ResetContentfulPreviewSecretErrors = {
+  type: errorsActions.RESET_CONTENTFUL_PREVIEW_SECRET_ERRORS;
 };
 
 type UpdateProjectSelectionError = {
@@ -41,6 +51,8 @@ type ResetPreviewPathErrors = {
 export type ErrorAction =
   | UpdateAuthenticationError
   | ResetAuthenticationErrors
+  | UpdateContentfulPreviewSecretError
+  | ResetContentfulPreviewSecretErrors
   | UpdateProjectSelectionError
   | ResetProjectSelectionErrors
   | UpdateApiPathSelectionError
@@ -51,6 +63,8 @@ export type ErrorAction =
 const {
   UPDATE_AUTHENTICATION_ERRORS,
   RESET_AUTHENTICATION_ERRORS,
+  UPDATE_CONTENTFUL_PREVIEW_SECRET_ERRORS,
+  RESET_CONTENTFUL_PREVIEW_SECRET_ERRORS,
   UPDATE_PROJECT_SELECTION_ERRORS,
   UPDATE_API_PATH_SELECTION_ERRORS,
   UPDATE_PREVIEW_PATH_ERRORS,
@@ -71,6 +85,7 @@ const errorsReducer = (state: Errors, action: ErrorAction): Errors => {
         },
       };
     }
+
     case RESET_AUTHENTICATION_ERRORS: {
       return {
         ...state,
@@ -79,6 +94,26 @@ const errorsReducer = (state: Errors, action: ErrorAction): Errors => {
         },
       };
     }
+
+    case UPDATE_CONTENTFUL_PREVIEW_SECRET_ERRORS: {
+      const contentfulErrorType = action.payload;
+      return {
+        ...state,
+        contentfulPreviewSecret: {
+          ...initialErrors.contentfulPreviewSecret,
+          [contentfulErrorType]: true,
+        },
+      };
+    }
+    case RESET_CONTENTFUL_PREVIEW_SECRET_ERRORS: {
+      return {
+        ...state,
+        contentfulPreviewSecret: {
+          ...initialErrors.contentfulPreviewSecret,
+        },
+      };
+    }
+
     case UPDATE_PROJECT_SELECTION_ERRORS: {
       const projectErrorType = action.payload;
       return {

--- a/apps/vercel/frontend/src/reducers/errorsReducer.ts
+++ b/apps/vercel/frontend/src/reducers/errorsReducer.ts
@@ -7,7 +7,6 @@ type UpdateAuthenticationError = {
   payload: keyof Errors['authentication'];
 };
 
-
 type ResetAuthenticationErrors = {
   type: errorsActions.RESET_AUTHENTICATION_ERRORS;
 };

--- a/apps/vercel/frontend/src/reducers/parameterReducer.ts
+++ b/apps/vercel/frontend/src/reducers/parameterReducer.ts
@@ -10,6 +10,11 @@ type VercelAccessTokenAction = {
   payload: string;
 };
 
+type ContentfulPreviewSecretAction = {
+  type: parametersActions.UPDATE_CONTENTFUL_PREVIEW_SECRET;
+  payload: string;
+};
+
 type VercelSelectedProjectAction = {
   type: parametersActions.APPLY_SELECTED_PROJECT;
   payload: string;
@@ -42,6 +47,7 @@ type ApplyTeamId = {
 
 export type ParameterAction =
   | VercelAccessTokenAction
+  | ContentfulPreviewSecretAction
   | ApplyContentfulParametersAction
   | VercelSelectedProjectAction
   | AddContentTypePreviewPathSelectionAction
@@ -51,6 +57,7 @@ export type ParameterAction =
 
 const {
   UPDATE_VERCEL_ACCESS_TOKEN,
+  UPDATE_CONTENTFUL_PREVIEW_SECRET,
   APPLY_CONTENTFUL_PARAMETERS,
   APPLY_SELECTED_PROJECT,
   ADD_CONTENT_TYPE_PREVIEW_PATH_SELECTION,
@@ -69,11 +76,18 @@ const parameterReducer = (
         ...state,
         vercelAccessToken: action.payload,
       };
+
+    case UPDATE_CONTENTFUL_PREVIEW_SECRET:
+      return {
+        ...state,
+        contentfulPreviewSecret: action.payload,
+      };
     case APPLY_CONTENTFUL_PARAMETERS: {
       const parameters = action.payload;
       return {
         ...state,
         vercelAccessToken: parameters.vercelAccessToken,
+        contentfulPreviewSecret: parameters.contentfulPreviewSecret,
         contentTypePreviewPathSelections: parameters.contentTypePreviewPathSelections,
         selectedProject: parameters.selectedProject,
         selectedApiPath: parameters.selectedApiPath,

--- a/apps/vercel/frontend/test/mocks/mockSdk.ts
+++ b/apps/vercel/frontend/test/mocks/mockSdk.ts
@@ -6,6 +6,7 @@ export const SPACE_ID = '1234';
 export const mockParameters: AppInstallationParameters = {
   vercelAccessToken: 'abc-123',
   selectedProject: 'test-project-id',
+  contentfulPreviewSecret: 'test-preview-secret',
   selectedApiPath: 'test-api-path',
   contentTypePreviewPathSelections: [
     { contentType: 'test-content-type', previewPath: 'test-preview-path' },


### PR DESCRIPTION
## Purpose

We want live preview to work for Hobby, Pro and Enterprise accounts. Currently, we use Vercel Protection Bypass Secret to validate the request from Contentful to Vercel. However, Hobby accounts do not have access to Vercel Protection Bypass. Therefore, we need to set an environment variable that's responsible for validating the request came from Contentful.

## Approach

Adding this input for Contentful Preview Secret allows a user to install the integration on their Contentful Space and update their Vercel project's environment variables at the same time. This input will check to make sure the environment variable doesn't already exist, explain to the user that they need to delete it in their Vercel project if it does exist, and then will save the secret to Contentful and Vercel to make sure it's in sync and the same value.

## Testing steps

Initial Setup:
1. Install the app
2. Create access token and open that project in Vercel
3. Go to environment variables for that project
4. Make sure there is not a CONTENTFUL_PREVIEW_SECRET variable.

Fresh Install Test:
1. Install the app
2. Create access token and open that project in Vercel
3. Select the same project in Contentful
4. Enter a random value for the Contentful Preview Secret
5. Save
6. You should see a disabled field in Contentful saying the variable exists
7. You should see the variable in your Vercel environment variables for the project
8. These two values should be equal

Possible Collision Test:
1. Install the app
2. Create access token and open that project in Vercel
3. Create an environment variable on Vercel in that project called CONTENTFUL_PREVIEW_SECRET with any value
4. Select that project in Contentful
5. You should see a disabled field AND an error telling you to delete the variable in Vercel.
6. Delete the variable in Vercel
7. Click "Retry"
8. The field should be enabled, blank and allow you to save
9. Environment variable should be present in Vercel after you save.


## Breaking Changes

Yes, this change is also dependent on the SDK being updated. First, we need to send this CONTENTFUL_PREVIEW_SECRET value in a header (best case) or query param (worst case). Then, the SDK needs to validate the request using this secret instead of the Vercel Protection Bypass cookie.

## Dependencies and/or References

Talk to @jsdalton or @malewis5

## Deployment

Do not deploy this change until the SDK has been tested alongside it.
We should also write better tests, this isn't my strong suite.
