### PR TITLE
fix: bump f36-components package to 4.67.3 in examples [ZEND-5170]

### DIFF
--- a/examples/function-mock-shop/package-lock.json
+++ b/examples/function-mock-shop/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@contentful/app-sdk": "^4.28.0",
-        "@contentful/f36-components": "4.67.2",
+        "@contentful/f36-components": "4.67.3",
         "@contentful/f36-tokens": "4.0.5",
         "@contentful/react-apps-toolkit": "1.2.16",
         "@tanstack/react-query": "^5.51.11",
@@ -2190,15 +2190,15 @@
       }
     },
     "node_modules/@contentful/f36-accordion": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.67.2.tgz",
-      "integrity": "sha512-cX7xIX+fZadUNNFG+uzAOXeZ/GkMs+Y0bvgpxkpqW3ILu6GIXHsXetnRocxVaYUrQ1C/k6wEsd4xSv5y2uQBIg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.67.3.tgz",
+      "integrity": "sha512-d2Hwqg2Y8Pe9DP8XUAtVP8wKvqL6y4u9ydcSQDdQ4AZBT297zVzaXhTYzv7Bwi+Dq+4lagtkj39eU2IHXg/Aew==",
       "dependencies": {
-        "@contentful/f36-collapse": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-collapse": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2207,15 +2207,15 @@
       }
     },
     "node_modules/@contentful/f36-asset": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.67.2.tgz",
-      "integrity": "sha512-cUQaZQeXIr3oLy255cuL+mXNiYOpMvAzW7BxE3l903ShzlwVFqZr/FIaWAo2t488sWbGeXNXxVBcEbLzQUMIdA==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.67.3.tgz",
+      "integrity": "sha512-XTYNl6mS69By8MOvQwaHcIwxf+hnodUNzmMW3DgiGlptfKHtsgV6RlKil4PSluOaqtHUrIuXzPozCyMxPjf+0w==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2224,18 +2224,18 @@
       }
     },
     "node_modules/@contentful/f36-autocomplete": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.67.2.tgz",
-      "integrity": "sha512-1cZHVa2cskh4DvachcgaQeEuyjuAlxvvyJCqvpHpP+R3ISS6CsC44252fH52NcLryvfFG1zX24nZECgFOY/S+A==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.67.3.tgz",
+      "integrity": "sha512-meEb8OnRBDHrffLxqxfXfmKxyIKQPyFEMtjW6zRrilvDhFxw4KvKFU8XWX3gv3oBpWdpm5LEY/YnZuPqsRshow==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-popover": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-forms": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-popover": "^4.67.3",
+        "@contentful/f36-skeleton": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "@contentful/f36-utils": "^4.24.3",
         "downshift": "^6.1.12",
         "emotion": "^10.0.17"
@@ -2246,15 +2246,15 @@
       }
     },
     "node_modules/@contentful/f36-avatar": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-avatar/-/f36-avatar-4.67.2.tgz",
-      "integrity": "sha512-bKxmWgi67V6tPCX2mlSxJKtQ8IANoO7jU9qH74Fqe11ATgG84Oqy9iQgjJDQvfFMjyT9n+3zUtUCwo/waHHrQg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-avatar/-/f36-avatar-4.67.3.tgz",
+      "integrity": "sha512-gyVW7kJqrxZFOOhDzOsxkpelT7i6kE+TxbPrSClIpSfSWSWAQZnKFjBK3oeUH5VxnOrrZUO4IDIUTAIjF0UiDQ==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-image": "4.67.2",
-        "@contentful/f36-menu": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-image": "4.67.3",
+        "@contentful/f36-menu": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.5",
-        "@contentful/f36-tooltip": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2263,12 +2263,12 @@
       }
     },
     "node_modules/@contentful/f36-badge": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.67.2.tgz",
-      "integrity": "sha512-cWfb3Nk9+CdgmTvc75gzD6uJ4XCbK23pB1t9BV9ZvytvnuaQElZYh7WciyRKJtU51khb0KOuVCb/TOnjecU4xQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.67.3.tgz",
+      "integrity": "sha512-/9IzwrWLdv00t+iy0OfIwRCIQjxmdLcJCSzNFWHnbNSrjwCUPK3buZgtq9F8ueoFMobPuYed6b5X+VMAMlL4Hg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2278,12 +2278,12 @@
       }
     },
     "node_modules/@contentful/f36-button": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.67.2.tgz",
-      "integrity": "sha512-1/1dYtgfVk3wiP5SoaoQEWlM7VYp/Pju17agu5Y0MGuGo7LwjTCzLJQ4OeRvdubTYCW+iXc20sEG2H3OyRoz6w==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.67.3.tgz",
+      "integrity": "sha512-/w13GeJq4xN563Mrs5L6V6fEG2JHA3unsR/Rg+88agvoIgEj7bVNA6IunWVhKEHIfSucDJ+1hktNGfh1mPMQ4w==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-spinner": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-spinner": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
@@ -2294,22 +2294,22 @@
       }
     },
     "node_modules/@contentful/f36-card": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.67.2.tgz",
-      "integrity": "sha512-f1Ck9hbbfdX7/OIWPfXJSdriDVjoTQOdz4aXo1QVd2fmsTAzQCfH0llwXtCk8TCg4DbSwaS/ldB/CJV3oCN1AA==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.67.3.tgz",
+      "integrity": "sha512-LiCr/9sByOeY6GU6rW8HrSCJIdNVgO8IUwvPlciuqxKPyNgWOnqUiYpBZZNf74lqtLKuDXCzkKZaaF3j1JShLA==",
       "dependencies": {
-        "@contentful/f36-asset": "^4.67.2",
-        "@contentful/f36-badge": "^4.67.2",
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-asset": "^4.67.3",
+        "@contentful/f36-badge": "^4.67.3",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-drag-handle": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-menu": "^4.67.3",
+        "@contentful/f36-skeleton": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.3",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17",
         "truncate": "^3.0.0"
       },
@@ -2319,11 +2319,11 @@
       }
     },
     "node_modules/@contentful/f36-collapse": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.67.2.tgz",
-      "integrity": "sha512-EWkl653S3gnhVkq39Z0vDrIHQxvqJnN9XfrrORpX56ZCc4kHs1MzbbbDjnlj3udCy9Cj4Q50hiXpmeO/JogDlg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.67.3.tgz",
+      "integrity": "sha512-W8RQzN7H0x2jRNz6NN8EYLVDREwdPWPTTx89pSWnXaTG1EyITVUSGlgvc/kfOpLjbTC3HI1jwIlll+RGMFGs8A==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2333,47 +2333,47 @@
       }
     },
     "node_modules/@contentful/f36-components": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.67.2.tgz",
-      "integrity": "sha512-JNBX8YzP+mt2/d2m5uUnpFLGnzyRAsggWpEBUe8QgPRwkJ8bZIDrnm2TELIFqrY2t4Lvs2AJw8L/3kDaJvMNCQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.67.3.tgz",
+      "integrity": "sha512-AFw5q0JzT/L60w4tM3H399pXDO3lOcZootFwjKIaupHRjNPHHGQ1MlgMqNEIz1qSEbBbqKY3O6HlA2CmowznaQ==",
       "dependencies": {
-        "@contentful/f36-accordion": "^4.67.2",
-        "@contentful/f36-asset": "^4.67.2",
-        "@contentful/f36-autocomplete": "^4.67.2",
-        "@contentful/f36-avatar": "4.67.2",
-        "@contentful/f36-badge": "^4.67.2",
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-card": "^4.67.2",
-        "@contentful/f36-collapse": "^4.67.2",
-        "@contentful/f36-copybutton": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-datepicker": "^4.67.2",
-        "@contentful/f36-datetime": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-empty-state": "^4.67.2",
-        "@contentful/f36-entity-list": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
-        "@contentful/f36-header": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-image": "4.67.2",
-        "@contentful/f36-list": "^4.67.2",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-modal": "^4.67.2",
-        "@contentful/f36-navbar": "^4.67.2",
-        "@contentful/f36-note": "^4.67.2",
-        "@contentful/f36-notification": "^4.67.2",
-        "@contentful/f36-pagination": "^4.67.2",
-        "@contentful/f36-pill": "^4.67.2",
-        "@contentful/f36-popover": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
-        "@contentful/f36-spinner": "^4.67.2",
-        "@contentful/f36-table": "^4.67.2",
-        "@contentful/f36-tabs": "^4.67.2",
-        "@contentful/f36-text-link": "^4.67.2",
+        "@contentful/f36-accordion": "^4.67.3",
+        "@contentful/f36-asset": "^4.67.3",
+        "@contentful/f36-autocomplete": "^4.67.3",
+        "@contentful/f36-avatar": "4.67.3",
+        "@contentful/f36-badge": "^4.67.3",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-card": "^4.67.3",
+        "@contentful/f36-collapse": "^4.67.3",
+        "@contentful/f36-copybutton": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-datepicker": "^4.67.3",
+        "@contentful/f36-datetime": "^4.67.3",
+        "@contentful/f36-drag-handle": "^4.67.3",
+        "@contentful/f36-empty-state": "^4.67.3",
+        "@contentful/f36-entity-list": "^4.67.3",
+        "@contentful/f36-forms": "^4.67.3",
+        "@contentful/f36-header": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-image": "4.67.3",
+        "@contentful/f36-list": "^4.67.3",
+        "@contentful/f36-menu": "^4.67.3",
+        "@contentful/f36-modal": "^4.67.3",
+        "@contentful/f36-navbar": "^4.67.3",
+        "@contentful/f36-note": "^4.67.3",
+        "@contentful/f36-notification": "^4.67.3",
+        "@contentful/f36-pagination": "^4.67.3",
+        "@contentful/f36-pill": "^4.67.3",
+        "@contentful/f36-popover": "^4.67.3",
+        "@contentful/f36-skeleton": "^4.67.3",
+        "@contentful/f36-spinner": "^4.67.3",
+        "@contentful/f36-table": "^4.67.3",
+        "@contentful/f36-tabs": "^4.67.3",
+        "@contentful/f36-text-link": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.3",
+        "@contentful/f36-typography": "^4.67.3",
         "@contentful/f36-utils": "^4.24.3"
       },
       "peerDependencies": {
@@ -2392,15 +2392,15 @@
       }
     },
     "node_modules/@contentful/f36-copybutton": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.67.2.tgz",
-      "integrity": "sha512-hb/DCGE6TTdepsjZvmDgog1glfF8WxGCx+F1S7FbwTZ4NutWeHEa7+E63t2tELTRx07FoVmkICmPtp89mCXKEw==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.67.3.tgz",
+      "integrity": "sha512-N6xD+oPlVL3dYXb4slnMfXFXw39kMexzHiFuQn9J/dsZyyhW+HYFB8hZ804U/s3YHJxSmwjhz22eBzqNbQrS1Q==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2409,9 +2409,9 @@
       }
     },
     "node_modules/@contentful/f36-core": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.67.2.tgz",
-      "integrity": "sha512-iSzA/OuhU4rIlBOlUTIczMuqDQZqLR1tmZJtZyouhfWkEc0VGUCX6S2FnBEXlMbnMzaL70lTXYUNu2bKxK4PfA==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.67.3.tgz",
+      "integrity": "sha512-W+wFcljUBvMP0mV6P3boqpARw2N71l01OrbkqfdG+A+jhVpFpbQTICuXnF9YmDDBjz+AXlUvSVDMmBLuQjm8/Q==",
       "dependencies": {
         "@contentful/f36-tokens": "^4.0.4",
         "@emotion/core": "^10.1.1",
@@ -2425,17 +2425,17 @@
       }
     },
     "node_modules/@contentful/f36-datepicker": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.67.2.tgz",
-      "integrity": "sha512-qGfVEjdZaMwdDBr1uWfgQtnCd8L+ZyVBpFiI8TyFUdQd6L9blHexr99Wg12uBNSub9zaL5fs4wrHZ5vMpGEjGQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.67.3.tgz",
+      "integrity": "sha512-0AR4KVIMkzcRbkfMYF/XR4RL4vaIg1zjCQh9M/F26R3Eb57DCsOgnK1bIY4YpazqU1s9YSiu2VGi7kEA//scuQ==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-popover": "^4.67.2",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-forms": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-popover": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "date-fns": "^2.28.0",
         "emotion": "^10.0.17",
         "react-day-picker": "^8.7.1",
@@ -2447,11 +2447,11 @@
       }
     },
     "node_modules/@contentful/f36-datetime": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.67.2.tgz",
-      "integrity": "sha512-7kz4I/CzRkupPb43dtAQ3a1bHffdx3ZQ0i9ueUl9CSs+dKhl9gwiH0bmoNN5pnULAQF4i7WQmNueEfQvh9zgvA==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.67.3.tgz",
+      "integrity": "sha512-BadR5IcrM/WYBmF8Yml4pMqz9LB4A5CsmlsolvevluNmxr2XoS9Y1cMKYujemiYs+86o9st+oh2+O7nz1BbpPQ==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "dayjs": "^1.11.5",
         "emotion": "^10.0.17"
@@ -2462,12 +2462,12 @@
       }
     },
     "node_modules/@contentful/f36-drag-handle": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.67.2.tgz",
-      "integrity": "sha512-7e38V/dJ79m4uVlnf1H1xpRY28DPwaMQOMgFWwPKCdketfr+YU8KI7kE2ssrd1EsM9av7Z0Dcwz6pF89wuxViA==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.67.3.tgz",
+      "integrity": "sha512-vrWf9W6h/2tWrU8iYekAbAmIBYqikUE8RJ0259PdQwrOS7gwDYHmKnv2uSEZJAmLtT7KrWWVyF6Jm2F8HmjdNg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
@@ -2478,12 +2478,12 @@
       }
     },
     "node_modules/@contentful/f36-empty-state": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.67.2.tgz",
-      "integrity": "sha512-ghzqNmwAOv0mAUvXDyLLtlAOXj5RPas/stJ8etPpb339NGFj5ueYf9+EBrgTCWrMK/JCBhcogV5bgKRsc9VKlg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.67.3.tgz",
+      "integrity": "sha512-D8nc+3IH8v4STkyJmXYM8cpO4o3qaslgoYb7Bz3RvZGtVNyBvD2bavg3zjQbKvsnV6bxtRXeDk9LjoCq/NjpoA==",
       "dependencies": {
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2492,21 +2492,20 @@
       }
     },
     "node_modules/@contentful/f36-entity-list": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.67.2.tgz",
-      "integrity": "sha512-G37dKH3yRD++fOA924UROtZdeIiNFmrjfVOobC03jdvk6o21AN2kMyDzML2Uc0+kMg+ofe4G08KC/OmDSUkSAg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.67.3.tgz",
+      "integrity": "sha512-yUkW3U7CkG+dsZ0LYK80rZMPxkQmI1LTGJmjct3IqukY+c9lni77acyVLd0p+BJUixO91SRcnKGysbpa9/keKg==",
       "dependencies": {
-        "@contentful/f36-badge": "^4.67.2",
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-icons-alpha": "npm:@contentful/f36-icons@^5.0.0-alpha.26",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-badge": "^4.67.3",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-drag-handle": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-menu": "^4.67.3",
+        "@contentful/f36-skeleton": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2515,14 +2514,14 @@
       }
     },
     "node_modules/@contentful/f36-forms": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.67.2.tgz",
-      "integrity": "sha512-+XxpnCiBKtZw2hYo5QZWVayWMPKzbarOIWzZUMm6Ttoru00zn5u3tlvue7c9W2zqkNFuUNOopAwXBwQ0h+z+bQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.67.3.tgz",
+      "integrity": "sha512-O+JJUZF0iOn2Y8AU6ooD8BLEvFC5X8tNDYAouux62gd+WQFGCyn7hkpN70wjNRiR0cNrS9QW+cs1pl/pLipy3g==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
@@ -2532,15 +2531,15 @@
       }
     },
     "node_modules/@contentful/f36-header": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-header/-/f36-header-4.67.2.tgz",
-      "integrity": "sha512-DjI5JnJuXixG8bAj03lRvISuAgwA2X6PnYifa//967Dd0qQTBw/CkB96AhrgVUjTw+jt3xAprwv0SUKF8x9S8g==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-header/-/f36-header-4.67.3.tgz",
+      "integrity": "sha512-cUth5PtzLzGQmG1rev++F5VWl/36TMy1GhSK06sjpgRxs0BCFEWgs4UJnelPLyyajkfTx4GUrP+CiHACkIMPKA==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.2",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.5",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2549,32 +2548,13 @@
       }
     },
     "node_modules/@contentful/f36-icon": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.67.2.tgz",
-      "integrity": "sha512-vJAk6KO88GVnHdPSXurUA67F4wl01sZHaaE5eHGvt/s+YuI47dstgROr5+z66qmncKpcMWOTv4/+jqYV1Ko56A==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.67.3.tgz",
+      "integrity": "sha512-lD9L7iJPL7d7axJOIrQxF9X1g+uYl4v+lfORNguLaCdRAiZcwlbmn0GaIsQvfqsQxZudFu92N4MuT3rGlh9bPw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-icon-alpha": {
-      "name": "@contentful/f36-icon",
-      "version": "5.0.0-alpha.20",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-5.0.0-alpha.20.tgz",
-      "integrity": "sha512-kI7HJggp/H8whiUL/RrG988nEvQq2SuZVyQn4kyiWYSlMWBRqQXZRvXfsM/RILWMgz2LxryXaT1YGVy2E4UfJA==",
-      "dependencies": {
-        "@contentful/f36-core": "^4.65.4",
-        "@contentful/f36-tokens": "^4.0.4",
-        "@phosphor-icons/react": "^2.1.5",
-        "emotion": "^10.0.17"
-      },
-      "engines": {
-        "node": ">=16"
       },
       "peerDependencies": {
         "react": ">=16.8",
@@ -2582,34 +2562,14 @@
       }
     },
     "node_modules/@contentful/f36-icons": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-4.28.2.tgz",
-      "integrity": "sha512-p7oWbQ5ITlMMuEl/6t/6JLVrCVhDE2nA8mv1VR4DHjXPm0y9w14533rCKxNIREZX8iVmyBoaqI3vdPsjUs1CAw==",
+      "version": "4.29.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-4.29.0.tgz",
+      "integrity": "sha512-oo/e2UhugDuSw5AXp7aDPMaUMIJEuWTAk0UaYSqaDh3+cv/7yctyvhcU0mrolmhC8HDKBHXK4Z0/QZkvqNb+Mw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.65.0",
-        "@contentful/f36-icon": "^4.65.0",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-icons-alpha": {
-      "name": "@contentful/f36-icons",
-      "version": "5.0.0-alpha.29",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-5.0.0-alpha.29.tgz",
-      "integrity": "sha512-7QhDDAo95WiqFwB/ofWd57GEyeLgkDU/CgTStjhtBZssheMvVT6thiIFy6hSbo314d1RZ5Z8EBzH1MIJ/nyQhA==",
-      "dependencies": {
-        "@contentful/f36-core": "^4.67.1",
-        "@contentful/f36-icon-alpha": "npm:@contentful/f36-icon@5.0.0-alpha.20",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@phosphor-icons/react": "^2.1.4",
-        "emotion": "^10.0.17"
-      },
-      "engines": {
-        "node": ">=16"
       },
       "peerDependencies": {
         "react": ">=16.8",
@@ -2617,12 +2577,12 @@
       }
     },
     "node_modules/@contentful/f36-image": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-image/-/f36-image-4.67.2.tgz",
-      "integrity": "sha512-zB4D/fBmUyIj1WvF2tWQHsDxzTcZ+KOyiVu0483rxRNai8sae7BO3VSuevUzfi2Y+gaF3VCasPZudjgTeWD2pQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-image/-/f36-image-4.67.3.tgz",
+      "integrity": "sha512-KFE+S3rKTzj0rdVFTy96gMKvMzn8K4ydoeL0xkoIOkpy33VfgySZJwf9s82NUPLPa+h0Fz4GYGZ0WcbZ0haxiA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-skeleton": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.5",
         "emotion": "^10.0.17"
       },
@@ -2632,11 +2592,11 @@
       }
     },
     "node_modules/@contentful/f36-list": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.67.2.tgz",
-      "integrity": "sha512-ZkObExturTfxpNZOBcHJMozuLIbDLe8Us5qe4qJyVozIBH+Ol6xOHxEEyEu8GsRZp0+GU7K3fWExqLEV22oSUQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.67.3.tgz",
+      "integrity": "sha512-qIs8K14G8PZfUTkp3WXUhtZQKMFqomFhYwI3bd/yfpDbA/bkFgCuhlwqO5R5MYR3ZPfqto0Euddgy084vu5whA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2646,15 +2606,15 @@
       }
     },
     "node_modules/@contentful/f36-menu": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.67.2.tgz",
-      "integrity": "sha512-TF+tpTLqE22qeQTYHJFuxCm6Yt37VFtwM6X9O07GYTeXeDZE7ZI+FrA16y+fxFw2Zu0OpbLO0CWB/ViolvMlOw==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.67.3.tgz",
+      "integrity": "sha512-a6eNH3RTbLT31gUPuQcKgyHT0tbah2n2N5VtKUA35LOQRPa/rBVOX0FsRiXTht0Tnb1aDIO/gjmKZZkfCNdIcg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-popover": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-popover": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
@@ -2664,15 +2624,15 @@
       }
     },
     "node_modules/@contentful/f36-modal": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.67.2.tgz",
-      "integrity": "sha512-mrO5+mKytV/j759HI0y6fZskQG/EEY7iNaRjjeYmFRoT6MAgViebcIeht15CcFwnNQLAeS3MusvXiEzuUzweiQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.67.3.tgz",
+      "integrity": "sha512-/DM6TIAoW2J+v4XY4cplQYKoxF7W43Al22N6zHoh2QE0yG6AJvVOmIGYMgGk3nYany45GeXrCU/rGFOplWo6Jg==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "@types/react-modal": "^3.13.1",
         "emotion": "^10.0.17",
         "react-modal": "^3.16.1"
@@ -2683,16 +2643,16 @@
       }
     },
     "node_modules/@contentful/f36-navbar": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-navbar/-/f36-navbar-4.67.2.tgz",
-      "integrity": "sha512-58PYpIElqnfdYWpEkSaOmccSzcgudYUs009UWmtqHmv0n3c8eNoV8taoZdg92gYAsEc7G2VWl4AZ3wJy/kiAdg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-navbar/-/f36-navbar-4.67.3.tgz",
+      "integrity": "sha512-8KLvY+pVX+diuXcBmdbGhI8OYCPa4Ba4BoRHaNDWX1jbucJcuysjRwAUc7wnOSb1lLqjqtIRVOL/edxTjqLmNQ==",
       "dependencies": {
-        "@contentful/f36-avatar": "4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-avatar": "4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-menu": "^4.67.3",
+        "@contentful/f36-skeleton": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.1",
         "@contentful/f36-utils": "^4.23.2",
         "emotion": "^10.0.17"
@@ -2703,16 +2663,16 @@
       }
     },
     "node_modules/@contentful/f36-note": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.67.2.tgz",
-      "integrity": "sha512-DA0f1/j640SG3LOon1VcU6kDvNgUHxupH0Q1FXS01aRrWq12uMd2bLtb2k5A9qRyT6MB3OdAKFufwsBcSL6fYw==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.67.3.tgz",
+      "integrity": "sha512-Is7QO7i+Bayc17WZZiNm/ztGbRkMV2ft6WEFIu0ra6NhcMi5CW/7Q358po0QVhr13OpQFDnO3MYRaLxifU5mVg==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2721,16 +2681,16 @@
       }
     },
     "node_modules/@contentful/f36-notification": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.67.2.tgz",
-      "integrity": "sha512-x7qxuqOhQMyhhRfMrisAVXnAo/eL6A7RjL2PmTLylaqKrFnzDrr25BtzepdkgULj9VLh70vXM5QIzPwpKpIJBQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.67.3.tgz",
+      "integrity": "sha512-kd5eXd3ZCNNHCfo9V7PI6XB9p4uVUPX59j+7zGGgLDqD1+PS1D3kYPMMJ4C42Ni5B4uF2kLT9tSlSGm3WkbeYg==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-text-link": "^4.67.2",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-text-link": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "@swc/helpers": "^0.4.14",
         "emotion": "^10.0.17",
         "react-animate-height": "^3.0.4"
@@ -2741,16 +2701,16 @@
       }
     },
     "node_modules/@contentful/f36-pagination": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.67.2.tgz",
-      "integrity": "sha512-/UePF1fbr2wvJHtJ9ncWaz5eg/VTdA8VqEBFJXge/IBgPVyMgQxQRxSDhvMj0j2Iit90qAzPedEDZK+jp6CyTg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.67.3.tgz",
+      "integrity": "sha512-fXwjCy20GkqljjsC8/z8Xg0beMYeIKw0nZpK/qMGs85vEW54py3PkwP8KwmRWkTFy7U8Q0D7USa2oOO65Ffv6Q==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-forms": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2759,16 +2719,16 @@
       }
     },
     "node_modules/@contentful/f36-pill": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.67.2.tgz",
-      "integrity": "sha512-015oRkVVnshvWAJ/kR5yJBD+soWmDcHFy5FGXDaIR5moTCejjqiLG1g8H6MolaF8oeKSOhbhgfX/dpEHn5/Z4g==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.67.3.tgz",
+      "integrity": "sha512-2bfYm8bhyeH1BNa8ioFAl6v3jq1C6sd9L8/oh6Sn9cKIsxAvqgIGTP+YOaRH+OqjDQxuHDNmld3XuTPlco8IRg==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-drag-handle": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2777,11 +2737,11 @@
       }
     },
     "node_modules/@contentful/f36-popover": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.67.2.tgz",
-      "integrity": "sha512-NJx54sqQEmuWIsBySXf/B+ZW/RoIkRzb7cnQ5aucN3nUd4ZaHOvcmYVLJMqfCV8ipzpMxLgoc8p3v6OcRdi72A==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.67.3.tgz",
+      "integrity": "sha512-3/eMw2gL1iEDswKUuRrMRAOFkzvrEk+DRXENejL2t8Fb/WU9lP1sOyYUG58UvzMLFDchzVLKHbcLPDTaaNaorw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -2794,12 +2754,12 @@
       }
     },
     "node_modules/@contentful/f36-skeleton": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.67.2.tgz",
-      "integrity": "sha512-4T8r/G8b9DFkLErIo8d2cGS71tWy1yNDZIThoHBWIhLRcstal8K7Ag5dQwPsaoSew/859oXC2rvPP0Ep+4FtCg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.67.3.tgz",
+      "integrity": "sha512-7qdbeIqnPie0NoKPVI6ebAGlBvxsNkGVbcieSecpZuCnIZGdm+E4AWgQ+Lm1CMw8CPYX0B4p94l5YDysGTZyxA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-table": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-table": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2809,11 +2769,11 @@
       }
     },
     "node_modules/@contentful/f36-spinner": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.67.2.tgz",
-      "integrity": "sha512-sBitcudBc4DwAOPn6MLuArLje7aym47GoIDI0kN9zQtolVwlVH92/zNpZmnm+zbP4Ku56/TgbL/v5SFTh+YB2w==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.67.3.tgz",
+      "integrity": "sha512-e1NJFcvLYphC321tDyTacnYOTcbv+yeQ1EcmIlmbSOYENZxTxzVMjD4uikrx8gm/CdquG8ahwf9/BYC07N9dJg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2823,14 +2783,14 @@
       }
     },
     "node_modules/@contentful/f36-table": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.67.2.tgz",
