### PR TITLE
fix: revert forma36 version update in examples

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -110,6 +110,7 @@ updates:
     - dependency-name: "emotion"
       versions:
         - ">=11"
+    - dependency-name: "@contentful/f36-components"
 
 - package-ecosystem: npm
   directory: "/examples/javascript"
@@ -128,6 +129,7 @@ updates:
     - dependency-name: "emotion"
       versions:
         - ">=11"
+    - dependency-name: '@contentful/f36-components'
 
 - package-ecosystem: npm
   directory: "/examples/function-mock-shop"
@@ -146,6 +148,7 @@ updates:
     - dependency-name: "emotion"
       versions:
         - ">=11"
+    - dependency-name: '@contentful/f36-components'
 
 - package-ecosystem: npm
   directory: "/examples/function-potterdb"
@@ -164,6 +167,7 @@ updates:
     - dependency-name: "emotion"
       versions:
         - ">=11"
+    - dependency-name: '@contentful/f36-components'
 
 - package-ecosystem: npm
   directory: "/examples/function-potterdb-rest-api"
@@ -182,6 +186,7 @@ updates:
     - dependency-name: "emotion"
       versions:
         - ">=11"
+    - dependency-name: '@contentful/f36-components'
 
 - package-ecosystem: npm
   directory: "/examples/function-templates/javascript"
@@ -200,6 +205,7 @@ updates:
     - dependency-name: "emotion"
       versions:
         - ">=11"
+    - dependency-name: '@contentful/f36-components'
 
 - package-ecosystem: npm
   directory: "/examples/function-templates/typescript"
@@ -218,6 +224,7 @@ updates:
     - dependency-name: "emotion"
       versions:
         - ">=11"
+    - dependency-name: '@contentful/f36-components'
 
 - package-ecosystem: docker
   directory: "/apps/slack/lambda/"

--- a/examples/function-mock-shop/package-lock.json
+++ b/examples/function-mock-shop/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@contentful/app-sdk": "^4.28.0",
-        "@contentful/f36-components": "4.67.2",
+        "@contentful/f36-components": "4.67.1",
         "@contentful/f36-tokens": "4.0.5",
         "@contentful/react-apps-toolkit": "1.2.16",
         "@tanstack/react-query": "^5.51.1",
@@ -2190,15 +2190,15 @@
       }
     },
     "node_modules/@contentful/f36-accordion": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.67.2.tgz",
-      "integrity": "sha512-cX7xIX+fZadUNNFG+uzAOXeZ/GkMs+Y0bvgpxkpqW3ILu6GIXHsXetnRocxVaYUrQ1C/k6wEsd4xSv5y2uQBIg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.67.1.tgz",
+      "integrity": "sha512-rIGmO28PcSdfyUpaPfpeMO8qT/y8wMpQcyASHIUY8m6YRrn97vIlfDMQlzuyfoDBXQI3Lkza5RzbEFQVu7capg==",
       "dependencies": {
-        "@contentful/f36-collapse": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-collapse": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2207,15 +2207,15 @@
       }
     },
     "node_modules/@contentful/f36-asset": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.67.2.tgz",
-      "integrity": "sha512-cUQaZQeXIr3oLy255cuL+mXNiYOpMvAzW7BxE3l903ShzlwVFqZr/FIaWAo2t488sWbGeXNXxVBcEbLzQUMIdA==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.67.1.tgz",
+      "integrity": "sha512-BVRtLKxj/S+dGVJ0b88PVpBxE8mLiqDYATlE62Yb22CpncFpb9Kt7IRLto4KnD+SHZAJMORhoMNk7bQc103Dyw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-icon": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2224,18 +2224,18 @@
       }
     },
     "node_modules/@contentful/f36-autocomplete": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.67.2.tgz",
-      "integrity": "sha512-1cZHVa2cskh4DvachcgaQeEuyjuAlxvvyJCqvpHpP+R3ISS6CsC44252fH52NcLryvfFG1zX24nZECgFOY/S+A==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.67.1.tgz",
+      "integrity": "sha512-2aTKX92Q3HyVFexMkjkVw3D7wxTsxB/JJgT8Cy14b22leFk6Dup1Ui8Kt0LkjLYTX9vP3fru8XQ0cae4bCMsfQ==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-forms": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-popover": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-popover": "^4.67.1",
+        "@contentful/f36-skeleton": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "@contentful/f36-utils": "^4.24.3",
         "downshift": "^6.1.12",
         "emotion": "^10.0.17"
@@ -2246,15 +2246,15 @@
       }
     },
     "node_modules/@contentful/f36-avatar": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-avatar/-/f36-avatar-4.67.2.tgz",
-      "integrity": "sha512-bKxmWgi67V6tPCX2mlSxJKtQ8IANoO7jU9qH74Fqe11ATgG84Oqy9iQgjJDQvfFMjyT9n+3zUtUCwo/waHHrQg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-avatar/-/f36-avatar-4.67.1.tgz",
+      "integrity": "sha512-NaUNIFvinF1m3Tr7Gaj3/NREOf1ZYIobKLrtUMzbP0ULezHVvwUxGXbpDOAbLSt9jis9mvvrodBDvRJvmESiAw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-image": "4.67.2",
-        "@contentful/f36-menu": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-image": "4.67.1",
+        "@contentful/f36-menu": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.5",
-        "@contentful/f36-tooltip": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2263,11 +2263,11 @@
       }
     },
     "node_modules/@contentful/f36-badge": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.67.2.tgz",
-      "integrity": "sha512-cWfb3Nk9+CdgmTvc75gzD6uJ4XCbK23pB1t9BV9ZvytvnuaQElZYh7WciyRKJtU51khb0KOuVCb/TOnjecU4xQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.67.1.tgz",
+      "integrity": "sha512-jl944fd93dWrjdy853lGd4RSGtffij7PompadRsw1pbVqsKv5TmIlNGRr253EH4HN8+zIyJo5GTGHXCD9qV9Vw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
@@ -2278,12 +2278,12 @@
       }
     },
     "node_modules/@contentful/f36-button": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.67.2.tgz",
-      "integrity": "sha512-1/1dYtgfVk3wiP5SoaoQEWlM7VYp/Pju17agu5Y0MGuGo7LwjTCzLJQ4OeRvdubTYCW+iXc20sEG2H3OyRoz6w==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.67.1.tgz",
+      "integrity": "sha512-MnL1jFulLgM4ilDG2p06+bpv3dPFRSmjuDb6VlVdZx3JEtMJOK0fxIb1ylSHAE8AHJRDC64iArFCSoiz5zR6Rw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-spinner": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-spinner": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
@@ -2294,22 +2294,22 @@
       }
     },
     "node_modules/@contentful/f36-card": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.67.2.tgz",
-      "integrity": "sha512-f1Ck9hbbfdX7/OIWPfXJSdriDVjoTQOdz4aXo1QVd2fmsTAzQCfH0llwXtCk8TCg4DbSwaS/ldB/CJV3oCN1AA==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.67.1.tgz",
+      "integrity": "sha512-MarYmNmHM5WN9WEIsGAQywaQPethxjIGFI+LbttCP++HzEhY2xlJiQTLwy+X8sW+IncY5TE31AkF+EFkjODGEA==",
       "dependencies": {
-        "@contentful/f36-asset": "^4.67.2",
-        "@contentful/f36-badge": "^4.67.2",
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
+        "@contentful/f36-asset": "^4.67.1",
+        "@contentful/f36-badge": "^4.67.1",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-drag-handle": "^4.67.1",
+        "@contentful/f36-icon": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-menu": "^4.67.1",
+        "@contentful/f36-skeleton": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.1",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17",
         "truncate": "^3.0.0"
       },
@@ -2319,11 +2319,11 @@
       }
     },
     "node_modules/@contentful/f36-collapse": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.67.2.tgz",
-      "integrity": "sha512-EWkl653S3gnhVkq39Z0vDrIHQxvqJnN9XfrrORpX56ZCc4kHs1MzbbbDjnlj3udCy9Cj4Q50hiXpmeO/JogDlg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.67.1.tgz",
+      "integrity": "sha512-9oi/gUTgJTHEn8EoLsKQKd9JtaT5RkY7GZDKccztmWOhkkq9OZQyEgf3msw401CDGwp/pr/RdijjdvZNBFSIwA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2333,47 +2333,47 @@
       }
     },
     "node_modules/@contentful/f36-components": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.67.2.tgz",
-      "integrity": "sha512-JNBX8YzP+mt2/d2m5uUnpFLGnzyRAsggWpEBUe8QgPRwkJ8bZIDrnm2TELIFqrY2t4Lvs2AJw8L/3kDaJvMNCQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.67.1.tgz",
+      "integrity": "sha512-9p4MxsywvLbwX90HgqQI8FQJx9iOjqkC4bAIGLDbjI1CuuKhzACUSAkRvAYhO7N7ZR7c1Vrjr4pvYU7xy4+siw==",
       "dependencies": {
-        "@contentful/f36-accordion": "^4.67.2",
-        "@contentful/f36-asset": "^4.67.2",
-        "@contentful/f36-autocomplete": "^4.67.2",
-        "@contentful/f36-avatar": "4.67.2",
-        "@contentful/f36-badge": "^4.67.2",
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-card": "^4.67.2",
-        "@contentful/f36-collapse": "^4.67.2",
-        "@contentful/f36-copybutton": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-datepicker": "^4.67.2",
-        "@contentful/f36-datetime": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-empty-state": "^4.67.2",
-        "@contentful/f36-entity-list": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
-        "@contentful/f36-header": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
+        "@contentful/f36-accordion": "^4.67.1",
+        "@contentful/f36-asset": "^4.67.1",
+        "@contentful/f36-autocomplete": "^4.67.1",
+        "@contentful/f36-avatar": "4.67.1",
+        "@contentful/f36-badge": "^4.67.1",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-card": "^4.67.1",
+        "@contentful/f36-collapse": "^4.67.1",
+        "@contentful/f36-copybutton": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-datepicker": "^4.67.1",
+        "@contentful/f36-datetime": "^4.67.1",
+        "@contentful/f36-drag-handle": "^4.67.1",
+        "@contentful/f36-empty-state": "^4.67.1",
+        "@contentful/f36-entity-list": "^4.67.1",
+        "@contentful/f36-forms": "^4.67.1",
+        "@contentful/f36-header": "^4.67.1",
+        "@contentful/f36-icon": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-image": "4.67.2",
-        "@contentful/f36-list": "^4.67.2",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-modal": "^4.67.2",
-        "@contentful/f36-navbar": "^4.67.2",
-        "@contentful/f36-note": "^4.67.2",
-        "@contentful/f36-notification": "^4.67.2",
-        "@contentful/f36-pagination": "^4.67.2",
-        "@contentful/f36-pill": "^4.67.2",
-        "@contentful/f36-popover": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
-        "@contentful/f36-spinner": "^4.67.2",
-        "@contentful/f36-table": "^4.67.2",
-        "@contentful/f36-tabs": "^4.67.2",
-        "@contentful/f36-text-link": "^4.67.2",
+        "@contentful/f36-image": "4.67.1",
+        "@contentful/f36-list": "^4.67.1",
+        "@contentful/f36-menu": "^4.67.1",
+        "@contentful/f36-modal": "^4.67.1",
+        "@contentful/f36-navbar": "^4.67.1",
+        "@contentful/f36-note": "^4.67.1",
+        "@contentful/f36-notification": "^4.67.1",
+        "@contentful/f36-pagination": "^4.67.1",
+        "@contentful/f36-pill": "^4.67.1",
+        "@contentful/f36-popover": "^4.67.1",
+        "@contentful/f36-skeleton": "^4.67.1",
+        "@contentful/f36-spinner": "^4.67.1",
+        "@contentful/f36-table": "^4.67.1",
+        "@contentful/f36-tabs": "^4.67.1",
+        "@contentful/f36-text-link": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.1",
+        "@contentful/f36-typography": "^4.67.1",
         "@contentful/f36-utils": "^4.24.3"
       },
       "peerDependencies": {
@@ -2392,15 +2392,15 @@
       }
     },
     "node_modules/@contentful/f36-copybutton": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.67.2.tgz",
-      "integrity": "sha512-hb/DCGE6TTdepsjZvmDgog1glfF8WxGCx+F1S7FbwTZ4NutWeHEa7+E63t2tELTRx07FoVmkICmPtp89mCXKEw==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.67.1.tgz",
+      "integrity": "sha512-riw5JBm4X8jTZH8ZZa7Acfc+ef5QOZhNoc4xfi63gIuiC96pa3s0eBlWogBXjJStm6hQcr1IDbg+o4hRgh0uwg==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2409,9 +2409,9 @@
       }
     },
     "node_modules/@contentful/f36-core": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.67.2.tgz",
-      "integrity": "sha512-iSzA/OuhU4rIlBOlUTIczMuqDQZqLR1tmZJtZyouhfWkEc0VGUCX6S2FnBEXlMbnMzaL70lTXYUNu2bKxK4PfA==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.67.1.tgz",
+      "integrity": "sha512-qeBBaRoqCi3sUMKwJF1g3MQ6jawCGTZROMkjkb2+P6GpmNitbeFBW/J0VJY2g/ixCMN5NORSyf/1CBRMXFwUOw==",
       "dependencies": {
         "@contentful/f36-tokens": "^4.0.4",
         "@emotion/core": "^10.1.1",
@@ -2425,17 +2425,17 @@
       }
     },
     "node_modules/@contentful/f36-datepicker": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.67.2.tgz",
-      "integrity": "sha512-qGfVEjdZaMwdDBr1uWfgQtnCd8L+ZyVBpFiI8TyFUdQd6L9blHexr99Wg12uBNSub9zaL5fs4wrHZ5vMpGEjGQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.67.1.tgz",
+      "integrity": "sha512-ftHXPc6+hL8E5rkLxTPI9uk/kaAyEhl+ClqLapmd3AyaNrfVojAYJ9Bhe62GIz1gFU0bMXukslCU8xwbrdlFQA==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-forms": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-popover": "^4.67.2",
+        "@contentful/f36-popover": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "date-fns": "^2.28.0",
         "emotion": "^10.0.17",
         "react-day-picker": "^8.7.1",
@@ -2447,11 +2447,11 @@
       }
     },
     "node_modules/@contentful/f36-datetime": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.67.2.tgz",
-      "integrity": "sha512-7kz4I/CzRkupPb43dtAQ3a1bHffdx3ZQ0i9ueUl9CSs+dKhl9gwiH0bmoNN5pnULAQF4i7WQmNueEfQvh9zgvA==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.67.1.tgz",
+      "integrity": "sha512-WlJTeOpyxjxoVWY5DSF9RzkqnAc+80XMo00b0vN2XKc9lKLozMgFrApTeUSZGTcPX0ymKjEdJGqqP/d2o/YbGg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "dayjs": "^1.11.5",
         "emotion": "^10.0.17"
@@ -2462,11 +2462,11 @@
       }
     },
     "node_modules/@contentful/f36-drag-handle": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.67.2.tgz",
-      "integrity": "sha512-7e38V/dJ79m4uVlnf1H1xpRY28DPwaMQOMgFWwPKCdketfr+YU8KI7kE2ssrd1EsM9av7Z0Dcwz6pF89wuxViA==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.67.1.tgz",
+      "integrity": "sha512-wO5ru3zl3qm5KtAylWYQCvdeE0TLda+3gXCMxeNHyJTOcW2/vSB6L31T9zVihFRK/5vgDvGWkcTt/R17OW+qzg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
@@ -2478,12 +2478,12 @@
       }
     },
     "node_modules/@contentful/f36-empty-state": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.67.2.tgz",
-      "integrity": "sha512-ghzqNmwAOv0mAUvXDyLLtlAOXj5RPas/stJ8etPpb339NGFj5ueYf9+EBrgTCWrMK/JCBhcogV5bgKRsc9VKlg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.67.1.tgz",
+      "integrity": "sha512-VPiAfHYCJr3DdhrXXgKzTIKnXZgjugrKwtGbyJQX7cRmwnNRjZCMwMl3F0pPvhPAfI1rzwZzm/wqAtWeBsN51A==",
       "dependencies": {
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2492,21 +2492,20 @@
       }
     },
     "node_modules/@contentful/f36-entity-list": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.67.2.tgz",
-      "integrity": "sha512-G37dKH3yRD++fOA924UROtZdeIiNFmrjfVOobC03jdvk6o21AN2kMyDzML2Uc0+kMg+ofe4G08KC/OmDSUkSAg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.67.1.tgz",
+      "integrity": "sha512-JFxQ2v+Vi6jgPxIkWfiKPPt5U+RKF5hEqHX6Xxndcgcjg0aamb7iJ3rR8mln9cWULIqPJhSTawQujeBgonLktw==",
       "dependencies": {
-        "@contentful/f36-badge": "^4.67.2",
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
+        "@contentful/f36-badge": "^4.67.1",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-drag-handle": "^4.67.1",
+        "@contentful/f36-icon": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-icons-alpha": "npm:@contentful/f36-icons@^5.0.0-alpha.26",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-menu": "^4.67.1",
+        "@contentful/f36-skeleton": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2515,14 +2514,14 @@
       }
     },
     "node_modules/@contentful/f36-forms": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.67.2.tgz",
-      "integrity": "sha512-+XxpnCiBKtZw2hYo5QZWVayWMPKzbarOIWzZUMm6Ttoru00zn5u3tlvue7c9W2zqkNFuUNOopAwXBwQ0h+z+bQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.67.1.tgz",
+      "integrity": "sha512-YRifViI6tLRoJyc3kaAy7TM6gjAoDiaFYfv0k42mEMAC5XOkEwFVHORpRkfCDrYwEC7Zk9crEdOy0vfZ3QlH0Q==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
@@ -2532,15 +2531,15 @@
       }
     },
     "node_modules/@contentful/f36-header": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-header/-/f36-header-4.67.2.tgz",
-      "integrity": "sha512-DjI5JnJuXixG8bAj03lRvISuAgwA2X6PnYifa//967Dd0qQTBw/CkB96AhrgVUjTw+jt3xAprwv0SUKF8x9S8g==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-header/-/f36-header-4.67.1.tgz",
+      "integrity": "sha512-8eith4p/4tc5ZSVPQkWfd4jBNDOq3iSTbBW7jeyB9p+oeB/0cOpJCfjB1RwUTvBamn+MrKnLNtt/TkUa+7C9aw==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.2",
         "@contentful/f36-tokens": "^4.0.5",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2549,32 +2548,13 @@
       }
     },
     "node_modules/@contentful/f36-icon": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.67.2.tgz",
-      "integrity": "sha512-vJAk6KO88GVnHdPSXurUA67F4wl01sZHaaE5eHGvt/s+YuI47dstgROr5+z66qmncKpcMWOTv4/+jqYV1Ko56A==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.67.1.tgz",
+      "integrity": "sha512-Exug8bPfTv0JY2rs7ZxuG9IsrLcQLG0SV7LC76INMwwOIdLWiRFK4k+Se2Or9Ox9ga2pBEPlWr5hBBSgPSj6Gw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-icon-alpha": {
-      "name": "@contentful/f36-icon",
-      "version": "5.0.0-alpha.20",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-5.0.0-alpha.20.tgz",
-      "integrity": "sha512-kI7HJggp/H8whiUL/RrG988nEvQq2SuZVyQn4kyiWYSlMWBRqQXZRvXfsM/RILWMgz2LxryXaT1YGVy2E4UfJA==",
-      "dependencies": {
-        "@contentful/f36-core": "^4.65.4",
-        "@contentful/f36-tokens": "^4.0.4",
-        "@phosphor-icons/react": "^2.1.5",
-        "emotion": "^10.0.17"
-      },
-      "engines": {
-        "node": ">=16"
       },
       "peerDependencies": {
         "react": ">=16.8",
@@ -2596,33 +2576,13 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/@contentful/f36-icons-alpha": {
-      "name": "@contentful/f36-icons",
-      "version": "5.0.0-alpha.29",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-5.0.0-alpha.29.tgz",
-      "integrity": "sha512-7QhDDAo95WiqFwB/ofWd57GEyeLgkDU/CgTStjhtBZssheMvVT6thiIFy6hSbo314d1RZ5Z8EBzH1MIJ/nyQhA==",
+    "node_modules/@contentful/f36-image": {
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-image/-/f36-image-4.67.1.tgz",
+      "integrity": "sha512-FYoeHHAWrRG2YuCXl7VifRjAkDXijENzhV1bgD38eKtBpLbmnnJm+vxbQRAKBvkkwLwFEHvVsdZ2XBoCs6WgmA==",
       "dependencies": {
         "@contentful/f36-core": "^4.67.1",
-        "@contentful/f36-icon-alpha": "npm:@contentful/f36-icon@5.0.0-alpha.20",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@phosphor-icons/react": "^2.1.4",
-        "emotion": "^10.0.17"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-image": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-image/-/f36-image-4.67.2.tgz",
-      "integrity": "sha512-zB4D/fBmUyIj1WvF2tWQHsDxzTcZ+KOyiVu0483rxRNai8sae7BO3VSuevUzfi2Y+gaF3VCasPZudjgTeWD2pQ==",
-      "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-skeleton": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.5",
         "emotion": "^10.0.17"
       },
@@ -2632,11 +2592,11 @@
       }
     },
     "node_modules/@contentful/f36-list": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.67.2.tgz",
-      "integrity": "sha512-ZkObExturTfxpNZOBcHJMozuLIbDLe8Us5qe4qJyVozIBH+Ol6xOHxEEyEu8GsRZp0+GU7K3fWExqLEV22oSUQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.67.1.tgz",
+      "integrity": "sha512-WLSyAWDjjr+DHrh5pOIGMlWKeWxyxu1HPlwI/deQEmr/PXjuPLMewH393+HE3LJbrWwpqU3J/U+v1H62XTbFCg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2646,15 +2606,15 @@
       }
     },
     "node_modules/@contentful/f36-menu": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.67.2.tgz",
-      "integrity": "sha512-TF+tpTLqE22qeQTYHJFuxCm6Yt37VFtwM6X9O07GYTeXeDZE7ZI+FrA16y+fxFw2Zu0OpbLO0CWB/ViolvMlOw==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.67.1.tgz",
+      "integrity": "sha512-M9UOD8sEwyPHP9gpDkTgXCeFwpS2cZMI0zoNOr/9vxY/XaLR3iN2W4D+FXtD71FVxy83Fs+ap12gTyKBn7dY6w==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-popover": "^4.67.2",
+        "@contentful/f36-popover": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
@@ -2664,15 +2624,15 @@
       }
     },
     "node_modules/@contentful/f36-modal": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.67.2.tgz",
-      "integrity": "sha512-mrO5+mKytV/j759HI0y6fZskQG/EEY7iNaRjjeYmFRoT6MAgViebcIeht15CcFwnNQLAeS3MusvXiEzuUzweiQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.67.1.tgz",
+      "integrity": "sha512-10LfRE5sKz9QJpSP7D8/PQDpOpq+5086HK51uKUnuPZeszXYfRUgRWTcfkkPvaihqGGx0JZLiRNvGFOBYWVP1A==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "@types/react-modal": "^3.13.1",
         "emotion": "^10.0.17",
         "react-modal": "^3.16.1"
@@ -2683,16 +2643,16 @@
       }
     },
     "node_modules/@contentful/f36-navbar": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-navbar/-/f36-navbar-4.67.2.tgz",
-      "integrity": "sha512-58PYpIElqnfdYWpEkSaOmccSzcgudYUs009UWmtqHmv0n3c8eNoV8taoZdg92gYAsEc7G2VWl4AZ3wJy/kiAdg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-navbar/-/f36-navbar-4.67.1.tgz",
+      "integrity": "sha512-kvlQ+jEyPxuFqtO6itMCSQbNZFFTInTJOi7xtYGTC07S49Gn22/Nb9GNJ7lT9pzTm4q0ss+Q+Xv/PtyVsSGnHg==",
       "dependencies": {
-        "@contentful/f36-avatar": "4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
+        "@contentful/f36-avatar": "4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-icon": "^4.67.1",
         "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-menu": "^4.67.1",
+        "@contentful/f36-skeleton": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.1",
         "@contentful/f36-utils": "^4.23.2",
         "emotion": "^10.0.17"
@@ -2703,16 +2663,16 @@
       }
     },
     "node_modules/@contentful/f36-note": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.67.2.tgz",
-      "integrity": "sha512-DA0f1/j640SG3LOon1VcU6kDvNgUHxupH0Q1FXS01aRrWq12uMd2bLtb2k5A9qRyT6MB3OdAKFufwsBcSL6fYw==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.67.1.tgz",
+      "integrity": "sha512-6rhGqt5MdH53XXNVbIo9cqmswjSzonHSZ5FdqrJ+rF6uOOghT+zzQCq65PRIBufihvZVh/mD/7vVjCpD6BxnnQ==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-icon": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2721,16 +2681,16 @@
       }
     },
     "node_modules/@contentful/f36-notification": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.67.2.tgz",
-      "integrity": "sha512-x7qxuqOhQMyhhRfMrisAVXnAo/eL6A7RjL2PmTLylaqKrFnzDrr25BtzepdkgULj9VLh70vXM5QIzPwpKpIJBQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.67.1.tgz",
+      "integrity": "sha512-JPYhOqz0rsipqHrtSoWnuPkrqndRz7XX72/0Mfj3dWV4MAK78rxVAQl17qDVliRZTp9NtWXBYseJiPhOsfAw+Q==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-text-link": "^4.67.2",
+        "@contentful/f36-text-link": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "@swc/helpers": "^0.4.14",
         "emotion": "^10.0.17",
         "react-animate-height": "^3.0.4"
@@ -2741,16 +2701,16 @@
       }
     },
     "node_modules/@contentful/f36-pagination": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.67.2.tgz",
-      "integrity": "sha512-/UePF1fbr2wvJHtJ9ncWaz5eg/VTdA8VqEBFJXge/IBgPVyMgQxQRxSDhvMj0j2Iit90qAzPedEDZK+jp6CyTg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.67.1.tgz",
+      "integrity": "sha512-NgK22JvCtBvBfE5NeKFRqtLIoeY6CXDTpKpSu70QZxWp4C/z9U7qhyr0d12SHYgFFUJwnAl67A5qaEyth2NvJw==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-forms": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2759,16 +2719,16 @@
       }
     },
     "node_modules/@contentful/f36-pill": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.67.2.tgz",
