### PR TITLE
chore: adjust vercel error state for bypass protection

### DIFF
--- a/apps/vercel/frontend/src/clients/Vercel.ts
+++ b/apps/vercel/frontend/src/clients/Vercel.ts
@@ -11,6 +11,7 @@ import {
 } from '@customTypes/configPage';
 
 const CONTENTFUL_SPACE_ID = 'CONTENTFUL_SPACE_ID';
+const CONTENTFUL_PREVIEW_SECRET = 'CONTENTFUL_PREVIEW_SECRET';
 
 interface GetToken {
   ok: boolean;
@@ -179,6 +180,19 @@ export default class VercelClient implements VercelAPIClient {
         const data = await res.json();
         return data.value === currentSpaceId;
       }
+    } catch (e) {
+      // let user continue if there is an error validating env value
+      console.error(e);
+    }
+
+    return false;
+  }
+
+  async validateProjectPreviewSecret(projectId: string, teamId: string) {
+    try {
+      const data = await this.getProject(projectId, teamId);
+      const envs = data.env;
+      return Boolean(envs.find((env) => env.key === CONTENTFUL_PREVIEW_SECRET));
     } catch (e) {
       // let user continue if there is an error validating env value
       console.error(e);

--- a/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.spec.tsx
+++ b/apps/vercel/frontend/src/components/common/SelectSection/SelectSection.spec.tsx
@@ -84,6 +84,7 @@ describe('SelectSection', () => {
       projectNotFound: true,
       cannotFetchProjects: false,
       invalidSpaceId: false,
+      invalidProjectSettings: false,
     };
     const mockHandleInvalidSelectionError = vi.fn(() => {});
     const { unmount } = render(

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionList/ContentTypePreviewPathSelectionList.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionList/ContentTypePreviewPathSelectionList.tsx
@@ -67,6 +67,7 @@ export const ContentTypePreviewPathSelectionList = () => {
         onParameterUpdate={handleUpdateParameters}
         onRemoveRow={handleRemoveRow}
         renderLabel={index === 0}
+        rowId={index}
       />
     ));
   };

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.spec.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.spec.tsx
@@ -24,6 +24,7 @@ describe('ContentTypePreviewPathSelectionRow', () => {
         contentTypes={mockContentTypes}
         onParameterUpdate={mockOnUpdate}
         onRemoveRow={() => null}
+        rowId={0}
       />
     );
 
@@ -47,6 +48,7 @@ describe('ContentTypePreviewPathSelectionRow', () => {
         onParameterUpdate={() => null}
         onRemoveRow={mockOnRemoveRow}
         configuredContentTypePreviewPathSelection={selection}
+        rowId={0}
       />
     );
 
@@ -63,6 +65,7 @@ describe('ContentTypePreviewPathSelectionRow', () => {
         contentTypes={mockContentTypes}
         onParameterUpdate={() => null}
         onRemoveRow={() => null}
+        rowId={0}
       />
     );
 
@@ -78,6 +81,7 @@ describe('ContentTypePreviewPathSelectionRow', () => {
         onParameterUpdate={() => null}
         onRemoveRow={() => null}
         configuredContentTypePreviewPathSelection={selection}
+        rowId={0}
       />
     );
 
@@ -92,6 +96,7 @@ describe('ContentTypePreviewPathSelectionRow', () => {
         onParameterUpdate={() => null}
         onRemoveRow={() => null}
         configuredContentTypePreviewPathSelection={selection}
+        rowId={0}
       />
     );
 
@@ -120,6 +125,7 @@ describe('ContentTypePreviewPathSelectionRow', () => {
         onParameterUpdate={vi.fn()}
         onRemoveRow={() => null}
         configuredContentTypePreviewPathSelection={selection}
+        rowId={0}
       />,
       { isAppConfigurationSaved: true, errors }
     );
@@ -148,6 +154,7 @@ describe('ContentTypePreviewPathSelectionRow', () => {
         onParameterUpdate={vi.fn()}
         onRemoveRow={() => null}
         configuredContentTypePreviewPathSelection={selection}
+        rowId={0}
       />,
       { isAppConfigurationSaved: true, errors }
     );

--- a/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ContentTypePreviewPathSection/ContentTypePreviewPathSelectionRow/ContentTypePreviewPathSelectionRow.tsx
@@ -28,6 +28,7 @@ interface Props {
   onParameterUpdate: (parameters: ApplyContentTypePreviewPathSelectionPayload) => void;
   onRemoveRow: (parameters: ContentTypePreviewPathSelection) => void;
   renderLabel?: boolean;
+  rowId: number;
 }
 
 export const ContentTypePreviewPathSelectionRow = ({
@@ -36,6 +37,7 @@ export const ContentTypePreviewPathSelectionRow = ({
   onParameterUpdate,
   onRemoveRow,
   renderLabel,
+  rowId,
 }: Props) => {
   const { isAppConfigurationSaved, isLoading, dispatchErrors, errors } =
     useContext(ConfigPageContext);
@@ -133,7 +135,7 @@ export const ContentTypePreviewPathSelectionRow = ({
 
   return (
     <Box className={styles.wrapper}>
-      <FormControl marginBottom="spacingM" id="contentTypePreviewPathSelection">
+      <FormControl marginBottom="spacingM" id={'contentTypePreviewPathSelection-' + rowId}>
         <Flex
           flexDirection="row"
           justifyContent="space-evenly"

--- a/apps/vercel/frontend/src/components/config-screen/ProjectSelectionSection/ProjectSelectionSection.spec.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ProjectSelectionSection/ProjectSelectionSection.spec.tsx
@@ -55,7 +55,7 @@ describe('ProjectSelectionSection', () => {
     const overrides = {
       dispatchParameters: mockDispatchParameters,
       handleAppConfigurationChange: mockHandleAppConfigurationChange,
-      parameters: { teamId: '1234', selectedProject: projects[0].id },
+      parameters: { teamId: '1234', selectedProject: 'Project 2' },
     } as unknown as AppInstallationParameters;
 
     const { unmount } = renderConfigPageComponent(<ProjectSelectionSection projects={projects} />, {

--- a/apps/vercel/frontend/src/components/config-screen/ProjectSelectionSection/ProjectSelectionSection.tsx
+++ b/apps/vercel/frontend/src/components/config-screen/ProjectSelectionSection/ProjectSelectionSection.tsx
@@ -35,6 +35,10 @@ export const ProjectSelectionSection = ({ projects }: Props) => {
   });
 
   const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    if (event.target.value === parameters.selectedProject) {
+      return;
+    }
+
     // indicate app config change when project has been re-selected
     handleAppConfigurationChange();
 
@@ -52,9 +56,14 @@ export const ProjectSelectionSection = ({ projects }: Props) => {
 
   useEffect(() => {
     const currentSpaceId = sdk.ids.space;
+    const selectedProjectObject = projects.find(
+      (project) => project.id === parameters.selectedProject
+    );
+
     const validateProjectSelectionEnv = async () => {
-      await validateProjectEnv(currentSpaceId, parameters.selectedProject);
+      await validateProjectEnv(currentSpaceId, parameters.selectedProject, selectedProjectObject);
     };
+
     if (parameters.selectedProject) validateProjectSelectionEnv();
   }, [parameters.selectedProject, vercelClient, parameters.teamId]);
 

--- a/apps/vercel/frontend/src/constants/defaultParams.ts
+++ b/apps/vercel/frontend/src/constants/defaultParams.ts
@@ -18,6 +18,7 @@ export const initialErrors: Errors = {
     projectNotFound: false,
     cannotFetchProjects: false,
     invalidSpaceId: false,
+    invalidProjectSettings: false,
   },
   apiPathSelection: {
     apiPathNotFound: false,

--- a/apps/vercel/frontend/src/constants/enums.ts
+++ b/apps/vercel/frontend/src/constants/enums.ts
@@ -30,6 +30,7 @@ export enum errorTypes {
   EXPIRED_TOKEN = 'expiredToken',
   PROJECT_NOT_FOUND = 'projectNotFound',
   CANNOT_FETCH_PROJECTS = 'cannotFetchProjects',
+  INVALID_PROJECT_SETTINGS = 'invalidProjectSettings',
   API_PATH_NOT_FOUND = 'apiPathNotFound',
   CANNOT_FETCH_API_PATHS = 'cannotFetchApiPaths',
   INVALID_PREVIEW_PATH_FORMAT = 'invalidPreviewPathFormat',

--- a/apps/vercel/frontend/src/constants/errorMessages.ts
+++ b/apps/vercel/frontend/src/constants/errorMessages.ts
@@ -7,7 +7,7 @@ export const errorMessages = {
   cannotFetchProjects: 'We had trouble fetching your Vercel projects.',
   // placeholder error message for now until implement manual fix for this.
   invalidProjectSettings:
-    'The settings that allow live preview of your Vercel project within Contentful are invalid. Please ensure bypass protection is enabled. ',
+    'The settings that allow live preview of your Vercel project within Contentful are invalid. Please ensure either bypass protection is enabled or there exists a CONTENTFUL_PREVIEW_SECRET env variable within your project with Vercel Authentication disabled. ',
   apiPathNotFound:
     'The route you previously selected is no longer available. Please select another one.',
   apiPathsEmpty: "It looks like your Vercel project doesn't have any routes configured yet.",

--- a/apps/vercel/frontend/src/constants/errorMessages.ts
+++ b/apps/vercel/frontend/src/constants/errorMessages.ts
@@ -5,6 +5,9 @@ export const errorMessages = {
   projectNotFound:
     'The project you have configured is no longer available. Please select another one.',
   cannotFetchProjects: 'We had trouble fetching your Vercel projects.',
+  // placeholder error message for now until implement manual fix for this.
+  invalidProjectSettings:
+    'The settings that allow live preview of your Vercel project within Contentful are invalid. Please ensure bypass protection is enabled. ',
   apiPathNotFound:
     'The route you previously selected is no longer available. Please select another one.',
   apiPathsEmpty: "It looks like your Vercel project doesn't have any routes configured yet.",

--- a/apps/vercel/frontend/src/constants/errorMessages.ts
+++ b/apps/vercel/frontend/src/constants/errorMessages.ts
@@ -5,9 +5,9 @@ export const errorMessages = {
   projectNotFound:
     'The project you have configured is no longer available. Please select another one.',
   cannotFetchProjects: 'We had trouble fetching your Vercel projects.',
-  // placeholder error message for now until implement manual fix for this.
+  // placeholder error message for now until implement automated fix for this.
   invalidProjectSettings:
-    'The settings that allow live preview of your Vercel project within Contentful are invalid. Please ensure either bypass protection is enabled or there exists a CONTENTFUL_PREVIEW_SECRET env variable within your project with Vercel Authentication disabled. ',
+    'The settings that allow live preview of your Vercel project within Contentful are invalid. Please ensure either bypass protection is enabled or that there exists a CONTENTFUL_PREVIEW_SECRET env variable within your project along with Vercel Authentication disabled. ',
   apiPathNotFound:
     'The route you previously selected is no longer available. Please select another one.',
   apiPathsEmpty: "It looks like your Vercel project doesn't have any routes configured yet.",

--- a/apps/vercel/frontend/src/customTypes/configPage.ts
+++ b/apps/vercel/frontend/src/customTypes/configPage.ts
@@ -31,6 +31,13 @@ export interface Project {
     };
   };
   env: ProjectEnv[];
+  protectionBypass?: {
+    [key: string]: {
+      createdAt: number;
+      createdBy: string;
+      scope: string;
+    };
+  };
 }
 
 export interface Deployment {
@@ -93,6 +100,7 @@ export type Errors = {
     projectNotFound: boolean;
     cannotFetchProjects: boolean;
     invalidSpaceId: boolean;
+    invalidProjectSettings: boolean;
   };
   apiPathSelection: {
     apiPathNotFound: boolean;

--- a/apps/vercel/frontend/src/hooks/useError/useError.spec.tsx
+++ b/apps/vercel/frontend/src/hooks/useError/useError.spec.tsx
@@ -59,6 +59,7 @@ describe('useError', () => {
       invalidSpaceId: true,
       projectNotFound: false,
       cannotFetchProjects: false,
+      invalidProjectSettings: false,
     };
 
     renderHook(

--- a/apps/vercel/frontend/src/locations/ConfigScreen.spec.tsx
+++ b/apps/vercel/frontend/src/locations/ConfigScreen.spec.tsx
@@ -34,6 +34,7 @@ describe('ConfigScreen', () => {
             },
           },
           env: [],
+          protectionBypass: {},
         },
       ],
     });

--- a/apps/vercel/frontend/src/locations/ConfigScreen.tsx
+++ b/apps/vercel/frontend/src/locations/ConfigScreen.tsx
@@ -13,7 +13,7 @@ import { ApiPath, Project } from '@customTypes/configPage';
 import { ApiPathSelectionSection } from '@components/config-screen/ApiPathSelectionSection/ApiPathSelectionSection';
 import { AuthenticationSection } from '@components/config-screen/AuthenticationSection/AuthenticationSection';
 import { copies } from '@constants/copies';
-import { errorsActions, parametersActions } from '@constants/enums';
+import { parametersActions } from '@constants/enums';
 import { ConfigPageProvider } from '@contexts/ConfigPageProvider';
 import { GettingStartedSection } from '@components/config-screen/GettingStartedSection/GettingStartedSection';
 import errorsReducer from '@reducers/errorsReducer';
@@ -132,14 +132,7 @@ const ConfigScreen = () => {
     });
 
     async function checkToken() {
-      // if the token is empty, reset all authentication errors and skip validation
-      if (e.target.value === '') {
-        dispatchErrors({
-          type: errorsActions.RESET_AUTHENTICATION_ERRORS,
-        });
-      } else {
-        await validateToken(updateTokenValidityState, new VercelClient(e.target.value));
-      }
+      await validateToken(updateTokenValidityState, new VercelClient(e.target.value));
     }
 
     checkToken();
@@ -159,7 +152,7 @@ const ConfigScreen = () => {
     !errors.projectSelection.projectNotFound &&
     !errors.projectSelection.cannotFetchProjects &&
     parameters.selectedProject &&
-    projects.length;
+    !!projects.length;
 
   return (
     <ConfigPageProvider


### PR DESCRIPTION
## Purpose

The purpose of this PR is to implement a light weight way to communicate errors to the user in the case that bypass protection is not enabled AND there does not yet exist a `CONTENTFUL_PREVIEW_SECRET`. This is a step to try and at least communicate the errors to the user so they might have a chance in resolving it before reaching a dysfunctional live preview. See follow-up work for more detail. 
## Approach

For now we are just appropriately displaying an error to user if the project settings are not valid. The rules checked are as follows: 1. bypass protection is enabled 2. If not, then there is a CONTENTFUL_PREVIEW_SECRET. If neither of these are true, then the error appears. 

I am still trying to figure out how to confirm that Vercel Authentication is also disabled in that second block for hobby accounts. But figured checking the first two is an improvement to no errors existing at all right now. 
![Screenshot 2024-06-05 at 8 19 20 AM](https://github.com/contentful/apps/assets/58186851/9638eb33-5ad0-470e-b94d-de888df29401)


## Testing steps

On the Vercel configuration page, paste a token from a hobby account, and select a project without a CONTENTFUL_PREVIEW_SECRET. The error should appear. 

The same error should appear if you paste a token from an enterprise account and the selected project does not have protection bypass enabled. 
## Follow-up

Implement a way to either resolve these settings automatically for the user OR describe in greater detail how they can resolve these issues themselves, perhaps in the help guide documentation. 

Additionally, figure out how to check is Vercel Authentication is off. 

