### PR TITLE
Add host name options to package.json scripts to be more easily adapted to EU DR

### DIFF
--- a/examples/native-external-references/package.json
+++ b/examples/native-external-references/package.json
@@ -21,12 +21,12 @@
     "eject": "react-scripts eject",
     "create-app-definition": "contentful-app-scripts create-app-definition",
     "upload": "contentful-app-scripts upload --bundle-dir ./build",
-    "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN",
+    "upload-ci": "contentful-app-scripts upload --ci --host api.contentful.com --bundle-dir ./build --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN",
     "prettier": "prettier --write functions",
     "open-settings": "contentful-app-scripts open-settings",
     "install-app": "contentful-app-scripts install",
-    "create-resource-entities": "ts-node -T -r dotenv/config ./src/tools/create-resource-entities.ts",
-    "show-resource-entities": "ts-node -T -r dotenv/config ./src/tools/show-resource-entities.ts"
+    "create-resource-entities": "HOST=api.contentful.com ts-node -T -r dotenv/config ./src/tools/create-resource-entities.ts",
+    "show-resource-entities": "HOST=api.contentful.com ts-node -T -r dotenv/config ./src/tools/show-resource-entities.ts"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/examples/native-external-references/package.json
+++ b/examples/native-external-references/package.json
@@ -25,8 +25,8 @@
     "prettier": "prettier --write functions",
     "open-settings": "contentful-app-scripts open-settings",
     "install-app": "contentful-app-scripts install",
-    "create-resource-entities": "HOST=api.contentful.com ts-node -T -r dotenv/config ./src/tools/create-resource-entities.ts",
-    "show-resource-entities": "HOST=api.contentful.com ts-node -T -r dotenv/config ./src/tools/show-resource-entities.ts"
+    "create-resource-entities": "CONTENTFUL_HOST=api.contentful.com ts-node -T -r dotenv/config ./src/tools/create-resource-entities.ts",
+    "show-resource-entities": "CONTENTFUL_HOST=api.contentful.com ts-node -T -r dotenv/config ./src/tools/show-resource-entities.ts"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/examples/native-external-references/src/locations/ConfigScreen.tsx
+++ b/examples/native-external-references/src/locations/ConfigScreen.tsx
@@ -64,12 +64,12 @@ const ConfigScreen = () => {
             onChange={updateParameters('tmdbAccessToken')}
           />
           <FormControl.HelpText>
-            Provide the access token for TMDB
+            Provide the API Read Access Token for TMDB
           </FormControl.HelpText>
           {!parameters.tmdbAccessToken && (
             <FormControl.ValidationMessage>
-              Please, provide a valid API token. You can get one by signing up
-              at{' '}
+              Please, provide a valid API Read Access Token. You can get one by
+              signing up at{' '}
               <TextLink
                 href="https://www.themoviedb.org/"
                 target="_blank"

--- a/examples/native-external-references/src/tools/http.ts
+++ b/examples/native-external-references/src/tools/http.ts
@@ -19,7 +19,7 @@ import {
 type ResourceProviderResult = APIError | APIResourceProvider;
 type ResourceTypeResult = APIError | APIResourceType;
 
-const host = process.env.HOST ?? 'api.contentful.com';
+const host = process.env.CONTENTFUL_HOST ?? 'api.contentful.com';
 
 const client = createClient({ accessToken }, { type: 'plain' });
 

--- a/examples/native-external-references/src/tools/http.ts
+++ b/examples/native-external-references/src/tools/http.ts
@@ -19,6 +19,8 @@ import {
 type ResourceProviderResult = APIError | APIResourceProvider;
 type ResourceTypeResult = APIError | APIResourceType;
 
+const host = process.env.HOST ?? 'api.contentful.com';
+
 const client = createClient({ accessToken }, { type: 'plain' });
 
 const put = async <T>({ resource, url }: { resource: string; url: string }) => {


### PR DESCRIPTION
## Purpose

For customers using EU Data Residency it is not trivial to get our `native-external-references` example to work. 
I've added environment variables to the custom scripts to allow customers to switch the hostname with `api.eu.contentful.com` easily