-      "integrity": "sha512-015oRkVVnshvWAJ/kR5yJBD+soWmDcHFy5FGXDaIR5moTCejjqiLG1g8H6MolaF8oeKSOhbhgfX/dpEHn5/Z4g==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.67.1.tgz",
+      "integrity": "sha512-Ycn1bkAtNlc2FOFuwiSlDK3rgVgPruHXG6m+dla8Hp/ZL/MH2xUcQqir3SlLCZeR+gSx1cuzI9ga8/UjsKf1qQ==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-drag-handle": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2777,11 +2737,11 @@
       }
     },
     "node_modules/@contentful/f36-popover": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.67.2.tgz",
-      "integrity": "sha512-NJx54sqQEmuWIsBySXf/B+ZW/RoIkRzb7cnQ5aucN3nUd4ZaHOvcmYVLJMqfCV8ipzpMxLgoc8p3v6OcRdi72A==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.67.1.tgz",
+      "integrity": "sha512-loWXCV7BswsBvcBENRzEbMCjITodK5RnT7DNSeaZvvhOa87Gp+aCcGIpHaS0Jxrhy3OvUOdPxaRUXmoMkrP7Hg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -2794,12 +2754,12 @@
       }
     },
     "node_modules/@contentful/f36-skeleton": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.67.2.tgz",
-      "integrity": "sha512-4T8r/G8b9DFkLErIo8d2cGS71tWy1yNDZIThoHBWIhLRcstal8K7Ag5dQwPsaoSew/859oXC2rvPP0Ep+4FtCg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.67.1.tgz",
+      "integrity": "sha512-hJR/M6u2al75mCMJcdR9xxRfKQdqqFvsRY6mbwYO6bZ+6odYhMqoRNR1C0WK7+uWlEDYUlOnF7+T2vfRB4IfVg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-table": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-table": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2809,11 +2769,11 @@
       }
     },
     "node_modules/@contentful/f36-spinner": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.67.2.tgz",
-      "integrity": "sha512-sBitcudBc4DwAOPn6MLuArLje7aym47GoIDI0kN9zQtolVwlVH92/zNpZmnm+zbP4Ku56/TgbL/v5SFTh+YB2w==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.67.1.tgz",
+      "integrity": "sha512-KCyPb37/Xvr51b6gibw//yLm16uN7+z505+z2B2YH53t70+uIgADKtS7APtaMCbVH6fliVa9/GkXE3WYv/xJhA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2823,14 +2783,14 @@
       }
     },
     "node_modules/@contentful/f36-table": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.67.2.tgz",
-      "integrity": "sha512-YtUkXwFmBLgAi5Glgi1vXqNbr+U2riadB9O+Aq8t2R/vpXMCIA4WlmXSqunwPW9UrrilalrK49l0IkDNpcRUbQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.67.1.tgz",
+      "integrity": "sha512-/UtSfNFwnjGCSLcxeGGBI5Dz/isQsgNNeFJyo2I+xcYPPehZ9o6eHf0+CeRuIW3+OCXYAyliydig+/T+le3/rA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2839,11 +2799,11 @@
       }
     },
     "node_modules/@contentful/f36-tabs": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.67.2.tgz",
-      "integrity": "sha512-rPPJQHmCoD8492yKufelL7MCj0j4FqcPc5yFhD29sqpGDqTko8Xf/V/q4/LPYUtXttH8myfTINEyNTsR/lZINg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.67.1.tgz",
+      "integrity": "sha512-2Nd1UCdBArAWKDvFOgGdd+KV+4SdHGpnx253FEMT4jsRnxeirw/qK+Pn5fBUK5f+KC8ShmxUMpH3Qjf2JTHi9w==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@radix-ui/react-tabs": "^1.0.1",
         "emotion": "^10.0.17"
@@ -2854,11 +2814,11 @@
       }
     },
     "node_modules/@contentful/f36-text-link": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.67.2.tgz",
-      "integrity": "sha512-mWE4KsqQV93SNAFtYWqQB61/TLHuX1D3vVJ1rFqAp1kndPy7UyGcrQrGoPmM1l20Y9YaYIWYwo5eGKygY3iwIA==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.67.1.tgz",
+      "integrity": "sha512-SSwbr0ZZoBrXrBwwfCvZIYOh+9yu+J71qgv7dl3jqo0i9bautc6sAIRrrhjT8C0rcUTi6/HRzi0w882ORCgaEg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2873,11 +2833,11 @@
       "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
     },
     "node_modules/@contentful/f36-tooltip": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.67.2.tgz",
-      "integrity": "sha512-BFSKsJySAK1ipIOXueq6rgsJlmZDVBd60fjicALWiVX/GnxyDO3OkdX8nfK4Id0rbllf8+WBSR5UcVzNjuLe4Q==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.67.1.tgz",
+      "integrity": "sha512-i/FO4F9UHVggL0ScMrayZ6p1rs9oFGhUVZ4B3TKtrVRKXNfFQIzwXFPY45/ZAzdfgxdn90XCvMEo2j86l3fWXA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -2891,11 +2851,11 @@
       }
     },
     "node_modules/@contentful/f36-typography": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.67.2.tgz",
-      "integrity": "sha512-zfCVUQfD5wueT4mFNxLO+2SaUTFVHxE+7v8YKt53SvIiN+s/vXJnABOKPZsjYAYkwQwSrwPYIdIxMtaULwjoCw==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.67.1.tgz",
+      "integrity": "sha512-VES06vg9Bnp09IvJm8yea//IgI2m4aCz5weSD+LUV+vpjtBMM/0w+95cP67KvS6Rg3sEr3yx1bja8gSoTDahpw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
@@ -4810,18 +4770,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@phosphor-icons/react": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.1.7.tgz",
-      "integrity": "sha512-g2e2eVAn1XG2a+LI09QU3IORLhnFNAFkNbo2iwbX6NOKSLOwvEMmTa7CgOzEbgNWR47z8i8kwjdvYZ5fkGx1mQ==",
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": ">= 16.8",
-        "react-dom": ">= 16.8"
       }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {

--- a/examples/function-mock-shop/package.json
+++ b/examples/function-mock-shop/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@contentful/app-sdk": "^4.28.0",
-    "@contentful/f36-components": "4.67.2",
+    "@contentful/f36-components": "4.67.1",
     "@contentful/f36-tokens": "4.0.5",
     "@contentful/react-apps-toolkit": "1.2.16",
     "@tanstack/react-query": "^5.51.1",

--- a/examples/function-potterdb-rest-api/package-lock.json
+++ b/examples/function-potterdb-rest-api/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@contentful/app-sdk": "^4.28.0",
-        "@contentful/f36-components": "4.67.2",
+        "@contentful/f36-components": "4.67.1",
         "@contentful/f36-icons": "^4.28.0",
         "@contentful/f36-tokens": "4.0.5",
         "@contentful/field-editor-single-line": "^1.4.2",
@@ -2188,15 +2188,15 @@
       }
     },
     "node_modules/@contentful/f36-accordion": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.67.2.tgz",
-      "integrity": "sha512-cX7xIX+fZadUNNFG+uzAOXeZ/GkMs+Y0bvgpxkpqW3ILu6GIXHsXetnRocxVaYUrQ1C/k6wEsd4xSv5y2uQBIg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.67.1.tgz",
+      "integrity": "sha512-rIGmO28PcSdfyUpaPfpeMO8qT/y8wMpQcyASHIUY8m6YRrn97vIlfDMQlzuyfoDBXQI3Lkza5RzbEFQVu7capg==",
       "dependencies": {
-        "@contentful/f36-collapse": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-collapse": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2205,15 +2205,15 @@
       }
     },
     "node_modules/@contentful/f36-asset": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.67.2.tgz",
-      "integrity": "sha512-cUQaZQeXIr3oLy255cuL+mXNiYOpMvAzW7BxE3l903ShzlwVFqZr/FIaWAo2t488sWbGeXNXxVBcEbLzQUMIdA==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.67.1.tgz",
+      "integrity": "sha512-BVRtLKxj/S+dGVJ0b88PVpBxE8mLiqDYATlE62Yb22CpncFpb9Kt7IRLto4KnD+SHZAJMORhoMNk7bQc103Dyw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-icon": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2222,18 +2222,18 @@
       }
     },
     "node_modules/@contentful/f36-autocomplete": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.67.2.tgz",
-      "integrity": "sha512-1cZHVa2cskh4DvachcgaQeEuyjuAlxvvyJCqvpHpP+R3ISS6CsC44252fH52NcLryvfFG1zX24nZECgFOY/S+A==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.67.1.tgz",
+      "integrity": "sha512-2aTKX92Q3HyVFexMkjkVw3D7wxTsxB/JJgT8Cy14b22leFk6Dup1Ui8Kt0LkjLYTX9vP3fru8XQ0cae4bCMsfQ==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-forms": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-popover": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-popover": "^4.67.1",
+        "@contentful/f36-skeleton": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "@contentful/f36-utils": "^4.24.3",
         "downshift": "^6.1.12",
         "emotion": "^10.0.17"
@@ -2244,15 +2244,15 @@
       }
     },
     "node_modules/@contentful/f36-avatar": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-avatar/-/f36-avatar-4.67.2.tgz",
-      "integrity": "sha512-bKxmWgi67V6tPCX2mlSxJKtQ8IANoO7jU9qH74Fqe11ATgG84Oqy9iQgjJDQvfFMjyT9n+3zUtUCwo/waHHrQg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-avatar/-/f36-avatar-4.67.1.tgz",
+      "integrity": "sha512-NaUNIFvinF1m3Tr7Gaj3/NREOf1ZYIobKLrtUMzbP0ULezHVvwUxGXbpDOAbLSt9jis9mvvrodBDvRJvmESiAw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-image": "4.67.2",
-        "@contentful/f36-menu": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-image": "4.67.1",
+        "@contentful/f36-menu": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.5",
-        "@contentful/f36-tooltip": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2261,11 +2261,11 @@
       }
     },
     "node_modules/@contentful/f36-badge": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.67.2.tgz",
-      "integrity": "sha512-cWfb3Nk9+CdgmTvc75gzD6uJ4XCbK23pB1t9BV9ZvytvnuaQElZYh7WciyRKJtU51khb0KOuVCb/TOnjecU4xQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.67.1.tgz",
+      "integrity": "sha512-jl944fd93dWrjdy853lGd4RSGtffij7PompadRsw1pbVqsKv5TmIlNGRr253EH4HN8+zIyJo5GTGHXCD9qV9Vw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
@@ -2276,12 +2276,12 @@
       }
     },
     "node_modules/@contentful/f36-button": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.67.2.tgz",
-      "integrity": "sha512-1/1dYtgfVk3wiP5SoaoQEWlM7VYp/Pju17agu5Y0MGuGo7LwjTCzLJQ4OeRvdubTYCW+iXc20sEG2H3OyRoz6w==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.67.1.tgz",
+      "integrity": "sha512-MnL1jFulLgM4ilDG2p06+bpv3dPFRSmjuDb6VlVdZx3JEtMJOK0fxIb1ylSHAE8AHJRDC64iArFCSoiz5zR6Rw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-spinner": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-spinner": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
@@ -2292,22 +2292,22 @@
       }
     },
     "node_modules/@contentful/f36-card": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.67.2.tgz",
-      "integrity": "sha512-f1Ck9hbbfdX7/OIWPfXJSdriDVjoTQOdz4aXo1QVd2fmsTAzQCfH0llwXtCk8TCg4DbSwaS/ldB/CJV3oCN1AA==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.67.1.tgz",
+      "integrity": "sha512-MarYmNmHM5WN9WEIsGAQywaQPethxjIGFI+LbttCP++HzEhY2xlJiQTLwy+X8sW+IncY5TE31AkF+EFkjODGEA==",
       "dependencies": {
-        "@contentful/f36-asset": "^4.67.2",
-        "@contentful/f36-badge": "^4.67.2",
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
+        "@contentful/f36-asset": "^4.67.1",
+        "@contentful/f36-badge": "^4.67.1",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-drag-handle": "^4.67.1",
+        "@contentful/f36-icon": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-menu": "^4.67.1",
+        "@contentful/f36-skeleton": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.1",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17",
         "truncate": "^3.0.0"
       },
@@ -2317,11 +2317,11 @@
       }
     },
     "node_modules/@contentful/f36-collapse": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.67.2.tgz",
-      "integrity": "sha512-EWkl653S3gnhVkq39Z0vDrIHQxvqJnN9XfrrORpX56ZCc4kHs1MzbbbDjnlj3udCy9Cj4Q50hiXpmeO/JogDlg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.67.1.tgz",
+      "integrity": "sha512-9oi/gUTgJTHEn8EoLsKQKd9JtaT5RkY7GZDKccztmWOhkkq9OZQyEgf3msw401CDGwp/pr/RdijjdvZNBFSIwA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2331,47 +2331,47 @@
       }
     },
     "node_modules/@contentful/f36-components": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.67.2.tgz",
-      "integrity": "sha512-JNBX8YzP+mt2/d2m5uUnpFLGnzyRAsggWpEBUe8QgPRwkJ8bZIDrnm2TELIFqrY2t4Lvs2AJw8L/3kDaJvMNCQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.67.1.tgz",
+      "integrity": "sha512-9p4MxsywvLbwX90HgqQI8FQJx9iOjqkC4bAIGLDbjI1CuuKhzACUSAkRvAYhO7N7ZR7c1Vrjr4pvYU7xy4+siw==",
       "dependencies": {
-        "@contentful/f36-accordion": "^4.67.2",
-        "@contentful/f36-asset": "^4.67.2",
-        "@contentful/f36-autocomplete": "^4.67.2",
-        "@contentful/f36-avatar": "4.67.2",
-        "@contentful/f36-badge": "^4.67.2",
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-card": "^4.67.2",
-        "@contentful/f36-collapse": "^4.67.2",
-        "@contentful/f36-copybutton": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-datepicker": "^4.67.2",
-        "@contentful/f36-datetime": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-empty-state": "^4.67.2",
-        "@contentful/f36-entity-list": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
-        "@contentful/f36-header": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
+        "@contentful/f36-accordion": "^4.67.1",
+        "@contentful/f36-asset": "^4.67.1",
+        "@contentful/f36-autocomplete": "^4.67.1",
+        "@contentful/f36-avatar": "4.67.1",
+        "@contentful/f36-badge": "^4.67.1",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-card": "^4.67.1",
+        "@contentful/f36-collapse": "^4.67.1",
+        "@contentful/f36-copybutton": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-datepicker": "^4.67.1",
+        "@contentful/f36-datetime": "^4.67.1",
+        "@contentful/f36-drag-handle": "^4.67.1",
+        "@contentful/f36-empty-state": "^4.67.1",
+        "@contentful/f36-entity-list": "^4.67.1",
+        "@contentful/f36-forms": "^4.67.1",
+        "@contentful/f36-header": "^4.67.1",
+        "@contentful/f36-icon": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-image": "4.67.2",
-        "@contentful/f36-list": "^4.67.2",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-modal": "^4.67.2",
-        "@contentful/f36-navbar": "^4.67.2",
-        "@contentful/f36-note": "^4.67.2",
-        "@contentful/f36-notification": "^4.67.2",
-        "@contentful/f36-pagination": "^4.67.2",
-        "@contentful/f36-pill": "^4.67.2",
-        "@contentful/f36-popover": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
-        "@contentful/f36-spinner": "^4.67.2",
-        "@contentful/f36-table": "^4.67.2",
-        "@contentful/f36-tabs": "^4.67.2",
-        "@contentful/f36-text-link": "^4.67.2",
+        "@contentful/f36-image": "4.67.1",
+        "@contentful/f36-list": "^4.67.1",
+        "@contentful/f36-menu": "^4.67.1",
+        "@contentful/f36-modal": "^4.67.1",
+        "@contentful/f36-navbar": "^4.67.1",
+        "@contentful/f36-note": "^4.67.1",
+        "@contentful/f36-notification": "^4.67.1",
+        "@contentful/f36-pagination": "^4.67.1",
+        "@contentful/f36-pill": "^4.67.1",
+        "@contentful/f36-popover": "^4.67.1",
+        "@contentful/f36-skeleton": "^4.67.1",
+        "@contentful/f36-spinner": "^4.67.1",
+        "@contentful/f36-table": "^4.67.1",
+        "@contentful/f36-tabs": "^4.67.1",
+        "@contentful/f36-text-link": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.1",
+        "@contentful/f36-typography": "^4.67.1",
         "@contentful/f36-utils": "^4.24.3"
       },
       "peerDependencies": {
@@ -2390,15 +2390,15 @@
       }
     },
     "node_modules/@contentful/f36-copybutton": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.67.2.tgz",
-      "integrity": "sha512-hb/DCGE6TTdepsjZvmDgog1glfF8WxGCx+F1S7FbwTZ4NutWeHEa7+E63t2tELTRx07FoVmkICmPtp89mCXKEw==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.67.1.tgz",
+      "integrity": "sha512-riw5JBm4X8jTZH8ZZa7Acfc+ef5QOZhNoc4xfi63gIuiC96pa3s0eBlWogBXjJStm6hQcr1IDbg+o4hRgh0uwg==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2407,9 +2407,9 @@
       }
     },
     "node_modules/@contentful/f36-core": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.67.2.tgz",
-      "integrity": "sha512-iSzA/OuhU4rIlBOlUTIczMuqDQZqLR1tmZJtZyouhfWkEc0VGUCX6S2FnBEXlMbnMzaL70lTXYUNu2bKxK4PfA==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.67.1.tgz",
+      "integrity": "sha512-qeBBaRoqCi3sUMKwJF1g3MQ6jawCGTZROMkjkb2+P6GpmNitbeFBW/J0VJY2g/ixCMN5NORSyf/1CBRMXFwUOw==",
       "dependencies": {
         "@contentful/f36-tokens": "^4.0.4",
         "@emotion/core": "^10.1.1",
@@ -2423,17 +2423,17 @@
       }
     },
     "node_modules/@contentful/f36-datepicker": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.67.2.tgz",
-      "integrity": "sha512-qGfVEjdZaMwdDBr1uWfgQtnCd8L+ZyVBpFiI8TyFUdQd6L9blHexr99Wg12uBNSub9zaL5fs4wrHZ5vMpGEjGQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.67.1.tgz",
+      "integrity": "sha512-ftHXPc6+hL8E5rkLxTPI9uk/kaAyEhl+ClqLapmd3AyaNrfVojAYJ9Bhe62GIz1gFU0bMXukslCU8xwbrdlFQA==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-forms": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-popover": "^4.67.2",
+        "@contentful/f36-popover": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "date-fns": "^2.28.0",
         "emotion": "^10.0.17",
         "react-day-picker": "^8.7.1",
@@ -2445,11 +2445,11 @@
       }
     },
     "node_modules/@contentful/f36-datetime": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.67.2.tgz",
-      "integrity": "sha512-7kz4I/CzRkupPb43dtAQ3a1bHffdx3ZQ0i9ueUl9CSs+dKhl9gwiH0bmoNN5pnULAQF4i7WQmNueEfQvh9zgvA==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.67.1.tgz",
+      "integrity": "sha512-WlJTeOpyxjxoVWY5DSF9RzkqnAc+80XMo00b0vN2XKc9lKLozMgFrApTeUSZGTcPX0ymKjEdJGqqP/d2o/YbGg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "dayjs": "^1.11.5",
         "emotion": "^10.0.17"
@@ -2460,11 +2460,11 @@
       }
     },
     "node_modules/@contentful/f36-drag-handle": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.67.2.tgz",
-      "integrity": "sha512-7e38V/dJ79m4uVlnf1H1xpRY28DPwaMQOMgFWwPKCdketfr+YU8KI7kE2ssrd1EsM9av7Z0Dcwz6pF89wuxViA==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.67.1.tgz",
+      "integrity": "sha512-wO5ru3zl3qm5KtAylWYQCvdeE0TLda+3gXCMxeNHyJTOcW2/vSB6L31T9zVihFRK/5vgDvGWkcTt/R17OW+qzg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
@@ -2476,12 +2476,12 @@
       }
     },
     "node_modules/@contentful/f36-empty-state": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.67.2.tgz",
-      "integrity": "sha512-ghzqNmwAOv0mAUvXDyLLtlAOXj5RPas/stJ8etPpb339NGFj5ueYf9+EBrgTCWrMK/JCBhcogV5bgKRsc9VKlg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.67.1.tgz",
+      "integrity": "sha512-VPiAfHYCJr3DdhrXXgKzTIKnXZgjugrKwtGbyJQX7cRmwnNRjZCMwMl3F0pPvhPAfI1rzwZzm/wqAtWeBsN51A==",
       "dependencies": {
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2490,21 +2490,20 @@
       }
     },
     "node_modules/@contentful/f36-entity-list": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.67.2.tgz",
-      "integrity": "sha512-G37dKH3yRD++fOA924UROtZdeIiNFmrjfVOobC03jdvk6o21AN2kMyDzML2Uc0+kMg+ofe4G08KC/OmDSUkSAg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.67.1.tgz",
+      "integrity": "sha512-JFxQ2v+Vi6jgPxIkWfiKPPt5U+RKF5hEqHX6Xxndcgcjg0aamb7iJ3rR8mln9cWULIqPJhSTawQujeBgonLktw==",
       "dependencies": {
-        "@contentful/f36-badge": "^4.67.2",
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
+        "@contentful/f36-badge": "^4.67.1",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-drag-handle": "^4.67.1",
+        "@contentful/f36-icon": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-icons-alpha": "npm:@contentful/f36-icons@^5.0.0-alpha.26",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-menu": "^4.67.1",
+        "@contentful/f36-skeleton": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2513,14 +2512,14 @@
       }
     },
     "node_modules/@contentful/f36-forms": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.67.2.tgz",
-      "integrity": "sha512-+XxpnCiBKtZw2hYo5QZWVayWMPKzbarOIWzZUMm6Ttoru00zn5u3tlvue7c9W2zqkNFuUNOopAwXBwQ0h+z+bQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.67.1.tgz",
+      "integrity": "sha512-YRifViI6tLRoJyc3kaAy7TM6gjAoDiaFYfv0k42mEMAC5XOkEwFVHORpRkfCDrYwEC7Zk9crEdOy0vfZ3QlH0Q==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
@@ -2530,15 +2529,15 @@
       }
     },
     "node_modules/@contentful/f36-header": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-header/-/f36-header-4.67.2.tgz",
-      "integrity": "sha512-DjI5JnJuXixG8bAj03lRvISuAgwA2X6PnYifa//967Dd0qQTBw/CkB96AhrgVUjTw+jt3xAprwv0SUKF8x9S8g==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-header/-/f36-header-4.67.1.tgz",
+      "integrity": "sha512-8eith4p/4tc5ZSVPQkWfd4jBNDOq3iSTbBW7jeyB9p+oeB/0cOpJCfjB1RwUTvBamn+MrKnLNtt/TkUa+7C9aw==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.2",
         "@contentful/f36-tokens": "^4.0.5",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2547,32 +2546,13 @@
       }
     },
     "node_modules/@contentful/f36-icon": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.67.2.tgz",
-      "integrity": "sha512-vJAk6KO88GVnHdPSXurUA67F4wl01sZHaaE5eHGvt/s+YuI47dstgROr5+z66qmncKpcMWOTv4/+jqYV1Ko56A==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.67.1.tgz",
+      "integrity": "sha512-Exug8bPfTv0JY2rs7ZxuG9IsrLcQLG0SV7LC76INMwwOIdLWiRFK4k+Se2Or9Ox9ga2pBEPlWr5hBBSgPSj6Gw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-icon-alpha": {
-      "name": "@contentful/f36-icon",
-      "version": "5.0.0-alpha.20",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-5.0.0-alpha.20.tgz",
-      "integrity": "sha512-kI7HJggp/H8whiUL/RrG988nEvQq2SuZVyQn4kyiWYSlMWBRqQXZRvXfsM/RILWMgz2LxryXaT1YGVy2E4UfJA==",
-      "dependencies": {
-        "@contentful/f36-core": "^4.65.4",
-        "@contentful/f36-tokens": "^4.0.4",
-        "@phosphor-icons/react": "^2.1.5",
-        "emotion": "^10.0.17"
-      },
-      "engines": {
-        "node": ">=16"
       },
       "peerDependencies": {
         "react": ">=16.8",
@@ -2594,33 +2574,13 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/@contentful/f36-icons-alpha": {
-      "name": "@contentful/f36-icons",
-      "version": "5.0.0-alpha.29",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-5.0.0-alpha.29.tgz",
-      "integrity": "sha512-7QhDDAo95WiqFwB/ofWd57GEyeLgkDU/CgTStjhtBZssheMvVT6thiIFy6hSbo314d1RZ5Z8EBzH1MIJ/nyQhA==",
+    "node_modules/@contentful/f36-image": {
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-image/-/f36-image-4.67.1.tgz",
+      "integrity": "sha512-FYoeHHAWrRG2YuCXl7VifRjAkDXijENzhV1bgD38eKtBpLbmnnJm+vxbQRAKBvkkwLwFEHvVsdZ2XBoCs6WgmA==",
       "dependencies": {
         "@contentful/f36-core": "^4.67.1",
-        "@contentful/f36-icon-alpha": "npm:@contentful/f36-icon@5.0.0-alpha.20",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@phosphor-icons/react": "^2.1.4",
-        "emotion": "^10.0.17"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-image": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-image/-/f36-image-4.67.2.tgz",
-      "integrity": "sha512-zB4D/fBmUyIj1WvF2tWQHsDxzTcZ+KOyiVu0483rxRNai8sae7BO3VSuevUzfi2Y+gaF3VCasPZudjgTeWD2pQ==",
-      "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-skeleton": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.5",
         "emotion": "^10.0.17"
       },
@@ -2630,11 +2590,11 @@
       }
     },
     "node_modules/@contentful/f36-list": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.67.2.tgz",
-      "integrity": "sha512-ZkObExturTfxpNZOBcHJMozuLIbDLe8Us5qe4qJyVozIBH+Ol6xOHxEEyEu8GsRZp0+GU7K3fWExqLEV22oSUQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.67.1.tgz",
+      "integrity": "sha512-WLSyAWDjjr+DHrh5pOIGMlWKeWxyxu1HPlwI/deQEmr/PXjuPLMewH393+HE3LJbrWwpqU3J/U+v1H62XTbFCg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2644,15 +2604,15 @@
       }
     },
     "node_modules/@contentful/f36-menu": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.67.2.tgz",
