### PR TITLE
fix: handler example comments [EXT-00]

### DIFF
--- a/examples/function-appevent-handler/javascript/example.js
+++ b/examples/function-appevent-handler/javascript/example.js
@@ -51,8 +51,8 @@ const exampleAnalyticsHandler = async (event) => {
   }
 };
 
-// Since our function only accepts filter events,
-// we can safely assume the event is of type appevent.filter
+// Since our function only accepts handler events,
+// we can safely assume the event is of type appevent.handler
 export const handler = async (event, context) => {
   // This function will check to see if the event is an Entry and then send it to multiple external services to be handled
   if (event.headers['X-Contentful-Topic'].includes('Entry')) {

--- a/examples/function-appevent-handler/typescript/example.ts
+++ b/examples/function-appevent-handler/typescript/example.ts
@@ -58,8 +58,8 @@ const exampleAnalyticsHandler = async (event: AppEventEntry) => {
   }
 };
 
-// Since our function only accepts filter events,
-// we can safely assume the event is of type appevent.filter
+// Since our function only accepts handler events,
+// we can safely assume the event is of type appevent.handler
 export const handler: EventHandler<'appevent.handler'> = async (
   event: AppEventRequest,
   context: FunctionEventContext


### PR DESCRIPTION
## Purpose

<!-- Why are we introducing this change now? What problem does it solve? What is the story/background for it? -->

Comment in example handler functions incorrectly refers to filter events
