### PR TITLE
Adding type password to the contentful api key input

### DIFF
--- a/apps/braze/src/locations/ConfigScreen.tsx
+++ b/apps/braze/src/locations/ConfigScreen.tsx
@@ -128,7 +128,7 @@ const ConfigScreen = () => {
               data-testid="apiKey"
               isInvalid={!apiKeyIsValid}
               placeholder="ex. 0ab1c234DE56f..."
-              type={'password'}
+              type="password"
               onChange={(e) => setParameters({ ...parameters, apiKey: e.target.value })}
             />
             {!apiKeyIsValid && (

--- a/apps/braze/src/locations/ConfigScreen.tsx
+++ b/apps/braze/src/locations/ConfigScreen.tsx
@@ -128,6 +128,7 @@ const ConfigScreen = () => {
               data-testid="apiKey"
               isInvalid={!apiKeyIsValid}
               placeholder="ex. 0ab1c234DE56f..."
+              type={'password'}
               onChange={(e) => setParameters({ ...parameters, apiKey: e.target.value })}
             />
             {!apiKeyIsValid && (


### PR DESCRIPTION
## Purpose

Adding a type password for the Contentful API key input in the configuration screen that was removed in a previous [PR](https://github.com/contentful/apps/pull/9577).