### PR TITLE
fix: don't run pr title check workflow for dependabot PRs [INTEG-2430]

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   check-title:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: deepakputhraya/action-pr-title@master


### PR DESCRIPTION
Dependabot PRs are all failing the pr title workflow check to enforce attaching JIRA tickets. We shouldn't enforce this for dependabot PRs.