### PR TITLE
feat: bump app-script & add add-locations script [EXT-6267]

### DIFF
--- a/examples/app-parameters/package.json
+++ b/examples/app-parameters/package.json
@@ -20,12 +20,13 @@
     "build": "tsc && vite build",
     "test": "vitest",
     "create-app-definition": "contentful-app-scripts create-app-definition",
+    "add-locations": "contentful-app-scripts add-locations",
     "upload": "contentful-app-scripts upload --bundle-dir ./dist",
     "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./dist  --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN",
     "setup": "ts-node scripts/setup.ts"
   },
   "devDependencies": {
-    "@contentful/app-scripts": "1.19.1",
+    "@contentful/app-scripts": "^2.3.0",
     "@testing-library/react": "^16.2.0",
     "@types/node": "^16.18.124",
     "@types/react": "18.3.1",

--- a/examples/asset-upload/package.json
+++ b/examples/asset-upload/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@contentful/app-scripts": "^1.30.1",
+    "@contentful/app-scripts": "^2.3.0",
     "@contentful/app-sdk": "4.22.0",
     "@contentful/f36-components": "4.45.0",
     "@contentful/f36-tokens": "4.0.2",
@@ -18,6 +18,7 @@
     "start": "vite",
     "build": "tsc && vite build",
     "create-app-definition": "contentful-app-scripts create-app-definition",
+    "add-locations": "contentful-app-scripts add-locations",
     "upload": "contentful-app-scripts upload --bundle-dir ./dist",
     "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./dist  --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN"
   },

--- a/examples/autotagger/functions/INSTRUCTIONS.md
+++ b/examples/autotagger/functions/INSTRUCTIONS.md
@@ -8,7 +8,7 @@ npx create-contentful-app@latest --example function-appevent-handler
 
 ### Creating an app
 
-You can create an app using CLI using `npm run create-app-definition`. This will prompt you to enter details for your new app and organization details. You can also create an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Create App" button on the top right.
+You can create an app using the CLI command `npm run create-app-definition`. This will prompt you to enter details for your new app and organization details. You can also create an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Create App" button on the top right.
 
 ### Using environment variables
 
@@ -24,7 +24,7 @@ It as simple using the CLI command `npm run upload-ci`. This will perform two ac
 
 ### Adding locations to an app
 
-You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
+You can add locations to an existing app using the CLI command `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
 You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the **"Edit"** flyout button for your app and selecting locations on the **"General"** tab.
 
 ## Utilizing app event handler functions

--- a/examples/autotagger/functions/INSTRUCTIONS.md
+++ b/examples/autotagger/functions/INSTRUCTIONS.md
@@ -22,6 +22,10 @@ You will need to set the following environment variables as listed below:
 
 It as simple using the CLI command `npm run upload-ci`. This will perform two actions: upload the code, linking it to the app, and then finally activating the code ready for usage in both
 
+### Adding locations to an app
+
+You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt to allow you to select locations to add to your app. You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Edit" flyout button for your app and selecting locations on the "General" tab.
+
 ## Utilizing app event handler functions
 
 When you create an app that utilizes [app events](https://www.contentful.com/developers/docs/extensibility/app-framework/app-events/), you can define the entities and topics for these events. However, you may also want to do some additional handling when these events occur. For example, you may want to send a copy of the event to an external service for logging or monitoring purposes.

--- a/examples/autotagger/functions/INSTRUCTIONS.md
+++ b/examples/autotagger/functions/INSTRUCTIONS.md
@@ -24,10 +24,11 @@ It as simple using the CLI command `npm run upload-ci`. This will perform two ac
 
 ### Adding locations to an app
 
-You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt to allow you to select locations to add to your app. You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Edit" flyout button for your app and selecting locations on the "General" tab.
+You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
+You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the **"Edit"** flyout button for your app and selecting locations on the **"General"** tab.
 
 ## Utilizing app event handler functions
 
 When you create an app that utilizes [app events](https://www.contentful.com/developers/docs/extensibility/app-framework/app-events/), you can define the entities and topics for these events. However, you may also want to do some additional handling when these events occur. For example, you may want to send a copy of the event to an external service for logging or monitoring purposes.
 
-Once you have built and uploaded your functions to Contentful, link them to your app event subscription using the [CMA](https://www.contentful.com/developers/docs/references/content-management-api/#/reference/app-event-subscriptions/app-event-subscription/update-or-subscribe-to-events/console/js-plain) or the [Events](https://app.contentful.com/deeplink?link=app-definition&tab=events) tab on the App details page.  
+Once you have built and uploaded your functions to Contentful, link them to your app event subscription using the [CMA](https://www.contentful.com/developers/docs/references/content-management-api/#/reference/app-event-subscriptions/app-event-subscription/update-or-subscribe-to-events/console/js-plain) or the [Events](https://app.contentful.com/deeplink?link=app-definition&tab=events) tab on the App details page.

--- a/examples/autotagger/package.json
+++ b/examples/autotagger/package.json
@@ -19,6 +19,7 @@
     "build:functions": "contentful-app-scripts build-functions --ci",
     "test": "vitest run --passWithNoTests",
     "create-app-definition": "contentful-app-scripts create-app-definition",
+    "add-locations": "contentful-app-scripts add-locations",
     "upload": "contentful-app-scripts upload --bundle-dir ./build",
     "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN"
   },
@@ -38,7 +39,7 @@
     ]
   },
   "devDependencies": {
-    "@contentful/app-scripts": "2.1.2",
+    "@contentful/app-scripts": "^2.3.0",
     "@contentful/node-apps-toolkit": "^3.11.1",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",

--- a/examples/blog-post-metrics/package.json
+++ b/examples/blog-post-metrics/package.json
@@ -20,11 +20,12 @@
     "build": "vite build",
     "preview": "vite preview",
     "create-app-definition": "contentful-app-scripts create-app-definition",
+    "add-locations": "contentful-app-scripts add-locations",
     "upload": "contentful-app-scripts upload --bundle-dir ./dist",
     "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./dist --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN"
   },
   "devDependencies": {
-    "@contentful/app-scripts": "1.10.2",
+    "@contentful/app-scripts": "^2.3.0",
     "@testing-library/jest-dom": "5.16.5",
     "@testing-library/react": "14.0.0",
     "@tsconfig/create-react-app": "2.0.0",

--- a/examples/commercelayer/package.json
+++ b/examples/commercelayer/package.json
@@ -3,7 +3,7 @@
   "version": "1.5.89",
   "private": true,
   "devDependencies": {
-    "@contentful/app-scripts": "1.15.0",
+    "@contentful/app-scripts": "^2.3.0",
     "cross-env": "7.0.3",
     "vite": "^5.0.0",
     "@vitejs/plugin-react": "^4.0.3"
@@ -20,6 +20,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
+    "create-app-definition": "contentful-app-scripts create-app-definition",
+    "add-locations": "contentful-app-scripts add-locations",
     "upload": "contentful-app-scripts upload --bundle-dir ./dist",
     "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./dist --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN"
   },

--- a/examples/compare-entries/package.json
+++ b/examples/compare-entries/package.json
@@ -17,7 +17,7 @@
     "react-dom": "^16.14.0"
   },
   "devDependencies": {
-    "@contentful/app-scripts": "1.10.2",
+    "@contentful/app-scripts": "^2.3.0",
     "@tsconfig/create-react-app": "2.0.0",
     "@vitejs/plugin-react": "^4.0.3",
     "cross-env": "7.0.3",
@@ -29,6 +29,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "create-app-definition": "contentful-app-scripts create-app-definition",
+    "add-locations": "contentful-app-scripts add-locations",
     "upload": "contentful-app-scripts upload --bundle-dir ./dist",
     "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./dist --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN"
   },

--- a/examples/custom-validation/package.json
+++ b/examples/custom-validation/package.json
@@ -4,11 +4,13 @@
   "scripts": {
     "start": "vite",
     "build": "tsc --noEmit && vite build",
+    "create-app-definition": "contentful-app-scripts create-app-definition",
+    "add-locations": "contentful-app-scripts add-locations",
     "upload": "contentful-app-scripts upload --bundle-dir ./dist",
     "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./dist  --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN"
   },
   "dependencies": {
-    "@contentful/app-scripts": "1.10.2",
+    "@contentful/app-scripts": "^2.3.0",
     "@contentful/app-sdk": "4.22.0",
     "@contentful/f36-components": "4.45.0",
     "@contentful/react-apps-toolkit": "1.2.16",

--- a/examples/dam-app/package.json
+++ b/examples/dam-app/package.json
@@ -10,7 +10,7 @@
     "react-dom": "17.0.2"
   },
   "devDependencies": {
-    "@contentful/app-scripts": "1.15.0",
+    "@contentful/app-scripts": "^2.3.0",
     "cross-env": "7.0.3",
     "vite": "^5.0.0",
     "@vitejs/plugin-react": "^4.0.3"
@@ -19,6 +19,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
+    "create-app-definition": "contentful-app-scripts create-app-definition",
+    "add-locations": "contentful-app-scripts add-locations",
     "upload": "contentful-app-scripts upload --bundle-dir ./dist",
     "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./dist --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN"
   },

--- a/examples/ecommerce-app/package.json
+++ b/examples/ecommerce-app/package.json
@@ -10,7 +10,7 @@
     "react-dom": "17.0.2"
   },
   "devDependencies": {
-    "@contentful/app-scripts": "1.15.0",
+    "@contentful/app-scripts": "^2.3.0",
     "cross-env": "7.0.3",
     "vite": "^5.0.0",
     "@vitejs/plugin-react": "^4.0.3"
@@ -19,6 +19,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
+    "create-app-definition": "contentful-app-scripts create-app-definition",
+    "add-locations": "contentful-app-scripts add-locations",
     "upload": "contentful-app-scripts upload --bundle-dir ./dist",
     "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./dist --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN"
   },

--- a/examples/editor-assignment/package.json
+++ b/examples/editor-assignment/package.json
@@ -17,7 +17,7 @@
     "vitest": "^3.0.7"
   },
   "devDependencies": {
-    "@contentful/app-scripts": "1.10.2",
+    "@contentful/app-scripts": "^2.3.0",
     "@testing-library/jest-dom": "5.16.5",
     "@testing-library/react": "14.0.0",
     "@tsconfig/create-react-app": "2.0.0",
@@ -37,6 +37,7 @@
     "test": "vitest",
     "preview": "vite preview",
     "create-app-definition": "contentful-app-scripts create-app-definition",
+    "add-locations": "contentful-app-scripts add-locations",
     "upload": "contentful-app-scripts upload --bundle-dir ./dist",
     "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./dist --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN"
   },

--- a/examples/function-appaction/INSTRUCTIONS.md
+++ b/examples/function-appaction/INSTRUCTIONS.md
@@ -51,6 +51,10 @@ npm run upload
 
 The interactive CLI will prompt you to provide additional details, such as a CMA endpoint URL. Select **Yes** when prompted if you’d like to activate the bundle after upload.
 
+### Adding locations to an app
+
+You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt to allow you to select locations to add to your app. You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Edit" flyout button for your app and selecting locations on the "General" tab.
+
 ### Create an App Action
 
 You can create an app action by navigating to the app definition in the Contentful web UI and following [these instructions](https://www.contentful.com/developers/docs/extensibility/app-framework/app-actions/#create-an-app-action), ensuring that you select `function-invocation` for the type and choosing your uploaded function.

--- a/examples/function-appaction/INSTRUCTIONS.md
+++ b/examples/function-appaction/INSTRUCTIONS.md
@@ -53,7 +53,8 @@ The interactive CLI will prompt you to provide additional details, such as a CMA
 
 ### Adding locations to an app
 
-You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt to allow you to select locations to add to your app. You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Edit" flyout button for your app and selecting locations on the "General" tab.
+You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
+You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the **"Edit"** flyout button for your app and selecting locations on the **"General"** tab.
 
 ### Create an App Action
 

--- a/examples/function-appaction/INSTRUCTIONS.md
+++ b/examples/function-appaction/INSTRUCTIONS.md
@@ -53,7 +53,7 @@ The interactive CLI will prompt you to provide additional details, such as a CMA
 
 ### Adding locations to an app
 
-You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
+You can add locations to an existing app using the CLI command `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
 You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the **"Edit"** flyout button for your app and selecting locations on the **"General"** tab.
 
 ### Create an App Action

