### PR TITLE
chore: update dev doc links in function templates [EXT-5566]

### DIFF
--- a/function-examples/appaction-call/javascript/INSTRUCTIONS.md
+++ b/function-examples/appaction-call/javascript/INSTRUCTIONS.md
@@ -32,7 +32,7 @@ This command will generate a basic app template that includes:
 - All necessary scripts for building and deploying your function
 - App manifest file
 - This file ensures that Contentful can properly identify, configure, and run your function.
-  - For more information see: [Creating and Uploading a Function - Tutorial](https://www.contentful.com/developers/docs/extensibility/app-framework/function-tutorial/)
+  - For more information see: [Working with Functions](https://www.contentful.com/developers/docs/extensibility/app-framework/working-with-functions/)
 
 #### Adding the Function to an Existing App
 
@@ -260,4 +260,5 @@ If you're adding actions programmatically, you must update the `actions` array i
 ## Additional Resources
 
 - [Contentful App Functions Documentation](https://www.contentful.com/developers/docs/extensibility/app-framework/functions/)
+- [Working with Functions](https://www.contentful.com/developers/docs/extensibility/app-framework/working-with-functions/)
 - [App Actions Overview](https://www.contentful.com/developers/docs/extensibility/app-framework/app-actions/)

--- a/function-examples/appaction-call/typescript/INSTRUCTIONS.md
+++ b/function-examples/appaction-call/typescript/INSTRUCTIONS.md
@@ -32,7 +32,7 @@ This command will generate a basic app template that includes:
 - All necessary scripts for building and deploying your function
 - App manifest file
   - This file ensures that Contentful can properly identify, configure, and run your function.
-  - For more information see: [Creating and Uploading a Function - Tutorial](https://www.contentful.com/developers/docs/extensibility/app-framework/function-tutorial/)
+  - For more information see: [Working with Functions](https://www.contentful.com/developers/docs/extensibility/app-framework/working-with-functions/)
 
 #### Adding the Function to an Existing App
 
@@ -261,4 +261,5 @@ If you're adding actions programmatically, you must update the `actions` array i
 ## Additional Resources
 
 - [Contentful App Functions Documentation](https://www.contentful.com/developers/docs/extensibility/app-framework/functions/)
+- [Working with Functions](https://www.contentful.com/developers/docs/extensibility/app-framework/working-with-functions/)
 - [App Actions Overview](https://www.contentful.com/developers/docs/extensibility/app-framework/app-actions/)

--- a/function-examples/appevent-filter/javascript/INSTRUCTIONS.md
+++ b/function-examples/appevent-filter/javascript/INSTRUCTIONS.md
@@ -29,7 +29,7 @@ This command will generate a basic app template that includes:
 - All necessary scripts for building and deploying your function
 - App manifest file
   - This file ensures that Contentful can properly identify, configure, and run your function.
-  - For more information see: [Creating and Uploading a Function - Tutorial](https://www.contentful.com/developers/docs/extensibility/app-framework/function-tutorial/)
+  - For more information see: [Working with Functions](https://www.contentful.com/developers/docs/extensibility/app-framework/working-with-functions/)
 
 #### Adding the Function to an Existing App
 
@@ -220,5 +220,6 @@ Use the CMA to programmatically subscribe your function to events. This approach
 ## Additional Resources
 
 - [Contentful App Functions Documentation](https://www.contentful.com/developers/docs/extensibility/app-framework/functions/)
+- [Working with Functions](https://www.contentful.com/developers/docs/extensibility/app-framework/working-with-functions/)
 - [App Event Subscriptions API Reference](https://www.contentful.com/developers/docs/references/content-management-api/#/reference/app-event-subscriptions)
 - [App Events Overview](https://www.contentful.com/developers/docs/extensibility/app-framework/app-events/)

--- a/function-examples/appevent-filter/typescript/INSTRUCTIONS.md
+++ b/function-examples/appevent-filter/typescript/INSTRUCTIONS.md
@@ -29,7 +29,7 @@ This command will generate a basic app template that includes:
 - All necessary scripts for building and deploying your function
 - App manifest file
   - This file ensures that Contentful can properly identify, configure, and run your function.
-  - For more information see: [Creating and Uploading a Function - Tutorial](https://www.contentful.com/developers/docs/extensibility/app-framework/function-tutorial/)
+  - For more information see: [Working with Functions](https://www.contentful.com/developers/docs/extensibility/app-framework/working-with-functions/)
 
 #### Adding the Function to an Existing App
 
@@ -220,5 +220,6 @@ Use the CMA to programmatically subscribe your function to events. This approach
 ## Additional Resources
 
 - [Contentful App Functions Documentation](https://www.contentful.com/developers/docs/extensibility/app-framework/functions/)
+- [Working with Functions](https://www.contentful.com/developers/docs/extensibility/app-framework/working-with-functions/)
 - [App Event Subscriptions API Reference](https://www.contentful.com/developers/docs/references/content-management-api/#/reference/app-event-subscriptions)
 - [App Events Overview](https://www.contentful.com/developers/docs/extensibility/app-framework/app-events/)

--- a/function-examples/appevent-handler/javascript/INSTRUCTIONS.md
+++ b/function-examples/appevent-handler/javascript/INSTRUCTIONS.md
@@ -30,7 +30,7 @@ This command will generate a basic app template that includes:
 - All necessary scripts for building and deploying your function
 - App manifest file
   - This file ensures that Contentful can properly identify, configure, and run your function.
-  - For more information see: [Creating and Uploading a Function - Tutorial](https://www.contentful.com/developers/docs/extensibility/app-framework/function-tutorial/)
+  - For more information see: [Working with Functions](https://www.contentful.com/developers/docs/extensibility/app-framework/working-with-functions/)
 
 #### Adding the Function to an Existing App
 
@@ -244,5 +244,6 @@ Use the CMA to programmatically subscribe your function to events. This approach
 ## Additional Resources
 
 - [Contentful App Functions Documentation](https://www.contentful.com/developers/docs/extensibility/app-framework/functions/)
+- [Working with Functions](https://www.contentful.com/developers/docs/extensibility/app-framework/working-with-functions/)
 - [App Event Subscriptions API Reference](https://www.contentful.com/developers/docs/references/content-management-api/#/reference/app-event-subscriptions)
 - [App Events Overview](https://www.contentful.com/developers/docs/extensibility/app-framework/app-events/)

--- a/function-examples/appevent-handler/typescript/INSTRUCTIONS.md
+++ b/function-examples/appevent-handler/typescript/INSTRUCTIONS.md
@@ -30,7 +30,7 @@ This command will generate a basic app template that includes:
 - All necessary scripts for building and deploying your function
 - App manifest file
   - This file ensures that Contentful can properly identify, configure, and run your function.
-  - For more information see: [Creating and Uploading a Function - Tutorial](https://www.contentful.com/developers/docs/extensibility/app-framework/function-tutorial/)
+  - For more information see: [Working with Functions](https://www.contentful.com/developers/docs/extensibility/app-framework/working-with-functions/)
 
 #### Adding the Function to an Existing App
 
@@ -246,5 +246,6 @@ Use the CMA to programmatically subscribe your function to events. This approach
 ## Additional Resources
 
 - [Contentful App Functions Documentation](https://www.contentful.com/developers/docs/extensibility/app-framework/functions/)
+- [Working with Functions](https://www.contentful.com/developers/docs/extensibility/app-framework/working-with-functions/)
 - [App Event Subscriptions API Reference](https://www.contentful.com/developers/docs/references/content-management-api/#/reference/app-event-subscriptions)
 - [App Events Overview](https://www.contentful.com/developers/docs/extensibility/app-framework/app-events/)

--- a/function-examples/appevent-transformation/javascript/INSTRUCTIONS.md
+++ b/function-examples/appevent-transformation/javascript/INSTRUCTIONS.md
@@ -32,7 +32,7 @@ This command will generate a basic app template that includes:
 - All necessary scripts for building and deploying your function
 - App manifest file
   - This file ensures that Contentful can properly identify, configure, and run your function.
-  - For more information see: [Creating and Uploading a Function - Tutorial](https://www.contentful.com/developers/docs/extensibility/app-framework/function-tutorial/)
+  - For more information see: [Working with Functions](https://www.contentful.com/developers/docs/extensibility/app-framework/working-with-functions/)
 
 #### Adding the Function to an Existing App
 
@@ -259,5 +259,6 @@ Use the CMA to programmatically subscribe your function to events. This approach
 ## Additional Resources
 
 - [Contentful App Functions Documentation](https://www.contentful.com/developers/docs/extensibility/app-framework/functions/)
+- [Working with Functions](https://www.contentful.com/developers/docs/extensibility/app-framework/working-with-functions/)
 - [App Event Subscriptions API Reference](https://www.contentful.com/developers/docs/references/content-management-api/#/reference/app-event-subscriptions)
 - [App Events Overview](https://www.contentful.com/developers/docs/extensibility/app-framework/app-events/)

--- a/function-examples/appevent-transformation/typescript/INSTRUCTIONS.md
+++ b/function-examples/appevent-transformation/typescript/INSTRUCTIONS.md
@@ -32,7 +32,7 @@ This command will generate a basic app template that includes:
 - All necessary scripts for building and deploying your function
 - App manifest file
   - This file ensures that Contentful can properly identify, configure, and run your function.
-  - For more information see: [Creating and Uploading a Function - Tutorial](https://www.contentful.com/developers/docs/extensibility/app-framework/function-tutorial/)
+  - For more information see: [Working with Functions](https://www.contentful.com/developers/docs/extensibility/app-framework/working-with-functions/)
 
 #### Adding the Function to an Existing App
 
@@ -263,5 +263,6 @@ Use the CMA to programmatically subscribe your function to events. This approach
 ## Additional Resources
 
 - [Contentful App Functions Documentation](https://www.contentful.com/developers/docs/extensibility/app-framework/functions/)
+- [Working with Functions](https://www.contentful.com/developers/docs/extensibility/app-framework/working-with-functions/)
 - [App Event Subscriptions API Reference](https://www.contentful.com/developers/docs/references/content-management-api/#/reference/app-event-subscriptions)
 - [App Events Overview](https://www.contentful.com/developers/docs/extensibility/app-framework/app-events/)

--- a/function-examples/external-references/javascript/INSTRUCTIONS.md
+++ b/function-examples/external-references/javascript/INSTRUCTIONS.md
@@ -26,4 +26,9 @@ Supported field types for field data resolution are: Short text (`Symbol`) or JS
 To set up the field location for your app use the [web UI](https://app.contentful.com/deeplink?link=app-definition-list) by going under the "Locations" section in the app details UI, then selecting the appropriate supported locations. After [installing an app to your space environment](https://www.contentful.com/developers/docs/extensibility/app-framework/tutorial/#install-your-app-to-a-space), you can go under the [respective content type](https://app.contentful.com/deeplink?link=content-model) you want to assign the app and visit the appearance section for supported field and selecting the app which will reveal a checkbox to resolve the field when using Contentful's GraphQL API.
 
 ### Using GraphQL app to see your app in action
-The simplest way test whether your app is resolving data correctly is to install the [GraphQL Playground app](https://app.contentful.com/deeplink?link=apps&id=graphql-playground). You should see a new field with a suffix `_data` when querying for your content type, which should contain data resolved from your app.
+The simplest way test whether your app is resolving data correctly is to install the [GraphiQL app](https://app.contentful.com/deeplink?link=apps&id=graphiql). You should see a new field with a suffix `_data` when querying for your content type, which should contain data resolved from your app.
+
+## Additional Resources
+
+- [Contentful App Functions Documentation](https://www.contentful.com/developers/docs/extensibility/app-framework/functions/)
+- [Working with Functions](https://www.contentful.com/developers/docs/extensibility/app-framework/working-with-functions/)

--- a/function-examples/external-references/typescript/INSTRUCTIONS.md
+++ b/function-examples/external-references/typescript/INSTRUCTIONS.md
@@ -26,4 +26,9 @@ The field is required to be one of the supported types for function: Short text 
 To set up the field location for your app use the [web UI](https://app.contentful.com/deeplink?link=app-definition-list) by going under the "Locations" section in the app details UI, then selecting the appropriate supported locations. After [installing an app to your space environment](https://www.contentful.com/developers/docs/extensibility/app-framework/tutorial/#install-your-app-to-a-space), you can go under the [respective content type](https://app.contentful.com/deeplink?link=content-model) you want to assign the app and visit the appearance section for supported field and selecting the app which will reveal a checkbox to resolve the field when using Contentful's GraphQL API.
 
 ### Using GraphQL app to see your app in action
-The simplest way test whether your app is resolving data correctly is to install the [GraphQL Playground app](https://app.contentful.com/deeplink?link=apps&id=graphql-playground). You should see a new field with a suffix `_data` when querying for your content type, which should contain data resolved from your app.
+The simplest way test whether your app is resolving data correctly is to install the [GraphiQL app](https://app.contentful.com/deeplink?link=apps&id=graphiql). You should see a new field with a suffix `_data` when querying for your content type, which should contain data resolved from your app.
+
+## Additional Resources
+
+- [Contentful App Functions Documentation](https://www.contentful.com/developers/docs/extensibility/app-framework/functions/)
+- [Working with Functions](https://www.contentful.com/developers/docs/extensibility/app-framework/working-with-functions/)

--- a/function-examples/kitchen-sink/javascript/INSTRUCTIONS.md
+++ b/function-examples/kitchen-sink/javascript/INSTRUCTIONS.md
@@ -184,5 +184,6 @@ Create Event Subscriptions via the Web UI or using the Content Management API. W
 ## Additional Resources
 
 - [Contentful App Functions Documentation](https://www.contentful.com/developers/docs/extensibility/app-framework/functions/)
+- [Working with Functions](https://www.contentful.com/developers/docs/extensibility/app-framework/working-with-functions/)
 - [App Actions Overview](https://www.contentful.com/developers/docs/extensibility/app-framework/app-actions/)
 - [App Events Overview](https://www.contentful.com/developers/docs/extensibility/app-framework/app-events/)

--- a/function-examples/kitchen-sink/typescript/INSTRUCTIONS.md
+++ b/function-examples/kitchen-sink/typescript/INSTRUCTIONS.md
@@ -184,5 +184,6 @@ Create Event Subscriptions via the Web UI or using the Content Management API. W
 ## Additional Resources
 
 - [Contentful App Functions Documentation](https://www.contentful.com/developers/docs/extensibility/app-framework/functions/)
+- [Working with Functions](https://www.contentful.com/developers/docs/extensibility/app-framework/working-with-functions/)
 - [App Actions Overview](https://www.contentful.com/developers/docs/extensibility/app-framework/app-actions/)
 - [App Events Overview](https://www.contentful.com/developers/docs/extensibility/app-framework/app-events/)


### PR DESCRIPTION
## Purpose

The `INSTRUCTIONS.md` files in our new function templates were referencing a [CER tutorial](https://www.contentful.com/developers/docs/extensibility/app-framework/function-tutorial/). Now that we published the new [Working with Functions](https://www.contentful.com/developers/docs/extensibility/app-framework/working-with-functions/) guide, we want to link this guide instead.

## Approach

Change all references to the old tutorial to instead link to the new guide.

Also, in the `external-references` template, I added additional resources links and removed reference to the deprecated GraphQL Playground app and instead replaced that with the new GraphiQL app link.

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
