### PR TITLE
feat: update cca to use vite for javascript and typescript examples [INTEG-2432]

### DIFF
--- a/apps/smartling/lambda/serverless.yml
+++ b/apps/smartling/lambda/serverless.yml
@@ -21,7 +21,7 @@ custom:
 
 provider:
   name: aws
-  runtime: nodejs16.x
+  runtime: nodejs22.x
   stage: ${opt:stage, 'test'}
   region: 'us-east-1'
   deploymentBucket:

--- a/examples/javascript/index.html
+++ b/examples/javascript/index.html
@@ -7,7 +7,7 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
+    <script type="module" src="/src/index.jsx"></script>
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.

--- a/examples/javascript/index.html
+++ b/examples/javascript/index.html
@@ -7,6 +7,7 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.

--- a/examples/javascript/package.json
+++ b/examples/javascript/package.json
@@ -4,23 +4,22 @@
   "private": true,
   "dependencies": {
     "@contentful/app-sdk": "^4.29.1",
-    "@contentful/f36-components": "4.78.0",
+    "@contentful/f36-components": "^4.78.0",
     "@contentful/f36-tokens": "4.2.0",
     "@contentful/react-apps-toolkit": "1.2.16",
     "contentful-management": "10.46.4",
     "emotion": "10.0.27",
     "react": "18.3.1",
-    "react-dom": "18.3.1",
-    "react-scripts": "5.0.1"
+    "react-dom": "18.3.1"
   },
   "scripts": {
-    "start": "cross-env BROWSER=none react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
-    "eject": "react-scripts eject",
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "vitest",
     "create-app-definition": "contentful-app-scripts create-app-definition",
-    "upload": "contentful-app-scripts upload --bundle-dir ./build",
-    "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN"
+    "upload": "contentful-app-scripts upload --bundle-dir ./dist",
+    "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./dist --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN"
   },
   "eslintConfig": {
     "extends": "react-app"
@@ -41,7 +40,10 @@
     "@contentful/app-scripts": "1.33.0",
     "@testing-library/jest-dom": "5.17.0",
     "@testing-library/react": "14.3.1",
-    "cross-env": "7.0.3"
+    "@vitejs/plugin-react": "^4.0.3",
+    "cross-env": "7.0.3",
+    "vite": "^5.0.0",
+    "vitest": "^1.0.0"
   },
   "homepage": "."
 }

--- a/examples/javascript/package.json
+++ b/examples/javascript/package.json
@@ -38,12 +38,13 @@
   },
   "devDependencies": {
     "@contentful/app-scripts": "1.33.0",
-    "@testing-library/jest-dom": "5.17.0",
-    "@testing-library/react": "14.3.1",
+    "@testing-library/jest-dom": "^5.17.0",
+    "@testing-library/react": "^14.3.1",
     "@vitejs/plugin-react": "^4.0.3",
     "cross-env": "7.0.3",
+    "jsdom": "^26.0.0",
     "vite": "^5.0.0",
-    "vitest": "^1.0.0"
+    "vitest": "^1.6.1"
   },
   "homepage": "."
 }

--- a/examples/javascript/src/locations/ConfigScreen.spec.jsx
+++ b/examples/javascript/src/locations/ConfigScreen.spec.jsx
@@ -2,8 +2,9 @@ import React from 'react';
 import ConfigScreen from './ConfigScreen';
 import { render } from '@testing-library/react';
 import { mockCma, mockSdk } from '../../test/mocks';
+import { vi } from 'vitest';
 