-      "integrity": "sha512-TF+tpTLqE22qeQTYHJFuxCm6Yt37VFtwM6X9O07GYTeXeDZE7ZI+FrA16y+fxFw2Zu0OpbLO0CWB/ViolvMlOw==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.67.1.tgz",
+      "integrity": "sha512-M9UOD8sEwyPHP9gpDkTgXCeFwpS2cZMI0zoNOr/9vxY/XaLR3iN2W4D+FXtD71FVxy83Fs+ap12gTyKBn7dY6w==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-popover": "^4.67.2",
+        "@contentful/f36-popover": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
@@ -2662,15 +2622,15 @@
       }
     },
     "node_modules/@contentful/f36-modal": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.67.2.tgz",
-      "integrity": "sha512-mrO5+mKytV/j759HI0y6fZskQG/EEY7iNaRjjeYmFRoT6MAgViebcIeht15CcFwnNQLAeS3MusvXiEzuUzweiQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.67.1.tgz",
+      "integrity": "sha512-10LfRE5sKz9QJpSP7D8/PQDpOpq+5086HK51uKUnuPZeszXYfRUgRWTcfkkPvaihqGGx0JZLiRNvGFOBYWVP1A==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "@types/react-modal": "^3.13.1",
         "emotion": "^10.0.17",
         "react-modal": "^3.16.1"
@@ -2681,16 +2641,16 @@
       }
     },
     "node_modules/@contentful/f36-navbar": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-navbar/-/f36-navbar-4.67.2.tgz",
-      "integrity": "sha512-58PYpIElqnfdYWpEkSaOmccSzcgudYUs009UWmtqHmv0n3c8eNoV8taoZdg92gYAsEc7G2VWl4AZ3wJy/kiAdg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-navbar/-/f36-navbar-4.67.1.tgz",
+      "integrity": "sha512-kvlQ+jEyPxuFqtO6itMCSQbNZFFTInTJOi7xtYGTC07S49Gn22/Nb9GNJ7lT9pzTm4q0ss+Q+Xv/PtyVsSGnHg==",
       "dependencies": {
-        "@contentful/f36-avatar": "4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
+        "@contentful/f36-avatar": "4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-icon": "^4.67.1",
         "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-menu": "^4.67.1",
+        "@contentful/f36-skeleton": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.1",
         "@contentful/f36-utils": "^4.23.2",
         "emotion": "^10.0.17"
@@ -2701,16 +2661,16 @@
       }
     },
     "node_modules/@contentful/f36-note": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.67.2.tgz",
-      "integrity": "sha512-DA0f1/j640SG3LOon1VcU6kDvNgUHxupH0Q1FXS01aRrWq12uMd2bLtb2k5A9qRyT6MB3OdAKFufwsBcSL6fYw==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.67.1.tgz",
+      "integrity": "sha512-6rhGqt5MdH53XXNVbIo9cqmswjSzonHSZ5FdqrJ+rF6uOOghT+zzQCq65PRIBufihvZVh/mD/7vVjCpD6BxnnQ==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-icon": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2719,16 +2679,16 @@
       }
     },
     "node_modules/@contentful/f36-notification": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.67.2.tgz",
-      "integrity": "sha512-x7qxuqOhQMyhhRfMrisAVXnAo/eL6A7RjL2PmTLylaqKrFnzDrr25BtzepdkgULj9VLh70vXM5QIzPwpKpIJBQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.67.1.tgz",
+      "integrity": "sha512-JPYhOqz0rsipqHrtSoWnuPkrqndRz7XX72/0Mfj3dWV4MAK78rxVAQl17qDVliRZTp9NtWXBYseJiPhOsfAw+Q==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-text-link": "^4.67.2",
+        "@contentful/f36-text-link": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "@swc/helpers": "^0.4.14",
         "emotion": "^10.0.17",
         "react-animate-height": "^3.0.4"
@@ -2739,16 +2699,16 @@
       }
     },
     "node_modules/@contentful/f36-pagination": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.67.2.tgz",
-      "integrity": "sha512-/UePF1fbr2wvJHtJ9ncWaz5eg/VTdA8VqEBFJXge/IBgPVyMgQxQRxSDhvMj0j2Iit90qAzPedEDZK+jp6CyTg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.67.1.tgz",
+      "integrity": "sha512-NgK22JvCtBvBfE5NeKFRqtLIoeY6CXDTpKpSu70QZxWp4C/z9U7qhyr0d12SHYgFFUJwnAl67A5qaEyth2NvJw==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-forms": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2757,16 +2717,16 @@
       }
     },
     "node_modules/@contentful/f36-pill": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.67.2.tgz",
-      "integrity": "sha512-015oRkVVnshvWAJ/kR5yJBD+soWmDcHFy5FGXDaIR5moTCejjqiLG1g8H6MolaF8oeKSOhbhgfX/dpEHn5/Z4g==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.67.1.tgz",
+      "integrity": "sha512-Ycn1bkAtNlc2FOFuwiSlDK3rgVgPruHXG6m+dla8Hp/ZL/MH2xUcQqir3SlLCZeR+gSx1cuzI9ga8/UjsKf1qQ==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-drag-handle": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2775,11 +2735,11 @@
       }
     },
     "node_modules/@contentful/f36-popover": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.67.2.tgz",
-      "integrity": "sha512-NJx54sqQEmuWIsBySXf/B+ZW/RoIkRzb7cnQ5aucN3nUd4ZaHOvcmYVLJMqfCV8ipzpMxLgoc8p3v6OcRdi72A==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.67.1.tgz",
+      "integrity": "sha512-loWXCV7BswsBvcBENRzEbMCjITodK5RnT7DNSeaZvvhOa87Gp+aCcGIpHaS0Jxrhy3OvUOdPxaRUXmoMkrP7Hg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -2792,12 +2752,12 @@
       }
     },
     "node_modules/@contentful/f36-skeleton": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.67.2.tgz",
-      "integrity": "sha512-4T8r/G8b9DFkLErIo8d2cGS71tWy1yNDZIThoHBWIhLRcstal8K7Ag5dQwPsaoSew/859oXC2rvPP0Ep+4FtCg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.67.1.tgz",
+      "integrity": "sha512-hJR/M6u2al75mCMJcdR9xxRfKQdqqFvsRY6mbwYO6bZ+6odYhMqoRNR1C0WK7+uWlEDYUlOnF7+T2vfRB4IfVg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-table": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-table": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2807,11 +2767,11 @@
       }
     },
     "node_modules/@contentful/f36-spinner": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.67.2.tgz",
-      "integrity": "sha512-sBitcudBc4DwAOPn6MLuArLje7aym47GoIDI0kN9zQtolVwlVH92/zNpZmnm+zbP4Ku56/TgbL/v5SFTh+YB2w==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.67.1.tgz",
+      "integrity": "sha512-KCyPb37/Xvr51b6gibw//yLm16uN7+z505+z2B2YH53t70+uIgADKtS7APtaMCbVH6fliVa9/GkXE3WYv/xJhA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2821,14 +2781,14 @@
       }
     },
     "node_modules/@contentful/f36-table": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.67.2.tgz",
-      "integrity": "sha512-YtUkXwFmBLgAi5Glgi1vXqNbr+U2riadB9O+Aq8t2R/vpXMCIA4WlmXSqunwPW9UrrilalrK49l0IkDNpcRUbQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.67.1.tgz",
+      "integrity": "sha512-/UtSfNFwnjGCSLcxeGGBI5Dz/isQsgNNeFJyo2I+xcYPPehZ9o6eHf0+CeRuIW3+OCXYAyliydig+/T+le3/rA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2837,11 +2797,11 @@
       }
     },
     "node_modules/@contentful/f36-tabs": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.67.2.tgz",
-      "integrity": "sha512-rPPJQHmCoD8492yKufelL7MCj0j4FqcPc5yFhD29sqpGDqTko8Xf/V/q4/LPYUtXttH8myfTINEyNTsR/lZINg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.67.1.tgz",
+      "integrity": "sha512-2Nd1UCdBArAWKDvFOgGdd+KV+4SdHGpnx253FEMT4jsRnxeirw/qK+Pn5fBUK5f+KC8ShmxUMpH3Qjf2JTHi9w==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@radix-ui/react-tabs": "^1.0.1",
         "emotion": "^10.0.17"
@@ -2852,11 +2812,11 @@
       }
     },
     "node_modules/@contentful/f36-text-link": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.67.2.tgz",
-      "integrity": "sha512-mWE4KsqQV93SNAFtYWqQB61/TLHuX1D3vVJ1rFqAp1kndPy7UyGcrQrGoPmM1l20Y9YaYIWYwo5eGKygY3iwIA==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.67.1.tgz",
+      "integrity": "sha512-SSwbr0ZZoBrXrBwwfCvZIYOh+9yu+J71qgv7dl3jqo0i9bautc6sAIRrrhjT8C0rcUTi6/HRzi0w882ORCgaEg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2871,11 +2831,11 @@
       "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
     },
     "node_modules/@contentful/f36-tooltip": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.67.2.tgz",
-      "integrity": "sha512-BFSKsJySAK1ipIOXueq6rgsJlmZDVBd60fjicALWiVX/GnxyDO3OkdX8nfK4Id0rbllf8+WBSR5UcVzNjuLe4Q==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.67.1.tgz",
+      "integrity": "sha512-i/FO4F9UHVggL0ScMrayZ6p1rs9oFGhUVZ4B3TKtrVRKXNfFQIzwXFPY45/ZAzdfgxdn90XCvMEo2j86l3fWXA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -2889,11 +2849,11 @@
       }
     },
     "node_modules/@contentful/f36-typography": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.67.2.tgz",
-      "integrity": "sha512-zfCVUQfD5wueT4mFNxLO+2SaUTFVHxE+7v8YKt53SvIiN+s/vXJnABOKPZsjYAYkwQwSrwPYIdIxMtaULwjoCw==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.67.1.tgz",
+      "integrity": "sha512-VES06vg9Bnp09IvJm8yea//IgI2m4aCz5weSD+LUV+vpjtBMM/0w+95cP67KvS6Rg3sEr3yx1bja8gSoTDahpw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
@@ -4965,18 +4925,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@phosphor-icons/react": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.1.7.tgz",
-      "integrity": "sha512-g2e2eVAn1XG2a+LI09QU3IORLhnFNAFkNbo2iwbX6NOKSLOwvEMmTa7CgOzEbgNWR47z8i8kwjdvYZ5fkGx1mQ==",
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": ">= 16.8",
-        "react-dom": ">= 16.8"
       }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {

--- a/examples/function-potterdb-rest-api/package.json
+++ b/examples/function-potterdb-rest-api/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@contentful/app-sdk": "^4.28.0",
-    "@contentful/f36-components": "4.67.2",
+    "@contentful/f36-components": "4.67.1",
     "@contentful/f36-icons": "^4.28.0",
     "@contentful/f36-tokens": "4.0.5",
     "@contentful/field-editor-single-line": "^1.4.2",

--- a/examples/function-potterdb/package-lock.json
+++ b/examples/function-potterdb/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@contentful/app-sdk": "^4.28.0",
-        "@contentful/f36-components": "4.67.2",
+        "@contentful/f36-components": "4.67.1",
         "@contentful/f36-icons": "^4.28.2",
         "@contentful/f36-tokens": "4.0.5",
         "@contentful/field-editor-single-line": "^1.4.2",
@@ -2186,15 +2186,15 @@
       }
     },
     "node_modules/@contentful/f36-accordion": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.67.2.tgz",
-      "integrity": "sha512-cX7xIX+fZadUNNFG+uzAOXeZ/GkMs+Y0bvgpxkpqW3ILu6GIXHsXetnRocxVaYUrQ1C/k6wEsd4xSv5y2uQBIg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.67.1.tgz",
+      "integrity": "sha512-rIGmO28PcSdfyUpaPfpeMO8qT/y8wMpQcyASHIUY8m6YRrn97vIlfDMQlzuyfoDBXQI3Lkza5RzbEFQVu7capg==",
       "dependencies": {
-        "@contentful/f36-collapse": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-collapse": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2203,15 +2203,15 @@
       }
     },
     "node_modules/@contentful/f36-asset": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.67.2.tgz",
-      "integrity": "sha512-cUQaZQeXIr3oLy255cuL+mXNiYOpMvAzW7BxE3l903ShzlwVFqZr/FIaWAo2t488sWbGeXNXxVBcEbLzQUMIdA==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.67.1.tgz",
+      "integrity": "sha512-BVRtLKxj/S+dGVJ0b88PVpBxE8mLiqDYATlE62Yb22CpncFpb9Kt7IRLto4KnD+SHZAJMORhoMNk7bQc103Dyw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-icon": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2220,18 +2220,18 @@
       }
     },
     "node_modules/@contentful/f36-autocomplete": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.67.2.tgz",
-      "integrity": "sha512-1cZHVa2cskh4DvachcgaQeEuyjuAlxvvyJCqvpHpP+R3ISS6CsC44252fH52NcLryvfFG1zX24nZECgFOY/S+A==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.67.1.tgz",
+      "integrity": "sha512-2aTKX92Q3HyVFexMkjkVw3D7wxTsxB/JJgT8Cy14b22leFk6Dup1Ui8Kt0LkjLYTX9vP3fru8XQ0cae4bCMsfQ==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-forms": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-popover": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-popover": "^4.67.1",
+        "@contentful/f36-skeleton": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "@contentful/f36-utils": "^4.24.3",
         "downshift": "^6.1.12",
         "emotion": "^10.0.17"
@@ -2242,15 +2242,15 @@
       }
     },
     "node_modules/@contentful/f36-avatar": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-avatar/-/f36-avatar-4.67.2.tgz",
-      "integrity": "sha512-bKxmWgi67V6tPCX2mlSxJKtQ8IANoO7jU9qH74Fqe11ATgG84Oqy9iQgjJDQvfFMjyT9n+3zUtUCwo/waHHrQg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-avatar/-/f36-avatar-4.67.1.tgz",
+      "integrity": "sha512-NaUNIFvinF1m3Tr7Gaj3/NREOf1ZYIobKLrtUMzbP0ULezHVvwUxGXbpDOAbLSt9jis9mvvrodBDvRJvmESiAw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-image": "4.67.2",
-        "@contentful/f36-menu": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-image": "4.67.1",
+        "@contentful/f36-menu": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.5",
-        "@contentful/f36-tooltip": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2259,11 +2259,11 @@
       }
     },
     "node_modules/@contentful/f36-badge": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.67.2.tgz",
-      "integrity": "sha512-cWfb3Nk9+CdgmTvc75gzD6uJ4XCbK23pB1t9BV9ZvytvnuaQElZYh7WciyRKJtU51khb0KOuVCb/TOnjecU4xQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.67.1.tgz",
+      "integrity": "sha512-jl944fd93dWrjdy853lGd4RSGtffij7PompadRsw1pbVqsKv5TmIlNGRr253EH4HN8+zIyJo5GTGHXCD9qV9Vw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
@@ -2274,12 +2274,12 @@
       }
     },
     "node_modules/@contentful/f36-button": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.67.2.tgz",
-      "integrity": "sha512-1/1dYtgfVk3wiP5SoaoQEWlM7VYp/Pju17agu5Y0MGuGo7LwjTCzLJQ4OeRvdubTYCW+iXc20sEG2H3OyRoz6w==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.67.1.tgz",
+      "integrity": "sha512-MnL1jFulLgM4ilDG2p06+bpv3dPFRSmjuDb6VlVdZx3JEtMJOK0fxIb1ylSHAE8AHJRDC64iArFCSoiz5zR6Rw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-spinner": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-spinner": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
@@ -2290,22 +2290,22 @@
       }
     },
     "node_modules/@contentful/f36-card": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.67.2.tgz",
-      "integrity": "sha512-f1Ck9hbbfdX7/OIWPfXJSdriDVjoTQOdz4aXo1QVd2fmsTAzQCfH0llwXtCk8TCg4DbSwaS/ldB/CJV3oCN1AA==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.67.1.tgz",
+      "integrity": "sha512-MarYmNmHM5WN9WEIsGAQywaQPethxjIGFI+LbttCP++HzEhY2xlJiQTLwy+X8sW+IncY5TE31AkF+EFkjODGEA==",
       "dependencies": {
-        "@contentful/f36-asset": "^4.67.2",
-        "@contentful/f36-badge": "^4.67.2",
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
+        "@contentful/f36-asset": "^4.67.1",
+        "@contentful/f36-badge": "^4.67.1",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-drag-handle": "^4.67.1",
+        "@contentful/f36-icon": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-menu": "^4.67.1",
+        "@contentful/f36-skeleton": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.1",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17",
         "truncate": "^3.0.0"
       },
@@ -2315,11 +2315,11 @@
       }
     },
     "node_modules/@contentful/f36-collapse": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.67.2.tgz",
-      "integrity": "sha512-EWkl653S3gnhVkq39Z0vDrIHQxvqJnN9XfrrORpX56ZCc4kHs1MzbbbDjnlj3udCy9Cj4Q50hiXpmeO/JogDlg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.67.1.tgz",
+      "integrity": "sha512-9oi/gUTgJTHEn8EoLsKQKd9JtaT5RkY7GZDKccztmWOhkkq9OZQyEgf3msw401CDGwp/pr/RdijjdvZNBFSIwA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2329,47 +2329,47 @@
       }
     },
     "node_modules/@contentful/f36-components": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.67.2.tgz",
-      "integrity": "sha512-JNBX8YzP+mt2/d2m5uUnpFLGnzyRAsggWpEBUe8QgPRwkJ8bZIDrnm2TELIFqrY2t4Lvs2AJw8L/3kDaJvMNCQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.67.1.tgz",
+      "integrity": "sha512-9p4MxsywvLbwX90HgqQI8FQJx9iOjqkC4bAIGLDbjI1CuuKhzACUSAkRvAYhO7N7ZR7c1Vrjr4pvYU7xy4+siw==",
       "dependencies": {
-        "@contentful/f36-accordion": "^4.67.2",
-        "@contentful/f36-asset": "^4.67.2",
-        "@contentful/f36-autocomplete": "^4.67.2",
-        "@contentful/f36-avatar": "4.67.2",
-        "@contentful/f36-badge": "^4.67.2",
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-card": "^4.67.2",
-        "@contentful/f36-collapse": "^4.67.2",
-        "@contentful/f36-copybutton": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-datepicker": "^4.67.2",
-        "@contentful/f36-datetime": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-empty-state": "^4.67.2",
-        "@contentful/f36-entity-list": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
-        "@contentful/f36-header": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
+        "@contentful/f36-accordion": "^4.67.1",
+        "@contentful/f36-asset": "^4.67.1",
+        "@contentful/f36-autocomplete": "^4.67.1",
+        "@contentful/f36-avatar": "4.67.1",
+        "@contentful/f36-badge": "^4.67.1",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-card": "^4.67.1",
+        "@contentful/f36-collapse": "^4.67.1",
+        "@contentful/f36-copybutton": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-datepicker": "^4.67.1",
+        "@contentful/f36-datetime": "^4.67.1",
+        "@contentful/f36-drag-handle": "^4.67.1",
+        "@contentful/f36-empty-state": "^4.67.1",
+        "@contentful/f36-entity-list": "^4.67.1",
+        "@contentful/f36-forms": "^4.67.1",
+        "@contentful/f36-header": "^4.67.1",
+        "@contentful/f36-icon": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-image": "4.67.2",
-        "@contentful/f36-list": "^4.67.2",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-modal": "^4.67.2",
-        "@contentful/f36-navbar": "^4.67.2",
-        "@contentful/f36-note": "^4.67.2",
-        "@contentful/f36-notification": "^4.67.2",
-        "@contentful/f36-pagination": "^4.67.2",
-        "@contentful/f36-pill": "^4.67.2",
-        "@contentful/f36-popover": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
-        "@contentful/f36-spinner": "^4.67.2",
-        "@contentful/f36-table": "^4.67.2",
-        "@contentful/f36-tabs": "^4.67.2",
-        "@contentful/f36-text-link": "^4.67.2",
+        "@contentful/f36-image": "4.67.1",
+        "@contentful/f36-list": "^4.67.1",
+        "@contentful/f36-menu": "^4.67.1",
+        "@contentful/f36-modal": "^4.67.1",
+        "@contentful/f36-navbar": "^4.67.1",
+        "@contentful/f36-note": "^4.67.1",
+        "@contentful/f36-notification": "^4.67.1",
+        "@contentful/f36-pagination": "^4.67.1",
+        "@contentful/f36-pill": "^4.67.1",
+        "@contentful/f36-popover": "^4.67.1",
+        "@contentful/f36-skeleton": "^4.67.1",
+        "@contentful/f36-spinner": "^4.67.1",
+        "@contentful/f36-table": "^4.67.1",
+        "@contentful/f36-tabs": "^4.67.1",
+        "@contentful/f36-text-link": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.1",
+        "@contentful/f36-typography": "^4.67.1",
         "@contentful/f36-utils": "^4.24.3"
       },
       "peerDependencies": {
@@ -2388,15 +2388,15 @@
       }
     },
     "node_modules/@contentful/f36-copybutton": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.67.2.tgz",
-      "integrity": "sha512-hb/DCGE6TTdepsjZvmDgog1glfF8WxGCx+F1S7FbwTZ4NutWeHEa7+E63t2tELTRx07FoVmkICmPtp89mCXKEw==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.67.1.tgz",
+      "integrity": "sha512-riw5JBm4X8jTZH8ZZa7Acfc+ef5QOZhNoc4xfi63gIuiC96pa3s0eBlWogBXjJStm6hQcr1IDbg+o4hRgh0uwg==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2405,9 +2405,9 @@
       }
     },
     "node_modules/@contentful/f36-core": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.67.2.tgz",
-      "integrity": "sha512-iSzA/OuhU4rIlBOlUTIczMuqDQZqLR1tmZJtZyouhfWkEc0VGUCX6S2FnBEXlMbnMzaL70lTXYUNu2bKxK4PfA==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.67.1.tgz",
+      "integrity": "sha512-qeBBaRoqCi3sUMKwJF1g3MQ6jawCGTZROMkjkb2+P6GpmNitbeFBW/J0VJY2g/ixCMN5NORSyf/1CBRMXFwUOw==",
       "dependencies": {
         "@contentful/f36-tokens": "^4.0.4",
         "@emotion/core": "^10.1.1",
@@ -2421,17 +2421,17 @@
       }
     },
     "node_modules/@contentful/f36-datepicker": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.67.2.tgz",
-      "integrity": "sha512-qGfVEjdZaMwdDBr1uWfgQtnCd8L+ZyVBpFiI8TyFUdQd6L9blHexr99Wg12uBNSub9zaL5fs4wrHZ5vMpGEjGQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.67.1.tgz",
+      "integrity": "sha512-ftHXPc6+hL8E5rkLxTPI9uk/kaAyEhl+ClqLapmd3AyaNrfVojAYJ9Bhe62GIz1gFU0bMXukslCU8xwbrdlFQA==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-forms": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-popover": "^4.67.2",
+        "@contentful/f36-popover": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "date-fns": "^2.28.0",
         "emotion": "^10.0.17",
         "react-day-picker": "^8.7.1",
@@ -2443,11 +2443,11 @@
       }
     },
     "node_modules/@contentful/f36-datetime": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.67.2.tgz",
-      "integrity": "sha512-7kz4I/CzRkupPb43dtAQ3a1bHffdx3ZQ0i9ueUl9CSs+dKhl9gwiH0bmoNN5pnULAQF4i7WQmNueEfQvh9zgvA==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.67.1.tgz",
+      "integrity": "sha512-WlJTeOpyxjxoVWY5DSF9RzkqnAc+80XMo00b0vN2XKc9lKLozMgFrApTeUSZGTcPX0ymKjEdJGqqP/d2o/YbGg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "dayjs": "^1.11.5",
         "emotion": "^10.0.17"
@@ -2458,11 +2458,11 @@
       }
     },
     "node_modules/@contentful/f36-drag-handle": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.67.2.tgz",
-      "integrity": "sha512-7e38V/dJ79m4uVlnf1H1xpRY28DPwaMQOMgFWwPKCdketfr+YU8KI7kE2ssrd1EsM9av7Z0Dcwz6pF89wuxViA==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.67.1.tgz",
+      "integrity": "sha512-wO5ru3zl3qm5KtAylWYQCvdeE0TLda+3gXCMxeNHyJTOcW2/vSB6L31T9zVihFRK/5vgDvGWkcTt/R17OW+qzg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
@@ -2474,12 +2474,12 @@
       }
     },
     "node_modules/@contentful/f36-empty-state": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.67.2.tgz",
-      "integrity": "sha512-ghzqNmwAOv0mAUvXDyLLtlAOXj5RPas/stJ8etPpb339NGFj5ueYf9+EBrgTCWrMK/JCBhcogV5bgKRsc9VKlg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.67.1.tgz",
+      "integrity": "sha512-VPiAfHYCJr3DdhrXXgKzTIKnXZgjugrKwtGbyJQX7cRmwnNRjZCMwMl3F0pPvhPAfI1rzwZzm/wqAtWeBsN51A==",
       "dependencies": {
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2488,21 +2488,20 @@
       }
     },
     "node_modules/@contentful/f36-entity-list": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.67.2.tgz",
-      "integrity": "sha512-G37dKH3yRD++fOA924UROtZdeIiNFmrjfVOobC03jdvk6o21AN2kMyDzML2Uc0+kMg+ofe4G08KC/OmDSUkSAg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.67.1.tgz",
+      "integrity": "sha512-JFxQ2v+Vi6jgPxIkWfiKPPt5U+RKF5hEqHX6Xxndcgcjg0aamb7iJ3rR8mln9cWULIqPJhSTawQujeBgonLktw==",
       "dependencies": {
-        "@contentful/f36-badge": "^4.67.2",
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
+        "@contentful/f36-badge": "^4.67.1",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-drag-handle": "^4.67.1",
+        "@contentful/f36-icon": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-icons-alpha": "npm:@contentful/f36-icons@^5.0.0-alpha.26",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-menu": "^4.67.1",
+        "@contentful/f36-skeleton": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2511,14 +2510,14 @@
       }
     },
     "node_modules/@contentful/f36-forms": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.67.2.tgz",
-      "integrity": "sha512-+XxpnCiBKtZw2hYo5QZWVayWMPKzbarOIWzZUMm6Ttoru00zn5u3tlvue7c9W2zqkNFuUNOopAwXBwQ0h+z+bQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.67.1.tgz",
+      "integrity": "sha512-YRifViI6tLRoJyc3kaAy7TM6gjAoDiaFYfv0k42mEMAC5XOkEwFVHORpRkfCDrYwEC7Zk9crEdOy0vfZ3QlH0Q==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
@@ -2528,15 +2527,15 @@
       }
     },
     "node_modules/@contentful/f36-header": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-header/-/f36-header-4.67.2.tgz",
