### PR TITLE
fix: handle teamId in Vercel API call

### DIFF
--- a/apps/vercel/app-actions/src/actions/get-preview-envs.ts
+++ b/apps/vercel/app-actions/src/actions/get-preview-envs.ts
@@ -23,9 +23,10 @@ export const handler = withAsyncAppActionErrorHandling(
       selectedProject: vercelProjectId,
       contentTypePreviewPathSelections,
       selectedApiPath,
+      teamId,
     } = await fetchAppInstallationParameters(appActionCallContext, cma);
 
-    const vercelService = new VercelService(vercelAccessToken);
+    const vercelService = new VercelService(vercelAccessToken, teamId);
     const vercelProject = await vercelService.getProject(vercelProjectId);
 
     const previewUrlsByContentType = buildPreviewUrlsForContentTypes(

--- a/apps/vercel/app-actions/src/helpers/fetch-app-installation-parameters.ts
+++ b/apps/vercel/app-actions/src/helpers/fetch-app-installation-parameters.ts
@@ -6,6 +6,7 @@ const REQUIRED_PARAMS = [
   'selectedProject',
   'contentTypePreviewPathSelections',
   'selectedApiPath',
+  'teamId',
 ];
 
 function assertAppInstallationParameters(

--- a/apps/vercel/app-actions/src/services/vercel-service.spec.ts
+++ b/apps/vercel/app-actions/src/services/vercel-service.spec.ts
@@ -9,7 +9,8 @@ chai.use(sinonChai);
 describe('VercelService', () => {
   const vercelAccessToken = 'vercel-access-token';
   const vercelProjectId = 'vercel-project-id';
-  const vercelService = new VercelService(vercelAccessToken);
+  const vercelTeamId = 'vercel-team-id';
+  const vercelService = new VercelService(vercelAccessToken, vercelTeamId);
   let stubbedFetch: sinon.SinonStub;
 
   beforeEach(() => {
@@ -27,7 +28,7 @@ describe('VercelService', () => {
     it('calls fetch with the appropriate values', async () => {
       await vercelService.getProject(vercelProjectId);
       expect(stubbedFetch).to.have.been.calledWith(
-        'https://api.vercel.com/v9/projects/vercel-project-id',
+        'https://api.vercel.com/v9/projects/vercel-project-id?teamId=vercel-team-id',
         {
           method: 'GET',
           headers: {
@@ -36,6 +37,25 @@ describe('VercelService', () => {
           },
         }
       );
+    });
+
+    describe('when error status (non-200) is received', () => {
+      beforeEach(() => {
+        const mockFetchResponse = makeMockFetchResponse(mockVercelProject, {}, 500);
+        sinon.restore();
+        stubbedFetch = sinon.stub(global, 'fetch');
+        stubbedFetch.resolves(mockFetchResponse);
+      });
+
+      it('throws an an error', async () => {
+        let error: any;
+        try {
+          await vercelService.getProject(vercelProjectId);
+        } catch (e) {
+          error = e;
+        }
+        expect(error).to.be.an('Error');
+      });
     });
   });
 });

--- a/apps/vercel/app-actions/src/services/vercel-service.ts
+++ b/apps/vercel/app-actions/src/services/vercel-service.ts
@@ -8,7 +8,7 @@ export class VercelService {
       method: 'GET',
       headers: this.buildRequestHeaders(),
     });
-    await this.maybeThrowApiError(response);
+    await this.handleApiError(response);
     const vercelProject = await response.json();
     this.assertVercelProject(vercelProject);
     return vercelProject;
@@ -16,7 +16,7 @@ export class VercelService {
 
   // cheap and dirty error handling -- could later provide a more structured error response
   // when API errors are encountered
-  private async maybeThrowApiError(response: Response): Promise<void> {
+  private async handleApiError(response: Response): Promise<void> {
     if (response.status < 400) return;
     const errorResponse: string = await response.text();
     const { status } = response;

--- a/apps/vercel/app-actions/src/services/vercel-service.ts
+++ b/apps/vercel/app-actions/src/services/vercel-service.ts
@@ -1,16 +1,27 @@
 import { VercelProject } from '../types';
 
 export class VercelService {
-  constructor(readonly accessToken: string) {}
+  constructor(readonly accessToken: string, readonly teamId: string) {}
 
   public async getProject(projectId: string): Promise<VercelProject> {
     const response = await fetch(this.buildProjectUrl(projectId), {
       method: 'GET',
       headers: this.buildRequestHeaders(),
     });
+    await this.maybeThrowApiError(response);
     const vercelProject = await response.json();
     this.assertVercelProject(vercelProject);
     return vercelProject;
+  }
+
+  // cheap and dirty error handling -- could later provide a more structured error response
+  // when API errors are encountered
+  private async maybeThrowApiError(response: Response): Promise<void> {
+    if (response.status < 400) return;
+    const errorResponse: string = await response.text();
+    const { status } = response;
+    const msg = `Vercel API error: ${errorResponse} [status: ${status}]`;
+    throw new Error(msg);
   }
 
   private buildRequestHeaders() {
@@ -21,7 +32,9 @@ export class VercelService {
   }
 
   private buildProjectUrl(projectId: string) {
-    return `https://api.vercel.com/v9/projects/${projectId}`;
+    const url = new URL(`https://api.vercel.com/v9/projects/${projectId}`);
+    url.searchParams.set('teamId', this.teamId);
+    return url.toString();
   }
 
   private assertVercelProject(value: unknown): asserts value is VercelProject {

--- a/apps/vercel/app-actions/src/types.ts
+++ b/apps/vercel/app-actions/src/types.ts
@@ -54,6 +54,7 @@ export interface AppInstallationParameters {
   selectedProject: string;
   contentTypePreviewPathSelections: ContentTypePreviewPathSelection[];
   selectedApiPath: string;
+  teamId: string;
 }
 
 /* END copied over from frontend app installation types */

--- a/apps/vercel/app-actions/test/mocks.ts
+++ b/apps/vercel/app-actions/test/mocks.ts
@@ -23,10 +23,11 @@ export const makeMockPlainClient = (responses: any[], stub: sinon.SinonStub): Pl
 
 export const makeMockFetchResponse = (
   body: object,
-  headers: Record<string, string> = {}
+  headers: Record<string, string> = {},
+  status: number = 200
 ): Response => {
   const responseBody = JSON.stringify(body);
-  return new Response(responseBody, { headers });
+  return new Response(responseBody, { headers, status });
 };
 
 export const makeMockAppActionCallContext = (
@@ -53,6 +54,7 @@ export const mockAppInstallationParameters: AppInstallationParameters = {
     { contentType: 'blog', previewPath: '/blogs/{entry.fields.slug}' },
   ],
   selectedApiPath: 'api/enable-draft',
+  teamId: 'vercel-team-id',
 };
 
 export const makeMockAppInstallation = (


### PR DESCRIPTION
## Purpose

* Team ID is required in Vercel API calls. We've added it to all our frontend API calls but missed updating the app action
* We should handle error responses from the Vercel API (at least acknowledge what went wrong and capture the error)

## Approach

* Add the teamId as a query param. Since it's "required" by the frontend now we will assume it's present in the app installation parameter
* Add a rudimentary error handler to the app action Vercel api service

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
