### PR TITLE
Braze app: Adjust checkbox 'select all' behaviour [INTEG-2507]

### DIFF
--- a/apps/braze/src/components/CheckboxCard.tsx
+++ b/apps/braze/src/components/CheckboxCard.tsx
@@ -32,7 +32,11 @@ function CheckboxCard(props: CheckboxCardProps) {
       alignItems="center"
       margin="spacingXs"
       padding="spacingXs">
-      <Checkbox id={id} isChecked={selected} onChange={handleChange} isDisabled={isDisabled}>
+      <Checkbox
+        id={id}
+        isChecked={!isDisabled && selected}
+        onChange={handleChange}
+        isDisabled={isDisabled}>
         <Text fontWeight={fontWeight}>{title}</Text>
       </Checkbox>
       {children}

--- a/apps/braze/src/components/CheckboxCard.tsx
+++ b/apps/braze/src/components/CheckboxCard.tsx
@@ -1,28 +1,37 @@
 import { Flex, Checkbox, Text, MarginProps } from '@contentful/f36-components';
 import { FontWeightTokens } from '@contentful/f36-tokens';
 import { checkboxCard } from './CheckboxCard.styles';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 interface CheckboxCardProps extends MarginProps {
   id: string;
-  isSelected: boolean;
   title: string;
+  selectedFields: Set<string>;
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   fontWeight?: FontWeightTokens;
   children?: React.ReactNode;
 }
 function CheckboxCard(props: CheckboxCardProps) {
-  const { id, isSelected, title, onChange, fontWeight, children, margin, ...otherProps } = props;
+  const { id, title, selectedFields, onChange, fontWeight, children } = props;
+  const [selected, setSelected] = useState(() => selectedFields.has(id));
+
+  useEffect(() => {
+    setSelected(selectedFields.has(id));
+  }, [selectedFields]);
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setSelected(event.target.checked);
+    onChange(event);
+  };
 
   return (
     <Flex
       className={checkboxCard}
       justifyContent="space-between"
       alignItems="center"
-      margin={margin || 'spacingXs'}
-      padding="spacingXs"
-      {...otherProps}>
-      <Checkbox id={id} isChecked={isSelected} onChange={onChange}>
+      margin="spacingXs"
+      padding="spacingXs">
+      <Checkbox id={id} isChecked={selected} onChange={handleChange}>
         <Text fontWeight={fontWeight}>{title}</Text>
       </Checkbox>
       {children}

--- a/apps/braze/src/components/FieldCheckbox.tsx
+++ b/apps/braze/src/components/FieldCheckbox.tsx
@@ -13,27 +13,42 @@ type FieldCheckboxProps =
   | ReferenceArrayCheckboxProps
   | ReferenceItemCheckboxProps;
 const FieldCheckbox = (props: FieldCheckboxProps) => {
-  const { field, handleToggle } = props;
+  const { field, selectedFields, handleToggle } = props;
   if (field instanceof ReferenceField) {
-    return <ReferenceCheckbox key={field.id} field={field} handleToggle={handleToggle} />;
+    return (
+      <ReferenceCheckbox
+        field={field}
+        selectedFields={selectedFields}
+        handleToggle={handleToggle}
+      />
+    );
   } else if (field instanceof ReferenceArrayField) {
-    return <ReferenceArrayCheckbox key={field.id} field={field} handleToggle={handleToggle} />;
+    return (
+      <ReferenceArrayCheckbox
+        field={field}
+        selectedFields={selectedFields}
+        handleToggle={handleToggle}
+      />
+    );
   }
-  return <BasicFieldCheckbox key={field.id} field={field} handleToggle={handleToggle} />;
+  return (
+    <BasicFieldCheckbox field={field} selectedFields={selectedFields} handleToggle={handleToggle} />
+  );
 };
 
 type BasicFieldCheckboxProps = {
   field: Field;
+  selectedFields: Set<string>;
   handleToggle: (event: React.ChangeEvent<HTMLInputElement>) => void;
 };
 
 const BasicFieldCheckbox = (props: BasicFieldCheckboxProps) => {
-  const { field, handleToggle } = props;
+  const { field, selectedFields, handleToggle } = props;
   return (
     <CheckboxCard
       id={field.uniqueId()}
-      isSelected={field.selected}
       title={field.displayName()}
+      selectedFields={selectedFields}
       onChange={handleToggle}
     />
   );
@@ -41,20 +56,28 @@ const BasicFieldCheckbox = (props: BasicFieldCheckboxProps) => {
 
 type ReferenceCheckboxProps = {
   field: ReferenceField;
+  selectedFields: Set<string>;
   handleToggle: (event: React.ChangeEvent<HTMLInputElement>) => void;
 };
 const ReferenceCheckbox = (props: ReferenceCheckboxProps) => {
-  const { field, handleToggle } = props;
+  const { field, selectedFields, handleToggle } = props;
   const [show, setShow] = useState(false);
   return (
     <>
-      <CheckboxContainer field={field} handleToggle={handleToggle} show={show} setShow={setShow} />
+      <CheckboxContainer
+        field={field}
+        selectedFields={selectedFields}
+        handleToggle={handleToggle}
+        show={show}
+        setShow={setShow}
+      />
       {show && (
         <Box paddingLeft="spacingL">
           {field.fields.map((nestedField) => {
             return (
               <FieldCheckbox
                 key={nestedField.uniqueId()}
+                selectedFields={selectedFields}
                 field={nestedField}
                 handleToggle={handleToggle}
               />
@@ -68,14 +91,21 @@ const ReferenceCheckbox = (props: ReferenceCheckboxProps) => {
 
 type ReferenceArrayCheckboxProps = {
   field: ReferenceArrayField;
+  selectedFields: Set<string>;
   handleToggle: (event: React.ChangeEvent<HTMLInputElement>) => void;
 };
 const ReferenceArrayCheckbox = (props: ReferenceArrayCheckboxProps) => {
-  const { field, handleToggle } = props;
+  const { field, selectedFields, handleToggle } = props;
   const [show, setShow] = useState(false);
   return (
     <>
-      <CheckboxContainer field={field} handleToggle={handleToggle} show={show} setShow={setShow} />
+      <CheckboxContainer
+        field={field}
+        selectedFields={selectedFields}
+        handleToggle={handleToggle}
+        show={show}
+        setShow={setShow}
+      />
       {show && (
         <Box paddingLeft="spacingL">
           {field.items.map((item) => {
@@ -83,6 +113,7 @@ const ReferenceArrayCheckbox = (props: ReferenceArrayCheckboxProps) => {
               <ReferenceItemCheckbox
                 key={item.uniqueId()}
                 field={item}
+                selectedFields={selectedFields}
                 handleToggle={handleToggle}
               />
             );
@@ -95,19 +126,31 @@ const ReferenceArrayCheckbox = (props: ReferenceArrayCheckboxProps) => {
 
 type ReferenceItemCheckboxProps = {
   field: ReferenceItem;
+  selectedFields: Set<string>;
   handleToggle: (event: React.ChangeEvent<HTMLInputElement>) => void;
 };
 const ReferenceItemCheckbox = (props: ReferenceItemCheckboxProps) => {
-  const { field, handleToggle } = props;
+  const { field, selectedFields, handleToggle } = props;
   const [show, setShow] = useState(false);
   return (
     <>
-      <CheckboxContainer field={field} handleToggle={handleToggle} show={show} setShow={setShow} />
+      <CheckboxContainer
+        field={field}
+        selectedFields={selectedFields}
+        handleToggle={handleToggle}
+        show={show}
+        setShow={setShow}
+      />
       {show && (
         <Box paddingLeft="spacingL">
           {field.fields.map((field) => {
             return (
-              <FieldCheckbox key={field.uniqueId()} field={field} handleToggle={handleToggle} />
+              <FieldCheckbox
+                key={field.uniqueId()}
+                field={field}
+                selectedFields={selectedFields}
+                handleToggle={handleToggle}
+              />
             );
           })}
         </Box>
@@ -118,17 +161,18 @@ const ReferenceItemCheckbox = (props: ReferenceItemCheckboxProps) => {
 
 const CheckboxContainer = (props: {
   field: Field;
+  selectedFields: Set<string>;
   handleToggle: (event: React.ChangeEvent<HTMLInputElement>) => void;
   show: boolean;
   setShow: (show: boolean) => void;
 }) => {
-  const { field, handleToggle, show, setShow } = props;
+  const { field, selectedFields, handleToggle, show, setShow } = props;
 
   return (
     <CheckboxCard
       id={field.uniqueId()}
-      isSelected={field.selected}
       title={field.displayName()}
+      selectedFields={selectedFields}
       onChange={handleToggle}
       fontWeight="fontWeightDemiBold">
       <IconButton

--- a/apps/braze/src/components/FieldsSelectionStep.tsx
+++ b/apps/braze/src/components/FieldsSelectionStep.tsx
@@ -62,10 +62,9 @@ const FieldsSelectionStep = (props: FieldsSelectionStepProps) => {
     const children = field.parent.getChildren();
 
     const allChildrenSelected = children.every((child) => selectedSet.has(child.uniqueId()));
-    const anyChildrenSelected = children.some((child) => selectedSet.has(child.uniqueId()));
     if (allChildrenSelected) {
       selectedSet.add(field.parent.uniqueId());
-    } else if (!anyChildrenSelected) {
+    } else {
       selectedSet.delete(field.parent.uniqueId());
     }
 

--- a/apps/braze/src/components/FieldsSelectionStep.tsx
+++ b/apps/braze/src/components/FieldsSelectionStep.tsx
@@ -128,7 +128,11 @@ const FieldsSelectionStep = (props: FieldsSelectionStepProps) => {
       </Box>
 
       <WizardFooter>
-        <Button variant="primary" size="small" onClick={handleNextStep} isDisabled={!entrySelected}>
+        <Button
+          variant="primary"
+          size="small"
+          onClick={handleNextStep}
+          isDisabled={selectedFields.size === 0}>
           Next
         </Button>
       </WizardFooter>

--- a/apps/braze/src/components/FieldsSelectionStep.tsx
+++ b/apps/braze/src/components/FieldsSelectionStep.tsx
@@ -31,12 +31,7 @@ const FieldsSelectionStep = (props: FieldsSelectionStepProps) => {
     field.toggle(checked);
     const newSelectedFields = new Set(selectedFields);
 
-    if (checked) {
-      newSelectedFields.add(field.uniqueId());
-    } else {
-      newSelectedFields.delete(field.uniqueId());
-    }
-
+    updateSelectedFields(checked, newSelectedFields, field.uniqueId());
     toggleNestedFields(field, checked, newSelectedFields);
     toggleParentField(field, newSelectedFields, allFields);
 
@@ -44,13 +39,17 @@ const FieldsSelectionStep = (props: FieldsSelectionStepProps) => {
     setEntrySelected(newSelectedFields.size === allFields.length);
   };
 
+  const updateSelectedFields = (
+    checked: boolean,
+    selectedFields: Set<string>,
+    id: string
+  ): void => {
+    checked ? selectedFields.add(id) : selectedFields.delete(id);
+  };
+
   const toggleNestedFields = (field: any, checked: boolean, selectedFields: Set<string>): void => {
     for (const child of field.getChildren()) {
-      if (checked) {
-        selectedFields.add(child.uniqueId());
-      } else {
-        selectedFields.delete(child.uniqueId());
-      }
+      updateSelectedFields(checked, selectedFields, child.uniqueId());
 
       if (child.getChildren().length > 0) {
         toggleNestedFields(child, checked, selectedFields);
@@ -60,10 +59,13 @@ const FieldsSelectionStep = (props: FieldsSelectionStepProps) => {
 
   const toggleParentField = (field: Field, selectedSet: Set<string>, allFields: any[]): void => {
     if (!field.parent) return;
+    const children = field.parent.getChildren();
 
-    if (field.parent.getChildren().every((child) => selectedSet.has(child.uniqueId()))) {
+    const allChildrenSelected = children.every((child) => selectedSet.has(child.uniqueId()));
+    const anyChildrenSelected = children.some((child) => selectedSet.has(child.uniqueId()));
+    if (allChildrenSelected) {
       selectedSet.add(field.parent.uniqueId());
-    } else if (field.parent.getChildren().some((child) => !selectedSet.has(child.uniqueId()))) {
+    } else if (!anyChildrenSelected) {
       selectedSet.delete(field.parent.uniqueId());
     }
 

--- a/apps/braze/src/fields/Entry.ts
+++ b/apps/braze/src/fields/Entry.ts
@@ -69,7 +69,7 @@ export class Entry {
 
   getAllFields(): Field[] {
     return this.fields.flatMap((field) => {
-      return field.getAllFields();
+      return [field, ...field.getChildren()];
     });
   }
 

--- a/apps/braze/src/fields/Field.ts
+++ b/apps/braze/src/fields/Field.ts
@@ -45,7 +45,7 @@ export abstract class Field {
     return !!this.parent ? `${this.parent.uniqueId()}.${this.id}` : this.id;
   }
 
-  getAllFields(): Field[] {
-    return [this];
+  getChildren(): Field[] {
+    return [];
   }
 }

--- a/apps/braze/src/fields/ReferenceArrayField.ts
+++ b/apps/braze/src/fields/ReferenceArrayField.ts
@@ -47,10 +47,10 @@ export class ReferenceArrayField extends Field {
     }
   }
 
-  getAllFields(): Field[] {
-    const fields: Field[] = [this];
+  getChildren(): Field[] {
+    const fields: Field[] = [];
     this.items.forEach((item) => {
-      fields.push(...item.getAllFields());
+      fields.push(...[item, ...item.getChildren()]);
     });
     return fields;
   }

--- a/apps/braze/src/fields/ReferenceField.ts
+++ b/apps/braze/src/fields/ReferenceField.ts
@@ -62,10 +62,10 @@ export class ReferenceField extends Field {
     }
   }
 
-  getAllFields(): Field[] {
-    const fields: Field[] = [this];
+  getChildren(): Field[] {
+    const fields: Field[] = [];
     this.fields.forEach((field) => {
-      fields.push(...field.getAllFields());
+      fields.push(...[field, ...field.getChildren()]);
     });
     return fields;
   }

--- a/apps/braze/src/fields/ReferenceItem.ts
+++ b/apps/braze/src/fields/ReferenceItem.ts
@@ -39,8 +39,4 @@ export class ReferenceItem extends ReferenceField {
   generateLiquidTagForType(template: string): string[] {
     return this.selectedFields().flatMap((field) => field.generateLiquidTagForType(`${template}`));
   }
-
-  uniqueId(): string {
-    return !!this.parent ? `${this.parent.uniqueId()}${this.id}` : this.id;
-  }
 }

--- a/apps/braze/test/components/FieldCheckbox.spec.tsx
+++ b/apps/braze/test/components/FieldCheckbox.spec.tsx
@@ -8,7 +8,7 @@ describe('FieldCheckbox component', () => {
   it('Rich text field shows as disabled', () => {
     const richTextField = new RichTextField('id', 'name', 'contentType', false);
     const { getByText, container } = render(
-      <FieldCheckbox field={richTextField} handleToggle={() => {}} />
+      <FieldCheckbox field={richTextField} handleToggle={() => {}} selectedFields={new Set()} />
     );
     expect(getByText(richTextField.displayName())).toBeTruthy();
     const checkbox = container.querySelector('input[type="checkbox"]') as HTMLInputElement;


### PR DESCRIPTION
## Purpose

We're updating the checkbox behavior per the designs.
Before: if at least one nested checkbox was selected, the parent checkbox was selected as well
Now: all nested checkboxes need to be selected in order for the parent to be automatically selected

## Approach

We've separated the "internal" `selected` logic (used for assembling the graphql query and the liquid tags) from the view logic (what is shown to the user).
The internal logic needs that the parent checkbox if at least one of the nested ones are selected (which is different from the view logic).

## Testing steps

Use the app with a content type that has references or array of references.

## Breaking Changes

N/A

## Dependencies and/or References

The base of this PR is not master, so we may need to update it if the base branch gets squashed

## Deployment

N/A

https://github.com/user-attachments/assets/4d8c54ad-6f02-4d8d-9562-77d10e4bee53

Previous PR: #9616 (creating a new one since the original base of this branch got squashed into master)