-      "integrity": "sha512-DjI5JnJuXixG8bAj03lRvISuAgwA2X6PnYifa//967Dd0qQTBw/CkB96AhrgVUjTw+jt3xAprwv0SUKF8x9S8g==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-header/-/f36-header-4.67.1.tgz",
+      "integrity": "sha512-8eith4p/4tc5ZSVPQkWfd4jBNDOq3iSTbBW7jeyB9p+oeB/0cOpJCfjB1RwUTvBamn+MrKnLNtt/TkUa+7C9aw==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.2",
         "@contentful/f36-tokens": "^4.0.5",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2545,32 +2544,13 @@
       }
     },
     "node_modules/@contentful/f36-icon": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.67.2.tgz",
-      "integrity": "sha512-vJAk6KO88GVnHdPSXurUA67F4wl01sZHaaE5eHGvt/s+YuI47dstgROr5+z66qmncKpcMWOTv4/+jqYV1Ko56A==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.67.1.tgz",
+      "integrity": "sha512-Exug8bPfTv0JY2rs7ZxuG9IsrLcQLG0SV7LC76INMwwOIdLWiRFK4k+Se2Or9Ox9ga2pBEPlWr5hBBSgPSj6Gw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-icon-alpha": {
-      "name": "@contentful/f36-icon",
-      "version": "5.0.0-alpha.20",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-5.0.0-alpha.20.tgz",
-      "integrity": "sha512-kI7HJggp/H8whiUL/RrG988nEvQq2SuZVyQn4kyiWYSlMWBRqQXZRvXfsM/RILWMgz2LxryXaT1YGVy2E4UfJA==",
-      "dependencies": {
-        "@contentful/f36-core": "^4.65.4",
-        "@contentful/f36-tokens": "^4.0.4",
-        "@phosphor-icons/react": "^2.1.5",
-        "emotion": "^10.0.17"
-      },
-      "engines": {
-        "node": ">=16"
       },
       "peerDependencies": {
         "react": ">=16.8",
@@ -2592,33 +2572,13 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/@contentful/f36-icons-alpha": {
-      "name": "@contentful/f36-icons",
-      "version": "5.0.0-alpha.29",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-5.0.0-alpha.29.tgz",
-      "integrity": "sha512-7QhDDAo95WiqFwB/ofWd57GEyeLgkDU/CgTStjhtBZssheMvVT6thiIFy6hSbo314d1RZ5Z8EBzH1MIJ/nyQhA==",
+    "node_modules/@contentful/f36-image": {
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-image/-/f36-image-4.67.1.tgz",
+      "integrity": "sha512-FYoeHHAWrRG2YuCXl7VifRjAkDXijENzhV1bgD38eKtBpLbmnnJm+vxbQRAKBvkkwLwFEHvVsdZ2XBoCs6WgmA==",
       "dependencies": {
         "@contentful/f36-core": "^4.67.1",
-        "@contentful/f36-icon-alpha": "npm:@contentful/f36-icon@5.0.0-alpha.20",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@phosphor-icons/react": "^2.1.4",
-        "emotion": "^10.0.17"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-image": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-image/-/f36-image-4.67.2.tgz",
-      "integrity": "sha512-zB4D/fBmUyIj1WvF2tWQHsDxzTcZ+KOyiVu0483rxRNai8sae7BO3VSuevUzfi2Y+gaF3VCasPZudjgTeWD2pQ==",
-      "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-skeleton": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.5",
         "emotion": "^10.0.17"
       },
@@ -2628,11 +2588,11 @@
       }
     },
     "node_modules/@contentful/f36-list": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.67.2.tgz",
-      "integrity": "sha512-ZkObExturTfxpNZOBcHJMozuLIbDLe8Us5qe4qJyVozIBH+Ol6xOHxEEyEu8GsRZp0+GU7K3fWExqLEV22oSUQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.67.1.tgz",
+      "integrity": "sha512-WLSyAWDjjr+DHrh5pOIGMlWKeWxyxu1HPlwI/deQEmr/PXjuPLMewH393+HE3LJbrWwpqU3J/U+v1H62XTbFCg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2642,15 +2602,15 @@
       }
     },
     "node_modules/@contentful/f36-menu": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.67.2.tgz",
-      "integrity": "sha512-TF+tpTLqE22qeQTYHJFuxCm6Yt37VFtwM6X9O07GYTeXeDZE7ZI+FrA16y+fxFw2Zu0OpbLO0CWB/ViolvMlOw==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.67.1.tgz",
+      "integrity": "sha512-M9UOD8sEwyPHP9gpDkTgXCeFwpS2cZMI0zoNOr/9vxY/XaLR3iN2W4D+FXtD71FVxy83Fs+ap12gTyKBn7dY6w==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-popover": "^4.67.2",
+        "@contentful/f36-popover": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
@@ -2660,15 +2620,15 @@
       }
     },
     "node_modules/@contentful/f36-modal": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.67.2.tgz",
-      "integrity": "sha512-mrO5+mKytV/j759HI0y6fZskQG/EEY7iNaRjjeYmFRoT6MAgViebcIeht15CcFwnNQLAeS3MusvXiEzuUzweiQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.67.1.tgz",
+      "integrity": "sha512-10LfRE5sKz9QJpSP7D8/PQDpOpq+5086HK51uKUnuPZeszXYfRUgRWTcfkkPvaihqGGx0JZLiRNvGFOBYWVP1A==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "@types/react-modal": "^3.13.1",
         "emotion": "^10.0.17",
         "react-modal": "^3.16.1"
@@ -2679,16 +2639,16 @@
       }
     },
     "node_modules/@contentful/f36-navbar": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-navbar/-/f36-navbar-4.67.2.tgz",
-      "integrity": "sha512-58PYpIElqnfdYWpEkSaOmccSzcgudYUs009UWmtqHmv0n3c8eNoV8taoZdg92gYAsEc7G2VWl4AZ3wJy/kiAdg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-navbar/-/f36-navbar-4.67.1.tgz",
+      "integrity": "sha512-kvlQ+jEyPxuFqtO6itMCSQbNZFFTInTJOi7xtYGTC07S49Gn22/Nb9GNJ7lT9pzTm4q0ss+Q+Xv/PtyVsSGnHg==",
       "dependencies": {
-        "@contentful/f36-avatar": "4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
+        "@contentful/f36-avatar": "4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-icon": "^4.67.1",
         "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-menu": "^4.67.1",
+        "@contentful/f36-skeleton": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.1",
         "@contentful/f36-utils": "^4.23.2",
         "emotion": "^10.0.17"
@@ -2699,16 +2659,16 @@
       }
     },
     "node_modules/@contentful/f36-note": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.67.2.tgz",
-      "integrity": "sha512-DA0f1/j640SG3LOon1VcU6kDvNgUHxupH0Q1FXS01aRrWq12uMd2bLtb2k5A9qRyT6MB3OdAKFufwsBcSL6fYw==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.67.1.tgz",
+      "integrity": "sha512-6rhGqt5MdH53XXNVbIo9cqmswjSzonHSZ5FdqrJ+rF6uOOghT+zzQCq65PRIBufihvZVh/mD/7vVjCpD6BxnnQ==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-icon": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2717,16 +2677,16 @@
       }
     },
     "node_modules/@contentful/f36-notification": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.67.2.tgz",
-      "integrity": "sha512-x7qxuqOhQMyhhRfMrisAVXnAo/eL6A7RjL2PmTLylaqKrFnzDrr25BtzepdkgULj9VLh70vXM5QIzPwpKpIJBQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.67.1.tgz",
+      "integrity": "sha512-JPYhOqz0rsipqHrtSoWnuPkrqndRz7XX72/0Mfj3dWV4MAK78rxVAQl17qDVliRZTp9NtWXBYseJiPhOsfAw+Q==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-text-link": "^4.67.2",
+        "@contentful/f36-text-link": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "@swc/helpers": "^0.4.14",
         "emotion": "^10.0.17",
         "react-animate-height": "^3.0.4"
@@ -2737,16 +2697,16 @@
       }
     },
     "node_modules/@contentful/f36-pagination": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.67.2.tgz",
-      "integrity": "sha512-/UePF1fbr2wvJHtJ9ncWaz5eg/VTdA8VqEBFJXge/IBgPVyMgQxQRxSDhvMj0j2Iit90qAzPedEDZK+jp6CyTg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.67.1.tgz",
+      "integrity": "sha512-NgK22JvCtBvBfE5NeKFRqtLIoeY6CXDTpKpSu70QZxWp4C/z9U7qhyr0d12SHYgFFUJwnAl67A5qaEyth2NvJw==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-forms": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2755,16 +2715,16 @@
       }
     },
     "node_modules/@contentful/f36-pill": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.67.2.tgz",
-      "integrity": "sha512-015oRkVVnshvWAJ/kR5yJBD+soWmDcHFy5FGXDaIR5moTCejjqiLG1g8H6MolaF8oeKSOhbhgfX/dpEHn5/Z4g==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.67.1.tgz",
+      "integrity": "sha512-Ycn1bkAtNlc2FOFuwiSlDK3rgVgPruHXG6m+dla8Hp/ZL/MH2xUcQqir3SlLCZeR+gSx1cuzI9ga8/UjsKf1qQ==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-drag-handle": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2773,11 +2733,11 @@
       }
     },
     "node_modules/@contentful/f36-popover": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.67.2.tgz",
-      "integrity": "sha512-NJx54sqQEmuWIsBySXf/B+ZW/RoIkRzb7cnQ5aucN3nUd4ZaHOvcmYVLJMqfCV8ipzpMxLgoc8p3v6OcRdi72A==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.67.1.tgz",
+      "integrity": "sha512-loWXCV7BswsBvcBENRzEbMCjITodK5RnT7DNSeaZvvhOa87Gp+aCcGIpHaS0Jxrhy3OvUOdPxaRUXmoMkrP7Hg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -2790,12 +2750,12 @@
       }
     },
     "node_modules/@contentful/f36-skeleton": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.67.2.tgz",
-      "integrity": "sha512-4T8r/G8b9DFkLErIo8d2cGS71tWy1yNDZIThoHBWIhLRcstal8K7Ag5dQwPsaoSew/859oXC2rvPP0Ep+4FtCg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.67.1.tgz",
+      "integrity": "sha512-hJR/M6u2al75mCMJcdR9xxRfKQdqqFvsRY6mbwYO6bZ+6odYhMqoRNR1C0WK7+uWlEDYUlOnF7+T2vfRB4IfVg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-table": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-table": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2805,11 +2765,11 @@
       }
     },
     "node_modules/@contentful/f36-spinner": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.67.2.tgz",
-      "integrity": "sha512-sBitcudBc4DwAOPn6MLuArLje7aym47GoIDI0kN9zQtolVwlVH92/zNpZmnm+zbP4Ku56/TgbL/v5SFTh+YB2w==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.67.1.tgz",
+      "integrity": "sha512-KCyPb37/Xvr51b6gibw//yLm16uN7+z505+z2B2YH53t70+uIgADKtS7APtaMCbVH6fliVa9/GkXE3WYv/xJhA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2819,14 +2779,14 @@
       }
     },
     "node_modules/@contentful/f36-table": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.67.2.tgz",
-      "integrity": "sha512-YtUkXwFmBLgAi5Glgi1vXqNbr+U2riadB9O+Aq8t2R/vpXMCIA4WlmXSqunwPW9UrrilalrK49l0IkDNpcRUbQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.67.1.tgz",
+      "integrity": "sha512-/UtSfNFwnjGCSLcxeGGBI5Dz/isQsgNNeFJyo2I+xcYPPehZ9o6eHf0+CeRuIW3+OCXYAyliydig+/T+le3/rA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2835,11 +2795,11 @@
       }
     },
     "node_modules/@contentful/f36-tabs": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.67.2.tgz",
-      "integrity": "sha512-rPPJQHmCoD8492yKufelL7MCj0j4FqcPc5yFhD29sqpGDqTko8Xf/V/q4/LPYUtXttH8myfTINEyNTsR/lZINg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.67.1.tgz",
+      "integrity": "sha512-2Nd1UCdBArAWKDvFOgGdd+KV+4SdHGpnx253FEMT4jsRnxeirw/qK+Pn5fBUK5f+KC8ShmxUMpH3Qjf2JTHi9w==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@radix-ui/react-tabs": "^1.0.1",
         "emotion": "^10.0.17"
@@ -2850,11 +2810,11 @@
       }
     },
     "node_modules/@contentful/f36-text-link": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.67.2.tgz",
-      "integrity": "sha512-mWE4KsqQV93SNAFtYWqQB61/TLHuX1D3vVJ1rFqAp1kndPy7UyGcrQrGoPmM1l20Y9YaYIWYwo5eGKygY3iwIA==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.67.1.tgz",
+      "integrity": "sha512-SSwbr0ZZoBrXrBwwfCvZIYOh+9yu+J71qgv7dl3jqo0i9bautc6sAIRrrhjT8C0rcUTi6/HRzi0w882ORCgaEg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2869,11 +2829,11 @@
       "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
     },
     "node_modules/@contentful/f36-tooltip": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.67.2.tgz",
-      "integrity": "sha512-BFSKsJySAK1ipIOXueq6rgsJlmZDVBd60fjicALWiVX/GnxyDO3OkdX8nfK4Id0rbllf8+WBSR5UcVzNjuLe4Q==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.67.1.tgz",
+      "integrity": "sha512-i/FO4F9UHVggL0ScMrayZ6p1rs9oFGhUVZ4B3TKtrVRKXNfFQIzwXFPY45/ZAzdfgxdn90XCvMEo2j86l3fWXA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -2887,11 +2847,11 @@
       }
     },
     "node_modules/@contentful/f36-typography": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.67.2.tgz",
-      "integrity": "sha512-zfCVUQfD5wueT4mFNxLO+2SaUTFVHxE+7v8YKt53SvIiN+s/vXJnABOKPZsjYAYkwQwSrwPYIdIxMtaULwjoCw==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.67.1.tgz",
+      "integrity": "sha512-VES06vg9Bnp09IvJm8yea//IgI2m4aCz5weSD+LUV+vpjtBMM/0w+95cP67KvS6Rg3sEr3yx1bja8gSoTDahpw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
@@ -4829,18 +4789,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@phosphor-icons/react": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.1.7.tgz",
-      "integrity": "sha512-g2e2eVAn1XG2a+LI09QU3IORLhnFNAFkNbo2iwbX6NOKSLOwvEMmTa7CgOzEbgNWR47z8i8kwjdvYZ5fkGx1mQ==",
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": ">= 16.8",
-        "react-dom": ">= 16.8"
       }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {

--- a/examples/function-potterdb/package.json
+++ b/examples/function-potterdb/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@contentful/app-sdk": "^4.28.0",
-    "@contentful/f36-components": "4.67.2",
+    "@contentful/f36-components": "4.67.1",
     "@contentful/f36-icons": "^4.28.2",
     "@contentful/f36-tokens": "4.0.5",
     "@contentful/field-editor-single-line": "^1.4.2",

--- a/examples/javascript/package-lock.json
+++ b/examples/javascript/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@contentful/app-sdk": "^4.28.0",
-        "@contentful/f36-components": "4.67.2",
+        "@contentful/f36-components": "4.67.1",
         "@contentful/f36-tokens": "4.0.5",
         "@contentful/react-apps-toolkit": "1.2.16",
         "contentful-management": "10.46.4",
@@ -2051,15 +2051,15 @@
       }
     },
     "node_modules/@contentful/f36-accordion": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.67.2.tgz",
-      "integrity": "sha512-cX7xIX+fZadUNNFG+uzAOXeZ/GkMs+Y0bvgpxkpqW3ILu6GIXHsXetnRocxVaYUrQ1C/k6wEsd4xSv5y2uQBIg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.67.1.tgz",
+      "integrity": "sha512-rIGmO28PcSdfyUpaPfpeMO8qT/y8wMpQcyASHIUY8m6YRrn97vIlfDMQlzuyfoDBXQI3Lkza5RzbEFQVu7capg==",
       "dependencies": {
-        "@contentful/f36-collapse": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-collapse": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2068,15 +2068,15 @@
       }
     },
     "node_modules/@contentful/f36-asset": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.67.2.tgz",
-      "integrity": "sha512-cUQaZQeXIr3oLy255cuL+mXNiYOpMvAzW7BxE3l903ShzlwVFqZr/FIaWAo2t488sWbGeXNXxVBcEbLzQUMIdA==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.67.1.tgz",
+      "integrity": "sha512-BVRtLKxj/S+dGVJ0b88PVpBxE8mLiqDYATlE62Yb22CpncFpb9Kt7IRLto4KnD+SHZAJMORhoMNk7bQc103Dyw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-icon": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2085,18 +2085,18 @@
       }
     },
     "node_modules/@contentful/f36-autocomplete": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.67.2.tgz",
-      "integrity": "sha512-1cZHVa2cskh4DvachcgaQeEuyjuAlxvvyJCqvpHpP+R3ISS6CsC44252fH52NcLryvfFG1zX24nZECgFOY/S+A==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.67.1.tgz",
+      "integrity": "sha512-2aTKX92Q3HyVFexMkjkVw3D7wxTsxB/JJgT8Cy14b22leFk6Dup1Ui8Kt0LkjLYTX9vP3fru8XQ0cae4bCMsfQ==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-forms": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-popover": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-popover": "^4.67.1",
+        "@contentful/f36-skeleton": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "@contentful/f36-utils": "^4.24.3",
         "downshift": "^6.1.12",
         "emotion": "^10.0.17"
@@ -2107,15 +2107,15 @@
       }
     },
     "node_modules/@contentful/f36-avatar": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-avatar/-/f36-avatar-4.67.2.tgz",
-      "integrity": "sha512-bKxmWgi67V6tPCX2mlSxJKtQ8IANoO7jU9qH74Fqe11ATgG84Oqy9iQgjJDQvfFMjyT9n+3zUtUCwo/waHHrQg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-avatar/-/f36-avatar-4.67.1.tgz",
+      "integrity": "sha512-NaUNIFvinF1m3Tr7Gaj3/NREOf1ZYIobKLrtUMzbP0ULezHVvwUxGXbpDOAbLSt9jis9mvvrodBDvRJvmESiAw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-image": "4.67.2",
-        "@contentful/f36-menu": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-image": "4.67.1",
+        "@contentful/f36-menu": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.5",
-        "@contentful/f36-tooltip": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2124,11 +2124,11 @@
       }
     },
     "node_modules/@contentful/f36-badge": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.67.2.tgz",
-      "integrity": "sha512-cWfb3Nk9+CdgmTvc75gzD6uJ4XCbK23pB1t9BV9ZvytvnuaQElZYh7WciyRKJtU51khb0KOuVCb/TOnjecU4xQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.67.1.tgz",
+      "integrity": "sha512-jl944fd93dWrjdy853lGd4RSGtffij7PompadRsw1pbVqsKv5TmIlNGRr253EH4HN8+zIyJo5GTGHXCD9qV9Vw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
@@ -2139,12 +2139,12 @@
       }
     },
     "node_modules/@contentful/f36-button": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.67.2.tgz",
-      "integrity": "sha512-1/1dYtgfVk3wiP5SoaoQEWlM7VYp/Pju17agu5Y0MGuGo7LwjTCzLJQ4OeRvdubTYCW+iXc20sEG2H3OyRoz6w==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.67.1.tgz",
+      "integrity": "sha512-MnL1jFulLgM4ilDG2p06+bpv3dPFRSmjuDb6VlVdZx3JEtMJOK0fxIb1ylSHAE8AHJRDC64iArFCSoiz5zR6Rw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-spinner": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-spinner": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
@@ -2155,22 +2155,22 @@
       }
     },
     "node_modules/@contentful/f36-card": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.67.2.tgz",
-      "integrity": "sha512-f1Ck9hbbfdX7/OIWPfXJSdriDVjoTQOdz4aXo1QVd2fmsTAzQCfH0llwXtCk8TCg4DbSwaS/ldB/CJV3oCN1AA==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.67.1.tgz",
+      "integrity": "sha512-MarYmNmHM5WN9WEIsGAQywaQPethxjIGFI+LbttCP++HzEhY2xlJiQTLwy+X8sW+IncY5TE31AkF+EFkjODGEA==",
       "dependencies": {
-        "@contentful/f36-asset": "^4.67.2",
-        "@contentful/f36-badge": "^4.67.2",
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
+        "@contentful/f36-asset": "^4.67.1",
+        "@contentful/f36-badge": "^4.67.1",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-drag-handle": "^4.67.1",
+        "@contentful/f36-icon": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-menu": "^4.67.1",
+        "@contentful/f36-skeleton": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.1",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17",
         "truncate": "^3.0.0"
       },
@@ -2180,11 +2180,11 @@
       }
     },
     "node_modules/@contentful/f36-collapse": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.67.2.tgz",
-      "integrity": "sha512-EWkl653S3gnhVkq39Z0vDrIHQxvqJnN9XfrrORpX56ZCc4kHs1MzbbbDjnlj3udCy9Cj4Q50hiXpmeO/JogDlg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.67.1.tgz",
+      "integrity": "sha512-9oi/gUTgJTHEn8EoLsKQKd9JtaT5RkY7GZDKccztmWOhkkq9OZQyEgf3msw401CDGwp/pr/RdijjdvZNBFSIwA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2194,47 +2194,47 @@
       }
     },
     "node_modules/@contentful/f36-components": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.67.2.tgz",
-      "integrity": "sha512-JNBX8YzP+mt2/d2m5uUnpFLGnzyRAsggWpEBUe8QgPRwkJ8bZIDrnm2TELIFqrY2t4Lvs2AJw8L/3kDaJvMNCQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.67.1.tgz",
+      "integrity": "sha512-9p4MxsywvLbwX90HgqQI8FQJx9iOjqkC4bAIGLDbjI1CuuKhzACUSAkRvAYhO7N7ZR7c1Vrjr4pvYU7xy4+siw==",
       "dependencies": {
-        "@contentful/f36-accordion": "^4.67.2",
-        "@contentful/f36-asset": "^4.67.2",
-        "@contentful/f36-autocomplete": "^4.67.2",
-        "@contentful/f36-avatar": "4.67.2",
-        "@contentful/f36-badge": "^4.67.2",
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-card": "^4.67.2",
-        "@contentful/f36-collapse": "^4.67.2",
-        "@contentful/f36-copybutton": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-datepicker": "^4.67.2",
-        "@contentful/f36-datetime": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-empty-state": "^4.67.2",
-        "@contentful/f36-entity-list": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
-        "@contentful/f36-header": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
+        "@contentful/f36-accordion": "^4.67.1",
+        "@contentful/f36-asset": "^4.67.1",
+        "@contentful/f36-autocomplete": "^4.67.1",
+        "@contentful/f36-avatar": "4.67.1",
+        "@contentful/f36-badge": "^4.67.1",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-card": "^4.67.1",
+        "@contentful/f36-collapse": "^4.67.1",
+        "@contentful/f36-copybutton": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-datepicker": "^4.67.1",
+        "@contentful/f36-datetime": "^4.67.1",
+        "@contentful/f36-drag-handle": "^4.67.1",
+        "@contentful/f36-empty-state": "^4.67.1",
+        "@contentful/f36-entity-list": "^4.67.1",
+        "@contentful/f36-forms": "^4.67.1",
+        "@contentful/f36-header": "^4.67.1",
+        "@contentful/f36-icon": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-image": "4.67.2",
-        "@contentful/f36-list": "^4.67.2",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-modal": "^4.67.2",
-        "@contentful/f36-navbar": "^4.67.2",
-        "@contentful/f36-note": "^4.67.2",
-        "@contentful/f36-notification": "^4.67.2",
-        "@contentful/f36-pagination": "^4.67.2",
-        "@contentful/f36-pill": "^4.67.2",
-        "@contentful/f36-popover": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
-        "@contentful/f36-spinner": "^4.67.2",
-        "@contentful/f36-table": "^4.67.2",
-        "@contentful/f36-tabs": "^4.67.2",
-        "@contentful/f36-text-link": "^4.67.2",
+        "@contentful/f36-image": "4.67.1",
+        "@contentful/f36-list": "^4.67.1",
+        "@contentful/f36-menu": "^4.67.1",
+        "@contentful/f36-modal": "^4.67.1",
+        "@contentful/f36-navbar": "^4.67.1",
+        "@contentful/f36-note": "^4.67.1",
+        "@contentful/f36-notification": "^4.67.1",
+        "@contentful/f36-pagination": "^4.67.1",
+        "@contentful/f36-pill": "^4.67.1",
+        "@contentful/f36-popover": "^4.67.1",
+        "@contentful/f36-skeleton": "^4.67.1",
+        "@contentful/f36-spinner": "^4.67.1",
+        "@contentful/f36-table": "^4.67.1",
+        "@contentful/f36-tabs": "^4.67.1",
+        "@contentful/f36-text-link": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.1",
+        "@contentful/f36-typography": "^4.67.1",
         "@contentful/f36-utils": "^4.24.3"
       },
       "peerDependencies": {
@@ -2253,15 +2253,15 @@
       }
     },
     "node_modules/@contentful/f36-copybutton": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.67.2.tgz",
-      "integrity": "sha512-hb/DCGE6TTdepsjZvmDgog1glfF8WxGCx+F1S7FbwTZ4NutWeHEa7+E63t2tELTRx07FoVmkICmPtp89mCXKEw==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.67.1.tgz",
+      "integrity": "sha512-riw5JBm4X8jTZH8ZZa7Acfc+ef5QOZhNoc4xfi63gIuiC96pa3s0eBlWogBXjJStm6hQcr1IDbg+o4hRgh0uwg==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2270,9 +2270,9 @@
       }
     },
     "node_modules/@contentful/f36-core": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.67.2.tgz",
