### PR TITLE
feat: upgrade ai-image-tagging node version [INTEG-2179]

### DIFF
--- a/apps/ai-image-tagging/lambda/serverless.yml
+++ b/apps/ai-image-tagging/lambda/serverless.yml
@@ -16,7 +16,7 @@ custom:
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs22.x
   stage: ${opt:stage, 'test'}
   region: 'us-east-1'
   deploymentBucket:


### PR DESCRIPTION
## Purpose

We need to upgrade node to LTS

[INTEG-2179](https://contentful.atlassian.net/browse/INTEG-2179)

## Approach

<!-- Why did we do it the way we did? Did we consider alternatives? What other implementation details or artifacts (screenshots etc.) would help reviewers contextualize change? -->

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->


[INTEG-2179]: https://contentful.atlassian.net/browse/INTEG-2179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