### PR TITLE
chore: add fusion to codeowners for delivery function examples []

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,14 @@
-# team tundra owns all code in this repository by default
+# team marketplace owns all code in this repository by default
 
 * @contentful/team-marketplace
 
-examples/function-mock-shop @contentful/team-monet
-examples/function-potterdb @contentful/team-monet
-examples/function-potterdb-rest-api @contentful/team-monet
-examples/function-templates @contentful/team-monet
+examples/function-mock-shop @contentful/team-fusion
+examples/function-potterdb @contentful/team-fusion
+examples/function-potterdb-rest-api @contentful/team-fusion
+examples/function-templates @contentful/team-fusion
+examples/native-external-references-mockshop @contentful/team-fusion
+examples/native-external-references-tmdb @contentful/team-fusion
+function-examples/external-references @contentful/team-fusion
 
 # package.json and package-lock.json should be unowned so that dependabot can automatically update dependencies
 


### PR DESCRIPTION
## Purpose

Change ownership of the delivery function (CER/NER) examples from Monet to Fusion

## Approach

<!-- Why did we do it the way we did? Did we consider alternatives? What other implementation details or artifacts (screenshots etc.) would help reviewers contextualize change? -->

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