-      "integrity": "sha512-iSzA/OuhU4rIlBOlUTIczMuqDQZqLR1tmZJtZyouhfWkEc0VGUCX6S2FnBEXlMbnMzaL70lTXYUNu2bKxK4PfA==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.67.1.tgz",
+      "integrity": "sha512-qeBBaRoqCi3sUMKwJF1g3MQ6jawCGTZROMkjkb2+P6GpmNitbeFBW/J0VJY2g/ixCMN5NORSyf/1CBRMXFwUOw==",
       "dependencies": {
         "@contentful/f36-tokens": "^4.0.4",
         "@emotion/core": "^10.1.1",
@@ -2291,17 +2291,17 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/@contentful/f36-datepicker": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.67.2.tgz",
-      "integrity": "sha512-qGfVEjdZaMwdDBr1uWfgQtnCd8L+ZyVBpFiI8TyFUdQd6L9blHexr99Wg12uBNSub9zaL5fs4wrHZ5vMpGEjGQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.67.1.tgz",
+      "integrity": "sha512-ftHXPc6+hL8E5rkLxTPI9uk/kaAyEhl+ClqLapmd3AyaNrfVojAYJ9Bhe62GIz1gFU0bMXukslCU8xwbrdlFQA==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-forms": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-popover": "^4.67.2",
+        "@contentful/f36-popover": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "date-fns": "^2.28.0",
         "emotion": "^10.0.17",
         "react-day-picker": "^8.7.1",
@@ -2313,11 +2313,11 @@
       }
     },
     "node_modules/@contentful/f36-datetime": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.67.2.tgz",
-      "integrity": "sha512-7kz4I/CzRkupPb43dtAQ3a1bHffdx3ZQ0i9ueUl9CSs+dKhl9gwiH0bmoNN5pnULAQF4i7WQmNueEfQvh9zgvA==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.67.1.tgz",
+      "integrity": "sha512-WlJTeOpyxjxoVWY5DSF9RzkqnAc+80XMo00b0vN2XKc9lKLozMgFrApTeUSZGTcPX0ymKjEdJGqqP/d2o/YbGg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "dayjs": "^1.11.5",
         "emotion": "^10.0.17"
@@ -2328,11 +2328,11 @@
       }
     },
     "node_modules/@contentful/f36-drag-handle": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.67.2.tgz",
-      "integrity": "sha512-7e38V/dJ79m4uVlnf1H1xpRY28DPwaMQOMgFWwPKCdketfr+YU8KI7kE2ssrd1EsM9av7Z0Dcwz6pF89wuxViA==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.67.1.tgz",
+      "integrity": "sha512-wO5ru3zl3qm5KtAylWYQCvdeE0TLda+3gXCMxeNHyJTOcW2/vSB6L31T9zVihFRK/5vgDvGWkcTt/R17OW+qzg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
@@ -2344,12 +2344,12 @@
       }
     },
     "node_modules/@contentful/f36-empty-state": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.67.2.tgz",
-      "integrity": "sha512-ghzqNmwAOv0mAUvXDyLLtlAOXj5RPas/stJ8etPpb339NGFj5ueYf9+EBrgTCWrMK/JCBhcogV5bgKRsc9VKlg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.67.1.tgz",
+      "integrity": "sha512-VPiAfHYCJr3DdhrXXgKzTIKnXZgjugrKwtGbyJQX7cRmwnNRjZCMwMl3F0pPvhPAfI1rzwZzm/wqAtWeBsN51A==",
       "dependencies": {
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2358,21 +2358,20 @@
       }
     },
     "node_modules/@contentful/f36-entity-list": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.67.2.tgz",
-      "integrity": "sha512-G37dKH3yRD++fOA924UROtZdeIiNFmrjfVOobC03jdvk6o21AN2kMyDzML2Uc0+kMg+ofe4G08KC/OmDSUkSAg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.67.1.tgz",
+      "integrity": "sha512-JFxQ2v+Vi6jgPxIkWfiKPPt5U+RKF5hEqHX6Xxndcgcjg0aamb7iJ3rR8mln9cWULIqPJhSTawQujeBgonLktw==",
       "dependencies": {
-        "@contentful/f36-badge": "^4.67.2",
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
+        "@contentful/f36-badge": "^4.67.1",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-drag-handle": "^4.67.1",
+        "@contentful/f36-icon": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-icons-alpha": "npm:@contentful/f36-icons@^5.0.0-alpha.26",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-menu": "^4.67.1",
+        "@contentful/f36-skeleton": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2381,14 +2380,14 @@
       }
     },
     "node_modules/@contentful/f36-forms": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.67.2.tgz",
-      "integrity": "sha512-+XxpnCiBKtZw2hYo5QZWVayWMPKzbarOIWzZUMm6Ttoru00zn5u3tlvue7c9W2zqkNFuUNOopAwXBwQ0h+z+bQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.67.1.tgz",
+      "integrity": "sha512-YRifViI6tLRoJyc3kaAy7TM6gjAoDiaFYfv0k42mEMAC5XOkEwFVHORpRkfCDrYwEC7Zk9crEdOy0vfZ3QlH0Q==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
@@ -2398,15 +2397,15 @@
       }
     },
     "node_modules/@contentful/f36-header": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-header/-/f36-header-4.67.2.tgz",
-      "integrity": "sha512-DjI5JnJuXixG8bAj03lRvISuAgwA2X6PnYifa//967Dd0qQTBw/CkB96AhrgVUjTw+jt3xAprwv0SUKF8x9S8g==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-header/-/f36-header-4.67.1.tgz",
+      "integrity": "sha512-8eith4p/4tc5ZSVPQkWfd4jBNDOq3iSTbBW7jeyB9p+oeB/0cOpJCfjB1RwUTvBamn+MrKnLNtt/TkUa+7C9aw==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.2",
         "@contentful/f36-tokens": "^4.0.5",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2415,32 +2414,13 @@
       }
     },
     "node_modules/@contentful/f36-icon": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.67.2.tgz",
-      "integrity": "sha512-vJAk6KO88GVnHdPSXurUA67F4wl01sZHaaE5eHGvt/s+YuI47dstgROr5+z66qmncKpcMWOTv4/+jqYV1Ko56A==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.67.1.tgz",
+      "integrity": "sha512-Exug8bPfTv0JY2rs7ZxuG9IsrLcQLG0SV7LC76INMwwOIdLWiRFK4k+Se2Or9Ox9ga2pBEPlWr5hBBSgPSj6Gw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-icon-alpha": {
-      "name": "@contentful/f36-icon",
-      "version": "5.0.0-alpha.20",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-5.0.0-alpha.20.tgz",
-      "integrity": "sha512-kI7HJggp/H8whiUL/RrG988nEvQq2SuZVyQn4kyiWYSlMWBRqQXZRvXfsM/RILWMgz2LxryXaT1YGVy2E4UfJA==",
-      "dependencies": {
-        "@contentful/f36-core": "^4.65.4",
-        "@contentful/f36-tokens": "^4.0.4",
-        "@phosphor-icons/react": "^2.1.5",
-        "emotion": "^10.0.17"
-      },
-      "engines": {
-        "node": ">=16"
       },
       "peerDependencies": {
         "react": ">=16.8",
@@ -2462,33 +2442,13 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/@contentful/f36-icons-alpha": {
-      "name": "@contentful/f36-icons",
-      "version": "5.0.0-alpha.29",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-5.0.0-alpha.29.tgz",
-      "integrity": "sha512-7QhDDAo95WiqFwB/ofWd57GEyeLgkDU/CgTStjhtBZssheMvVT6thiIFy6hSbo314d1RZ5Z8EBzH1MIJ/nyQhA==",
+    "node_modules/@contentful/f36-image": {
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-image/-/f36-image-4.67.1.tgz",
+      "integrity": "sha512-FYoeHHAWrRG2YuCXl7VifRjAkDXijENzhV1bgD38eKtBpLbmnnJm+vxbQRAKBvkkwLwFEHvVsdZ2XBoCs6WgmA==",
       "dependencies": {
         "@contentful/f36-core": "^4.67.1",
-        "@contentful/f36-icon-alpha": "npm:@contentful/f36-icon@5.0.0-alpha.20",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@phosphor-icons/react": "^2.1.4",
-        "emotion": "^10.0.17"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-image": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-image/-/f36-image-4.67.2.tgz",
-      "integrity": "sha512-zB4D/fBmUyIj1WvF2tWQHsDxzTcZ+KOyiVu0483rxRNai8sae7BO3VSuevUzfi2Y+gaF3VCasPZudjgTeWD2pQ==",
-      "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-skeleton": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.5",
         "emotion": "^10.0.17"
       },
@@ -2498,11 +2458,11 @@
       }
     },
     "node_modules/@contentful/f36-list": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.67.2.tgz",
-      "integrity": "sha512-ZkObExturTfxpNZOBcHJMozuLIbDLe8Us5qe4qJyVozIBH+Ol6xOHxEEyEu8GsRZp0+GU7K3fWExqLEV22oSUQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.67.1.tgz",
+      "integrity": "sha512-WLSyAWDjjr+DHrh5pOIGMlWKeWxyxu1HPlwI/deQEmr/PXjuPLMewH393+HE3LJbrWwpqU3J/U+v1H62XTbFCg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2512,15 +2472,15 @@
       }
     },
     "node_modules/@contentful/f36-menu": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.67.2.tgz",
-      "integrity": "sha512-TF+tpTLqE22qeQTYHJFuxCm6Yt37VFtwM6X9O07GYTeXeDZE7ZI+FrA16y+fxFw2Zu0OpbLO0CWB/ViolvMlOw==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.67.1.tgz",
+      "integrity": "sha512-M9UOD8sEwyPHP9gpDkTgXCeFwpS2cZMI0zoNOr/9vxY/XaLR3iN2W4D+FXtD71FVxy83Fs+ap12gTyKBn7dY6w==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-popover": "^4.67.2",
+        "@contentful/f36-popover": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
@@ -2530,15 +2490,15 @@
       }
     },
     "node_modules/@contentful/f36-modal": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.67.2.tgz",
-      "integrity": "sha512-mrO5+mKytV/j759HI0y6fZskQG/EEY7iNaRjjeYmFRoT6MAgViebcIeht15CcFwnNQLAeS3MusvXiEzuUzweiQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.67.1.tgz",
+      "integrity": "sha512-10LfRE5sKz9QJpSP7D8/PQDpOpq+5086HK51uKUnuPZeszXYfRUgRWTcfkkPvaihqGGx0JZLiRNvGFOBYWVP1A==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "@types/react-modal": "^3.13.1",
         "emotion": "^10.0.17",
         "react-modal": "^3.16.1"
@@ -2549,16 +2509,16 @@
       }
     },
     "node_modules/@contentful/f36-navbar": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-navbar/-/f36-navbar-4.67.2.tgz",
-      "integrity": "sha512-58PYpIElqnfdYWpEkSaOmccSzcgudYUs009UWmtqHmv0n3c8eNoV8taoZdg92gYAsEc7G2VWl4AZ3wJy/kiAdg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-navbar/-/f36-navbar-4.67.1.tgz",
+      "integrity": "sha512-kvlQ+jEyPxuFqtO6itMCSQbNZFFTInTJOi7xtYGTC07S49Gn22/Nb9GNJ7lT9pzTm4q0ss+Q+Xv/PtyVsSGnHg==",
       "dependencies": {
-        "@contentful/f36-avatar": "4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
+        "@contentful/f36-avatar": "4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-icon": "^4.67.1",
         "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-menu": "^4.67.1",
+        "@contentful/f36-skeleton": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.1",
         "@contentful/f36-utils": "^4.23.2",
         "emotion": "^10.0.17"
@@ -2569,16 +2529,16 @@
       }
     },
     "node_modules/@contentful/f36-note": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.67.2.tgz",
-      "integrity": "sha512-DA0f1/j640SG3LOon1VcU6kDvNgUHxupH0Q1FXS01aRrWq12uMd2bLtb2k5A9qRyT6MB3OdAKFufwsBcSL6fYw==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.67.1.tgz",
+      "integrity": "sha512-6rhGqt5MdH53XXNVbIo9cqmswjSzonHSZ5FdqrJ+rF6uOOghT+zzQCq65PRIBufihvZVh/mD/7vVjCpD6BxnnQ==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-icon": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2587,16 +2547,16 @@
       }
     },
     "node_modules/@contentful/f36-notification": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.67.2.tgz",
-      "integrity": "sha512-x7qxuqOhQMyhhRfMrisAVXnAo/eL6A7RjL2PmTLylaqKrFnzDrr25BtzepdkgULj9VLh70vXM5QIzPwpKpIJBQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.67.1.tgz",
+      "integrity": "sha512-JPYhOqz0rsipqHrtSoWnuPkrqndRz7XX72/0Mfj3dWV4MAK78rxVAQl17qDVliRZTp9NtWXBYseJiPhOsfAw+Q==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-text-link": "^4.67.2",
+        "@contentful/f36-text-link": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "@swc/helpers": "^0.4.14",
         "emotion": "^10.0.17",
         "react-animate-height": "^3.0.4"
@@ -2607,16 +2567,16 @@
       }
     },
     "node_modules/@contentful/f36-pagination": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.67.2.tgz",
-      "integrity": "sha512-/UePF1fbr2wvJHtJ9ncWaz5eg/VTdA8VqEBFJXge/IBgPVyMgQxQRxSDhvMj0j2Iit90qAzPedEDZK+jp6CyTg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.67.1.tgz",
+      "integrity": "sha512-NgK22JvCtBvBfE5NeKFRqtLIoeY6CXDTpKpSu70QZxWp4C/z9U7qhyr0d12SHYgFFUJwnAl67A5qaEyth2NvJw==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-forms": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2625,16 +2585,16 @@
       }
     },
     "node_modules/@contentful/f36-pill": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.67.2.tgz",
-      "integrity": "sha512-015oRkVVnshvWAJ/kR5yJBD+soWmDcHFy5FGXDaIR5moTCejjqiLG1g8H6MolaF8oeKSOhbhgfX/dpEHn5/Z4g==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.67.1.tgz",
+      "integrity": "sha512-Ycn1bkAtNlc2FOFuwiSlDK3rgVgPruHXG6m+dla8Hp/ZL/MH2xUcQqir3SlLCZeR+gSx1cuzI9ga8/UjsKf1qQ==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-drag-handle": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2643,11 +2603,11 @@
       }
     },
     "node_modules/@contentful/f36-popover": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.67.2.tgz",
-      "integrity": "sha512-NJx54sqQEmuWIsBySXf/B+ZW/RoIkRzb7cnQ5aucN3nUd4ZaHOvcmYVLJMqfCV8ipzpMxLgoc8p3v6OcRdi72A==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.67.1.tgz",
+      "integrity": "sha512-loWXCV7BswsBvcBENRzEbMCjITodK5RnT7DNSeaZvvhOa87Gp+aCcGIpHaS0Jxrhy3OvUOdPxaRUXmoMkrP7Hg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -2660,12 +2620,12 @@
       }
     },
     "node_modules/@contentful/f36-skeleton": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.67.2.tgz",
-      "integrity": "sha512-4T8r/G8b9DFkLErIo8d2cGS71tWy1yNDZIThoHBWIhLRcstal8K7Ag5dQwPsaoSew/859oXC2rvPP0Ep+4FtCg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.67.1.tgz",
+      "integrity": "sha512-hJR/M6u2al75mCMJcdR9xxRfKQdqqFvsRY6mbwYO6bZ+6odYhMqoRNR1C0WK7+uWlEDYUlOnF7+T2vfRB4IfVg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-table": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-table": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2675,11 +2635,11 @@
       }
     },
     "node_modules/@contentful/f36-spinner": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.67.2.tgz",
-      "integrity": "sha512-sBitcudBc4DwAOPn6MLuArLje7aym47GoIDI0kN9zQtolVwlVH92/zNpZmnm+zbP4Ku56/TgbL/v5SFTh+YB2w==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.67.1.tgz",
+      "integrity": "sha512-KCyPb37/Xvr51b6gibw//yLm16uN7+z505+z2B2YH53t70+uIgADKtS7APtaMCbVH6fliVa9/GkXE3WYv/xJhA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2689,14 +2649,14 @@
       }
     },
     "node_modules/@contentful/f36-table": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.67.2.tgz",
-      "integrity": "sha512-YtUkXwFmBLgAi5Glgi1vXqNbr+U2riadB9O+Aq8t2R/vpXMCIA4WlmXSqunwPW9UrrilalrK49l0IkDNpcRUbQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.67.1.tgz",
+      "integrity": "sha512-/UtSfNFwnjGCSLcxeGGBI5Dz/isQsgNNeFJyo2I+xcYPPehZ9o6eHf0+CeRuIW3+OCXYAyliydig+/T+le3/rA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2705,11 +2665,11 @@
       }
     },
     "node_modules/@contentful/f36-tabs": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.67.2.tgz",
-      "integrity": "sha512-rPPJQHmCoD8492yKufelL7MCj0j4FqcPc5yFhD29sqpGDqTko8Xf/V/q4/LPYUtXttH8myfTINEyNTsR/lZINg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.67.1.tgz",
+      "integrity": "sha512-2Nd1UCdBArAWKDvFOgGdd+KV+4SdHGpnx253FEMT4jsRnxeirw/qK+Pn5fBUK5f+KC8ShmxUMpH3Qjf2JTHi9w==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@radix-ui/react-tabs": "^1.0.1",
         "emotion": "^10.0.17"
@@ -2720,11 +2680,11 @@
       }
     },
     "node_modules/@contentful/f36-text-link": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.67.2.tgz",
-      "integrity": "sha512-mWE4KsqQV93SNAFtYWqQB61/TLHuX1D3vVJ1rFqAp1kndPy7UyGcrQrGoPmM1l20Y9YaYIWYwo5eGKygY3iwIA==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.67.1.tgz",
+      "integrity": "sha512-SSwbr0ZZoBrXrBwwfCvZIYOh+9yu+J71qgv7dl3jqo0i9bautc6sAIRrrhjT8C0rcUTi6/HRzi0w882ORCgaEg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2739,11 +2699,11 @@
       "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
     },
     "node_modules/@contentful/f36-tooltip": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.67.2.tgz",
-      "integrity": "sha512-BFSKsJySAK1ipIOXueq6rgsJlmZDVBd60fjicALWiVX/GnxyDO3OkdX8nfK4Id0rbllf8+WBSR5UcVzNjuLe4Q==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.67.1.tgz",
+      "integrity": "sha512-i/FO4F9UHVggL0ScMrayZ6p1rs9oFGhUVZ4B3TKtrVRKXNfFQIzwXFPY45/ZAzdfgxdn90XCvMEo2j86l3fWXA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -2762,11 +2722,11 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/@contentful/f36-typography": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.67.2.tgz",
-      "integrity": "sha512-zfCVUQfD5wueT4mFNxLO+2SaUTFVHxE+7v8YKt53SvIiN+s/vXJnABOKPZsjYAYkwQwSrwPYIdIxMtaULwjoCw==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.67.1.tgz",
+      "integrity": "sha512-VES06vg9Bnp09IvJm8yea//IgI2m4aCz5weSD+LUV+vpjtBMM/0w+95cP67KvS6Rg3sEr3yx1bja8gSoTDahpw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
@@ -3904,18 +3864,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@phosphor-icons/react": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.1.7.tgz",
-      "integrity": "sha512-g2e2eVAn1XG2a+LI09QU3IORLhnFNAFkNbo2iwbX6NOKSLOwvEMmTa7CgOzEbgNWR47z8i8kwjdvYZ5fkGx1mQ==",
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": ">= 16.8",
-        "react-dom": ">= 16.8"
       }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -20432,178 +20380,178 @@
       }
     },
     "@contentful/f36-accordion": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.67.2.tgz",
-      "integrity": "sha512-cX7xIX+fZadUNNFG+uzAOXeZ/GkMs+Y0bvgpxkpqW3ILu6GIXHsXetnRocxVaYUrQ1C/k6wEsd4xSv5y2uQBIg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.67.1.tgz",
+      "integrity": "sha512-rIGmO28PcSdfyUpaPfpeMO8qT/y8wMpQcyASHIUY8m6YRrn97vIlfDMQlzuyfoDBXQI3Lkza5RzbEFQVu7capg==",
       "requires": {
-        "@contentful/f36-collapse": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-collapse": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-asset": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.67.2.tgz",
-      "integrity": "sha512-cUQaZQeXIr3oLy255cuL+mXNiYOpMvAzW7BxE3l903ShzlwVFqZr/FIaWAo2t488sWbGeXNXxVBcEbLzQUMIdA==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.67.1.tgz",
+      "integrity": "sha512-BVRtLKxj/S+dGVJ0b88PVpBxE8mLiqDYATlE62Yb22CpncFpb9Kt7IRLto4KnD+SHZAJMORhoMNk7bQc103Dyw==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-icon": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-autocomplete": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.67.2.tgz",
-      "integrity": "sha512-1cZHVa2cskh4DvachcgaQeEuyjuAlxvvyJCqvpHpP+R3ISS6CsC44252fH52NcLryvfFG1zX24nZECgFOY/S+A==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.67.1.tgz",
+      "integrity": "sha512-2aTKX92Q3HyVFexMkjkVw3D7wxTsxB/JJgT8Cy14b22leFk6Dup1Ui8Kt0LkjLYTX9vP3fru8XQ0cae4bCMsfQ==",
       "requires": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-forms": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-popover": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-popover": "^4.67.1",
+        "@contentful/f36-skeleton": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "@contentful/f36-utils": "^4.24.3",
         "downshift": "^6.1.12",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-avatar": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-avatar/-/f36-avatar-4.67.2.tgz",
-      "integrity": "sha512-bKxmWgi67V6tPCX2mlSxJKtQ8IANoO7jU9qH74Fqe11ATgG84Oqy9iQgjJDQvfFMjyT9n+3zUtUCwo/waHHrQg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-avatar/-/f36-avatar-4.67.1.tgz",
+      "integrity": "sha512-NaUNIFvinF1m3Tr7Gaj3/NREOf1ZYIobKLrtUMzbP0ULezHVvwUxGXbpDOAbLSt9jis9mvvrodBDvRJvmESiAw==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-image": "4.67.2",
-        "@contentful/f36-menu": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-image": "4.67.1",
+        "@contentful/f36-menu": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.5",
-        "@contentful/f36-tooltip": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-badge": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.67.2.tgz",
-      "integrity": "sha512-cWfb3Nk9+CdgmTvc75gzD6uJ4XCbK23pB1t9BV9ZvytvnuaQElZYh7WciyRKJtU51khb0KOuVCb/TOnjecU4xQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.67.1.tgz",
+      "integrity": "sha512-jl944fd93dWrjdy853lGd4RSGtffij7PompadRsw1pbVqsKv5TmIlNGRr253EH4HN8+zIyJo5GTGHXCD9qV9Vw==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-button": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.67.2.tgz",
-      "integrity": "sha512-1/1dYtgfVk3wiP5SoaoQEWlM7VYp/Pju17agu5Y0MGuGo7LwjTCzLJQ4OeRvdubTYCW+iXc20sEG2H3OyRoz6w==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.67.1.tgz",
+      "integrity": "sha512-MnL1jFulLgM4ilDG2p06+bpv3dPFRSmjuDb6VlVdZx3JEtMJOK0fxIb1ylSHAE8AHJRDC64iArFCSoiz5zR6Rw==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-spinner": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-spinner": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-card": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.67.2.tgz",
-      "integrity": "sha512-f1Ck9hbbfdX7/OIWPfXJSdriDVjoTQOdz4aXo1QVd2fmsTAzQCfH0llwXtCk8TCg4DbSwaS/ldB/CJV3oCN1AA==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.67.1.tgz",
+      "integrity": "sha512-MarYmNmHM5WN9WEIsGAQywaQPethxjIGFI+LbttCP++HzEhY2xlJiQTLwy+X8sW+IncY5TE31AkF+EFkjODGEA==",
       "requires": {
-        "@contentful/f36-asset": "^4.67.2",
-        "@contentful/f36-badge": "^4.67.2",
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
+        "@contentful/f36-asset": "^4.67.1",
+        "@contentful/f36-badge": "^4.67.1",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-drag-handle": "^4.67.1",
+        "@contentful/f36-icon": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-menu": "^4.67.1",
+        "@contentful/f36-skeleton": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.1",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17",
         "truncate": "^3.0.0"
       }
     },
     "@contentful/f36-collapse": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.67.2.tgz",
-      "integrity": "sha512-EWkl653S3gnhVkq39Z0vDrIHQxvqJnN9XfrrORpX56ZCc4kHs1MzbbbDjnlj3udCy9Cj4Q50hiXpmeO/JogDlg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.67.1.tgz",
+      "integrity": "sha512-9oi/gUTgJTHEn8EoLsKQKd9JtaT5RkY7GZDKccztmWOhkkq9OZQyEgf3msw401CDGwp/pr/RdijjdvZNBFSIwA==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-components": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.67.2.tgz",
-      "integrity": "sha512-JNBX8YzP+mt2/d2m5uUnpFLGnzyRAsggWpEBUe8QgPRwkJ8bZIDrnm2TELIFqrY2t4Lvs2AJw8L/3kDaJvMNCQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.67.1.tgz",
+      "integrity": "sha512-9p4MxsywvLbwX90HgqQI8FQJx9iOjqkC4bAIGLDbjI1CuuKhzACUSAkRvAYhO7N7ZR7c1Vrjr4pvYU7xy4+siw==",
       "requires": {
-        "@contentful/f36-accordion": "^4.67.2",
-        "@contentful/f36-asset": "^4.67.2",
-        "@contentful/f36-autocomplete": "^4.67.2",
-        "@contentful/f36-avatar": "4.67.2",
-        "@contentful/f36-badge": "^4.67.2",
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-card": "^4.67.2",
-        "@contentful/f36-collapse": "^4.67.2",
-        "@contentful/f36-copybutton": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-datepicker": "^4.67.2",
-        "@contentful/f36-datetime": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-empty-state": "^4.67.2",
-        "@contentful/f36-entity-list": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
-        "@contentful/f36-header": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
+        "@contentful/f36-accordion": "^4.67.1",
+        "@contentful/f36-asset": "^4.67.1",
+        "@contentful/f36-autocomplete": "^4.67.1",
+        "@contentful/f36-avatar": "4.67.1",
+        "@contentful/f36-badge": "^4.67.1",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-card": "^4.67.1",
+        "@contentful/f36-collapse": "^4.67.1",
+        "@contentful/f36-copybutton": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-datepicker": "^4.67.1",
+        "@contentful/f36-datetime": "^4.67.1",
+        "@contentful/f36-drag-handle": "^4.67.1",
+        "@contentful/f36-empty-state": "^4.67.1",
+        "@contentful/f36-entity-list": "^4.67.1",
+        "@contentful/f36-forms": "^4.67.1",
+        "@contentful/f36-header": "^4.67.1",
+        "@contentful/f36-icon": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-image": "4.67.2",
-        "@contentful/f36-list": "^4.67.2",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-modal": "^4.67.2",
-        "@contentful/f36-navbar": "^4.67.2",
-        "@contentful/f36-note": "^4.67.2",
-        "@contentful/f36-notification": "^4.67.2",
-        "@contentful/f36-pagination": "^4.67.2",
-        "@contentful/f36-pill": "^4.67.2",
-        "@contentful/f36-popover": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
-        "@contentful/f36-spinner": "^4.67.2",
-        "@contentful/f36-table": "^4.67.2",
-        "@contentful/f36-tabs": "^4.67.2",
-        "@contentful/f36-text-link": "^4.67.2",
+        "@contentful/f36-image": "4.67.1",
+        "@contentful/f36-list": "^4.67.1",
+        "@contentful/f36-menu": "^4.67.1",
+        "@contentful/f36-modal": "^4.67.1",
+        "@contentful/f36-navbar": "^4.67.1",
+        "@contentful/f36-note": "^4.67.1",
+        "@contentful/f36-notification": "^4.67.1",
+        "@contentful/f36-pagination": "^4.67.1",
+        "@contentful/f36-pill": "^4.67.1",
+        "@contentful/f36-popover": "^4.67.1",
+        "@contentful/f36-skeleton": "^4.67.1",
+        "@contentful/f36-spinner": "^4.67.1",
+        "@contentful/f36-table": "^4.67.1",
+        "@contentful/f36-tabs": "^4.67.1",
+        "@contentful/f36-text-link": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.1",
+        "@contentful/f36-typography": "^4.67.1",
         "@contentful/f36-utils": "^4.24.3"
       }
     },
     "@contentful/f36-copybutton": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.67.2.tgz",
