### PR TITLE
fix: correct banner date in graphql app [INTEG-2425]

### DIFF
--- a/apps/graphql-playground/src/components/GqlPlayground.tsx
+++ b/apps/graphql-playground/src/components/GqlPlayground.tsx
@@ -116,7 +116,7 @@ function GqlPlayground(props: GqlPlaygroundProps) {
       )}
       <Provider store={store}>
         <Note noteType="warning">
-          The GraphQL Playground App is sunsetting on 2-31-2025. Please begin using the new{' '}
+          The GraphQL Playground App is sunsetting on 3-31-2025. Please begin using the new{' '}
           <a
             target="_blank"
             rel="noreferrer"


### PR DESCRIPTION
The banner saying we're sunsetting the app has a date of 2-31-25 instead of 3-31-25
