### PR TITLE
Chore: set last modified header for apps using express to serve frontend assets [INTEG-2309]

### DIFF
--- a/apps/ai-image-tagging/lambda/app.js
+++ b/apps/ai-image-tagging/lambda/app.js
@@ -21,12 +21,34 @@ const app = express();
 
 const FRONTEND = path.dirname(require.resolve('@contentful/ai-image-tagging-frontend'));
 
+const computeLastModifiedTime = () => {
+  const deployTime = process.env.DEPLOY_TIME_UNIX;
+  if (typeof deployTime === 'undefined') {
+    throw new Error('Missing DEPLOY_TIME_UNIX env var');
+  }
+
+  // JS uses number of _milliseconds_ since epoch, whereas unix generates number in
+  // _seconds_ since epoch. So we have to convert
+  const epochTime = Number(deployTime) * 1000;
+  return new Date(epochTime).toUTCString();
+};
+
 app.use('/tags', async (req, res) => {
   const { status, body } = await handle(req.method, req.path, deps);
   res.status(status).json(body);
 });
 
-app.use('/frontend', express.static(FRONTEND));
+const lastModified = computeLastModifiedTime();
+
+app.use(
+  '/frontend',
+  express.static(FRONTEND, {
+    lastModified,
+    setHeaders: (res) => {
+      res.setHeader('Last-Modified', lastModified);
+    },
+  })
+);
 app.use((_req, res) => res.status(404).send('Not found'));
 
 module.exports = app;

--- a/apps/typeform/lambda/app.js
+++ b/apps/typeform/lambda/app.js
@@ -64,7 +64,15 @@ app.use('/callback', async (req, res) => {
 });
 
 const lastModified = computeLastModifiedTime();
-app.use('/frontend', express.static(FRONTEND, { lastModified }));
+app.use(
+  '/frontend',
+  express.static(FRONTEND, {
+    lastModified,
+    setHeaders: (res) => {
+      res.setHeader('Last-Modified', lastModified);
+    },
+  })
+);
 
 app.use((_req, res) => res.status(404).send('Not found'));
 

--- a/apps/typeform/lambda/app.js
+++ b/apps/typeform/lambda/app.js
@@ -24,7 +24,7 @@ const computeLastModifiedTime = () => {
   // JS uses number of _milliseconds_ since epoch, whereas unix generates number in
   // _seconds_ since epoch. So we have to convert
   const epochTime = Number(deployTime) * 1000;
-  return new Date(epochTime).toGMTString();
+  return new Date(epochTime).toUTCString();
 };
 
 app.use('/forms', async (req, res) => {


### PR DESCRIPTION
Resolves a caching issue for apps frontend assets, done for Smartling in this PR https://github.com/contentful/apps/pull/9228 following up to apply the same pattern to Typeform and AI image tagging which likely have the same issue