-      "integrity": "sha512-hb/DCGE6TTdepsjZvmDgog1glfF8WxGCx+F1S7FbwTZ4NutWeHEa7+E63t2tELTRx07FoVmkICmPtp89mCXKEw==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.67.1.tgz",
+      "integrity": "sha512-riw5JBm4X8jTZH8ZZa7Acfc+ef5QOZhNoc4xfi63gIuiC96pa3s0eBlWogBXjJStm6hQcr1IDbg+o4hRgh0uwg==",
       "requires": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-core": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.67.2.tgz",
-      "integrity": "sha512-iSzA/OuhU4rIlBOlUTIczMuqDQZqLR1tmZJtZyouhfWkEc0VGUCX6S2FnBEXlMbnMzaL70lTXYUNu2bKxK4PfA==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.67.1.tgz",
+      "integrity": "sha512-qeBBaRoqCi3sUMKwJF1g3MQ6jawCGTZROMkjkb2+P6GpmNitbeFBW/J0VJY2g/ixCMN5NORSyf/1CBRMXFwUOw==",
       "requires": {
         "@contentful/f36-tokens": "^4.0.4",
         "@emotion/core": "^10.1.1",
@@ -20620,17 +20568,17 @@
       }
     },
     "@contentful/f36-datepicker": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.67.2.tgz",
-      "integrity": "sha512-qGfVEjdZaMwdDBr1uWfgQtnCd8L+ZyVBpFiI8TyFUdQd6L9blHexr99Wg12uBNSub9zaL5fs4wrHZ5vMpGEjGQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.67.1.tgz",
+      "integrity": "sha512-ftHXPc6+hL8E5rkLxTPI9uk/kaAyEhl+ClqLapmd3AyaNrfVojAYJ9Bhe62GIz1gFU0bMXukslCU8xwbrdlFQA==",
       "requires": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-forms": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-popover": "^4.67.2",
+        "@contentful/f36-popover": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "date-fns": "^2.28.0",
         "emotion": "^10.0.17",
         "react-day-picker": "^8.7.1",
@@ -20638,22 +20586,22 @@
       }
     },
     "@contentful/f36-datetime": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.67.2.tgz",
-      "integrity": "sha512-7kz4I/CzRkupPb43dtAQ3a1bHffdx3ZQ0i9ueUl9CSs+dKhl9gwiH0bmoNN5pnULAQF4i7WQmNueEfQvh9zgvA==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.67.1.tgz",
+      "integrity": "sha512-WlJTeOpyxjxoVWY5DSF9RzkqnAc+80XMo00b0vN2XKc9lKLozMgFrApTeUSZGTcPX0ymKjEdJGqqP/d2o/YbGg==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "dayjs": "^1.11.5",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-drag-handle": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.67.2.tgz",
-      "integrity": "sha512-7e38V/dJ79m4uVlnf1H1xpRY28DPwaMQOMgFWwPKCdketfr+YU8KI7kE2ssrd1EsM9av7Z0Dcwz6pF89wuxViA==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.67.1.tgz",
+      "integrity": "sha512-wO5ru3zl3qm5KtAylWYQCvdeE0TLda+3gXCMxeNHyJTOcW2/vSB6L31T9zVihFRK/5vgDvGWkcTt/R17OW+qzg==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
@@ -20661,78 +20609,66 @@
       }
     },
     "@contentful/f36-empty-state": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.67.2.tgz",
-      "integrity": "sha512-ghzqNmwAOv0mAUvXDyLLtlAOXj5RPas/stJ8etPpb339NGFj5ueYf9+EBrgTCWrMK/JCBhcogV5bgKRsc9VKlg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.67.1.tgz",
+      "integrity": "sha512-VPiAfHYCJr3DdhrXXgKzTIKnXZgjugrKwtGbyJQX7cRmwnNRjZCMwMl3F0pPvhPAfI1rzwZzm/wqAtWeBsN51A==",
       "requires": {
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-entity-list": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.67.2.tgz",
-      "integrity": "sha512-G37dKH3yRD++fOA924UROtZdeIiNFmrjfVOobC03jdvk6o21AN2kMyDzML2Uc0+kMg+ofe4G08KC/OmDSUkSAg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.67.1.tgz",
+      "integrity": "sha512-JFxQ2v+Vi6jgPxIkWfiKPPt5U+RKF5hEqHX6Xxndcgcjg0aamb7iJ3rR8mln9cWULIqPJhSTawQujeBgonLktw==",
       "requires": {
-        "@contentful/f36-badge": "^4.67.2",
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
+        "@contentful/f36-badge": "^4.67.1",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-drag-handle": "^4.67.1",
+        "@contentful/f36-icon": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-icons-alpha": "npm:@contentful/f36-icons@^5.0.0-alpha.26",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-menu": "^4.67.1",
+        "@contentful/f36-skeleton": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-forms": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.67.2.tgz",
-      "integrity": "sha512-+XxpnCiBKtZw2hYo5QZWVayWMPKzbarOIWzZUMm6Ttoru00zn5u3tlvue7c9W2zqkNFuUNOopAwXBwQ0h+z+bQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.67.1.tgz",
+      "integrity": "sha512-YRifViI6tLRoJyc3kaAy7TM6gjAoDiaFYfv0k42mEMAC5XOkEwFVHORpRkfCDrYwEC7Zk9crEdOy0vfZ3QlH0Q==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-header": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-header/-/f36-header-4.67.2.tgz",
-      "integrity": "sha512-DjI5JnJuXixG8bAj03lRvISuAgwA2X6PnYifa//967Dd0qQTBw/CkB96AhrgVUjTw+jt3xAprwv0SUKF8x9S8g==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-header/-/f36-header-4.67.1.tgz",
+      "integrity": "sha512-8eith4p/4tc5ZSVPQkWfd4jBNDOq3iSTbBW7jeyB9p+oeB/0cOpJCfjB1RwUTvBamn+MrKnLNtt/TkUa+7C9aw==",
       "requires": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.2",
         "@contentful/f36-tokens": "^4.0.5",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-icon": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.67.2.tgz",
-      "integrity": "sha512-vJAk6KO88GVnHdPSXurUA67F4wl01sZHaaE5eHGvt/s+YuI47dstgROr5+z66qmncKpcMWOTv4/+jqYV1Ko56A==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.67.1.tgz",
+      "integrity": "sha512-Exug8bPfTv0JY2rs7ZxuG9IsrLcQLG0SV7LC76INMwwOIdLWiRFK4k+Se2Or9Ox9ga2pBEPlWr5hBBSgPSj6Gw==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "emotion": "^10.0.17"
-      }
-    },
-    "@contentful/f36-icon-alpha": {
-      "version": "npm:@contentful/f36-icon@5.0.0-alpha.20",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-5.0.0-alpha.20.tgz",
-      "integrity": "sha512-kI7HJggp/H8whiUL/RrG988nEvQq2SuZVyQn4kyiWYSlMWBRqQXZRvXfsM/RILWMgz2LxryXaT1YGVy2E4UfJA==",
-      "requires": {
-        "@contentful/f36-core": "^4.65.4",
-        "@contentful/f36-tokens": "^4.0.4",
-        "@phosphor-icons/react": "^2.1.5",
         "emotion": "^10.0.17"
       }
     },
@@ -20747,148 +20683,136 @@
         "emotion": "^10.0.17"
       }
     },
-    "@contentful/f36-icons-alpha": {
-      "version": "npm:@contentful/f36-icons@5.0.0-alpha.29",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-5.0.0-alpha.29.tgz",
-      "integrity": "sha512-7QhDDAo95WiqFwB/ofWd57GEyeLgkDU/CgTStjhtBZssheMvVT6thiIFy6hSbo314d1RZ5Z8EBzH1MIJ/nyQhA==",
+    "@contentful/f36-image": {
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-image/-/f36-image-4.67.1.tgz",
+      "integrity": "sha512-FYoeHHAWrRG2YuCXl7VifRjAkDXijENzhV1bgD38eKtBpLbmnnJm+vxbQRAKBvkkwLwFEHvVsdZ2XBoCs6WgmA==",
       "requires": {
         "@contentful/f36-core": "^4.67.1",
-        "@contentful/f36-icon-alpha": "npm:@contentful/f36-icon@5.0.0-alpha.20",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@phosphor-icons/react": "^2.1.4",
-        "emotion": "^10.0.17"
-      }
-    },
-    "@contentful/f36-image": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-image/-/f36-image-4.67.2.tgz",
-      "integrity": "sha512-zB4D/fBmUyIj1WvF2tWQHsDxzTcZ+KOyiVu0483rxRNai8sae7BO3VSuevUzfi2Y+gaF3VCasPZudjgTeWD2pQ==",
-      "requires": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-skeleton": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.5",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-list": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.67.2.tgz",
-      "integrity": "sha512-ZkObExturTfxpNZOBcHJMozuLIbDLe8Us5qe4qJyVozIBH+Ol6xOHxEEyEu8GsRZp0+GU7K3fWExqLEV22oSUQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.67.1.tgz",
+      "integrity": "sha512-WLSyAWDjjr+DHrh5pOIGMlWKeWxyxu1HPlwI/deQEmr/PXjuPLMewH393+HE3LJbrWwpqU3J/U+v1H62XTbFCg==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-menu": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.67.2.tgz",
-      "integrity": "sha512-TF+tpTLqE22qeQTYHJFuxCm6Yt37VFtwM6X9O07GYTeXeDZE7ZI+FrA16y+fxFw2Zu0OpbLO0CWB/ViolvMlOw==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.67.1.tgz",
+      "integrity": "sha512-M9UOD8sEwyPHP9gpDkTgXCeFwpS2cZMI0zoNOr/9vxY/XaLR3iN2W4D+FXtD71FVxy83Fs+ap12gTyKBn7dY6w==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-popover": "^4.67.2",
+        "@contentful/f36-popover": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-modal": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.67.2.tgz",
-      "integrity": "sha512-mrO5+mKytV/j759HI0y6fZskQG/EEY7iNaRjjeYmFRoT6MAgViebcIeht15CcFwnNQLAeS3MusvXiEzuUzweiQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.67.1.tgz",
+      "integrity": "sha512-10LfRE5sKz9QJpSP7D8/PQDpOpq+5086HK51uKUnuPZeszXYfRUgRWTcfkkPvaihqGGx0JZLiRNvGFOBYWVP1A==",
       "requires": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "@types/react-modal": "^3.13.1",
         "emotion": "^10.0.17",
         "react-modal": "^3.16.1"
       }
     },
     "@contentful/f36-navbar": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-navbar/-/f36-navbar-4.67.2.tgz",
-      "integrity": "sha512-58PYpIElqnfdYWpEkSaOmccSzcgudYUs009UWmtqHmv0n3c8eNoV8taoZdg92gYAsEc7G2VWl4AZ3wJy/kiAdg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-navbar/-/f36-navbar-4.67.1.tgz",
+      "integrity": "sha512-kvlQ+jEyPxuFqtO6itMCSQbNZFFTInTJOi7xtYGTC07S49Gn22/Nb9GNJ7lT9pzTm4q0ss+Q+Xv/PtyVsSGnHg==",
       "requires": {
-        "@contentful/f36-avatar": "4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
+        "@contentful/f36-avatar": "4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-icon": "^4.67.1",
         "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-menu": "^4.67.1",
+        "@contentful/f36-skeleton": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.1",
         "@contentful/f36-utils": "^4.23.2",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-note": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.67.2.tgz",
-      "integrity": "sha512-DA0f1/j640SG3LOon1VcU6kDvNgUHxupH0Q1FXS01aRrWq12uMd2bLtb2k5A9qRyT6MB3OdAKFufwsBcSL6fYw==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.67.1.tgz",
+      "integrity": "sha512-6rhGqt5MdH53XXNVbIo9cqmswjSzonHSZ5FdqrJ+rF6uOOghT+zzQCq65PRIBufihvZVh/mD/7vVjCpD6BxnnQ==",
       "requires": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-icon": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-notification": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.67.2.tgz",
-      "integrity": "sha512-x7qxuqOhQMyhhRfMrisAVXnAo/eL6A7RjL2PmTLylaqKrFnzDrr25BtzepdkgULj9VLh70vXM5QIzPwpKpIJBQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.67.1.tgz",
+      "integrity": "sha512-JPYhOqz0rsipqHrtSoWnuPkrqndRz7XX72/0Mfj3dWV4MAK78rxVAQl17qDVliRZTp9NtWXBYseJiPhOsfAw+Q==",
       "requires": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-text-link": "^4.67.2",
+        "@contentful/f36-text-link": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "@swc/helpers": "^0.4.14",
         "emotion": "^10.0.17",
         "react-animate-height": "^3.0.4"
       }
     },
     "@contentful/f36-pagination": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.67.2.tgz",
-      "integrity": "sha512-/UePF1fbr2wvJHtJ9ncWaz5eg/VTdA8VqEBFJXge/IBgPVyMgQxQRxSDhvMj0j2Iit90qAzPedEDZK+jp6CyTg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.67.1.tgz",
+      "integrity": "sha512-NgK22JvCtBvBfE5NeKFRqtLIoeY6CXDTpKpSu70QZxWp4C/z9U7qhyr0d12SHYgFFUJwnAl67A5qaEyth2NvJw==",
       "requires": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-forms": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-pill": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.67.2.tgz",
-      "integrity": "sha512-015oRkVVnshvWAJ/kR5yJBD+soWmDcHFy5FGXDaIR5moTCejjqiLG1g8H6MolaF8oeKSOhbhgfX/dpEHn5/Z4g==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.67.1.tgz",
+      "integrity": "sha512-Ycn1bkAtNlc2FOFuwiSlDK3rgVgPruHXG6m+dla8Hp/ZL/MH2xUcQqir3SlLCZeR+gSx1cuzI9ga8/UjsKf1qQ==",
       "requires": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-drag-handle": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-popover": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.67.2.tgz",
-      "integrity": "sha512-NJx54sqQEmuWIsBySXf/B+ZW/RoIkRzb7cnQ5aucN3nUd4ZaHOvcmYVLJMqfCV8ipzpMxLgoc8p3v6OcRdi72A==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.67.1.tgz",
+      "integrity": "sha512-loWXCV7BswsBvcBENRzEbMCjITodK5RnT7DNSeaZvvhOa87Gp+aCcGIpHaS0Jxrhy3OvUOdPxaRUXmoMkrP7Hg==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -20897,55 +20821,55 @@
       }
     },
     "@contentful/f36-skeleton": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.67.2.tgz",
-      "integrity": "sha512-4T8r/G8b9DFkLErIo8d2cGS71tWy1yNDZIThoHBWIhLRcstal8K7Ag5dQwPsaoSew/859oXC2rvPP0Ep+4FtCg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.67.1.tgz",
+      "integrity": "sha512-hJR/M6u2al75mCMJcdR9xxRfKQdqqFvsRY6mbwYO6bZ+6odYhMqoRNR1C0WK7+uWlEDYUlOnF7+T2vfRB4IfVg==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-table": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-table": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-spinner": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.67.2.tgz",
-      "integrity": "sha512-sBitcudBc4DwAOPn6MLuArLje7aym47GoIDI0kN9zQtolVwlVH92/zNpZmnm+zbP4Ku56/TgbL/v5SFTh+YB2w==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.67.1.tgz",
+      "integrity": "sha512-KCyPb37/Xvr51b6gibw//yLm16uN7+z505+z2B2YH53t70+uIgADKtS7APtaMCbVH6fliVa9/GkXE3WYv/xJhA==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-table": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.67.2.tgz",
-      "integrity": "sha512-YtUkXwFmBLgAi5Glgi1vXqNbr+U2riadB9O+Aq8t2R/vpXMCIA4WlmXSqunwPW9UrrilalrK49l0IkDNpcRUbQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.67.1.tgz",
+      "integrity": "sha512-/UtSfNFwnjGCSLcxeGGBI5Dz/isQsgNNeFJyo2I+xcYPPehZ9o6eHf0+CeRuIW3+OCXYAyliydig+/T+le3/rA==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-tabs": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.67.2.tgz",
-      "integrity": "sha512-rPPJQHmCoD8492yKufelL7MCj0j4FqcPc5yFhD29sqpGDqTko8Xf/V/q4/LPYUtXttH8myfTINEyNTsR/lZINg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.67.1.tgz",
+      "integrity": "sha512-2Nd1UCdBArAWKDvFOgGdd+KV+4SdHGpnx253FEMT4jsRnxeirw/qK+Pn5fBUK5f+KC8ShmxUMpH3Qjf2JTHi9w==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@radix-ui/react-tabs": "^1.0.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-text-link": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.67.2.tgz",
-      "integrity": "sha512-mWE4KsqQV93SNAFtYWqQB61/TLHuX1D3vVJ1rFqAp1kndPy7UyGcrQrGoPmM1l20Y9YaYIWYwo5eGKygY3iwIA==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.67.1.tgz",
+      "integrity": "sha512-SSwbr0ZZoBrXrBwwfCvZIYOh+9yu+J71qgv7dl3jqo0i9bautc6sAIRrrhjT8C0rcUTi6/HRzi0w882ORCgaEg==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
@@ -20956,11 +20880,11 @@
       "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
     },
     "@contentful/f36-tooltip": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.67.2.tgz",
-      "integrity": "sha512-BFSKsJySAK1ipIOXueq6rgsJlmZDVBd60fjicALWiVX/GnxyDO3OkdX8nfK4Id0rbllf8+WBSR5UcVzNjuLe4Q==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.67.1.tgz",
+      "integrity": "sha512-i/FO4F9UHVggL0ScMrayZ6p1rs9oFGhUVZ4B3TKtrVRKXNfFQIzwXFPY45/ZAzdfgxdn90XCvMEo2j86l3fWXA==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -20977,11 +20901,11 @@
       }
     },
     "@contentful/f36-typography": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.67.2.tgz",
-      "integrity": "sha512-zfCVUQfD5wueT4mFNxLO+2SaUTFVHxE+7v8YKt53SvIiN+s/vXJnABOKPZsjYAYkwQwSrwPYIdIxMtaULwjoCw==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.67.1.tgz",
+      "integrity": "sha512-VES06vg9Bnp09IvJm8yea//IgI2m4aCz5weSD+LUV+vpjtBMM/0w+95cP67KvS6Rg3sEr3yx1bja8gSoTDahpw==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
@@ -21824,12 +21748,6 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
-    },
-    "@phosphor-icons/react": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.1.7.tgz",
-      "integrity": "sha512-g2e2eVAn1XG2a+LI09QU3IORLhnFNAFkNbo2iwbX6NOKSLOwvEMmTa7CgOzEbgNWR47z8i8kwjdvYZ5fkGx1mQ==",
-      "requires": {}
     },
     "@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.5.5",

--- a/examples/javascript/package.json
+++ b/examples/javascript/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@contentful/app-sdk": "^4.28.0",
-    "@contentful/f36-components": "4.67.2",
+    "@contentful/f36-components": "4.67.1",
     "@contentful/f36-tokens": "4.0.5",
     "@contentful/react-apps-toolkit": "1.2.16",
     "contentful-management": "10.46.4",

--- a/examples/typescript/package-lock.json
+++ b/examples/typescript/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@contentful/app-sdk": "^4.28.0",
-        "@contentful/f36-components": "4.67.2",
+        "@contentful/f36-components": "4.67.1",
         "@contentful/f36-tokens": "4.0.5",
         "@contentful/react-apps-toolkit": "1.2.16",
         "contentful-management": "10.46.4",
@@ -2077,15 +2077,15 @@
       }
     },
     "node_modules/@contentful/f36-accordion": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.67.2.tgz",
-      "integrity": "sha512-cX7xIX+fZadUNNFG+uzAOXeZ/GkMs+Y0bvgpxkpqW3ILu6GIXHsXetnRocxVaYUrQ1C/k6wEsd4xSv5y2uQBIg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.67.1.tgz",
+      "integrity": "sha512-rIGmO28PcSdfyUpaPfpeMO8qT/y8wMpQcyASHIUY8m6YRrn97vIlfDMQlzuyfoDBXQI3Lkza5RzbEFQVu7capg==",
       "dependencies": {
-        "@contentful/f36-collapse": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-collapse": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2094,15 +2094,15 @@
       }
     },
     "node_modules/@contentful/f36-asset": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.67.2.tgz",
-      "integrity": "sha512-cUQaZQeXIr3oLy255cuL+mXNiYOpMvAzW7BxE3l903ShzlwVFqZr/FIaWAo2t488sWbGeXNXxVBcEbLzQUMIdA==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.67.1.tgz",
+      "integrity": "sha512-BVRtLKxj/S+dGVJ0b88PVpBxE8mLiqDYATlE62Yb22CpncFpb9Kt7IRLto4KnD+SHZAJMORhoMNk7bQc103Dyw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-icon": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2111,18 +2111,18 @@
       }
     },
     "node_modules/@contentful/f36-autocomplete": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.67.2.tgz",
-      "integrity": "sha512-1cZHVa2cskh4DvachcgaQeEuyjuAlxvvyJCqvpHpP+R3ISS6CsC44252fH52NcLryvfFG1zX24nZECgFOY/S+A==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.67.1.tgz",
+      "integrity": "sha512-2aTKX92Q3HyVFexMkjkVw3D7wxTsxB/JJgT8Cy14b22leFk6Dup1Ui8Kt0LkjLYTX9vP3fru8XQ0cae4bCMsfQ==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-forms": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-popover": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-popover": "^4.67.1",
+        "@contentful/f36-skeleton": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "@contentful/f36-utils": "^4.24.3",
         "downshift": "^6.1.12",
         "emotion": "^10.0.17"
@@ -2133,15 +2133,15 @@
       }
     },
     "node_modules/@contentful/f36-avatar": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-avatar/-/f36-avatar-4.67.2.tgz",
-      "integrity": "sha512-bKxmWgi67V6tPCX2mlSxJKtQ8IANoO7jU9qH74Fqe11ATgG84Oqy9iQgjJDQvfFMjyT9n+3zUtUCwo/waHHrQg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-avatar/-/f36-avatar-4.67.1.tgz",
+      "integrity": "sha512-NaUNIFvinF1m3Tr7Gaj3/NREOf1ZYIobKLrtUMzbP0ULezHVvwUxGXbpDOAbLSt9jis9mvvrodBDvRJvmESiAw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-image": "4.67.2",
-        "@contentful/f36-menu": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-image": "4.67.1",
+        "@contentful/f36-menu": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.5",
-        "@contentful/f36-tooltip": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2150,11 +2150,11 @@
       }
     },
     "node_modules/@contentful/f36-badge": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.67.2.tgz",
-      "integrity": "sha512-cWfb3Nk9+CdgmTvc75gzD6uJ4XCbK23pB1t9BV9ZvytvnuaQElZYh7WciyRKJtU51khb0KOuVCb/TOnjecU4xQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.67.1.tgz",
+      "integrity": "sha512-jl944fd93dWrjdy853lGd4RSGtffij7PompadRsw1pbVqsKv5TmIlNGRr253EH4HN8+zIyJo5GTGHXCD9qV9Vw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
@@ -2165,12 +2165,12 @@
       }
     },
     "node_modules/@contentful/f36-button": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.67.2.tgz",
-      "integrity": "sha512-1/1dYtgfVk3wiP5SoaoQEWlM7VYp/Pju17agu5Y0MGuGo7LwjTCzLJQ4OeRvdubTYCW+iXc20sEG2H3OyRoz6w==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.67.1.tgz",
+      "integrity": "sha512-MnL1jFulLgM4ilDG2p06+bpv3dPFRSmjuDb6VlVdZx3JEtMJOK0fxIb1ylSHAE8AHJRDC64iArFCSoiz5zR6Rw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-spinner": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-spinner": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
@@ -2181,22 +2181,22 @@
       }
     },
     "node_modules/@contentful/f36-card": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.67.2.tgz",
-      "integrity": "sha512-f1Ck9hbbfdX7/OIWPfXJSdriDVjoTQOdz4aXo1QVd2fmsTAzQCfH0llwXtCk8TCg4DbSwaS/ldB/CJV3oCN1AA==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.67.1.tgz",
+      "integrity": "sha512-MarYmNmHM5WN9WEIsGAQywaQPethxjIGFI+LbttCP++HzEhY2xlJiQTLwy+X8sW+IncY5TE31AkF+EFkjODGEA==",
       "dependencies": {
-        "@contentful/f36-asset": "^4.67.2",
-        "@contentful/f36-badge": "^4.67.2",
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
+        "@contentful/f36-asset": "^4.67.1",
+        "@contentful/f36-badge": "^4.67.1",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-drag-handle": "^4.67.1",
+        "@contentful/f36-icon": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-menu": "^4.67.1",
+        "@contentful/f36-skeleton": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.1",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17",
         "truncate": "^3.0.0"
       },
@@ -2206,11 +2206,11 @@
       }
     },
     "node_modules/@contentful/f36-collapse": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.67.2.tgz",
