### PR TITLE
fix: add yargs as dev dep for functions build [ZEND-5632]

### DIFF
--- a/examples/autotagger/package.json
+++ b/examples/autotagger/package.json
@@ -51,7 +51,8 @@
     "happy-dom": "^14.12.3",
     "typescript": "4.9.5",
     "vite": "^5.4.6",
-    "vitest": "^2.0.5"
+    "vitest": "^2.0.5",
+    "yargs": "^17.7.2"
   },
   "homepage": ".",
   "type": "module"


### PR DESCRIPTION
## Purpose

Similar to [this PR](https://github.com/contentful/apps/pull/9186), this resolves an issue with the autotagger example where a customer was reporting that they were seeing an error `Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'yargs'` after copying this example. 

## Approach

<!-- Why did we do it the way we did? Did we consider alternatives? What other implementation details or artifacts (screenshots etc.) would help reviewers contextualize change? -->

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
