### PR TITLE
Braze app config validations

### DIFF
--- a/apps/braze/src/locations/ConfigScreen.tsx
+++ b/apps/braze/src/locations/ConfigScreen.tsx
@@ -33,6 +33,11 @@ const ConfigScreen = () => {
   const onConfigure = useCallback(async () => {
     const currentState = await sdk.app.getCurrentState();
 
+    if (!parameters.apiKey) {
+      sdk.notifier.error('A valid Contentful API key is required');
+      return false;
+    }
+
     return {
       parameters,
       targetState: currentState,

--- a/apps/braze/src/locations/ConfigScreen.tsx
+++ b/apps/braze/src/locations/ConfigScreen.tsx
@@ -22,7 +22,7 @@ export interface AppInstallationParameters {
 
 export const BRAZE_DOCUMENTATION =
   'https://braze.com/docs/user_guide/personalization_and_dynamic_content/connected_content';
-export const BRAZE_BASE_URL = 'https://cdn.contentful.com/spaces/';
+export const CONTENTFUL_BASE_URL = 'https://cdn.contentful.com/spaces/';
 
 export async function callToContentful(url: string, newApiKey: string) {
   return await fetch(url, {
@@ -35,30 +35,24 @@ export async function callToContentful(url: string, newApiKey: string) {
 }
 
 const ConfigScreen = () => {
-  const [apiKeyIsValid, setApiKeyIsValid] = useState(false);
+  const [apiKeyIsValid, setApiKeyIsValid] = useState(true);
   const [parameters, setParameters] = useState<AppInstallationParameters>({
     apiKey: '',
   });
   const sdk = useSDK<ConfigAppSDK>();
   const spaceId = sdk.ids.space;
 
-  async function apiKeyCheck(newApiKey: string, displayNotification: boolean) {
+  async function apiKeyCheck(newApiKey: string) {
     if (!newApiKey) {
       setApiKeyIsValid(false);
       return false;
     }
 
-    const url = `${BRAZE_BASE_URL}${sdk.ids.space}`;
+    const url = `${CONTENTFUL_BASE_URL}${sdk.ids.space}`;
     const response: Response = await callToContentful(url, newApiKey);
 
     const isValid = response.ok;
     setApiKeyIsValid(isValid);
-
-    if (displayNotification) {
-      isValid
-        ? sdk.notifier.success(`Contentful API key was validated successfully`)
-        : sdk.notifier.warning(`API key doesn't connect to Contentful`);
-    }
 
     return isValid;
   }
@@ -66,7 +60,7 @@ const ConfigScreen = () => {
   const onConfigure = useCallback(async () => {
     const currentState = await sdk.app.getCurrentState();
 
-    const isValid = await apiKeyCheck(parameters.apiKey, false);
+    const isValid = await apiKeyCheck(parameters.apiKey);
 
     if (!parameters.apiKey || !isValid) {
       sdk.notifier.error('A valid Contentful API key is required');
@@ -94,12 +88,6 @@ const ConfigScreen = () => {
       sdk.app.setReady();
     })();
   }, [sdk]);
-
-  useEffect(() => {
-    const getData = setTimeout(() => apiKeyCheck(parameters.apiKey, true), 800);
-
-    return () => clearTimeout(getData);
-  }, [parameters.apiKey]);
 
   return (
     <Flex justifyContent="center" alignContent="center">

--- a/apps/braze/src/locations/ConfigScreen.tsx
+++ b/apps/braze/src/locations/ConfigScreen.tsx
@@ -139,6 +139,9 @@ const ConfigScreen = () => {
               placeholder="ex. 0ab1c234DE56f..."
               onChange={(e) => setParameters({ ...parameters, apiKey: e.target.value })}
             />
+            {!apiKeyValid && (
+              <FormControl.ValidationMessage>Invalid API key</FormControl.ValidationMessage>
+            )}
           </Form>
         </Box>
       </Box>

--- a/apps/braze/test/locations/ConfigScreen.spec.tsx
+++ b/apps/braze/test/locations/ConfigScreen.spec.tsx
@@ -11,6 +11,15 @@ vi.mock('@contentful/react-apps-toolkit', () => ({
   useCMA: () => mockCma,
 }));
 
+vi.mock('./ConfigScreen', async () => {
+  const actual: any = await vi.importActual('./ConfigScreen');
+
+  return {
+    ...actual,
+    callContentful: vi.fn().mockResolvedValue({ ok: true, error: null }),
+  };
+});
+
 async function saveAppInstallation() {
   return await mockSdk.app.onConfigure.mock.calls.at(-1)[0]();
 }
@@ -56,9 +65,12 @@ describe('Config Screen component', () => {
   describe('installation', () => {
     it('when installed the api key is set correctly', async () => {
       const user = userEvent.setup();
-
       const apiKeyInput = screen.getAllByTestId('apiKey')[0];
       await user.type(apiKeyInput, 'valid-api-key-123');
+      vi.spyOn(window, 'fetch').mockImplementationOnce((): any => {
+        return { ok: true, error: null };
+      });
+
       const result = await saveAppInstallation();
 
       expect(result).toEqual({

--- a/apps/braze/test/locations/ConfigScreen.spec.tsx
+++ b/apps/braze/test/locations/ConfigScreen.spec.tsx
@@ -78,19 +78,16 @@ describe('Config Screen component', () => {
       });
     });
 
-    it('an invalid api key, the api key is not set', async () => {
-      const user = userEvent.setup();
-      const apiKeyInput = screen.getAllByTestId('apiKey')[0];
-      await user.type(apiKeyInput, 'invalid-api-key-123');
-
-      vi.spyOn(window, 'fetch').mockImplementationOnce(() =>
-        Promise.resolve({
-          ok: false,
-          json: () => Promise.resolve({ error: 'Invalid API key' }),
-        } as Response)
-      );
-
-      await expect(saveAppInstallation()).rejects.toThrow();
-    });
+    // it('an invalid api key, a toast error is shown and the api key is not set', async () => {
+    //   const user = userEvent.setup();
+    //   const apiKeyInput = screen.getAllByTestId('apiKey')[0];
+    //   await user.type(apiKeyInput, 'invalid-api-key-123');
+    //
+    //   vi.spyOn(window, 'fetch').mockImplementationOnce((): any => {
+    //     return { ok: true, error: null };
+    //   });
+    //
+    //   expect(mockSdk.notifier.error).toHaveBeenCalledWith('A valid Contentful API key is required');
+    // });
   });
 });

--- a/apps/braze/test/locations/ConfigScreen.spec.tsx
+++ b/apps/braze/test/locations/ConfigScreen.spec.tsx
@@ -62,8 +62,8 @@ describe('Config Screen component', () => {
     });
   });
 
-  describe('installation', () => {
-    it('when installed the api key is set correctly', async () => {
+  describe('when installed ', () => {
+    it('a valid api key, the api key is set correctly', async () => {
       const user = userEvent.setup();
       const apiKeyInput = screen.getAllByTestId('apiKey')[0];
       await user.type(apiKeyInput, 'valid-api-key-123');
@@ -76,6 +76,21 @@ describe('Config Screen component', () => {
       expect(result).toEqual({
         parameters: { apiKey: 'valid-api-key-123' },
       });
+    });
+
+    it('an invalid api key, the api key is not set', async () => {
+      const user = userEvent.setup();
+      const apiKeyInput = screen.getAllByTestId('apiKey')[0];
+      await user.type(apiKeyInput, 'invalid-api-key-123');
+
+      vi.spyOn(window, 'fetch').mockImplementationOnce(() =>
+        Promise.resolve({
+          ok: false,
+          json: () => Promise.resolve({ error: 'Invalid API key' }),
+        } as Response)
+      );
+
+      await expect(saveAppInstallation()).rejects.toThrow();
     });
   });
 });

--- a/apps/braze/test/locations/ConfigScreen.spec.tsx
+++ b/apps/braze/test/locations/ConfigScreen.spec.tsx
@@ -62,13 +62,13 @@ describe('Config Screen component', () => {
     });
   });
 
-  describe('when installed ', () => {
-    it('a valid api key, the api key is set correctly', async () => {
+  describe('installation ', () => {
+    it('sets the parameters correctly if the api key is valid', async () => {
       const user = userEvent.setup();
       const apiKeyInput = screen.getAllByTestId('apiKey')[0];
       await user.type(apiKeyInput, 'valid-api-key-123');
       vi.spyOn(window, 'fetch').mockImplementationOnce((): any => {
-        return { ok: true, error: null };
+        return { ok: true, status: 200 };
       });
 
       const result = await saveAppInstallation();
@@ -78,16 +78,17 @@ describe('Config Screen component', () => {
       });
     });
 
-    // it('an invalid api key, a toast error is shown and the api key is not set', async () => {
-    //   const user = userEvent.setup();
-    //   const apiKeyInput = screen.getAllByTestId('apiKey')[0];
-    //   await user.type(apiKeyInput, 'invalid-api-key-123');
-    //
-    //   vi.spyOn(window, 'fetch').mockImplementationOnce((): any => {
-    //     return { ok: true, error: null };
-    //   });
-    //
-    //   expect(mockSdk.notifier.error).toHaveBeenCalledWith('A valid Contentful API key is required');
-    // });
+    it('shows a toast error if the api key is invalid', async () => {
+      const user = userEvent.setup();
+      const apiKeyInput = screen.getAllByTestId('apiKey')[0];
+      await user.type(apiKeyInput, 'invalid-api-key-123');
+      vi.spyOn(window, 'fetch').mockImplementationOnce((): any => {
+        return { ok: false, status: 401 };
+      });
+
+      await saveAppInstallation();
+
+      expect(mockSdk.notifier.error).toHaveBeenCalledWith('A valid Contentful API key is required');
+    });
   });
 });

--- a/apps/braze/test/mocks/mockSdk.ts
+++ b/apps/braze/test/mocks/mockSdk.ts
@@ -27,6 +27,9 @@ const mockSdk: any = {
     default: 'en-US',
     available: ['en-US', 'es-AR'],
   },
+  notifier: {
+    error: vi.fn(),
+  },
 };
 
 export { mockSdk };


### PR DESCRIPTION
## Purpose

Adding validation in the config screen location in order not to allow the user to install the application if the api key is not valid.

## Approach

There are two validations:

1. Checking that the api key input is not empty.
2. Checking that the api key entered can connect to contentful successfully.

Note: This validations are done when the user click the install button.

Video showing this validations:

https://github.com/user-attachments/assets/55b0af83-8444-4088-a169-06ffc2473f99

## Testing

- Adding test to check the error message shown if the api key entered is invalid.
- Fixed a test to validate if the parameters are set correctly when the api key is valid.

## Dependencies and/or References

Link to the [ticket](https://contentful.atlassian.net/browse/INTEG-2404)
