### PR TITLE
chore: update AICG config page text []

### DIFF
--- a/apps/ai-content-generator/src/components/config/configText.ts
+++ b/apps/ai-content-generator/src/components/config/configText.ts
@@ -2,10 +2,7 @@ import { ProfileFields } from './appInstallationParameters';
 
 const ModelText = {
   title: 'Machine Learning Model',
-  helpText:
-    'According to the provider, for many basic tasks, the difference between GPT-4 and GPT-3.5 ' +
-    'models is not significant. However, in more complex reasoning situations, GPT-4 is much more ' +
-    'capable than any previous models.',
+  helpText: 'Select one of the available models based on your OpenAI API Key.',
 };
 
 export enum FieldTypes {
@@ -84,9 +81,9 @@ const Sections = {
   addToSidebarDescription: 'Assign AI Content Generator to content types.',
   costHeading: 'Cost',
   costSubheading: 'Generating content uses your Open AI tokens.',
-  costDescription: 'View the current pricing model at openai.com/pricing',
-  costLinkSubstring: 'openai.com/pricing',
-  costLink: 'https://openai.com/pricing',
+  costDescription: 'View the current pricing model at openai.com/api/pricing',
+  costLinkSubstring: 'openai.com/api/pricing',
+  costLink: 'https://openai.com/api/pricing/',
   rateLimitDescription: "Chat GPT enforces usage quotas. Learn about Chat GPT's rate limits",
   rateLimitLinkSubstring: "Chat GPT's rate limits",
   rateLimitLink: 'https://platform.openai.com/docs/guides/rate-limits/overview',


### PR DESCRIPTION
## Purpose

Update text on the AI Content Generator app config page, specifically the help text for models and the link to the pricing page.

## Approach

The help text for the models was out of date, especially since we updated the dropdown to display all models available via the API key. The pricing info info was for ChatGPT as a whole, and not for API usage specifically, so I updated this link with the more relevant API pricing info.

## Testing steps

Before:
<img width="856" alt="Screenshot 2024-11-20 at 4 04 17 PM" src="https://github.com/user-attachments/assets/5b9a841c-6553-469e-92f9-3dbbd8645935">

After:
<img width="699" alt="Screenshot 2024-11-20 at 4 21 25 PM" src="https://github.com/user-attachments/assets/0e008953-ff11-40da-88cf-439fec2e4938">


## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
