### PR TITLE
fix: added a fix to handle undefined appInstallationParameters

### DIFF
--- a/examples/native-external-references-mockshop/functions/utils.ts
+++ b/examples/native-external-references-mockshop/functions/utils.ts
@@ -2,7 +2,8 @@ import { FunctionEventContext } from '@contentful/node-apps-toolkit';
 import { Product } from './types';
 
 export const getMockShopUrl = (context: FunctionEventContext<Record<string, any>>) => {
-  const { apiEndpoint: mockShopUrl } = context.appInstallationParameters;
+  const mockShopUrl = context.appInstallationParameters?.apiEndpoint;
+
   if (!mockShopUrl) {
     console.warn(`No API url configured, using default: https://mock.shop/api`);
     return 'https://mock.shop/api';


### PR DESCRIPTION
## Purpose

Modifying the `getMockShopUrl` in mock shop Graph QL example to handle the undefined appInstallationParameters.

## Approach

<!-- Why did we do it the way we did? Did we consider alternatives? What other implementation details or artifacts (screenshots etc.) would help reviewers contextualize change? -->

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
