### PR TITLE
Fix ecommerce-app-base bug in drag-n-drop refetch logic

### DIFF
--- a/packages/ecommerce-app-base/src/AppConfig/AppConfig.spec.tsx
+++ b/packages/ecommerce-app-base/src/AppConfig/AppConfig.spec.tsx
@@ -5,53 +5,7 @@ import { ConfigAppSDK } from '@contentful/app-sdk';
 
 import AppConfig from './AppConfig';
 import { definitions } from './parameters.spec';
-
-const contentTypes = [
-  {
-    sys: { id: 'ct1' },
-    name: 'CT1',
-    fields: [
-      { id: 'product_x', name: 'Product X', type: 'Symbol' },
-      { id: 'y', name: 'Y', type: 'Object' },
-    ],
-  },
-  {
-    sys: { id: 'ct2' },
-    name: 'CT2',
-    fields: [
-      { id: 'foo', name: 'FOO', type: 'Text' },
-      { id: 'z', name: 'Z', type: 'Array', items: { type: 'Symbol' } },
-    ],
-  },
-  {
-    sys: { id: 'ct3' },
-    name: 'CT3',
-    fields: [
-      { id: 'bar', name: 'BAR', type: 'Object' },
-      { id: 'baz', name: 'BAZ', type: 'Object' },
-      { id: 'product_d', name: 'Product D', type: 'Array', items: { type: 'Symbol' } },
-      { id: 'product_a', name: 'Product A', type: 'Symbol' },
-    ],
-  },
-];
-
-const makeSdkMock = () => ({
-  ids: {
-    app: 'some-app',
-  },
-  hostnames: {
-    webapp: 'app.contentful.com',
-  },
-  space: {
-    getContentTypes: jest.fn().mockResolvedValue({ items: contentTypes }),
-    getEditorInterfaces: jest.fn().mockResolvedValue({ items: [] }),
-  },
-  app: {
-    setReady: jest.fn(),
-    getParameters: jest.fn().mockResolvedValue(null),
-    onConfigure: jest.fn().mockReturnValue(undefined),
-  },
-});
+import { makeSdkMock } from '../__mocks__';
 
 const validate = () => null; // Means no error
 