-      "integrity": "sha512-YtUkXwFmBLgAi5Glgi1vXqNbr+U2riadB9O+Aq8t2R/vpXMCIA4WlmXSqunwPW9UrrilalrK49l0IkDNpcRUbQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.67.3.tgz",
+      "integrity": "sha512-nzFIe28T4aBV7SXv6H8cefCuLAvsNlII9JxeBwI5JFUSgACpJsh1ANVdkDVilTo3cgiUFmvQmErYqiH0MMiy/Q==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2839,11 +2799,11 @@
       }
     },
     "node_modules/@contentful/f36-tabs": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.67.2.tgz",
-      "integrity": "sha512-rPPJQHmCoD8492yKufelL7MCj0j4FqcPc5yFhD29sqpGDqTko8Xf/V/q4/LPYUtXttH8myfTINEyNTsR/lZINg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.67.3.tgz",
+      "integrity": "sha512-tjdPelHm3L3DzHSWjHz+v7hciRG3QPs5y3WzloCgBjzgSk1BlcEiD2GuoWhPZM9WuUq3C92PwsVq/lB5urHyNA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@radix-ui/react-tabs": "^1.0.1",
         "emotion": "^10.0.17"
@@ -2854,11 +2814,11 @@
       }
     },
     "node_modules/@contentful/f36-text-link": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.67.2.tgz",
-      "integrity": "sha512-mWE4KsqQV93SNAFtYWqQB61/TLHuX1D3vVJ1rFqAp1kndPy7UyGcrQrGoPmM1l20Y9YaYIWYwo5eGKygY3iwIA==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.67.3.tgz",
+      "integrity": "sha512-jgWCMdeFwzMHHtHRHOcutq6x+hb2ipKXrSpZaiY8O/8Rh2wzKL6BIj/v+Jio4DJkaoGT8cEQLVuCP2JYiwm09A==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2873,11 +2833,11 @@
       "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
     },
     "node_modules/@contentful/f36-tooltip": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.67.2.tgz",
-      "integrity": "sha512-BFSKsJySAK1ipIOXueq6rgsJlmZDVBd60fjicALWiVX/GnxyDO3OkdX8nfK4Id0rbllf8+WBSR5UcVzNjuLe4Q==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.67.3.tgz",
+      "integrity": "sha512-40VkWQxm57Rf2ZydCPwnkiG+6WXBuswj+/nB97kpqjRohbSxKR0IzA5u0sAiWUglXDPH0Tu9IOtRz6PVAL4UZQ==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -2891,11 +2851,11 @@
       }
     },
     "node_modules/@contentful/f36-typography": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.67.2.tgz",
-      "integrity": "sha512-zfCVUQfD5wueT4mFNxLO+2SaUTFVHxE+7v8YKt53SvIiN+s/vXJnABOKPZsjYAYkwQwSrwPYIdIxMtaULwjoCw==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.67.3.tgz",
+      "integrity": "sha512-ujLg2yibJQxyHrJbCmv9ksWtNn3QuqOMew3i6WClUq2/BOdUjvdMtCW9zK8RbSXNV94FJXB0+AvG+dRQ4hqMNg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
@@ -3286,17 +3246,17 @@
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
     },
     "node_modules/@emotion/is-prop-valid": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz",
-      "integrity": "sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.3.0.tgz",
+      "integrity": "sha512-SHetuSLvJDzuNbOdtPVbq6yMMMlLoW5Q94uDqJZqy50gcmAjxFkVqmzqSGEFq9gT2iMuIeKV1PXVWmvUhuZLlQ==",
       "dependencies": {
-        "@emotion/memoize": "^0.8.1"
+        "@emotion/memoize": "^0.9.0"
       }
     },
     "node_modules/@emotion/memoize": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
-      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ=="
     },
     "node_modules/@emotion/serialize": {
       "version": "0.11.16",
@@ -4810,18 +4770,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@phosphor-icons/react": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.1.7.tgz",
-      "integrity": "sha512-g2e2eVAn1XG2a+LI09QU3IORLhnFNAFkNbo2iwbX6NOKSLOwvEMmTa7CgOzEbgNWR47z8i8kwjdvYZ5fkGx1mQ==",
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": ">= 16.8",
-        "react-dom": ">= 16.8"
       }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -8744,9 +8692,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.11",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.11.tgz",
-      "integrity": "sha512-okzr3f11N6WuqYtZSvm+F776mB41wRZMhKP+hc34YdW+KmtYYK9iqvHSwo2k9FEH3fhGXvOPV6yz2IcSrfRUDg=="
+      "version": "1.11.12",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.12.tgz",
+      "integrity": "sha512-Rt2g+nTbLlDWZTwwrIXjy9MeiZmSDI375FvZs72ngxx8PDC6YXOeR3q5LAuPzjZQxhiWdRKac7RKV+YyQYfYIg=="
     },
     "node_modules/debug": {
       "version": "4.3.4",

--- a/examples/function-mock-shop/package.json
+++ b/examples/function-mock-shop/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@contentful/app-sdk": "^4.28.0",
-    "@contentful/f36-components": "4.67.2",
+    "@contentful/f36-components": "4.67.3",
     "@contentful/f36-tokens": "4.0.5",
     "@contentful/react-apps-toolkit": "1.2.16",
     "@tanstack/react-query": "^5.51.11",

--- a/examples/function-potterdb-rest-api/package-lock.json
+++ b/examples/function-potterdb-rest-api/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@contentful/app-sdk": "^4.28.0",
-        "@contentful/f36-components": "4.67.2",
+        "@contentful/f36-components": "4.67.3",
         "@contentful/f36-icons": "^4.28.0",
         "@contentful/f36-tokens": "4.0.5",
         "@contentful/field-editor-single-line": "^1.4.2",
@@ -2188,15 +2188,15 @@
       }
     },
     "node_modules/@contentful/f36-accordion": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.67.2.tgz",
-      "integrity": "sha512-cX7xIX+fZadUNNFG+uzAOXeZ/GkMs+Y0bvgpxkpqW3ILu6GIXHsXetnRocxVaYUrQ1C/k6wEsd4xSv5y2uQBIg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.67.3.tgz",
+      "integrity": "sha512-d2Hwqg2Y8Pe9DP8XUAtVP8wKvqL6y4u9ydcSQDdQ4AZBT297zVzaXhTYzv7Bwi+Dq+4lagtkj39eU2IHXg/Aew==",
       "dependencies": {
-        "@contentful/f36-collapse": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-collapse": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2205,15 +2205,15 @@
       }
     },
     "node_modules/@contentful/f36-asset": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.67.2.tgz",
-      "integrity": "sha512-cUQaZQeXIr3oLy255cuL+mXNiYOpMvAzW7BxE3l903ShzlwVFqZr/FIaWAo2t488sWbGeXNXxVBcEbLzQUMIdA==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.67.3.tgz",
+      "integrity": "sha512-XTYNl6mS69By8MOvQwaHcIwxf+hnodUNzmMW3DgiGlptfKHtsgV6RlKil4PSluOaqtHUrIuXzPozCyMxPjf+0w==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2222,18 +2222,18 @@
       }
     },
     "node_modules/@contentful/f36-autocomplete": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.67.2.tgz",
-      "integrity": "sha512-1cZHVa2cskh4DvachcgaQeEuyjuAlxvvyJCqvpHpP+R3ISS6CsC44252fH52NcLryvfFG1zX24nZECgFOY/S+A==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.67.3.tgz",
+      "integrity": "sha512-meEb8OnRBDHrffLxqxfXfmKxyIKQPyFEMtjW6zRrilvDhFxw4KvKFU8XWX3gv3oBpWdpm5LEY/YnZuPqsRshow==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-popover": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-forms": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-popover": "^4.67.3",
+        "@contentful/f36-skeleton": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "@contentful/f36-utils": "^4.24.3",
         "downshift": "^6.1.12",
         "emotion": "^10.0.17"
@@ -2244,15 +2244,15 @@
       }
     },
     "node_modules/@contentful/f36-avatar": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-avatar/-/f36-avatar-4.67.2.tgz",
-      "integrity": "sha512-bKxmWgi67V6tPCX2mlSxJKtQ8IANoO7jU9qH74Fqe11ATgG84Oqy9iQgjJDQvfFMjyT9n+3zUtUCwo/waHHrQg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-avatar/-/f36-avatar-4.67.3.tgz",
+      "integrity": "sha512-gyVW7kJqrxZFOOhDzOsxkpelT7i6kE+TxbPrSClIpSfSWSWAQZnKFjBK3oeUH5VxnOrrZUO4IDIUTAIjF0UiDQ==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-image": "4.67.2",
-        "@contentful/f36-menu": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-image": "4.67.3",
+        "@contentful/f36-menu": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.5",
-        "@contentful/f36-tooltip": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2261,12 +2261,12 @@
       }
     },
     "node_modules/@contentful/f36-badge": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.67.2.tgz",
-      "integrity": "sha512-cWfb3Nk9+CdgmTvc75gzD6uJ4XCbK23pB1t9BV9ZvytvnuaQElZYh7WciyRKJtU51khb0KOuVCb/TOnjecU4xQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.67.3.tgz",
+      "integrity": "sha512-/9IzwrWLdv00t+iy0OfIwRCIQjxmdLcJCSzNFWHnbNSrjwCUPK3buZgtq9F8ueoFMobPuYed6b5X+VMAMlL4Hg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2276,12 +2276,12 @@
       }
     },
     "node_modules/@contentful/f36-button": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.67.2.tgz",
-      "integrity": "sha512-1/1dYtgfVk3wiP5SoaoQEWlM7VYp/Pju17agu5Y0MGuGo7LwjTCzLJQ4OeRvdubTYCW+iXc20sEG2H3OyRoz6w==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.67.3.tgz",
+      "integrity": "sha512-/w13GeJq4xN563Mrs5L6V6fEG2JHA3unsR/Rg+88agvoIgEj7bVNA6IunWVhKEHIfSucDJ+1hktNGfh1mPMQ4w==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-spinner": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-spinner": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
@@ -2292,22 +2292,22 @@
       }
     },
     "node_modules/@contentful/f36-card": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.67.2.tgz",
-      "integrity": "sha512-f1Ck9hbbfdX7/OIWPfXJSdriDVjoTQOdz4aXo1QVd2fmsTAzQCfH0llwXtCk8TCg4DbSwaS/ldB/CJV3oCN1AA==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.67.3.tgz",
+      "integrity": "sha512-LiCr/9sByOeY6GU6rW8HrSCJIdNVgO8IUwvPlciuqxKPyNgWOnqUiYpBZZNf74lqtLKuDXCzkKZaaF3j1JShLA==",
       "dependencies": {
-        "@contentful/f36-asset": "^4.67.2",
-        "@contentful/f36-badge": "^4.67.2",
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-asset": "^4.67.3",
+        "@contentful/f36-badge": "^4.67.3",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-drag-handle": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-menu": "^4.67.3",
+        "@contentful/f36-skeleton": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.3",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17",
         "truncate": "^3.0.0"
       },
@@ -2317,11 +2317,11 @@
       }
     },
     "node_modules/@contentful/f36-collapse": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.67.2.tgz",
-      "integrity": "sha512-EWkl653S3gnhVkq39Z0vDrIHQxvqJnN9XfrrORpX56ZCc4kHs1MzbbbDjnlj3udCy9Cj4Q50hiXpmeO/JogDlg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.67.3.tgz",
+      "integrity": "sha512-W8RQzN7H0x2jRNz6NN8EYLVDREwdPWPTTx89pSWnXaTG1EyITVUSGlgvc/kfOpLjbTC3HI1jwIlll+RGMFGs8A==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2331,47 +2331,47 @@
       }
     },
     "node_modules/@contentful/f36-components": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.67.2.tgz",
-      "integrity": "sha512-JNBX8YzP+mt2/d2m5uUnpFLGnzyRAsggWpEBUe8QgPRwkJ8bZIDrnm2TELIFqrY2t4Lvs2AJw8L/3kDaJvMNCQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.67.3.tgz",
+      "integrity": "sha512-AFw5q0JzT/L60w4tM3H399pXDO3lOcZootFwjKIaupHRjNPHHGQ1MlgMqNEIz1qSEbBbqKY3O6HlA2CmowznaQ==",
       "dependencies": {
-        "@contentful/f36-accordion": "^4.67.2",
-        "@contentful/f36-asset": "^4.67.2",
-        "@contentful/f36-autocomplete": "^4.67.2",
-        "@contentful/f36-avatar": "4.67.2",
-        "@contentful/f36-badge": "^4.67.2",
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-card": "^4.67.2",
-        "@contentful/f36-collapse": "^4.67.2",
-        "@contentful/f36-copybutton": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-datepicker": "^4.67.2",
-        "@contentful/f36-datetime": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-empty-state": "^4.67.2",
-        "@contentful/f36-entity-list": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
-        "@contentful/f36-header": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-image": "4.67.2",
-        "@contentful/f36-list": "^4.67.2",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-modal": "^4.67.2",
-        "@contentful/f36-navbar": "^4.67.2",
-        "@contentful/f36-note": "^4.67.2",
-        "@contentful/f36-notification": "^4.67.2",
-        "@contentful/f36-pagination": "^4.67.2",
-        "@contentful/f36-pill": "^4.67.2",
-        "@contentful/f36-popover": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
-        "@contentful/f36-spinner": "^4.67.2",
-        "@contentful/f36-table": "^4.67.2",
-        "@contentful/f36-tabs": "^4.67.2",
-        "@contentful/f36-text-link": "^4.67.2",
+        "@contentful/f36-accordion": "^4.67.3",
+        "@contentful/f36-asset": "^4.67.3",
+        "@contentful/f36-autocomplete": "^4.67.3",
+        "@contentful/f36-avatar": "4.67.3",
+        "@contentful/f36-badge": "^4.67.3",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-card": "^4.67.3",
+        "@contentful/f36-collapse": "^4.67.3",
+        "@contentful/f36-copybutton": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-datepicker": "^4.67.3",
+        "@contentful/f36-datetime": "^4.67.3",
+        "@contentful/f36-drag-handle": "^4.67.3",
+        "@contentful/f36-empty-state": "^4.67.3",
+        "@contentful/f36-entity-list": "^4.67.3",
+        "@contentful/f36-forms": "^4.67.3",
+        "@contentful/f36-header": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-image": "4.67.3",
+        "@contentful/f36-list": "^4.67.3",
+        "@contentful/f36-menu": "^4.67.3",
+        "@contentful/f36-modal": "^4.67.3",
+        "@contentful/f36-navbar": "^4.67.3",
+        "@contentful/f36-note": "^4.67.3",
+        "@contentful/f36-notification": "^4.67.3",
+        "@contentful/f36-pagination": "^4.67.3",
+        "@contentful/f36-pill": "^4.67.3",
+        "@contentful/f36-popover": "^4.67.3",
+        "@contentful/f36-skeleton": "^4.67.3",
+        "@contentful/f36-spinner": "^4.67.3",
+        "@contentful/f36-table": "^4.67.3",
+        "@contentful/f36-tabs": "^4.67.3",
+        "@contentful/f36-text-link": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.3",
+        "@contentful/f36-typography": "^4.67.3",
         "@contentful/f36-utils": "^4.24.3"
       },
       "peerDependencies": {
@@ -2390,15 +2390,15 @@
       }
     },
     "node_modules/@contentful/f36-copybutton": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.67.2.tgz",
-      "integrity": "sha512-hb/DCGE6TTdepsjZvmDgog1glfF8WxGCx+F1S7FbwTZ4NutWeHEa7+E63t2tELTRx07FoVmkICmPtp89mCXKEw==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.67.3.tgz",
+      "integrity": "sha512-N6xD+oPlVL3dYXb4slnMfXFXw39kMexzHiFuQn9J/dsZyyhW+HYFB8hZ804U/s3YHJxSmwjhz22eBzqNbQrS1Q==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2407,9 +2407,9 @@
       }
     },
     "node_modules/@contentful/f36-core": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.67.2.tgz",
-      "integrity": "sha512-iSzA/OuhU4rIlBOlUTIczMuqDQZqLR1tmZJtZyouhfWkEc0VGUCX6S2FnBEXlMbnMzaL70lTXYUNu2bKxK4PfA==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.67.3.tgz",
+      "integrity": "sha512-W+wFcljUBvMP0mV6P3boqpARw2N71l01OrbkqfdG+A+jhVpFpbQTICuXnF9YmDDBjz+AXlUvSVDMmBLuQjm8/Q==",
       "dependencies": {
         "@contentful/f36-tokens": "^4.0.4",
         "@emotion/core": "^10.1.1",
@@ -2423,17 +2423,17 @@
       }
     },
     "node_modules/@contentful/f36-datepicker": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.67.2.tgz",
-      "integrity": "sha512-qGfVEjdZaMwdDBr1uWfgQtnCd8L+ZyVBpFiI8TyFUdQd6L9blHexr99Wg12uBNSub9zaL5fs4wrHZ5vMpGEjGQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.67.3.tgz",
+      "integrity": "sha512-0AR4KVIMkzcRbkfMYF/XR4RL4vaIg1zjCQh9M/F26R3Eb57DCsOgnK1bIY4YpazqU1s9YSiu2VGi7kEA//scuQ==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-popover": "^4.67.2",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-forms": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-popover": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "date-fns": "^2.28.0",
         "emotion": "^10.0.17",
         "react-day-picker": "^8.7.1",
@@ -2445,11 +2445,11 @@
       }
     },
     "node_modules/@contentful/f36-datetime": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.67.2.tgz",
-      "integrity": "sha512-7kz4I/CzRkupPb43dtAQ3a1bHffdx3ZQ0i9ueUl9CSs+dKhl9gwiH0bmoNN5pnULAQF4i7WQmNueEfQvh9zgvA==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.67.3.tgz",
+      "integrity": "sha512-BadR5IcrM/WYBmF8Yml4pMqz9LB4A5CsmlsolvevluNmxr2XoS9Y1cMKYujemiYs+86o9st+oh2+O7nz1BbpPQ==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "dayjs": "^1.11.5",
         "emotion": "^10.0.17"
@@ -2460,12 +2460,12 @@
       }
     },
     "node_modules/@contentful/f36-drag-handle": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.67.2.tgz",
-      "integrity": "sha512-7e38V/dJ79m4uVlnf1H1xpRY28DPwaMQOMgFWwPKCdketfr+YU8KI7kE2ssrd1EsM9av7Z0Dcwz6pF89wuxViA==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.67.3.tgz",
+      "integrity": "sha512-vrWf9W6h/2tWrU8iYekAbAmIBYqikUE8RJ0259PdQwrOS7gwDYHmKnv2uSEZJAmLtT7KrWWVyF6Jm2F8HmjdNg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
@@ -2476,12 +2476,12 @@
       }
     },
     "node_modules/@contentful/f36-empty-state": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.67.2.tgz",
-      "integrity": "sha512-ghzqNmwAOv0mAUvXDyLLtlAOXj5RPas/stJ8etPpb339NGFj5ueYf9+EBrgTCWrMK/JCBhcogV5bgKRsc9VKlg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.67.3.tgz",
+      "integrity": "sha512-D8nc+3IH8v4STkyJmXYM8cpO4o3qaslgoYb7Bz3RvZGtVNyBvD2bavg3zjQbKvsnV6bxtRXeDk9LjoCq/NjpoA==",
       "dependencies": {
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2490,21 +2490,20 @@
       }
     },
     "node_modules/@contentful/f36-entity-list": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.67.2.tgz",
-      "integrity": "sha512-G37dKH3yRD++fOA924UROtZdeIiNFmrjfVOobC03jdvk6o21AN2kMyDzML2Uc0+kMg+ofe4G08KC/OmDSUkSAg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.67.3.tgz",
+      "integrity": "sha512-yUkW3U7CkG+dsZ0LYK80rZMPxkQmI1LTGJmjct3IqukY+c9lni77acyVLd0p+BJUixO91SRcnKGysbpa9/keKg==",
       "dependencies": {
-        "@contentful/f36-badge": "^4.67.2",
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-icons-alpha": "npm:@contentful/f36-icons@^5.0.0-alpha.26",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-badge": "^4.67.3",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-drag-handle": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-menu": "^4.67.3",
+        "@contentful/f36-skeleton": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2513,14 +2512,14 @@
       }
     },
     "node_modules/@contentful/f36-forms": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.67.2.tgz",
-      "integrity": "sha512-+XxpnCiBKtZw2hYo5QZWVayWMPKzbarOIWzZUMm6Ttoru00zn5u3tlvue7c9W2zqkNFuUNOopAwXBwQ0h+z+bQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.67.3.tgz",
+      "integrity": "sha512-O+JJUZF0iOn2Y8AU6ooD8BLEvFC5X8tNDYAouux62gd+WQFGCyn7hkpN70wjNRiR0cNrS9QW+cs1pl/pLipy3g==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
@@ -2530,15 +2529,15 @@
       }
     },
     "node_modules/@contentful/f36-header": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-header/-/f36-header-4.67.2.tgz",
-      "integrity": "sha512-DjI5JnJuXixG8bAj03lRvISuAgwA2X6PnYifa//967Dd0qQTBw/CkB96AhrgVUjTw+jt3xAprwv0SUKF8x9S8g==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-header/-/f36-header-4.67.3.tgz",
+      "integrity": "sha512-cUth5PtzLzGQmG1rev++F5VWl/36TMy1GhSK06sjpgRxs0BCFEWgs4UJnelPLyyajkfTx4GUrP+CiHACkIMPKA==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.2",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.5",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2547,32 +2546,13 @@
       }
     },
     "node_modules/@contentful/f36-icon": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.67.2.tgz",
-      "integrity": "sha512-vJAk6KO88GVnHdPSXurUA67F4wl01sZHaaE5eHGvt/s+YuI47dstgROr5+z66qmncKpcMWOTv4/+jqYV1Ko56A==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.67.3.tgz",
+      "integrity": "sha512-lD9L7iJPL7d7axJOIrQxF9X1g+uYl4v+lfORNguLaCdRAiZcwlbmn0GaIsQvfqsQxZudFu92N4MuT3rGlh9bPw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-icon-alpha": {
-      "name": "@contentful/f36-icon",
-      "version": "5.0.0-alpha.20",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-5.0.0-alpha.20.tgz",
-      "integrity": "sha512-kI7HJggp/H8whiUL/RrG988nEvQq2SuZVyQn4kyiWYSlMWBRqQXZRvXfsM/RILWMgz2LxryXaT1YGVy2E4UfJA==",
-      "dependencies": {
-        "@contentful/f36-core": "^4.65.4",
-        "@contentful/f36-tokens": "^4.0.4",
-        "@phosphor-icons/react": "^2.1.5",
-        "emotion": "^10.0.17"
-      },
-      "engines": {
-        "node": ">=16"
       },
       "peerDependencies": {
         "react": ">=16.8",
@@ -2580,34 +2560,14 @@
       }
     },
     "node_modules/@contentful/f36-icons": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-4.28.2.tgz",
-      "integrity": "sha512-p7oWbQ5ITlMMuEl/6t/6JLVrCVhDE2nA8mv1VR4DHjXPm0y9w14533rCKxNIREZX8iVmyBoaqI3vdPsjUs1CAw==",
+      "version": "4.29.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-4.29.0.tgz",
+      "integrity": "sha512-oo/e2UhugDuSw5AXp7aDPMaUMIJEuWTAk0UaYSqaDh3+cv/7yctyvhcU0mrolmhC8HDKBHXK4Z0/QZkvqNb+Mw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.65.0",
-        "@contentful/f36-icon": "^4.65.0",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-icons-alpha": {
-      "name": "@contentful/f36-icons",
-      "version": "5.0.0-alpha.29",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-5.0.0-alpha.29.tgz",
-      "integrity": "sha512-7QhDDAo95WiqFwB/ofWd57GEyeLgkDU/CgTStjhtBZssheMvVT6thiIFy6hSbo314d1RZ5Z8EBzH1MIJ/nyQhA==",
-      "dependencies": {
-        "@contentful/f36-core": "^4.67.1",
-        "@contentful/f36-icon-alpha": "npm:@contentful/f36-icon@5.0.0-alpha.20",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@phosphor-icons/react": "^2.1.4",
-        "emotion": "^10.0.17"
-      },
-      "engines": {
-        "node": ">=16"
       },
       "peerDependencies": {
         "react": ">=16.8",
@@ -2615,12 +2575,12 @@
       }
     },
     "node_modules/@contentful/f36-image": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-image/-/f36-image-4.67.2.tgz",
-      "integrity": "sha512-zB4D/fBmUyIj1WvF2tWQHsDxzTcZ+KOyiVu0483rxRNai8sae7BO3VSuevUzfi2Y+gaF3VCasPZudjgTeWD2pQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-image/-/f36-image-4.67.3.tgz",
+      "integrity": "sha512-KFE+S3rKTzj0rdVFTy96gMKvMzn8K4ydoeL0xkoIOkpy33VfgySZJwf9s82NUPLPa+h0Fz4GYGZ0WcbZ0haxiA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-skeleton": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.5",
         "emotion": "^10.0.17"
       },
@@ -2630,11 +2590,11 @@
       }
     },
     "node_modules/@contentful/f36-list": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.67.2.tgz",
-      "integrity": "sha512-ZkObExturTfxpNZOBcHJMozuLIbDLe8Us5qe4qJyVozIBH+Ol6xOHxEEyEu8GsRZp0+GU7K3fWExqLEV22oSUQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.67.3.tgz",
+      "integrity": "sha512-qIs8K14G8PZfUTkp3WXUhtZQKMFqomFhYwI3bd/yfpDbA/bkFgCuhlwqO5R5MYR3ZPfqto0Euddgy084vu5whA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2644,15 +2604,15 @@
       }
     },
     "node_modules/@contentful/f36-menu": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.67.2.tgz",
-      "integrity": "sha512-TF+tpTLqE22qeQTYHJFuxCm6Yt37VFtwM6X9O07GYTeXeDZE7ZI+FrA16y+fxFw2Zu0OpbLO0CWB/ViolvMlOw==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.67.3.tgz",
+      "integrity": "sha512-a6eNH3RTbLT31gUPuQcKgyHT0tbah2n2N5VtKUA35LOQRPa/rBVOX0FsRiXTht0Tnb1aDIO/gjmKZZkfCNdIcg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-popover": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-popover": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
@@ -2662,15 +2622,15 @@
       }
     },
     "node_modules/@contentful/f36-modal": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.67.2.tgz",
-      "integrity": "sha512-mrO5+mKytV/j759HI0y6fZskQG/EEY7iNaRjjeYmFRoT6MAgViebcIeht15CcFwnNQLAeS3MusvXiEzuUzweiQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.67.3.tgz",
+      "integrity": "sha512-/DM6TIAoW2J+v4XY4cplQYKoxF7W43Al22N6zHoh2QE0yG6AJvVOmIGYMgGk3nYany45GeXrCU/rGFOplWo6Jg==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "@types/react-modal": "^3.13.1",
         "emotion": "^10.0.17",
         "react-modal": "^3.16.1"
@@ -2681,16 +2641,16 @@
       }
     },
     "node_modules/@contentful/f36-navbar": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-navbar/-/f36-navbar-4.67.2.tgz",
-      "integrity": "sha512-58PYpIElqnfdYWpEkSaOmccSzcgudYUs009UWmtqHmv0n3c8eNoV8taoZdg92gYAsEc7G2VWl4AZ3wJy/kiAdg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-navbar/-/f36-navbar-4.67.3.tgz",
+      "integrity": "sha512-8KLvY+pVX+diuXcBmdbGhI8OYCPa4Ba4BoRHaNDWX1jbucJcuysjRwAUc7wnOSb1lLqjqtIRVOL/edxTjqLmNQ==",
       "dependencies": {
-        "@contentful/f36-avatar": "4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-avatar": "4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-menu": "^4.67.3",
+        "@contentful/f36-skeleton": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.1",
         "@contentful/f36-utils": "^4.23.2",
         "emotion": "^10.0.17"
@@ -2701,16 +2661,16 @@
       }
     },
     "node_modules/@contentful/f36-note": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.67.2.tgz",
