### PR TITLE
fix: package publishing []

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ commands:
       - run:
           name: Setup GitHub packages
           command: |
+            rm -f ./.npmrc
             echo "//npm.pkg.github.com/:_authToken=${GITHUB_PACKAGES_WRITE_TOKEN}" > ~/.npmrc
             echo "@contentful:registry=https://npm.pkg.github.com" >> ~/.npmrc
       - run:

--- a/packages/eslint-plugin-contentful-apps/package.json
+++ b/packages/eslint-plugin-contentful-apps/package.json
@@ -20,7 +20,7 @@
   },
   "author": "Contentful GmbH",
   "license": "MIT",
-  "description": "Base eslint configuration for Contentful apps",
+  "description": "Eslint plugin for Contentful App Framework Apps",
   "scripts": {
     "build": "rm -rf ./dist && tsup",
     "prepublishOnly": "npm run build"


### PR DESCRIPTION
## Purpose

- override repo level npmrc with registry setup and auth on publish step
- bump eslint-plugin-contentful-apps to deploy
