### PR TITLE
feat: allow autotagger to be called by an app action [EXT-00]

### DIFF
--- a/examples/autotagger/README.md
+++ b/examples/autotagger/README.md
@@ -1,17 +1,18 @@
 ## AI Autotagger Example Function
 
-This project includes an example of using the Contentful Management API (CMA) within an App Event Handler Function to automatically tag entries based on their content using OpenAI's GPT-4 model.
+This project includes an example of using the Contentful Management API (CMA) within an App Event Handler/App Action Call Function to automatically tag entries based on their content using OpenAI's GPT-4 model.
 
 ### Files Associated with the Example
 
-- **autotagger.ts**: Defines the event handler that automatically tags entries.
-- **selected-content-types-filter.ts**: Ensures only entries of selected content types are autotagged.
+- **autotagger.ts**: Defines the event handlers that automatically tag entries.
+- **selected-content-types-filter.ts**: Ensures only entries of selected content types are autotagged when using app events.
 - **ConfigScreen.tsx**: Provides the configuration screen for setting up the app.
+- **Sidebar.tsx**: Provides a button that will call an app action to perform on demand autotagging.
 - **contentful-app-manifest.json**: Defines the functions and their configurations.
 
 ### autotagger.ts
 
-Handles the `appevent.handler` event to automatically tag entries using OpenAI's GPT-4.
+Handles the `appevent.handler` and `appaction.call` events to automatically tag entries using OpenAI's GPT-4.
 
 ### selected-content-types-filter.ts
 
@@ -28,9 +29,13 @@ Defines the functions, their paths, and configurations used in the app:
 - **autotagger**: Automatically tags entries using AI.
 - **filter**: Ensures only selected content types are autotagged.
 