-      "integrity": "sha512-DA0f1/j640SG3LOon1VcU6kDvNgUHxupH0Q1FXS01aRrWq12uMd2bLtb2k5A9qRyT6MB3OdAKFufwsBcSL6fYw==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.67.3.tgz",
+      "integrity": "sha512-Is7QO7i+Bayc17WZZiNm/ztGbRkMV2ft6WEFIu0ra6NhcMi5CW/7Q358po0QVhr13OpQFDnO3MYRaLxifU5mVg==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2719,16 +2679,16 @@
       }
     },
     "node_modules/@contentful/f36-notification": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.67.2.tgz",
-      "integrity": "sha512-x7qxuqOhQMyhhRfMrisAVXnAo/eL6A7RjL2PmTLylaqKrFnzDrr25BtzepdkgULj9VLh70vXM5QIzPwpKpIJBQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.67.3.tgz",
+      "integrity": "sha512-kd5eXd3ZCNNHCfo9V7PI6XB9p4uVUPX59j+7zGGgLDqD1+PS1D3kYPMMJ4C42Ni5B4uF2kLT9tSlSGm3WkbeYg==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-text-link": "^4.67.2",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-text-link": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "@swc/helpers": "^0.4.14",
         "emotion": "^10.0.17",
         "react-animate-height": "^3.0.4"
@@ -2739,16 +2699,16 @@
       }
     },
     "node_modules/@contentful/f36-pagination": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.67.2.tgz",
-      "integrity": "sha512-/UePF1fbr2wvJHtJ9ncWaz5eg/VTdA8VqEBFJXge/IBgPVyMgQxQRxSDhvMj0j2Iit90qAzPedEDZK+jp6CyTg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.67.3.tgz",
+      "integrity": "sha512-fXwjCy20GkqljjsC8/z8Xg0beMYeIKw0nZpK/qMGs85vEW54py3PkwP8KwmRWkTFy7U8Q0D7USa2oOO65Ffv6Q==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-forms": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2757,16 +2717,16 @@
       }
     },
     "node_modules/@contentful/f36-pill": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.67.2.tgz",
-      "integrity": "sha512-015oRkVVnshvWAJ/kR5yJBD+soWmDcHFy5FGXDaIR5moTCejjqiLG1g8H6MolaF8oeKSOhbhgfX/dpEHn5/Z4g==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.67.3.tgz",
+      "integrity": "sha512-2bfYm8bhyeH1BNa8ioFAl6v3jq1C6sd9L8/oh6Sn9cKIsxAvqgIGTP+YOaRH+OqjDQxuHDNmld3XuTPlco8IRg==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-drag-handle": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2775,11 +2735,11 @@
       }
     },
     "node_modules/@contentful/f36-popover": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.67.2.tgz",
-      "integrity": "sha512-NJx54sqQEmuWIsBySXf/B+ZW/RoIkRzb7cnQ5aucN3nUd4ZaHOvcmYVLJMqfCV8ipzpMxLgoc8p3v6OcRdi72A==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.67.3.tgz",
+      "integrity": "sha512-3/eMw2gL1iEDswKUuRrMRAOFkzvrEk+DRXENejL2t8Fb/WU9lP1sOyYUG58UvzMLFDchzVLKHbcLPDTaaNaorw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -2792,12 +2752,12 @@
       }
     },
     "node_modules/@contentful/f36-skeleton": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.67.2.tgz",
-      "integrity": "sha512-4T8r/G8b9DFkLErIo8d2cGS71tWy1yNDZIThoHBWIhLRcstal8K7Ag5dQwPsaoSew/859oXC2rvPP0Ep+4FtCg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.67.3.tgz",
+      "integrity": "sha512-7qdbeIqnPie0NoKPVI6ebAGlBvxsNkGVbcieSecpZuCnIZGdm+E4AWgQ+Lm1CMw8CPYX0B4p94l5YDysGTZyxA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-table": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-table": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2807,11 +2767,11 @@
       }
     },
     "node_modules/@contentful/f36-spinner": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.67.2.tgz",
-      "integrity": "sha512-sBitcudBc4DwAOPn6MLuArLje7aym47GoIDI0kN9zQtolVwlVH92/zNpZmnm+zbP4Ku56/TgbL/v5SFTh+YB2w==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.67.3.tgz",
+      "integrity": "sha512-e1NJFcvLYphC321tDyTacnYOTcbv+yeQ1EcmIlmbSOYENZxTxzVMjD4uikrx8gm/CdquG8ahwf9/BYC07N9dJg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2821,14 +2781,14 @@
       }
     },
     "node_modules/@contentful/f36-table": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.67.2.tgz",
-      "integrity": "sha512-YtUkXwFmBLgAi5Glgi1vXqNbr+U2riadB9O+Aq8t2R/vpXMCIA4WlmXSqunwPW9UrrilalrK49l0IkDNpcRUbQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.67.3.tgz",
+      "integrity": "sha512-nzFIe28T4aBV7SXv6H8cefCuLAvsNlII9JxeBwI5JFUSgACpJsh1ANVdkDVilTo3cgiUFmvQmErYqiH0MMiy/Q==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2837,11 +2797,11 @@
       }
     },
     "node_modules/@contentful/f36-tabs": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.67.2.tgz",
-      "integrity": "sha512-rPPJQHmCoD8492yKufelL7MCj0j4FqcPc5yFhD29sqpGDqTko8Xf/V/q4/LPYUtXttH8myfTINEyNTsR/lZINg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.67.3.tgz",
+      "integrity": "sha512-tjdPelHm3L3DzHSWjHz+v7hciRG3QPs5y3WzloCgBjzgSk1BlcEiD2GuoWhPZM9WuUq3C92PwsVq/lB5urHyNA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@radix-ui/react-tabs": "^1.0.1",
         "emotion": "^10.0.17"
@@ -2852,11 +2812,11 @@
       }
     },
     "node_modules/@contentful/f36-text-link": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.67.2.tgz",
-      "integrity": "sha512-mWE4KsqQV93SNAFtYWqQB61/TLHuX1D3vVJ1rFqAp1kndPy7UyGcrQrGoPmM1l20Y9YaYIWYwo5eGKygY3iwIA==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.67.3.tgz",
+      "integrity": "sha512-jgWCMdeFwzMHHtHRHOcutq6x+hb2ipKXrSpZaiY8O/8Rh2wzKL6BIj/v+Jio4DJkaoGT8cEQLVuCP2JYiwm09A==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2871,11 +2831,11 @@
       "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
     },
     "node_modules/@contentful/f36-tooltip": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.67.2.tgz",
-      "integrity": "sha512-BFSKsJySAK1ipIOXueq6rgsJlmZDVBd60fjicALWiVX/GnxyDO3OkdX8nfK4Id0rbllf8+WBSR5UcVzNjuLe4Q==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.67.3.tgz",
+      "integrity": "sha512-40VkWQxm57Rf2ZydCPwnkiG+6WXBuswj+/nB97kpqjRohbSxKR0IzA5u0sAiWUglXDPH0Tu9IOtRz6PVAL4UZQ==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -2889,11 +2849,11 @@
       }
     },
     "node_modules/@contentful/f36-typography": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.67.2.tgz",
-      "integrity": "sha512-zfCVUQfD5wueT4mFNxLO+2SaUTFVHxE+7v8YKt53SvIiN+s/vXJnABOKPZsjYAYkwQwSrwPYIdIxMtaULwjoCw==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.67.3.tgz",
+      "integrity": "sha512-ujLg2yibJQxyHrJbCmv9ksWtNn3QuqOMew3i6WClUq2/BOdUjvdMtCW9zK8RbSXNV94FJXB0+AvG+dRQ4hqMNg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
@@ -4965,18 +4925,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@phosphor-icons/react": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.1.7.tgz",
-      "integrity": "sha512-g2e2eVAn1XG2a+LI09QU3IORLhnFNAFkNbo2iwbX6NOKSLOwvEMmTa7CgOzEbgNWR47z8i8kwjdvYZ5fkGx1mQ==",
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": ">= 16.8",
-        "react-dom": ">= 16.8"
       }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -8934,9 +8882,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.11",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.11.tgz",
-      "integrity": "sha512-okzr3f11N6WuqYtZSvm+F776mB41wRZMhKP+hc34YdW+KmtYYK9iqvHSwo2k9FEH3fhGXvOPV6yz2IcSrfRUDg=="
+      "version": "1.11.12",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.12.tgz",
+      "integrity": "sha512-Rt2g+nTbLlDWZTwwrIXjy9MeiZmSDI375FvZs72ngxx8PDC6YXOeR3q5LAuPzjZQxhiWdRKac7RKV+YyQYfYIg=="
     },
     "node_modules/debug": {
       "version": "4.3.4",

--- a/examples/function-potterdb-rest-api/package.json
+++ b/examples/function-potterdb-rest-api/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@contentful/app-sdk": "^4.28.0",
-    "@contentful/f36-components": "4.67.2",
+    "@contentful/f36-components": "4.67.3",
     "@contentful/f36-icons": "^4.28.0",
     "@contentful/f36-tokens": "4.0.5",
     "@contentful/field-editor-single-line": "^1.4.2",

--- a/examples/function-potterdb/package-lock.json
+++ b/examples/function-potterdb/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@contentful/app-sdk": "^4.28.0",
-        "@contentful/f36-components": "4.67.2",
+        "@contentful/f36-components": "4.67.3",
         "@contentful/f36-icons": "^4.28.2",
         "@contentful/f36-tokens": "4.0.5",
         "@contentful/field-editor-single-line": "^1.4.2",
@@ -2186,15 +2186,15 @@
       }
     },
     "node_modules/@contentful/f36-accordion": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.67.2.tgz",
-      "integrity": "sha512-cX7xIX+fZadUNNFG+uzAOXeZ/GkMs+Y0bvgpxkpqW3ILu6GIXHsXetnRocxVaYUrQ1C/k6wEsd4xSv5y2uQBIg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.67.3.tgz",
+      "integrity": "sha512-d2Hwqg2Y8Pe9DP8XUAtVP8wKvqL6y4u9ydcSQDdQ4AZBT297zVzaXhTYzv7Bwi+Dq+4lagtkj39eU2IHXg/Aew==",
       "dependencies": {
-        "@contentful/f36-collapse": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-collapse": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2203,15 +2203,15 @@
       }
     },
     "node_modules/@contentful/f36-asset": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.67.2.tgz",
-      "integrity": "sha512-cUQaZQeXIr3oLy255cuL+mXNiYOpMvAzW7BxE3l903ShzlwVFqZr/FIaWAo2t488sWbGeXNXxVBcEbLzQUMIdA==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.67.3.tgz",
+      "integrity": "sha512-XTYNl6mS69By8MOvQwaHcIwxf+hnodUNzmMW3DgiGlptfKHtsgV6RlKil4PSluOaqtHUrIuXzPozCyMxPjf+0w==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2220,18 +2220,18 @@
       }
     },
     "node_modules/@contentful/f36-autocomplete": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.67.2.tgz",
-      "integrity": "sha512-1cZHVa2cskh4DvachcgaQeEuyjuAlxvvyJCqvpHpP+R3ISS6CsC44252fH52NcLryvfFG1zX24nZECgFOY/S+A==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.67.3.tgz",
+      "integrity": "sha512-meEb8OnRBDHrffLxqxfXfmKxyIKQPyFEMtjW6zRrilvDhFxw4KvKFU8XWX3gv3oBpWdpm5LEY/YnZuPqsRshow==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-popover": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-forms": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-popover": "^4.67.3",
+        "@contentful/f36-skeleton": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "@contentful/f36-utils": "^4.24.3",
         "downshift": "^6.1.12",
         "emotion": "^10.0.17"
@@ -2242,15 +2242,15 @@
       }
     },
     "node_modules/@contentful/f36-avatar": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-avatar/-/f36-avatar-4.67.2.tgz",
-      "integrity": "sha512-bKxmWgi67V6tPCX2mlSxJKtQ8IANoO7jU9qH74Fqe11ATgG84Oqy9iQgjJDQvfFMjyT9n+3zUtUCwo/waHHrQg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-avatar/-/f36-avatar-4.67.3.tgz",
+      "integrity": "sha512-gyVW7kJqrxZFOOhDzOsxkpelT7i6kE+TxbPrSClIpSfSWSWAQZnKFjBK3oeUH5VxnOrrZUO4IDIUTAIjF0UiDQ==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-image": "4.67.2",
-        "@contentful/f36-menu": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-image": "4.67.3",
+        "@contentful/f36-menu": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.5",
-        "@contentful/f36-tooltip": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2259,12 +2259,12 @@
       }
     },
     "node_modules/@contentful/f36-badge": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.67.2.tgz",
-      "integrity": "sha512-cWfb3Nk9+CdgmTvc75gzD6uJ4XCbK23pB1t9BV9ZvytvnuaQElZYh7WciyRKJtU51khb0KOuVCb/TOnjecU4xQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.67.3.tgz",
+      "integrity": "sha512-/9IzwrWLdv00t+iy0OfIwRCIQjxmdLcJCSzNFWHnbNSrjwCUPK3buZgtq9F8ueoFMobPuYed6b5X+VMAMlL4Hg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2274,12 +2274,12 @@
       }
     },
     "node_modules/@contentful/f36-button": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.67.2.tgz",
-      "integrity": "sha512-1/1dYtgfVk3wiP5SoaoQEWlM7VYp/Pju17agu5Y0MGuGo7LwjTCzLJQ4OeRvdubTYCW+iXc20sEG2H3OyRoz6w==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.67.3.tgz",
+      "integrity": "sha512-/w13GeJq4xN563Mrs5L6V6fEG2JHA3unsR/Rg+88agvoIgEj7bVNA6IunWVhKEHIfSucDJ+1hktNGfh1mPMQ4w==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-spinner": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-spinner": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
@@ -2290,22 +2290,22 @@
       }
     },
     "node_modules/@contentful/f36-card": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.67.2.tgz",
-      "integrity": "sha512-f1Ck9hbbfdX7/OIWPfXJSdriDVjoTQOdz4aXo1QVd2fmsTAzQCfH0llwXtCk8TCg4DbSwaS/ldB/CJV3oCN1AA==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.67.3.tgz",
+      "integrity": "sha512-LiCr/9sByOeY6GU6rW8HrSCJIdNVgO8IUwvPlciuqxKPyNgWOnqUiYpBZZNf74lqtLKuDXCzkKZaaF3j1JShLA==",
       "dependencies": {
-        "@contentful/f36-asset": "^4.67.2",
-        "@contentful/f36-badge": "^4.67.2",
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-asset": "^4.67.3",
+        "@contentful/f36-badge": "^4.67.3",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-drag-handle": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-menu": "^4.67.3",
+        "@contentful/f36-skeleton": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.3",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17",
         "truncate": "^3.0.0"
       },
@@ -2315,11 +2315,11 @@
       }
     },
     "node_modules/@contentful/f36-collapse": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.67.2.tgz",
-      "integrity": "sha512-EWkl653S3gnhVkq39Z0vDrIHQxvqJnN9XfrrORpX56ZCc4kHs1MzbbbDjnlj3udCy9Cj4Q50hiXpmeO/JogDlg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.67.3.tgz",
+      "integrity": "sha512-W8RQzN7H0x2jRNz6NN8EYLVDREwdPWPTTx89pSWnXaTG1EyITVUSGlgvc/kfOpLjbTC3HI1jwIlll+RGMFGs8A==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2329,47 +2329,47 @@
       }
     },
     "node_modules/@contentful/f36-components": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.67.2.tgz",
-      "integrity": "sha512-JNBX8YzP+mt2/d2m5uUnpFLGnzyRAsggWpEBUe8QgPRwkJ8bZIDrnm2TELIFqrY2t4Lvs2AJw8L/3kDaJvMNCQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.67.3.tgz",
+      "integrity": "sha512-AFw5q0JzT/L60w4tM3H399pXDO3lOcZootFwjKIaupHRjNPHHGQ1MlgMqNEIz1qSEbBbqKY3O6HlA2CmowznaQ==",
       "dependencies": {
-        "@contentful/f36-accordion": "^4.67.2",
-        "@contentful/f36-asset": "^4.67.2",
-        "@contentful/f36-autocomplete": "^4.67.2",
-        "@contentful/f36-avatar": "4.67.2",
-        "@contentful/f36-badge": "^4.67.2",
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-card": "^4.67.2",
-        "@contentful/f36-collapse": "^4.67.2",
-        "@contentful/f36-copybutton": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-datepicker": "^4.67.2",
-        "@contentful/f36-datetime": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-empty-state": "^4.67.2",
-        "@contentful/f36-entity-list": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
-        "@contentful/f36-header": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-image": "4.67.2",
-        "@contentful/f36-list": "^4.67.2",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-modal": "^4.67.2",
-        "@contentful/f36-navbar": "^4.67.2",
-        "@contentful/f36-note": "^4.67.2",
-        "@contentful/f36-notification": "^4.67.2",
-        "@contentful/f36-pagination": "^4.67.2",
-        "@contentful/f36-pill": "^4.67.2",
-        "@contentful/f36-popover": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
-        "@contentful/f36-spinner": "^4.67.2",
-        "@contentful/f36-table": "^4.67.2",
-        "@contentful/f36-tabs": "^4.67.2",
-        "@contentful/f36-text-link": "^4.67.2",
+        "@contentful/f36-accordion": "^4.67.3",
+        "@contentful/f36-asset": "^4.67.3",
+        "@contentful/f36-autocomplete": "^4.67.3",
+        "@contentful/f36-avatar": "4.67.3",
+        "@contentful/f36-badge": "^4.67.3",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-card": "^4.67.3",
+        "@contentful/f36-collapse": "^4.67.3",
+        "@contentful/f36-copybutton": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-datepicker": "^4.67.3",
+        "@contentful/f36-datetime": "^4.67.3",
+        "@contentful/f36-drag-handle": "^4.67.3",
+        "@contentful/f36-empty-state": "^4.67.3",
+        "@contentful/f36-entity-list": "^4.67.3",
+        "@contentful/f36-forms": "^4.67.3",
+        "@contentful/f36-header": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-image": "4.67.3",
+        "@contentful/f36-list": "^4.67.3",
+        "@contentful/f36-menu": "^4.67.3",
+        "@contentful/f36-modal": "^4.67.3",
+        "@contentful/f36-navbar": "^4.67.3",
+        "@contentful/f36-note": "^4.67.3",
+        "@contentful/f36-notification": "^4.67.3",
+        "@contentful/f36-pagination": "^4.67.3",
+        "@contentful/f36-pill": "^4.67.3",
+        "@contentful/f36-popover": "^4.67.3",
+        "@contentful/f36-skeleton": "^4.67.3",
+        "@contentful/f36-spinner": "^4.67.3",
+        "@contentful/f36-table": "^4.67.3",
+        "@contentful/f36-tabs": "^4.67.3",
+        "@contentful/f36-text-link": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.3",
+        "@contentful/f36-typography": "^4.67.3",
         "@contentful/f36-utils": "^4.24.3"
       },
       "peerDependencies": {
@@ -2388,15 +2388,15 @@
       }
     },
     "node_modules/@contentful/f36-copybutton": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.67.2.tgz",
-      "integrity": "sha512-hb/DCGE6TTdepsjZvmDgog1glfF8WxGCx+F1S7FbwTZ4NutWeHEa7+E63t2tELTRx07FoVmkICmPtp89mCXKEw==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.67.3.tgz",
+      "integrity": "sha512-N6xD+oPlVL3dYXb4slnMfXFXw39kMexzHiFuQn9J/dsZyyhW+HYFB8hZ804U/s3YHJxSmwjhz22eBzqNbQrS1Q==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2405,9 +2405,9 @@
       }
     },
     "node_modules/@contentful/f36-core": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.67.2.tgz",
-      "integrity": "sha512-iSzA/OuhU4rIlBOlUTIczMuqDQZqLR1tmZJtZyouhfWkEc0VGUCX6S2FnBEXlMbnMzaL70lTXYUNu2bKxK4PfA==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.67.3.tgz",
+      "integrity": "sha512-W+wFcljUBvMP0mV6P3boqpARw2N71l01OrbkqfdG+A+jhVpFpbQTICuXnF9YmDDBjz+AXlUvSVDMmBLuQjm8/Q==",
       "dependencies": {
         "@contentful/f36-tokens": "^4.0.4",
         "@emotion/core": "^10.1.1",
@@ -2421,17 +2421,17 @@
       }
     },
     "node_modules/@contentful/f36-datepicker": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.67.2.tgz",
-      "integrity": "sha512-qGfVEjdZaMwdDBr1uWfgQtnCd8L+ZyVBpFiI8TyFUdQd6L9blHexr99Wg12uBNSub9zaL5fs4wrHZ5vMpGEjGQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.67.3.tgz",
+      "integrity": "sha512-0AR4KVIMkzcRbkfMYF/XR4RL4vaIg1zjCQh9M/F26R3Eb57DCsOgnK1bIY4YpazqU1s9YSiu2VGi7kEA//scuQ==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-popover": "^4.67.2",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-forms": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-popover": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "date-fns": "^2.28.0",
         "emotion": "^10.0.17",
         "react-day-picker": "^8.7.1",
@@ -2443,11 +2443,11 @@
       }
     },
     "node_modules/@contentful/f36-datetime": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.67.2.tgz",
-      "integrity": "sha512-7kz4I/CzRkupPb43dtAQ3a1bHffdx3ZQ0i9ueUl9CSs+dKhl9gwiH0bmoNN5pnULAQF4i7WQmNueEfQvh9zgvA==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.67.3.tgz",
+      "integrity": "sha512-BadR5IcrM/WYBmF8Yml4pMqz9LB4A5CsmlsolvevluNmxr2XoS9Y1cMKYujemiYs+86o9st+oh2+O7nz1BbpPQ==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "dayjs": "^1.11.5",
         "emotion": "^10.0.17"
@@ -2458,12 +2458,12 @@
       }
     },
     "node_modules/@contentful/f36-drag-handle": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.67.2.tgz",
-      "integrity": "sha512-7e38V/dJ79m4uVlnf1H1xpRY28DPwaMQOMgFWwPKCdketfr+YU8KI7kE2ssrd1EsM9av7Z0Dcwz6pF89wuxViA==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.67.3.tgz",
+      "integrity": "sha512-vrWf9W6h/2tWrU8iYekAbAmIBYqikUE8RJ0259PdQwrOS7gwDYHmKnv2uSEZJAmLtT7KrWWVyF6Jm2F8HmjdNg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
@@ -2474,12 +2474,12 @@
       }
     },
     "node_modules/@contentful/f36-empty-state": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.67.2.tgz",
-      "integrity": "sha512-ghzqNmwAOv0mAUvXDyLLtlAOXj5RPas/stJ8etPpb339NGFj5ueYf9+EBrgTCWrMK/JCBhcogV5bgKRsc9VKlg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.67.3.tgz",
+      "integrity": "sha512-D8nc+3IH8v4STkyJmXYM8cpO4o3qaslgoYb7Bz3RvZGtVNyBvD2bavg3zjQbKvsnV6bxtRXeDk9LjoCq/NjpoA==",
       "dependencies": {
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2488,21 +2488,20 @@
       }
     },
     "node_modules/@contentful/f36-entity-list": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.67.2.tgz",
-      "integrity": "sha512-G37dKH3yRD++fOA924UROtZdeIiNFmrjfVOobC03jdvk6o21AN2kMyDzML2Uc0+kMg+ofe4G08KC/OmDSUkSAg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.67.3.tgz",
+      "integrity": "sha512-yUkW3U7CkG+dsZ0LYK80rZMPxkQmI1LTGJmjct3IqukY+c9lni77acyVLd0p+BJUixO91SRcnKGysbpa9/keKg==",
       "dependencies": {
-        "@contentful/f36-badge": "^4.67.2",
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-icons-alpha": "npm:@contentful/f36-icons@^5.0.0-alpha.26",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-badge": "^4.67.3",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-drag-handle": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-menu": "^4.67.3",
+        "@contentful/f36-skeleton": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2511,14 +2510,14 @@
       }
     },
     "node_modules/@contentful/f36-forms": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.67.2.tgz",
-      "integrity": "sha512-+XxpnCiBKtZw2hYo5QZWVayWMPKzbarOIWzZUMm6Ttoru00zn5u3tlvue7c9W2zqkNFuUNOopAwXBwQ0h+z+bQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.67.3.tgz",
+      "integrity": "sha512-O+JJUZF0iOn2Y8AU6ooD8BLEvFC5X8tNDYAouux62gd+WQFGCyn7hkpN70wjNRiR0cNrS9QW+cs1pl/pLipy3g==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
@@ -2528,15 +2527,15 @@
       }
     },
     "node_modules/@contentful/f36-header": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-header/-/f36-header-4.67.2.tgz",
-      "integrity": "sha512-DjI5JnJuXixG8bAj03lRvISuAgwA2X6PnYifa//967Dd0qQTBw/CkB96AhrgVUjTw+jt3xAprwv0SUKF8x9S8g==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-header/-/f36-header-4.67.3.tgz",
+      "integrity": "sha512-cUth5PtzLzGQmG1rev++F5VWl/36TMy1GhSK06sjpgRxs0BCFEWgs4UJnelPLyyajkfTx4GUrP+CiHACkIMPKA==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.2",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.5",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2545,32 +2544,13 @@
       }
     },
     "node_modules/@contentful/f36-icon": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.67.2.tgz",
-      "integrity": "sha512-vJAk6KO88GVnHdPSXurUA67F4wl01sZHaaE5eHGvt/s+YuI47dstgROr5+z66qmncKpcMWOTv4/+jqYV1Ko56A==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.67.3.tgz",
+      "integrity": "sha512-lD9L7iJPL7d7axJOIrQxF9X1g+uYl4v+lfORNguLaCdRAiZcwlbmn0GaIsQvfqsQxZudFu92N4MuT3rGlh9bPw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-icon-alpha": {
-      "name": "@contentful/f36-icon",
-      "version": "5.0.0-alpha.20",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-5.0.0-alpha.20.tgz",
-      "integrity": "sha512-kI7HJggp/H8whiUL/RrG988nEvQq2SuZVyQn4kyiWYSlMWBRqQXZRvXfsM/RILWMgz2LxryXaT1YGVy2E4UfJA==",
-      "dependencies": {
-        "@contentful/f36-core": "^4.65.4",
-        "@contentful/f36-tokens": "^4.0.4",
-        "@phosphor-icons/react": "^2.1.5",
-        "emotion": "^10.0.17"
-      },
-      "engines": {
-        "node": ">=16"
       },
       "peerDependencies": {
         "react": ">=16.8",
@@ -2578,34 +2558,14 @@
       }
     },
     "node_modules/@contentful/f36-icons": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-4.28.2.tgz",
