### PR TITLE
fix: update Vite config in JS and TS example apps [EXT-6273]

### DIFF
--- a/examples/javascript/package.json
+++ b/examples/javascript/package.json
@@ -13,13 +13,14 @@
     "react-dom": "18.3.1"
   },
   "scripts": {
+    "start": "vite",
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest",
     "create-app-definition": "contentful-app-scripts create-app-definition",
-    "upload": "contentful-app-scripts upload --bundle-dir ./dist",
-    "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./dist --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN"
+    "upload": "contentful-app-scripts upload --bundle-dir ./build",
+    "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN"
   },
   "eslintConfig": {
     "extends": "react-app"
@@ -37,14 +38,14 @@
     ]
   },
   "devDependencies": {
-    "@contentful/app-scripts": "1.33.2",
+    "@contentful/app-scripts": "^2.2.0",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^14.3.1",
     "@vitejs/plugin-react": "^4.0.3",
     "cross-env": "7.0.3",
     "jsdom": "^26.0.0",
-    "vite": "^5.0.0",
-    "vitest": "^1.6.1"
+    "vite": "^6.2.2",
+    "vitest": "^3.0.9"
   },
   "homepage": "."
 }

--- a/examples/javascript/vite.config.mjs
+++ b/examples/javascript/vite.config.mjs
@@ -9,4 +9,11 @@ export default defineConfig({
     setupFiles: './src/setupTests.js', // Equivalent to Jest's setup file
   },
   base: '',
+  build: {
+    outDir: 'build',
+  },
+  server: {
+    host: 'localhost',
+    port: 3000,
+  },
 });

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -7,20 +7,20 @@
     "@contentful/f36-components": "4.78.0",
     "@contentful/f36-tokens": "4.2.0",
     "@contentful/react-apps-toolkit": "1.2.16",
-    "@types/node": "^22.13.5",
     "contentful-management": "10.46.4",
     "emotion": "10.0.27",
     "react": "18.3.1",
     "react-dom": "18.3.1"
   },
   "scripts": {
+    "start": "vite",
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest",
     "create-app-definition": "contentful-app-scripts create-app-definition",
-    "upload": "contentful-app-scripts upload --bundle-dir ./dist",
-    "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./dist --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN"
+    "upload": "contentful-app-scripts upload --bundle-dir ./build",
+    "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN"
   },
   "eslintConfig": {
     "extends": "react-app"
@@ -38,18 +38,18 @@
     ]
   },
   "devDependencies": {
-    "@contentful/app-scripts": "1.33.2",
+    "@contentful/app-scripts": "^2.2.0",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^14.3.1",
-    "@tsconfig/create-react-app": "2.0.5",
+    "@types/node": "^22.13.5",
     "@types/react": "18.3.13",
     "@types/react-dom": "18.3.1",
     "@vitejs/plugin-react": "^4.0.3",
     "cross-env": "7.0.3",
     "jsdom": "^26.0.0",
     "typescript": "4.9.5",
-    "vite": "^5.0.0",
-    "vitest": "^1.6.1"
+    "vite": "^6.2.2",
+    "vitest": "^3.0.9"
   },
   "homepage": "."
 }

--- a/examples/typescript/src/App.tsx
+++ b/examples/typescript/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { locations } from '@contentful/app-sdk';
 import ConfigScreen from './locations/ConfigScreen';
 import Field from './locations/Field';

--- a/examples/typescript/src/components/LocalhostWarning.tsx
+++ b/examples/typescript/src/components/LocalhostWarning.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Paragraph, TextLink, Note, Flex } from '@contentful/f36-components';
 
 const LocalhostWarning = () => {

--- a/examples/typescript/src/locations/ConfigScreen.spec.tsx
+++ b/examples/typescript/src/locations/ConfigScreen.spec.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ConfigScreen from './ConfigScreen';
 import { render } from '@testing-library/react';
 import { mockCma, mockSdk } from '../../test/mocks';

--- a/examples/typescript/src/locations/ConfigScreen.tsx
+++ b/examples/typescript/src/locations/ConfigScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, useEffect } from 'react';
+import { useCallback, useState, useEffect } from 'react';
 import { ConfigAppSDK } from '@contentful/app-sdk';
 import { Heading, Form, Paragraph, Flex } from '@contentful/f36-components';
 import { css } from 'emotion';

--- a/examples/typescript/src/locations/Dialog.spec.tsx
+++ b/examples/typescript/src/locations/Dialog.spec.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Dialog from './Dialog';
 import { render } from '@testing-library/react';
 import { mockCma, mockSdk } from '../../test/mocks';

--- a/examples/typescript/src/locations/Dialog.tsx
+++ b/examples/typescript/src/locations/Dialog.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Paragraph } from '@contentful/f36-components';
 import { DialogAppSDK } from '@contentful/app-sdk';
 import { /* useCMA, */ useSDK } from '@contentful/react-apps-toolkit';