--- a/packages/ecommerce-app-base/src/Editor/SortableComponent.spec.tsx
+++ b/packages/ecommerce-app-base/src/Editor/SortableComponent.spec.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { render, cleanup, waitFor } from '@testing-library/react';
+import { SortableComponent } from './SortableComponent';
+import { makeSdkMock, productsList } from '../__mocks__';
+import { FieldAppSDK } from '@contentful/app-sdk';
+import { ProductPreviewsFn } from '../types';
+
+const mockSdk = makeSdkMock();
+const skus = ['M0E20130820E90Z', 'A0E2300FX102203', 'M0E21300900DZN7'];
+const mockConfig = {};
+const mockSkuType = 'mock-sku-type';
+
+describe('SortableComponent', () => {
+  let mockFetchProductPreviews: ProductPreviewsFn;
+
+  beforeEach(() => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore - typescript is upset because jest.fn() returns a type different than ProductPreviewsFn
+    mockFetchProductPreviews = jest.fn().mockImplementation(() => {
+      return Promise.resolve(productsList);
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    jest.resetAllMocks();
+  });
+
+  it('calls `fetchProductPreviews()` to retrieve list of products for associated skus', async () => {
+    waitFor(() => {
+      render(
+        <SortableComponent
+          sdk={mockSdk as unknown as FieldAppSDK}
+          disabled={false}
+          config={mockConfig}
+          skus={skus}
+          onChange={jest.fn()}
+          fetchProductPreviews={mockFetchProductPreviews}
+          skuType={mockSkuType}
+        />
+      );
+    });
+
+    expect(mockFetchProductPreviews).toHaveBeenCalledTimes(1);
+    expect(mockFetchProductPreviews).toHaveBeenLastCalledWith(skus, mockConfig, mockSkuType);
+  });
+
+  it('refetches list of products for associated skus, when skus are added/removed', async () => {
+    const newSkus = [...skus, 'new-sku-item'];
+
+    await waitFor(() => {
+      // initial mount with original skus
+      const { rerender } = render(
+        <SortableComponent
+          sdk={mockSdk as unknown as FieldAppSDK}
+          disabled={false}
+          config={mockConfig}
+          skus={skus}
+          onChange={jest.fn()}
+          fetchProductPreviews={mockFetchProductPreviews}
+          skuType={mockSkuType}
+        />
+      );
+
+      // rerender with additional sku
+      rerender(
+        <SortableComponent
+          skus={newSkus}
+          sdk={mockSdk as unknown as FieldAppSDK}
+          disabled={false}
+          config={mockConfig}
+          onChange={jest.fn()}
+          fetchProductPreviews={mockFetchProductPreviews}
+          skuType={mockSkuType}
+        />
+      );
+    });
+
+    expect(mockFetchProductPreviews).toHaveBeenCalledTimes(2);
+    expect(mockFetchProductPreviews).toHaveBeenLastCalledWith(newSkus, mockConfig, mockSkuType);
+  });
+
+  it('does NOT refetch list of products when skus have simply been reordered', async () => {
+    const reorderedSkus = [skus[1], skus[0], skus[2]];
+
+    await waitFor(() => {
+      // initial mount with original skus
+      const { rerender } = render(
+        <SortableComponent
+          sdk={mockSdk as unknown as FieldAppSDK}
+          disabled={false}
+          config={mockConfig}
+          skus={skus}
+          onChange={jest.fn()}
+          fetchProductPreviews={mockFetchProductPreviews}
+          skuType={mockSkuType}
+        />
+      );
+
+      // rerender with new skus, just reordered
+      rerender(
+        <SortableComponent
+          skus={reorderedSkus}
+          sdk={mockSdk as unknown as FieldAppSDK}
+          disabled={false}
+          config={mockConfig}
+          onChange={jest.fn()}
+          fetchProductPreviews={mockFetchProductPreviews}
+          skuType={mockSkuType}
+        />
+      );
+
+      expect(mockFetchProductPreviews).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/ecommerce-app-base/src/__mocks__/index.ts
+++ b/packages/ecommerce-app-base/src/__mocks__/index.ts
@@ -1,1 +1,3 @@
 export { products, productsList } from './products';
+export { makeSdkMock } from './mockSdk';
+export { mockContentTypes } from './mockContentTypes';

--- a/packages/ecommerce-app-base/src/__mocks__/mockContentTypes.ts
+++ b/packages/ecommerce-app-base/src/__mocks__/mockContentTypes.ts
@@ -1,0 +1,28 @@
+export const mockContentTypes = [
+  {
+    sys: { id: 'ct1' },
+    name: 'CT1',
+    fields: [
+      { id: 'product_x', name: 'Product X', type: 'Symbol' },
+      { id: 'y', name: 'Y', type: 'Object' },
+    ],
+  },
+  {
+    sys: { id: 'ct2' },
+    name: 'CT2',
+    fields: [
+      { id: 'foo', name: 'FOO', type: 'Text' },
+      { id: 'z', name: 'Z', type: 'Array', items: { type: 'Symbol' } },
+    ],
+  },
+  {
+    sys: { id: 'ct3' },
+    name: 'CT3',
+    fields: [
+      { id: 'bar', name: 'BAR', type: 'Object' },
+      { id: 'baz', name: 'BAZ', type: 'Object' },
+      { id: 'product_d', name: 'Product D', type: 'Array', items: { type: 'Symbol' } },
+      { id: 'product_a', name: 'Product A', type: 'Symbol' },
+    ],
+  },
+];

--- a/packages/ecommerce-app-base/src/__mocks__/mockSdk.ts
+++ b/packages/ecommerce-app-base/src/__mocks__/mockSdk.ts
@@ -1,0 +1,22 @@
+import { mockContentTypes } from './mockContentTypes';
+
+export const makeSdkMock = () => ({
+  ids: {
+    app: 'some-app',
+  },
+  hostnames: {
+    webapp: 'app.contentful.com',
+  },
+  space: {
+    getContentTypes: jest.fn().mockResolvedValue({ items: mockContentTypes }),
+    getEditorInterfaces: jest.fn().mockResolvedValue({ items: [] }),
+  },
+  app: {
+    setReady: jest.fn(),
+    getParameters: jest.fn().mockResolvedValue(null),
+    onConfigure: jest.fn().mockReturnValue(undefined),
+  },
+  notifier: {
+    error: (msg: string) => console.log(`[mockSdk] error: ${msg}`),
+  },
+});


### PR DESCRIPTION
## Purpose
Fix a bug that was introduced in this [PR](https://github.com/contentful/apps/pull/7666) that was causing an infinite loop rerender to occur.

**Root cause**
1. On initial render, `usePreviousSkus()` hook is invoked to track `skus` from previous mount, 
2. This [useEffect](https://github.com/contentful/apps/blob/master/packages/ecommerce-app-base/src/Editor/SortableComponent.tsx#L75C3-L82) invokes `fetchProductPreviews()` on mount, as expected.
3. `fetchProductPreviews()` retrieves product previews via network request
4. `fetchProductPreviews()` updates the `productPreviews` state, causing a rerender, as expected.
5. on rerender, `usePreviousSkus()` runs and retrieves the list of skus from previous mount, as well as updates the current ref to the most current list of skus (list of skus received via props).
6. since the useEffect (see number 1) lists `previousSkus` as a dependency, the useEffect runs again.  Setting off an **infinite loop**.


### Screen capture of working solution
![shopify-fixed](https://github.com/contentful/apps/assets/158083968/a64772dd-5d31-48f2-ae8e-d5d6ddd13cab)







<!-- Why are we introducing this change now? What problem does it solve? What is the story/background for it? -->

## Approach

<!-- Why did we do it the way we did? Did we consider alternatives? What other implementation details or artifacts (screenshots etc.) would help reviewers contextualize change? -->

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