-      "integrity": "sha512-p7oWbQ5ITlMMuEl/6t/6JLVrCVhDE2nA8mv1VR4DHjXPm0y9w14533rCKxNIREZX8iVmyBoaqI3vdPsjUs1CAw==",
+      "version": "4.29.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-4.29.0.tgz",
+      "integrity": "sha512-oo/e2UhugDuSw5AXp7aDPMaUMIJEuWTAk0UaYSqaDh3+cv/7yctyvhcU0mrolmhC8HDKBHXK4Z0/QZkvqNb+Mw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.65.0",
-        "@contentful/f36-icon": "^4.65.0",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-icons-alpha": {
-      "name": "@contentful/f36-icons",
-      "version": "5.0.0-alpha.29",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-5.0.0-alpha.29.tgz",
-      "integrity": "sha512-7QhDDAo95WiqFwB/ofWd57GEyeLgkDU/CgTStjhtBZssheMvVT6thiIFy6hSbo314d1RZ5Z8EBzH1MIJ/nyQhA==",
-      "dependencies": {
-        "@contentful/f36-core": "^4.67.1",
-        "@contentful/f36-icon-alpha": "npm:@contentful/f36-icon@5.0.0-alpha.20",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@phosphor-icons/react": "^2.1.4",
-        "emotion": "^10.0.17"
-      },
-      "engines": {
-        "node": ">=16"
       },
       "peerDependencies": {
         "react": ">=16.8",
@@ -2613,12 +2573,12 @@
       }
     },
     "node_modules/@contentful/f36-image": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-image/-/f36-image-4.67.2.tgz",
-      "integrity": "sha512-zB4D/fBmUyIj1WvF2tWQHsDxzTcZ+KOyiVu0483rxRNai8sae7BO3VSuevUzfi2Y+gaF3VCasPZudjgTeWD2pQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-image/-/f36-image-4.67.3.tgz",
+      "integrity": "sha512-KFE+S3rKTzj0rdVFTy96gMKvMzn8K4ydoeL0xkoIOkpy33VfgySZJwf9s82NUPLPa+h0Fz4GYGZ0WcbZ0haxiA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-skeleton": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.5",
         "emotion": "^10.0.17"
       },
@@ -2628,11 +2588,11 @@
       }
     },
     "node_modules/@contentful/f36-list": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.67.2.tgz",
-      "integrity": "sha512-ZkObExturTfxpNZOBcHJMozuLIbDLe8Us5qe4qJyVozIBH+Ol6xOHxEEyEu8GsRZp0+GU7K3fWExqLEV22oSUQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.67.3.tgz",
+      "integrity": "sha512-qIs8K14G8PZfUTkp3WXUhtZQKMFqomFhYwI3bd/yfpDbA/bkFgCuhlwqO5R5MYR3ZPfqto0Euddgy084vu5whA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2642,15 +2602,15 @@
       }
     },
     "node_modules/@contentful/f36-menu": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.67.2.tgz",
-      "integrity": "sha512-TF+tpTLqE22qeQTYHJFuxCm6Yt37VFtwM6X9O07GYTeXeDZE7ZI+FrA16y+fxFw2Zu0OpbLO0CWB/ViolvMlOw==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.67.3.tgz",
+      "integrity": "sha512-a6eNH3RTbLT31gUPuQcKgyHT0tbah2n2N5VtKUA35LOQRPa/rBVOX0FsRiXTht0Tnb1aDIO/gjmKZZkfCNdIcg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-popover": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-popover": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
@@ -2660,15 +2620,15 @@
       }
     },
     "node_modules/@contentful/f36-modal": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.67.2.tgz",
-      "integrity": "sha512-mrO5+mKytV/j759HI0y6fZskQG/EEY7iNaRjjeYmFRoT6MAgViebcIeht15CcFwnNQLAeS3MusvXiEzuUzweiQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.67.3.tgz",
+      "integrity": "sha512-/DM6TIAoW2J+v4XY4cplQYKoxF7W43Al22N6zHoh2QE0yG6AJvVOmIGYMgGk3nYany45GeXrCU/rGFOplWo6Jg==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "@types/react-modal": "^3.13.1",
         "emotion": "^10.0.17",
         "react-modal": "^3.16.1"
@@ -2679,16 +2639,16 @@
       }
     },
     "node_modules/@contentful/f36-navbar": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-navbar/-/f36-navbar-4.67.2.tgz",
-      "integrity": "sha512-58PYpIElqnfdYWpEkSaOmccSzcgudYUs009UWmtqHmv0n3c8eNoV8taoZdg92gYAsEc7G2VWl4AZ3wJy/kiAdg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-navbar/-/f36-navbar-4.67.3.tgz",
+      "integrity": "sha512-8KLvY+pVX+diuXcBmdbGhI8OYCPa4Ba4BoRHaNDWX1jbucJcuysjRwAUc7wnOSb1lLqjqtIRVOL/edxTjqLmNQ==",
       "dependencies": {
-        "@contentful/f36-avatar": "4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-avatar": "4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-menu": "^4.67.3",
+        "@contentful/f36-skeleton": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.1",
         "@contentful/f36-utils": "^4.23.2",
         "emotion": "^10.0.17"
@@ -2699,16 +2659,16 @@
       }
     },
     "node_modules/@contentful/f36-note": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.67.2.tgz",
-      "integrity": "sha512-DA0f1/j640SG3LOon1VcU6kDvNgUHxupH0Q1FXS01aRrWq12uMd2bLtb2k5A9qRyT6MB3OdAKFufwsBcSL6fYw==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.67.3.tgz",
+      "integrity": "sha512-Is7QO7i+Bayc17WZZiNm/ztGbRkMV2ft6WEFIu0ra6NhcMi5CW/7Q358po0QVhr13OpQFDnO3MYRaLxifU5mVg==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2717,16 +2677,16 @@
       }
     },
     "node_modules/@contentful/f36-notification": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.67.2.tgz",
-      "integrity": "sha512-x7qxuqOhQMyhhRfMrisAVXnAo/eL6A7RjL2PmTLylaqKrFnzDrr25BtzepdkgULj9VLh70vXM5QIzPwpKpIJBQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.67.3.tgz",
+      "integrity": "sha512-kd5eXd3ZCNNHCfo9V7PI6XB9p4uVUPX59j+7zGGgLDqD1+PS1D3kYPMMJ4C42Ni5B4uF2kLT9tSlSGm3WkbeYg==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-text-link": "^4.67.2",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-text-link": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "@swc/helpers": "^0.4.14",
         "emotion": "^10.0.17",
         "react-animate-height": "^3.0.4"
@@ -2737,16 +2697,16 @@
       }
     },
     "node_modules/@contentful/f36-pagination": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.67.2.tgz",
-      "integrity": "sha512-/UePF1fbr2wvJHtJ9ncWaz5eg/VTdA8VqEBFJXge/IBgPVyMgQxQRxSDhvMj0j2Iit90qAzPedEDZK+jp6CyTg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.67.3.tgz",
+      "integrity": "sha512-fXwjCy20GkqljjsC8/z8Xg0beMYeIKw0nZpK/qMGs85vEW54py3PkwP8KwmRWkTFy7U8Q0D7USa2oOO65Ffv6Q==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-forms": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2755,16 +2715,16 @@
       }
     },
     "node_modules/@contentful/f36-pill": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.67.2.tgz",
-      "integrity": "sha512-015oRkVVnshvWAJ/kR5yJBD+soWmDcHFy5FGXDaIR5moTCejjqiLG1g8H6MolaF8oeKSOhbhgfX/dpEHn5/Z4g==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.67.3.tgz",
+      "integrity": "sha512-2bfYm8bhyeH1BNa8ioFAl6v3jq1C6sd9L8/oh6Sn9cKIsxAvqgIGTP+YOaRH+OqjDQxuHDNmld3XuTPlco8IRg==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-drag-handle": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2773,11 +2733,11 @@
       }
     },
     "node_modules/@contentful/f36-popover": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.67.2.tgz",
-      "integrity": "sha512-NJx54sqQEmuWIsBySXf/B+ZW/RoIkRzb7cnQ5aucN3nUd4ZaHOvcmYVLJMqfCV8ipzpMxLgoc8p3v6OcRdi72A==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.67.3.tgz",
+      "integrity": "sha512-3/eMw2gL1iEDswKUuRrMRAOFkzvrEk+DRXENejL2t8Fb/WU9lP1sOyYUG58UvzMLFDchzVLKHbcLPDTaaNaorw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -2790,12 +2750,12 @@
       }
     },
     "node_modules/@contentful/f36-skeleton": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.67.2.tgz",
-      "integrity": "sha512-4T8r/G8b9DFkLErIo8d2cGS71tWy1yNDZIThoHBWIhLRcstal8K7Ag5dQwPsaoSew/859oXC2rvPP0Ep+4FtCg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.67.3.tgz",
+      "integrity": "sha512-7qdbeIqnPie0NoKPVI6ebAGlBvxsNkGVbcieSecpZuCnIZGdm+E4AWgQ+Lm1CMw8CPYX0B4p94l5YDysGTZyxA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-table": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-table": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2805,11 +2765,11 @@
       }
     },
     "node_modules/@contentful/f36-spinner": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.67.2.tgz",
-      "integrity": "sha512-sBitcudBc4DwAOPn6MLuArLje7aym47GoIDI0kN9zQtolVwlVH92/zNpZmnm+zbP4Ku56/TgbL/v5SFTh+YB2w==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.67.3.tgz",
+      "integrity": "sha512-e1NJFcvLYphC321tDyTacnYOTcbv+yeQ1EcmIlmbSOYENZxTxzVMjD4uikrx8gm/CdquG8ahwf9/BYC07N9dJg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2819,14 +2779,14 @@
       }
     },
     "node_modules/@contentful/f36-table": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.67.2.tgz",
-      "integrity": "sha512-YtUkXwFmBLgAi5Glgi1vXqNbr+U2riadB9O+Aq8t2R/vpXMCIA4WlmXSqunwPW9UrrilalrK49l0IkDNpcRUbQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.67.3.tgz",
+      "integrity": "sha512-nzFIe28T4aBV7SXv6H8cefCuLAvsNlII9JxeBwI5JFUSgACpJsh1ANVdkDVilTo3cgiUFmvQmErYqiH0MMiy/Q==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2835,11 +2795,11 @@
       }
     },
     "node_modules/@contentful/f36-tabs": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.67.2.tgz",
-      "integrity": "sha512-rPPJQHmCoD8492yKufelL7MCj0j4FqcPc5yFhD29sqpGDqTko8Xf/V/q4/LPYUtXttH8myfTINEyNTsR/lZINg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.67.3.tgz",
+      "integrity": "sha512-tjdPelHm3L3DzHSWjHz+v7hciRG3QPs5y3WzloCgBjzgSk1BlcEiD2GuoWhPZM9WuUq3C92PwsVq/lB5urHyNA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@radix-ui/react-tabs": "^1.0.1",
         "emotion": "^10.0.17"
@@ -2850,11 +2810,11 @@
       }
     },
     "node_modules/@contentful/f36-text-link": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.67.2.tgz",
-      "integrity": "sha512-mWE4KsqQV93SNAFtYWqQB61/TLHuX1D3vVJ1rFqAp1kndPy7UyGcrQrGoPmM1l20Y9YaYIWYwo5eGKygY3iwIA==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.67.3.tgz",
+      "integrity": "sha512-jgWCMdeFwzMHHtHRHOcutq6x+hb2ipKXrSpZaiY8O/8Rh2wzKL6BIj/v+Jio4DJkaoGT8cEQLVuCP2JYiwm09A==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2869,11 +2829,11 @@
       "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
     },
     "node_modules/@contentful/f36-tooltip": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.67.2.tgz",
-      "integrity": "sha512-BFSKsJySAK1ipIOXueq6rgsJlmZDVBd60fjicALWiVX/GnxyDO3OkdX8nfK4Id0rbllf8+WBSR5UcVzNjuLe4Q==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.67.3.tgz",
+      "integrity": "sha512-40VkWQxm57Rf2ZydCPwnkiG+6WXBuswj+/nB97kpqjRohbSxKR0IzA5u0sAiWUglXDPH0Tu9IOtRz6PVAL4UZQ==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -2887,11 +2847,11 @@
       }
     },
     "node_modules/@contentful/f36-typography": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.67.2.tgz",
-      "integrity": "sha512-zfCVUQfD5wueT4mFNxLO+2SaUTFVHxE+7v8YKt53SvIiN+s/vXJnABOKPZsjYAYkwQwSrwPYIdIxMtaULwjoCw==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.67.3.tgz",
+      "integrity": "sha512-ujLg2yibJQxyHrJbCmv9ksWtNn3QuqOMew3i6WClUq2/BOdUjvdMtCW9zK8RbSXNV94FJXB0+AvG+dRQ4hqMNg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
@@ -4829,18 +4789,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@phosphor-icons/react": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.1.7.tgz",
-      "integrity": "sha512-g2e2eVAn1XG2a+LI09QU3IORLhnFNAFkNbo2iwbX6NOKSLOwvEMmTa7CgOzEbgNWR47z8i8kwjdvYZ5fkGx1mQ==",
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": ">= 16.8",
-        "react-dom": ">= 16.8"
       }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -8735,9 +8683,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.11",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.11.tgz",
-      "integrity": "sha512-okzr3f11N6WuqYtZSvm+F776mB41wRZMhKP+hc34YdW+KmtYYK9iqvHSwo2k9FEH3fhGXvOPV6yz2IcSrfRUDg=="
+      "version": "1.11.12",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.12.tgz",
+      "integrity": "sha512-Rt2g+nTbLlDWZTwwrIXjy9MeiZmSDI375FvZs72ngxx8PDC6YXOeR3q5LAuPzjZQxhiWdRKac7RKV+YyQYfYIg=="
     },
     "node_modules/debug": {
       "version": "4.3.4",

--- a/examples/function-potterdb/package.json
+++ b/examples/function-potterdb/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@contentful/app-sdk": "^4.28.0",
-    "@contentful/f36-components": "4.67.2",
+    "@contentful/f36-components": "4.67.3",
     "@contentful/f36-icons": "^4.28.2",
     "@contentful/f36-tokens": "4.0.5",
     "@contentful/field-editor-single-line": "^1.4.2",

--- a/examples/javascript/package-lock.json
+++ b/examples/javascript/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@contentful/app-sdk": "^4.28.0",
-        "@contentful/f36-components": "4.67.2",
+        "@contentful/f36-components": "4.67.3",
         "@contentful/f36-tokens": "4.0.5",
         "@contentful/react-apps-toolkit": "1.2.16",
         "contentful-management": "10.46.4",
@@ -2051,15 +2051,15 @@
       }
     },
     "node_modules/@contentful/f36-accordion": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.67.2.tgz",
-      "integrity": "sha512-cX7xIX+fZadUNNFG+uzAOXeZ/GkMs+Y0bvgpxkpqW3ILu6GIXHsXetnRocxVaYUrQ1C/k6wEsd4xSv5y2uQBIg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.67.3.tgz",
+      "integrity": "sha512-d2Hwqg2Y8Pe9DP8XUAtVP8wKvqL6y4u9ydcSQDdQ4AZBT297zVzaXhTYzv7Bwi+Dq+4lagtkj39eU2IHXg/Aew==",
       "dependencies": {
-        "@contentful/f36-collapse": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-collapse": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2068,15 +2068,15 @@
       }
     },
     "node_modules/@contentful/f36-asset": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.67.2.tgz",
-      "integrity": "sha512-cUQaZQeXIr3oLy255cuL+mXNiYOpMvAzW7BxE3l903ShzlwVFqZr/FIaWAo2t488sWbGeXNXxVBcEbLzQUMIdA==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.67.3.tgz",
+      "integrity": "sha512-XTYNl6mS69By8MOvQwaHcIwxf+hnodUNzmMW3DgiGlptfKHtsgV6RlKil4PSluOaqtHUrIuXzPozCyMxPjf+0w==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2085,18 +2085,18 @@
       }
     },
     "node_modules/@contentful/f36-autocomplete": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.67.2.tgz",
-      "integrity": "sha512-1cZHVa2cskh4DvachcgaQeEuyjuAlxvvyJCqvpHpP+R3ISS6CsC44252fH52NcLryvfFG1zX24nZECgFOY/S+A==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.67.3.tgz",
+      "integrity": "sha512-meEb8OnRBDHrffLxqxfXfmKxyIKQPyFEMtjW6zRrilvDhFxw4KvKFU8XWX3gv3oBpWdpm5LEY/YnZuPqsRshow==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-popover": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-forms": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-popover": "^4.67.3",
+        "@contentful/f36-skeleton": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "@contentful/f36-utils": "^4.24.3",
         "downshift": "^6.1.12",
         "emotion": "^10.0.17"
@@ -2107,15 +2107,15 @@
       }
     },
     "node_modules/@contentful/f36-avatar": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-avatar/-/f36-avatar-4.67.2.tgz",
-      "integrity": "sha512-bKxmWgi67V6tPCX2mlSxJKtQ8IANoO7jU9qH74Fqe11ATgG84Oqy9iQgjJDQvfFMjyT9n+3zUtUCwo/waHHrQg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-avatar/-/f36-avatar-4.67.3.tgz",
+      "integrity": "sha512-gyVW7kJqrxZFOOhDzOsxkpelT7i6kE+TxbPrSClIpSfSWSWAQZnKFjBK3oeUH5VxnOrrZUO4IDIUTAIjF0UiDQ==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-image": "4.67.2",
-        "@contentful/f36-menu": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-image": "4.67.3",
+        "@contentful/f36-menu": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.5",
-        "@contentful/f36-tooltip": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2124,12 +2124,12 @@
       }
     },
     "node_modules/@contentful/f36-badge": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.67.2.tgz",
-      "integrity": "sha512-cWfb3Nk9+CdgmTvc75gzD6uJ4XCbK23pB1t9BV9ZvytvnuaQElZYh7WciyRKJtU51khb0KOuVCb/TOnjecU4xQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.67.3.tgz",
+      "integrity": "sha512-/9IzwrWLdv00t+iy0OfIwRCIQjxmdLcJCSzNFWHnbNSrjwCUPK3buZgtq9F8ueoFMobPuYed6b5X+VMAMlL4Hg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2139,12 +2139,12 @@
       }
     },
     "node_modules/@contentful/f36-button": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.67.2.tgz",
-      "integrity": "sha512-1/1dYtgfVk3wiP5SoaoQEWlM7VYp/Pju17agu5Y0MGuGo7LwjTCzLJQ4OeRvdubTYCW+iXc20sEG2H3OyRoz6w==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.67.3.tgz",
+      "integrity": "sha512-/w13GeJq4xN563Mrs5L6V6fEG2JHA3unsR/Rg+88agvoIgEj7bVNA6IunWVhKEHIfSucDJ+1hktNGfh1mPMQ4w==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-spinner": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-spinner": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
@@ -2155,22 +2155,22 @@
       }
     },
     "node_modules/@contentful/f36-card": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.67.2.tgz",
-      "integrity": "sha512-f1Ck9hbbfdX7/OIWPfXJSdriDVjoTQOdz4aXo1QVd2fmsTAzQCfH0llwXtCk8TCg4DbSwaS/ldB/CJV3oCN1AA==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.67.3.tgz",
+      "integrity": "sha512-LiCr/9sByOeY6GU6rW8HrSCJIdNVgO8IUwvPlciuqxKPyNgWOnqUiYpBZZNf74lqtLKuDXCzkKZaaF3j1JShLA==",
       "dependencies": {
-        "@contentful/f36-asset": "^4.67.2",
-        "@contentful/f36-badge": "^4.67.2",
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-asset": "^4.67.3",
+        "@contentful/f36-badge": "^4.67.3",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-drag-handle": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-menu": "^4.67.3",
+        "@contentful/f36-skeleton": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.3",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17",
         "truncate": "^3.0.0"
       },
@@ -2180,11 +2180,11 @@
       }
     },
     "node_modules/@contentful/f36-collapse": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.67.2.tgz",
-      "integrity": "sha512-EWkl653S3gnhVkq39Z0vDrIHQxvqJnN9XfrrORpX56ZCc4kHs1MzbbbDjnlj3udCy9Cj4Q50hiXpmeO/JogDlg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.67.3.tgz",
+      "integrity": "sha512-W8RQzN7H0x2jRNz6NN8EYLVDREwdPWPTTx89pSWnXaTG1EyITVUSGlgvc/kfOpLjbTC3HI1jwIlll+RGMFGs8A==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2194,47 +2194,47 @@
       }
     },
     "node_modules/@contentful/f36-components": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.67.2.tgz",
-      "integrity": "sha512-JNBX8YzP+mt2/d2m5uUnpFLGnzyRAsggWpEBUe8QgPRwkJ8bZIDrnm2TELIFqrY2t4Lvs2AJw8L/3kDaJvMNCQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.67.3.tgz",
+      "integrity": "sha512-AFw5q0JzT/L60w4tM3H399pXDO3lOcZootFwjKIaupHRjNPHHGQ1MlgMqNEIz1qSEbBbqKY3O6HlA2CmowznaQ==",
       "dependencies": {
-        "@contentful/f36-accordion": "^4.67.2",
-        "@contentful/f36-asset": "^4.67.2",
-        "@contentful/f36-autocomplete": "^4.67.2",
-        "@contentful/f36-avatar": "4.67.2",
-        "@contentful/f36-badge": "^4.67.2",
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-card": "^4.67.2",
-        "@contentful/f36-collapse": "^4.67.2",
-        "@contentful/f36-copybutton": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-datepicker": "^4.67.2",
-        "@contentful/f36-datetime": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-empty-state": "^4.67.2",
-        "@contentful/f36-entity-list": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
-        "@contentful/f36-header": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-image": "4.67.2",
-        "@contentful/f36-list": "^4.67.2",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-modal": "^4.67.2",
-        "@contentful/f36-navbar": "^4.67.2",
-        "@contentful/f36-note": "^4.67.2",
-        "@contentful/f36-notification": "^4.67.2",
-        "@contentful/f36-pagination": "^4.67.2",
-        "@contentful/f36-pill": "^4.67.2",
-        "@contentful/f36-popover": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
-        "@contentful/f36-spinner": "^4.67.2",
-        "@contentful/f36-table": "^4.67.2",
-        "@contentful/f36-tabs": "^4.67.2",
-        "@contentful/f36-text-link": "^4.67.2",
+        "@contentful/f36-accordion": "^4.67.3",
+        "@contentful/f36-asset": "^4.67.3",
+        "@contentful/f36-autocomplete": "^4.67.3",
+        "@contentful/f36-avatar": "4.67.3",
+        "@contentful/f36-badge": "^4.67.3",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-card": "^4.67.3",
+        "@contentful/f36-collapse": "^4.67.3",
+        "@contentful/f36-copybutton": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-datepicker": "^4.67.3",
+        "@contentful/f36-datetime": "^4.67.3",
+        "@contentful/f36-drag-handle": "^4.67.3",
+        "@contentful/f36-empty-state": "^4.67.3",
+        "@contentful/f36-entity-list": "^4.67.3",
+        "@contentful/f36-forms": "^4.67.3",
+        "@contentful/f36-header": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-image": "4.67.3",
+        "@contentful/f36-list": "^4.67.3",
+        "@contentful/f36-menu": "^4.67.3",
+        "@contentful/f36-modal": "^4.67.3",
+        "@contentful/f36-navbar": "^4.67.3",
+        "@contentful/f36-note": "^4.67.3",
+        "@contentful/f36-notification": "^4.67.3",
+        "@contentful/f36-pagination": "^4.67.3",
+        "@contentful/f36-pill": "^4.67.3",
+        "@contentful/f36-popover": "^4.67.3",
+        "@contentful/f36-skeleton": "^4.67.3",
+        "@contentful/f36-spinner": "^4.67.3",
+        "@contentful/f36-table": "^4.67.3",
+        "@contentful/f36-tabs": "^4.67.3",
+        "@contentful/f36-text-link": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.3",
+        "@contentful/f36-typography": "^4.67.3",
         "@contentful/f36-utils": "^4.24.3"
       },
       "peerDependencies": {
@@ -2253,15 +2253,15 @@
       }
     },
     "node_modules/@contentful/f36-copybutton": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.67.2.tgz",
-      "integrity": "sha512-hb/DCGE6TTdepsjZvmDgog1glfF8WxGCx+F1S7FbwTZ4NutWeHEa7+E63t2tELTRx07FoVmkICmPtp89mCXKEw==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.67.3.tgz",
+      "integrity": "sha512-N6xD+oPlVL3dYXb4slnMfXFXw39kMexzHiFuQn9J/dsZyyhW+HYFB8hZ804U/s3YHJxSmwjhz22eBzqNbQrS1Q==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2270,9 +2270,9 @@
       }
     },
     "node_modules/@contentful/f36-core": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.67.2.tgz",
-      "integrity": "sha512-iSzA/OuhU4rIlBOlUTIczMuqDQZqLR1tmZJtZyouhfWkEc0VGUCX6S2FnBEXlMbnMzaL70lTXYUNu2bKxK4PfA==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.67.3.tgz",
+      "integrity": "sha512-W+wFcljUBvMP0mV6P3boqpARw2N71l01OrbkqfdG+A+jhVpFpbQTICuXnF9YmDDBjz+AXlUvSVDMmBLuQjm8/Q==",
       "dependencies": {
         "@contentful/f36-tokens": "^4.0.4",
         "@emotion/core": "^10.1.1",
@@ -2291,17 +2291,17 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/@contentful/f36-datepicker": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.67.2.tgz",
-      "integrity": "sha512-qGfVEjdZaMwdDBr1uWfgQtnCd8L+ZyVBpFiI8TyFUdQd6L9blHexr99Wg12uBNSub9zaL5fs4wrHZ5vMpGEjGQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.67.3.tgz",
+      "integrity": "sha512-0AR4KVIMkzcRbkfMYF/XR4RL4vaIg1zjCQh9M/F26R3Eb57DCsOgnK1bIY4YpazqU1s9YSiu2VGi7kEA//scuQ==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-popover": "^4.67.2",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-forms": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-popover": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "date-fns": "^2.28.0",
         "emotion": "^10.0.17",
         "react-day-picker": "^8.7.1",
@@ -2313,11 +2313,11 @@
       }
     },
     "node_modules/@contentful/f36-datetime": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.67.2.tgz",
-      "integrity": "sha512-7kz4I/CzRkupPb43dtAQ3a1bHffdx3ZQ0i9ueUl9CSs+dKhl9gwiH0bmoNN5pnULAQF4i7WQmNueEfQvh9zgvA==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.67.3.tgz",
+      "integrity": "sha512-BadR5IcrM/WYBmF8Yml4pMqz9LB4A5CsmlsolvevluNmxr2XoS9Y1cMKYujemiYs+86o9st+oh2+O7nz1BbpPQ==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "dayjs": "^1.11.5",
         "emotion": "^10.0.17"
@@ -2328,12 +2328,12 @@
       }
     },
     "node_modules/@contentful/f36-drag-handle": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.67.2.tgz",
-      "integrity": "sha512-7e38V/dJ79m4uVlnf1H1xpRY28DPwaMQOMgFWwPKCdketfr+YU8KI7kE2ssrd1EsM9av7Z0Dcwz6pF89wuxViA==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.67.3.tgz",
+      "integrity": "sha512-vrWf9W6h/2tWrU8iYekAbAmIBYqikUE8RJ0259PdQwrOS7gwDYHmKnv2uSEZJAmLtT7KrWWVyF6Jm2F8HmjdNg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
@@ -2344,12 +2344,12 @@
       }
     },
     "node_modules/@contentful/f36-empty-state": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.67.2.tgz",
-      "integrity": "sha512-ghzqNmwAOv0mAUvXDyLLtlAOXj5RPas/stJ8etPpb339NGFj5ueYf9+EBrgTCWrMK/JCBhcogV5bgKRsc9VKlg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.67.3.tgz",
+      "integrity": "sha512-D8nc+3IH8v4STkyJmXYM8cpO4o3qaslgoYb7Bz3RvZGtVNyBvD2bavg3zjQbKvsnV6bxtRXeDk9LjoCq/NjpoA==",
       "dependencies": {
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2358,21 +2358,20 @@
       }
     },
     "node_modules/@contentful/f36-entity-list": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.67.2.tgz",
