### PR TITLE
Braze app: allow to select locales

### DIFF
--- a/apps/braze/package-lock.json
+++ b/apps/braze/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@contentful/app-sdk": "4.25.0",
         "@contentful/f36-components": "4.65.4",
+        "@contentful/f36-multiselect": "^4.26.0",
         "@contentful/f36-tokens": "4.0.2",
         "@contentful/react-apps-toolkit": "1.2.16",
         "@testing-library/user-event": "^14.6.1",
@@ -481,14 +482,15 @@
       "integrity": "sha512-fB7ZEO8+NJPlcGvx6EHuEoPdhgpaFAeCnymXlgC+xVLTXYKXSk8JJD4WEr9rBLcXpyyS+e3g51kNFv90cDOeEQ=="
     },
     "node_modules/@contentful/f36-button": {
-      "version": "4.77.5",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.77.5.tgz",
-      "integrity": "sha512-+lY4QyiXHyNrGzDQ2EuzK3b/TPmr2mgzZqO/20J/KN+0Dojmdpn/aLNlRHOnbkZkqkRVpysVXuxr9RRkG3BZBw==",
+      "version": "4.78.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.78.0.tgz",
+      "integrity": "sha512-uYXtObysu+YUqSQ7QFkpwdcEY7iXRusLNUCl7RgRF4jPyRmFujwzSNLQrjFQztVsvpTe9JQAR1IKoFaqRIotzQ==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.77.5",
-        "@contentful/f36-spinner": "^4.77.5",
+        "@contentful/f36-core": "^4.78.0",
+        "@contentful/f36-spinner": "^4.78.0",
         "@contentful/f36-tokens": "^4.2.0",
-        "@contentful/f36-tooltip": "^4.77.5",
+        "@contentful/f36-tooltip": "^4.78.0",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"
       },