-      "integrity": "sha512-EWkl653S3gnhVkq39Z0vDrIHQxvqJnN9XfrrORpX56ZCc4kHs1MzbbbDjnlj3udCy9Cj4Q50hiXpmeO/JogDlg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.67.1.tgz",
+      "integrity": "sha512-9oi/gUTgJTHEn8EoLsKQKd9JtaT5RkY7GZDKccztmWOhkkq9OZQyEgf3msw401CDGwp/pr/RdijjdvZNBFSIwA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2220,47 +2220,47 @@
       }
     },
     "node_modules/@contentful/f36-components": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.67.2.tgz",
-      "integrity": "sha512-JNBX8YzP+mt2/d2m5uUnpFLGnzyRAsggWpEBUe8QgPRwkJ8bZIDrnm2TELIFqrY2t4Lvs2AJw8L/3kDaJvMNCQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.67.1.tgz",
+      "integrity": "sha512-9p4MxsywvLbwX90HgqQI8FQJx9iOjqkC4bAIGLDbjI1CuuKhzACUSAkRvAYhO7N7ZR7c1Vrjr4pvYU7xy4+siw==",
       "dependencies": {
-        "@contentful/f36-accordion": "^4.67.2",
-        "@contentful/f36-asset": "^4.67.2",
-        "@contentful/f36-autocomplete": "^4.67.2",
-        "@contentful/f36-avatar": "4.67.2",
-        "@contentful/f36-badge": "^4.67.2",
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-card": "^4.67.2",
-        "@contentful/f36-collapse": "^4.67.2",
-        "@contentful/f36-copybutton": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-datepicker": "^4.67.2",
-        "@contentful/f36-datetime": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-empty-state": "^4.67.2",
-        "@contentful/f36-entity-list": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
-        "@contentful/f36-header": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
+        "@contentful/f36-accordion": "^4.67.1",
+        "@contentful/f36-asset": "^4.67.1",
+        "@contentful/f36-autocomplete": "^4.67.1",
+        "@contentful/f36-avatar": "4.67.1",
+        "@contentful/f36-badge": "^4.67.1",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-card": "^4.67.1",
+        "@contentful/f36-collapse": "^4.67.1",
+        "@contentful/f36-copybutton": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-datepicker": "^4.67.1",
+        "@contentful/f36-datetime": "^4.67.1",
+        "@contentful/f36-drag-handle": "^4.67.1",
+        "@contentful/f36-empty-state": "^4.67.1",
+        "@contentful/f36-entity-list": "^4.67.1",
+        "@contentful/f36-forms": "^4.67.1",
+        "@contentful/f36-header": "^4.67.1",
+        "@contentful/f36-icon": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-image": "4.67.2",
-        "@contentful/f36-list": "^4.67.2",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-modal": "^4.67.2",
-        "@contentful/f36-navbar": "^4.67.2",
-        "@contentful/f36-note": "^4.67.2",
-        "@contentful/f36-notification": "^4.67.2",
-        "@contentful/f36-pagination": "^4.67.2",
-        "@contentful/f36-pill": "^4.67.2",
-        "@contentful/f36-popover": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
-        "@contentful/f36-spinner": "^4.67.2",
-        "@contentful/f36-table": "^4.67.2",
-        "@contentful/f36-tabs": "^4.67.2",
-        "@contentful/f36-text-link": "^4.67.2",
+        "@contentful/f36-image": "4.67.1",
+        "@contentful/f36-list": "^4.67.1",
+        "@contentful/f36-menu": "^4.67.1",
+        "@contentful/f36-modal": "^4.67.1",
+        "@contentful/f36-navbar": "^4.67.1",
+        "@contentful/f36-note": "^4.67.1",
+        "@contentful/f36-notification": "^4.67.1",
+        "@contentful/f36-pagination": "^4.67.1",
+        "@contentful/f36-pill": "^4.67.1",
+        "@contentful/f36-popover": "^4.67.1",
+        "@contentful/f36-skeleton": "^4.67.1",
+        "@contentful/f36-spinner": "^4.67.1",
+        "@contentful/f36-table": "^4.67.1",
+        "@contentful/f36-tabs": "^4.67.1",
+        "@contentful/f36-text-link": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.1",
+        "@contentful/f36-typography": "^4.67.1",
         "@contentful/f36-utils": "^4.24.3"
       },
       "peerDependencies": {
@@ -2279,15 +2279,15 @@
       }
     },
     "node_modules/@contentful/f36-copybutton": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.67.2.tgz",
-      "integrity": "sha512-hb/DCGE6TTdepsjZvmDgog1glfF8WxGCx+F1S7FbwTZ4NutWeHEa7+E63t2tELTRx07FoVmkICmPtp89mCXKEw==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.67.1.tgz",
+      "integrity": "sha512-riw5JBm4X8jTZH8ZZa7Acfc+ef5QOZhNoc4xfi63gIuiC96pa3s0eBlWogBXjJStm6hQcr1IDbg+o4hRgh0uwg==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2296,9 +2296,9 @@
       }
     },
     "node_modules/@contentful/f36-core": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.67.2.tgz",
-      "integrity": "sha512-iSzA/OuhU4rIlBOlUTIczMuqDQZqLR1tmZJtZyouhfWkEc0VGUCX6S2FnBEXlMbnMzaL70lTXYUNu2bKxK4PfA==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.67.1.tgz",
+      "integrity": "sha512-qeBBaRoqCi3sUMKwJF1g3MQ6jawCGTZROMkjkb2+P6GpmNitbeFBW/J0VJY2g/ixCMN5NORSyf/1CBRMXFwUOw==",
       "dependencies": {
         "@contentful/f36-tokens": "^4.0.4",
         "@emotion/core": "^10.1.1",
@@ -2317,17 +2317,17 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/@contentful/f36-datepicker": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.67.2.tgz",
-      "integrity": "sha512-qGfVEjdZaMwdDBr1uWfgQtnCd8L+ZyVBpFiI8TyFUdQd6L9blHexr99Wg12uBNSub9zaL5fs4wrHZ5vMpGEjGQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.67.1.tgz",
+      "integrity": "sha512-ftHXPc6+hL8E5rkLxTPI9uk/kaAyEhl+ClqLapmd3AyaNrfVojAYJ9Bhe62GIz1gFU0bMXukslCU8xwbrdlFQA==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-forms": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-popover": "^4.67.2",
+        "@contentful/f36-popover": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "date-fns": "^2.28.0",
         "emotion": "^10.0.17",
         "react-day-picker": "^8.7.1",
@@ -2339,11 +2339,11 @@
       }
     },
     "node_modules/@contentful/f36-datetime": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.67.2.tgz",
-      "integrity": "sha512-7kz4I/CzRkupPb43dtAQ3a1bHffdx3ZQ0i9ueUl9CSs+dKhl9gwiH0bmoNN5pnULAQF4i7WQmNueEfQvh9zgvA==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.67.1.tgz",
+      "integrity": "sha512-WlJTeOpyxjxoVWY5DSF9RzkqnAc+80XMo00b0vN2XKc9lKLozMgFrApTeUSZGTcPX0ymKjEdJGqqP/d2o/YbGg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "dayjs": "^1.11.5",
         "emotion": "^10.0.17"
@@ -2354,11 +2354,11 @@
       }
     },
     "node_modules/@contentful/f36-drag-handle": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.67.2.tgz",
-      "integrity": "sha512-7e38V/dJ79m4uVlnf1H1xpRY28DPwaMQOMgFWwPKCdketfr+YU8KI7kE2ssrd1EsM9av7Z0Dcwz6pF89wuxViA==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.67.1.tgz",
+      "integrity": "sha512-wO5ru3zl3qm5KtAylWYQCvdeE0TLda+3gXCMxeNHyJTOcW2/vSB6L31T9zVihFRK/5vgDvGWkcTt/R17OW+qzg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
@@ -2370,12 +2370,12 @@
       }
     },
     "node_modules/@contentful/f36-empty-state": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.67.2.tgz",
-      "integrity": "sha512-ghzqNmwAOv0mAUvXDyLLtlAOXj5RPas/stJ8etPpb339NGFj5ueYf9+EBrgTCWrMK/JCBhcogV5bgKRsc9VKlg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.67.1.tgz",
+      "integrity": "sha512-VPiAfHYCJr3DdhrXXgKzTIKnXZgjugrKwtGbyJQX7cRmwnNRjZCMwMl3F0pPvhPAfI1rzwZzm/wqAtWeBsN51A==",
       "dependencies": {
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2384,21 +2384,20 @@
       }
     },
     "node_modules/@contentful/f36-entity-list": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.67.2.tgz",
-      "integrity": "sha512-G37dKH3yRD++fOA924UROtZdeIiNFmrjfVOobC03jdvk6o21AN2kMyDzML2Uc0+kMg+ofe4G08KC/OmDSUkSAg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.67.1.tgz",
+      "integrity": "sha512-JFxQ2v+Vi6jgPxIkWfiKPPt5U+RKF5hEqHX6Xxndcgcjg0aamb7iJ3rR8mln9cWULIqPJhSTawQujeBgonLktw==",
       "dependencies": {
-        "@contentful/f36-badge": "^4.67.2",
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
+        "@contentful/f36-badge": "^4.67.1",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-drag-handle": "^4.67.1",
+        "@contentful/f36-icon": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-icons-alpha": "npm:@contentful/f36-icons@^5.0.0-alpha.26",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-menu": "^4.67.1",
+        "@contentful/f36-skeleton": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2407,14 +2406,14 @@
       }
     },
     "node_modules/@contentful/f36-forms": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.67.2.tgz",
-      "integrity": "sha512-+XxpnCiBKtZw2hYo5QZWVayWMPKzbarOIWzZUMm6Ttoru00zn5u3tlvue7c9W2zqkNFuUNOopAwXBwQ0h+z+bQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.67.1.tgz",
+      "integrity": "sha512-YRifViI6tLRoJyc3kaAy7TM6gjAoDiaFYfv0k42mEMAC5XOkEwFVHORpRkfCDrYwEC7Zk9crEdOy0vfZ3QlH0Q==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
@@ -2424,15 +2423,15 @@
       }
     },
     "node_modules/@contentful/f36-header": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-header/-/f36-header-4.67.2.tgz",
-      "integrity": "sha512-DjI5JnJuXixG8bAj03lRvISuAgwA2X6PnYifa//967Dd0qQTBw/CkB96AhrgVUjTw+jt3xAprwv0SUKF8x9S8g==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-header/-/f36-header-4.67.1.tgz",
+      "integrity": "sha512-8eith4p/4tc5ZSVPQkWfd4jBNDOq3iSTbBW7jeyB9p+oeB/0cOpJCfjB1RwUTvBamn+MrKnLNtt/TkUa+7C9aw==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.2",
         "@contentful/f36-tokens": "^4.0.5",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2441,32 +2440,13 @@
       }
     },
     "node_modules/@contentful/f36-icon": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.67.2.tgz",
-      "integrity": "sha512-vJAk6KO88GVnHdPSXurUA67F4wl01sZHaaE5eHGvt/s+YuI47dstgROr5+z66qmncKpcMWOTv4/+jqYV1Ko56A==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.67.1.tgz",
+      "integrity": "sha512-Exug8bPfTv0JY2rs7ZxuG9IsrLcQLG0SV7LC76INMwwOIdLWiRFK4k+Se2Or9Ox9ga2pBEPlWr5hBBSgPSj6Gw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-icon-alpha": {
-      "name": "@contentful/f36-icon",
-      "version": "5.0.0-alpha.20",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-5.0.0-alpha.20.tgz",
-      "integrity": "sha512-kI7HJggp/H8whiUL/RrG988nEvQq2SuZVyQn4kyiWYSlMWBRqQXZRvXfsM/RILWMgz2LxryXaT1YGVy2E4UfJA==",
-      "dependencies": {
-        "@contentful/f36-core": "^4.65.4",
-        "@contentful/f36-tokens": "^4.0.4",
-        "@phosphor-icons/react": "^2.1.5",
-        "emotion": "^10.0.17"
-      },
-      "engines": {
-        "node": ">=16"
       },
       "peerDependencies": {
         "react": ">=16.8",
@@ -2488,33 +2468,13 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/@contentful/f36-icons-alpha": {
-      "name": "@contentful/f36-icons",
-      "version": "5.0.0-alpha.29",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-5.0.0-alpha.29.tgz",
-      "integrity": "sha512-7QhDDAo95WiqFwB/ofWd57GEyeLgkDU/CgTStjhtBZssheMvVT6thiIFy6hSbo314d1RZ5Z8EBzH1MIJ/nyQhA==",
+    "node_modules/@contentful/f36-image": {
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-image/-/f36-image-4.67.1.tgz",
+      "integrity": "sha512-FYoeHHAWrRG2YuCXl7VifRjAkDXijENzhV1bgD38eKtBpLbmnnJm+vxbQRAKBvkkwLwFEHvVsdZ2XBoCs6WgmA==",
       "dependencies": {
         "@contentful/f36-core": "^4.67.1",
-        "@contentful/f36-icon-alpha": "npm:@contentful/f36-icon@5.0.0-alpha.20",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@phosphor-icons/react": "^2.1.4",
-        "emotion": "^10.0.17"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-image": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-image/-/f36-image-4.67.2.tgz",
-      "integrity": "sha512-zB4D/fBmUyIj1WvF2tWQHsDxzTcZ+KOyiVu0483rxRNai8sae7BO3VSuevUzfi2Y+gaF3VCasPZudjgTeWD2pQ==",
-      "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-skeleton": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.5",
         "emotion": "^10.0.17"
       },
@@ -2524,11 +2484,11 @@
       }
     },
     "node_modules/@contentful/f36-list": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.67.2.tgz",
-      "integrity": "sha512-ZkObExturTfxpNZOBcHJMozuLIbDLe8Us5qe4qJyVozIBH+Ol6xOHxEEyEu8GsRZp0+GU7K3fWExqLEV22oSUQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.67.1.tgz",
+      "integrity": "sha512-WLSyAWDjjr+DHrh5pOIGMlWKeWxyxu1HPlwI/deQEmr/PXjuPLMewH393+HE3LJbrWwpqU3J/U+v1H62XTbFCg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2538,15 +2498,15 @@
       }
     },
     "node_modules/@contentful/f36-menu": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.67.2.tgz",
-      "integrity": "sha512-TF+tpTLqE22qeQTYHJFuxCm6Yt37VFtwM6X9O07GYTeXeDZE7ZI+FrA16y+fxFw2Zu0OpbLO0CWB/ViolvMlOw==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.67.1.tgz",
+      "integrity": "sha512-M9UOD8sEwyPHP9gpDkTgXCeFwpS2cZMI0zoNOr/9vxY/XaLR3iN2W4D+FXtD71FVxy83Fs+ap12gTyKBn7dY6w==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-popover": "^4.67.2",
+        "@contentful/f36-popover": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
@@ -2556,15 +2516,15 @@
       }
     },
     "node_modules/@contentful/f36-modal": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.67.2.tgz",
-      "integrity": "sha512-mrO5+mKytV/j759HI0y6fZskQG/EEY7iNaRjjeYmFRoT6MAgViebcIeht15CcFwnNQLAeS3MusvXiEzuUzweiQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.67.1.tgz",
+      "integrity": "sha512-10LfRE5sKz9QJpSP7D8/PQDpOpq+5086HK51uKUnuPZeszXYfRUgRWTcfkkPvaihqGGx0JZLiRNvGFOBYWVP1A==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "@types/react-modal": "^3.13.1",
         "emotion": "^10.0.17",
         "react-modal": "^3.16.1"
@@ -2575,16 +2535,16 @@
       }
     },
     "node_modules/@contentful/f36-navbar": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-navbar/-/f36-navbar-4.67.2.tgz",
-      "integrity": "sha512-58PYpIElqnfdYWpEkSaOmccSzcgudYUs009UWmtqHmv0n3c8eNoV8taoZdg92gYAsEc7G2VWl4AZ3wJy/kiAdg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-navbar/-/f36-navbar-4.67.1.tgz",
+      "integrity": "sha512-kvlQ+jEyPxuFqtO6itMCSQbNZFFTInTJOi7xtYGTC07S49Gn22/Nb9GNJ7lT9pzTm4q0ss+Q+Xv/PtyVsSGnHg==",
       "dependencies": {
-        "@contentful/f36-avatar": "4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
+        "@contentful/f36-avatar": "4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-icon": "^4.67.1",
         "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-menu": "^4.67.1",
+        "@contentful/f36-skeleton": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.1",
         "@contentful/f36-utils": "^4.23.2",
         "emotion": "^10.0.17"
@@ -2595,16 +2555,16 @@
       }
     },
     "node_modules/@contentful/f36-note": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.67.2.tgz",
-      "integrity": "sha512-DA0f1/j640SG3LOon1VcU6kDvNgUHxupH0Q1FXS01aRrWq12uMd2bLtb2k5A9qRyT6MB3OdAKFufwsBcSL6fYw==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.67.1.tgz",
+      "integrity": "sha512-6rhGqt5MdH53XXNVbIo9cqmswjSzonHSZ5FdqrJ+rF6uOOghT+zzQCq65PRIBufihvZVh/mD/7vVjCpD6BxnnQ==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-icon": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2613,16 +2573,16 @@
       }
     },
     "node_modules/@contentful/f36-notification": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.67.2.tgz",
-      "integrity": "sha512-x7qxuqOhQMyhhRfMrisAVXnAo/eL6A7RjL2PmTLylaqKrFnzDrr25BtzepdkgULj9VLh70vXM5QIzPwpKpIJBQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.67.1.tgz",
+      "integrity": "sha512-JPYhOqz0rsipqHrtSoWnuPkrqndRz7XX72/0Mfj3dWV4MAK78rxVAQl17qDVliRZTp9NtWXBYseJiPhOsfAw+Q==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-text-link": "^4.67.2",
+        "@contentful/f36-text-link": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "@swc/helpers": "^0.4.14",
         "emotion": "^10.0.17",
         "react-animate-height": "^3.0.4"
@@ -2633,16 +2593,16 @@
       }
     },
     "node_modules/@contentful/f36-pagination": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.67.2.tgz",
-      "integrity": "sha512-/UePF1fbr2wvJHtJ9ncWaz5eg/VTdA8VqEBFJXge/IBgPVyMgQxQRxSDhvMj0j2Iit90qAzPedEDZK+jp6CyTg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.67.1.tgz",
+      "integrity": "sha512-NgK22JvCtBvBfE5NeKFRqtLIoeY6CXDTpKpSu70QZxWp4C/z9U7qhyr0d12SHYgFFUJwnAl67A5qaEyth2NvJw==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-forms": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2651,16 +2611,16 @@
       }
     },
     "node_modules/@contentful/f36-pill": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.67.2.tgz",
-      "integrity": "sha512-015oRkVVnshvWAJ/kR5yJBD+soWmDcHFy5FGXDaIR5moTCejjqiLG1g8H6MolaF8oeKSOhbhgfX/dpEHn5/Z4g==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.67.1.tgz",
+      "integrity": "sha512-Ycn1bkAtNlc2FOFuwiSlDK3rgVgPruHXG6m+dla8Hp/ZL/MH2xUcQqir3SlLCZeR+gSx1cuzI9ga8/UjsKf1qQ==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-drag-handle": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2669,11 +2629,11 @@
       }
     },
     "node_modules/@contentful/f36-popover": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.67.2.tgz",
-      "integrity": "sha512-NJx54sqQEmuWIsBySXf/B+ZW/RoIkRzb7cnQ5aucN3nUd4ZaHOvcmYVLJMqfCV8ipzpMxLgoc8p3v6OcRdi72A==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.67.1.tgz",
+      "integrity": "sha512-loWXCV7BswsBvcBENRzEbMCjITodK5RnT7DNSeaZvvhOa87Gp+aCcGIpHaS0Jxrhy3OvUOdPxaRUXmoMkrP7Hg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -2686,12 +2646,12 @@
       }
     },
     "node_modules/@contentful/f36-skeleton": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.67.2.tgz",
-      "integrity": "sha512-4T8r/G8b9DFkLErIo8d2cGS71tWy1yNDZIThoHBWIhLRcstal8K7Ag5dQwPsaoSew/859oXC2rvPP0Ep+4FtCg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.67.1.tgz",
+      "integrity": "sha512-hJR/M6u2al75mCMJcdR9xxRfKQdqqFvsRY6mbwYO6bZ+6odYhMqoRNR1C0WK7+uWlEDYUlOnF7+T2vfRB4IfVg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-table": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-table": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2701,11 +2661,11 @@
       }
     },
     "node_modules/@contentful/f36-spinner": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.67.2.tgz",
-      "integrity": "sha512-sBitcudBc4DwAOPn6MLuArLje7aym47GoIDI0kN9zQtolVwlVH92/zNpZmnm+zbP4Ku56/TgbL/v5SFTh+YB2w==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.67.1.tgz",
+      "integrity": "sha512-KCyPb37/Xvr51b6gibw//yLm16uN7+z505+z2B2YH53t70+uIgADKtS7APtaMCbVH6fliVa9/GkXE3WYv/xJhA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2715,14 +2675,14 @@
       }
     },
     "node_modules/@contentful/f36-table": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.67.2.tgz",
-      "integrity": "sha512-YtUkXwFmBLgAi5Glgi1vXqNbr+U2riadB9O+Aq8t2R/vpXMCIA4WlmXSqunwPW9UrrilalrK49l0IkDNpcRUbQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.67.1.tgz",
+      "integrity": "sha512-/UtSfNFwnjGCSLcxeGGBI5Dz/isQsgNNeFJyo2I+xcYPPehZ9o6eHf0+CeRuIW3+OCXYAyliydig+/T+le3/rA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2731,11 +2691,11 @@
       }
     },
     "node_modules/@contentful/f36-tabs": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.67.2.tgz",
-      "integrity": "sha512-rPPJQHmCoD8492yKufelL7MCj0j4FqcPc5yFhD29sqpGDqTko8Xf/V/q4/LPYUtXttH8myfTINEyNTsR/lZINg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.67.1.tgz",
+      "integrity": "sha512-2Nd1UCdBArAWKDvFOgGdd+KV+4SdHGpnx253FEMT4jsRnxeirw/qK+Pn5fBUK5f+KC8ShmxUMpH3Qjf2JTHi9w==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@radix-ui/react-tabs": "^1.0.1",
         "emotion": "^10.0.17"
@@ -2746,11 +2706,11 @@
       }
     },
     "node_modules/@contentful/f36-text-link": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.67.2.tgz",
-      "integrity": "sha512-mWE4KsqQV93SNAFtYWqQB61/TLHuX1D3vVJ1rFqAp1kndPy7UyGcrQrGoPmM1l20Y9YaYIWYwo5eGKygY3iwIA==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.67.1.tgz",
+      "integrity": "sha512-SSwbr0ZZoBrXrBwwfCvZIYOh+9yu+J71qgv7dl3jqo0i9bautc6sAIRrrhjT8C0rcUTi6/HRzi0w882ORCgaEg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2765,11 +2725,11 @@
       "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
     },
     "node_modules/@contentful/f36-tooltip": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.67.2.tgz",
-      "integrity": "sha512-BFSKsJySAK1ipIOXueq6rgsJlmZDVBd60fjicALWiVX/GnxyDO3OkdX8nfK4Id0rbllf8+WBSR5UcVzNjuLe4Q==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.67.1.tgz",
+      "integrity": "sha512-i/FO4F9UHVggL0ScMrayZ6p1rs9oFGhUVZ4B3TKtrVRKXNfFQIzwXFPY45/ZAzdfgxdn90XCvMEo2j86l3fWXA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -2788,11 +2748,11 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/@contentful/f36-typography": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.67.2.tgz",
-      "integrity": "sha512-zfCVUQfD5wueT4mFNxLO+2SaUTFVHxE+7v8YKt53SvIiN+s/vXJnABOKPZsjYAYkwQwSrwPYIdIxMtaULwjoCw==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.67.1.tgz",
+      "integrity": "sha512-VES06vg9Bnp09IvJm8yea//IgI2m4aCz5weSD+LUV+vpjtBMM/0w+95cP67KvS6Rg3sEr3yx1bja8gSoTDahpw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
@@ -3622,18 +3582,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@phosphor-icons/react": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.1.7.tgz",
-      "integrity": "sha512-g2e2eVAn1XG2a+LI09QU3IORLhnFNAFkNbo2iwbX6NOKSLOwvEMmTa7CgOzEbgNWR47z8i8kwjdvYZ5fkGx1mQ==",
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": ">= 16.8",
-        "react-dom": ">= 16.8"
       }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -18769,178 +18717,178 @@
       }
     },
     "@contentful/f36-accordion": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.67.2.tgz",