-      "integrity": "sha512-G37dKH3yRD++fOA924UROtZdeIiNFmrjfVOobC03jdvk6o21AN2kMyDzML2Uc0+kMg+ofe4G08KC/OmDSUkSAg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.67.3.tgz",
+      "integrity": "sha512-yUkW3U7CkG+dsZ0LYK80rZMPxkQmI1LTGJmjct3IqukY+c9lni77acyVLd0p+BJUixO91SRcnKGysbpa9/keKg==",
       "dependencies": {
-        "@contentful/f36-badge": "^4.67.2",
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-icons-alpha": "npm:@contentful/f36-icons@^5.0.0-alpha.26",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-badge": "^4.67.3",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-drag-handle": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-menu": "^4.67.3",
+        "@contentful/f36-skeleton": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2381,14 +2380,14 @@
       }
     },
     "node_modules/@contentful/f36-forms": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.67.2.tgz",
-      "integrity": "sha512-+XxpnCiBKtZw2hYo5QZWVayWMPKzbarOIWzZUMm6Ttoru00zn5u3tlvue7c9W2zqkNFuUNOopAwXBwQ0h+z+bQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.67.3.tgz",
+      "integrity": "sha512-O+JJUZF0iOn2Y8AU6ooD8BLEvFC5X8tNDYAouux62gd+WQFGCyn7hkpN70wjNRiR0cNrS9QW+cs1pl/pLipy3g==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
@@ -2398,15 +2397,15 @@
       }
     },
     "node_modules/@contentful/f36-header": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-header/-/f36-header-4.67.2.tgz",
-      "integrity": "sha512-DjI5JnJuXixG8bAj03lRvISuAgwA2X6PnYifa//967Dd0qQTBw/CkB96AhrgVUjTw+jt3xAprwv0SUKF8x9S8g==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-header/-/f36-header-4.67.3.tgz",
+      "integrity": "sha512-cUth5PtzLzGQmG1rev++F5VWl/36TMy1GhSK06sjpgRxs0BCFEWgs4UJnelPLyyajkfTx4GUrP+CiHACkIMPKA==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.2",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.5",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2415,32 +2414,13 @@
       }
     },
     "node_modules/@contentful/f36-icon": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.67.2.tgz",
-      "integrity": "sha512-vJAk6KO88GVnHdPSXurUA67F4wl01sZHaaE5eHGvt/s+YuI47dstgROr5+z66qmncKpcMWOTv4/+jqYV1Ko56A==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.67.3.tgz",
+      "integrity": "sha512-lD9L7iJPL7d7axJOIrQxF9X1g+uYl4v+lfORNguLaCdRAiZcwlbmn0GaIsQvfqsQxZudFu92N4MuT3rGlh9bPw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-icon-alpha": {
-      "name": "@contentful/f36-icon",
-      "version": "5.0.0-alpha.20",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-5.0.0-alpha.20.tgz",
-      "integrity": "sha512-kI7HJggp/H8whiUL/RrG988nEvQq2SuZVyQn4kyiWYSlMWBRqQXZRvXfsM/RILWMgz2LxryXaT1YGVy2E4UfJA==",
-      "dependencies": {
-        "@contentful/f36-core": "^4.65.4",
-        "@contentful/f36-tokens": "^4.0.4",
-        "@phosphor-icons/react": "^2.1.5",
-        "emotion": "^10.0.17"
-      },
-      "engines": {
-        "node": ">=16"
       },
       "peerDependencies": {
         "react": ">=16.8",
@@ -2448,34 +2428,14 @@
       }
     },
     "node_modules/@contentful/f36-icons": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-4.28.2.tgz",
-      "integrity": "sha512-p7oWbQ5ITlMMuEl/6t/6JLVrCVhDE2nA8mv1VR4DHjXPm0y9w14533rCKxNIREZX8iVmyBoaqI3vdPsjUs1CAw==",
+      "version": "4.29.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-4.29.0.tgz",
+      "integrity": "sha512-oo/e2UhugDuSw5AXp7aDPMaUMIJEuWTAk0UaYSqaDh3+cv/7yctyvhcU0mrolmhC8HDKBHXK4Z0/QZkvqNb+Mw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.65.0",
-        "@contentful/f36-icon": "^4.65.0",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-icons-alpha": {
-      "name": "@contentful/f36-icons",
-      "version": "5.0.0-alpha.29",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-5.0.0-alpha.29.tgz",
-      "integrity": "sha512-7QhDDAo95WiqFwB/ofWd57GEyeLgkDU/CgTStjhtBZssheMvVT6thiIFy6hSbo314d1RZ5Z8EBzH1MIJ/nyQhA==",
-      "dependencies": {
-        "@contentful/f36-core": "^4.67.1",
-        "@contentful/f36-icon-alpha": "npm:@contentful/f36-icon@5.0.0-alpha.20",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@phosphor-icons/react": "^2.1.4",
-        "emotion": "^10.0.17"
-      },
-      "engines": {
-        "node": ">=16"
       },
       "peerDependencies": {
         "react": ">=16.8",
@@ -2483,12 +2443,12 @@
       }
     },
     "node_modules/@contentful/f36-image": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-image/-/f36-image-4.67.2.tgz",
-      "integrity": "sha512-zB4D/fBmUyIj1WvF2tWQHsDxzTcZ+KOyiVu0483rxRNai8sae7BO3VSuevUzfi2Y+gaF3VCasPZudjgTeWD2pQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-image/-/f36-image-4.67.3.tgz",
+      "integrity": "sha512-KFE+S3rKTzj0rdVFTy96gMKvMzn8K4ydoeL0xkoIOkpy33VfgySZJwf9s82NUPLPa+h0Fz4GYGZ0WcbZ0haxiA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-skeleton": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.5",
         "emotion": "^10.0.17"
       },
@@ -2498,11 +2458,11 @@
       }
     },
     "node_modules/@contentful/f36-list": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.67.2.tgz",
-      "integrity": "sha512-ZkObExturTfxpNZOBcHJMozuLIbDLe8Us5qe4qJyVozIBH+Ol6xOHxEEyEu8GsRZp0+GU7K3fWExqLEV22oSUQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.67.3.tgz",
+      "integrity": "sha512-qIs8K14G8PZfUTkp3WXUhtZQKMFqomFhYwI3bd/yfpDbA/bkFgCuhlwqO5R5MYR3ZPfqto0Euddgy084vu5whA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2512,15 +2472,15 @@
       }
     },
     "node_modules/@contentful/f36-menu": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.67.2.tgz",
-      "integrity": "sha512-TF+tpTLqE22qeQTYHJFuxCm6Yt37VFtwM6X9O07GYTeXeDZE7ZI+FrA16y+fxFw2Zu0OpbLO0CWB/ViolvMlOw==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.67.3.tgz",
+      "integrity": "sha512-a6eNH3RTbLT31gUPuQcKgyHT0tbah2n2N5VtKUA35LOQRPa/rBVOX0FsRiXTht0Tnb1aDIO/gjmKZZkfCNdIcg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-popover": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-popover": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
@@ -2530,15 +2490,15 @@
       }
     },
     "node_modules/@contentful/f36-modal": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.67.2.tgz",
-      "integrity": "sha512-mrO5+mKytV/j759HI0y6fZskQG/EEY7iNaRjjeYmFRoT6MAgViebcIeht15CcFwnNQLAeS3MusvXiEzuUzweiQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.67.3.tgz",
+      "integrity": "sha512-/DM6TIAoW2J+v4XY4cplQYKoxF7W43Al22N6zHoh2QE0yG6AJvVOmIGYMgGk3nYany45GeXrCU/rGFOplWo6Jg==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "@types/react-modal": "^3.13.1",
         "emotion": "^10.0.17",
         "react-modal": "^3.16.1"
@@ -2549,16 +2509,16 @@
       }
     },
     "node_modules/@contentful/f36-navbar": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-navbar/-/f36-navbar-4.67.2.tgz",
-      "integrity": "sha512-58PYpIElqnfdYWpEkSaOmccSzcgudYUs009UWmtqHmv0n3c8eNoV8taoZdg92gYAsEc7G2VWl4AZ3wJy/kiAdg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-navbar/-/f36-navbar-4.67.3.tgz",
+      "integrity": "sha512-8KLvY+pVX+diuXcBmdbGhI8OYCPa4Ba4BoRHaNDWX1jbucJcuysjRwAUc7wnOSb1lLqjqtIRVOL/edxTjqLmNQ==",
       "dependencies": {
-        "@contentful/f36-avatar": "4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-avatar": "4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-menu": "^4.67.3",
+        "@contentful/f36-skeleton": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.1",
         "@contentful/f36-utils": "^4.23.2",
         "emotion": "^10.0.17"
@@ -2569,16 +2529,16 @@
       }
     },
     "node_modules/@contentful/f36-note": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.67.2.tgz",
-      "integrity": "sha512-DA0f1/j640SG3LOon1VcU6kDvNgUHxupH0Q1FXS01aRrWq12uMd2bLtb2k5A9qRyT6MB3OdAKFufwsBcSL6fYw==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.67.3.tgz",
+      "integrity": "sha512-Is7QO7i+Bayc17WZZiNm/ztGbRkMV2ft6WEFIu0ra6NhcMi5CW/7Q358po0QVhr13OpQFDnO3MYRaLxifU5mVg==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2587,16 +2547,16 @@
       }
     },
     "node_modules/@contentful/f36-notification": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.67.2.tgz",
-      "integrity": "sha512-x7qxuqOhQMyhhRfMrisAVXnAo/eL6A7RjL2PmTLylaqKrFnzDrr25BtzepdkgULj9VLh70vXM5QIzPwpKpIJBQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.67.3.tgz",
+      "integrity": "sha512-kd5eXd3ZCNNHCfo9V7PI6XB9p4uVUPX59j+7zGGgLDqD1+PS1D3kYPMMJ4C42Ni5B4uF2kLT9tSlSGm3WkbeYg==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-text-link": "^4.67.2",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-text-link": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "@swc/helpers": "^0.4.14",
         "emotion": "^10.0.17",
         "react-animate-height": "^3.0.4"
@@ -2607,16 +2567,16 @@
       }
     },
     "node_modules/@contentful/f36-pagination": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.67.2.tgz",
-      "integrity": "sha512-/UePF1fbr2wvJHtJ9ncWaz5eg/VTdA8VqEBFJXge/IBgPVyMgQxQRxSDhvMj0j2Iit90qAzPedEDZK+jp6CyTg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.67.3.tgz",
+      "integrity": "sha512-fXwjCy20GkqljjsC8/z8Xg0beMYeIKw0nZpK/qMGs85vEW54py3PkwP8KwmRWkTFy7U8Q0D7USa2oOO65Ffv6Q==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-forms": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2625,16 +2585,16 @@
       }
     },
     "node_modules/@contentful/f36-pill": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.67.2.tgz",
-      "integrity": "sha512-015oRkVVnshvWAJ/kR5yJBD+soWmDcHFy5FGXDaIR5moTCejjqiLG1g8H6MolaF8oeKSOhbhgfX/dpEHn5/Z4g==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.67.3.tgz",
+      "integrity": "sha512-2bfYm8bhyeH1BNa8ioFAl6v3jq1C6sd9L8/oh6Sn9cKIsxAvqgIGTP+YOaRH+OqjDQxuHDNmld3XuTPlco8IRg==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-drag-handle": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2643,11 +2603,11 @@
       }
     },
     "node_modules/@contentful/f36-popover": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.67.2.tgz",
-      "integrity": "sha512-NJx54sqQEmuWIsBySXf/B+ZW/RoIkRzb7cnQ5aucN3nUd4ZaHOvcmYVLJMqfCV8ipzpMxLgoc8p3v6OcRdi72A==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.67.3.tgz",
+      "integrity": "sha512-3/eMw2gL1iEDswKUuRrMRAOFkzvrEk+DRXENejL2t8Fb/WU9lP1sOyYUG58UvzMLFDchzVLKHbcLPDTaaNaorw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -2660,12 +2620,12 @@
       }
     },
     "node_modules/@contentful/f36-skeleton": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.67.2.tgz",
-      "integrity": "sha512-4T8r/G8b9DFkLErIo8d2cGS71tWy1yNDZIThoHBWIhLRcstal8K7Ag5dQwPsaoSew/859oXC2rvPP0Ep+4FtCg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.67.3.tgz",
+      "integrity": "sha512-7qdbeIqnPie0NoKPVI6ebAGlBvxsNkGVbcieSecpZuCnIZGdm+E4AWgQ+Lm1CMw8CPYX0B4p94l5YDysGTZyxA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-table": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-table": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2675,11 +2635,11 @@
       }
     },
     "node_modules/@contentful/f36-spinner": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.67.2.tgz",
-      "integrity": "sha512-sBitcudBc4DwAOPn6MLuArLje7aym47GoIDI0kN9zQtolVwlVH92/zNpZmnm+zbP4Ku56/TgbL/v5SFTh+YB2w==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.67.3.tgz",
+      "integrity": "sha512-e1NJFcvLYphC321tDyTacnYOTcbv+yeQ1EcmIlmbSOYENZxTxzVMjD4uikrx8gm/CdquG8ahwf9/BYC07N9dJg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2689,14 +2649,14 @@
       }
     },
     "node_modules/@contentful/f36-table": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.67.2.tgz",
-      "integrity": "sha512-YtUkXwFmBLgAi5Glgi1vXqNbr+U2riadB9O+Aq8t2R/vpXMCIA4WlmXSqunwPW9UrrilalrK49l0IkDNpcRUbQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.67.3.tgz",
+      "integrity": "sha512-nzFIe28T4aBV7SXv6H8cefCuLAvsNlII9JxeBwI5JFUSgACpJsh1ANVdkDVilTo3cgiUFmvQmErYqiH0MMiy/Q==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2705,11 +2665,11 @@
       }
     },
     "node_modules/@contentful/f36-tabs": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.67.2.tgz",
-      "integrity": "sha512-rPPJQHmCoD8492yKufelL7MCj0j4FqcPc5yFhD29sqpGDqTko8Xf/V/q4/LPYUtXttH8myfTINEyNTsR/lZINg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.67.3.tgz",
+      "integrity": "sha512-tjdPelHm3L3DzHSWjHz+v7hciRG3QPs5y3WzloCgBjzgSk1BlcEiD2GuoWhPZM9WuUq3C92PwsVq/lB5urHyNA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@radix-ui/react-tabs": "^1.0.1",
         "emotion": "^10.0.17"
@@ -2720,11 +2680,11 @@
       }
     },
     "node_modules/@contentful/f36-text-link": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.67.2.tgz",
-      "integrity": "sha512-mWE4KsqQV93SNAFtYWqQB61/TLHuX1D3vVJ1rFqAp1kndPy7UyGcrQrGoPmM1l20Y9YaYIWYwo5eGKygY3iwIA==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.67.3.tgz",
+      "integrity": "sha512-jgWCMdeFwzMHHtHRHOcutq6x+hb2ipKXrSpZaiY8O/8Rh2wzKL6BIj/v+Jio4DJkaoGT8cEQLVuCP2JYiwm09A==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2739,11 +2699,11 @@
       "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
     },
     "node_modules/@contentful/f36-tooltip": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.67.2.tgz",
-      "integrity": "sha512-BFSKsJySAK1ipIOXueq6rgsJlmZDVBd60fjicALWiVX/GnxyDO3OkdX8nfK4Id0rbllf8+WBSR5UcVzNjuLe4Q==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.67.3.tgz",
+      "integrity": "sha512-40VkWQxm57Rf2ZydCPwnkiG+6WXBuswj+/nB97kpqjRohbSxKR0IzA5u0sAiWUglXDPH0Tu9IOtRz6PVAL4UZQ==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -2762,11 +2722,11 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/@contentful/f36-typography": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.67.2.tgz",
-      "integrity": "sha512-zfCVUQfD5wueT4mFNxLO+2SaUTFVHxE+7v8YKt53SvIiN+s/vXJnABOKPZsjYAYkwQwSrwPYIdIxMtaULwjoCw==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.67.3.tgz",
+      "integrity": "sha512-ujLg2yibJQxyHrJbCmv9ksWtNn3QuqOMew3i6WClUq2/BOdUjvdMtCW9zK8RbSXNV94FJXB0+AvG+dRQ4hqMNg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
@@ -2983,17 +2943,17 @@
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
     },
     "node_modules/@emotion/is-prop-valid": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz",
-      "integrity": "sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.3.0.tgz",
+      "integrity": "sha512-SHetuSLvJDzuNbOdtPVbq6yMMMlLoW5Q94uDqJZqy50gcmAjxFkVqmzqSGEFq9gT2iMuIeKV1PXVWmvUhuZLlQ==",
       "dependencies": {
-        "@emotion/memoize": "^0.8.1"
+        "@emotion/memoize": "^0.9.0"
       }
     },
     "node_modules/@emotion/is-prop-valid/node_modules/@emotion/memoize": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
-      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ=="
     },
     "node_modules/@emotion/memoize": {
       "version": "0.7.4",
@@ -3904,18 +3864,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@phosphor-icons/react": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.1.7.tgz",
-      "integrity": "sha512-g2e2eVAn1XG2a+LI09QU3IORLhnFNAFkNbo2iwbX6NOKSLOwvEMmTa7CgOzEbgNWR47z8i8kwjdvYZ5fkGx1mQ==",
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": ">= 16.8",
-        "react-dom": ">= 16.8"
       }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -7818,9 +7766,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.11",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.11.tgz",
-      "integrity": "sha512-okzr3f11N6WuqYtZSvm+F776mB41wRZMhKP+hc34YdW+KmtYYK9iqvHSwo2k9FEH3fhGXvOPV6yz2IcSrfRUDg=="
+      "version": "1.11.12",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.12.tgz",
+      "integrity": "sha512-Rt2g+nTbLlDWZTwwrIXjy9MeiZmSDI375FvZs72ngxx8PDC6YXOeR3q5LAuPzjZQxhiWdRKac7RKV+YyQYfYIg=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -20432,178 +20380,178 @@
       }
     },
     "@contentful/f36-accordion": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.67.2.tgz",
-      "integrity": "sha512-cX7xIX+fZadUNNFG+uzAOXeZ/GkMs+Y0bvgpxkpqW3ILu6GIXHsXetnRocxVaYUrQ1C/k6wEsd4xSv5y2uQBIg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.67.3.tgz",
+      "integrity": "sha512-d2Hwqg2Y8Pe9DP8XUAtVP8wKvqL6y4u9ydcSQDdQ4AZBT297zVzaXhTYzv7Bwi+Dq+4lagtkj39eU2IHXg/Aew==",
       "requires": {
-        "@contentful/f36-collapse": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-collapse": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-asset": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.67.2.tgz",
-      "integrity": "sha512-cUQaZQeXIr3oLy255cuL+mXNiYOpMvAzW7BxE3l903ShzlwVFqZr/FIaWAo2t488sWbGeXNXxVBcEbLzQUMIdA==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.67.3.tgz",
+      "integrity": "sha512-XTYNl6mS69By8MOvQwaHcIwxf+hnodUNzmMW3DgiGlptfKHtsgV6RlKil4PSluOaqtHUrIuXzPozCyMxPjf+0w==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-autocomplete": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.67.2.tgz",
-      "integrity": "sha512-1cZHVa2cskh4DvachcgaQeEuyjuAlxvvyJCqvpHpP+R3ISS6CsC44252fH52NcLryvfFG1zX24nZECgFOY/S+A==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.67.3.tgz",
+      "integrity": "sha512-meEb8OnRBDHrffLxqxfXfmKxyIKQPyFEMtjW6zRrilvDhFxw4KvKFU8XWX3gv3oBpWdpm5LEY/YnZuPqsRshow==",
       "requires": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-popover": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-forms": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-popover": "^4.67.3",
+        "@contentful/f36-skeleton": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "@contentful/f36-utils": "^4.24.3",
         "downshift": "^6.1.12",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-avatar": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-avatar/-/f36-avatar-4.67.2.tgz",
-      "integrity": "sha512-bKxmWgi67V6tPCX2mlSxJKtQ8IANoO7jU9qH74Fqe11ATgG84Oqy9iQgjJDQvfFMjyT9n+3zUtUCwo/waHHrQg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-avatar/-/f36-avatar-4.67.3.tgz",
+      "integrity": "sha512-gyVW7kJqrxZFOOhDzOsxkpelT7i6kE+TxbPrSClIpSfSWSWAQZnKFjBK3oeUH5VxnOrrZUO4IDIUTAIjF0UiDQ==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-image": "4.67.2",
-        "@contentful/f36-menu": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-image": "4.67.3",
+        "@contentful/f36-menu": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.5",
-        "@contentful/f36-tooltip": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-badge": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.67.2.tgz",
-      "integrity": "sha512-cWfb3Nk9+CdgmTvc75gzD6uJ4XCbK23pB1t9BV9ZvytvnuaQElZYh7WciyRKJtU51khb0KOuVCb/TOnjecU4xQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.67.3.tgz",
+      "integrity": "sha512-/9IzwrWLdv00t+iy0OfIwRCIQjxmdLcJCSzNFWHnbNSrjwCUPK3buZgtq9F8ueoFMobPuYed6b5X+VMAMlL4Hg==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-button": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.67.2.tgz",
-      "integrity": "sha512-1/1dYtgfVk3wiP5SoaoQEWlM7VYp/Pju17agu5Y0MGuGo7LwjTCzLJQ4OeRvdubTYCW+iXc20sEG2H3OyRoz6w==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.67.3.tgz",
+      "integrity": "sha512-/w13GeJq4xN563Mrs5L6V6fEG2JHA3unsR/Rg+88agvoIgEj7bVNA6IunWVhKEHIfSucDJ+1hktNGfh1mPMQ4w==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-spinner": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-spinner": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-card": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.67.2.tgz",
-      "integrity": "sha512-f1Ck9hbbfdX7/OIWPfXJSdriDVjoTQOdz4aXo1QVd2fmsTAzQCfH0llwXtCk8TCg4DbSwaS/ldB/CJV3oCN1AA==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.67.3.tgz",
+      "integrity": "sha512-LiCr/9sByOeY6GU6rW8HrSCJIdNVgO8IUwvPlciuqxKPyNgWOnqUiYpBZZNf74lqtLKuDXCzkKZaaF3j1JShLA==",
       "requires": {
-        "@contentful/f36-asset": "^4.67.2",
-        "@contentful/f36-badge": "^4.67.2",
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-asset": "^4.67.3",
+        "@contentful/f36-badge": "^4.67.3",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-drag-handle": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-menu": "^4.67.3",
+        "@contentful/f36-skeleton": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.3",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17",
         "truncate": "^3.0.0"
       }
     },
     "@contentful/f36-collapse": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.67.2.tgz",
-      "integrity": "sha512-EWkl653S3gnhVkq39Z0vDrIHQxvqJnN9XfrrORpX56ZCc4kHs1MzbbbDjnlj3udCy9Cj4Q50hiXpmeO/JogDlg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.67.3.tgz",
+      "integrity": "sha512-W8RQzN7H0x2jRNz6NN8EYLVDREwdPWPTTx89pSWnXaTG1EyITVUSGlgvc/kfOpLjbTC3HI1jwIlll+RGMFGs8A==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-components": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.67.2.tgz",
-      "integrity": "sha512-JNBX8YzP+mt2/d2m5uUnpFLGnzyRAsggWpEBUe8QgPRwkJ8bZIDrnm2TELIFqrY2t4Lvs2AJw8L/3kDaJvMNCQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.67.3.tgz",
+      "integrity": "sha512-AFw5q0JzT/L60w4tM3H399pXDO3lOcZootFwjKIaupHRjNPHHGQ1MlgMqNEIz1qSEbBbqKY3O6HlA2CmowznaQ==",
       "requires": {
-        "@contentful/f36-accordion": "^4.67.2",
-        "@contentful/f36-asset": "^4.67.2",
-        "@contentful/f36-autocomplete": "^4.67.2",
-        "@contentful/f36-avatar": "4.67.2",
-        "@contentful/f36-badge": "^4.67.2",
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-card": "^4.67.2",
-        "@contentful/f36-collapse": "^4.67.2",
-        "@contentful/f36-copybutton": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-datepicker": "^4.67.2",
-        "@contentful/f36-datetime": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-empty-state": "^4.67.2",
-        "@contentful/f36-entity-list": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
-        "@contentful/f36-header": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-image": "4.67.2",
-        "@contentful/f36-list": "^4.67.2",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-modal": "^4.67.2",
-        "@contentful/f36-navbar": "^4.67.2",
-        "@contentful/f36-note": "^4.67.2",
-        "@contentful/f36-notification": "^4.67.2",
-        "@contentful/f36-pagination": "^4.67.2",
-        "@contentful/f36-pill": "^4.67.2",
-        "@contentful/f36-popover": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
-        "@contentful/f36-spinner": "^4.67.2",
-        "@contentful/f36-table": "^4.67.2",
-        "@contentful/f36-tabs": "^4.67.2",
-        "@contentful/f36-text-link": "^4.67.2",
+        "@contentful/f36-accordion": "^4.67.3",
+        "@contentful/f36-asset": "^4.67.3",
+        "@contentful/f36-autocomplete": "^4.67.3",
+        "@contentful/f36-avatar": "4.67.3",
+        "@contentful/f36-badge": "^4.67.3",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-card": "^4.67.3",
+        "@contentful/f36-collapse": "^4.67.3",
+        "@contentful/f36-copybutton": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-datepicker": "^4.67.3",
+        "@contentful/f36-datetime": "^4.67.3",
+        "@contentful/f36-drag-handle": "^4.67.3",
+        "@contentful/f36-empty-state": "^4.67.3",
+        "@contentful/f36-entity-list": "^4.67.3",
+        "@contentful/f36-forms": "^4.67.3",
+        "@contentful/f36-header": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-image": "4.67.3",
+        "@contentful/f36-list": "^4.67.3",
+        "@contentful/f36-menu": "^4.67.3",
+        "@contentful/f36-modal": "^4.67.3",
+        "@contentful/f36-navbar": "^4.67.3",
+        "@contentful/f36-note": "^4.67.3",
+        "@contentful/f36-notification": "^4.67.3",
+        "@contentful/f36-pagination": "^4.67.3",
+        "@contentful/f36-pill": "^4.67.3",
+        "@contentful/f36-popover": "^4.67.3",
+        "@contentful/f36-skeleton": "^4.67.3",
+        "@contentful/f36-spinner": "^4.67.3",
+        "@contentful/f36-table": "^4.67.3",
+        "@contentful/f36-tabs": "^4.67.3",
+        "@contentful/f36-text-link": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.3",
+        "@contentful/f36-typography": "^4.67.3",
         "@contentful/f36-utils": "^4.24.3"
       }
     },
     "@contentful/f36-copybutton": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.67.2.tgz",
-      "integrity": "sha512-hb/DCGE6TTdepsjZvmDgog1glfF8WxGCx+F1S7FbwTZ4NutWeHEa7+E63t2tELTRx07FoVmkICmPtp89mCXKEw==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.67.3.tgz",
+      "integrity": "sha512-N6xD+oPlVL3dYXb4slnMfXFXw39kMexzHiFuQn9J/dsZyyhW+HYFB8hZ804U/s3YHJxSmwjhz22eBzqNbQrS1Q==",
       "requires": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-core": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.67.2.tgz",
