### PR TITLE
feat: use functions-types as source of type definitions

### DIFF
--- a/examples/native-external-references/functions/helpers.spec.ts
+++ b/examples/native-external-references/functions/helpers.spec.ts
@@ -51,7 +51,9 @@ describe('Getting the URLs', () => {
       lookupUrls: [
         'https://api.themoviedb.org/3/movie/urn:123?language=en-US',
         'https://api.themoviedb.org/3/movie/urn:456?language=en-US'
-      ]
+      ],
+      trendingUrl:
+        'https://api.themoviedb.org/3/trending/movie/day?language=en-US'
     });
   });
 
@@ -68,7 +70,9 @@ describe('Getting the URLs', () => {
       lookupUrls: [
         'https://api.themoviedb.org/3/person/urn:123?language=en-US',
         'https://api.themoviedb.org/3/person/urn:456?language=en-US'
-      ]
+      ],
+      trendingUrl:
+        'https://api.themoviedb.org/3/trending/person/day?language=en-US'
     });
   });
 });

--- a/examples/native-external-references/functions/helpers.ts
+++ b/examples/native-external-references/functions/helpers.ts
@@ -1,4 +1,4 @@
-import { FunctionEventContext } from '@contentful/node-apps-toolkit';
+import type { FunctionEventContext } from '@contentful/functions-types';
 import { AppInstallationParameters, Scalar } from './types/common';
 import {
   TmdbItem,
@@ -55,7 +55,7 @@ export const fetchApi = async <
 type Params = {
   query?: string;
   page?: string;
-  urns?: Scalar[];
+  urns?: Scalar | Scalar[];
 };
 
 export const getUrls = (
@@ -64,12 +64,13 @@ export const getUrls = (
 ) => {
   const type = resourceType === 'TMDB:Movie' ? 'movie' : 'person';
   const encodedQuery = encodeURIComponent(query);
+  const urnsArray = Array.isArray(urns) ? urns : [urns];
 
   return {
     prefixUrl: `https://www.themoviedb.org/${type}`,
     searchUrl: `https://api.themoviedb.org/3/search/${type}?query=${encodedQuery}&include_adult=false&language=en-US&page=${page}`,
     trendingUrl: `https://api.themoviedb.org/3/trending/${type}/day?language=en-US`,
-    lookupUrls: urns.map(
+    lookupUrls: urnsArray.map(
       (urn) => `https://api.themoviedb.org/3/${type}/${urn}?language=en-US`
     )
   };

--- a/examples/native-external-references/functions/index.ts
+++ b/examples/native-external-references/functions/index.ts
@@ -1,19 +1,13 @@
-import {
+import type {
   FunctionEvent,
   FunctionEventContext
-} from '@contentful/node-apps-toolkit';
+} from '@contentful/functions-types';
 import { searchHandler } from './searchHandler';
 import { lookupHandler } from './lookupHandler';
 import { AppInstallationParameters } from './types/common';
-import {
-  ResourcesLookupRequest,
-  ResourcesSearchRequest
-} from './types/handler';
-
-type Event = FunctionEvent | ResourcesSearchRequest | ResourcesLookupRequest;
 
 export const handler = (
-  event: Event,
+  event: FunctionEvent,
   context: FunctionEventContext<AppInstallationParameters>
 ) => {
   if (!context.appInstallationParameters.tmdbAccessToken) {

--- a/examples/native-external-references/functions/lookupHandler.spec.ts
+++ b/examples/native-external-references/functions/lookupHandler.spec.ts
@@ -32,15 +32,15 @@ describe('Lookup handler', () => {
   });
 
   it('returns a response with populated items', async () => {
+    const urns = Array.isArray(testLookupEvent.lookupBy.urns)
+      ? testLookupEvent.lookupBy.urns
+      : [testLookupEvent.lookupBy.urns];
+
     mockApi.mockImplementationOnce(() =>
-      Promise.resolve(
-        createTmdbLookupResponse(Number(testLookupEvent.lookupBy.urns[0]))
-      )
+      Promise.resolve(createTmdbLookupResponse(Number(urns[0])))
     );
     mockApi.mockImplementationOnce(() =>
-      Promise.resolve(
-        createTmdbLookupResponse(Number(testLookupEvent.lookupBy.urns[1]))
-      )
+      Promise.resolve(createTmdbLookupResponse(Number(urns[1])))
     );
 
     const response = await lookupHandler(testLookupEvent, context);

--- a/examples/native-external-references/functions/lookupHandler.ts
+++ b/examples/native-external-references/functions/lookupHandler.ts
@@ -1,7 +1,7 @@
-import {
+import type {
   FunctionEventContext,
-  FunctionEventHandler
-} from '@contentful/node-apps-toolkit';
+  ResourcesLookupRequest
+} from '@contentful/functions-types';
 import { fetchApi, getUrls, transformResult } from './helpers';
 import { AppInstallationParameters } from './types/common';
 import { TmdbLookupResponse } from './types/tmdb';
@@ -29,10 +29,10 @@ const fetchLookup = async (
   );
 };
 
-export const lookupHandler: FunctionEventHandler<
-  'resources.lookup',
-  AppInstallationParameters
-> = async (event, context) => {
+export const lookupHandler = async (
+  event: ResourcesLookupRequest,
+  context: FunctionEventContext<AppInstallationParameters>
+) => {
   const { lookupUrls, prefixUrl } = getUrls(event.resourceType, {
     urns: event.lookupBy.urns
   });

--- a/examples/native-external-references/functions/searchHandler.ts
+++ b/examples/native-external-references/functions/searchHandler.ts
@@ -1,7 +1,7 @@
-import {
+import type {
   FunctionEventContext,
-  FunctionEventHandler
-} from '@contentful/node-apps-toolkit';
+  ResourcesSearchRequest
+} from '@contentful/functions-types';
 import { fetchApi, getUrls, transformResult } from './helpers';
 import { AppInstallationParameters } from './types/common';
 import { TmdbSearchResponse } from './types/tmdb';
@@ -28,10 +28,10 @@ const fetchSearch = async (
   };
 };
 
-export const searchHandler: FunctionEventHandler<
-  'resources.search',
-  AppInstallationParameters
-> = async (event, context) => {
+export const searchHandler = async (
+  event: ResourcesSearchRequest,
+  context: FunctionEventContext<AppInstallationParameters>
+) => {
   const { prefixUrl, searchUrl, trendingUrl } = getUrls(event.resourceType, {
     query: event.query,
     page: event.pages?.nextCursor ?? '1'

--- a/examples/native-external-references/package.json
+++ b/examples/native-external-references/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@contentful/app-scripts": "1.27.0",
-    "@contentful/node-apps-toolkit": "3.6.0",
+    "@contentful/functions-types": "1.3.0",
     "@testing-library/jest-dom": "5.17.0",
     "@testing-library/react": "14.2.2",
     "@tsconfig/create-react-app": "2.0.3",

--- a/examples/native-external-references/test/mocks/mockEvents.ts
+++ b/examples/native-external-references/test/mocks/mockEvents.ts
@@ -1,5 +1,7 @@
-import { FunctionEventHandler } from '@contentful/node-apps-toolkit';
-import { AppInstallationParameters } from '../../functions/types/common';
+import type {
+  ResourcesSearchRequest,
+  ResourcesLookupRequest
+} from '@contentful/functions-types';
 import {
   TmdbItem,
   TmdbLookupResponse,
@@ -7,25 +9,18 @@ import {
 } from '../../functions/types/tmdb';
 
 export const context = {} as any;
-
-type SearchEvent = Parameters<
-  FunctionEventHandler<'resources.search', AppInstallationParameters>
->[0];
-
-type LookupEvent = Parameters<
-  FunctionEventHandler<'resources.lookup', AppInstallationParameters>
->[0];
-
-export const testSearchEvent: SearchEvent = {
+export const testSearchEvent: ResourcesSearchRequest = {
   type: 'resources.search',
   resourceType: 'TMDB:Person',
-  query: 'test query'
+  query: 'test query',
+  limit: 10
 };
 
-export const testLookupEvent: LookupEvent = {
+export const testLookupEvent: ResourcesLookupRequest = {
   type: 'resources.lookup',
   resourceType: 'TMDB:Person',
-  lookupBy: { urns: ['15', '22'] }
+  lookupBy: { urns: ['15', '22'] },
+  limit: 10
 };
 
 const createSingleTmdbResponse = (id: number): TmdbItem => ({


### PR DESCRIPTION
We have created type definitions for NER events in `functions-types` package, and now we want to consolidate all NER-related types to be imported from that one source of truth. This PR removes the dependency to `node-apps-toolkit` (it will also be pulling type definitions from `functions-types`).