--- a/examples/function-appaction/package.json
+++ b/examples/function-appaction/package.json
@@ -20,6 +20,7 @@
     "build": "vite build && npm run build:functions",
     "test": "vitest",
     "create-app-definition": "contentful-app-scripts create-app-definition",
+    "add-locations": "contentful-app-scripts add-locations",
     "upload": "contentful-app-scripts upload --bundle-dir ./build",
     "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN",
     "build:functions": "contentful-app-scripts build-functions --ci",
@@ -43,7 +44,7 @@
     ]
   },
   "devDependencies": {
-    "@contentful/app-scripts": "^2.1.2",
+    "@contentful/app-scripts": "^2.3.0",
     "@contentful/node-apps-toolkit": "^3.11.1",
     "@testing-library/jest-dom": "6.6.3",
     "@testing-library/react": "16.2.0",

--- a/examples/function-appevent-filter/javascript/INSTRUCTIONS.md
+++ b/examples/function-appevent-filter/javascript/INSTRUCTIONS.md
@@ -22,6 +22,10 @@ You will need to set the following environment variables as listed below:
 
 It as simple using the CLI command `npm run upload-ci`. This will perform two actions: upload the code, linking it to the app, and then finally activating the code ready for usage in both
 
+### Adding locations to an app
+
+You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt to allow you to select locations to add to your app. You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Edit" flyout button for your app and selecting locations on the "General" tab.
+
 ## Utilizing app event filter functions
 
 When you create an app that utilizes [app events](https://www.contentful.com/developers/docs/extensibility/app-framework/app-events/), you can define the entities and topics for these events. However, you may also want to do some additional filtering for these app events. For example, you might want to filter Entry events so that they are only sent for certain content types. App event filter functions are a flexible way of making app events even more powerful for your apps.

--- a/examples/function-appevent-filter/javascript/INSTRUCTIONS.md
+++ b/examples/function-appevent-filter/javascript/INSTRUCTIONS.md
@@ -8,7 +8,7 @@ npx create-contentful-app@latest --example function-appevent-filter --javascript
 
 ### Creating an app
 
-You can create an app using CLI using `npm run create-app-definition`. This will prompt you to enter details for your new app and organization details. You can also create an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Create App" button on the top right.
+You can create an app using the CLI command `npm run create-app-definition`. This will prompt you to enter details for your new app and organization details. You can also create an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Create App" button on the top right.
 
 ### Using environment variables
 
@@ -24,7 +24,7 @@ It as simple using the CLI command `npm run upload-ci`. This will perform two ac
 
 ### Adding locations to an app
 
-You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
+You can add locations to an existing app using the CLI command `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
 You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the **"Edit"** flyout button for your app and selecting locations on the **"General"** tab.
 
 ## Utilizing app event filter functions

--- a/examples/function-appevent-filter/javascript/INSTRUCTIONS.md
+++ b/examples/function-appevent-filter/javascript/INSTRUCTIONS.md
@@ -24,10 +24,11 @@ It as simple using the CLI command `npm run upload-ci`. This will perform two ac
 
 ### Adding locations to an app
 
-You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt to allow you to select locations to add to your app. You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Edit" flyout button for your app and selecting locations on the "General" tab.
+You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
+You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the **"Edit"** flyout button for your app and selecting locations on the **"General"** tab.
 
 ## Utilizing app event filter functions
 
 When you create an app that utilizes [app events](https://www.contentful.com/developers/docs/extensibility/app-framework/app-events/), you can define the entities and topics for these events. However, you may also want to do some additional filtering for these app events. For example, you might want to filter Entry events so that they are only sent for certain content types. App event filter functions are a flexible way of making app events even more powerful for your apps.
 
-Once you have built and uploaded your functions to Contentful, link them to your app event subscription using the [CMA](https://www.contentful.com/developers/docs/references/content-management-api/#/reference/app-event-subscriptions/app-event-subscription/update-or-subscribe-to-events/console/js-plain) or the [Events](https://app.contentful.com/deeplink?link=app-definition&tab=events) tab on the App details page.  
+Once you have built and uploaded your functions to Contentful, link them to your app event subscription using the [CMA](https://www.contentful.com/developers/docs/references/content-management-api/#/reference/app-event-subscriptions/app-event-subscription/update-or-subscribe-to-events/console/js-plain) or the [Events](https://app.contentful.com/deeplink?link=app-definition&tab=events) tab on the App details page.

--- a/examples/function-appevent-filter/javascript/package.json
+++ b/examples/function-appevent-filter/javascript/package.json
@@ -3,7 +3,7 @@
     "build": "contentful-app-scripts build-functions --ci"
   },
   "devDependencies": {
-    "@contentful/app-scripts": "^2.1.2",
+    "@contentful/app-scripts": "^2.3.0",
     "sentiment": "^5.0.2"
   }
 }

--- a/examples/function-appevent-filter/typescript/INSTRUCTIONS.md
+++ b/examples/function-appevent-filter/typescript/INSTRUCTIONS.md
@@ -22,6 +22,10 @@ You will need to set the following environment variables as listed below:
 
 It as simple using the CLI command `npm run upload-ci`. This will perform two actions: upload the code, linking it to the app, and then finally activating the code ready for usage in both
 
+### Adding locations to an app
+
+You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt to allow you to select locations to add to your app. You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Edit" flyout button for your app and selecting locations on the "General" tab.
+
 ## Utilizing app event filter functions
 
 When you create an app that utilizes [app events](https://www.contentful.com/developers/docs/extensibility/app-framework/app-events/), you can define the entities and topics for these events. However, you may also want to do some additional filtering for these app events. For example, you might want to filter Entry events so that they are only sent for certain content types. App event filter functions are a flexible way of making app events even more powerful for your apps.

--- a/examples/function-appevent-filter/typescript/INSTRUCTIONS.md
+++ b/examples/function-appevent-filter/typescript/INSTRUCTIONS.md
@@ -24,10 +24,11 @@ It as simple using the CLI command `npm run upload-ci`. This will perform two ac
 
 ### Adding locations to an app
 
-You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt to allow you to select locations to add to your app. You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Edit" flyout button for your app and selecting locations on the "General" tab.
+You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
+You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the **"Edit"** flyout button for your app and selecting locations on the **"General"** tab.
 
 ## Utilizing app event filter functions
 
 When you create an app that utilizes [app events](https://www.contentful.com/developers/docs/extensibility/app-framework/app-events/), you can define the entities and topics for these events. However, you may also want to do some additional filtering for these app events. For example, you might want to filter Entry events so that they are only sent for certain content types. App event filter functions are a flexible way of making app events even more powerful for your apps.
 
-Once you have built and uploaded your functions to Contentful, link them to your app event subscription using the [CMA](https://www.contentful.com/developers/docs/references/content-management-api/#/reference/app-event-subscriptions/app-event-subscription/update-or-subscribe-to-events/console/js-plain) or the [Events](https://app.contentful.com/deeplink?link=app-definition&tab=events) tab on the App details page.  
+Once you have built and uploaded your functions to Contentful, link them to your app event subscription using the [CMA](https://www.contentful.com/developers/docs/references/content-management-api/#/reference/app-event-subscriptions/app-event-subscription/update-or-subscribe-to-events/console/js-plain) or the [Events](https://app.contentful.com/deeplink?link=app-definition&tab=events) tab on the App details page.

--- a/examples/function-appevent-filter/typescript/INSTRUCTIONS.md
+++ b/examples/function-appevent-filter/typescript/INSTRUCTIONS.md
@@ -8,7 +8,7 @@ npx create-contentful-app@latest --example function-appevent-filter
 
 ### Creating an app
 
-You can create an app using CLI using `npm run create-app-definition`. This will prompt you to enter details for your new app and organization details. You can also create an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Create App" button on the top right.
+You can create an app using the CLI command `npm run create-app-definition`. This will prompt you to enter details for your new app and organization details. You can also create an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Create App" button on the top right.
 
 ### Using environment variables
 
@@ -24,7 +24,7 @@ It as simple using the CLI command `npm run upload-ci`. This will perform two ac
 
 ### Adding locations to an app
 
-You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
+You can add locations to an existing app using the CLI command `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
 You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the **"Edit"** flyout button for your app and selecting locations on the **"General"** tab.
 
 ## Utilizing app event filter functions

--- a/examples/function-appevent-filter/typescript/package.json
+++ b/examples/function-appevent-filter/typescript/package.json
@@ -3,7 +3,7 @@
     "build": "contentful-app-scripts build-functions --ci"
   },
   "devDependencies": {
-    "@contentful/app-scripts": "^2.1.2",
+    "@contentful/app-scripts": "^2.3.0",
     "@contentful/node-apps-toolkit": "^3.11.1",
     "@tsconfig/recommended": "1.0.8",
     "@types/sentiment": "^5.0.4",

--- a/examples/function-appevent-handler/javascript/INSTRUCTIONS.md
+++ b/examples/function-appevent-handler/javascript/INSTRUCTIONS.md
@@ -22,6 +22,10 @@ You will need to set the following environment variables as listed below:
 
 It as simple using the CLI command `npm run upload-ci`. This will perform two actions: upload the code, linking it to the app, and then finally activating the code ready for usage in both
 
+### Adding locations to an app
+
+You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt to allow you to select locations to add to your app. You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Edit" flyout button for your app and selecting locations on the "General" tab.
+
 ## Utilizing app event handler functions
 
 When you create an app that utilizes [app events](https://www.contentful.com/developers/docs/extensibility/app-framework/app-events/), you can define the entities and topics for these events. However, you may also want to do some additional handling when these events occur. For example, you may want to send a copy of the event to an external service for logging or monitoring purposes.

--- a/examples/function-appevent-handler/javascript/INSTRUCTIONS.md
+++ b/examples/function-appevent-handler/javascript/INSTRUCTIONS.md
@@ -24,10 +24,11 @@ It as simple using the CLI command `npm run upload-ci`. This will perform two ac
 
 ### Adding locations to an app
 
-You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt to allow you to select locations to add to your app. You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Edit" flyout button for your app and selecting locations on the "General" tab.
+You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
+You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the **"Edit"** flyout button for your app and selecting locations on the **"General"** tab.
 
 ## Utilizing app event handler functions
 
 When you create an app that utilizes [app events](https://www.contentful.com/developers/docs/extensibility/app-framework/app-events/), you can define the entities and topics for these events. However, you may also want to do some additional handling when these events occur. For example, you may want to send a copy of the event to an external service for logging or monitoring purposes.
 
-Once you have built and uploaded your functions to Contentful, link them to your app event subscription using the [CMA](https://www.contentful.com/developers/docs/references/content-management-api/#/reference/app-event-subscriptions/app-event-subscription/update-or-subscribe-to-events/console/js-plain) or the [Events](https://app.contentful.com/deeplink?link=app-definition&tab=events) tab on the App details page.  
+Once you have built and uploaded your functions to Contentful, link them to your app event subscription using the [CMA](https://www.contentful.com/developers/docs/references/content-management-api/#/reference/app-event-subscriptions/app-event-subscription/update-or-subscribe-to-events/console/js-plain) or the [Events](https://app.contentful.com/deeplink?link=app-definition&tab=events) tab on the App details page.

--- a/examples/function-appevent-handler/javascript/INSTRUCTIONS.md
+++ b/examples/function-appevent-handler/javascript/INSTRUCTIONS.md
@@ -8,7 +8,7 @@ npx create-contentful-app@latest --example function-appevent-handler --javascrip
 
 ### Creating an app
 
-You can create an app using CLI using `npm run create-app-definition`. This will prompt you to enter details for your new app and organization details. You can also create an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Create App" button on the top right.
+You can create an app using the CLI command `npm run create-app-definition`. This will prompt you to enter details for your new app and organization details. You can also create an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Create App" button on the top right.
 
 ### Using environment variables
 
@@ -24,7 +24,7 @@ It as simple using the CLI command `npm run upload-ci`. This will perform two ac
 
 ### Adding locations to an app
 
-You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
+You can add locations to an existing app using the CLI command `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
 You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the **"Edit"** flyout button for your app and selecting locations on the **"General"** tab.
 
 ## Utilizing app event handler functions

--- a/examples/function-appevent-handler/javascript/package.json
+++ b/examples/function-appevent-handler/javascript/package.json
@@ -3,6 +3,6 @@
     "build": "contentful-app-scripts build-functions --ci"
   },
   "devDependencies": {
-    "@contentful/app-scripts": "^2.1.2"
+    "@contentful/app-scripts": "^2.3.0"
   }
 }

--- a/examples/function-appevent-handler/typescript/INSTRUCTIONS.md
+++ b/examples/function-appevent-handler/typescript/INSTRUCTIONS.md
@@ -8,7 +8,7 @@ npx create-contentful-app@latest --example function-appevent-handler
 
 ### Creating an app
 
-You can create an app using CLI using `npm run create-app-definition`. This will prompt you to enter details for your new app and organization details. You can also create an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Create App" button on the top right.
+You can create an app using the CLI command `npm run create-app-definition`. This will prompt you to enter details for your new app and organization details. You can also create an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Create App" button on the top right.
 
 ### Using environment variables
 
@@ -24,7 +24,7 @@ It as simple using the CLI command `npm run upload-ci`. This will perform two ac
 
 ### Adding locations to an app
 
-You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
+You can add locations to an existing app using the CLI command `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
 You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the **"Edit"** flyout button for your app and selecting locations on the **"General"** tab.
 
 ## Utilizing app event handler functions

--- a/examples/function-appevent-handler/typescript/INSTRUCTIONS.md
+++ b/examples/function-appevent-handler/typescript/INSTRUCTIONS.md
@@ -22,6 +22,10 @@ You will need to set the following environment variables as listed below:
 
 It as simple using the CLI command `npm run upload-ci`. This will perform two actions: upload the code, linking it to the app, and then finally activating the code ready for usage in both
 
+### Adding locations to an app
+
+You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt to allow you to select locations to add to your app. You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Edit" flyout button for your app and selecting locations on the "General" tab.
+
 ## Utilizing app event handler functions
 
 When you create an app that utilizes [app events](https://www.contentful.com/developers/docs/extensibility/app-framework/app-events/), you can define the entities and topics for these events. However, you may also want to do some additional handling when these events occur. For example, you may want to send a copy of the event to an external service for logging or monitoring purposes.

--- a/examples/function-appevent-handler/typescript/INSTRUCTIONS.md
+++ b/examples/function-appevent-handler/typescript/INSTRUCTIONS.md
@@ -24,10 +24,11 @@ It as simple using the CLI command `npm run upload-ci`. This will perform two ac
 
 ### Adding locations to an app
 
-You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt to allow you to select locations to add to your app. You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Edit" flyout button for your app and selecting locations on the "General" tab.
+You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
+You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the **"Edit"** flyout button for your app and selecting locations on the **"General"** tab.
 
 ## Utilizing app event handler functions
 
 When you create an app that utilizes [app events](https://www.contentful.com/developers/docs/extensibility/app-framework/app-events/), you can define the entities and topics for these events. However, you may also want to do some additional handling when these events occur. For example, you may want to send a copy of the event to an external service for logging or monitoring purposes.
 
-Once you have built and uploaded your functions to Contentful, link them to your app event subscription using the [CMA](https://www.contentful.com/developers/docs/references/content-management-api/#/reference/app-event-subscriptions/app-event-subscription/update-or-subscribe-to-events/console/js-plain) or the [Events](https://app.contentful.com/deeplink?link=app-definition&tab=events) tab on the App details page.  
+Once you have built and uploaded your functions to Contentful, link them to your app event subscription using the [CMA](https://www.contentful.com/developers/docs/references/content-management-api/#/reference/app-event-subscriptions/app-event-subscription/update-or-subscribe-to-events/console/js-plain) or the [Events](https://app.contentful.com/deeplink?link=app-definition&tab=events) tab on the App details page.

--- a/examples/function-appevent-handler/typescript/package.json
+++ b/examples/function-appevent-handler/typescript/package.json
@@ -3,7 +3,7 @@
     "build": "contentful-app-scripts build-functions --ci"
   },
   "devDependencies": {
-    "@contentful/app-scripts": "^2.1.2",
+    "@contentful/app-scripts": "^2.3.0",
     "@contentful/node-apps-toolkit": "^3.11.1",
     "@tsconfig/recommended": "1.0.8"
   }

--- a/examples/function-appevent-transformation/javascript/INSTRUCTIONS.md
+++ b/examples/function-appevent-transformation/javascript/INSTRUCTIONS.md
@@ -8,7 +8,7 @@ npx create-contentful-app@latest --example function-appevent-transformation --ja
 
 ### Creating an app
 
-You can create an app using CLI using `npm run create-app-definition`. This will prompt you to enter details for your new app and organization details. You can also create an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Create App" button on the top right.
+You can create an app using the CLI command `npm run create-app-definition`. This will prompt you to enter details for your new app and organization details. You can also create an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Create App" button on the top right.
 
 ### Using environment variables
 
@@ -24,7 +24,7 @@ It as simple using the CLI command `npm run upload-ci`. This will perform two ac
 
 ### Adding locations to an app
 
-You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
+You can add locations to an existing app using the CLI command `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
 You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the **"Edit"** flyout button for your app and selecting locations on the **"General"** tab.
 
 ## Utilizing app event transformation functions

--- a/examples/function-appevent-transformation/javascript/INSTRUCTIONS.md
+++ b/examples/function-appevent-transformation/javascript/INSTRUCTIONS.md
@@ -24,10 +24,11 @@ It as simple using the CLI command `npm run upload-ci`. This will perform two ac
 
 ### Adding locations to an app
 
-You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt to allow you to select locations to add to your app. You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Edit" flyout button for your app and selecting locations on the "General" tab.
+You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
+You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the **"Edit"** flyout button for your app and selecting locations on the **"General"** tab.
 
 ## Utilizing app event transformation functions
 
 When you create an app that utilizes [app events](https://www.contentful.com/developers/docs/extensibility/app-framework/app-events/), you can define the entities and topics for these events. An app event transformation function allows you to transform the payload of these events before they are sent off. This example demonstrates how to use the app event transformation function to transform the payload of the `entry.publish` event, by geocoding a latitude and longitude field to a human-readable address.
 
-Once you have built and uploaded your functions to Contentful, link them to your app event subscription using the [CMA](https://www.contentful.com/developers/docs/references/content-management-api/#/reference/app-event-subscriptions/app-event-subscription/update-or-subscribe-to-events/console/js-plain) or the [Events](https://app.contentful.com/deeplink?link=app-definition&tab=events) tab on the App details page.  
+Once you have built and uploaded your functions to Contentful, link them to your app event subscription using the [CMA](https://www.contentful.com/developers/docs/references/content-management-api/#/reference/app-event-subscriptions/app-event-subscription/update-or-subscribe-to-events/console/js-plain) or the [Events](https://app.contentful.com/deeplink?link=app-definition&tab=events) tab on the App details page.

--- a/examples/function-appevent-transformation/javascript/INSTRUCTIONS.md
+++ b/examples/function-appevent-transformation/javascript/INSTRUCTIONS.md
@@ -22,6 +22,10 @@ You will need to set the following environment variables as listed below:
 
 It as simple using the CLI command `npm run upload-ci`. This will perform two actions: upload the code, linking it to the app, and then finally activating the code ready for usage in both
 
+### Adding locations to an app
+
+You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt to allow you to select locations to add to your app. You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Edit" flyout button for your app and selecting locations on the "General" tab.
+
 ## Utilizing app event transformation functions
 
 When you create an app that utilizes [app events](https://www.contentful.com/developers/docs/extensibility/app-framework/app-events/), you can define the entities and topics for these events. An app event transformation function allows you to transform the payload of these events before they are sent off. This example demonstrates how to use the app event transformation function to transform the payload of the `entry.publish` event, by geocoding a latitude and longitude field to a human-readable address.

--- a/examples/function-appevent-transformation/javascript/package.json
+++ b/examples/function-appevent-transformation/javascript/package.json
@@ -3,6 +3,6 @@
     "build": "contentful-app-scripts build-functions --ci"
   },
   "devDependencies": {
-    "@contentful/app-scripts": "^2.0.2"
+    "@contentful/app-scripts": "^2.3.0"
   }
 }

--- a/examples/function-appevent-transformation/typescript/INSTRUCTIONS.md
+++ b/examples/function-appevent-transformation/typescript/INSTRUCTIONS.md
@@ -24,10 +24,11 @@ It as simple using the CLI command `npm run upload-ci`. This will perform two ac
 
 ### Adding locations to an app
 
-You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt to allow you to select locations to add to your app. You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Edit" flyout button for your app and selecting locations on the "General" tab.
+You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
+You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the **"Edit"** flyout button for your app and selecting locations on the **"General"** tab.
 
 ## Utilizing app event transformation functions
 
 When you create an app that utilizes [app events](https://www.contentful.com/developers/docs/extensibility/app-framework/app-events/), you can define the entities and topics for these events. An app event transformation function allows you to transform the payload of these events before they are sent off. This example demonstrates how to use the app event transformation function to transform the payload of the `entry.publish` event, by geocoding a latitude and longitude field to a human-readable address.
 
-Once you have built and uploaded your functions to Contentful, link them to your app event subscription using the [CMA](https://www.contentful.com/developers/docs/references/content-management-api/#/reference/app-event-subscriptions/app-event-subscription/update-or-subscribe-to-events/console/js-plain) or the [Events](https://app.contentful.com/deeplink?link=app-definition&tab=events) tab on the App details page. 
+Once you have built and uploaded your functions to Contentful, link them to your app event subscription using the [CMA](https://www.contentful.com/developers/docs/references/content-management-api/#/reference/app-event-subscriptions/app-event-subscription/update-or-subscribe-to-events/console/js-plain) or the [Events](https://app.contentful.com/deeplink?link=app-definition&tab=events) tab on the App details page.

--- a/examples/function-appevent-transformation/typescript/INSTRUCTIONS.md
+++ b/examples/function-appevent-transformation/typescript/INSTRUCTIONS.md
@@ -8,7 +8,7 @@ npx create-contentful-app@latest --example function-appevent-transformation
 
 ### Creating an app
 
-You can create an app using CLI using `npm run create-app-definition`. This will prompt you to enter details for your new app and organization details. You can also create an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Create App" button on the top right.
+You can create an app using the CLI command `npm run create-app-definition`. This will prompt you to enter details for your new app and organization details. You can also create an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Create App" button on the top right.
 
 ### Using environment variables
 
@@ -24,7 +24,7 @@ It as simple using the CLI command `npm run upload-ci`. This will perform two ac
 
 ### Adding locations to an app
 
-You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
+You can add locations to an existing app using the CLI command `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
 You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the **"Edit"** flyout button for your app and selecting locations on the **"General"** tab.
 
 ## Utilizing app event transformation functions

--- a/examples/function-appevent-transformation/typescript/INSTRUCTIONS.md
+++ b/examples/function-appevent-transformation/typescript/INSTRUCTIONS.md
@@ -22,6 +22,10 @@ You will need to set the following environment variables as listed below:
 
 It as simple using the CLI command `npm run upload-ci`. This will perform two actions: upload the code, linking it to the app, and then finally activating the code ready for usage in both
 
+### Adding locations to an app
+
+You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt to allow you to select locations to add to your app. You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Edit" flyout button for your app and selecting locations on the "General" tab.
+
 ## Utilizing app event transformation functions
 
 When you create an app that utilizes [app events](https://www.contentful.com/developers/docs/extensibility/app-framework/app-events/), you can define the entities and topics for these events. An app event transformation function allows you to transform the payload of these events before they are sent off. This example demonstrates how to use the app event transformation function to transform the payload of the `entry.publish` event, by geocoding a latitude and longitude field to a human-readable address.

--- a/examples/function-appevent-transformation/typescript/package.json
+++ b/examples/function-appevent-transformation/typescript/package.json
@@ -3,7 +3,7 @@
     "build": "contentful-app-scripts build-functions --ci"
   },
   "devDependencies": {
-    "@contentful/app-scripts": "^2.1.2",
+    "@contentful/app-scripts": "^2.3.0",
     "@contentful/node-apps-toolkit": "^3.11.1",
     "@tsconfig/recommended": "1.0.8"
   }

--- a/examples/function-comment-bot/javascript/INSTRUCTIONS.md
+++ b/examples/function-comment-bot/javascript/INSTRUCTIONS.md
@@ -20,6 +20,7 @@ This project is an example of a Contentful App Event Function that reacts to com
 ### Building your Function
 
 Use the command below to install this template:
+
 ```shell
 npx create-contentful-app@latest -–example function-comment-bot --javascript
 ```
@@ -42,7 +43,8 @@ When using functions, you don't need to worry about hosting your own code. Conte
 
 ### Adding locations to an app
 
-You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt to allow you to select locations to add to your app. You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Edit" flyout button for your app and selecting locations on the "General" tab.
+You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
+You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the **"Edit"** flyout button for your app and selecting locations on the **"General"** tab.
 
 ## Utilizing app event handler functions
 
@@ -59,7 +61,7 @@ This app contains a comment bot, a Contentful Function that is triggered by comm
 Supported commands out of the box:
 
 - `/show-publish`: Adds the publication widget to the entry’s sidebar.
--	`/hide-publish`: Removes the publication widget from the entry’s sidebar.
+- `/hide-publish`: Removes the publication widget from the entry’s sidebar.
 
 More commands can be added by introducing new actions to the project.
 
@@ -68,9 +70,10 @@ More commands can be added by introducing new actions to the project.
 To add a new action:
 
 1. Create a New Bot Action File: In the [bot-actions](./bot-actions/) directory, create a new file (e.g., yourAction.js).
-2. Implement the Bot Action. If you'd like you can also extend the `BotActionBase` class to gain access to common shared functionality. 
+2. Implement the Bot Action. If you'd like you can also extend the `BotActionBase` class to gain access to common shared functionality.
+
 ```typescript
-import { BotActionBase } from "./bot-action-base";
+import { BotActionBase } from './bot-action-base';
 
 export class YourAction extends BotActionBase {
   async execute(params): Promise<void> {
@@ -80,12 +83,14 @@ export class YourAction extends BotActionBase {
 ```
 
 3. Register the Action: Add the new action to the [bot-action-registry.js] file.
+
 ```typescript
-import { YourAction } from "./yourAction";
+import { YourAction } from './yourAction';
 
 const actionRegistry = {
-  "/your-command": new YourAction(),
+  '/your-command': new YourAction(),
   // Other actions...
 };
 ```
+
 4. Test Your Action: Make a comment on a Contentful entry with your new command, and observe the bot in action.

--- a/examples/function-comment-bot/javascript/INSTRUCTIONS.md
+++ b/examples/function-comment-bot/javascript/INSTRUCTIONS.md
@@ -27,7 +27,7 @@ npx create-contentful-app@latest -–example function-comment-bot --javascript
 
 ### Creating an App
 
-You can create an app using CLI with `npm run create-app-definition`. This will prompt you to enter details for your new app and organization details. You can also create an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Create App" button on the top right.
+You can create an app using the CLI command `npm run create-app-definition`. This will prompt you to enter details for your new app and organization details. You can also create an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Create App" button on the top right.
 
 ### Using Environment Variables
 
@@ -43,7 +43,7 @@ When using functions, you don't need to worry about hosting your own code. Conte
 
 ### Adding locations to an app
 
-You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
+You can add locations to an existing app using the CLI command `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
 You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the **"Edit"** flyout button for your app and selecting locations on the **"General"** tab.
 
 ## Utilizing app event handler functions

--- a/examples/function-comment-bot/javascript/INSTRUCTIONS.md
+++ b/examples/function-comment-bot/javascript/INSTRUCTIONS.md
@@ -40,6 +40,10 @@ You will need to set the following environment variables as listed below:
 
 When using functions, you don't need to worry about hosting your own code. Contentful handles everything, and you just need to use the CLI command `npm run upload`, or, if you have configured the [environment variables](#using-environment-variables) for your project, `npm run upload-ci`. This will perform several actions: uploading the code, linking it to the app, and finally activating the code, making it ready for usage.
 
+### Adding locations to an app
+
+You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt to allow you to select locations to add to your app. You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Edit" flyout button for your app and selecting locations on the "General" tab.
+
 ## Utilizing app event handler functions
 
 When you create an app that utilizes [app events](https://www.contentful.com/developers/docs/extensibility/app-framework/app-events/), you can define the entities and topics for these events. However, you may also want to do some additional handling when these events occur. For example, you may want to send a copy of the event to an external service for logging or monitoring purposes.

--- a/examples/function-comment-bot/javascript/package.json
+++ b/examples/function-comment-bot/javascript/package.json
@@ -3,7 +3,7 @@
     "build": "contentful-app-scripts build-functions --ci"
   },
   "devDependencies": {
-    "@contentful/app-scripts": "^2.1.2",
+    "@contentful/app-scripts": "^2.3.0",
     "@contentful/node-apps-toolkit": "^3.11.1"
   }
 }

--- a/examples/function-comment-bot/typescript/INSTRUCTIONS.md
+++ b/examples/function-comment-bot/typescript/INSTRUCTIONS.md
@@ -20,6 +20,7 @@ This project is an example of a Contentful App Event Function that reacts to com
 ### Building your Function
 
 Use the command below to install this template:
+
 ```shell
 npx create-contentful-app@latest --example function-comment-bot
 ```
@@ -42,7 +43,8 @@ When using functions, you don't need to worry about hosting your own code. Conte
 
 ### Adding locations to an app
 
-You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt to allow you to select locations to add to your app. You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Edit" flyout button for your app and selecting locations on the "General" tab.
+You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
+You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the **"Edit"** flyout button for your app and selecting locations on the **"General"** tab.
 
 ## Utilizing app event handler functions
 
@@ -59,7 +61,7 @@ This app contains a comment bot, a Contentful Function that is triggered by comm
 Supported commands out of the box:
 
 - `/show-publish`: Adds the publication widget to the entry’s sidebar.
--	`/hide-publish`: Removes the publication widget from the entry’s sidebar.
+- `/hide-publish`: Removes the publication widget from the entry’s sidebar.
 
 More commands can be added by introducing new actions to the project.
 
@@ -68,10 +70,11 @@ More commands can be added by introducing new actions to the project.
 To add a new action:
 
 1. Create a New Bot Action File: In the [bot-actions](./bot-actions/) directory, create a new file (e.g., yourAction.ts).
-2. Implement the `BotAction` Interface: Ensure the new bot action implements the `BotAction` interface defined in the [types](types.ts). If you'd like you can also extend the `BotActionBase` class to gain access to common shared functionality. 
+2. Implement the `BotAction` Interface: Ensure the new bot action implements the `BotAction` interface defined in the [types](types.ts). If you'd like you can also extend the `BotActionBase` class to gain access to common shared functionality.
+
 ```typescript
-import { BotActionBase } from "./bot-action-base";
-import type { BotAction, BotActionParams } from "../types";
+import { BotActionBase } from './bot-action-base';
+import type { BotAction, BotActionParams } from '../types';
 
 export class YourAction extends BotActionBase implements BotAction {
   async execute(params: BotActionParams): Promise<void> {
@@ -81,12 +84,14 @@ export class YourAction extends BotActionBase implements BotAction {
 ```
 
 3. Register the Action: Add the new action to the [bot-action-registry.ts](./bot-actions/bot-action-registry.ts) file.
+
 ```typescript
-import { YourAction } from "./yourAction";
+import { YourAction } from './yourAction';
 
 const actionRegistry: { [key: string]: BotAction } = {
-  "/your-command": new YourAction(),
+  '/your-command': new YourAction(),
   // Other actions...
 };
 ```
+
 4. Test Your Action: Make a comment on a Contentful entry with your new command, and observe the bot in action.

--- a/examples/function-comment-bot/typescript/INSTRUCTIONS.md
+++ b/examples/function-comment-bot/typescript/INSTRUCTIONS.md
@@ -27,7 +27,7 @@ npx create-contentful-app@latest --example function-comment-bot
 
 ### Creating an App
 
-You can create an app using CLI with `npm run create-app-definition`. This will prompt you to enter details for your new app and organization details. You can also create an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Create App" button on the top right.
+You can create an app using the CLI command `npm run create-app-definition`. This will prompt you to enter details for your new app and organization details. You can also create an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Create App" button on the top right.
 
 ### Using Environment Variables
 
@@ -43,7 +43,7 @@ When using functions, you don't need to worry about hosting your own code. Conte
 
 ### Adding locations to an app
 
-You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
+You can add locations to an existing app using the CLI command `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
 You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the **"Edit"** flyout button for your app and selecting locations on the **"General"** tab.
 
 ## Utilizing app event handler functions

--- a/examples/function-comment-bot/typescript/INSTRUCTIONS.md
+++ b/examples/function-comment-bot/typescript/INSTRUCTIONS.md
@@ -40,6 +40,10 @@ You will need to set the following environment variables as listed below:
 
 When using functions, you don't need to worry about hosting your own code. Contentful handles everything, and you just need to use the CLI command `npm run upload`, or, if you have configured the [environment variables](#using-environment-variables) for your project, `npm run upload-ci`. This will perform several actions: uploading the code, linking it to the app, and finally activating the code, making it ready for usage.
 
+### Adding locations to an app
+
+You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt to allow you to select locations to add to your app. You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Edit" flyout button for your app and selecting locations on the "General" tab.
+
 ## Utilizing app event handler functions
 
 When you create an app that utilizes [app events](https://www.contentful.com/developers/docs/extensibility/app-framework/app-events/), you can define the entities and topics for these events. However, you may also want to do some additional handling when these events occur. For example, you may want to send a copy of the event to an external service for logging or monitoring purposes.

--- a/examples/function-comment-bot/typescript/package.json
+++ b/examples/function-comment-bot/typescript/package.json
@@ -3,7 +3,7 @@
     "build": "contentful-app-scripts build-functions --ci"
   },
   "devDependencies": {
-    "@contentful/app-scripts": "^2.1.2",
+    "@contentful/app-scripts": "^2.3.0",
     "@contentful/node-apps-toolkit": "^3.11.1",
     "@tsconfig/recommended": "1.0.8"
   }

--- a/examples/function-mock-shop/package.json
+++ b/examples/function-mock-shop/package.json
@@ -19,6 +19,7 @@
     "build": "vite build && npm run build:functions",
     "test": "vitest",
     "create-app-definition": "contentful-app-scripts create-app-definition",
+    "add-locations": "contentful-app-scripts add-locations",
     "upload": "contentful-app-scripts upload --bundle-dir ./build",
     "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN",
     "build:functions": "contentful-app-scripts build-functions --ci"

--- a/examples/function-potterdb-rest-api/INSTRUCTIONS.md
+++ b/examples/function-potterdb-rest-api/INSTRUCTIONS.md
@@ -1,27 +1,34 @@
 ## Building your Function
 
 ### Creating an app
+
 You can create an app using CLI using `npm run create-app-definition`. This will prompt you to enter details for your new app and organization details. You can also create an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Create App" button on the top right.
 
 ### Using environment variables
+
 You will need to set the following environment variables as listed below:
+
 - `CONTENTFUL_ACCESS_TOKEN`: User management token used for authentication/authorization
 - `CONTENTFUL_ORG_ID`: Organization id where the app lives under
 - `CONTENTFUL_APP_DEF_ID`: App definition id for identifying the app
 
 ### Uploading the code to Contentful
-It as simple using the CLI command `npm run upload-ci`. This will perform two actions: upload the code, linking it to the app, and then finally activating the code ready for usage in both 
+
+It as simple using the CLI command `npm run upload-ci`. This will perform two actions: upload the code, linking it to the app, and then finally activating the code ready for usage in both
 
 ### Adding locations to an app
 
-You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt to allow you to select locations to add to your app. You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Edit" flyout button for your app and selecting locations on the "General" tab.
+You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
+You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the **"Edit"** flyout button for your app and selecting locations on the **"General"** tab.
 
 ### Assigning an app to a field
-Functions are meant to help with resolving field data, meaning the app has to be assigned to a field location. You can read more about different app locations [here](https://www.contentful.com/developers/docs/extensibility/app-framework/locations/). 
+
+Functions are meant to help with resolving field data, meaning the app has to be assigned to a field location. You can read more about different app locations [here](https://www.contentful.com/developers/docs/extensibility/app-framework/locations/).
 
 The field is required to be one of the supported types for function: Short text (`Symbol`) or JSON fields (`Object`).
 
 To set up the field location for your app use the [web UI](https://app.contentful.com/deeplink?link=app-definition-list) by going under the "Locations" section in the app details UI, then selecting the appropriate supported locations. After [installing an app to your space environment](https://www.contentful.com/developers/docs/extensibility/app-framework/tutorial/#install-your-app-to-a-space), you can go under the [respective content type](https://app.contentful.com/deeplink?link=content-model) you want to assign the app and visit the appearance section for supported field and selecting the app which will reveal a checkbox to resolve the field when using Contentful's GraphQL API.
 
 ### Using GraphQL app to see your app in action
+
 The simplest way test whether your app is resolving data correctly is to install the [GraphQL app](https://app.contentful.com/deeplink?link=apps&id=graphiql). You should see a new field with a suffix `_data` when querying for your content type, which should contain data resolved from your app.

--- a/examples/function-potterdb-rest-api/INSTRUCTIONS.md
+++ b/examples/function-potterdb-rest-api/INSTRUCTIONS.md
@@ -2,7 +2,7 @@
 
 ### Creating an app
 
-You can create an app using CLI using `npm run create-app-definition`. This will prompt you to enter details for your new app and organization details. You can also create an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Create App" button on the top right.
+You can create an app using the CLI command `npm run create-app-definition`. This will prompt you to enter details for your new app and organization details. You can also create an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Create App" button on the top right.
 
 ### Using environment variables
 
@@ -18,7 +18,7 @@ It as simple using the CLI command `npm run upload-ci`. This will perform two ac
 
 ### Adding locations to an app
 
-You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
+You can add locations to an existing app using the CLI command `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
 You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the **"Edit"** flyout button for your app and selecting locations on the **"General"** tab.
 
 ### Assigning an app to a field

--- a/examples/function-potterdb-rest-api/INSTRUCTIONS.md
+++ b/examples/function-potterdb-rest-api/INSTRUCTIONS.md
@@ -12,6 +12,10 @@ You will need to set the following environment variables as listed below:
 ### Uploading the code to Contentful
 It as simple using the CLI command `npm run upload-ci`. This will perform two actions: upload the code, linking it to the app, and then finally activating the code ready for usage in both 
 
+### Adding locations to an app
+
+You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt to allow you to select locations to add to your app. You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Edit" flyout button for your app and selecting locations on the "General" tab.
+
 ### Assigning an app to a field
 Functions are meant to help with resolving field data, meaning the app has to be assigned to a field location. You can read more about different app locations [here](https://www.contentful.com/developers/docs/extensibility/app-framework/locations/). 
 

--- a/examples/function-potterdb-rest-api/package.json
+++ b/examples/function-potterdb-rest-api/package.json
@@ -23,6 +23,7 @@
     "build": "vite build && npm run build:functions",
     "test": "vitest",
     "create-app-definition": "contentful-app-scripts create-app-definition",
+    "add-locations": "contentful-app-scripts add-locations",
     "upload": "contentful-app-scripts upload --bundle-dir ./build",
     "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN",
     "build:functions": "contentful-app-scripts build-functions --ci"

--- a/examples/function-potterdb/INSTRUCTIONS.md
+++ b/examples/function-potterdb/INSTRUCTIONS.md
@@ -2,7 +2,7 @@
 
 ### Creating an app
 
-You can create an app using CLI using `npm run create-app-definition`. This will prompt you to enter details for your new app and organization details. You can also create an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Create App" button on the top right.
+You can create an app using the CLI command `npm run create-app-definition`. This will prompt you to enter details for your new app and organization details. You can also create an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Create App" button on the top right.
 
 ### Using environment variables
 
@@ -18,7 +18,7 @@ It as simple using the CLI command `npm run upload-ci`. This will perform two ac
 
 ### Adding locations to an app
 
-You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
+You can add locations to an existing app using the CLI command `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
 You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the **"Edit"** flyout button for your app and selecting locations on the **"General"** tab.
 
 ### Assigning an app to a field

--- a/examples/function-potterdb/INSTRUCTIONS.md
+++ b/examples/function-potterdb/INSTRUCTIONS.md
@@ -1,27 +1,34 @@
 ## Building your Function
 
 ### Creating an app
+
 You can create an app using CLI using `npm run create-app-definition`. This will prompt you to enter details for your new app and organization details. You can also create an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Create App" button on the top right.
 
 ### Using environment variables
+
 You will need to set the following environment variables as listed below:
+
 - `CONTENTFUL_ACCESS_TOKEN`: User management token used for authentication/authorization
 - `CONTENTFUL_ORG_ID`: Organization id where the app lives under
 - `CONTENTFUL_APP_DEF_ID`: App definition id for identifying the app
 
 ### Uploading the code to Contentful
-It as simple using the CLI command `npm run upload-ci`. This will perform two actions: upload the code, linking it to the app, and then finally activating the code ready for usage in both 
+
+It as simple using the CLI command `npm run upload-ci`. This will perform two actions: upload the code, linking it to the app, and then finally activating the code ready for usage in both
 
 ### Adding locations to an app
 
-You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt to allow you to select locations to add to your app. You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Edit" flyout button for your app and selecting locations on the "General" tab.
+You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
+You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the **"Edit"** flyout button for your app and selecting locations on the **"General"** tab.
 
 ### Assigning an app to a field
-Functions are meant to help with resolving field data, meaning the app has to be assigned to a field location. You can read more about different app locations [here](https://www.contentful.com/developers/docs/extensibility/app-framework/locations/). 
+
+Functions are meant to help with resolving field data, meaning the app has to be assigned to a field location. You can read more about different app locations [here](https://www.contentful.com/developers/docs/extensibility/app-framework/locations/).
 
 The field is required to be one of the supported types for function: Short text (`Symbol`) or JSON fields (`Object`).
 
 To set up the field location for your app use the [web UI](https://app.contentful.com/deeplink?link=app-definition-list) by going under the "Locations" section in the app details UI, then selecting the appropriate supported locations. After [installing an app to your space environment](https://www.contentful.com/developers/docs/extensibility/app-framework/tutorial/#install-your-app-to-a-space), you can go under the [respective content type](https://app.contentful.com/deeplink?link=content-model) you want to assign the app and visit the appearance section for supported field and selecting the app which will reveal a checkbox to resolve the field when using Contentful's GraphQL API.
 
 ### Using GraphQL app to see your app in action
+
 The simplest way test whether your app is resolving data correctly is to install the [GraphiQL app](https://app.contentful.com/deeplink?link=apps&id=graphiql). You should see a new field with a suffix `_data` when querying for your content type, which should contain data resolved from your app.

--- a/examples/function-potterdb/INSTRUCTIONS.md
+++ b/examples/function-potterdb/INSTRUCTIONS.md
@@ -12,6 +12,10 @@ You will need to set the following environment variables as listed below:
 ### Uploading the code to Contentful
 It as simple using the CLI command `npm run upload-ci`. This will perform two actions: upload the code, linking it to the app, and then finally activating the code ready for usage in both 
 
+### Adding locations to an app
+
+You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt to allow you to select locations to add to your app. You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Edit" flyout button for your app and selecting locations on the "General" tab.
+
 ### Assigning an app to a field
 Functions are meant to help with resolving field data, meaning the app has to be assigned to a field location. You can read more about different app locations [here](https://www.contentful.com/developers/docs/extensibility/app-framework/locations/). 
 

--- a/examples/function-potterdb/package.json
+++ b/examples/function-potterdb/package.json
@@ -20,6 +20,7 @@
     "build": "vite build && npm run build:functions",
     "test": "vitest",
     "create-app-definition": "contentful-app-scripts create-app-definition",
+    "add-locations": "contentful-app-scripts add-locations",
     "upload": "contentful-app-scripts upload --bundle-dir ./build",
     "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN",
     "build:functions": "contentful-app-scripts build-functions --ci"

--- a/examples/function-templates/javascript/INSTRUCTIONS.md
+++ b/examples/function-templates/javascript/INSTRUCTIONS.md
@@ -18,6 +18,10 @@ You will need to set the following environment variables as listed below:
 ### Uploading the code to Contentful
 It as simple using the CLI command `npm run upload-ci`. This will perform two actions: upload the code, linking it to the app, and then finally activating the code ready for usage in both 
 
+### Adding locations to an app
+
+You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt to allow you to select locations to add to your app. You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Edit" flyout button for your app and selecting locations on the "General" tab.
+
 ### Assigning an app to a field
 Functions that support resolving field data on the GraphQL API have to be assigned to a field location. You can read more about different app locations [here](https://www.contentful.com/developers/docs/extensibility/app-framework/locations/). 
 

--- a/examples/function-templates/javascript/INSTRUCTIONS.md
+++ b/examples/function-templates/javascript/INSTRUCTIONS.md
@@ -7,27 +7,34 @@ npx create-contentful-app@latest --javascript --function external-references
 ```
 
 ### Creating an app
+
 You can create an app using CLI using `npm run create-app-definition`. This will prompt you to enter details for your new app and organization details. You can also create an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Create App" button on the top right.
 
 ### Using environment variables
+
 You will need to set the following environment variables as listed below:
+
 - `CONTENTFUL_ACCESS_TOKEN`: User management token used for authentication/authorization
 - `CONTENTFUL_ORG_ID`: Organization id where the app lives under
 - `CONTENTFUL_APP_DEF_ID`: App definition id for identifying the app
 
 ### Uploading the code to Contentful
-It as simple using the CLI command `npm run upload-ci`. This will perform two actions: upload the code, linking it to the app, and then finally activating the code ready for usage in both 
+
+It as simple using the CLI command `npm run upload-ci`. This will perform two actions: upload the code, linking it to the app, and then finally activating the code ready for usage in both
 
 ### Adding locations to an app
 
-You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt to allow you to select locations to add to your app. You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Edit" flyout button for your app and selecting locations on the "General" tab.
+You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
+You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the **"Edit"** flyout button for your app and selecting locations on the **"General"** tab.
 
 ### Assigning an app to a field
-Functions that support resolving field data on the GraphQL API have to be assigned to a field location. You can read more about different app locations [here](https://www.contentful.com/developers/docs/extensibility/app-framework/locations/). 
+
+Functions that support resolving field data on the GraphQL API have to be assigned to a field location. You can read more about different app locations [here](https://www.contentful.com/developers/docs/extensibility/app-framework/locations/).
 
 Supported field types for field data resolution are: Short text (`Symbol`) or JSON fields (`Object`).
 
 To set up the field location for your app use the [web UI](https://app.contentful.com/deeplink?link=app-definition-list) by going under the "Locations" section in the app details UI, then selecting the appropriate supported locations. After [installing an app to your space environment](https://www.contentful.com/developers/docs/extensibility/app-framework/tutorial/#install-your-app-to-a-space), you can go under the [respective content type](https://app.contentful.com/deeplink?link=content-model) you want to assign the app and visit the appearance section for supported field and selecting the app which will reveal a checkbox to resolve the field when using Contentful's GraphQL API.
 
 ### Using GraphQL app to see your app in action
+
 The simplest way test whether your app is resolving data correctly is to install the [GraphQL Playground app](https://app.contentful.com/deeplink?link=apps&id=graphql-playground). You should see a new field with a suffix `_data` when querying for your content type, which should contain data resolved from your app.

--- a/examples/function-templates/javascript/INSTRUCTIONS.md
+++ b/examples/function-templates/javascript/INSTRUCTIONS.md
@@ -8,7 +8,7 @@ npx create-contentful-app@latest --javascript --function external-references
 
 ### Creating an app
 
-You can create an app using CLI using `npm run create-app-definition`. This will prompt you to enter details for your new app and organization details. You can also create an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Create App" button on the top right.
+You can create an app using the CLI command `npm run create-app-definition`. This will prompt you to enter details for your new app and organization details. You can also create an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Create App" button on the top right.
 
 ### Using environment variables
 
@@ -24,7 +24,7 @@ It as simple using the CLI command `npm run upload-ci`. This will perform two ac
 
 ### Adding locations to an app
 
-You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
+You can add locations to an existing app using the CLI command `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
 You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the **"Edit"** flyout button for your app and selecting locations on the **"General"** tab.
 
 ### Assigning an app to a field

--- a/examples/function-templates/javascript/package.json
+++ b/examples/function-templates/javascript/package.json
@@ -3,6 +3,6 @@
     "build": "contentful-app-scripts build-functions --ci"
   },
   "devDependencies": {
-    "@contentful/app-scripts": "^1.32.0"
+    "@contentful/app-scripts": "^2.3.0"
   }
 }

--- a/examples/function-templates/typescript/INSTRUCTIONS.md
+++ b/examples/function-templates/typescript/INSTRUCTIONS.md
@@ -7,27 +7,34 @@ npx create-contentful-app@latest --function external-references
 ```
 
 ### Creating an app
+
 You can create an app using CLI using `npm run create-app-definition`. This will prompt you to enter details for your new app and organization details. You can also create an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Create App" button on the top right.
 
 ### Using environment variables
+
 You will need to set the following environment variables as listed below:
+
 - `CONTENTFUL_ACCESS_TOKEN`: User management token used for authentication/authorization
 - `CONTENTFUL_ORG_ID`: Organization id where the app lives under
 - `CONTENTFUL_APP_DEF_ID`: App definition id for identifying the app
 
 ### Uploading the code to Contentful
-It as simple using the CLI command `npm run upload-ci`. This will perform two actions: upload the code, linking it to the app, and then finally activating the code ready for usage in both 
+
+It as simple using the CLI command `npm run upload-ci`. This will perform two actions: upload the code, linking it to the app, and then finally activating the code ready for usage in both
 
 ### Adding locations to an app
 
-You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt to allow you to select locations to add to your app. You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Edit" flyout button for your app and selecting locations on the "General" tab.
+You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
+You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the **"Edit"** flyout button for your app and selecting locations on the **"General"** tab.
 
 ### Assigning an app to a field
-Functions are meant to help with resolving field data, meaning the app has to be assigned to a field location. You can read more about different app locations [here](https://www.contentful.com/developers/docs/extensibility/app-framework/locations/). 
+
+Functions are meant to help with resolving field data, meaning the app has to be assigned to a field location. You can read more about different app locations [here](https://www.contentful.com/developers/docs/extensibility/app-framework/locations/).
 
 The field is required to be one of the supported types for function: Short text (`Symbol`) or JSON fields (`Object`).
 
 To set up the field location for your app use the [web UI](https://app.contentful.com/deeplink?link=app-definition-list) by going under the "Locations" section in the app details UI, then selecting the appropriate supported locations. After [installing an app to your space environment](https://www.contentful.com/developers/docs/extensibility/app-framework/tutorial/#install-your-app-to-a-space), you can go under the [respective content type](https://app.contentful.com/deeplink?link=content-model) you want to assign the app and visit the appearance section for supported field and selecting the app which will reveal a checkbox to resolve the field when using Contentful's GraphQL API.
 
 ### Using GraphQL app to see your app in action
+
 The simplest way test whether your app is resolving data correctly is to install the [GraphQL Playground app](https://app.contentful.com/deeplink?link=apps&id=graphql-playground). You should see a new field with a suffix `_data` when querying for your content type, which should contain data resolved from your app.

--- a/examples/function-templates/typescript/INSTRUCTIONS.md
+++ b/examples/function-templates/typescript/INSTRUCTIONS.md
@@ -18,6 +18,10 @@ You will need to set the following environment variables as listed below:
 ### Uploading the code to Contentful
 It as simple using the CLI command `npm run upload-ci`. This will perform two actions: upload the code, linking it to the app, and then finally activating the code ready for usage in both 
 
+### Adding locations to an app
+
+You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt to allow you to select locations to add to your app. You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Edit" flyout button for your app and selecting locations on the "General" tab.
+
 ### Assigning an app to a field
 Functions are meant to help with resolving field data, meaning the app has to be assigned to a field location. You can read more about different app locations [here](https://www.contentful.com/developers/docs/extensibility/app-framework/locations/). 
 

--- a/examples/function-templates/typescript/INSTRUCTIONS.md
+++ b/examples/function-templates/typescript/INSTRUCTIONS.md
@@ -8,7 +8,7 @@ npx create-contentful-app@latest --function external-references
 
 ### Creating an app
 
-You can create an app using CLI using `npm run create-app-definition`. This will prompt you to enter details for your new app and organization details. You can also create an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Create App" button on the top right.
+You can create an app using the CLI command `npm run create-app-definition`. This will prompt you to enter details for your new app and organization details. You can also create an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Create App" button on the top right.
 
 ### Using environment variables
 
@@ -24,7 +24,7 @@ It as simple using the CLI command `npm run upload-ci`. This will perform two ac
 
 ### Adding locations to an app
 
-You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
+You can add locations to an existing app using the CLI command `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
 You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the **"Edit"** flyout button for your app and selecting locations on the **"General"** tab.
 
 ### Assigning an app to a field

--- a/examples/function-templates/typescript/package.json
+++ b/examples/function-templates/typescript/package.json
@@ -3,7 +3,7 @@
     "build": "contentful-app-scripts build-functions --ci"
   },
   "devDependencies": {
-    "@contentful/app-scripts": "^1.32.0",
+    "@contentful/app-scripts": "^2.3.0",
     "@contentful/node-apps-toolkit": "^3.9.0",
     "@tsconfig/recommended": "1.0.8"
   }

--- a/examples/home-location/package.json
+++ b/examples/home-location/package.json
@@ -19,6 +19,7 @@
     "build": "vite build",
     "test": "vitest",
     "create-app-definition": "contentful-app-scripts create-app-definition",
+    "add-locations": "contentful-app-scripts add-locations",
     "upload": "contentful-app-scripts upload --bundle-dir ./dist",
     "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./dist --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN"
   },
@@ -38,7 +39,7 @@
     ]
   },
   "devDependencies": {
-    "@contentful/app-scripts": "1.10.2",
+    "@contentful/app-scripts": "^2.3.0",
     "@testing-library/jest-dom": "5.16.5",
     "@testing-library/react": "14.0.0",
     "@tsconfig/create-react-app": "2.0.0",

--- a/examples/javascript/package.json
+++ b/examples/javascript/package.json
@@ -19,6 +19,7 @@
     "preview": "vite preview",
     "test": "vitest",
     "create-app-definition": "contentful-app-scripts create-app-definition",
+    "add-locations": "contentful-app-scripts add-locations",
     "upload": "contentful-app-scripts upload --bundle-dir ./build",
     "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN"
   },
@@ -38,7 +39,7 @@
     ]
   },
   "devDependencies": {
-    "@contentful/app-scripts": "^2.2.0",
+    "@contentful/app-scripts": "^2.3.0",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^14.3.1",
     "@vitejs/plugin-react": "^4.0.3",

--- a/examples/last-fm/package.json
+++ b/examples/last-fm/package.json
@@ -18,6 +18,7 @@
     "build": "vite build",
     "eject": "vite eject",
     "create-app-definition": "contentful-app-scripts create-app-definition",
+    "add-locations": "contentful-app-scripts add-locations",
     "upload": "contentful-app-scripts upload --bundle-dir ./dist",
     "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./dist --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN"
   },
@@ -37,7 +38,7 @@
     ]
   },
   "devDependencies": {
-    "@contentful/app-scripts": "1.10.2",
+    "@contentful/app-scripts": "^2.3.0",
     "@tsconfig/create-react-app": "2.0.0",
     "@types/jest": "29.5.2",
     "@types/node": "16.18.38",

--- a/examples/native-external-references-mockshop/package.json
+++ b/examples/native-external-references-mockshop/package.json
@@ -6,6 +6,7 @@
     "build": "npm run build:functions",
     "build:functions": "contentful-app-scripts build-functions --ci",
     "create-app-definition": "contentful-app-scripts create-app-definition",
+    "add-locations": "contentful-app-scripts add-locations",
     "upload": "contentful-app-scripts upload --bundle-dir ./build",
     "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN",
     "open-settings": "contentful-app-scripts open-settings",
@@ -16,7 +17,7 @@
     "prettier": "prettier --write functions, src"
   },
   "devDependencies": {
-    "@contentful/app-scripts": "^2.2.0",
+    "@contentful/app-scripts": "^2.3.0",
     "@tsconfig/recommended": "^1.0.8",
     "@types/node": "^16.18.126",
     "contentful-management": "^11.48.0",

--- a/examples/native-external-references-tmdb/README.md
+++ b/examples/native-external-references-tmdb/README.md
@@ -121,7 +121,7 @@ The interactive CLI will prompt you to provide additional details, such as a CMA
 
 ## Adding locations to an app
 
-You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
+You can add locations to an existing app using the CLI command `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
 You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the **"Edit"** flyout button for your app and selecting locations on the **"General"** tab.
 
 ### Running the app locally

--- a/examples/native-external-references-tmdb/README.md
+++ b/examples/native-external-references-tmdb/README.md
@@ -120,6 +120,10 @@ npm run upload
 
 The interactive CLI will prompt you to provide additional details, such as a CMA endpoint URL. Select **Yes** when prompted if you’d like to activate the bundle after upload.
 
+## Adding locations to an app
+
+You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt to allow you to select locations to add to your app. You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Edit" flyout button for your app and selecting locations on the "General" tab.
+
 ### Running the app locally
 
 The steps above will upload the app to Contentful's infrastructure. However, you can also run the app locally to be able to easier debug the code. To do this:

--- a/examples/native-external-references-tmdb/README.md
+++ b/examples/native-external-references-tmdb/README.md
@@ -7,23 +7,22 @@ This project was bootstrapped with [Create Contentful App](https://github.com/co
 1. [Prerequisites](#prerequisites)
 2. [Description](#description)
 3. [Instructions to create and run the app](#instructions-to-create-and-run-the-app)
-    - [Copying the example](#copying-the-example)
-    - [Creating a custom app definition](#creating-a-custom-app-definition)
-    - [Building and uploading the app](#building-and-uploading-the-app)
-      - [Running the app locally](#running-the-app-locally)
-    - [Creating resource entities](#creating-resource-entities)
-    - [Installing the app](#installing-the-app)
+   - [Copying the example](#copying-the-example)
+   - [Creating a custom app definition](#creating-a-custom-app-definition)
+   - [Building and uploading the app](#building-and-uploading-the-app)
+     - [Running the app locally](#running-the-app-locally)
+   - [Creating resource entities](#creating-resource-entities)
+   - [Installing the app](#installing-the-app)
 4. [Entities overview](#entities-overview)
 5. [Code structure](#code-structure)
-    - [Functions](#functions)
-      - [Search request](#search-request)
-      - [Lookup request](#lookup-request)
-      - [Response](#response)
-      - [Example](#example)
-    - [Property mapping for rendering in the Web app](#property-mapping-for-rendering-in-the-web-app)
-    - [App manifest](#app-manifest)
+   - [Functions](#functions)
+     - [Search request](#search-request)
+     - [Lookup request](#lookup-request)
+     - [Response](#response)
+     - [Example](#example)
+   - [Property mapping for rendering in the Web app](#property-mapping-for-rendering-in-the-web-app)
+   - [App manifest](#app-manifest)
 6. [Available Scripts](#available-scripts)
-
 
 # Prerequisites
 
@@ -32,8 +31,8 @@ This project was bootstrapped with [Create Contentful App](https://github.com/co
   - [Functions](https://www.contentful.com/developers/docs/extensibility/app-framework/functions/)
 - The space where you will install the application has the [Orchestration](https://www.contentful.com/help/orchestration/) feature enabled.
 - A valid API token for the TMDB API is required to run this app. You can get one by signing up at [TMDB](https://www.themoviedb.org/signup).
-> **NOTE:**
-> TMDB does not generate the API token instantly. Make sure you initiate the signup process in advance to prevent any hindrance to your progress.
+  > **NOTE:**
+  > TMDB does not generate the API token instantly. Make sure you initiate the signup process in advance to prevent any hindrance to your progress.
 - Your system has installed:
   - [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
   - The latest LTS version of [Node.js](https://nodejs.org/en/)
@@ -47,7 +46,7 @@ Contentful provides a method for integrating content from external sources using
 
 To overcome these challenges, we offer a more streamlined and cohesive approach to linking third-party systems through existing content model Reference Fields. This upgraded version of fields is referred to as **Native external references**.
 
-This example is designed to walk you through the beta version of the extended linking feature. Currently, the application setup primarily revolves around command-line operations. However, you can also view the connected content displayed in the user interface. 
+This example is designed to walk you through the beta version of the extended linking feature. Currently, the application setup primarily revolves around command-line operations. However, you can also view the connected content displayed in the user interface.
 For the purpose of this example, we will be connecting to the [Movie Database](https://www.themoviedb.org/) external system.
 
 With Native external references we introduce the following new entity types that allow us to model the data from third-party systems in Contentful:
@@ -60,7 +59,7 @@ With Native external references we introduce the following new entity types that
 
 ## Copying the example
 
-To get started with your application, you need to make a local copy of the example code by running the following command in your terminal. 
+To get started with your application, you need to make a local copy of the example code by running the following command in your terminal.
 
 > **NOTE:**
 > Make sure you replace `<name-of-your-app>` with the name of your choice.
@@ -104,8 +103,8 @@ You will need to answer the following questions on the terminal. Feel free to pr
 - Select **Symbol** as type and mark the parameter as required.
 
 5. The next steps will lead you through the process of providing a Contentful access token to the application and specifying the organization to which the application should be assigned.
-> **NOTE:**
-> Make sure the organization ID you select here is the Organization that has access to the Native external references feature.
+   > **NOTE:**
+   > Make sure the organization ID you select here is the Organization that has access to the Native external references feature.
 
 You now have a basic application that can be enriched with additional information that will enable the example project you downloaded to function properly.
 
@@ -122,7 +121,8 @@ The interactive CLI will prompt you to provide additional details, such as a CMA
 
 ## Adding locations to an app
 
-You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt to allow you to select locations to add to your app. You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the "Edit" flyout button for your app and selecting locations on the "General" tab.
+You can add locations to an existing app using CLI using `npm run add-locations`. This will launch an interactive prompt, allowing you to select locations to add to your app.
+You can also add locations to an app definition by [visiting the apps section](https://app.contentful.com/deeplink?link=app-definition-list) under your organization settings in the Contentful web UI and clicking on the **"Edit"** flyout button for your app and selecting locations on the **"General"** tab.
 
 ### Running the app locally
 
@@ -144,9 +144,8 @@ npm run create-resource-entities
 
 This will tell Contentful that we want to connect to `TMDB` via the function we uploaded in [Building and uploading the app](#building-and-uploading-the-app) step and that the same function can provide `TMDB:Movie` and `TMDB:Person` _Resource Types_.
 
-> **NOTE:**
-> `create-resource-entities` script generates new entities within the system, and prints out a minimal log when the operation has succeeded.
-> 
+> **NOTE:** > `create-resource-entities` script generates new entities within the system, and prints out a minimal log when the operation has succeeded.
+>
 > If you would like to list all the previously created entities, you can utilize a similar script that prints out more verbose details: `npm run show-resource-entities`.
 
 ## Installing the app
@@ -240,7 +239,7 @@ type ResourcesSearchRequest = {
 
 | property         | type                          | description                                                                                                                        |
 | ---------------- | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| limit            | number (required)             | Number defining the maximum items that should be returned                                                                       |
+| limit            | number (required)             | Number defining the maximum items that should be returned                                                                          |
 | pages            | object (optional)             |
 | pages.nextCursor | string (required)             | Cursor string pointing to the specific page of results to be used as a starting point for the request                              |
 | resourceType     | string (required)             | String consisting of the name of the provider and the resource within the provider, in a format `{Provider}:{Type}, eg. TMDB:Movie |
@@ -269,7 +268,7 @@ type ResourcesLookupRequest<
 
 | property         | type                          | description                                                                                                                        |
 | ---------------- | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| limit            | number (required)             | Number defining the maximum items that should be returned                                                                       |
+| limit            | number (required)             | Number defining the maximum items that should be returned                                                                          |
 | pages            | object (optional)             |
 | pages.nextCursor | string (required)             | Cursor string pointing to the specific page of results to be used as a starting point for the request                              |
 | resourceType     | string (required)             | String consisting of the name of the provider and the resource within the provider, in a format `{Provider}:{Type}, eg. TMDB:Movie |

--- a/examples/native-external-references-tmdb/package.json
+++ b/examples/native-external-references-tmdb/package.json
@@ -20,6 +20,7 @@
     "preview": "vite preview",
     "test": "vitest",
     "create-app-definition": "contentful-app-scripts create-app-definition",
+    "add-locations": "contentful-app-scripts add-locations",
     "upload": "contentful-app-scripts upload --bundle-dir ./build",
     "upload-ci": "contentful-app-scripts upload --ci --host api.contentful.com --bundle-dir ./build --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN",
     "prettier": "prettier --write functions",

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -9,7 +9,8 @@
     "lint": "next lint",
     "test": "jest --watch",
     "test:ci": "jest --ci",
-    "create-app-definition": "contentful-app-scripts create-app-definition"
+    "create-app-definition": "contentful-app-scripts create-app-definition",
+    "add-locations": "contentful-app-scripts add-locations"
   },
   "dependencies": {
     "@contentful/app-sdk": "4.22.0",
@@ -21,7 +22,7 @@
     "react-dom": "18.2.0"
   },
   "devDependencies": {
-    "@contentful/app-scripts": "1.15.0",
+    "@contentful/app-scripts": "^2.3.0",
     "@testing-library/jest-dom": "5.16.5",
     "@testing-library/react": "14.0.0",
     "@types/node": "16.18.38",

--- a/examples/page-location/package.json
+++ b/examples/page-location/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@contentful/app-scripts": "^1.30.1",
+    "@contentful/app-scripts": "^2.3.0",
     "@contentful/app-sdk": "4.22.0",
     "@contentful/f36-components": "4.45.0",
     "@contentful/f36-tokens": "4.0.2",
@@ -23,6 +23,7 @@
     "start": "vite",
     "build": "tsc && vite build",
     "create-app-definition": "contentful-app-scripts create-app-definition",
+    "add-locations": "contentful-app-scripts add-locations",
     "upload": "contentful-app-scripts upload --bundle-dir ./dist",
     "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./dist  --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN"
   },

--- a/examples/remix/package.json
+++ b/examples/remix/package.json
@@ -13,7 +13,7 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@contentful/app-scripts": "^1.30.1",
+    "@contentful/app-scripts": "^2.3.0",
     "@contentful/app-sdk": "^4.29.1",
     "@contentful/f36-components": "^4.68.1",
     "@contentful/f36-tokens": "^4.0.5",

--- a/examples/stateful-sidebar-with-dialog/package.json
+++ b/examples/stateful-sidebar-with-dialog/package.json
@@ -18,11 +18,12 @@
     "preview": "vite preview",
     "test": "vitest",
     "create-app-definition": "contentful-app-scripts create-app-definition",
+    "add-locations": "contentful-app-scripts add-locations",
     "upload": "contentful-app-scripts upload --bundle-dir ./dist",
     "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./dist --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN"
   },
   "devDependencies": {
-    "@contentful/app-scripts": "1.26.0",
+    "@contentful/app-scripts": "^2.3.0",
     "@testing-library/jest-dom": "^6.4.8",
     "@testing-library/react": "14.3.1",
     "@tsconfig/create-react-app": "2.0.0",

--- a/examples/typescript-github-action/package.json
+++ b/examples/typescript-github-action/package.json
@@ -18,11 +18,12 @@
     "preview": "vite preview",
     "test": "vitest",
     "create-app-definition": "contentful-app-scripts create-app-definition",
+    "add-locations": "contentful-app-scripts add-locations",
     "upload": "contentful-app-scripts upload --bundle-dir ./dist",
     "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./dist --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN"
   },
   "devDependencies": {
-    "@contentful/app-scripts": "1.10.2",
+    "@contentful/app-scripts": "^2.3.0",
     "@testing-library/jest-dom": "^6.4.8",
     "@testing-library/react": "14.0.0",
     "@tsconfig/create-react-app": "2.0.0",

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -19,6 +19,7 @@
     "preview": "vite preview",
     "test": "vitest",
     "create-app-definition": "contentful-app-scripts create-app-definition",
+    "add-locations": "contentful-app-scripts add-locations",
     "upload": "contentful-app-scripts upload --bundle-dir ./build",
     "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN"
   },
@@ -38,7 +39,7 @@
     ]
   },
   "devDependencies": {
-    "@contentful/app-scripts": "^2.2.0",
+    "@contentful/app-scripts": "^2.3.0",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^14.3.1",
     "@types/node": "^22.13.5",

--- a/examples/vite-react/package.json
+++ b/examples/vite-react/package.json
@@ -18,11 +18,12 @@
     "build": "tsc && vite build",
     "test": "vitest",
     "create-app-definition": "contentful-app-scripts create-app-definition",
+    "add-locations": "contentful-app-scripts add-locations",
     "upload": "contentful-app-scripts upload --bundle-dir ./dist",
     "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./dist  --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN"
   },
   "devDependencies": {
-    "@contentful/app-scripts": "1.19.1",
+    "@contentful/app-scripts": "^2.3.0",
     "@testing-library/react": "14.0.0",
     "@types/node": "16.18.38",
     "@types/react": "18.3.1",

--- a/examples/vue/package.json
+++ b/examples/vue/package.json
@@ -9,6 +9,7 @@
     "typecheck": "vue-tsc --noEmit -p tsconfig.vitest.json --composite false",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore",
     "create-app-definition": "contentful-app-scripts create-app-definition",
+    "add-locations": "contentful-app-scripts add-locations",
     "upload": "contentful-app-scripts upload --bundle-dir ./dist",
     "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./dist --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN"
   },
@@ -18,7 +19,7 @@
   },
   "devDependencies": {
     "@babel/types": "7.22.5",
-    "@contentful/app-scripts": "1.15.0",
+    "@contentful/app-scripts": "^2.3.0",
     "@rushstack/eslint-patch": "1.3.2",
     "@types/jsdom": "21.1.1",
     "@types/node": "16.18.38",

--- a/function-examples/appaction-call/javascript/package.json
+++ b/function-examples/appaction-call/javascript/package.json
@@ -4,7 +4,7 @@
     "upsert-actions": "contentful-app-scripts upsert-actions --ci --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN"
   },
   "devDependencies": {
-    "@contentful/app-scripts": "^2.1.2",
+    "@contentful/app-scripts": "^2.3.0",
     "@contentful/node-apps-toolkit": "^3.11.1",
     "@tsconfig/recommended": "1.0.8"
   }

--- a/function-examples/appaction-call/typescript/package.json
+++ b/function-examples/appaction-call/typescript/package.json
@@ -4,7 +4,7 @@
     "upsert-actions": "contentful-app-scripts upsert-actions --ci --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN"
   },
   "devDependencies": {
-    "@contentful/app-scripts": "^2.1.2",
+    "@contentful/app-scripts": "^2.3.0",
     "@contentful/node-apps-toolkit": "^3.11.1",
     "@tsconfig/recommended": "1.0.8"
   }

--- a/function-examples/appevent-filter/javascript/package.json
+++ b/function-examples/appevent-filter/javascript/package.json
@@ -3,7 +3,7 @@
     "build": "contentful-app-scripts build-functions --ci"
   },
   "devDependencies": {
-    "@contentful/app-scripts": "^2.1.2",
+    "@contentful/app-scripts": "^2.3.0",
     "sentiment": "^5.0.2"
   }
 }

--- a/function-examples/appevent-filter/typescript/package.json
+++ b/function-examples/appevent-filter/typescript/package.json
@@ -3,7 +3,7 @@
     "build": "contentful-app-scripts build-functions --ci"
   },
   "devDependencies": {
-    "@contentful/app-scripts": "^2.1.2",
+    "@contentful/app-scripts": "^2.3.0",
     "@contentful/node-apps-toolkit": "^3.11.1",
     "@tsconfig/recommended": "1.0.8",
     "@types/sentiment": "^5.0.4",

--- a/function-examples/appevent-handler/javascript/package.json
+++ b/function-examples/appevent-handler/javascript/package.json
@@ -3,6 +3,6 @@
     "build": "contentful-app-scripts build-functions --ci"
   },
   "devDependencies": {
-    "@contentful/app-scripts": "^2.1.2"
+    "@contentful/app-scripts": "^2.3.0"
   }
 }

--- a/function-examples/appevent-handler/typescript/package.json
+++ b/function-examples/appevent-handler/typescript/package.json
@@ -3,7 +3,7 @@
     "build": "contentful-app-scripts build-functions --ci"
   },
   "devDependencies": {
-    "@contentful/app-scripts": "^2.1.2",
+    "@contentful/app-scripts": "^2.3.0",
     "@contentful/node-apps-toolkit": "^3.11.1",
     "@tsconfig/recommended": "1.0.8"
   }

--- a/function-examples/appevent-transformation/javascript/package.json
+++ b/function-examples/appevent-transformation/javascript/package.json
@@ -3,6 +3,6 @@
     "build": "contentful-app-scripts build-functions --ci"
   },
   "devDependencies": {
-    "@contentful/app-scripts": "^2.1.2"
+    "@contentful/app-scripts": "^2.3.0"
   }
 }

--- a/function-examples/appevent-transformation/typescript/package.json
+++ b/function-examples/appevent-transformation/typescript/package.json
@@ -3,7 +3,7 @@
     "build": "contentful-app-scripts build-functions --ci"
   },
   "devDependencies": {
-    "@contentful/app-scripts": "^2.1.2",
+    "@contentful/app-scripts": "^2.3.0",
     "@contentful/node-apps-toolkit": "^3.11.1",
     "@tsconfig/recommended": "1.0.8"
   }

--- a/function-examples/external-references/javascript/package.json
+++ b/function-examples/external-references/javascript/package.json
@@ -3,6 +3,6 @@
     "build": "contentful-app-scripts build-functions --ci"
   },
   "devDependencies": {
-    "@contentful/app-scripts": "^2.1.2"
+    "@contentful/app-scripts": "^2.3.0"
   }
 }

--- a/function-examples/external-references/typescript/package.json
+++ b/function-examples/external-references/typescript/package.json
@@ -3,7 +3,7 @@
     "build": "contentful-app-scripts build-functions --ci"
   },
   "devDependencies": {
-    "@contentful/app-scripts": "^2.1.2",
+    "@contentful/app-scripts": "^2.3.0",
     "@contentful/node-apps-toolkit": "^3.11.1",
     "@tsconfig/recommended": "1.0.8"
   }

--- a/function-examples/kitchen-sink/javascript/package.json
+++ b/function-examples/kitchen-sink/javascript/package.json
@@ -4,7 +4,7 @@
     "upsert-actions": "contentful-app-scripts upsert-actions --ci --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN"
   },
   "devDependencies": {
-    "@contentful/app-scripts": "^2.1.2",
+    "@contentful/app-scripts": "^2.3.0",
     "@contentful/node-apps-toolkit": "^3.11.1",
     "@tsconfig/recommended": "1.0.8"
   }

--- a/function-examples/kitchen-sink/typescript/package.json
+++ b/function-examples/kitchen-sink/typescript/package.json
@@ -4,7 +4,7 @@
     "upsert-actions": "contentful-app-scripts upsert-actions --ci --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN"
   },
   "devDependencies": {
-    "@contentful/app-scripts": "^2.1.2",
+    "@contentful/app-scripts": "^2.3.0",
     "@contentful/node-apps-toolkit": "^3.11.1",
     "@tsconfig/recommended": "1.0.8"
   }


### PR DESCRIPTION
## Purpose

Bump @contentful/app-scripts to ^2.3.0 for all examples
Add a new add-locations interactive script to all examples

## Approach

Some of the examples have sub folders for javascript / typescript.  For those the script was omitted under the assumption that those package scripts would be merged with another package that has the script.

## Testing steps

From CCA I was able to create

- Create a example using --example flag
- Create a template using --function flag
- `npm run create-app-definition` from both folders
- `npm run add-locations` from both folders

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