-      "integrity": "sha512-iSzA/OuhU4rIlBOlUTIczMuqDQZqLR1tmZJtZyouhfWkEc0VGUCX6S2FnBEXlMbnMzaL70lTXYUNu2bKxK4PfA==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.67.3.tgz",
+      "integrity": "sha512-W+wFcljUBvMP0mV6P3boqpARw2N71l01OrbkqfdG+A+jhVpFpbQTICuXnF9YmDDBjz+AXlUvSVDMmBLuQjm8/Q==",
       "requires": {
         "@contentful/f36-tokens": "^4.0.4",
         "@emotion/core": "^10.1.1",
@@ -20620,17 +20568,17 @@
       }
     },
     "@contentful/f36-datepicker": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.67.2.tgz",
-      "integrity": "sha512-qGfVEjdZaMwdDBr1uWfgQtnCd8L+ZyVBpFiI8TyFUdQd6L9blHexr99Wg12uBNSub9zaL5fs4wrHZ5vMpGEjGQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.67.3.tgz",
+      "integrity": "sha512-0AR4KVIMkzcRbkfMYF/XR4RL4vaIg1zjCQh9M/F26R3Eb57DCsOgnK1bIY4YpazqU1s9YSiu2VGi7kEA//scuQ==",
       "requires": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-popover": "^4.67.2",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-forms": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-popover": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "date-fns": "^2.28.0",
         "emotion": "^10.0.17",
         "react-day-picker": "^8.7.1",
@@ -20638,257 +20586,233 @@
       }
     },
     "@contentful/f36-datetime": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.67.2.tgz",
-      "integrity": "sha512-7kz4I/CzRkupPb43dtAQ3a1bHffdx3ZQ0i9ueUl9CSs+dKhl9gwiH0bmoNN5pnULAQF4i7WQmNueEfQvh9zgvA==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.67.3.tgz",
+      "integrity": "sha512-BadR5IcrM/WYBmF8Yml4pMqz9LB4A5CsmlsolvevluNmxr2XoS9Y1cMKYujemiYs+86o9st+oh2+O7nz1BbpPQ==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "dayjs": "^1.11.5",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-drag-handle": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.67.2.tgz",
-      "integrity": "sha512-7e38V/dJ79m4uVlnf1H1xpRY28DPwaMQOMgFWwPKCdketfr+YU8KI7kE2ssrd1EsM9av7Z0Dcwz6pF89wuxViA==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.67.3.tgz",
+      "integrity": "sha512-vrWf9W6h/2tWrU8iYekAbAmIBYqikUE8RJ0259PdQwrOS7gwDYHmKnv2uSEZJAmLtT7KrWWVyF6Jm2F8HmjdNg==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-empty-state": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.67.2.tgz",
-      "integrity": "sha512-ghzqNmwAOv0mAUvXDyLLtlAOXj5RPas/stJ8etPpb339NGFj5ueYf9+EBrgTCWrMK/JCBhcogV5bgKRsc9VKlg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.67.3.tgz",
+      "integrity": "sha512-D8nc+3IH8v4STkyJmXYM8cpO4o3qaslgoYb7Bz3RvZGtVNyBvD2bavg3zjQbKvsnV6bxtRXeDk9LjoCq/NjpoA==",
       "requires": {
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-entity-list": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.67.2.tgz",
-      "integrity": "sha512-G37dKH3yRD++fOA924UROtZdeIiNFmrjfVOobC03jdvk6o21AN2kMyDzML2Uc0+kMg+ofe4G08KC/OmDSUkSAg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.67.3.tgz",
+      "integrity": "sha512-yUkW3U7CkG+dsZ0LYK80rZMPxkQmI1LTGJmjct3IqukY+c9lni77acyVLd0p+BJUixO91SRcnKGysbpa9/keKg==",
       "requires": {
-        "@contentful/f36-badge": "^4.67.2",
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-icons-alpha": "npm:@contentful/f36-icons@^5.0.0-alpha.26",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-badge": "^4.67.3",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-drag-handle": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-menu": "^4.67.3",
+        "@contentful/f36-skeleton": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-forms": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.67.2.tgz",
-      "integrity": "sha512-+XxpnCiBKtZw2hYo5QZWVayWMPKzbarOIWzZUMm6Ttoru00zn5u3tlvue7c9W2zqkNFuUNOopAwXBwQ0h+z+bQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.67.3.tgz",
+      "integrity": "sha512-O+JJUZF0iOn2Y8AU6ooD8BLEvFC5X8tNDYAouux62gd+WQFGCyn7hkpN70wjNRiR0cNrS9QW+cs1pl/pLipy3g==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-header": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-header/-/f36-header-4.67.2.tgz",
-      "integrity": "sha512-DjI5JnJuXixG8bAj03lRvISuAgwA2X6PnYifa//967Dd0qQTBw/CkB96AhrgVUjTw+jt3xAprwv0SUKF8x9S8g==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-header/-/f36-header-4.67.3.tgz",
+      "integrity": "sha512-cUth5PtzLzGQmG1rev++F5VWl/36TMy1GhSK06sjpgRxs0BCFEWgs4UJnelPLyyajkfTx4GUrP+CiHACkIMPKA==",
       "requires": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.2",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.5",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-icon": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.67.2.tgz",
-      "integrity": "sha512-vJAk6KO88GVnHdPSXurUA67F4wl01sZHaaE5eHGvt/s+YuI47dstgROr5+z66qmncKpcMWOTv4/+jqYV1Ko56A==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.67.3.tgz",
+      "integrity": "sha512-lD9L7iJPL7d7axJOIrQxF9X1g+uYl4v+lfORNguLaCdRAiZcwlbmn0GaIsQvfqsQxZudFu92N4MuT3rGlh9bPw==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "emotion": "^10.0.17"
-      }
-    },
-    "@contentful/f36-icon-alpha": {
-      "version": "npm:@contentful/f36-icon@5.0.0-alpha.20",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-5.0.0-alpha.20.tgz",
-      "integrity": "sha512-kI7HJggp/H8whiUL/RrG988nEvQq2SuZVyQn4kyiWYSlMWBRqQXZRvXfsM/RILWMgz2LxryXaT1YGVy2E4UfJA==",
-      "requires": {
-        "@contentful/f36-core": "^4.65.4",
-        "@contentful/f36-tokens": "^4.0.4",
-        "@phosphor-icons/react": "^2.1.5",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-icons": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-4.28.2.tgz",
-      "integrity": "sha512-p7oWbQ5ITlMMuEl/6t/6JLVrCVhDE2nA8mv1VR4DHjXPm0y9w14533rCKxNIREZX8iVmyBoaqI3vdPsjUs1CAw==",
+      "version": "4.29.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-4.29.0.tgz",
+      "integrity": "sha512-oo/e2UhugDuSw5AXp7aDPMaUMIJEuWTAk0UaYSqaDh3+cv/7yctyvhcU0mrolmhC8HDKBHXK4Z0/QZkvqNb+Mw==",
       "requires": {
-        "@contentful/f36-core": "^4.65.0",
-        "@contentful/f36-icon": "^4.65.0",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "emotion": "^10.0.17"
-      }
-    },
-    "@contentful/f36-icons-alpha": {
-      "version": "npm:@contentful/f36-icons@5.0.0-alpha.29",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-5.0.0-alpha.29.tgz",
-      "integrity": "sha512-7QhDDAo95WiqFwB/ofWd57GEyeLgkDU/CgTStjhtBZssheMvVT6thiIFy6hSbo314d1RZ5Z8EBzH1MIJ/nyQhA==",
-      "requires": {
-        "@contentful/f36-core": "^4.67.1",
-        "@contentful/f36-icon-alpha": "npm:@contentful/f36-icon@5.0.0-alpha.20",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@phosphor-icons/react": "^2.1.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-image": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-image/-/f36-image-4.67.2.tgz",
-      "integrity": "sha512-zB4D/fBmUyIj1WvF2tWQHsDxzTcZ+KOyiVu0483rxRNai8sae7BO3VSuevUzfi2Y+gaF3VCasPZudjgTeWD2pQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-image/-/f36-image-4.67.3.tgz",
+      "integrity": "sha512-KFE+S3rKTzj0rdVFTy96gMKvMzn8K4ydoeL0xkoIOkpy33VfgySZJwf9s82NUPLPa+h0Fz4GYGZ0WcbZ0haxiA==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-skeleton": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.5",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-list": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.67.2.tgz",
-      "integrity": "sha512-ZkObExturTfxpNZOBcHJMozuLIbDLe8Us5qe4qJyVozIBH+Ol6xOHxEEyEu8GsRZp0+GU7K3fWExqLEV22oSUQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.67.3.tgz",
+      "integrity": "sha512-qIs8K14G8PZfUTkp3WXUhtZQKMFqomFhYwI3bd/yfpDbA/bkFgCuhlwqO5R5MYR3ZPfqto0Euddgy084vu5whA==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-menu": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.67.2.tgz",
-      "integrity": "sha512-TF+tpTLqE22qeQTYHJFuxCm6Yt37VFtwM6X9O07GYTeXeDZE7ZI+FrA16y+fxFw2Zu0OpbLO0CWB/ViolvMlOw==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.67.3.tgz",
+      "integrity": "sha512-a6eNH3RTbLT31gUPuQcKgyHT0tbah2n2N5VtKUA35LOQRPa/rBVOX0FsRiXTht0Tnb1aDIO/gjmKZZkfCNdIcg==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-popover": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-popover": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-modal": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.67.2.tgz",
-      "integrity": "sha512-mrO5+mKytV/j759HI0y6fZskQG/EEY7iNaRjjeYmFRoT6MAgViebcIeht15CcFwnNQLAeS3MusvXiEzuUzweiQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.67.3.tgz",
+      "integrity": "sha512-/DM6TIAoW2J+v4XY4cplQYKoxF7W43Al22N6zHoh2QE0yG6AJvVOmIGYMgGk3nYany45GeXrCU/rGFOplWo6Jg==",
       "requires": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "@types/react-modal": "^3.13.1",
         "emotion": "^10.0.17",
         "react-modal": "^3.16.1"
       }
     },
     "@contentful/f36-navbar": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-navbar/-/f36-navbar-4.67.2.tgz",
-      "integrity": "sha512-58PYpIElqnfdYWpEkSaOmccSzcgudYUs009UWmtqHmv0n3c8eNoV8taoZdg92gYAsEc7G2VWl4AZ3wJy/kiAdg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-navbar/-/f36-navbar-4.67.3.tgz",
+      "integrity": "sha512-8KLvY+pVX+diuXcBmdbGhI8OYCPa4Ba4BoRHaNDWX1jbucJcuysjRwAUc7wnOSb1lLqjqtIRVOL/edxTjqLmNQ==",
       "requires": {
-        "@contentful/f36-avatar": "4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-avatar": "4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-menu": "^4.67.3",
+        "@contentful/f36-skeleton": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.1",
         "@contentful/f36-utils": "^4.23.2",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-note": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.67.2.tgz",
-      "integrity": "sha512-DA0f1/j640SG3LOon1VcU6kDvNgUHxupH0Q1FXS01aRrWq12uMd2bLtb2k5A9qRyT6MB3OdAKFufwsBcSL6fYw==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.67.3.tgz",
+      "integrity": "sha512-Is7QO7i+Bayc17WZZiNm/ztGbRkMV2ft6WEFIu0ra6NhcMi5CW/7Q358po0QVhr13OpQFDnO3MYRaLxifU5mVg==",
       "requires": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-notification": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.67.2.tgz",
-      "integrity": "sha512-x7qxuqOhQMyhhRfMrisAVXnAo/eL6A7RjL2PmTLylaqKrFnzDrr25BtzepdkgULj9VLh70vXM5QIzPwpKpIJBQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.67.3.tgz",
+      "integrity": "sha512-kd5eXd3ZCNNHCfo9V7PI6XB9p4uVUPX59j+7zGGgLDqD1+PS1D3kYPMMJ4C42Ni5B4uF2kLT9tSlSGm3WkbeYg==",
       "requires": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-text-link": "^4.67.2",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-text-link": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "@swc/helpers": "^0.4.14",
         "emotion": "^10.0.17",
         "react-animate-height": "^3.0.4"
       }
     },
     "@contentful/f36-pagination": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.67.2.tgz",
-      "integrity": "sha512-/UePF1fbr2wvJHtJ9ncWaz5eg/VTdA8VqEBFJXge/IBgPVyMgQxQRxSDhvMj0j2Iit90qAzPedEDZK+jp6CyTg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.67.3.tgz",
+      "integrity": "sha512-fXwjCy20GkqljjsC8/z8Xg0beMYeIKw0nZpK/qMGs85vEW54py3PkwP8KwmRWkTFy7U8Q0D7USa2oOO65Ffv6Q==",
       "requires": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-forms": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-pill": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.67.2.tgz",
-      "integrity": "sha512-015oRkVVnshvWAJ/kR5yJBD+soWmDcHFy5FGXDaIR5moTCejjqiLG1g8H6MolaF8oeKSOhbhgfX/dpEHn5/Z4g==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.67.3.tgz",
+      "integrity": "sha512-2bfYm8bhyeH1BNa8ioFAl6v3jq1C6sd9L8/oh6Sn9cKIsxAvqgIGTP+YOaRH+OqjDQxuHDNmld3XuTPlco8IRg==",
       "requires": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-drag-handle": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-popover": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.67.2.tgz",
-      "integrity": "sha512-NJx54sqQEmuWIsBySXf/B+ZW/RoIkRzb7cnQ5aucN3nUd4ZaHOvcmYVLJMqfCV8ipzpMxLgoc8p3v6OcRdi72A==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.67.3.tgz",
+      "integrity": "sha512-3/eMw2gL1iEDswKUuRrMRAOFkzvrEk+DRXENejL2t8Fb/WU9lP1sOyYUG58UvzMLFDchzVLKHbcLPDTaaNaorw==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -20897,55 +20821,55 @@
       }
     },
     "@contentful/f36-skeleton": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.67.2.tgz",
-      "integrity": "sha512-4T8r/G8b9DFkLErIo8d2cGS71tWy1yNDZIThoHBWIhLRcstal8K7Ag5dQwPsaoSew/859oXC2rvPP0Ep+4FtCg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.67.3.tgz",
+      "integrity": "sha512-7qdbeIqnPie0NoKPVI6ebAGlBvxsNkGVbcieSecpZuCnIZGdm+E4AWgQ+Lm1CMw8CPYX0B4p94l5YDysGTZyxA==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-table": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-table": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-spinner": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.67.2.tgz",
-      "integrity": "sha512-sBitcudBc4DwAOPn6MLuArLje7aym47GoIDI0kN9zQtolVwlVH92/zNpZmnm+zbP4Ku56/TgbL/v5SFTh+YB2w==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.67.3.tgz",
+      "integrity": "sha512-e1NJFcvLYphC321tDyTacnYOTcbv+yeQ1EcmIlmbSOYENZxTxzVMjD4uikrx8gm/CdquG8ahwf9/BYC07N9dJg==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-table": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.67.2.tgz",
-      "integrity": "sha512-YtUkXwFmBLgAi5Glgi1vXqNbr+U2riadB9O+Aq8t2R/vpXMCIA4WlmXSqunwPW9UrrilalrK49l0IkDNpcRUbQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.67.3.tgz",
+      "integrity": "sha512-nzFIe28T4aBV7SXv6H8cefCuLAvsNlII9JxeBwI5JFUSgACpJsh1ANVdkDVilTo3cgiUFmvQmErYqiH0MMiy/Q==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-tabs": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.67.2.tgz",
-      "integrity": "sha512-rPPJQHmCoD8492yKufelL7MCj0j4FqcPc5yFhD29sqpGDqTko8Xf/V/q4/LPYUtXttH8myfTINEyNTsR/lZINg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.67.3.tgz",
+      "integrity": "sha512-tjdPelHm3L3DzHSWjHz+v7hciRG3QPs5y3WzloCgBjzgSk1BlcEiD2GuoWhPZM9WuUq3C92PwsVq/lB5urHyNA==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@radix-ui/react-tabs": "^1.0.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-text-link": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.67.2.tgz",
-      "integrity": "sha512-mWE4KsqQV93SNAFtYWqQB61/TLHuX1D3vVJ1rFqAp1kndPy7UyGcrQrGoPmM1l20Y9YaYIWYwo5eGKygY3iwIA==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.67.3.tgz",
+      "integrity": "sha512-jgWCMdeFwzMHHtHRHOcutq6x+hb2ipKXrSpZaiY8O/8Rh2wzKL6BIj/v+Jio4DJkaoGT8cEQLVuCP2JYiwm09A==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
@@ -20956,11 +20880,11 @@
       "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
     },
     "@contentful/f36-tooltip": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.67.2.tgz",
-      "integrity": "sha512-BFSKsJySAK1ipIOXueq6rgsJlmZDVBd60fjicALWiVX/GnxyDO3OkdX8nfK4Id0rbllf8+WBSR5UcVzNjuLe4Q==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.67.3.tgz",
+      "integrity": "sha512-40VkWQxm57Rf2ZydCPwnkiG+6WXBuswj+/nB97kpqjRohbSxKR0IzA5u0sAiWUglXDPH0Tu9IOtRz6PVAL4UZQ==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -20977,11 +20901,11 @@
       }
     },
     "@contentful/f36-typography": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.67.2.tgz",
-      "integrity": "sha512-zfCVUQfD5wueT4mFNxLO+2SaUTFVHxE+7v8YKt53SvIiN+s/vXJnABOKPZsjYAYkwQwSrwPYIdIxMtaULwjoCw==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.67.3.tgz",
+      "integrity": "sha512-ujLg2yibJQxyHrJbCmv9ksWtNn3QuqOMew3i6WClUq2/BOdUjvdMtCW9zK8RbSXNV94FJXB0+AvG+dRQ4hqMNg==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
@@ -21120,17 +21044,17 @@
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
     },
     "@emotion/is-prop-valid": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz",
-      "integrity": "sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.3.0.tgz",
+      "integrity": "sha512-SHetuSLvJDzuNbOdtPVbq6yMMMlLoW5Q94uDqJZqy50gcmAjxFkVqmzqSGEFq9gT2iMuIeKV1PXVWmvUhuZLlQ==",
       "requires": {
-        "@emotion/memoize": "^0.8.1"
+        "@emotion/memoize": "^0.9.0"
       },
       "dependencies": {
         "@emotion/memoize": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
-          "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+          "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ=="
         }
       }
     },
@@ -21824,12 +21748,6 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
-    },
-    "@phosphor-icons/react": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.1.7.tgz",
-      "integrity": "sha512-g2e2eVAn1XG2a+LI09QU3IORLhnFNAFkNbo2iwbX6NOKSLOwvEMmTa7CgOzEbgNWR47z8i8kwjdvYZ5fkGx1mQ==",
-      "requires": {}
     },
     "@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.5.5",
@@ -24643,9 +24561,9 @@
       }
     },
     "dayjs": {
-      "version": "1.11.11",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.11.tgz",
-      "integrity": "sha512-okzr3f11N6WuqYtZSvm+F776mB41wRZMhKP+hc34YdW+KmtYYK9iqvHSwo2k9FEH3fhGXvOPV6yz2IcSrfRUDg=="
+      "version": "1.11.12",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.12.tgz",
+      "integrity": "sha512-Rt2g+nTbLlDWZTwwrIXjy9MeiZmSDI375FvZs72ngxx8PDC6YXOeR3q5LAuPzjZQxhiWdRKac7RKV+YyQYfYIg=="
     },
     "debug": {
       "version": "4.3.4",

--- a/examples/javascript/package.json
+++ b/examples/javascript/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@contentful/app-sdk": "^4.28.0",
-    "@contentful/f36-components": "4.67.2",
+    "@contentful/f36-components": "4.67.3",
     "@contentful/f36-tokens": "4.0.5",
     "@contentful/react-apps-toolkit": "1.2.16",
     "contentful-management": "10.46.4",

--- a/examples/typescript/package-lock.json
+++ b/examples/typescript/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@contentful/app-sdk": "^4.28.0",
-        "@contentful/f36-components": "4.67.2",
+        "@contentful/f36-components": "4.67.3",
         "@contentful/f36-tokens": "4.0.5",
         "@contentful/react-apps-toolkit": "1.2.16",
         "contentful-management": "10.46.4",
@@ -2077,15 +2077,15 @@
       }
     },
     "node_modules/@contentful/f36-accordion": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.67.2.tgz",
-      "integrity": "sha512-cX7xIX+fZadUNNFG+uzAOXeZ/GkMs+Y0bvgpxkpqW3ILu6GIXHsXetnRocxVaYUrQ1C/k6wEsd4xSv5y2uQBIg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.67.3.tgz",
+      "integrity": "sha512-d2Hwqg2Y8Pe9DP8XUAtVP8wKvqL6y4u9ydcSQDdQ4AZBT297zVzaXhTYzv7Bwi+Dq+4lagtkj39eU2IHXg/Aew==",
       "dependencies": {
-        "@contentful/f36-collapse": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-collapse": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2094,15 +2094,15 @@
       }
     },
     "node_modules/@contentful/f36-asset": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.67.2.tgz",
-      "integrity": "sha512-cUQaZQeXIr3oLy255cuL+mXNiYOpMvAzW7BxE3l903ShzlwVFqZr/FIaWAo2t488sWbGeXNXxVBcEbLzQUMIdA==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.67.3.tgz",
+      "integrity": "sha512-XTYNl6mS69By8MOvQwaHcIwxf+hnodUNzmMW3DgiGlptfKHtsgV6RlKil4PSluOaqtHUrIuXzPozCyMxPjf+0w==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2111,18 +2111,18 @@
       }
     },
     "node_modules/@contentful/f36-autocomplete": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.67.2.tgz",
-      "integrity": "sha512-1cZHVa2cskh4DvachcgaQeEuyjuAlxvvyJCqvpHpP+R3ISS6CsC44252fH52NcLryvfFG1zX24nZECgFOY/S+A==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.67.3.tgz",
+      "integrity": "sha512-meEb8OnRBDHrffLxqxfXfmKxyIKQPyFEMtjW6zRrilvDhFxw4KvKFU8XWX3gv3oBpWdpm5LEY/YnZuPqsRshow==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-popover": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-forms": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-popover": "^4.67.3",
+        "@contentful/f36-skeleton": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "@contentful/f36-utils": "^4.24.3",
         "downshift": "^6.1.12",
         "emotion": "^10.0.17"
@@ -2133,15 +2133,15 @@
       }
     },
     "node_modules/@contentful/f36-avatar": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-avatar/-/f36-avatar-4.67.2.tgz",
-      "integrity": "sha512-bKxmWgi67V6tPCX2mlSxJKtQ8IANoO7jU9qH74Fqe11ATgG84Oqy9iQgjJDQvfFMjyT9n+3zUtUCwo/waHHrQg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-avatar/-/f36-avatar-4.67.3.tgz",
+      "integrity": "sha512-gyVW7kJqrxZFOOhDzOsxkpelT7i6kE+TxbPrSClIpSfSWSWAQZnKFjBK3oeUH5VxnOrrZUO4IDIUTAIjF0UiDQ==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-image": "4.67.2",
-        "@contentful/f36-menu": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-image": "4.67.3",
+        "@contentful/f36-menu": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.5",
-        "@contentful/f36-tooltip": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2150,12 +2150,12 @@
       }
     },
     "node_modules/@contentful/f36-badge": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.67.2.tgz",
-      "integrity": "sha512-cWfb3Nk9+CdgmTvc75gzD6uJ4XCbK23pB1t9BV9ZvytvnuaQElZYh7WciyRKJtU51khb0KOuVCb/TOnjecU4xQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.67.3.tgz",
+      "integrity": "sha512-/9IzwrWLdv00t+iy0OfIwRCIQjxmdLcJCSzNFWHnbNSrjwCUPK3buZgtq9F8ueoFMobPuYed6b5X+VMAMlL4Hg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2165,12 +2165,12 @@
       }
     },
     "node_modules/@contentful/f36-button": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.67.2.tgz",
-      "integrity": "sha512-1/1dYtgfVk3wiP5SoaoQEWlM7VYp/Pju17agu5Y0MGuGo7LwjTCzLJQ4OeRvdubTYCW+iXc20sEG2H3OyRoz6w==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.67.3.tgz",
+      "integrity": "sha512-/w13GeJq4xN563Mrs5L6V6fEG2JHA3unsR/Rg+88agvoIgEj7bVNA6IunWVhKEHIfSucDJ+1hktNGfh1mPMQ4w==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-spinner": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-spinner": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
@@ -2181,22 +2181,22 @@
       }
     },
     "node_modules/@contentful/f36-card": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.67.2.tgz",
-      "integrity": "sha512-f1Ck9hbbfdX7/OIWPfXJSdriDVjoTQOdz4aXo1QVd2fmsTAzQCfH0llwXtCk8TCg4DbSwaS/ldB/CJV3oCN1AA==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.67.3.tgz",
+      "integrity": "sha512-LiCr/9sByOeY6GU6rW8HrSCJIdNVgO8IUwvPlciuqxKPyNgWOnqUiYpBZZNf74lqtLKuDXCzkKZaaF3j1JShLA==",
       "dependencies": {
-        "@contentful/f36-asset": "^4.67.2",
-        "@contentful/f36-badge": "^4.67.2",
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-asset": "^4.67.3",
+        "@contentful/f36-badge": "^4.67.3",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-drag-handle": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-menu": "^4.67.3",
+        "@contentful/f36-skeleton": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.3",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17",
         "truncate": "^3.0.0"
       },
@@ -2206,11 +2206,11 @@
       }
     },
     "node_modules/@contentful/f36-collapse": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.67.2.tgz",
-      "integrity": "sha512-EWkl653S3gnhVkq39Z0vDrIHQxvqJnN9XfrrORpX56ZCc4kHs1MzbbbDjnlj3udCy9Cj4Q50hiXpmeO/JogDlg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.67.3.tgz",
+      "integrity": "sha512-W8RQzN7H0x2jRNz6NN8EYLVDREwdPWPTTx89pSWnXaTG1EyITVUSGlgvc/kfOpLjbTC3HI1jwIlll+RGMFGs8A==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2220,47 +2220,47 @@
       }
     },
     "node_modules/@contentful/f36-components": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.67.2.tgz",
