### PR TITLE
fix: remove .rsc files from api paths.

### DIFF
--- a/apps/vercel/frontend/src/clients/Vercel.ts
+++ b/apps/vercel/frontend/src/clients/Vercel.ts
@@ -208,9 +208,10 @@ export default class VercelClient implements VercelAPIClient {
 
   private filterServerlessFunctions(data: ServerlessFunction[]) {
     const irrelevantServerlessFunctionType = 'ISR';
-    return data.filter(
-      (file: ServerlessFunction) =>
-        file.type != irrelevantServerlessFunctionType && file.path.includes('api')
+    return data.filter((file: ServerlessFunction) =>
+      file.type !== irrelevantServerlessFunctionType &&
+      file.path.includes('api') &&
+      !file.path.endsWith('.rsc')
     );
   }
 

--- a/apps/vercel/frontend/src/clients/Vercel.ts
+++ b/apps/vercel/frontend/src/clients/Vercel.ts
@@ -208,10 +208,12 @@ export default class VercelClient implements VercelAPIClient {
 
   private filterServerlessFunctions(data: ServerlessFunction[]) {
     const irrelevantServerlessFunctionType = 'ISR';
-    return data.filter((file: ServerlessFunction) =>
-      file.type !== irrelevantServerlessFunctionType &&
-      file.path.includes('api') &&
-      !file.path.endsWith('.rsc')
+
+    return data.filter(
+      (file: ServerlessFunction) =>
+        file.type !== irrelevantServerlessFunctionType &&
+        file.path.includes('api') &&
+        !file.path.endsWith('.rsc')
     );
   }
 


### PR DESCRIPTION
## Purpose
We added more information to the Vercel deployment metadata. This is an non-versioned API route so that's why it was an undocumented breaking change. The previous team was aware this was an non-versioned API route.

## Approach
Added a filter to remove .rsc files.

## Testing steps
Configure app and under Draft Mode route handler you shouldn't see any .rsc options.

## Breaking Changes
No

## Dependencies and/or References

N/A
## Deployment
No
