### PR TITLE
feat: debounce search and dialog component fixes [EXT-5636]

### DIFF
--- a/apps/sap-commerce-cloud/frontend/package-lock.json
+++ b/apps/sap-commerce-cloud/frontend/package-lock.json
@@ -21,7 +21,8 @@
         "cross-env": "^7.0.3",
         "lodash.get": "^4.4.2",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "use-debounce": "^10.0.3"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^5.11.9",
@@ -11515,6 +11516,17 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-debounce": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-10.0.3.tgz",
+      "integrity": "sha512-DxQSI9ZKso689WM1mjgGU3ozcxU1TJElBJ3X6S4SMzMNcm2lVH0AHmyXB+K7ewjz2BSUKJTDqTcwtSMRfB89dg==",
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/use-sidecar": {

--- a/apps/sap-commerce-cloud/frontend/package.json
+++ b/apps/sap-commerce-cloud/frontend/package.json
@@ -17,7 +17,8 @@
     "cross-env": "^7.0.3",
     "lodash.get": "^4.4.2",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "use-debounce": "^10.0.3"
   },
   "scripts": {
     "start": "vite",

--- a/apps/sap-commerce-cloud/frontend/src/components/Dialog/Dialog.spec.tsx
+++ b/apps/sap-commerce-cloud/frontend/src/components/Dialog/Dialog.spec.tsx
@@ -69,7 +69,7 @@ describe('Dialog', () => {
     render(<Dialog sdk={sdkMock} />);
     await waitFor(() => screen.getByText('Product 1'));
 
-    const searchInput = screen.getByPlaceholderText('Search Term...');
+    const searchInput = screen.getByPlaceholderText('Type to search products');
     fireEvent.change(searchInput, { target: { value: 'Product 1' } });
     fireEvent.keyPress(searchInput, { key: 'Enter', code: 'Enter' });
 

--- a/apps/sap-commerce-cloud/frontend/src/components/Dialog/Dialog.styles.ts
+++ b/apps/sap-commerce-cloud/frontend/src/components/Dialog/Dialog.styles.ts
@@ -9,4 +9,5 @@ export const styles = {
   pagination: css({ margin: tokens.spacingL }),
   nextButton: (page: number) => css({ marginLeft: page > 0 ? tokens.spacingL : '' }),
   selectProductsButton: css({ margin: tokens.spacingL }),
+  selectButton: css({ justifySelf: 'flex-end' }),
 };

--- a/apps/sap-commerce-cloud/frontend/src/components/Dialog/Dialog.tsx
+++ b/apps/sap-commerce-cloud/frontend/src/components/Dialog/Dialog.tsx
@@ -127,7 +127,7 @@ const Dialog: React.FC<DialogProps> = ({ sdk }) => {
         <GridItem>
           <TextInput
             type="text"
-            placeholder={'Type to search...'}
+            placeholder={'Type to search products'}
             className={cx(styles.textInput, 'f36-margin-bottom--m')}
             value={query}
             onChange={updateSearchTerm}

--- a/apps/sap-commerce-cloud/frontend/src/components/Dialog/Dialog.tsx
+++ b/apps/sap-commerce-cloud/frontend/src/components/Dialog/Dialog.tsx
@@ -23,7 +23,7 @@ import union from 'lodash/union';
 import { formatProductUrl } from '../../utils';
 import { styles } from './Dialog.styles';
 import { cx } from '@emotion/css';
-import { DoneIcon, SearchIcon } from '@contentful/f36-icons';
+import { DoneIcon } from '@contentful/f36-icons';
 import { useDebounce } from 'use-debounce';
 
 interface DialogProps {

--- a/apps/sap-commerce-cloud/frontend/src/components/Dialog/Dialog.tsx
+++ b/apps/sap-commerce-cloud/frontend/src/components/Dialog/Dialog.tsx
@@ -24,6 +24,7 @@ import { formatProductUrl } from '../../utils';
 import { styles } from './Dialog.styles';
 import { cx } from '@emotion/css';
 import { DoneIcon, SearchIcon } from '@contentful/f36-icons';
+import { useDebounce } from 'use-debounce';
 
 interface DialogProps {
   sdk: DialogAppSDK<AppParameters>;
@@ -33,6 +34,7 @@ const Dialog: React.FC<DialogProps> = ({ sdk }) => {
   const [baseSite, setBaseSite] = useState('');
   const [baseSites, setBaseSites] = useState<string[]>([]);
   const [query, setQuery] = useState('');
+  const [debouncedQuery] = useDebounce(query, 300);
   const [page, setPage] = useState(0);
   const [totalPages, setTotalPages] = useState(0);
   const [products, setProducts] = useState<Product[]>([]);
@@ -42,14 +44,14 @@ const Dialog: React.FC<DialogProps> = ({ sdk }) => {
   const load = useCallback(async () => {
     const { products, errors } = await fetchProductList(
       baseSite,
-      query,
+      debouncedQuery,
       page,
       sdk.parameters as SAPParameters,
       setTotalPages
     );
     setProducts(products);
     setErrors(errors);
-  }, [baseSite, query, page, sdk.parameters]);
+  }, [baseSite, debouncedQuery, page, sdk.parameters]);
 
   useEffect(() => {
     const loadBaseSites = async () => {
@@ -137,7 +139,7 @@ const Dialog: React.FC<DialogProps> = ({ sdk }) => {
         <GridItem>
           <TextInput
             type="text"
-            placeholder={'Search Term...'}
+            placeholder={'Type to search...'}
             className={cx(styles.textInput, 'f36-margin-bottom--m')}
             value={query}
             onChange={updateSearchTerm}
@@ -157,17 +159,8 @@ const Dialog: React.FC<DialogProps> = ({ sdk }) => {
             ))}
           </Select>
         </GridItem>
-        <GridItem>
-          <IconButton
-            variant="primary"
-            icon={<SearchIcon />}
-            aria-label="search"
-            onClick={searchButtonClickEvent}>
-            Search
-          </IconButton>
-        </GridItem>
         {isFieldTypeArray && (
-          <GridItem>
+          <GridItem className={styles.selectButton}>
             <IconButton
               variant="primary"
               icon={<DoneIcon />}

--- a/apps/sap-commerce-cloud/frontend/src/components/Dialog/Dialog.tsx
+++ b/apps/sap-commerce-cloud/frontend/src/components/Dialog/Dialog.tsx
@@ -54,6 +54,10 @@ const Dialog: React.FC<DialogProps> = ({ sdk }) => {
   }, [baseSite, debouncedQuery, page, sdk.parameters]);
 
   useEffect(() => {
+    load();
+  }, [load]);
+
+  useEffect(() => {
     const loadBaseSites = async () => {
       const baseSites = await fetchBaseSites(sdk.parameters as SAPParameters);
       const installationConfigBaseSites = `${get(sdk.parameters.invocation, 'baseSites', '')}`;
@@ -74,17 +78,11 @@ const Dialog: React.FC<DialogProps> = ({ sdk }) => {
     };
 
     loadBaseSites();
-    load();
-  }, [load, sdk.parameters]);
+  }, [sdk.parameters]);
 
-  const updateSearchTerm = (event: ChangeEvent<HTMLInputElement>) => {
-    setQuery(event.target.value);
-  };
+  const updateSearchTerm = (event: ChangeEvent<HTMLInputElement>) => setQuery(event.target.value);
 
-  const updateBaseSite = (event: ChangeEvent<HTMLSelectElement>) => {
-    setBaseSite(event.target.value);
-    load();
-  };
+  const updateBaseSite = (event: ChangeEvent<HTMLSelectElement>) => setBaseSite(event.target.value);
 
   const multiProductsCheckBoxClickEvent = (event: ChangeEvent<HTMLInputElement>) => {
     const skuId = event.target.id;
@@ -113,19 +111,9 @@ const Dialog: React.FC<DialogProps> = ({ sdk }) => {
     sdk.close(updatedField);
   };
 
-  const searchButtonClickEvent = () => {
-    load();
-  };
+  const nextPageButtonEvent = () => setPage((prevPage) => prevPage + 1);
 
-  const nextPageButtonEvent = () => {
-    setPage((prevPage) => prevPage + 1);
-    load();
-  };
-
-  const prevPageButtonEvent = () => {
-    setPage((prevPage) => prevPage - 1);
-    load();
-  };
+  const prevPageButtonEvent = () => setPage((prevPage) => prevPage - 1);
 
   const isFieldTypeArray = (get(sdk.parameters.invocation, 'fieldType', '') as string) === 'Array';
 
@@ -143,11 +131,6 @@ const Dialog: React.FC<DialogProps> = ({ sdk }) => {
             className={cx(styles.textInput, 'f36-margin-bottom--m')}
             value={query}
             onChange={updateSearchTerm}
-            onKeyPress={(event) => {
-              if (event.key === 'Enter') {
-                load();
-              }
-            }}
           />
         </GridItem>
         <GridItem>

--- a/apps/sap-commerce-cloud/frontend/src/components/Dialog/__snapshots__/Dialog.spec.tsx.snap
+++ b/apps/sap-commerce-cloud/frontend/src/components/Dialog/__snapshots__/Dialog.spec.tsx.snap
@@ -11,7 +11,7 @@ exports[`Dialog > renders correctly and matches snapshot 1`] = `
       <input
         class="f36-margin-bottom--m css-1w37lto"
         data-test-id="cf-ui-text-input"
-        placeholder="Search Term..."
+        placeholder="Type to search products"
         type="text"
         value=""
       />
@@ -51,42 +51,6 @@ exports[`Dialog > renders correctly and matches snapshot 1`] = `
           />
         </svg>
       </div>
-    </div>
-    <div
-      class="css-1vawd3v"
-    >
-      <button
-        aria-label="search"
-        class="css-12lzd3d"
-        data-test-id="cf-ui-icon-button"
-        type="button"
-      >
-        <span
-          class="css-3u52eb"
-        >
-          <svg
-            aria-hidden="true"
-            class="css-d29jlb"
-            color="currentColor"
-            data-test-id="cf-ui-icon"
-            role="img"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0016 9.5 6.5 6.5 0 109.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
-            />
-            <path
-              d="M0 0h24v24H0z"
-              fill="none"
-            />
-          </svg>
-        </span>
-        <span
-          class="css-40g50j"
-        >
-          Search
-        </span>
-      </button>
     </div>
   </div>
   <table


### PR DESCRIPTION
## Purpose

The dialog component is currently working both on keystroke and also has a search button. This PR removes that search button in favor of a search-as-you-type approach. A debounce was added to avoid fetching too often. 

Also in the Dialog component, a fix was implemented for being unable to change the selected basesite. 

Screenshot here showing the removal of the search button + the fact that the electronics-spa base site is actually shown as selected with the correct product list rendering. 

<img width="1475" alt="Screenshot 2024-08-21 at 4 05 44 PM" src="https://github.com/user-attachments/assets/71742194-6147-46b6-9652-b484e3300b3d">