-      "integrity": "sha512-JNBX8YzP+mt2/d2m5uUnpFLGnzyRAsggWpEBUe8QgPRwkJ8bZIDrnm2TELIFqrY2t4Lvs2AJw8L/3kDaJvMNCQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.67.3.tgz",
+      "integrity": "sha512-AFw5q0JzT/L60w4tM3H399pXDO3lOcZootFwjKIaupHRjNPHHGQ1MlgMqNEIz1qSEbBbqKY3O6HlA2CmowznaQ==",
       "dependencies": {
-        "@contentful/f36-accordion": "^4.67.2",
-        "@contentful/f36-asset": "^4.67.2",
-        "@contentful/f36-autocomplete": "^4.67.2",
-        "@contentful/f36-avatar": "4.67.2",
-        "@contentful/f36-badge": "^4.67.2",
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-card": "^4.67.2",
-        "@contentful/f36-collapse": "^4.67.2",
-        "@contentful/f36-copybutton": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-datepicker": "^4.67.2",
-        "@contentful/f36-datetime": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-empty-state": "^4.67.2",
-        "@contentful/f36-entity-list": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
-        "@contentful/f36-header": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-image": "4.67.2",
-        "@contentful/f36-list": "^4.67.2",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-modal": "^4.67.2",
-        "@contentful/f36-navbar": "^4.67.2",
-        "@contentful/f36-note": "^4.67.2",
-        "@contentful/f36-notification": "^4.67.2",
-        "@contentful/f36-pagination": "^4.67.2",
-        "@contentful/f36-pill": "^4.67.2",
-        "@contentful/f36-popover": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
-        "@contentful/f36-spinner": "^4.67.2",
-        "@contentful/f36-table": "^4.67.2",
-        "@contentful/f36-tabs": "^4.67.2",
-        "@contentful/f36-text-link": "^4.67.2",
+        "@contentful/f36-accordion": "^4.67.3",
+        "@contentful/f36-asset": "^4.67.3",
+        "@contentful/f36-autocomplete": "^4.67.3",
+        "@contentful/f36-avatar": "4.67.3",
+        "@contentful/f36-badge": "^4.67.3",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-card": "^4.67.3",
+        "@contentful/f36-collapse": "^4.67.3",
+        "@contentful/f36-copybutton": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-datepicker": "^4.67.3",
+        "@contentful/f36-datetime": "^4.67.3",
+        "@contentful/f36-drag-handle": "^4.67.3",
+        "@contentful/f36-empty-state": "^4.67.3",
+        "@contentful/f36-entity-list": "^4.67.3",
+        "@contentful/f36-forms": "^4.67.3",
+        "@contentful/f36-header": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-image": "4.67.3",
+        "@contentful/f36-list": "^4.67.3",
+        "@contentful/f36-menu": "^4.67.3",
+        "@contentful/f36-modal": "^4.67.3",
+        "@contentful/f36-navbar": "^4.67.3",
+        "@contentful/f36-note": "^4.67.3",
+        "@contentful/f36-notification": "^4.67.3",
+        "@contentful/f36-pagination": "^4.67.3",
+        "@contentful/f36-pill": "^4.67.3",
+        "@contentful/f36-popover": "^4.67.3",
+        "@contentful/f36-skeleton": "^4.67.3",
+        "@contentful/f36-spinner": "^4.67.3",
+        "@contentful/f36-table": "^4.67.3",
+        "@contentful/f36-tabs": "^4.67.3",
+        "@contentful/f36-text-link": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.3",
+        "@contentful/f36-typography": "^4.67.3",
         "@contentful/f36-utils": "^4.24.3"
       },
       "peerDependencies": {
@@ -2279,15 +2279,15 @@
       }
     },
     "node_modules/@contentful/f36-copybutton": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.67.2.tgz",
-      "integrity": "sha512-hb/DCGE6TTdepsjZvmDgog1glfF8WxGCx+F1S7FbwTZ4NutWeHEa7+E63t2tELTRx07FoVmkICmPtp89mCXKEw==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.67.3.tgz",
+      "integrity": "sha512-N6xD+oPlVL3dYXb4slnMfXFXw39kMexzHiFuQn9J/dsZyyhW+HYFB8hZ804U/s3YHJxSmwjhz22eBzqNbQrS1Q==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2296,9 +2296,9 @@
       }
     },
     "node_modules/@contentful/f36-core": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.67.2.tgz",
-      "integrity": "sha512-iSzA/OuhU4rIlBOlUTIczMuqDQZqLR1tmZJtZyouhfWkEc0VGUCX6S2FnBEXlMbnMzaL70lTXYUNu2bKxK4PfA==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.67.3.tgz",
+      "integrity": "sha512-W+wFcljUBvMP0mV6P3boqpARw2N71l01OrbkqfdG+A+jhVpFpbQTICuXnF9YmDDBjz+AXlUvSVDMmBLuQjm8/Q==",
       "dependencies": {
         "@contentful/f36-tokens": "^4.0.4",
         "@emotion/core": "^10.1.1",
@@ -2317,17 +2317,17 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/@contentful/f36-datepicker": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.67.2.tgz",
-      "integrity": "sha512-qGfVEjdZaMwdDBr1uWfgQtnCd8L+ZyVBpFiI8TyFUdQd6L9blHexr99Wg12uBNSub9zaL5fs4wrHZ5vMpGEjGQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.67.3.tgz",
+      "integrity": "sha512-0AR4KVIMkzcRbkfMYF/XR4RL4vaIg1zjCQh9M/F26R3Eb57DCsOgnK1bIY4YpazqU1s9YSiu2VGi7kEA//scuQ==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-popover": "^4.67.2",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-forms": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-popover": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "date-fns": "^2.28.0",
         "emotion": "^10.0.17",
         "react-day-picker": "^8.7.1",
@@ -2339,11 +2339,11 @@
       }
     },
     "node_modules/@contentful/f36-datetime": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.67.2.tgz",
-      "integrity": "sha512-7kz4I/CzRkupPb43dtAQ3a1bHffdx3ZQ0i9ueUl9CSs+dKhl9gwiH0bmoNN5pnULAQF4i7WQmNueEfQvh9zgvA==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.67.3.tgz",
+      "integrity": "sha512-BadR5IcrM/WYBmF8Yml4pMqz9LB4A5CsmlsolvevluNmxr2XoS9Y1cMKYujemiYs+86o9st+oh2+O7nz1BbpPQ==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "dayjs": "^1.11.5",
         "emotion": "^10.0.17"
@@ -2354,12 +2354,12 @@
       }
     },
     "node_modules/@contentful/f36-drag-handle": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.67.2.tgz",
-      "integrity": "sha512-7e38V/dJ79m4uVlnf1H1xpRY28DPwaMQOMgFWwPKCdketfr+YU8KI7kE2ssrd1EsM9av7Z0Dcwz6pF89wuxViA==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.67.3.tgz",
+      "integrity": "sha512-vrWf9W6h/2tWrU8iYekAbAmIBYqikUE8RJ0259PdQwrOS7gwDYHmKnv2uSEZJAmLtT7KrWWVyF6Jm2F8HmjdNg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
@@ -2370,12 +2370,12 @@
       }
     },
     "node_modules/@contentful/f36-empty-state": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.67.2.tgz",
-      "integrity": "sha512-ghzqNmwAOv0mAUvXDyLLtlAOXj5RPas/stJ8etPpb339NGFj5ueYf9+EBrgTCWrMK/JCBhcogV5bgKRsc9VKlg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.67.3.tgz",
+      "integrity": "sha512-D8nc+3IH8v4STkyJmXYM8cpO4o3qaslgoYb7Bz3RvZGtVNyBvD2bavg3zjQbKvsnV6bxtRXeDk9LjoCq/NjpoA==",
       "dependencies": {
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2384,21 +2384,20 @@
       }
     },
     "node_modules/@contentful/f36-entity-list": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.67.2.tgz",
-      "integrity": "sha512-G37dKH3yRD++fOA924UROtZdeIiNFmrjfVOobC03jdvk6o21AN2kMyDzML2Uc0+kMg+ofe4G08KC/OmDSUkSAg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.67.3.tgz",
+      "integrity": "sha512-yUkW3U7CkG+dsZ0LYK80rZMPxkQmI1LTGJmjct3IqukY+c9lni77acyVLd0p+BJUixO91SRcnKGysbpa9/keKg==",
       "dependencies": {
-        "@contentful/f36-badge": "^4.67.2",
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-icons-alpha": "npm:@contentful/f36-icons@^5.0.0-alpha.26",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-badge": "^4.67.3",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-drag-handle": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-menu": "^4.67.3",
+        "@contentful/f36-skeleton": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2407,14 +2406,14 @@
       }
     },
     "node_modules/@contentful/f36-forms": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.67.2.tgz",
-      "integrity": "sha512-+XxpnCiBKtZw2hYo5QZWVayWMPKzbarOIWzZUMm6Ttoru00zn5u3tlvue7c9W2zqkNFuUNOopAwXBwQ0h+z+bQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.67.3.tgz",
+      "integrity": "sha512-O+JJUZF0iOn2Y8AU6ooD8BLEvFC5X8tNDYAouux62gd+WQFGCyn7hkpN70wjNRiR0cNrS9QW+cs1pl/pLipy3g==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
@@ -2424,15 +2423,15 @@
       }
     },
     "node_modules/@contentful/f36-header": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-header/-/f36-header-4.67.2.tgz",
-      "integrity": "sha512-DjI5JnJuXixG8bAj03lRvISuAgwA2X6PnYifa//967Dd0qQTBw/CkB96AhrgVUjTw+jt3xAprwv0SUKF8x9S8g==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-header/-/f36-header-4.67.3.tgz",
+      "integrity": "sha512-cUth5PtzLzGQmG1rev++F5VWl/36TMy1GhSK06sjpgRxs0BCFEWgs4UJnelPLyyajkfTx4GUrP+CiHACkIMPKA==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.2",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.5",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2441,32 +2440,13 @@
       }
     },
     "node_modules/@contentful/f36-icon": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.67.2.tgz",
-      "integrity": "sha512-vJAk6KO88GVnHdPSXurUA67F4wl01sZHaaE5eHGvt/s+YuI47dstgROr5+z66qmncKpcMWOTv4/+jqYV1Ko56A==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.67.3.tgz",
+      "integrity": "sha512-lD9L7iJPL7d7axJOIrQxF9X1g+uYl4v+lfORNguLaCdRAiZcwlbmn0GaIsQvfqsQxZudFu92N4MuT3rGlh9bPw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-icon-alpha": {
-      "name": "@contentful/f36-icon",
-      "version": "5.0.0-alpha.20",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-5.0.0-alpha.20.tgz",
-      "integrity": "sha512-kI7HJggp/H8whiUL/RrG988nEvQq2SuZVyQn4kyiWYSlMWBRqQXZRvXfsM/RILWMgz2LxryXaT1YGVy2E4UfJA==",
-      "dependencies": {
-        "@contentful/f36-core": "^4.65.4",
-        "@contentful/f36-tokens": "^4.0.4",
-        "@phosphor-icons/react": "^2.1.5",
-        "emotion": "^10.0.17"
-      },
-      "engines": {
-        "node": ">=16"
       },
       "peerDependencies": {
         "react": ">=16.8",
@@ -2474,34 +2454,14 @@
       }
     },
     "node_modules/@contentful/f36-icons": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-4.28.2.tgz",
-      "integrity": "sha512-p7oWbQ5ITlMMuEl/6t/6JLVrCVhDE2nA8mv1VR4DHjXPm0y9w14533rCKxNIREZX8iVmyBoaqI3vdPsjUs1CAw==",
+      "version": "4.29.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-4.29.0.tgz",
+      "integrity": "sha512-oo/e2UhugDuSw5AXp7aDPMaUMIJEuWTAk0UaYSqaDh3+cv/7yctyvhcU0mrolmhC8HDKBHXK4Z0/QZkvqNb+Mw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.65.0",
-        "@contentful/f36-icon": "^4.65.0",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.1",
         "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-icons-alpha": {
-      "name": "@contentful/f36-icons",
-      "version": "5.0.0-alpha.29",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-5.0.0-alpha.29.tgz",
-      "integrity": "sha512-7QhDDAo95WiqFwB/ofWd57GEyeLgkDU/CgTStjhtBZssheMvVT6thiIFy6hSbo314d1RZ5Z8EBzH1MIJ/nyQhA==",
-      "dependencies": {
-        "@contentful/f36-core": "^4.67.1",
-        "@contentful/f36-icon-alpha": "npm:@contentful/f36-icon@5.0.0-alpha.20",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@phosphor-icons/react": "^2.1.4",
-        "emotion": "^10.0.17"
-      },
-      "engines": {
-        "node": ">=16"
       },
       "peerDependencies": {
         "react": ">=16.8",
@@ -2509,12 +2469,12 @@
       }
     },
     "node_modules/@contentful/f36-image": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-image/-/f36-image-4.67.2.tgz",
-      "integrity": "sha512-zB4D/fBmUyIj1WvF2tWQHsDxzTcZ+KOyiVu0483rxRNai8sae7BO3VSuevUzfi2Y+gaF3VCasPZudjgTeWD2pQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-image/-/f36-image-4.67.3.tgz",
+      "integrity": "sha512-KFE+S3rKTzj0rdVFTy96gMKvMzn8K4ydoeL0xkoIOkpy33VfgySZJwf9s82NUPLPa+h0Fz4GYGZ0WcbZ0haxiA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-skeleton": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.5",
         "emotion": "^10.0.17"
       },
@@ -2524,11 +2484,11 @@
       }
     },
     "node_modules/@contentful/f36-list": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.67.2.tgz",
-      "integrity": "sha512-ZkObExturTfxpNZOBcHJMozuLIbDLe8Us5qe4qJyVozIBH+Ol6xOHxEEyEu8GsRZp0+GU7K3fWExqLEV22oSUQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.67.3.tgz",
+      "integrity": "sha512-qIs8K14G8PZfUTkp3WXUhtZQKMFqomFhYwI3bd/yfpDbA/bkFgCuhlwqO5R5MYR3ZPfqto0Euddgy084vu5whA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2538,15 +2498,15 @@
       }
     },
     "node_modules/@contentful/f36-menu": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.67.2.tgz",
-      "integrity": "sha512-TF+tpTLqE22qeQTYHJFuxCm6Yt37VFtwM6X9O07GYTeXeDZE7ZI+FrA16y+fxFw2Zu0OpbLO0CWB/ViolvMlOw==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.67.3.tgz",
+      "integrity": "sha512-a6eNH3RTbLT31gUPuQcKgyHT0tbah2n2N5VtKUA35LOQRPa/rBVOX0FsRiXTht0Tnb1aDIO/gjmKZZkfCNdIcg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-popover": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-popover": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
@@ -2556,15 +2516,15 @@
       }
     },
     "node_modules/@contentful/f36-modal": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.67.2.tgz",
-      "integrity": "sha512-mrO5+mKytV/j759HI0y6fZskQG/EEY7iNaRjjeYmFRoT6MAgViebcIeht15CcFwnNQLAeS3MusvXiEzuUzweiQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.67.3.tgz",
+      "integrity": "sha512-/DM6TIAoW2J+v4XY4cplQYKoxF7W43Al22N6zHoh2QE0yG6AJvVOmIGYMgGk3nYany45GeXrCU/rGFOplWo6Jg==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "@types/react-modal": "^3.13.1",
         "emotion": "^10.0.17",
         "react-modal": "^3.16.1"
@@ -2575,16 +2535,16 @@
       }
     },
     "node_modules/@contentful/f36-navbar": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-navbar/-/f36-navbar-4.67.2.tgz",
-      "integrity": "sha512-58PYpIElqnfdYWpEkSaOmccSzcgudYUs009UWmtqHmv0n3c8eNoV8taoZdg92gYAsEc7G2VWl4AZ3wJy/kiAdg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-navbar/-/f36-navbar-4.67.3.tgz",
+      "integrity": "sha512-8KLvY+pVX+diuXcBmdbGhI8OYCPa4Ba4BoRHaNDWX1jbucJcuysjRwAUc7wnOSb1lLqjqtIRVOL/edxTjqLmNQ==",
       "dependencies": {
-        "@contentful/f36-avatar": "4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-avatar": "4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-menu": "^4.67.3",
+        "@contentful/f36-skeleton": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.1",
         "@contentful/f36-utils": "^4.23.2",
         "emotion": "^10.0.17"
@@ -2595,16 +2555,16 @@
       }
     },
     "node_modules/@contentful/f36-note": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.67.2.tgz",
-      "integrity": "sha512-DA0f1/j640SG3LOon1VcU6kDvNgUHxupH0Q1FXS01aRrWq12uMd2bLtb2k5A9qRyT6MB3OdAKFufwsBcSL6fYw==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.67.3.tgz",
+      "integrity": "sha512-Is7QO7i+Bayc17WZZiNm/ztGbRkMV2ft6WEFIu0ra6NhcMi5CW/7Q358po0QVhr13OpQFDnO3MYRaLxifU5mVg==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2613,16 +2573,16 @@
       }
     },
     "node_modules/@contentful/f36-notification": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.67.2.tgz",
-      "integrity": "sha512-x7qxuqOhQMyhhRfMrisAVXnAo/eL6A7RjL2PmTLylaqKrFnzDrr25BtzepdkgULj9VLh70vXM5QIzPwpKpIJBQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.67.3.tgz",
+      "integrity": "sha512-kd5eXd3ZCNNHCfo9V7PI6XB9p4uVUPX59j+7zGGgLDqD1+PS1D3kYPMMJ4C42Ni5B4uF2kLT9tSlSGm3WkbeYg==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-text-link": "^4.67.2",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-text-link": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "@swc/helpers": "^0.4.14",
         "emotion": "^10.0.17",
         "react-animate-height": "^3.0.4"
@@ -2633,16 +2593,16 @@
       }
     },
     "node_modules/@contentful/f36-pagination": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.67.2.tgz",
-      "integrity": "sha512-/UePF1fbr2wvJHtJ9ncWaz5eg/VTdA8VqEBFJXge/IBgPVyMgQxQRxSDhvMj0j2Iit90qAzPedEDZK+jp6CyTg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.67.3.tgz",
+      "integrity": "sha512-fXwjCy20GkqljjsC8/z8Xg0beMYeIKw0nZpK/qMGs85vEW54py3PkwP8KwmRWkTFy7U8Q0D7USa2oOO65Ffv6Q==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-forms": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2651,16 +2611,16 @@
       }
     },
     "node_modules/@contentful/f36-pill": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.67.2.tgz",
-      "integrity": "sha512-015oRkVVnshvWAJ/kR5yJBD+soWmDcHFy5FGXDaIR5moTCejjqiLG1g8H6MolaF8oeKSOhbhgfX/dpEHn5/Z4g==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.67.3.tgz",
+      "integrity": "sha512-2bfYm8bhyeH1BNa8ioFAl6v3jq1C6sd9L8/oh6Sn9cKIsxAvqgIGTP+YOaRH+OqjDQxuHDNmld3XuTPlco8IRg==",
       "dependencies": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-drag-handle": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2669,11 +2629,11 @@
       }
     },
     "node_modules/@contentful/f36-popover": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.67.2.tgz",
-      "integrity": "sha512-NJx54sqQEmuWIsBySXf/B+ZW/RoIkRzb7cnQ5aucN3nUd4ZaHOvcmYVLJMqfCV8ipzpMxLgoc8p3v6OcRdi72A==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.67.3.tgz",
+      "integrity": "sha512-3/eMw2gL1iEDswKUuRrMRAOFkzvrEk+DRXENejL2t8Fb/WU9lP1sOyYUG58UvzMLFDchzVLKHbcLPDTaaNaorw==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -2686,12 +2646,12 @@
       }
     },
     "node_modules/@contentful/f36-skeleton": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.67.2.tgz",
-      "integrity": "sha512-4T8r/G8b9DFkLErIo8d2cGS71tWy1yNDZIThoHBWIhLRcstal8K7Ag5dQwPsaoSew/859oXC2rvPP0Ep+4FtCg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.67.3.tgz",
+      "integrity": "sha512-7qdbeIqnPie0NoKPVI6ebAGlBvxsNkGVbcieSecpZuCnIZGdm+E4AWgQ+Lm1CMw8CPYX0B4p94l5YDysGTZyxA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-table": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-table": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2701,11 +2661,11 @@
       }
     },
     "node_modules/@contentful/f36-spinner": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.67.2.tgz",
-      "integrity": "sha512-sBitcudBc4DwAOPn6MLuArLje7aym47GoIDI0kN9zQtolVwlVH92/zNpZmnm+zbP4Ku56/TgbL/v5SFTh+YB2w==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.67.3.tgz",
+      "integrity": "sha512-e1NJFcvLYphC321tDyTacnYOTcbv+yeQ1EcmIlmbSOYENZxTxzVMjD4uikrx8gm/CdquG8ahwf9/BYC07N9dJg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2715,14 +2675,14 @@
       }
     },
     "node_modules/@contentful/f36-table": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.67.2.tgz",
-      "integrity": "sha512-YtUkXwFmBLgAi5Glgi1vXqNbr+U2riadB9O+Aq8t2R/vpXMCIA4WlmXSqunwPW9UrrilalrK49l0IkDNpcRUbQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.67.3.tgz",
+      "integrity": "sha512-nzFIe28T4aBV7SXv6H8cefCuLAvsNlII9JxeBwI5JFUSgACpJsh1ANVdkDVilTo3cgiUFmvQmErYqiH0MMiy/Q==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -2731,11 +2691,11 @@
       }
     },
     "node_modules/@contentful/f36-tabs": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.67.2.tgz",
-      "integrity": "sha512-rPPJQHmCoD8492yKufelL7MCj0j4FqcPc5yFhD29sqpGDqTko8Xf/V/q4/LPYUtXttH8myfTINEyNTsR/lZINg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.67.3.tgz",
+      "integrity": "sha512-tjdPelHm3L3DzHSWjHz+v7hciRG3QPs5y3WzloCgBjzgSk1BlcEiD2GuoWhPZM9WuUq3C92PwsVq/lB5urHyNA==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@radix-ui/react-tabs": "^1.0.1",
         "emotion": "^10.0.17"
@@ -2746,11 +2706,11 @@
       }
     },
     "node_modules/@contentful/f36-text-link": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.67.2.tgz",
-      "integrity": "sha512-mWE4KsqQV93SNAFtYWqQB61/TLHuX1D3vVJ1rFqAp1kndPy7UyGcrQrGoPmM1l20Y9YaYIWYwo5eGKygY3iwIA==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.67.3.tgz",
+      "integrity": "sha512-jgWCMdeFwzMHHtHRHOcutq6x+hb2ipKXrSpZaiY8O/8Rh2wzKL6BIj/v+Jio4DJkaoGT8cEQLVuCP2JYiwm09A==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       },
@@ -2765,11 +2725,11 @@
       "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
     },
     "node_modules/@contentful/f36-tooltip": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.67.2.tgz",
-      "integrity": "sha512-BFSKsJySAK1ipIOXueq6rgsJlmZDVBd60fjicALWiVX/GnxyDO3OkdX8nfK4Id0rbllf8+WBSR5UcVzNjuLe4Q==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.67.3.tgz",
+      "integrity": "sha512-40VkWQxm57Rf2ZydCPwnkiG+6WXBuswj+/nB97kpqjRohbSxKR0IzA5u0sAiWUglXDPH0Tu9IOtRz6PVAL4UZQ==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -2788,11 +2748,11 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/@contentful/f36-typography": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.67.2.tgz",
-      "integrity": "sha512-zfCVUQfD5wueT4mFNxLO+2SaUTFVHxE+7v8YKt53SvIiN+s/vXJnABOKPZsjYAYkwQwSrwPYIdIxMtaULwjoCw==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.67.3.tgz",
+      "integrity": "sha512-ujLg2yibJQxyHrJbCmv9ksWtNn3QuqOMew3i6WClUq2/BOdUjvdMtCW9zK8RbSXNV94FJXB0+AvG+dRQ4hqMNg==",
       "dependencies": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
@@ -3009,17 +2969,17 @@
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
     },
     "node_modules/@emotion/is-prop-valid": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz",
-      "integrity": "sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.3.0.tgz",
+      "integrity": "sha512-SHetuSLvJDzuNbOdtPVbq6yMMMlLoW5Q94uDqJZqy50gcmAjxFkVqmzqSGEFq9gT2iMuIeKV1PXVWmvUhuZLlQ==",
       "dependencies": {
-        "@emotion/memoize": "^0.8.1"
+        "@emotion/memoize": "^0.9.0"
       }
     },
     "node_modules/@emotion/is-prop-valid/node_modules/@emotion/memoize": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
-      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ=="
     },
     "node_modules/@emotion/memoize": {
       "version": "0.7.4",
@@ -3622,18 +3582,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@phosphor-icons/react": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.1.7.tgz",
-      "integrity": "sha512-g2e2eVAn1XG2a+LI09QU3IORLhnFNAFkNbo2iwbX6NOKSLOwvEMmTa7CgOzEbgNWR47z8i8kwjdvYZ5fkGx1mQ==",
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": ">= 16.8",
-        "react-dom": ">= 16.8"
       }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -7343,9 +7291,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.11",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.11.tgz",
-      "integrity": "sha512-okzr3f11N6WuqYtZSvm+F776mB41wRZMhKP+hc34YdW+KmtYYK9iqvHSwo2k9FEH3fhGXvOPV6yz2IcSrfRUDg=="
+      "version": "1.11.12",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.12.tgz",
+      "integrity": "sha512-Rt2g+nTbLlDWZTwwrIXjy9MeiZmSDI375FvZs72ngxx8PDC6YXOeR3q5LAuPzjZQxhiWdRKac7RKV+YyQYfYIg=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -18769,178 +18717,178 @@
       }
     },
     "@contentful/f36-accordion": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.67.2.tgz",
-      "integrity": "sha512-cX7xIX+fZadUNNFG+uzAOXeZ/GkMs+Y0bvgpxkpqW3ILu6GIXHsXetnRocxVaYUrQ1C/k6wEsd4xSv5y2uQBIg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.67.3.tgz",
+      "integrity": "sha512-d2Hwqg2Y8Pe9DP8XUAtVP8wKvqL6y4u9ydcSQDdQ4AZBT297zVzaXhTYzv7Bwi+Dq+4lagtkj39eU2IHXg/Aew==",
       "requires": {
-        "@contentful/f36-collapse": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-collapse": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-asset": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.67.2.tgz",
-      "integrity": "sha512-cUQaZQeXIr3oLy255cuL+mXNiYOpMvAzW7BxE3l903ShzlwVFqZr/FIaWAo2t488sWbGeXNXxVBcEbLzQUMIdA==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.67.3.tgz",
+      "integrity": "sha512-XTYNl6mS69By8MOvQwaHcIwxf+hnodUNzmMW3DgiGlptfKHtsgV6RlKil4PSluOaqtHUrIuXzPozCyMxPjf+0w==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-autocomplete": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.67.2.tgz",
-      "integrity": "sha512-1cZHVa2cskh4DvachcgaQeEuyjuAlxvvyJCqvpHpP+R3ISS6CsC44252fH52NcLryvfFG1zX24nZECgFOY/S+A==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.67.3.tgz",
+      "integrity": "sha512-meEb8OnRBDHrffLxqxfXfmKxyIKQPyFEMtjW6zRrilvDhFxw4KvKFU8XWX3gv3oBpWdpm5LEY/YnZuPqsRshow==",
       "requires": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-popover": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-forms": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-popover": "^4.67.3",
+        "@contentful/f36-skeleton": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "@contentful/f36-utils": "^4.24.3",
         "downshift": "^6.1.12",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-avatar": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-avatar/-/f36-avatar-4.67.2.tgz",
-      "integrity": "sha512-bKxmWgi67V6tPCX2mlSxJKtQ8IANoO7jU9qH74Fqe11ATgG84Oqy9iQgjJDQvfFMjyT9n+3zUtUCwo/waHHrQg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-avatar/-/f36-avatar-4.67.3.tgz",
+      "integrity": "sha512-gyVW7kJqrxZFOOhDzOsxkpelT7i6kE+TxbPrSClIpSfSWSWAQZnKFjBK3oeUH5VxnOrrZUO4IDIUTAIjF0UiDQ==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-image": "4.67.2",
-        "@contentful/f36-menu": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-image": "4.67.3",
+        "@contentful/f36-menu": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.5",
-        "@contentful/f36-tooltip": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-badge": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.67.2.tgz",
-      "integrity": "sha512-cWfb3Nk9+CdgmTvc75gzD6uJ4XCbK23pB1t9BV9ZvytvnuaQElZYh7WciyRKJtU51khb0KOuVCb/TOnjecU4xQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.67.3.tgz",
+      "integrity": "sha512-/9IzwrWLdv00t+iy0OfIwRCIQjxmdLcJCSzNFWHnbNSrjwCUPK3buZgtq9F8ueoFMobPuYed6b5X+VMAMlL4Hg==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-button": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.67.2.tgz",
-      "integrity": "sha512-1/1dYtgfVk3wiP5SoaoQEWlM7VYp/Pju17agu5Y0MGuGo7LwjTCzLJQ4OeRvdubTYCW+iXc20sEG2H3OyRoz6w==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.67.3.tgz",
+      "integrity": "sha512-/w13GeJq4xN563Mrs5L6V6fEG2JHA3unsR/Rg+88agvoIgEj7bVNA6IunWVhKEHIfSucDJ+1hktNGfh1mPMQ4w==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-spinner": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-spinner": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-card": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.67.2.tgz",
-      "integrity": "sha512-f1Ck9hbbfdX7/OIWPfXJSdriDVjoTQOdz4aXo1QVd2fmsTAzQCfH0llwXtCk8TCg4DbSwaS/ldB/CJV3oCN1AA==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.67.3.tgz",
+      "integrity": "sha512-LiCr/9sByOeY6GU6rW8HrSCJIdNVgO8IUwvPlciuqxKPyNgWOnqUiYpBZZNf74lqtLKuDXCzkKZaaF3j1JShLA==",
       "requires": {
-        "@contentful/f36-asset": "^4.67.2",
-        "@contentful/f36-badge": "^4.67.2",
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-asset": "^4.67.3",
+        "@contentful/f36-badge": "^4.67.3",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-drag-handle": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-menu": "^4.67.3",
+        "@contentful/f36-skeleton": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.3",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17",
         "truncate": "^3.0.0"
       }
     },
     "@contentful/f36-collapse": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.67.2.tgz",
