### PR TITLE
feat: allow web app to access Slack app

### DIFF
--- a/apps/slack/lambda/config/serverless.dev.yml.example
+++ b/apps/slack/lambda/config/serverless.dev.yml.example
@@ -13,6 +13,7 @@ variables:
   dynamoEndpoint: http://dynamodb:8000
   frontendUrl: 'http://localhost:1234'
   workflowsUrl: 'workflows-url-for-cors'
+  webAppUrl: 'https://app.contentful.com'
   serverless:
     pathPrefix: '/dev'
   customDomain:

--- a/apps/slack/lambda/config/serverless.prd.yml
+++ b/apps/slack/lambda/config/serverless.prd.yml
@@ -6,7 +6,8 @@ variables:
   dynamoEndpoint: dynamodb.${aws:region}.amazonaws.com
   frontendUrl: 'https://slack.ctfapps.net/index.html'
   workflowsUrl: 'https://17a00aa2-860a-4c54-849b-d831f0198a13.ctfcloud.net'
-  baseUrl: "https://api.contentful.com"
+  webAppUrl: 'https://app.contentful.com'
+  baseUrl: 'https://api.contentful.com'
   app:
     privateKey: ${ssm:/aws/reference/secretsmanager/ci/apps/slack/prd/private-key}
     id: '7ir40h24qLGSQWJ6JCS3sk'

--- a/apps/slack/lambda/config/serverless.test.yml
+++ b/apps/slack/lambda/config/serverless.test.yml
@@ -6,6 +6,7 @@ variables:
   dynamoEndpoint: dynamodb.${aws:region}.amazonaws.com
   frontendUrl: 'https://slack-test.ctfapps.net/index.html'
   workflowsUrl: ${env:STAGING_WORKFLOWS_URL}
+  webAppUrl: 'https://app.contentful.com'
   baseUrl: ${env:STAGING_CMA_HOST}
   app:
     privateKey: ${ssm:/aws/reference/secretsmanager/ci/apps/slack/test/private-key}

--- a/apps/slack/lambda/lib/config.ts
+++ b/apps/slack/lambda/lib/config.ts
@@ -14,6 +14,7 @@ export const config = {
   appId: envOr('APP_ID', 'unknown'),
   frontendUrl: envOr('FRONTEND_URL', 'https://localhost:3001'),
   workflowsUrl: envOr('WORKFLOWS_URL', 'https://localhost:3001'),
+  webappUrl: envOr('WEBAPP_YRL', 'https://localhost:3001'),
   backendUrl: envOr('BACKEND_URL', 'https://localhost:3000/dev/api'),
   signingSecret: envOr('SIGNING_SECRET', 'shhhh'),
   serverless: {

--- a/apps/slack/lambda/lib/config.ts
+++ b/apps/slack/lambda/lib/config.ts
@@ -14,7 +14,7 @@ export const config = {
   appId: envOr('APP_ID', 'unknown'),
   frontendUrl: envOr('FRONTEND_URL', 'https://localhost:3001'),
   workflowsUrl: envOr('WORKFLOWS_URL', 'https://localhost:3001'),
-  webappUrl: envOr('WEBAPP_YRL', 'https://localhost:3001'),
+  webAppUrl: envOr('WEB_APP_URL', 'https://localhost:3001'),
   backendUrl: envOr('BACKEND_URL', 'https://localhost:3000/dev/api'),
   signingSecret: envOr('SIGNING_SECRET', 'shhhh'),
   serverless: {

--- a/apps/slack/lambda/lib/middlewares/corsConfig.ts
+++ b/apps/slack/lambda/lib/middlewares/corsConfig.ts
@@ -3,7 +3,7 @@ import { config } from '../config';
 const frontendUrl = new URL(config.frontendUrl);
 const allowedUrls = [
   config.workflowsUrl,
-  config.webappUrl,
+  config.webAppUrl,
   frontendUrl.origin,
   /(http:\/\/localhost):(\d{1,4})/,
 ];

--- a/apps/slack/lambda/lib/middlewares/corsConfig.ts
+++ b/apps/slack/lambda/lib/middlewares/corsConfig.ts
@@ -1,7 +1,12 @@
 import { config } from '../config';
 
 const frontendUrl = new URL(config.frontendUrl);
-const allowedUrls = [config.workflowsUrl, frontendUrl.origin, /(http:\/\/localhost):(\d{1,4})/];
+const allowedUrls = [
+  config.workflowsUrl,
+  config.webappUrl,
+  frontendUrl.origin,
+  /(http:\/\/localhost):(\d{1,4})/,
+];
 
 export const corsConfig = {
   origin: allowedUrls,


### PR DESCRIPTION
## Purpose

Workflows call the Slack app's lambda to discover channels and get and save channel IDs in step configurations. After the Workflows frontend has been migrated into the web app this is broken due to CORS.

This PR adds the web app as an allowed request origin.

Ticket: https://contentful.atlassian.net/browse/CFISO-2167

## Approach

I added a new `webAppUrl` config key pointing to `'https://app.contentful.com'`.