### PR TITLE
Fix queries case

### DIFF
--- a/apps/braze/src/fields/Entry.ts
+++ b/apps/braze/src/fields/Entry.ts
@@ -1,4 +1,4 @@
-import { SAVED_RESPONSE } from '../utils';
+import { firstLetterToLowercase, SAVED_RESPONSE } from '../utils';
 import { Field } from './Field';
 
 export class Entry {
@@ -16,7 +16,7 @@ export class Entry {
     contentfulToken: string
   ) {
     this.id = id;
-    this.contentType = contentType;
+    this.contentType = firstLetterToLowercase(contentType);
     this.fields = fields;
     this.spaceId = spaceId;
     this.contentfulToken = contentfulToken;

--- a/apps/braze/src/fields/Field.ts
+++ b/apps/braze/src/fields/Field.ts
@@ -1,4 +1,4 @@
-import { SAVED_RESPONSE } from '../utils';
+import { firstLetterToLowercase, SAVED_RESPONSE } from '../utils';
 
 export abstract class Field {
   public id: string;
@@ -6,8 +6,8 @@ export abstract class Field {
   public entryContentTypeId: string;
 
   constructor(id: string, entryContentTypeId: string, localized: boolean) {
-    this.id = id;
-    this.entryContentTypeId = entryContentTypeId;
+    this.id = firstLetterToLowercase(id);
+    this.entryContentTypeId = firstLetterToLowercase(entryContentTypeId);
     this.localized = localized;
   }
 

--- a/apps/braze/src/fields/FieldsFactory.ts
+++ b/apps/braze/src/fields/FieldsFactory.ts
@@ -20,6 +20,7 @@ export class FieldsFactory {
     depth: number = 1
   ): Promise<Field[]> {
     const contentType = await cma.contentType.get({ contentTypeId: entry.sys.contentType.sys.id });
+    const contentTypeId = entry.sys.contentType.sys.id;
     const fields = [];
     for (const [name, fieldsValues] of Object.entries(entry.fields)) {
       const field = Object.values(fieldsValues as { [key: string]: any })[0];
@@ -27,10 +28,11 @@ export class FieldsFactory {
       if (!fieldInfo) {
         throw new Error('Field not found');
       }
+      const localized = fieldInfo.localized;
 
       if (fieldInfo.type === 'Link') {
         if (fieldInfo.linkType === 'Asset') {
-          const newField = new AssetField(name, contentType.name, fieldInfo.localized);
+          const newField = new AssetField(name, contentTypeId, localized);
           fields.push(newField);
         } else {
           if (depth >= this.NESTED_DEPTH) {
@@ -38,8 +40,8 @@ export class FieldsFactory {
           }
           const newField = new ReferenceField(
             name,
-            contentType.name,
-            fieldInfo.localized,
+            contentTypeId,
+            localized,
             field.sys.contentType.sys.id,
             await this.createFields(field, cma, depth + 1)
           );
@@ -47,10 +49,10 @@ export class FieldsFactory {
         }
       } else if (fieldInfo.type === 'Array') {
         if (fieldInfo.items && fieldInfo.items.type === 'Symbol') {
-          const newField = new TextArrayField(name, contentType.name, fieldInfo.localized);
+          const newField = new TextArrayField(name, contentTypeId, localized);
           fields.push(newField);
         } else if (fieldInfo.items && fieldInfo.items.linkType === 'Asset') {
-          const newField = new AssetArrayField(name, contentType.name, fieldInfo.localized);
+          const newField = new AssetArrayField(name, contentTypeId, localized);
           fields.push(newField);
         } else {
           if (depth >= this.NESTED_DEPTH) {
@@ -64,23 +66,18 @@ export class FieldsFactory {
               );
             })
           );
-          const newField = new ReferenceArrayField(
-            name,
-            contentType.name,
-            fieldInfo.localized,
-            items
-          );
+          const newField = new ReferenceArrayField(name, contentTypeId, localized, items);
           fields.push(newField);
         }
       } else {
         if (fieldInfo.type === 'RichText') {
-          const newField = new RichTextField(name, contentType.name, fieldInfo.localized);
+          const newField = new RichTextField(name, contentTypeId, localized);
           fields.push(newField);
         } else if (fieldInfo.type === 'Location') {
-          const newField = new LocationField(name, contentType.name, fieldInfo.localized);
+          const newField = new LocationField(name, contentTypeId, localized);
           fields.push(newField);
         } else {
-          const newField = new BasicField(name, contentType.name, fieldInfo.localized);
+          const newField = new BasicField(name, contentTypeId, localized);
           fields.push(newField);
         }
       }

--- a/apps/braze/src/utils.ts
+++ b/apps/braze/src/utils.ts
@@ -18,5 +18,5 @@ export function capitalize(s: string): string {
 }
 
 export function firstLetterToLowercase(s: string): string {
-  return s.charAt(0).toLocaleLowerCase() + s.slice(1);
+  return s.charAt(0).toLowerCase() + s.slice(1);
 }

--- a/apps/braze/src/utils.ts
+++ b/apps/braze/src/utils.ts
@@ -16,3 +16,7 @@ export const SIDEBAR_BUTTON_TEXT = 'Generate Braze Connected Content';
 export function capitalize(s: string): string {
   return s.charAt(0).toUpperCase() + s.slice(1);
 }
+
+export function firstLetterToLowercase(s: string): string {
+  return s.charAt(0).toLocaleLowerCase() + s.slice(1);
+}

--- a/apps/braze/test/fields/FieldsFactory.spec.ts
+++ b/apps/braze/test/fields/FieldsFactory.spec.ts
@@ -42,7 +42,7 @@ describe('FieldsFactory', () => {
     expect(result[0]).toBeInstanceOf(BasicField);
     const fieldInstance = result[0] as BasicField;
     expect(fieldInstance.id).toBe('title');
-    expect(fieldInstance.entryContentTypeId).toBe('Article');
+    expect(fieldInstance.entryContentTypeId).toBe('article');
     expect(fieldInstance.localized).toBe(true);
   });
 
@@ -72,7 +72,7 @@ describe('FieldsFactory', () => {
     expect(result[0]).toBeInstanceOf(AssetField);
     const fieldInstance = result[0] as AssetField;
     expect(fieldInstance.id).toBe('featuredImage');
-    expect(fieldInstance.entryContentTypeId).toBe('Article');
+    expect(fieldInstance.entryContentTypeId).toBe('article');
     expect(fieldInstance.localized).toBe(true);
   });
 
@@ -124,7 +124,7 @@ describe('FieldsFactory', () => {
     expect(result[0]).toBeInstanceOf(ReferenceField);
     const fieldInstance = result[0] as ReferenceField;
     expect(fieldInstance.id).toBe('author');
-    expect(fieldInstance.entryContentTypeId).toBe('Article');
+    expect(fieldInstance.entryContentTypeId).toBe('article');
     expect(fieldInstance.localized).toBe(false);
     expect(fieldInstance.referenceContentType).toBe('author');
 
@@ -158,7 +158,7 @@ describe('FieldsFactory', () => {
     expect(result[0]).toBeInstanceOf(TextArrayField);
     const fieldInstance = result[0] as TextArrayField;
     expect(fieldInstance.id).toBe('tags');
-    expect(fieldInstance.entryContentTypeId).toBe('Article');
+    expect(fieldInstance.entryContentTypeId).toBe('article');
     expect(fieldInstance.localized).toBe(true);
   });
 
@@ -196,7 +196,7 @@ describe('FieldsFactory', () => {
     expect(result[0]).toBeInstanceOf(AssetArrayField);
     const fieldInstance = result[0] as AssetArrayField;
     expect(fieldInstance.id).toBe('images');
-    expect(fieldInstance.entryContentTypeId).toBe('Gallery');
+    expect(fieldInstance.entryContentTypeId).toBe('gallery');
     expect(fieldInstance.localized).toBe(true);
   });
 
@@ -263,7 +263,7 @@ describe('FieldsFactory', () => {
     const fieldInstance = result[0] as ReferenceArrayField;
 
     expect(fieldInstance.id).toBe('categories');
-    expect(fieldInstance.entryContentTypeId).toBe('Article');
+    expect(fieldInstance.entryContentTypeId).toBe('article');
     expect(fieldInstance.localized).toBe(false);
 
     expect(fieldInstance.items).toHaveLength(2);


### PR DESCRIPTION
This PR includes two main changes:

- Save the id of the content type instead of the name
- Save the content type setting the first letter to lowercase