+## Utilizing App Action call Functions
+
+This app can utilize [app actions](https://www.contentful.com/developers/docs/extensibility/app-framework/app-actions/) to autotag events on demand. Once you have built and uploaded your app to Contentful, create an app action and link it to the autotagger function using the [CMA](https://www.contentful.com/developers/docs/references/content-management-api/#/reference/app-actions/app-actions-collection/create-an-action/console/js-plain) or the [Actions](https://app.contentful.com/deeplink?link=app-definition&tab=actions) tab on the App details page. Once you have created your action, place its id in the `appActionId` variable at the top of the [Sidebar.tsx](./src/locations/Sidebar.tsx) file, and reupload your app. 
+
 ## Utilizing App Event handler Functions
 
-This app utilizes [app events](https://www.contentful.com/developers/docs/extensibility/app-framework/app-events/) to subscribe to the `Entry.auto_save` event. Once you have built and uploaded your app to Contentful, link the autotagger and filter functions to your app event subscription and subscribe to the `Entry.auto_save` event using the [CMA](https://www.contentful.com/developers/docs/references/content-management-api/#/reference/app-event-subscriptions/app-event-subscription/update-or-subscribe-to-events/console/js-plain) or the [Events](https://app.contentful.com/deeplink?link=app-definition&tab=events) tab on the App details page.
+This app can utilize [app events](https://www.contentful.com/developers/docs/extensibility/app-framework/app-events/) to subscribe to the `Entry.auto_save` event. Once you have built and uploaded your app to Contentful, you can link the autotagger and filter functions to your app event subscription and subscribe to the `Entry.auto_save` event using the [CMA](https://www.contentful.com/developers/docs/references/content-management-api/#/reference/app-event-subscriptions/app-event-subscription/update-or-subscribe-to-events/console/js-plain) or the [Events](https://app.contentful.com/deeplink?link=app-definition&tab=events) tab on the App details page.
 
 ## Libraries to use
 

--- a/examples/autotagger/build-functions.js
+++ b/examples/autotagger/build-functions.js
@@ -1,9 +1,9 @@
-const esbuild = require('esbuild');
-const { join, parse, resolve } = require('path');
-const yargs = require('yargs/yargs');
-const { hideBin } = require('yargs/helpers');
+import { context as _context, build } from 'esbuild';
+import { join, parse, resolve } from 'path';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
 
-const manifest = require('./contentful-app-manifest.json');
+import contentfulAppManifestJson from './contentful-app-manifest.json' assert { type: 'json' };
 
 const argv = yargs(hideBin(process.argv)).argv;
 
@@ -11,7 +11,7 @@ const validateFunctions = () => {
   const requiredProperties = ['id', 'path', 'entryFile', 'accepts'];
   const uniqueValues = new Set();
 
-  manifest.functions.forEach((contentfulFunction) => {
+  contentfulAppManifestJson.functions.forEach((contentfulFunction) => {
     requiredProperties.forEach((property) => {
       if (!contentfulFunction.hasOwnProperty(property)) {
         throw new Error(
@@ -43,11 +43,11 @@ const validateFunctions = () => {
 };
 
 const getEntryPoints = () => {
-  return manifest.functions.reduce((result, contentfulFunction) => {
+  return contentfulAppManifestJson.functions.reduce((result, contentfulFunction) => {
     const fileProperties = parse(contentfulFunction.path);
     const fileName = join(fileProperties.dir, fileProperties.name);
 
-    result[fileName] = resolve(__dirname, contentfulFunction.entryFile);
+    result[fileName] = resolve(process.cwd(), contentfulFunction.entryFile);
 
     return result;
   }, {});
@@ -71,10 +71,10 @@ const main = async (watch = false) => {
     };
 
     if (watch) {
-      const context = await esbuild.context(config);
+      const context = await _context(config);
       await context.watch();
     } else {
-      await esbuild.build(config);
+      await build(config);
     }
   } catch (e) {
     console.error('Error building functions');

--- a/examples/autotagger/contentful-app-manifest.json
+++ b/examples/autotagger/contentful-app-manifest.json
@@ -6,8 +6,8 @@
       "description": "Automatically tag your entries using AI.",
       "path": "functions/autotagger.js",
       "entryFile": "functions/autotagger.ts",
-      "allowNetworks": ["api.flinkly.com", "api.openai.com"],
-      "accepts": ["appevent.handler"]
+      "allowNetworks": ["api.contentful.com", "api.openai.com"],
+      "accepts": ["appevent.handler", "appaction.call"]
     },
     {
       "id": "filter",

--- a/examples/autotagger/functions/autotagger.ts
+++ b/examples/autotagger/functions/autotagger.ts
@@ -56,9 +56,9 @@ async function createNewTags(cma: PlainClientAPI, newTags: string[]): Promise<vo
     await Promise.all(
       newTags.map((tag) =>
         cma.tag.createWithId(
-          { tagId: tag },
+          { tagId: tag.trim() },
           {
-            name: tag,
+            name: tag.trim(),
             sys: {
               visibility: 'private',
             },

--- a/examples/autotagger/functions/autotagger.ts
+++ b/examples/autotagger/functions/autotagger.ts
@@ -1,5 +1,6 @@
 import { FunctionEventHandler as EventHandler } from '@contentful/node-apps-toolkit';
 import {
+  AppActionRequest,
   AppEventEntry,
   AppEventRequest,
   FunctionEventContext,
@@ -96,31 +97,76 @@ async function updateEntryTags(
   }
 }
 
-export const handler: EventHandler<'appevent.handler'> = async (
+async function autotag(
+  entry: EntryProps,
+  cma: PlainClientAPI,
+  appInstallationParameters: Record<string, any>
+) {
+  const apiKey = appInstallationParameters.apiKey || '';
+  const apiUrl = appInstallationParameters.apiUrl || DEFAULT_API_URL;
+  const model = appInstallationParameters.model || DEFAULT_MODEL;
+  try {
+    const existingTags = await getExistingTags(cma);
+    const suggestedTags = await fetchOpenAiResponse(entry, apiKey, apiUrl, model);
+    const newTags = suggestedTags.filter((tag) => !existingTags.includes(tag));
+    await createNewTags(cma, newTags);
+    const entryTags = entry.metadata?.tags || [];
+    entryTags.push(
+      ...suggestedTags.map(
+        (tag) => ({ sys: { id: tag, linkType: 'Tag', type: 'Link' } } as Link<'Tag'>)
+      )
+    );
+    await updateEntryTags(cma, entry, entryTags);
+    console.log(`Autotagged ${entry.sys.id} with ${newTags.join(', ')} ✨`);
+  } catch (error) {
+    console.error('Error autotagging entry:', error);
+  }
+}
+
+const appActionHandler: EventHandler<'appaction.call'> = async (
+  event: AppActionRequest<'Custom' | 'Entries.v1.0' | 'Notification.v1.0'>,
+  context: FunctionEventContext
+) => {
+  const {
+    body: { entryId },
+  } = event as AppActionRequest<'Custom', { entryId: string }>;
+  const { cma, appInstallationParameters } = context as FunctionEventContext & {
+    cma: PlainClientAPI;
+  };
+  try {
+    const entry = await cma.entry.get({ entryId });
+    await autotag(entry, cma, appInstallationParameters);
+    return { success: true };
+  } catch (error) {
+    console.error('Error handling action:', error);
+    return { success: false };
+  }
+};
+
+const appEventHandler: EventHandler<'appevent.handler'> = async (
   event: AppEventRequest,
   context: FunctionEventContext
 ) => {
   const { cma, appInstallationParameters } = context as FunctionEventContext & {
     cma: PlainClientAPI;
   };
-  const apiKey = appInstallationParameters.apiKey || '';
-  const apiUrl = appInstallationParameters.apiUrl || DEFAULT_API_URL;
-  const model = appInstallationParameters.model || DEFAULT_MODEL;
-  const { body } = event as AppEventEntry;
   try {
-    const existingTags = await getExistingTags(cma);
-    const suggestedTags = await fetchOpenAiResponse(body, apiKey, apiUrl, model);
-    const newTags = suggestedTags.filter((tag) => !existingTags.includes(tag));
-    await createNewTags(cma, newTags);
-    const entryTags = body.metadata?.tags || [];
-    entryTags.push(
-      ...suggestedTags.map(
-        (tag) => ({ sys: { id: tag, linkType: 'Tag', type: 'Link' } } as Link<'Tag'>)
-      )
-    );
-    await updateEntryTags(cma, body, entryTags);
-    console.log(`Autotagged ${body.sys.id} with ${newTags.join(', ')} ✨`);
+    const { body: entry } = event as AppEventEntry;
+    await autotag(entry, cma, appInstallationParameters);
   } catch (error) {
     console.error('Error handling event:', error);
+  }
+};
+
+export const handler: EventHandler<'appaction.call' | 'appevent.handler'> = async (
+  event: AppActionRequest | AppEventRequest,
+  context: FunctionEventContext
+) => {
+  if (event.type === 'appaction.call') {
+    return appActionHandler(event, context);
+  } else if (event.type === 'appevent.handler') {
+    return appEventHandler(event, context);
+  } else {
+    throw new Error(`Unsupported event type ${event.type}`);
   }
 };

--- a/examples/autotagger/functions/autotagger.ts
+++ b/examples/autotagger/functions/autotagger.ts
@@ -44,7 +44,7 @@ async function fetchOpenAiResponse(
 async function getExistingTags(cma: PlainClientAPI): Promise<string[]> {
   try {
     const tags = await cma.tag.getMany({});
-    return tags.items.map((tag) => tag.name);
+    return tags.items.map((tag) => tag.sys.id);
   } catch (error) {
     console.error('Error fetching existing tags from Contentful:', error);
     throw error;

--- a/examples/autotagger/package.json
+++ b/examples/autotagger/package.json
@@ -38,8 +38,8 @@
     ]
   },
   "devDependencies": {
-    "@contentful/app-scripts": "1.25.0",
-    "@contentful/node-apps-toolkit": "^3.4.1",
+    "@contentful/app-scripts": "1.27.0",
+    "@contentful/node-apps-toolkit": "^3.9.0",
     "@testing-library/jest-dom": "^6.4.8",
     "@testing-library/react": "^16.0.0",
     "@tsconfig/recommended": "1.0.3",
@@ -53,5 +53,6 @@
     "vite": "^5.4.6",
     "vitest": "^2.0.5"
   },
-  "homepage": "."
+  "homepage": ".",
+  "type": "module"
 }

--- a/examples/autotagger/src/locations/ConfigScreen.tsx
+++ b/examples/autotagger/src/locations/ConfigScreen.tsx
@@ -35,10 +35,20 @@ const ConfigScreen: React.FC = () => {
 
   const onConfigure = useCallback(async () => {
     const currentState = await sdk.app.getCurrentState();
-
+    const targetState = {
+      EditorInterface: {
+        ...currentState?.EditorInterface,
+      },
+    };
+    parameters.contentTypes?.split(',').forEach((id) => {
+      // assign the app to the sidebar on all selected content types
+      targetState.EditorInterface[id] = {
+        sidebar: { position: 0 },
+      };
+    });
     return {
       parameters: { ...parameters },
-      targetState: currentState,
+      targetState,
     };
   }, [parameters, sdk]);
 

--- a/examples/autotagger/src/locations/Dialog.tsx
+++ b/examples/autotagger/src/locations/Dialog.tsx
@@ -1,15 +1,10 @@
 import React from 'react';
 import { Paragraph } from '@contentful/f36-components';
 import { DialogAppSDK } from '@contentful/app-sdk';
-import { /* useCMA, */ useSDK } from '@contentful/react-apps-toolkit';
+import { useSDK } from '@contentful/react-apps-toolkit';
 
 const Dialog = () => {
   const sdk = useSDK<DialogAppSDK>();
-  /*
-     To use the cma, inject it as follows.
-     If it is not needed, you can remove the next line.
-  */
-  // const cma = useCMA();
 
   return <Paragraph>Hello Dialog Component (AppId: {sdk.ids.app})</Paragraph>;
 };

--- a/examples/autotagger/src/locations/EntryEditor.tsx
+++ b/examples/autotagger/src/locations/EntryEditor.tsx
@@ -1,15 +1,10 @@
 import React from 'react';
 import { Paragraph } from '@contentful/f36-components';
 import { EditorAppSDK } from '@contentful/app-sdk';
-import { /* useCMA, */ useSDK } from '@contentful/react-apps-toolkit';
+import { useSDK } from '@contentful/react-apps-toolkit';
 
 const Entry = () => {
   const sdk = useSDK<EditorAppSDK>();
-  /*
-     To use the cma, inject it as follows.
-     If it is not needed, you can remove the next line.
-  */
-  // const cma = useCMA();
 
   return <Paragraph>Hello Entry Editor Component (AppId: {sdk.ids.app})</Paragraph>;
 };

--- a/examples/autotagger/src/locations/Field.tsx
+++ b/examples/autotagger/src/locations/Field.tsx
@@ -1,15 +1,11 @@
 import React from 'react';
 import { Paragraph } from '@contentful/f36-components';
 import { FieldAppSDK } from '@contentful/app-sdk';
-import { /* useCMA, */ useSDK } from '@contentful/react-apps-toolkit';
+import { useSDK } from '@contentful/react-apps-toolkit';
 
 const Field = () => {
   const sdk = useSDK<FieldAppSDK>();
-  /*
-     To use the cma, inject it as follows.
-     If it is not needed, you can remove the next line.
-  */
-  // const cma = useCMA();
+
   // If you only want to extend Contentful's default editing experience
   // reuse Contentful's editor components
   // -> https://www.contentful.com/developers/docs/extensibility/field-editors/

--- a/examples/autotagger/src/locations/Home.tsx
+++ b/examples/autotagger/src/locations/Home.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Paragraph } from '@contentful/f36-components';
 import { HomeAppSDK } from '@contentful/app-sdk';
-import { /* useCMA, */ useSDK } from '@contentful/react-apps-toolkit';
+import { useSDK } from '@contentful/react-apps-toolkit';
 
 const Home = () => {
   const sdk = useSDK<HomeAppSDK>();

--- a/examples/autotagger/src/locations/Home.tsx
+++ b/examples/autotagger/src/locations/Home.tsx
@@ -5,11 +5,6 @@ import { /* useCMA, */ useSDK } from '@contentful/react-apps-toolkit';
 
 const Home = () => {
   const sdk = useSDK<HomeAppSDK>();
-  /*
-     To use the cma, inject it as follows.
-     If it is not needed, you can remove the next line.
-  */
-  // const cma = useCMA();
 
   return <Paragraph>Hello Home Component (AppId: {sdk.ids.app})</Paragraph>;
 };

--- a/examples/autotagger/src/locations/Page.tsx
+++ b/examples/autotagger/src/locations/Page.tsx
@@ -1,16 +1,10 @@
 import React from 'react';
 import { Paragraph } from '@contentful/f36-components';
 import { PageAppSDK } from '@contentful/app-sdk';
-import { /* useCMA, */ useSDK } from '@contentful/react-apps-toolkit';
+import { useSDK } from '@contentful/react-apps-toolkit';
 
 const Page = () => {
   const sdk = useSDK<PageAppSDK>();
-  /*
-     To use the cma, inject it as follows.
-     If it is not needed, you can remove the next line.
-  */
-  // const cma = useCMA();
-
   return <Paragraph>Hello Page Component (AppId: {sdk.ids.app})</Paragraph>;
 };
 

--- a/examples/autotagger/src/locations/Sidebar.tsx
+++ b/examples/autotagger/src/locations/Sidebar.tsx
@@ -1,17 +1,39 @@
 import React from 'react';
-import { Paragraph } from '@contentful/f36-components';
+import { TagsIcon } from '@contentful/f36-icons';
+import { Button } from '@contentful/f36-components';
 import { SidebarAppSDK } from '@contentful/app-sdk';
-import { /* useCMA, */ useSDK } from '@contentful/react-apps-toolkit';
+import { useAutoResizer, useSDK } from '@contentful/react-apps-toolkit';
+
+const appActionId = 'YtIfXugb4P1w6Dqf4E8oq';
 
 const Sidebar = () => {
   const sdk = useSDK<SidebarAppSDK>();
-  /*
-     To use the cma, inject it as follows.
-     If it is not needed, you can remove the next line.
-  */
-  // const cma = useCMA();
 
-  return <Paragraph>Hello Sidebar Component (AppId: {sdk.ids.app})</Paragraph>;
+  const [isLoading, setIsLoading] = React.useState(false);
+
+  useAutoResizer();
+
+  async function callAppAction() {
+    setIsLoading(true);
+    await sdk.cma.appActionCall.createWithResponse(
+      {
+        appDefinitionId: sdk.ids.app,
+        appActionId,
+      },
+      {
+        parameters: {
+          entryId: sdk.ids.entry,
+        },
+      }
+    );
+    setIsLoading(false);
+  }
+
+  return (
+    <Button isLoading={isLoading} startIcon={<TagsIcon />} isFullWidth onClick={callAppAction}>
+      Autotag
+    </Button>
+  );
 };
 
 export default Sidebar;


### PR DESCRIPTION
## Purpose

<!-- Why are we introducing this change now? What problem does it solve? What is the story/background for it? -->

Contentful Functions can now be linked to App Actions (see https://www.contentful.com/developers/docs/extensibility/app-framework/functions/#use-case-app-actions)

This changeset extends the Autotagger example app, so that users can now trigger autotagging on demand using an App Action Function, as opposed to or in addition to using the existing App Event Function. 
