### PR TITLE
fix: update home location entry in nextjs example []

### DIFF
--- a/examples/nextjs/pages/index.tsx
+++ b/examples/nextjs/pages/index.tsx
@@ -16,7 +16,7 @@ const ComponentLocationSettings = {
   [locations.LOCATION_DIALOG]: Dialog,
   [locations.LOCATION_ENTRY_SIDEBAR]: Sidebar,
   [locations.LOCATION_PAGE]: Page,
-  [locations.LOCATION_PAGE]: Home,
+  [locations.LOCATION_HOME]: Home,
 };
 
 const App = () => {


### PR DESCRIPTION
## Purpose

As reported by #6904, the nextjs example had an error in the `index.tsx` file where the page location was listed twice in the `ComponentLocationSettings` object. This PR fixes this and correctly assigns the Home location for the Home component.

## Approach

<!-- Why did we do it the way we did? Did we consider alternatives? What other implementation details or artifacts (screenshots etc.) would help reviewers contextualize change? -->

## Testing steps

Verified that both the Home and Page component render as expected and that this example runs and build locally.

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