@@ -539,22 +541,6 @@
       "dependencies": {
         "@contentful/f36-core": "^4.78.0",
         "@contentful/f36-tokens": "^4.2.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-collapse/node_modules/@contentful/f36-core": {
-      "version": "4.78.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.78.0.tgz",
-      "integrity": "sha512-pVK8fBuTnesZuDtsKkKICINBFWGUrJbHlJB7ZFjy9Fyy8DV/qRYtHW6/rZsAE84vJH1kFFROyGxc+0D10PxQFQ==",
-      "dependencies": {
-        "@contentful/f36-tokens": "^4.2.0",
-        "@emotion/core": "^10.1.1",
-        "@emotion/is-prop-valid": "^1.2.0",
-        "csstype": "^3.1.1",
         "emotion": "^10.0.17"
       },
       "peerDependencies": {
@@ -651,9 +637,10 @@
       "integrity": "sha512-fB7ZEO8+NJPlcGvx6EHuEoPdhgpaFAeCnymXlgC+xVLTXYKXSk8JJD4WEr9rBLcXpyyS+e3g51kNFv90cDOeEQ=="
     },
     "node_modules/@contentful/f36-core": {
-      "version": "4.77.5",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.77.5.tgz",
-      "integrity": "sha512-5ZCoqd1PlGXBKnSnbttDzw4JDbcfy78BJ43G+EdkbCCbNWsAL4Uo5qG0RB1OsnAYYRS+yV3Chw5J2fIkxB/lgg==",
+      "version": "4.78.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.78.0.tgz",
+      "integrity": "sha512-pVK8fBuTnesZuDtsKkKICINBFWGUrJbHlJB7ZFjy9Fyy8DV/qRYtHW6/rZsAE84vJH1kFFROyGxc+0D10PxQFQ==",
+      "license": "MIT",
       "dependencies": {
         "@contentful/f36-tokens": "^4.2.0",
         "@emotion/core": "^10.1.1",
@@ -734,22 +721,6 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/@contentful/f36-drag-handle/node_modules/@contentful/f36-core": {
-      "version": "4.78.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.78.0.tgz",
-      "integrity": "sha512-pVK8fBuTnesZuDtsKkKICINBFWGUrJbHlJB7ZFjy9Fyy8DV/qRYtHW6/rZsAE84vJH1kFFROyGxc+0D10PxQFQ==",
-      "dependencies": {
-        "@contentful/f36-tokens": "^4.2.0",
-        "@emotion/core": "^10.1.1",
-        "@emotion/is-prop-valid": "^1.2.0",
-        "csstype": "^3.1.1",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
     "node_modules/@contentful/f36-drag-handle/node_modules/@contentful/f36-tokens": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-4.2.0.tgz",
@@ -818,41 +789,10 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/@contentful/f36-forms/node_modules/@contentful/f36-core": {
-      "version": "4.78.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.78.0.tgz",
-      "integrity": "sha512-pVK8fBuTnesZuDtsKkKICINBFWGUrJbHlJB7ZFjy9Fyy8DV/qRYtHW6/rZsAE84vJH1kFFROyGxc+0D10PxQFQ==",
-      "dependencies": {
-        "@contentful/f36-tokens": "^4.2.0",
-        "@emotion/core": "^10.1.1",
-        "@emotion/is-prop-valid": "^1.2.0",
-        "csstype": "^3.1.1",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
     "node_modules/@contentful/f36-forms/node_modules/@contentful/f36-tokens": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-4.2.0.tgz",
       "integrity": "sha512-fB7ZEO8+NJPlcGvx6EHuEoPdhgpaFAeCnymXlgC+xVLTXYKXSk8JJD4WEr9rBLcXpyyS+e3g51kNFv90cDOeEQ=="
-    },
-    "node_modules/@contentful/f36-forms/node_modules/@contentful/f36-typography": {
-      "version": "4.78.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.78.0.tgz",
-      "integrity": "sha512-Sq2N9j05JwFk+mxSg5CU8WpX6MT4aqYM3ObluWIJiPN4ENRAUo6VSEcBCG89tanVp+HlbLwQvPdiCHUTPhWEoQ==",
-      "dependencies": {
-        "@contentful/f36-core": "^4.78.0",
-        "@contentful/f36-tokens": "^4.2.0",
-        "@contentful/f36-utils": "^4.24.3",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
     },
     "node_modules/@contentful/f36-icon": {
       "version": "4.77.5",
@@ -974,6 +914,31 @@
       "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-4.2.0.tgz",
       "integrity": "sha512-fB7ZEO8+NJPlcGvx6EHuEoPdhgpaFAeCnymXlgC+xVLTXYKXSk8JJD4WEr9rBLcXpyyS+e3g51kNFv90cDOeEQ=="
     },
+    "node_modules/@contentful/f36-multiselect": {
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-multiselect/-/f36-multiselect-4.26.0.tgz",
+      "integrity": "sha512-KiUlRorlv2Xo37OEGJrx8vfkbpq/93APjUGISA6h3O4HTBMKcaFvlfOvSay/2etQO76FXB92uZWr0y4Vqd6qQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "@contentful/f36-button": "^4.78.0",
+        "@contentful/f36-core": "^4.78.0",
+        "@contentful/f36-forms": "^4.78.0",
+        "@contentful/f36-icons": "^4.20.8",
+        "@contentful/f36-popover": "^4.78.0",
+        "@contentful/f36-skeleton": "^4.78.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-tooltip": "^4.78.0",
+        "@contentful/f36-typography": "^4.78.0",
+        "@contentful/f36-utils": "^4.20.8",
+        "emotion": "^10.0.17",
+        "react-focus-lock": "^2.9.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
     "node_modules/@contentful/f36-navbar": {
       "version": "4.77.5",
       "resolved": "https://registry.npmjs.org/@contentful/f36-navbar/-/f36-navbar-4.77.5.tgz",
@@ -1093,11 +1058,12 @@
       "integrity": "sha512-fB7ZEO8+NJPlcGvx6EHuEoPdhgpaFAeCnymXlgC+xVLTXYKXSk8JJD4WEr9rBLcXpyyS+e3g51kNFv90cDOeEQ=="
     },
     "node_modules/@contentful/f36-popover": {
-      "version": "4.77.5",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.77.5.tgz",
-      "integrity": "sha512-48eDwolcMO53judV/+2DFz3EQttzeSHSxRv9GRNR7kt0EW///nxt1zXPQHzqKkFv63OSrHRmht0Ny/rc0Vw7dQ==",
+      "version": "4.78.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.78.0.tgz",
+      "integrity": "sha512-LIQPRbd9yakLwSkqJWzsrGuImt8Q8O3nwL52ozHOLCa/u6UUKB9rcdzI6Ecb3KfkoV8pZc3xa5XyiqjK4cCxhA==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.77.5",
+        "@contentful/f36-core": "^4.78.0",
         "@contentful/f36-tokens": "^4.2.0",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -1129,33 +1095,18 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/@contentful/f36-skeleton/node_modules/@contentful/f36-core": {
-      "version": "4.78.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.78.0.tgz",
-      "integrity": "sha512-pVK8fBuTnesZuDtsKkKICINBFWGUrJbHlJB7ZFjy9Fyy8DV/qRYtHW6/rZsAE84vJH1kFFROyGxc+0D10PxQFQ==",
-      "dependencies": {
-        "@contentful/f36-tokens": "^4.2.0",
-        "@emotion/core": "^10.1.1",
-        "@emotion/is-prop-valid": "^1.2.0",
-        "csstype": "^3.1.1",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
     "node_modules/@contentful/f36-skeleton/node_modules/@contentful/f36-tokens": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-4.2.0.tgz",
       "integrity": "sha512-fB7ZEO8+NJPlcGvx6EHuEoPdhgpaFAeCnymXlgC+xVLTXYKXSk8JJD4WEr9rBLcXpyyS+e3g51kNFv90cDOeEQ=="
     },
     "node_modules/@contentful/f36-spinner": {
-      "version": "4.77.5",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.77.5.tgz",
-      "integrity": "sha512-FpVTK4FvtiYngkMxzYWxdL9xvXMA/dPk+eedjWlM/riL9azIjU6eHedgHZPBdkH3lAevYigjSj7uis7heS1hOQ==",
+      "version": "4.78.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.78.0.tgz",
+      "integrity": "sha512-VKz214l9WOP33LQ3FmWkxy0wcP7mWDFj5NELz8UJH2Nmb0eOXs0i70O0vH9t5eqdUsGmfyYT283JTJL5E/+HgQ==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.77.5",
+        "@contentful/f36-core": "^4.78.0",
         "@contentful/f36-tokens": "^4.2.0",
         "emotion": "^10.0.17"
       },
@@ -1186,41 +1137,10 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/@contentful/f36-table/node_modules/@contentful/f36-core": {
-      "version": "4.78.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.78.0.tgz",
-      "integrity": "sha512-pVK8fBuTnesZuDtsKkKICINBFWGUrJbHlJB7ZFjy9Fyy8DV/qRYtHW6/rZsAE84vJH1kFFROyGxc+0D10PxQFQ==",
-      "dependencies": {
-        "@contentful/f36-tokens": "^4.2.0",
-        "@emotion/core": "^10.1.1",
-        "@emotion/is-prop-valid": "^1.2.0",
-        "csstype": "^3.1.1",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
     "node_modules/@contentful/f36-table/node_modules/@contentful/f36-tokens": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-4.2.0.tgz",
       "integrity": "sha512-fB7ZEO8+NJPlcGvx6EHuEoPdhgpaFAeCnymXlgC+xVLTXYKXSk8JJD4WEr9rBLcXpyyS+e3g51kNFv90cDOeEQ=="
-    },
-    "node_modules/@contentful/f36-table/node_modules/@contentful/f36-typography": {
-      "version": "4.78.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.78.0.tgz",
-      "integrity": "sha512-Sq2N9j05JwFk+mxSg5CU8WpX6MT4aqYM3ObluWIJiPN4ENRAUo6VSEcBCG89tanVp+HlbLwQvPdiCHUTPhWEoQ==",
-      "dependencies": {
-        "@contentful/f36-core": "^4.78.0",
-        "@contentful/f36-tokens": "^4.2.0",
-        "@contentful/f36-utils": "^4.24.3",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
     },
     "node_modules/@contentful/f36-tabs": {
       "version": "4.77.5",
@@ -1268,11 +1188,12 @@
       "license": "MIT"
     },
     "node_modules/@contentful/f36-tooltip": {
-      "version": "4.77.5",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.77.5.tgz",
-      "integrity": "sha512-NxSmv7fcaikkrALsJDzovKTgNdbwnmb/I5xoASClllL23SUWPERY138C+fhjAC7rg3ozIzcECSdy5QdZrWCR5g==",
+      "version": "4.78.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.78.0.tgz",
+      "integrity": "sha512-g5GVUxpCHmq+qGm2tbW1BOAiti0K/j+XKh4Zv6mHQ1mxt4BMff4A65TCPfvEie60jHH4omKbGI4vRE6HsH5WLA==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.77.5",
+        "@contentful/f36-core": "^4.78.0",
         "@contentful/f36-tokens": "^4.2.0",
         "@contentful/f36-utils": "^4.24.3",
         "@popperjs/core": "^2.11.5",
@@ -1291,11 +1212,12 @@
       "integrity": "sha512-fB7ZEO8+NJPlcGvx6EHuEoPdhgpaFAeCnymXlgC+xVLTXYKXSk8JJD4WEr9rBLcXpyyS+e3g51kNFv90cDOeEQ=="
     },
     "node_modules/@contentful/f36-typography": {
-      "version": "4.77.5",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.77.5.tgz",
-      "integrity": "sha512-oFdXm5ZNgVb54M2wNzUUwXEZ6OKzD7VR/v4NELPBs5YbgJSaB0Zw3CQgPJqG3KookobAnf91UXpGW5ASq6807w==",
+      "version": "4.78.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.78.0.tgz",
+      "integrity": "sha512-Sq2N9j05JwFk+mxSg5CU8WpX6MT4aqYM3ObluWIJiPN4ENRAUo6VSEcBCG89tanVp+HlbLwQvPdiCHUTPhWEoQ==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.77.5",
+        "@contentful/f36-core": "^4.78.0",
         "@contentful/f36-tokens": "^4.2.0",
         "@contentful/f36-utils": "^4.24.3",
         "emotion": "^10.0.17"

--- a/apps/braze/package.json
+++ b/apps/braze/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@contentful/app-sdk": "4.25.0",
     "@contentful/f36-components": "4.65.4",
+    "@contentful/f36-multiselect": "^4.26.0",
     "@contentful/f36-tokens": "4.0.2",
     "@contentful/react-apps-toolkit": "1.2.16",
     "@testing-library/user-event": "^14.6.1",

--- a/apps/braze/src/components/CodeBlocksStep.tsx
+++ b/apps/braze/src/components/CodeBlocksStep.tsx
@@ -1,12 +1,4 @@
-import {
-  Box,
-  Button,
-  Flex,
-  List,
-  ListItem,
-  Paragraph,
-  Subheading,
-} from '@contentful/f36-components';
+import { Box, Button, List, ListItem, Paragraph, Subheading } from '@contentful/f36-components';
 import Splitter from './Splitter';
 import tokens from '@contentful/f36-tokens';
 import { useState, useEffect } from 'react';
@@ -17,6 +9,7 @@ import {
 } from '../helpers/assembleQuery';
 import generateLiquidTags from '../helpers/generateLiquidTags';
 import { EntryInfo } from '../locations/Dialog';
+import WizardFooter from './WizardFooter';
 
 type CodeBlocksStepProps = {
   spaceId: string;
@@ -79,22 +72,14 @@ const CodeBlocksStep = (props: CodeBlocksStepProps) => {
         <code>{graphqlResponse}</code>
       </Box>
 
-      <Flex
-        padding="spacingM"
-        gap="spacingM"
-        justifyContent="end"
-        style={{
-          position: 'sticky',
-          bottom: 0,
-          background: 'white',
-        }}>
+      <WizardFooter>
         <Button variant="secondary" size="small" onClick={handlePreviousStep}>
           Back
         </Button>
         <Button variant="primary" size="small" onClick={handleClose}>
           Close
         </Button>
-      </Flex>
+      </WizardFooter>
     </>
   );
 };

--- a/apps/braze/src/components/CodeBlocksStep.tsx
+++ b/apps/braze/src/components/CodeBlocksStep.tsx
@@ -1,14 +1,46 @@
-import { Box, List, ListItem, Paragraph, Subheading } from '@contentful/f36-components';
+import {
+  Box,
+  Button,
+  Flex,
+  List,
+  ListItem,
+  Paragraph,
+  Subheading,
+} from '@contentful/f36-components';
 import Splitter from './Splitter';
 import tokens from '@contentful/f36-tokens';
+import { useState, useEffect } from 'react';
+import {
+  assembleQuery,
+  generateConnectedContentCall,
+  getGraphQLResponse,
+} from '../helpers/assembleQuery';
+import generateLiquidTags from '../helpers/generateLiquidTags';
+import { EntryInfo } from '../locations/Dialog';
 
-interface CodeBlocksStepProps {
-  connectedContentCall: string;
-  liquidTags: string[];
-  graphqlResponse: string;
-}
+type CodeBlocksStepProps = {
+  spaceId: string;
+  contentfulToken: string;
+  entryInfo: EntryInfo;
+  selectedLocales: string[];
+  handlePreviousStep: () => void;
+  handleClose: () => void;
+};
 const CodeBlocksStep = (props: CodeBlocksStepProps) => {
-  const { connectedContentCall, liquidTags, graphqlResponse } = props;
+  const { spaceId, contentfulToken, entryInfo, handlePreviousStep, handleClose } = props;
+  const [graphqlResponse, setGraphqlResponse] = useState<string>('');
+
+  const query = assembleQuery(entryInfo.contentTypeId, entryInfo.id, entryInfo.fields);
+  const connectedContentCall = generateConnectedContentCall(query, spaceId, contentfulToken);
+  const liquidTags = generateLiquidTags(entryInfo.contentTypeId, entryInfo.fields);
+  useEffect(() => {
+    const fetchEntry = async () => {
+      const response = await getGraphQLResponse(spaceId, contentfulToken, query);
+      setGraphqlResponse(JSON.stringify(response));
+    };
+    fetchEntry();
+  }, []);
+
   return (
     <>
       <Paragraph fontColor="gray700" lineHeight="lineHeightCondensed">
@@ -46,6 +78,23 @@ const CodeBlocksStep = (props: CodeBlocksStepProps) => {
         </Subheading>
         <code>{graphqlResponse}</code>
       </Box>
+
+      <Flex
+        padding="spacingM"
+        gap="spacingM"
+        justifyContent="end"
+        style={{
+          position: 'sticky',
+          bottom: 0,
+          background: 'white',
+        }}>
+        <Button variant="secondary" size="small" onClick={handlePreviousStep}>
+          Back
+        </Button>
+        <Button variant="primary" size="small" onClick={handleClose}>
+          Close
+        </Button>
+      </Flex>
     </>
   );
 };

--- a/apps/braze/src/components/FieldsSelectionStep.tsx
+++ b/apps/braze/src/components/FieldsSelectionStep.tsx
@@ -1,21 +1,41 @@
-import { Paragraph, TextLink } from '@contentful/f36-components';
+import { Button, Flex, Paragraph, TextLink } from '@contentful/f36-components';
 import { ExternalLinkIcon } from '@contentful/f36-icons';
 
-const FieldsSelectionStep = () => {
+type FieldsSelectionStepProps = {
+  handleNextStep: () => void;
+};
+const FieldsSelectionStep = (props: FieldsSelectionStepProps) => {
+  const { handleNextStep } = props;
   return (
-    <Paragraph fontColor="gray700" lineHeight="lineHeightCondensed">
-      Select which fields you would like to include in your Connected Content call. Selecting fields
-      from referenced entries is limited to 5 nested references. For more information on Braze
-      Connected Content {''}
-      <TextLink
-        icon={<ExternalLinkIcon />}
-        alignIcon="end"
-        href="https://www.braze.com/docs/user_guide/personalization_and_dynamic_content/connected_content"
-        target="_blank"
-        rel="noopener noreferrer">
-        view documentation here
-      </TextLink>
-    </Paragraph>
+    <>
+      <Paragraph fontColor="gray700" lineHeight="lineHeightCondensed">
+        Select which fields you would like to include in your Connected Content call. Selecting
+        fields from referenced entries is limited to 5 nested references. For more information on
+        Braze Connected Content {''}
+        <TextLink
+          icon={<ExternalLinkIcon />}
+          alignIcon="end"
+          href="https://www.braze.com/docs/user_guide/personalization_and_dynamic_content/connected_content"
+          target="_blank"
+          rel="noopener noreferrer">
+          view documentation here
+        </TextLink>
+      </Paragraph>
+
+      <Flex
+        padding="spacingM"
+        gap="spacingM"
+        justifyContent="end"
+        style={{
+          position: 'sticky',
+          bottom: 0,
+          background: 'white',
+        }}>
+        <Button variant="primary" size="small" onClick={handleNextStep}>
+          Next
+        </Button>
+      </Flex>
+    </>
   );
 };
 export default FieldsSelectionStep;

--- a/apps/braze/src/components/FieldsSelectionStep.tsx
+++ b/apps/braze/src/components/FieldsSelectionStep.tsx
@@ -1,5 +1,6 @@
-import { Button, Flex, Paragraph, TextLink } from '@contentful/f36-components';
+import { Button, Paragraph, TextLink } from '@contentful/f36-components';
 import { ExternalLinkIcon } from '@contentful/f36-icons';
+import WizardFooter from './WizardFooter';
 
 type FieldsSelectionStepProps = {
   handleNextStep: () => void;
@@ -21,20 +22,11 @@ const FieldsSelectionStep = (props: FieldsSelectionStepProps) => {
           view documentation here
         </TextLink>
       </Paragraph>
-
-      <Flex
-        padding="spacingM"
-        gap="spacingM"
-        justifyContent="end"
-        style={{
-          position: 'sticky',
-          bottom: 0,
-          background: 'white',
-        }}>
+      <WizardFooter>
         <Button variant="primary" size="small" onClick={handleNextStep}>
           Next
         </Button>
-      </Flex>
+      </WizardFooter>
     </>
   );
 };

--- a/apps/braze/src/components/LocalesSelectionStep.tsx
+++ b/apps/braze/src/components/LocalesSelectionStep.tsx
@@ -1,10 +1,74 @@
-import { Paragraph } from '@contentful/f36-components';
+import { Button, Flex, FormControl, Paragraph } from '@contentful/f36-components';
+import { Multiselect } from '@contentful/f36-multiselect';
+import { Dispatch, SetStateAction, useState } from 'react';
 
-const LocalesSelectionStep = () => {
+type LocalesSelectionStepProps = {
+  locales: string[];
+  selectedLocales: string[];
+  setSelectedLocales: Dispatch<SetStateAction<string[]>>;
+  handlePreviousStep: () => void;
+  handleNextStep: () => void;
+};
+const LocalesSelectionStep = (props: LocalesSelectionStepProps) => {
+  const { locales, selectedLocales, setSelectedLocales, handlePreviousStep, handleNextStep } =
+    props;
+
+  const handleSelectItem = (event: { target: { checked: boolean; value: string } }): void => {
+    const { checked, value } = event.target;
+    if (checked) {
+      setSelectedLocales((prevState: string[]) => [...prevState, value]);
+    } else {
+      const newSelectedSpaces = selectedLocales.filter((space: string) => space !== value);
+      setSelectedLocales(newSelectedSpaces);
+    }
+  };
+
   return (
-    <Paragraph fontColor="gray700" lineHeight="lineHeightCondensed">
-      Select the locales you want to reference in Braze messages.
-    </Paragraph>
+    <>
+      <Paragraph fontColor="gray700" lineHeight="lineHeightCondensed">
+        Select the locales you want to reference in Braze messages.
+      </Paragraph>
+
+      <FormControl isRequired isInvalid={selectedLocales.length === 0}>
+        <FormControl.Label>Locales</FormControl.Label>
+
+        <Multiselect
+          currentSelection={selectedLocales}
+          popoverProps={{ isFullWidth: true }}
+          placeholder="Select one or more">
+          {locales.map((local) => {
+            const val = local.toLowerCase().replace(/\s/g, '-');
+            return (
+              <Multiselect.Option
+                key={`key-${val}}`}
+                itemId={`space-${val}}`}
+                value={local}
+                label={local}
+                onSelectItem={handleSelectItem}
+                isChecked={selectedLocales.includes(local)}
+              />
+            );
+          })}
+        </Multiselect>
+      </FormControl>
+
+      <Flex
+        padding="spacingM"
+        gap="spacingM"
+        justifyContent="end"
+        style={{
+          position: 'sticky',
+          bottom: 0,
+          background: 'white',
+        }}>
+        <Button variant="secondary" size="small" onClick={handlePreviousStep}>
+          Back
+        </Button>
+        <Button variant="primary" size="small" onClick={handleNextStep}>
+          Next
+        </Button>
+      </Flex>
+    </>
   );
 };
 export default LocalesSelectionStep;

--- a/apps/braze/src/components/LocalesSelectionStep.tsx
+++ b/apps/braze/src/components/LocalesSelectionStep.tsx
@@ -1,6 +1,7 @@
-import { Button, Flex, FormControl, Paragraph } from '@contentful/f36-components';
+import { Button, FormControl, Paragraph } from '@contentful/f36-components';
 import { Multiselect } from '@contentful/f36-multiselect';
-import { Dispatch, SetStateAction, useState } from 'react';
+import { Dispatch, SetStateAction } from 'react';
+import WizardFooter from './WizardFooter';
 
 type LocalesSelectionStepProps = {
   locales: string[];
@@ -52,22 +53,14 @@ const LocalesSelectionStep = (props: LocalesSelectionStepProps) => {
         </Multiselect>
       </FormControl>
 
-      <Flex
-        padding="spacingM"
-        gap="spacingM"
-        justifyContent="end"
-        style={{
-          position: 'sticky',
-          bottom: 0,
-          background: 'white',
-        }}>
+      <WizardFooter>
         <Button variant="secondary" size="small" onClick={handlePreviousStep}>
           Back
         </Button>
         <Button variant="primary" size="small" onClick={handleNextStep}>
           Next
         </Button>
-      </Flex>
+      </WizardFooter>
     </>
   );
 };

--- a/apps/braze/src/components/WizardFooter.tsx
+++ b/apps/braze/src/components/WizardFooter.tsx
@@ -1,0 +1,19 @@
+import { Flex } from '@contentful/f36-components';
+
+const FieldsSelectionStep = (props: { children: React.ReactNode }) => {
+  const { children } = props;
+  return (
+    <Flex
+      padding="spacingM"
+      gap="spacingM"
+      justifyContent="end"
+      style={{
+        position: 'sticky',
+        bottom: 0,
+        background: 'white',
+      }}>
+      {children}
+    </Flex>
+  );
+};
+export default FieldsSelectionStep;

--- a/apps/braze/src/helpers/assembleQuery.ts
+++ b/apps/braze/src/helpers/assembleQuery.ts
@@ -3,17 +3,20 @@ import { ASSET_FIELDS_QUERY, SAVED_RESPONSE } from './utils';
 
 export type BasicField = {
   id: string;
+  localized: boolean;
   type: Exclude<FieldType, 'Array' | 'Link'>;
 };
 
 export type AssetField = {
   id: string;
+  localized: boolean;
   type: 'Link';
   linkType: 'Asset';
 };
 
 export type EntryField = {
   id: string;
+  localized: boolean;
   type: 'Link';
   linkType: 'Entry';
   entryContentType: string;
@@ -38,6 +41,7 @@ type SymbolItem = {
 
 export type BasicArrayField = {
   id: string;
+  localized: boolean;
   type: 'Array';
   arrayType: 'Symbol';
   items: SymbolItem;
@@ -45,6 +49,7 @@ export type BasicArrayField = {
 
 export type AssetArrayField = {
   id: string;
+  localized: boolean;
   type: 'Array';
   arrayType: 'Asset';
   items: AssetItem;
@@ -52,6 +57,7 @@ export type AssetArrayField = {
 
 export type EntryArrayField = {
   id: string;
+  localized: boolean;
   type: 'Array';
   arrayType: 'Entry';
   items: EntryItem[];

--- a/apps/braze/src/helpers/generateLiquidTags.spec.ts
+++ b/apps/braze/src/helpers/generateLiquidTags.spec.ts
@@ -8,6 +8,7 @@ describe('Generate liquid tags', () => {
     const entryField: Field[] = [
       {
         id: 'title',
+        localized: false,
         type: 'Symbol',
       },
     ];
@@ -22,30 +23,37 @@ describe('Generate liquid tags', () => {
     const entryFields: Field[] = [
       {
         id: 'title',
+        localized: false,
         type: 'Symbol',
       },
       {
         id: 'number',
+        localized: false,
         type: 'Integer',
       },
       {
         id: 'date',
+        localized: false,
         type: 'Date',
       },
       {
         id: 'bool',
+        localized: false,
         type: 'Boolean',
       },
       {
         id: 'longText',
+        localized: false,
         type: 'Text',
       },
       {
         id: 'decimal',
+        localized: false,
         type: 'Number',
       },
       {
         id: 'decimal',
+        localized: false,
         type: 'Number',
       },
     ];
@@ -66,6 +74,7 @@ describe('Generate liquid tags', () => {
     const entryFields: Field[] = [
       {
         id: 'asset',
+        localized: false,
         type: 'Link',
         linkType: 'Asset',
       },
@@ -83,6 +92,7 @@ describe('Generate liquid tags', () => {
     const entryFields: Field[] = [
       {
         id: 'address',
+        localized: false,
         type: 'Location',
       },
     ];
@@ -98,16 +108,19 @@ describe('Generate liquid tags', () => {
     const entryFields: Field[] = [
       {
         id: 'reference',
+        localized: false,
         type: 'Link',
         linkType: 'Entry',
         entryContentType: 'reference',
         fields: [
           {
             id: 'name',
+            localized: false,
             type: 'Symbol',
           },
           {
             id: 'phone',
+            localized: false,
             type: 'Integer',
           },
         ],
@@ -125,12 +138,14 @@ describe('Generate liquid tags', () => {
     const entryFields: Field[] = [
       {
         id: 'reference',
+        localized: false,
         type: 'Link',
         linkType: 'Entry',
         entryContentType: 'reference',
         fields: [
           {
             id: 'asset',
+            localized: false,
             type: 'Link',
             linkType: 'Asset',
           },
@@ -150,22 +165,26 @@ describe('Generate liquid tags', () => {
     const entryFields: Field[] = [
       {
         id: 'reference',
+        localized: false,
         type: 'Link',
         linkType: 'Entry',
         entryContentType: 'reference',
         fields: [
           {
             id: 'referenceWithinAReference',
+            localized: false,
             type: 'Link',
             linkType: 'Entry',
             entryContentType: 'reference',
             fields: [
               {
                 id: 'name',
+                localized: false,
                 type: 'Symbol',
               },
               {
                 id: 'phone',
+                localized: false,
                 type: 'Integer',
               },
             ],
@@ -187,6 +206,7 @@ describe('Generate liquid tags', () => {
     const entryFields: Field[] = [
       {
         id: 'listOfText',
+        localized: false,
         type: 'Array',
         arrayType: 'Symbol',
         items: {
@@ -207,6 +227,7 @@ describe('Generate liquid tags', () => {
     const entryFields: Field[] = [
       {
         id: 'listOfReferences',
+        localized: false,
         type: 'Array',
         arrayType: 'Entry',
         items: [
@@ -217,6 +238,7 @@ describe('Generate liquid tags', () => {
             fields: [
               {
                 id: 'name',
+                localized: false,
                 type: 'Symbol',
               },
             ],
@@ -235,6 +257,7 @@ describe('Generate liquid tags', () => {
     const entryFields: Field[] = [
       {
         id: 'listOfAsset',
+        localized: false,
         type: 'Array',
         arrayType: 'Asset',
         items: {
@@ -256,28 +279,33 @@ describe('Generate liquid tags', () => {
     const entryFields: Field[] = [
       {
         id: 'reference',
+        localized: false,
         type: 'Link',
         linkType: 'Entry',
         entryContentType: 'reference',
         fields: [
           {
             id: 'referenceWithinAReference',
+            localized: false,
             type: 'Link',
             linkType: 'Entry',
             entryContentType: 'reference',
             fields: [
               {
                 id: 'referenceWithAnotherAReference',
+                localized: false,
                 type: 'Link',
                 linkType: 'Entry',
                 entryContentType: 'reference',
                 fields: [
                   {
                     id: 'name',
+                    localized: false,
                     type: 'Symbol',
                   },
                   {
                     id: 'phone',
+                    localized: false,
                     type: 'Integer',
                   },
                 ],

--- a/apps/braze/src/locations/Dialog.tsx
+++ b/apps/braze/src/locations/Dialog.tsx
@@ -1,61 +1,33 @@
 import { DialogAppSDK } from '@contentful/app-sdk';
 import { useAutoResizer, useSDK } from '@contentful/react-apps-toolkit';
-import {
-  generateConnectedContentCall,
-  Field,
-  assembleQuery,
-  getGraphQLResponse,
-} from '../helpers/assembleQuery';
-import generateLiquidTags from '../helpers/generateLiquidTags';
+import { Field } from '../helpers/assembleQuery';
 
-import { Box, Button, Flex } from '@contentful/f36-components';
-import { useEffect, useState } from 'react';
+import { Box } from '@contentful/f36-components';
+import { useState } from 'react';
 import FieldsSelectionStep from '../components/FieldsSelectionStep';
 import CodeBlocksStep from '../components/CodeBlocksStep';
 import LocalesSelectionStep from '../components/LocalesSelectionStep';
 
-export type InvocationParams = {
-  entryId: string;
-  entryFields: Field[];
+export type EntryInfo = {
+  id: string;
+  fields: Field[];
   contentTypeId: string;
 };
 
-const STEPS = ['fields', 'locales', 'codeBlocks'];
-
-function nextStep(step: string): string {
-  const currentStepIndex = STEPS.findIndex((s) => s === step);
-  const nextStepIndex =
-    currentStepIndex < STEPS.length - 1 ? currentStepIndex + 1 : currentStepIndex;
-  return STEPS[nextStepIndex];
-}
-
-function previousStep(step: string): string {
-  const currentStepIndex = STEPS.findIndex((s) => s === step);
-  const nextStepIndex = currentStepIndex > 0 ? currentStepIndex - 1 : currentStepIndex;
-  return STEPS[nextStepIndex];
-}
+const FIELDS_STEP = 'fields';
+const LOCALES_STEP = 'locales';
+const CODE_BLOCKS_STEP = 'codeBlocks';
 
 const Dialog = () => {
   const sdk = useSDK<DialogAppSDK>();
   useAutoResizer();
-  const [graphqlResponse, setGraphqlResponse] = useState<string>('');
   const [step, setStep] = useState('fields');
+  const [selectedLocales, setSelectedLocales] = useState<string[]>([sdk.locales.default]);
 
-  const spaceId = sdk.ids.space;
-  const token = sdk.parameters.installation.apiKey;
-  const invocationParams = sdk.parameters.invocation as InvocationParams;
-  const contentTypeId = invocationParams.contentTypeId;
-  const entryId = invocationParams.entryId;
-  const query = assembleQuery(contentTypeId, entryId, invocationParams.entryFields);
-  const connectedContentCall = generateConnectedContentCall(query, spaceId, token);
-  const liquidTags = generateLiquidTags(contentTypeId, invocationParams.entryFields);
-  useEffect(() => {
-    const fetchEntry = async () => {
-      const response = await getGraphQLResponse(spaceId, token, query);
-      setGraphqlResponse(JSON.stringify(response));
-    };
-    fetchEntry();
-  }, []);
+  const entryInfo = sdk.parameters.invocation as EntryInfo;
+  const locales = sdk.locales.available;
+  const anyFieldIsLocalized = entryInfo.fields.some((field) => field.localized);
+  const shouldChooseLocales = locales.length > 1 && anyFieldIsLocalized;
 
   return (
     <Box
@@ -63,46 +35,29 @@ const Dialog = () => {
       paddingTop="spacingM"
       paddingLeft="spacingL"
       paddingRight="spacingL">
-      {step === 'fields' && <FieldsSelectionStep></FieldsSelectionStep>}
-      {step === 'locales' && <LocalesSelectionStep></LocalesSelectionStep>}
-      {step === 'codeBlocks' && (
-        <CodeBlocksStep
-          connectedContentCall={connectedContentCall}
-          liquidTags={liquidTags}
-          graphqlResponse={graphqlResponse}></CodeBlocksStep>
+      {step === FIELDS_STEP && (
+        <FieldsSelectionStep
+          handleNextStep={() =>
+            setStep(shouldChooseLocales ? LOCALES_STEP : CODE_BLOCKS_STEP)
+          }></FieldsSelectionStep>
       )}
-
-      <Flex
-        padding="spacingM"
-        gap="spacingM"
-        justifyContent="end"
-        style={{
-          position: 'sticky',
-          bottom: 0,
-          background: 'white',
-        }}>
-        {step !== 'fields' && (
-          <Button
-            variant="secondary"
-            size="small"
-            onClick={() => setStep((currentStep) => previousStep(currentStep))}>
-            Back
-          </Button>
-        )}
-        {step !== 'codeBlocks' && (
-          <Button
-            variant="primary"
-            size="small"
-            onClick={() => setStep((currentStep) => nextStep(currentStep))}>
-            Next
-          </Button>
-        )}
-        {step === 'codeBlocks' && (
-          <Button variant="primary" size="small" onClick={() => sdk.close()}>
-            Close
-          </Button>
-        )}
-      </Flex>
+      {step === LOCALES_STEP && (
+        <LocalesSelectionStep
+          locales={locales}
+          selectedLocales={selectedLocales}
+          setSelectedLocales={setSelectedLocales}
+          handlePreviousStep={() => setStep(FIELDS_STEP)}
+          handleNextStep={() => setStep(CODE_BLOCKS_STEP)}></LocalesSelectionStep>
+      )}
+      {step === CODE_BLOCKS_STEP && (
+        <CodeBlocksStep
+          spaceId={sdk.ids.space}
+          contentfulToken={sdk.parameters.installation.apiKey}
+          entryInfo={entryInfo}
+          selectedLocales={selectedLocales}
+          handlePreviousStep={() => setStep(shouldChooseLocales ? LOCALES_STEP : FIELDS_STEP)}
+          handleClose={() => sdk.close()}></CodeBlocksStep>
+      )}
     </Box>
   );
 };

--- a/apps/braze/src/locations/Dialog.tsx
+++ b/apps/braze/src/locations/Dialog.tsx
@@ -37,9 +37,8 @@ const Dialog = () => {
       paddingRight="spacingL">
       {step === FIELDS_STEP && (
         <FieldsSelectionStep
-          handleNextStep={() =>
-            setStep(shouldChooseLocales ? LOCALES_STEP : CODE_BLOCKS_STEP)
-          }></FieldsSelectionStep>
+          handleNextStep={() => setStep(shouldChooseLocales ? LOCALES_STEP : CODE_BLOCKS_STEP)}
+        />
       )}
       {step === LOCALES_STEP && (
         <LocalesSelectionStep
@@ -47,7 +46,8 @@ const Dialog = () => {
           selectedLocales={selectedLocales}
           setSelectedLocales={setSelectedLocales}
           handlePreviousStep={() => setStep(FIELDS_STEP)}
-          handleNextStep={() => setStep(CODE_BLOCKS_STEP)}></LocalesSelectionStep>
+          handleNextStep={() => setStep(CODE_BLOCKS_STEP)}
+        />
       )}
       {step === CODE_BLOCKS_STEP && (
         <CodeBlocksStep
@@ -56,7 +56,8 @@ const Dialog = () => {
           entryInfo={entryInfo}
           selectedLocales={selectedLocales}
           handlePreviousStep={() => setStep(shouldChooseLocales ? LOCALES_STEP : FIELDS_STEP)}
-          handleClose={() => sdk.close()}></CodeBlocksStep>
+          handleClose={() => sdk.close()}
+        />
       )}
     </Box>
   );

--- a/apps/braze/src/locations/Sidebar.tsx
+++ b/apps/braze/src/locations/Sidebar.tsx
@@ -2,7 +2,7 @@ import { SidebarAppSDK } from '@contentful/app-sdk';
 import { Button } from '@contentful/f36-components';
 import { useAutoResizer, useSDK } from '@contentful/react-apps-toolkit';
 import { transformEntryFields } from '../helpers/transformEntryFields';
-import { InvocationParams } from './Dialog';
+import { EntryInfo } from './Dialog';
 import { useEffect, useState } from 'react';
 import { createClient } from 'contentful-management';
 import { Field } from '../helpers/assembleQuery';
@@ -33,9 +33,9 @@ const Sidebar = () => {
     fetchEntry();
   }, []);
 
-  const invocationParams: InvocationParams = {
-    entryId: sdk.ids.entry,
-    entryFields: entryFields,
+  const invocationParams: EntryInfo = {
+    id: sdk.ids.entry,
+    fields: entryFields,
     contentTypeId: sdk.ids.contentType,
   };
 
@@ -49,6 +49,7 @@ const Sidebar = () => {
         sdk.dialogs.openCurrentApp({
           title: 'Generate Braze Connected Content Call',
           parameters: invocationParams,
+          width: 'fullWidth',
         });
       }}>
       Generate Braze Connected Content

--- a/apps/braze/test/mocks/mockSdk.ts
+++ b/apps/braze/test/mocks/mockSdk.ts
@@ -19,10 +19,14 @@ const mockSdk: any = {
       apiKey: 'test-apiKey',
     },
     invocation: {
-      entryId: 'test-entryId',
-      entryFields: [], // TODO: add fields?
+      id: 'test-entryId',
+      fields: [], // TODO: add fields?
       contentTypeId: 'test-contentTypeId',
     },
+  },
+  locales: {
+    default: 'en-US',
+    available: ['en-US', 'es-AR'],
   },
 };
 


### PR DESCRIPTION
## Purpose

Users are now able to select the locales so they can be used when generating the liquid tags

## Approach

The locales are retrieved from the space. If the entry has no localized fields, the step is skipped.

## Testing steps

Use the app with an entry that has localized fields

## Breaking Changes

N/A

## Dependencies and/or References

N/A

## Deployment

N/A
