### PR TITLE
fix: use index for deleting asset [ZEND-5025]

### DIFF
--- a/packages/dam-app-base/src/Editor/SortableComponent.tsx
+++ b/packages/dam-app-base/src/Editor/SortableComponent.tsx
@@ -242,12 +242,12 @@ export const SortableComponent = ({
   const [items, setItems] = useState<AssetWithId[]>([]);
 
   const deleteItem = useCallback(
-    (index: UniqueIdentifier) => {
+    (index: number) => {
       const myResources = [...resources];
-      myResources.splice(Number(index), 1);
+      myResources.splice(index, 1);
       onChange(myResources);
     },
-    [resources]
+    [resources, onChange]
   );
 
   useEffect(() => {
@@ -313,14 +313,14 @@ export const SortableComponent = ({
       <SortableContext items={items?.map((i) => i.key)} strategy={verticalListSortingStrategy}>
         <div className={styles.container} data-testid="container">
           <div className={styles.grid} data-testid="grid">
-            {items.map(({ key, alt, url, additionalData }) => (
+            {items.map(({ key, alt, url, additionalData }, index) => (
               <div key={key}>
                 <SortableItem
                   disabled={disabled}
                   url={url}
                   alt={alt}
                   uniqueId={key}
-                  onDelete={() => deleteItem(key)}
+                  onDelete={() => deleteItem(index)}
                   additionalData={additionalData}
                 />
               </div>


### PR DESCRIPTION
## Purpose

[This PR](https://github.com/contentful/apps/pull/7431/files) to get the `dam-app-base` ready to support React 18 introduced some changes to the `deleteItem` login in the `SortableComponent`. These changes caused issues with deleting, where when clicking on an item in the list to delete, the first item instead got deleted.

## Approach

The `key` was being used to splice the item from the list, but this turned out to be the URL of the asset, so this was getting passed as `NaN` and then removing the first item in the list. This PR updates the `deleteItem` logic to instead use index instead of key.

## Testing steps

I tested this locally using `npm pack` to test the changes to the `dam-app-base` within the Bynder app.

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

After updating the `dam-app-base` we will open a PR for the Bynder app to bump the package version.
