### PR TITLE
chore: fix build deploy script for gql app

### DIFF
--- a/apps/graphql-playground/package.json
+++ b/apps/graphql-playground/package.json
@@ -34,7 +34,7 @@
     "analyze": "source-map-explorer 'build/static/js/*.js'",
     "start": "vite",
     "build": "vite build",
-    "deploy": "echo 'pinned bundle, skip deploy'",
+    "deploy": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEFINITIONS_ORG_ID} --definition-id 66frtrAqmWSowDJzQNDiD --token ${CONTENTFUL_CMA_TOKEN}",
     "deploy:test": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEV_TESTING_ORG_ID} --definition-id 3pH3a4bjlsvhdepgoqgWNK --token ${TEST_CMA_TOKEN}",
     "test": "vitest",
     "eject": "vite eject"


### PR DESCRIPTION
## Purpose

The gql app had its deploy script disabled. We want to make a change to add the deprecation banner
