### PR TITLE
fix: add base to vite config for relative paths [EXT-5983]

### DIFF
--- a/examples/custom-validation/vite.config.ts
+++ b/examples/custom-validation/vite.config.ts
@@ -3,4 +3,5 @@ import { defineConfig } from 'vite';
 
 export default defineConfig((env) => ({
   plugins: [react()],
+  base: '', // relative paths
 }));


### PR DESCRIPTION
## Purpose

Our custom validation example did not have the base option set to support relative paths, so this warning was showing on upload and causing issues when using the app.

<img width="1302" alt="Screenshot 2024-11-27 at 9 08 10 AM" src="https://github.com/user-attachments/assets/6b456c96-f9b2-431a-b340-da746b59fedb">

## Approach

If you're using Vite, adding [`base: ''` or `base: './'`](https://vite.dev/config/shared-options.html#base) to your `vite.config.js` will resolve this warning. I have also submitted a PR to update this in our developer documentation here: https://www.contentful.com/developers/docs/extensibility/app-framework/app-bundle/#limitations 

## Testing steps

Tested to confirm that the example app works properly.

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