-      "integrity": "sha512-EWkl653S3gnhVkq39Z0vDrIHQxvqJnN9XfrrORpX56ZCc4kHs1MzbbbDjnlj3udCy9Cj4Q50hiXpmeO/JogDlg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.67.3.tgz",
+      "integrity": "sha512-W8RQzN7H0x2jRNz6NN8EYLVDREwdPWPTTx89pSWnXaTG1EyITVUSGlgvc/kfOpLjbTC3HI1jwIlll+RGMFGs8A==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-components": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.67.2.tgz",
-      "integrity": "sha512-JNBX8YzP+mt2/d2m5uUnpFLGnzyRAsggWpEBUe8QgPRwkJ8bZIDrnm2TELIFqrY2t4Lvs2AJw8L/3kDaJvMNCQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.67.3.tgz",
+      "integrity": "sha512-AFw5q0JzT/L60w4tM3H399pXDO3lOcZootFwjKIaupHRjNPHHGQ1MlgMqNEIz1qSEbBbqKY3O6HlA2CmowznaQ==",
       "requires": {
-        "@contentful/f36-accordion": "^4.67.2",
-        "@contentful/f36-asset": "^4.67.2",
-        "@contentful/f36-autocomplete": "^4.67.2",
-        "@contentful/f36-avatar": "4.67.2",
-        "@contentful/f36-badge": "^4.67.2",
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-card": "^4.67.2",
-        "@contentful/f36-collapse": "^4.67.2",
-        "@contentful/f36-copybutton": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-datepicker": "^4.67.2",
-        "@contentful/f36-datetime": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-empty-state": "^4.67.2",
-        "@contentful/f36-entity-list": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
-        "@contentful/f36-header": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-image": "4.67.2",
-        "@contentful/f36-list": "^4.67.2",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-modal": "^4.67.2",
-        "@contentful/f36-navbar": "^4.67.2",
-        "@contentful/f36-note": "^4.67.2",
-        "@contentful/f36-notification": "^4.67.2",
-        "@contentful/f36-pagination": "^4.67.2",
-        "@contentful/f36-pill": "^4.67.2",
-        "@contentful/f36-popover": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
-        "@contentful/f36-spinner": "^4.67.2",
-        "@contentful/f36-table": "^4.67.2",
-        "@contentful/f36-tabs": "^4.67.2",
-        "@contentful/f36-text-link": "^4.67.2",
+        "@contentful/f36-accordion": "^4.67.3",
+        "@contentful/f36-asset": "^4.67.3",
+        "@contentful/f36-autocomplete": "^4.67.3",
+        "@contentful/f36-avatar": "4.67.3",
+        "@contentful/f36-badge": "^4.67.3",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-card": "^4.67.3",
+        "@contentful/f36-collapse": "^4.67.3",
+        "@contentful/f36-copybutton": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-datepicker": "^4.67.3",
+        "@contentful/f36-datetime": "^4.67.3",
+        "@contentful/f36-drag-handle": "^4.67.3",
+        "@contentful/f36-empty-state": "^4.67.3",
+        "@contentful/f36-entity-list": "^4.67.3",
+        "@contentful/f36-forms": "^4.67.3",
+        "@contentful/f36-header": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-image": "4.67.3",
+        "@contentful/f36-list": "^4.67.3",
+        "@contentful/f36-menu": "^4.67.3",
+        "@contentful/f36-modal": "^4.67.3",
+        "@contentful/f36-navbar": "^4.67.3",
+        "@contentful/f36-note": "^4.67.3",
+        "@contentful/f36-notification": "^4.67.3",
+        "@contentful/f36-pagination": "^4.67.3",
+        "@contentful/f36-pill": "^4.67.3",
+        "@contentful/f36-popover": "^4.67.3",
+        "@contentful/f36-skeleton": "^4.67.3",
+        "@contentful/f36-spinner": "^4.67.3",
+        "@contentful/f36-table": "^4.67.3",
+        "@contentful/f36-tabs": "^4.67.3",
+        "@contentful/f36-text-link": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.3",
+        "@contentful/f36-typography": "^4.67.3",
         "@contentful/f36-utils": "^4.24.3"
       }
     },
     "@contentful/f36-copybutton": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.67.2.tgz",
-      "integrity": "sha512-hb/DCGE6TTdepsjZvmDgog1glfF8WxGCx+F1S7FbwTZ4NutWeHEa7+E63t2tELTRx07FoVmkICmPtp89mCXKEw==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.67.3.tgz",
+      "integrity": "sha512-N6xD+oPlVL3dYXb4slnMfXFXw39kMexzHiFuQn9J/dsZyyhW+HYFB8hZ804U/s3YHJxSmwjhz22eBzqNbQrS1Q==",
       "requires": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-core": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.67.2.tgz",
-      "integrity": "sha512-iSzA/OuhU4rIlBOlUTIczMuqDQZqLR1tmZJtZyouhfWkEc0VGUCX6S2FnBEXlMbnMzaL70lTXYUNu2bKxK4PfA==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.67.3.tgz",
+      "integrity": "sha512-W+wFcljUBvMP0mV6P3boqpARw2N71l01OrbkqfdG+A+jhVpFpbQTICuXnF9YmDDBjz+AXlUvSVDMmBLuQjm8/Q==",
       "requires": {
         "@contentful/f36-tokens": "^4.0.4",
         "@emotion/core": "^10.1.1",
@@ -18957,17 +18905,17 @@
       }
     },
     "@contentful/f36-datepicker": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.67.2.tgz",
-      "integrity": "sha512-qGfVEjdZaMwdDBr1uWfgQtnCd8L+ZyVBpFiI8TyFUdQd6L9blHexr99Wg12uBNSub9zaL5fs4wrHZ5vMpGEjGQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.67.3.tgz",
+      "integrity": "sha512-0AR4KVIMkzcRbkfMYF/XR4RL4vaIg1zjCQh9M/F26R3Eb57DCsOgnK1bIY4YpazqU1s9YSiu2VGi7kEA//scuQ==",
       "requires": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-popover": "^4.67.2",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-forms": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-popover": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "date-fns": "^2.28.0",
         "emotion": "^10.0.17",
         "react-day-picker": "^8.7.1",
@@ -18975,257 +18923,233 @@
       }
     },
     "@contentful/f36-datetime": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.67.2.tgz",
-      "integrity": "sha512-7kz4I/CzRkupPb43dtAQ3a1bHffdx3ZQ0i9ueUl9CSs+dKhl9gwiH0bmoNN5pnULAQF4i7WQmNueEfQvh9zgvA==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.67.3.tgz",
+      "integrity": "sha512-BadR5IcrM/WYBmF8Yml4pMqz9LB4A5CsmlsolvevluNmxr2XoS9Y1cMKYujemiYs+86o9st+oh2+O7nz1BbpPQ==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "dayjs": "^1.11.5",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-drag-handle": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.67.2.tgz",
-      "integrity": "sha512-7e38V/dJ79m4uVlnf1H1xpRY28DPwaMQOMgFWwPKCdketfr+YU8KI7kE2ssrd1EsM9av7Z0Dcwz6pF89wuxViA==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.67.3.tgz",
+      "integrity": "sha512-vrWf9W6h/2tWrU8iYekAbAmIBYqikUE8RJ0259PdQwrOS7gwDYHmKnv2uSEZJAmLtT7KrWWVyF6Jm2F8HmjdNg==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-empty-state": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.67.2.tgz",
-      "integrity": "sha512-ghzqNmwAOv0mAUvXDyLLtlAOXj5RPas/stJ8etPpb339NGFj5ueYf9+EBrgTCWrMK/JCBhcogV5bgKRsc9VKlg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.67.3.tgz",
+      "integrity": "sha512-D8nc+3IH8v4STkyJmXYM8cpO4o3qaslgoYb7Bz3RvZGtVNyBvD2bavg3zjQbKvsnV6bxtRXeDk9LjoCq/NjpoA==",
       "requires": {
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-entity-list": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.67.2.tgz",
-      "integrity": "sha512-G37dKH3yRD++fOA924UROtZdeIiNFmrjfVOobC03jdvk6o21AN2kMyDzML2Uc0+kMg+ofe4G08KC/OmDSUkSAg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.67.3.tgz",
+      "integrity": "sha512-yUkW3U7CkG+dsZ0LYK80rZMPxkQmI1LTGJmjct3IqukY+c9lni77acyVLd0p+BJUixO91SRcnKGysbpa9/keKg==",
       "requires": {
-        "@contentful/f36-badge": "^4.67.2",
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-icons-alpha": "npm:@contentful/f36-icons@^5.0.0-alpha.26",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-badge": "^4.67.3",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-drag-handle": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-menu": "^4.67.3",
+        "@contentful/f36-skeleton": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-forms": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.67.2.tgz",
-      "integrity": "sha512-+XxpnCiBKtZw2hYo5QZWVayWMPKzbarOIWzZUMm6Ttoru00zn5u3tlvue7c9W2zqkNFuUNOopAwXBwQ0h+z+bQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.67.3.tgz",
+      "integrity": "sha512-O+JJUZF0iOn2Y8AU6ooD8BLEvFC5X8tNDYAouux62gd+WQFGCyn7hkpN70wjNRiR0cNrS9QW+cs1pl/pLipy3g==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-header": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-header/-/f36-header-4.67.2.tgz",
-      "integrity": "sha512-DjI5JnJuXixG8bAj03lRvISuAgwA2X6PnYifa//967Dd0qQTBw/CkB96AhrgVUjTw+jt3xAprwv0SUKF8x9S8g==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-header/-/f36-header-4.67.3.tgz",
+      "integrity": "sha512-cUth5PtzLzGQmG1rev++F5VWl/36TMy1GhSK06sjpgRxs0BCFEWgs4UJnelPLyyajkfTx4GUrP+CiHACkIMPKA==",
       "requires": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.2",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.5",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-icon": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.67.2.tgz",
-      "integrity": "sha512-vJAk6KO88GVnHdPSXurUA67F4wl01sZHaaE5eHGvt/s+YuI47dstgROr5+z66qmncKpcMWOTv4/+jqYV1Ko56A==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.67.3.tgz",
+      "integrity": "sha512-lD9L7iJPL7d7axJOIrQxF9X1g+uYl4v+lfORNguLaCdRAiZcwlbmn0GaIsQvfqsQxZudFu92N4MuT3rGlh9bPw==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "emotion": "^10.0.17"
-      }
-    },
-    "@contentful/f36-icon-alpha": {
-      "version": "npm:@contentful/f36-icon@5.0.0-alpha.20",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-5.0.0-alpha.20.tgz",
-      "integrity": "sha512-kI7HJggp/H8whiUL/RrG988nEvQq2SuZVyQn4kyiWYSlMWBRqQXZRvXfsM/RILWMgz2LxryXaT1YGVy2E4UfJA==",
-      "requires": {
-        "@contentful/f36-core": "^4.65.4",
-        "@contentful/f36-tokens": "^4.0.4",
-        "@phosphor-icons/react": "^2.1.5",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-icons": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-4.28.2.tgz",
-      "integrity": "sha512-p7oWbQ5ITlMMuEl/6t/6JLVrCVhDE2nA8mv1VR4DHjXPm0y9w14533rCKxNIREZX8iVmyBoaqI3vdPsjUs1CAw==",
+      "version": "4.29.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-4.29.0.tgz",
+      "integrity": "sha512-oo/e2UhugDuSw5AXp7aDPMaUMIJEuWTAk0UaYSqaDh3+cv/7yctyvhcU0mrolmhC8HDKBHXK4Z0/QZkvqNb+Mw==",
       "requires": {
-        "@contentful/f36-core": "^4.65.0",
-        "@contentful/f36-icon": "^4.65.0",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.1",
-        "emotion": "^10.0.17"
-      }
-    },
-    "@contentful/f36-icons-alpha": {
-      "version": "npm:@contentful/f36-icons@5.0.0-alpha.29",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-5.0.0-alpha.29.tgz",
-      "integrity": "sha512-7QhDDAo95WiqFwB/ofWd57GEyeLgkDU/CgTStjhtBZssheMvVT6thiIFy6hSbo314d1RZ5Z8EBzH1MIJ/nyQhA==",
-      "requires": {
-        "@contentful/f36-core": "^4.67.1",
-        "@contentful/f36-icon-alpha": "npm:@contentful/f36-icon@5.0.0-alpha.20",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@phosphor-icons/react": "^2.1.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-image": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-image/-/f36-image-4.67.2.tgz",
-      "integrity": "sha512-zB4D/fBmUyIj1WvF2tWQHsDxzTcZ+KOyiVu0483rxRNai8sae7BO3VSuevUzfi2Y+gaF3VCasPZudjgTeWD2pQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-image/-/f36-image-4.67.3.tgz",
+      "integrity": "sha512-KFE+S3rKTzj0rdVFTy96gMKvMzn8K4ydoeL0xkoIOkpy33VfgySZJwf9s82NUPLPa+h0Fz4GYGZ0WcbZ0haxiA==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-skeleton": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.5",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-list": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.67.2.tgz",
-      "integrity": "sha512-ZkObExturTfxpNZOBcHJMozuLIbDLe8Us5qe4qJyVozIBH+Ol6xOHxEEyEu8GsRZp0+GU7K3fWExqLEV22oSUQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.67.3.tgz",
+      "integrity": "sha512-qIs8K14G8PZfUTkp3WXUhtZQKMFqomFhYwI3bd/yfpDbA/bkFgCuhlwqO5R5MYR3ZPfqto0Euddgy084vu5whA==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-menu": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.67.2.tgz",
-      "integrity": "sha512-TF+tpTLqE22qeQTYHJFuxCm6Yt37VFtwM6X9O07GYTeXeDZE7ZI+FrA16y+fxFw2Zu0OpbLO0CWB/ViolvMlOw==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.67.3.tgz",
+      "integrity": "sha512-a6eNH3RTbLT31gUPuQcKgyHT0tbah2n2N5VtKUA35LOQRPa/rBVOX0FsRiXTht0Tnb1aDIO/gjmKZZkfCNdIcg==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-popover": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-popover": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-modal": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.67.2.tgz",
-      "integrity": "sha512-mrO5+mKytV/j759HI0y6fZskQG/EEY7iNaRjjeYmFRoT6MAgViebcIeht15CcFwnNQLAeS3MusvXiEzuUzweiQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.67.3.tgz",
+      "integrity": "sha512-/DM6TIAoW2J+v4XY4cplQYKoxF7W43Al22N6zHoh2QE0yG6AJvVOmIGYMgGk3nYany45GeXrCU/rGFOplWo6Jg==",
       "requires": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "@types/react-modal": "^3.13.1",
         "emotion": "^10.0.17",
         "react-modal": "^3.16.1"
       }
     },
     "@contentful/f36-navbar": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-navbar/-/f36-navbar-4.67.2.tgz",
-      "integrity": "sha512-58PYpIElqnfdYWpEkSaOmccSzcgudYUs009UWmtqHmv0n3c8eNoV8taoZdg92gYAsEc7G2VWl4AZ3wJy/kiAdg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-navbar/-/f36-navbar-4.67.3.tgz",
+      "integrity": "sha512-8KLvY+pVX+diuXcBmdbGhI8OYCPa4Ba4BoRHaNDWX1jbucJcuysjRwAUc7wnOSb1lLqjqtIRVOL/edxTjqLmNQ==",
       "requires": {
-        "@contentful/f36-avatar": "4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
-        "@contentful/f36-icons": "^4.23.2",
-        "@contentful/f36-menu": "^4.67.2",
-        "@contentful/f36-skeleton": "^4.67.2",
+        "@contentful/f36-avatar": "4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-menu": "^4.67.3",
+        "@contentful/f36-skeleton": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.1",
         "@contentful/f36-utils": "^4.23.2",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-note": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.67.2.tgz",
-      "integrity": "sha512-DA0f1/j640SG3LOon1VcU6kDvNgUHxupH0Q1FXS01aRrWq12uMd2bLtb2k5A9qRyT6MB3OdAKFufwsBcSL6fYw==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.67.3.tgz",
+      "integrity": "sha512-Is7QO7i+Bayc17WZZiNm/ztGbRkMV2ft6WEFIu0ra6NhcMi5CW/7Q358po0QVhr13OpQFDnO3MYRaLxifU5mVg==",
       "requires": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icon": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icon": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-notification": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.67.2.tgz",
-      "integrity": "sha512-x7qxuqOhQMyhhRfMrisAVXnAo/eL6A7RjL2PmTLylaqKrFnzDrr25BtzepdkgULj9VLh70vXM5QIzPwpKpIJBQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.67.3.tgz",
+      "integrity": "sha512-kd5eXd3ZCNNHCfo9V7PI6XB9p4uVUPX59j+7zGGgLDqD1+PS1D3kYPMMJ4C42Ni5B4uF2kLT9tSlSGm3WkbeYg==",
       "requires": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
-        "@contentful/f36-text-link": "^4.67.2",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
+        "@contentful/f36-text-link": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "@swc/helpers": "^0.4.14",
         "emotion": "^10.0.17",
         "react-animate-height": "^3.0.4"
       }
     },
     "@contentful/f36-pagination": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.67.2.tgz",
-      "integrity": "sha512-/UePF1fbr2wvJHtJ9ncWaz5eg/VTdA8VqEBFJXge/IBgPVyMgQxQRxSDhvMj0j2Iit90qAzPedEDZK+jp6CyTg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.67.3.tgz",
+      "integrity": "sha512-fXwjCy20GkqljjsC8/z8Xg0beMYeIKw0nZpK/qMGs85vEW54py3PkwP8KwmRWkTFy7U8Q0D7USa2oOO65Ffv6Q==",
       "requires": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-forms": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-forms": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-pill": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.67.2.tgz",
-      "integrity": "sha512-015oRkVVnshvWAJ/kR5yJBD+soWmDcHFy5FGXDaIR5moTCejjqiLG1g8H6MolaF8oeKSOhbhgfX/dpEHn5/Z4g==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.67.3.tgz",
+      "integrity": "sha512-2bfYm8bhyeH1BNa8ioFAl6v3jq1C6sd9L8/oh6Sn9cKIsxAvqgIGTP+YOaRH+OqjDQxuHDNmld3XuTPlco8IRg==",
       "requires": {
-        "@contentful/f36-button": "^4.67.2",
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-drag-handle": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-button": "^4.67.3",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-drag-handle": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-tooltip": "^4.67.2",
+        "@contentful/f36-tooltip": "^4.67.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-popover": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.67.2.tgz",
-      "integrity": "sha512-NJx54sqQEmuWIsBySXf/B+ZW/RoIkRzb7cnQ5aucN3nUd4ZaHOvcmYVLJMqfCV8ipzpMxLgoc8p3v6OcRdi72A==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.67.3.tgz",
+      "integrity": "sha512-3/eMw2gL1iEDswKUuRrMRAOFkzvrEk+DRXENejL2t8Fb/WU9lP1sOyYUG58UvzMLFDchzVLKHbcLPDTaaNaorw==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -19234,55 +19158,55 @@
       }
     },
     "@contentful/f36-skeleton": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.67.2.tgz",
-      "integrity": "sha512-4T8r/G8b9DFkLErIo8d2cGS71tWy1yNDZIThoHBWIhLRcstal8K7Ag5dQwPsaoSew/859oXC2rvPP0Ep+4FtCg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.67.3.tgz",
+      "integrity": "sha512-7qdbeIqnPie0NoKPVI6ebAGlBvxsNkGVbcieSecpZuCnIZGdm+E4AWgQ+Lm1CMw8CPYX0B4p94l5YDysGTZyxA==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-table": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-table": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-spinner": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.67.2.tgz",
-      "integrity": "sha512-sBitcudBc4DwAOPn6MLuArLje7aym47GoIDI0kN9zQtolVwlVH92/zNpZmnm+zbP4Ku56/TgbL/v5SFTh+YB2w==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.67.3.tgz",
+      "integrity": "sha512-e1NJFcvLYphC321tDyTacnYOTcbv+yeQ1EcmIlmbSOYENZxTxzVMjD4uikrx8gm/CdquG8ahwf9/BYC07N9dJg==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-table": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.67.2.tgz",
-      "integrity": "sha512-YtUkXwFmBLgAi5Glgi1vXqNbr+U2riadB9O+Aq8t2R/vpXMCIA4WlmXSqunwPW9UrrilalrK49l0IkDNpcRUbQ==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.67.3.tgz",
+      "integrity": "sha512-nzFIe28T4aBV7SXv6H8cefCuLAvsNlII9JxeBwI5JFUSgACpJsh1ANVdkDVilTo3cgiUFmvQmErYqiH0MMiy/Q==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
-        "@contentful/f36-icons": "^4.28.1",
+        "@contentful/f36-core": "^4.67.3",
+        "@contentful/f36-icons": "^4.29.0",
         "@contentful/f36-tokens": "^4.0.4",
-        "@contentful/f36-typography": "^4.67.2",
+        "@contentful/f36-typography": "^4.67.3",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-tabs": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.67.2.tgz",
-      "integrity": "sha512-rPPJQHmCoD8492yKufelL7MCj0j4FqcPc5yFhD29sqpGDqTko8Xf/V/q4/LPYUtXttH8myfTINEyNTsR/lZINg==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.67.3.tgz",
+      "integrity": "sha512-tjdPelHm3L3DzHSWjHz+v7hciRG3QPs5y3WzloCgBjzgSk1BlcEiD2GuoWhPZM9WuUq3C92PwsVq/lB5urHyNA==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@radix-ui/react-tabs": "^1.0.1",
         "emotion": "^10.0.17"
       }
     },
     "@contentful/f36-text-link": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.67.2.tgz",
-      "integrity": "sha512-mWE4KsqQV93SNAFtYWqQB61/TLHuX1D3vVJ1rFqAp1kndPy7UyGcrQrGoPmM1l20Y9YaYIWYwo5eGKygY3iwIA==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.67.3.tgz",
+      "integrity": "sha512-jgWCMdeFwzMHHtHRHOcutq6x+hb2ipKXrSpZaiY8O/8Rh2wzKL6BIj/v+Jio4DJkaoGT8cEQLVuCP2JYiwm09A==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "emotion": "^10.0.17"
       }
@@ -19293,11 +19217,11 @@
       "integrity": "sha512-s2EB5De7ZCRASS6LnUIg42nyckP3yvZXAK+unROeYEzsV1hyV2WtdCfedHrNa3FA/mYnkPE7U/2XTUXNMKk+mA=="
     },
     "@contentful/f36-tooltip": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.67.2.tgz",
-      "integrity": "sha512-BFSKsJySAK1ipIOXueq6rgsJlmZDVBd60fjicALWiVX/GnxyDO3OkdX8nfK4Id0rbllf8+WBSR5UcVzNjuLe4Q==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.67.3.tgz",
+      "integrity": "sha512-40VkWQxm57Rf2ZydCPwnkiG+6WXBuswj+/nB97kpqjRohbSxKR0IzA5u0sAiWUglXDPH0Tu9IOtRz6PVAL4UZQ==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -19314,11 +19238,11 @@
       }
     },
     "@contentful/f36-typography": {
-      "version": "4.67.2",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.67.2.tgz",
-      "integrity": "sha512-zfCVUQfD5wueT4mFNxLO+2SaUTFVHxE+7v8YKt53SvIiN+s/vXJnABOKPZsjYAYkwQwSrwPYIdIxMtaULwjoCw==",
+      "version": "4.67.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.67.3.tgz",
+      "integrity": "sha512-ujLg2yibJQxyHrJbCmv9ksWtNn3QuqOMew3i6WClUq2/BOdUjvdMtCW9zK8RbSXNV94FJXB0+AvG+dRQ4hqMNg==",
       "requires": {
-        "@contentful/f36-core": "^4.67.2",
+        "@contentful/f36-core": "^4.67.3",
         "@contentful/f36-tokens": "^4.0.4",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
@@ -19457,17 +19381,17 @@
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
     },
     "@emotion/is-prop-valid": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz",
-      "integrity": "sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.3.0.tgz",
+      "integrity": "sha512-SHetuSLvJDzuNbOdtPVbq6yMMMlLoW5Q94uDqJZqy50gcmAjxFkVqmzqSGEFq9gT2iMuIeKV1PXVWmvUhuZLlQ==",
       "requires": {
-        "@emotion/memoize": "^0.8.1"
+        "@emotion/memoize": "^0.9.0"
       },
       "dependencies": {
         "@emotion/memoize": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
-          "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+          "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ=="
         }
       }
     },
@@ -19949,12 +19873,6 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
-    },
-    "@phosphor-icons/react": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.1.7.tgz",
-      "integrity": "sha512-g2e2eVAn1XG2a+LI09QU3IORLhnFNAFkNbo2iwbX6NOKSLOwvEMmTa7CgOzEbgNWR47z8i8kwjdvYZ5fkGx1mQ==",
-      "requires": {}
     },
     "@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.5.5",
@@ -22646,9 +22564,9 @@
       }
     },
     "dayjs": {
-      "version": "1.11.11",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.11.tgz",
-      "integrity": "sha512-okzr3f11N6WuqYtZSvm+F776mB41wRZMhKP+hc34YdW+KmtYYK9iqvHSwo2k9FEH3fhGXvOPV6yz2IcSrfRUDg=="
+      "version": "1.11.12",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.12.tgz",
+      "integrity": "sha512-Rt2g+nTbLlDWZTwwrIXjy9MeiZmSDI375FvZs72ngxx8PDC6YXOeR3q5LAuPzjZQxhiWdRKac7RKV+YyQYfYIg=="
     },
     "debug": {
       "version": "4.3.4",

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@contentful/app-sdk": "^4.28.0",
-    "@contentful/f36-components": "4.67.2",
+    "@contentful/f36-components": "4.67.3",
     "@contentful/f36-tokens": "4.0.5",
     "@contentful/react-apps-toolkit": "1.2.16",
     "contentful-management": "10.46.4",


### PR DESCRIPTION
## Purpose

This PR bumps the `f36-components` package to the newly released version (`4.67.3`) which includes a fix that should remove the issue where create-contentful-app CLI users were seeing the error `Attempted import error: 'PaintBrushIcon' is not exported from '@contentful/f36-icons-alpha' (imported as 'PaintBrushIcon')` when cloning from one of our examples that was on version `4.67.2`.

## Approach

Bump the package in the relevant examples. Verified that all packages are imported from npm instead of GitHub packages.

## Testing steps

I tested that I could run and build all of these examples. I also tested using the `EntityList` component in the Typescript example and it worked with no errors.

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