-      "integrity": "sha512-cX7xIX+fZadUNNFG+uzAOXeZ/GkMs+Y0bvgpxkpqW3ILu6GIXHsXetnRocxVaYUrQ1C/k6wEsd4xSv5y2uQBIg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.67.1.tgz",
+      "integrity": "sha512-rIGmO28PcSdfyUpaPfpeMO8qT/y8wMpQcyASHIUY8m6YRrn97vIlfDMQlzuyfoDBXQI3Lkza5RzbEFQVu7capg==",
       "requires": {
-        "@contentful/f36-collapse": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-collapse": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-asset": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.67.2.tgz",
-      "integrity": "sha512-cUQaZQeXIr3oLy255cuL+mXNiYOpMvAzW7BxE3l903ShzlwVFqZr/FIaWAo2t488sWbGeXNXxVBcEbLzQUMIdA==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.67.1.tgz",
+      "integrity": "sha512-BVRtLKxj/S+dGVJ0b88PVpBxE8mLiqDYATlE62Yb22CpncFpb9Kt7IRLto4KnD+SHZAJMORhoMNk7bQc103Dyw==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-icon": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-autocomplete": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.67.2.tgz",
-      "integrity": "sha512-1cZHVa2cskh4DvachcgaQeEuyjuAlxvvyJCqvpHpP+R3ISS6CsC44252fH52NcLryvfFG1zX24nZECgFOY/S+A==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.67.1.tgz",
+      "integrity": "sha512-2aTKX92Q3HyVFexMkjkVw3D7wxTsxB/JJgT8Cy14b22leFk6Dup1Ui8Kt0LkjLYTX9vP3fru8XQ0cae4bCMsfQ==",
       "requires": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-forms": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-popover": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-popover": "^4.67.1",
+        "@contentful/f36-skeleton": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "@contentful/f36-utils": "^4.24.3",
         "downshift": "^6.1.12",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-avatar": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-avatar/-/f36-avatar-4.67.2.tgz",
-      "integrity": "sha512-bKxmWgi67V6tPCX2mlSxJKtQ8IANoO7jU9qH74Fqe11ATgG84Oqy9iQgjJDQvfFMjyT9n+3zUtUCwo/waHHrQg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-avatar/-/f36-avatar-4.67.1.tgz",
+      "integrity": "sha512-NaUNIFvinF1m3Tr7Gaj3/NREOf1ZYIobKLrtUMzbP0ULezHVvwUxGXbpDOAbLSt9jis9mvvrodBDvRJvmESiAw==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-image": "4.67.2",
-        "@contentful/f36-menu": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-image": "4.67.1",
+        "@contentful/f36-menu": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.5",
-        "@contentful/f36-tooltip": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-badge": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.67.2.tgz",
-      "integrity": "sha512-cWfb3Nk9+CdgmTvc75gzD6uJ4XCbK23pB1t9BV9ZvytvnuaQElZYh7WciyRKJtU51khb0KOuVCb/TOnjecU4xQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.67.1.tgz",
+      "integrity": "sha512-jl944fd93dWrjdy853lGd4RSGtffij7PompadRsw1pbVqsKv5TmIlNGRr253EH4HN8+zIyJo5GTGHXCD9qV9Vw==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-button": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.67.2.tgz",
-      "integrity": "sha512-1/1dYtgfVk3wiP5SoaoQEWlM7VYp/Pju17agu5Y0MGuGo7LwjTCzLJQ4OeRvdubTYCW+iXc20sEG2H3OyRoz6w==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.67.1.tgz",
+      "integrity": "sha512-MnL1jFulLgM4ilDG2p06+bpv3dPFRSmjuDb6VlVdZx3JEtMJOK0fxIb1ylSHAE8AHJRDC64iArFCSoiz5zR6Rw==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-spinner": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-spinner": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-card": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.67.2.tgz",
-      "integrity": "sha512-f1Ck9hbbfdX7/OIWPfXJSdriDVjoTQOdz4aXo1QVd2fmsTAzQCfH0llwXtCk8TCg4DbSwaS/ldB/CJV3oCN1AA==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.67.1.tgz",
+      "integrity": "sha512-MarYmNmHM5WN9WEIsGAQywaQPethxjIGFI+LbttCP++HzEhY2xlJiQTLwy+X8sW+IncY5TE31AkF+EFkjODGEA==",
       "requires": {
-        "@contentful/f36-asset": "^4.67.2",
-        "@contentful/f36-badge": "^4.67.2",
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
+        "@contentful/f36-asset": "^4.67.1",
+        "@contentful/f36-badge": "^4.67.1",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-drag-handle": "^4.67.1",
+        "@contentful/f36-icon": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-menu": "^4.67.1",
+        "@contentful/f36-skeleton": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.1",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17",
         "truncate": "^3.0.0"
       }
     },
     "@contentful/f36-collapse": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.67.2.tgz",
-      "integrity": "sha512-EWkl653S3gnhVkq39Z0vDrIHQxvqJnN9XfrrORpX56ZCc4kHs1MzbbbDjnlj3udCy9Cj4Q50hiXpmeO/JogDlg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.67.1.tgz",
+      "integrity": "sha512-9oi/gUTgJTHEn8EoLsKQKd9JtaT5RkY7GZDKccztmWOhkkq9OZQyEgf3msw401CDGwp/pr/RdijjdvZNBFSIwA==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-components": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.67.2.tgz",
-      "integrity": "sha512-JNBX8YzP+mt2/d2m5uUnpFLGnzyRAsggWpEBUe8QgPRwkJ8bZIDrnm2TELIFqrY2t4Lvs2AJw8L/3kDaJvMNCQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.67.1.tgz",
+      "integrity": "sha512-9p4MxsywvLbwX90HgqQI8FQJx9iOjqkC4bAIGLDbjI1CuuKhzACUSAkRvAYhO7N7ZR7c1Vrjr4pvYU7xy4+siw==",
       "requires": {
-        "@contentful/f36-accordion": "^4.67.2",
-        "@contentful/f36-asset": "^4.67.2",
-        "@contentful/f36-autocomplete": "^4.67.2",
-        "@contentful/f36-avatar": "4.67.2",
-        "@contentful/f36-badge": "^4.67.2",
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-card": "^4.67.2",
-        "@contentful/f36-collapse": "^4.67.2",
-        "@contentful/f36-copybutton": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-datepicker": "^4.67.2",
-        "@contentful/f36-datetime": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-empty-state": "^4.67.2",
-        "@contentful/f36-entity-list": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
-        "@contentful/f36-header": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
+        "@contentful/f36-accordion": "^4.67.1",
+        "@contentful/f36-asset": "^4.67.1",
+        "@contentful/f36-autocomplete": "^4.67.1",
+        "@contentful/f36-avatar": "4.67.1",
+        "@contentful/f36-badge": "^4.67.1",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-card": "^4.67.1",
+        "@contentful/f36-collapse": "^4.67.1",
+        "@contentful/f36-copybutton": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-datepicker": "^4.67.1",
+        "@contentful/f36-datetime": "^4.67.1",
+        "@contentful/f36-drag-handle": "^4.67.1",
+        "@contentful/f36-empty-state": "^4.67.1",
+        "@contentful/f36-entity-list": "^4.67.1",
+        "@contentful/f36-forms": "^4.67.1",
+        "@contentful/f36-header": "^4.67.1",
+        "@contentful/f36-icon": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-image": "4.67.2",
-        "@contentful/f36-list": "^4.67.2",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-modal": "^4.67.2",
-        "@contentful/f36-navbar": "^4.67.2",
-        "@contentful/f36-note": "^4.67.2",
-        "@contentful/f36-notification": "^4.67.2",
-        "@contentful/f36-pagination": "^4.67.2",
-        "@contentful/f36-pill": "^4.67.2",
-        "@contentful/f36-popover": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
-        "@contentful/f36-spinner": "^4.67.2",
-        "@contentful/f36-table": "^4.67.2",
-        "@contentful/f36-tabs": "^4.67.2",
-        "@contentful/f36-text-link": "^4.67.2",
+        "@contentful/f36-image": "4.67.1",
+        "@contentful/f36-list": "^4.67.1",
+        "@contentful/f36-menu": "^4.67.1",
+        "@contentful/f36-modal": "^4.67.1",
+        "@contentful/f36-navbar": "^4.67.1",
+        "@contentful/f36-note": "^4.67.1",
+        "@contentful/f36-notification": "^4.67.1",
+        "@contentful/f36-pagination": "^4.67.1",
+        "@contentful/f36-pill": "^4.67.1",
+        "@contentful/f36-popover": "^4.67.1",
+        "@contentful/f36-skeleton": "^4.67.1",
+        "@contentful/f36-spinner": "^4.67.1",
+        "@contentful/f36-table": "^4.67.1",
+        "@contentful/f36-tabs": "^4.67.1",
+        "@contentful/f36-text-link": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.1",
+        "@contentful/f36-typography": "^4.67.1",
         "@contentful/f36-utils": "^4.24.3"
       }
     },
     "@contentful/f36-copybutton": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.67.2.tgz",
-      "integrity": "sha512-hb/DCGE6TTdepsjZvmDgog1glfF8WxGCx+F1S7FbwTZ4NutWeHEa7+E63t2tELTRx07FoVmkICmPtp89mCXKEw==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.67.1.tgz",
+      "integrity": "sha512-riw5JBm4X8jTZH8ZZa7Acfc+ef5QOZhNoc4xfi63gIuiC96pa3s0eBlWogBXjJStm6hQcr1IDbg+o4hRgh0uwg==",
       "requires": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-core": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.67.2.tgz",
-      "integrity": "sha512-iSzA/OuhU4rIlBOlUTIczMuqDQZqLR1tmZJtZyouhfWkEc0VGUCX6S2FnBEXlMbnMzaL70lTXYUNu2bKxK4PfA==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.67.1.tgz",
+      "integrity": "sha512-qeBBaRoqCi3sUMKwJF1g3MQ6jawCGTZROMkjkb2+P6GpmNitbeFBW/J0VJY2g/ixCMN5NORSyf/1CBRMXFwUOw==",
       "requires": {
         "@contentful/f36-tokens": "^4.0.4",
         "@emotion/core": "^10.1.1",
@@ -18957,17 +18905,17 @@
       }
     },
     "@contentful/f36-datepicker": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.67.2.tgz",
-      "integrity": "sha512-qGfVEjdZaMwdDBr1uWfgQtnCd8L+ZyVBpFiI8TyFUdQd6L9blHexr99Wg12uBNSub9zaL5fs4wrHZ5vMpGEjGQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.67.1.tgz",
+      "integrity": "sha512-ftHXPc6+hL8E5rkLxTPI9uk/kaAyEhl+ClqLapmd3AyaNrfVojAYJ9Bhe62GIz1gFU0bMXukslCU8xwbrdlFQA==",
       "requires": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-forms": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-popover": "^4.67.2",
+        "@contentful/f36-popover": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "date-fns": "^2.28.0",
         "emotion": "^10.0.17",
         "react-day-picker": "^8.7.1",
@@ -18975,22 +18923,22 @@
       }
     },
     "@contentful/f36-datetime": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.67.2.tgz",
-      "integrity": "sha512-7kz4I/CzRkupPb43dtAQ3a1bHffdx3ZQ0i9ueUl9CSs+dKhl9gwiH0bmoNN5pnULAQF4i7WQmNueEfQvh9zgvA==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.67.1.tgz",
+      "integrity": "sha512-WlJTeOpyxjxoVWY5DSF9RzkqnAc+80XMo00b0vN2XKc9lKLozMgFrApTeUSZGTcPX0ymKjEdJGqqP/d2o/YbGg==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "dayjs": "^1.11.5",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-drag-handle": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.67.2.tgz",
-      "integrity": "sha512-7e38V/dJ79m4uVlnf1H1xpRY28DPwaMQOMgFWwPKCdketfr+YU8KI7kE2ssrd1EsM9av7Z0Dcwz6pF89wuxViA==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.67.1.tgz",
+      "integrity": "sha512-wO5ru3zl3qm5KtAylWYQCvdeE0TLda+3gXCMxeNHyJTOcW2/vSB6L31T9zVihFRK/5vgDvGWkcTt/R17OW+qzg==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
@@ -18998,78 +18946,66 @@
       }
     },
     "@contentful/f36-empty-state": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.67.2.tgz",
-      "integrity": "sha512-ghzqNmwAOv0mAUvXDyLLtlAOXj5RPas/stJ8etPpb339NGFj5ueYf9+EBrgTCWrMK/JCBhcogV5bgKRsc9VKlg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.67.1.tgz",
+      "integrity": "sha512-VPiAfHYCJr3DdhrXXgKzTIKnXZgjugrKwtGbyJQX7cRmwnNRjZCMwMl3F0pPvhPAfI1rzwZzm/wqAtWeBsN51A==",
       "requires": {
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-entity-list": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.67.2.tgz",
-      "integrity": "sha512-G37dKH3yRD++fOA924UROtZdeIiNFmrjfVOobC03jdvk6o21AN2kMyDzML2Uc0+kMg+ofe4G08KC/OmDSUkSAg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.67.1.tgz",
+      "integrity": "sha512-JFxQ2v+Vi6jgPxIkWfiKPPt5U+RKF5hEqHX6Xxndcgcjg0aamb7iJ3rR8mln9cWULIqPJhSTawQujeBgonLktw==",
       "requires": {
-        "@contentful/f36-badge": "^4.67.2",
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
+        "@contentful/f36-badge": "^4.67.1",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-drag-handle": "^4.67.1",
+        "@contentful/f36-icon": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-icons-alpha": "npm:@contentful/f36-icons@^5.0.0-alpha.26",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-menu": "^4.67.1",
+        "@contentful/f36-skeleton": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-forms": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.67.2.tgz",
-      "integrity": "sha512-+XxpnCiBKtZw2hYo5QZWVayWMPKzbarOIWzZUMm6Ttoru00zn5u3tlvue7c9W2zqkNFuUNOopAwXBwQ0h+z+bQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.67.1.tgz",
+      "integrity": "sha512-YRifViI6tLRoJyc3kaAy7TM6gjAoDiaFYfv0k42mEMAC5XOkEwFVHORpRkfCDrYwEC7Zk9crEdOy0vfZ3QlH0Q==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-header": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-header/-/f36-header-4.67.2.tgz",
-      "integrity": "sha512-DjI5JnJuXixG8bAj03lRvISuAgwA2X6PnYifa//967Dd0qQTBw/CkB96AhrgVUjTw+jt3xAprwv0SUKF8x9S8g==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-header/-/f36-header-4.67.1.tgz",
+      "integrity": "sha512-8eith4p/4tc5ZSVPQkWfd4jBNDOq3iSTbBW7jeyB9p+oeB/0cOpJCfjB1RwUTvBamn+MrKnLNtt/TkUa+7C9aw==",
       "requires": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.2",
         "@contentful/f36-tokens": "^4.0.5",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-icon": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.67.2.tgz",
-      "integrity": "sha512-vJAk6KO88GVnHdPSXurUA67F4wl01sZHaaE5eHGvt/s+YuI47dstgROr5+z66qmncKpcMWOTv4/+jqYV1Ko56A==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.67.1.tgz",
+      "integrity": "sha512-Exug8bPfTv0JY2rs7ZxuG9IsrLcQLG0SV7LC76INMwwOIdLWiRFK4k+Se2Or9Ox9ga2pBEPlWr5hBBSgPSj6Gw==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "emotion": "^10.0.17"
-      }
-    },
-    "@contentful/f36-icon-alpha": {
-      "version": "npm:@contentful/f36-icon@5.0.0-alpha.20",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-5.0.0-alpha.20.tgz",
-      "integrity": "sha512-kI7HJggp/H8whiUL/RrG988nEvQq2SuZVyQn4kyiWYSlMWBRqQXZRvXfsM/RILWMgz2LxryXaT1YGVy2E4UfJA==",
-      "requires": {
-        "@contentful/f36-core": "^4.65.4",
-        "@contentful/f36-tokens": "^4.0.4",
-        "@phosphor-icons/react": "^2.1.5",
         "emotion": "^10.0.17"
       }
     },
@@ -19084,148 +19020,136 @@
         "emotion": "^10.0.17"
       }
     },
-    "@contentful/f36-icons-alpha": {
-      "version": "npm:@contentful/f36-icons@5.0.0-alpha.29",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-5.0.0-alpha.29.tgz",
-      "integrity": "sha512-7QhDDAo95WiqFwB/ofWd57GEyeLgkDU/CgTStjhtBZssheMvVT6thiIFy6hSbo314d1RZ5Z8EBzH1MIJ/nyQhA==",
+    "@contentful/f36-image": {
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-image/-/f36-image-4.67.1.tgz",
+      "integrity": "sha512-FYoeHHAWrRG2YuCXl7VifRjAkDXijENzhV1bgD38eKtBpLbmnnJm+vxbQRAKBvkkwLwFEHvVsdZ2XBoCs6WgmA==",
       "requires": {
         "@contentful/f36-core": "^4.67.1",
-        "@contentful/f36-icon-alpha": "npm:@contentful/f36-icon@5.0.0-alpha.20",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@phosphor-icons/react": "^2.1.4",
-        "emotion": "^10.0.17"
-      }
-    },
-    "@contentful/f36-image": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-image/-/f36-image-4.67.2.tgz",
-      "integrity": "sha512-zB4D/fBmUyIj1WvF2tWQHsDxzTcZ+KOyiVu0483rxRNai8sae7BO3VSuevUzfi2Y+gaF3VCasPZudjgTeWD2pQ==",
-      "requires": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-skeleton": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.5",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-list": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.67.2.tgz",
-      "integrity": "sha512-ZkObExturTfxpNZOBcHJMozuLIbDLe8Us5qe4qJyVozIBH+Ol6xOHxEEyEu8GsRZp0+GU7K3fWExqLEV22oSUQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.67.1.tgz",
+      "integrity": "sha512-WLSyAWDjjr+DHrh5pOIGMlWKeWxyxu1HPlwI/deQEmr/PXjuPLMewH393+HE3LJbrWwpqU3J/U+v1H62XTbFCg==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-menu": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.67.2.tgz",
-      "integrity": "sha512-TF+tpTLqE22qeQTYHJFuxCm6Yt37VFtwM6X9O07GYTeXeDZE7ZI+FrA16y+fxFw2Zu0OpbLO0CWB/ViolvMlOw==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.67.1.tgz",
+      "integrity": "sha512-M9UOD8sEwyPHP9gpDkTgXCeFwpS2cZMI0zoNOr/9vxY/XaLR3iN2W4D+FXtD71FVxy83Fs+ap12gTyKBn7dY6w==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-popover": "^4.67.2",
+        "@contentful/f36-popover": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-modal": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.67.2.tgz",
-      "integrity": "sha512-mrO5+mKytV/j759HI0y6fZskQG/EEY7iNaRjjeYmFRoT6MAgViebcIeht15CcFwnNQLAeS3MusvXiEzuUzweiQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.67.1.tgz",
+      "integrity": "sha512-10LfRE5sKz9QJpSP7D8/PQDpOpq+5086HK51uKUnuPZeszXYfRUgRWTcfkkPvaihqGGx0JZLiRNvGFOBYWVP1A==",
       "requires": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "@types/react-modal": "^3.13.1",
         "emotion": "^10.0.17",
         "react-modal": "^3.16.1"
       }
     },
     "@contentful/f36-navbar": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-navbar/-/f36-navbar-4.67.2.tgz",
-      "integrity": "sha512-58PYpIElqnfdYWpEkSaOmccSzcgudYUs009UWmtqHmv0n3c8eNoV8taoZdg92gYAsEc7G2VWl4AZ3wJy/kiAdg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-navbar/-/f36-navbar-4.67.1.tgz",
+      "integrity": "sha512-kvlQ+jEyPxuFqtO6itMCSQbNZFFTInTJOi7xtYGTC07S49Gn22/Nb9GNJ7lT9pzTm4q0ss+Q+Xv/PtyVsSGnHg==",
       "requires": {
-        "@contentful/f36-avatar": "4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
+        "@contentful/f36-avatar": "4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-icon": "^4.67.1",
         "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-menu": "^4.67.1",
+        "@contentful/f36-skeleton": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.1",
         "@contentful/f36-utils": "^4.23.2",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-note": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.67.2.tgz",
-      "integrity": "sha512-DA0f1/j640SG3LOon1VcU6kDvNgUHxupH0Q1FXS01aRrWq12uMd2bLtb2k5A9qRyT6MB3OdAKFufwsBcSL6fYw==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.67.1.tgz",
+      "integrity": "sha512-6rhGqt5MdH53XXNVbIo9cqmswjSzonHSZ5FdqrJ+rF6uOOghT+zzQCq65PRIBufihvZVh/mD/7vVjCpD6BxnnQ==",
       "requires": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-icon": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-notification": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.67.2.tgz",
-      "integrity": "sha512-x7qxuqOhQMyhhRfMrisAVXnAo/eL6A7RjL2PmTLylaqKrFnzDrr25BtzepdkgULj9VLh70vXM5QIzPwpKpIJBQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.67.1.tgz",
+      "integrity": "sha512-JPYhOqz0rsipqHrtSoWnuPkrqndRz7XX72/0Mfj3dWV4MAK78rxVAQl17qDVliRZTp9NtWXBYseJiPhOsfAw+Q==",
       "requires": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-text-link": "^4.67.2",
+        "@contentful/f36-text-link": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "@swc/helpers": "^0.4.14",
         "emotion": "^10.0.17",
         "react-animate-height": "^3.0.4"
       }
     },
     "@contentful/f36-pagination": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.67.2.tgz",
-      "integrity": "sha512-/UePF1fbr2wvJHtJ9ncWaz5eg/VTdA8VqEBFJXge/IBgPVyMgQxQRxSDhvMj0j2Iit90qAzPedEDZK+jp6CyTg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.67.1.tgz",
+      "integrity": "sha512-NgK22JvCtBvBfE5NeKFRqtLIoeY6CXDTpKpSu70QZxWp4C/z9U7qhyr0d12SHYgFFUJwnAl67A5qaEyth2NvJw==",
       "requires": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-forms": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-pill": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.67.2.tgz",
-      "integrity": "sha512-015oRkVVnshvWAJ/kR5yJBD+soWmDcHFy5FGXDaIR5moTCejjqiLG1g8H6MolaF8oeKSOhbhgfX/dpEHn5/Z4g==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.67.1.tgz",
+      "integrity": "sha512-Ycn1bkAtNlc2FOFuwiSlDK3rgVgPruHXG6m+dla8Hp/ZL/MH2xUcQqir3SlLCZeR+gSx1cuzI9ga8/UjsKf1qQ==",
       "requires": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
+        "@contentful/f36-button": "^4.67.1",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-drag-handle": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-popover": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.67.2.tgz",
-      "integrity": "sha512-NJx54sqQEmuWIsBySXf/B+ZW/RoIkRzb7cnQ5aucN3nUd4ZaHOvcmYVLJMqfCV8ipzpMxLgoc8p3v6OcRdi72A==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.67.1.tgz",
+      "integrity": "sha512-loWXCV7BswsBvcBENRzEbMCjITodK5RnT7DNSeaZvvhOa87Gp+aCcGIpHaS0Jxrhy3OvUOdPxaRUXmoMkrP7Hg==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -19234,55 +19158,55 @@
       }
     },
     "@contentful/f36-skeleton": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.67.2.tgz",
-      "integrity": "sha512-4T8r/G8b9DFkLErIo8d2cGS71tWy1yNDZIThoHBWIhLRcstal8K7Ag5dQwPsaoSew/859oXC2rvPP0Ep+4FtCg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.67.1.tgz",
+      "integrity": "sha512-hJR/M6u2al75mCMJcdR9xxRfKQdqqFvsRY6mbwYO6bZ+6odYhMqoRNR1C0WK7+uWlEDYUlOnF7+T2vfRB4IfVg==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-table": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
+        "@contentful/f36-table": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-spinner": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.67.2.tgz",
-      "integrity": "sha512-sBitcudBc4DwAOPn6MLuArLje7aym47GoIDI0kN9zQtolVwlVH92/zNpZmnm+zbP4Ku56/TgbL/v5SFTh+YB2w==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.67.1.tgz",
+      "integrity": "sha512-KCyPb37/Xvr51b6gibw//yLm16uN7+z505+z2B2YH53t70+uIgADKtS7APtaMCbVH6fliVa9/GkXE3WYv/xJhA==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-table": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.67.2.tgz",
-      "integrity": "sha512-YtUkXwFmBLgAi5Glgi1vXqNbr+U2riadB9O+Aq8t2R/vpXMCIA4WlmXSqunwPW9UrrilalrK49l0IkDNpcRUbQ==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.67.1.tgz",
+      "integrity": "sha512-/UtSfNFwnjGCSLcxeGGBI5Dz/isQsgNNeFJyo2I+xcYPPehZ9o6eHf0+CeRuIW3+OCXYAyliydig+/T+le3/rA==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-icons": "^4.28.1",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-tabs": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.67.2.tgz",
-      "integrity": "sha512-rPPJQHmCoD8492yKufelL7MCj0j4FqcPc5yFhD29sqpGDqTko8Xf/V/q4/LPYUtXttH8myfTINEyNTsR/lZINg==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.67.1.tgz",
+      "integrity": "sha512-2Nd1UCdBArAWKDvFOgGdd+KV+4SdHGpnx253FEMT4jsRnxeirw/qK+Pn5fBUK5f+KC8ShmxUMpH3Qjf2JTHi9w==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@radix-ui/react-tabs": "^1.0.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-text-link": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.67.2.tgz",
-      "integrity": "sha512-mWE4KsqQV93SNAFtYWqQB61/TLHuX1D3vVJ1rFqAp1kndPy7UyGcrQrGoPmM1l20Y9YaYIWYwo5eGKygY3iwIA==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.67.1.tgz",
+      "integrity": "sha512-SSwbr0ZZoBrXrBwwfCvZIYOh+9yu+J71qgv7dl3jqo0i9bautc6sAIRrrhjT8C0rcUTi6/HRzi0w882ORCgaEg==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
@@ -19293,11 +19217,11 @@
       "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
     },
     "@contentful/f36-tooltip": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.67.2.tgz",
-      "integrity": "sha512-BFSKsJySAK1ipIOXueq6rgsJlmZDVBd60fjicALWiVX/GnxyDO3OkdX8nfK4Id0rbllf8+WBSR5UcVzNjuLe4Q==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.67.1.tgz",
+      "integrity": "sha512-i/FO4F9UHVggL0ScMrayZ6p1rs9oFGhUVZ4B3TKtrVRKXNfFQIzwXFPY45/ZAzdfgxdn90XCvMEo2j86l3fWXA==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -19314,11 +19238,11 @@
       }
     },
     "@contentful/f36-typography": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.67.2.tgz",
-      "integrity": "sha512-zfCVUQfD5wueT4mFNxLO+2SaUTFVHxE+7v8YKt53SvIiN+s/vXJnABOKPZsjYAYkwQwSrwPYIdIxMtaULwjoCw==",
+      "version": "4.67.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.67.1.tgz",
+      "integrity": "sha512-VES06vg9Bnp09IvJm8yea//IgI2m4aCz5weSD+LUV+vpjtBMM/0w+95cP67KvS6Rg3sEr3yx1bja8gSoTDahpw==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.1",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
@@ -19949,12 +19873,6 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
-    },
-    "@phosphor-icons/react": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.1.7.tgz",
-      "integrity": "sha512-g2e2eVAn1XG2a+LI09QU3IORLhnFNAFkNbo2iwbX6NOKSLOwvEMmTa7CgOzEbgNWR47z8i8kwjdvYZ5fkGx1mQ==",
-      "requires": {}
     },
     "@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.5.5",

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@contentful/app-sdk": "^4.28.0",
-    "@contentful/f36-components": "4.67.2",
+    "@contentful/f36-components": "4.67.1",
     "@contentful/f36-tokens": "4.0.5",
     "@contentful/react-apps-toolkit": "1.2.16",
     "contentful-management": "10.46.4",


### PR DESCRIPTION
## Purpose

The `4.67.2` version of `@contentful/f36-components` has an issue that is causing builds to fail. This is a temporary fix to revert bumping this package in our examples. Our examples are being used by `create-contentful-app` and so using this broken version of the forma package is creating issues for apps created using CCA.

## Approach

<!-- Why did we do it the way we did? Did we consider alternatives? What other implementation details or artifacts (screenshots etc.) would help reviewers contextualize change? -->

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