--- a/examples/typescript/src/locations/EntryEditor.spec.tsx
+++ b/examples/typescript/src/locations/EntryEditor.spec.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import EntryEditor from './EntryEditor';
 import { render } from '@testing-library/react';
 import { mockCma, mockSdk } from '../../test/mocks';

--- a/examples/typescript/src/locations/EntryEditor.tsx
+++ b/examples/typescript/src/locations/EntryEditor.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Paragraph } from '@contentful/f36-components';
 import { EditorAppSDK } from '@contentful/app-sdk';
 import { /* useCMA, */ useSDK } from '@contentful/react-apps-toolkit';

--- a/examples/typescript/src/locations/Field.spec.tsx
+++ b/examples/typescript/src/locations/Field.spec.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Field from './Field';
 import { render } from '@testing-library/react';
 import { mockCma, mockSdk } from '../../test/mocks';

--- a/examples/typescript/src/locations/Field.tsx
+++ b/examples/typescript/src/locations/Field.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Paragraph } from '@contentful/f36-components';
 import { FieldAppSDK } from '@contentful/app-sdk';
 import { /* useCMA, */ useSDK } from '@contentful/react-apps-toolkit';

--- a/examples/typescript/src/locations/Home.spec.tsx
+++ b/examples/typescript/src/locations/Home.spec.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Home from './Home';
 import { render } from '@testing-library/react';
 import { mockCma, mockSdk } from '../../test/mocks';

--- a/examples/typescript/src/locations/Home.tsx
+++ b/examples/typescript/src/locations/Home.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Paragraph } from '@contentful/f36-components';
 import { HomeAppSDK } from '@contentful/app-sdk';
 import { /* useCMA, */ useSDK } from '@contentful/react-apps-toolkit';

--- a/examples/typescript/src/locations/Page.spec.tsx
+++ b/examples/typescript/src/locations/Page.spec.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Page from './Page';
 import { render } from '@testing-library/react';
 import { mockCma, mockSdk } from '../../test/mocks';

--- a/examples/typescript/src/locations/Page.tsx
+++ b/examples/typescript/src/locations/Page.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Paragraph } from '@contentful/f36-components';
 import { PageAppSDK } from '@contentful/app-sdk';
 import { /* useCMA, */ useSDK } from '@contentful/react-apps-toolkit';

--- a/examples/typescript/src/locations/Sidebar.spec.tsx
+++ b/examples/typescript/src/locations/Sidebar.spec.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Sidebar from './Sidebar';
 import { render } from '@testing-library/react';
 import { mockCma, mockSdk } from '../../test/mocks';

--- a/examples/typescript/src/locations/Sidebar.tsx
+++ b/examples/typescript/src/locations/Sidebar.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Paragraph } from '@contentful/f36-components';
 import { SidebarAppSDK } from '@contentful/app-sdk';
 import { /* useCMA, */ useSDK } from '@contentful/react-apps-toolkit';

--- a/examples/typescript/src/react-app-env.d.ts
+++ b/examples/typescript/src/react-app-env.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="react-scripts" />

--- a/examples/typescript/tsconfig.json
+++ b/examples/typescript/tsconfig.json
@@ -1,8 +1,17 @@
 {
-  "extends": "@tsconfig/create-react-app/tsconfig.json",
   "compilerOptions": {
-    "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"]
+    "target": "ESNext",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
   },
   "include": ["src"],
   "exclude": ["actions", "functions"]

--- a/examples/typescript/vite.config.mts
+++ b/examples/typescript/vite.config.mts
@@ -9,4 +9,11 @@ export default defineConfig({
     setupFiles: './src/setupTests.ts', // Equivalent to Jest's setup file
   },
   base: '',
+  build: {
+    outDir: 'build',
+  },
+  server: {
+    host: 'localhost',
+    port: 3000,
+  },
 });


### PR DESCRIPTION
## Purpose

We updated the JS and TS apps to use Vite instead of CRA in this PR: https://github.com/contentful/apps/pull/9516. This is a follow up PR to fix a few items in these examples; fixing a bug with how these templates work with the function templates and updating some dependencies.

## Approach

Here's a summary of the updates:
- When CCA users use a function template, the resulting code is based off of these TS or JS examples with functions added to them. The functions build script expects the build to be in a `./build` directory, but these examples were set to `./dist` for the build directory. In order to accommodate the functions templates, we are changing the build directory to `./build` for these TS and JS templates
- Added a `npm start` script in addition to `npm dev` since the `README` and `index.html` files mention running `npm start` to get started with the template
- Bumped Vite, Vitest, and App Scripts dependencies
- Made the port for the local server `3000`, since this is the default used by App Scripts when creating an app definition
- Removed CRA tsconfig from the TS example and updated the tsconfig with a base config
- Removed the unneeded React import from the TS components
- Renamed the `vite.config` files to import the ESM build of Vite and remove a warning ([see more here](https://vite.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated))

## Testing steps

I tested this locally within this repo and also with the CCA by pointing to this branch. I tested this with the TS and JS base templates and also the function templates.

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
