### PR TITLE
fix: add yargs as dev dependency for building functions []

### DIFF
--- a/examples/function-appaction/package.json
+++ b/examples/function-appaction/package.json
@@ -57,7 +57,8 @@
     "cross-env": "7.0.3",
     "esbuild": "0.19.2",
     "happy-dom": "^15.7.4",
-    "typescript": "4.9.5"
+    "typescript": "4.9.5",
+    "yargs": "^17.7.2"
   },
   "homepage": "."
 }


### PR DESCRIPTION
## Purpose

Add `yargs` as a dev dependency for the app action function example, as `yargs` is used in the `build-functions.js` script. Previously this was working fine when the example was using `react-scripts`, and now since refactoring to `vite`, this was not working properly. When running `npm run build`, I was seeing this error: `Cannot find module 'yargs/yargs'`.

## Approach

<!-- Why did we do it the way we did? Did we consider alternatives? What other implementation details or artifacts (screenshots etc.) would help reviewers contextualize change? -->

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