-jest.mock('@contentful/react-apps-toolkit', () => ({
+vi.mock('@contentful/react-apps-toolkit', () => ({
   useSDK: () => mockSdk,
   useCMA: () => mockCma,
 }));

--- a/examples/javascript/src/locations/Dialog.spec.jsx
+++ b/examples/javascript/src/locations/Dialog.spec.jsx
@@ -2,8 +2,9 @@ import React from 'react';
 import Dialog from './Dialog';
 import { render } from '@testing-library/react';
 import { mockCma, mockSdk } from '../../test/mocks';
+import { vi } from 'vitest';
 
-jest.mock('@contentful/react-apps-toolkit', () => ({
+vi.mock('@contentful/react-apps-toolkit', () => ({
   useSDK: () => mockSdk,
   useCMA: () => mockCma,
 }));

--- a/examples/javascript/src/locations/EntryEditor.spec.jsx
+++ b/examples/javascript/src/locations/EntryEditor.spec.jsx
@@ -2,8 +2,9 @@ import React from 'react';
 import EntryEditor from './EntryEditor';
 import { render } from '@testing-library/react';
 import { mockCma, mockSdk } from '../../test/mocks';
+import { vi } from 'vitest';
 
-jest.mock('@contentful/react-apps-toolkit', () => ({
+vi.mock('@contentful/react-apps-toolkit', () => ({
   useSDK: () => mockSdk,
   useCMA: () => mockCma,
 }));

--- a/examples/javascript/src/locations/Field.spec.jsx
+++ b/examples/javascript/src/locations/Field.spec.jsx
@@ -2,8 +2,9 @@ import React from 'react';
 import Field from './Field';
 import { render } from '@testing-library/react';
 import { mockCma, mockSdk } from '../../test/mocks';
+import { vi } from 'vitest';
 
-jest.mock('@contentful/react-apps-toolkit', () => ({
+vi.mock('@contentful/react-apps-toolkit', () => ({
   useSDK: () => mockSdk,
   useCMA: () => mockCma,
 }));

--- a/examples/javascript/src/locations/Home.spec.jsx
+++ b/examples/javascript/src/locations/Home.spec.jsx
@@ -2,8 +2,9 @@ import React from 'react';
 import Home from './Home';
 import { render } from '@testing-library/react';
 import { mockCma, mockSdk } from '../../test/mocks';
+import { vi } from 'vitest';
 
-jest.mock('@contentful/react-apps-toolkit', () => ({
+vi.mock('@contentful/react-apps-toolkit', () => ({
   useSDK: () => mockSdk,
   useCMA: () => mockCma,
 }));

--- a/examples/javascript/src/locations/Page.spec.jsx
+++ b/examples/javascript/src/locations/Page.spec.jsx
@@ -2,8 +2,9 @@ import React from 'react';
 import Page from './Page';
 import { render } from '@testing-library/react';
 import { mockCma, mockSdk } from '../../test/mocks';
+import { vi } from 'vitest';
 
-jest.mock('@contentful/react-apps-toolkit', () => ({
+vi.mock('@contentful/react-apps-toolkit', () => ({
   useSDK: () => mockSdk,
   useCMA: () => mockCma,
 }));

--- a/examples/javascript/src/locations/Sidebar.spec.jsx
+++ b/examples/javascript/src/locations/Sidebar.spec.jsx
@@ -2,8 +2,9 @@ import React from 'react';
 import Sidebar from './Sidebar';
 import { render } from '@testing-library/react';
 import { mockCma, mockSdk } from '../../test/mocks';
+import { vi } from 'vitest';
 
-jest.mock('@contentful/react-apps-toolkit', () => ({
+vi.mock('@contentful/react-apps-toolkit', () => ({
   useSDK: () => mockSdk,
   useCMA: () => mockCma,
 }));

--- a/examples/javascript/src/setupTests.js
+++ b/examples/javascript/src/setupTests.js
@@ -4,6 +4,11 @@
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
 import { configure } from '@testing-library/react';
+import { expect } from 'vitest';
+import matchers from '@testing-library/jest-dom/matchers';
+
 configure({
   testIdAttribute: 'data-test-id',
 });
+
+expect.extend(matchers);

--- a/examples/javascript/test/mocks/mockSdk.js
+++ b/examples/javascript/test/mocks/mockSdk.js
@@ -1,9 +1,11 @@
+import { vi } from 'vitest';
+
 const mockSdk = {
   app: {
-    onConfigure: jest.fn(),
-    getParameters: jest.fn().mockReturnValueOnce({}),
-    setReady: jest.fn(),
-    getCurrentState: jest.fn(),
+    onConfigure: vi.fn(),
+    getParameters: vi.fn().mockReturnValueOnce({}),
+    setReady: vi.fn(),
+    getCurrentState: vi.fn(),
   },
   ids: {
     app: 'test-app',

--- a/examples/javascript/vite.config.js
+++ b/examples/javascript/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});

--- a/examples/javascript/vite.config.js
+++ b/examples/javascript/vite.config.js
@@ -3,4 +3,9 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  test: {
+    globals: true, // Enables Jest-like global test functions (test, expect)
+    environment: 'jsdom', // Simulates a browser for component tests
+    setupFiles: './src/setupTests.js', // Equivalent to Jest's setup file
+  },
 });

--- a/examples/typescript/index.html
+++ b/examples/typescript/index.html
@@ -7,6 +7,7 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.

--- a/examples/typescript/index.html
+++ b/examples/typescript/index.html
@@ -7,7 +7,7 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="/src/index.tsx"></script>
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -4,23 +4,23 @@
   "private": true,
   "dependencies": {
     "@contentful/app-sdk": "^4.29.1",
-    "@contentful/f36-components": "4.78.0",
+    "@contentful/f36-components": "4.77.4",
     "@contentful/f36-tokens": "4.2.0",
     "@contentful/react-apps-toolkit": "1.2.16",
+    "@types/node": "^22.13.5",
     "contentful-management": "10.46.4",
     "emotion": "10.0.27",
     "react": "18.3.1",
-    "react-dom": "18.3.1",
-    "react-scripts": "5.0.1"
+    "react-dom": "18.3.1"
   },
   "scripts": {
-    "start": "cross-env BROWSER=none react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
-    "eject": "react-scripts eject",
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "vitest",
     "create-app-definition": "contentful-app-scripts create-app-definition",
-    "upload": "contentful-app-scripts upload --bundle-dir ./build",
-    "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN"
+    "upload": "contentful-app-scripts upload --bundle-dir ./dist",
+    "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./dist --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN"
   },
   "eslintConfig": {
     "extends": "react-app"
@@ -38,15 +38,17 @@
     ]
   },
   "devDependencies": {
-    "@contentful/app-scripts": "1.33.0",
+    "@contentful/app-scripts": "1.32.3",
     "@testing-library/jest-dom": "5.17.0",
     "@testing-library/react": "14.3.1",
     "@tsconfig/create-react-app": "2.0.5",
-    "@types/node": "16.18.126",
     "@types/react": "18.3.13",
     "@types/react-dom": "18.3.1",
+    "@vitejs/plugin-react": "^4.0.3",
     "cross-env": "7.0.3",
-    "typescript": "4.9.5"
+    "typescript": "4.9.5",
+    "vite": "^5.0.0",
+    "vitest": "^1.0.0"
   },
   "homepage": "."
 }

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -39,16 +39,17 @@
   },
   "devDependencies": {
     "@contentful/app-scripts": "1.32.3",
-    "@testing-library/jest-dom": "5.17.0",
-    "@testing-library/react": "14.3.1",
+    "@testing-library/jest-dom": "^5.17.0",
+    "@testing-library/react": "^14.3.1",
     "@tsconfig/create-react-app": "2.0.5",
     "@types/react": "18.3.13",
     "@types/react-dom": "18.3.1",
     "@vitejs/plugin-react": "^4.0.3",
     "cross-env": "7.0.3",
+    "jsdom": "^26.0.0",
     "typescript": "4.9.5",
     "vite": "^5.0.0",
-    "vitest": "^1.0.0"
+    "vitest": "^1.6.1"
   },
   "homepage": "."
 }

--- a/examples/typescript/src/locations/ConfigScreen.spec.tsx
+++ b/examples/typescript/src/locations/ConfigScreen.spec.tsx
@@ -2,8 +2,9 @@ import React from 'react';
 import ConfigScreen from './ConfigScreen';
 import { render } from '@testing-library/react';
 import { mockCma, mockSdk } from '../../test/mocks';
+import { vi } from 'vitest';
 
-jest.mock('@contentful/react-apps-toolkit', () => ({
+vi.mock('@contentful/react-apps-toolkit', () => ({
   useSDK: () => mockSdk,
   useCMA: () => mockCma,
 }));

--- a/examples/typescript/src/locations/Dialog.spec.tsx
+++ b/examples/typescript/src/locations/Dialog.spec.tsx
@@ -2,8 +2,9 @@ import React from 'react';
 import Dialog from './Dialog';
 import { render } from '@testing-library/react';
 import { mockCma, mockSdk } from '../../test/mocks';
+import { vi } from 'vitest';
 
-jest.mock('@contentful/react-apps-toolkit', () => ({
+vi.mock('@contentful/react-apps-toolkit', () => ({
   useSDK: () => mockSdk,
   useCMA: () => mockCma,
 }));

--- a/examples/typescript/src/locations/EntryEditor.spec.tsx
+++ b/examples/typescript/src/locations/EntryEditor.spec.tsx
@@ -2,8 +2,9 @@ import React from 'react';
 import EntryEditor from './EntryEditor';
 import { render } from '@testing-library/react';
 import { mockCma, mockSdk } from '../../test/mocks';
+import { vi } from 'vitest';
 
-jest.mock('@contentful/react-apps-toolkit', () => ({
+vi.mock('@contentful/react-apps-toolkit', () => ({
   useSDK: () => mockSdk,
   useCMA: () => mockCma,
 }));

--- a/examples/typescript/src/locations/Field.spec.tsx
+++ b/examples/typescript/src/locations/Field.spec.tsx
@@ -2,8 +2,9 @@ import React from 'react';
 import Field from './Field';
 import { render } from '@testing-library/react';
 import { mockCma, mockSdk } from '../../test/mocks';
+import { vi } from 'vitest';
 
-jest.mock('@contentful/react-apps-toolkit', () => ({
+vi.mock('@contentful/react-apps-toolkit', () => ({
   useSDK: () => mockSdk,
   useCMA: () => mockCma,
 }));

--- a/examples/typescript/src/locations/Home.spec.tsx
+++ b/examples/typescript/src/locations/Home.spec.tsx
@@ -2,8 +2,9 @@ import React from 'react';
 import Home from './Home';
 import { render } from '@testing-library/react';
 import { mockCma, mockSdk } from '../../test/mocks';
+import { vi } from 'vitest';
 
-jest.mock('@contentful/react-apps-toolkit', () => ({
+vi.mock('@contentful/react-apps-toolkit', () => ({
   useSDK: () => mockSdk,
   useCMA: () => mockCma,
 }));

--- a/examples/typescript/src/locations/Page.spec.tsx
+++ b/examples/typescript/src/locations/Page.spec.tsx
@@ -2,8 +2,9 @@ import React from 'react';
 import Page from './Page';
 import { render } from '@testing-library/react';
 import { mockCma, mockSdk } from '../../test/mocks';
+import { vi } from 'vitest';
 
-jest.mock('@contentful/react-apps-toolkit', () => ({
+vi.mock('@contentful/react-apps-toolkit', () => ({
   useSDK: () => mockSdk,
   useCMA: () => mockCma,
 }));

--- a/examples/typescript/src/locations/Sidebar.spec.tsx
+++ b/examples/typescript/src/locations/Sidebar.spec.tsx
@@ -2,8 +2,9 @@ import React from 'react';
 import Sidebar from './Sidebar';
 import { render } from '@testing-library/react';
 import { mockCma, mockSdk } from '../../test/mocks';
+import { vi } from 'vitest';
 
-jest.mock('@contentful/react-apps-toolkit', () => ({
+vi.mock('@contentful/react-apps-toolkit', () => ({
   useSDK: () => mockSdk,
   useCMA: () => mockCma,
 }));

--- a/examples/typescript/src/setupTests.ts
+++ b/examples/typescript/src/setupTests.ts
@@ -4,7 +4,11 @@
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
 import { configure } from '@testing-library/react';
+import { expect } from 'vitest';
+import matchers from '@testing-library/jest-dom/matchers';
 
 configure({
   testIdAttribute: 'data-test-id',
 });
+
+expect.extend(matchers);

--- a/examples/typescript/test/mocks/mockSdk.ts
+++ b/examples/typescript/test/mocks/mockSdk.ts
@@ -1,9 +1,11 @@
+import { vi } from 'vitest';
+
 const mockSdk: any = {
   app: {
-    onConfigure: jest.fn(),
-    getParameters: jest.fn().mockReturnValueOnce({}),
-    setReady: jest.fn(),
-    getCurrentState: jest.fn(),
+    onConfigure: vi.fn(),
+    getParameters: vi.fn().mockReturnValueOnce({}),
+    setReady: vi.fn(),
+    getCurrentState: vi.fn(),
   },
   ids: {
     app: 'test-app',

--- a/examples/typescript/vite.config.ts
+++ b/examples/typescript/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});

--- a/examples/typescript/vite.config.ts
+++ b/examples/typescript/vite.config.ts
@@ -3,4 +3,9 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  test: {
+    globals: true, // Enables Jest-like global test functions (test, expect)
+    environment: 'jsdom', // Simulates a browser for component tests
+    setupFiles: './src/setupTests.ts', // Equivalent to Jest's setup file
+  },
 });


### PR DESCRIPTION
## Purpose

React-scripts is outdated and causes security vulnerabilities

[INTEG-2432](https://contentful.atlassian.net/browse/INTEG-2432)


## Approach

<!-- Why did we do it the way we did? Did we consider alternatives? What other implementation details or artifacts (screenshots etc.) would help reviewers contextualize change? -->

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->


[INTEG-2432]: https://contentful.atlassian.net/browse/INTEG-2432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