### PR TITLE
fix: image focal point saved entries without focal point [ZEND-5811]

### DIFF
--- a/apps/image-focal-point/src/index.jsx
+++ b/apps/image-focal-point/src/index.jsx
@@ -29,7 +29,10 @@ export class App extends React.Component {
   componentDidMount() {
     const { sdk } = this.props;
     sdk.window.startAutoResizer();
-
+    const focalPointValue = sdk.field.getValue();
+    if (focalPointValue?.focalPoint === null) {
+      sdk.field.removeValue();
+    }
     // Handler for external field value changes (e.g. when multiple authors are working on the same entry).
     this.detachExternalChangeHandler = sdk.field.onValueChanged(this.onExternalChange);
   }


### PR DESCRIPTION
I recently merged a fix for the image focal point app and caught something I missed when testing in production

Previous work: https://github.com/contentful/apps/pull/9390

For any entries that were saved prior to that PR's fix, the validation won't work as expected when reopening the editor because the stored value is still a valid object.  This fix ensures that the SDK won't ever get the field updated to have the focal point as null - it'll either have an object with a focal point value or it'll be undefined. 