### PR TITLE
Braze app: adding content type section to config screen [INTEG-2534]

### DIFF
--- a/apps/braze/src/locations/ConfigScreen.tsx
+++ b/apps/braze/src/locations/ConfigScreen.tsx
@@ -9,6 +9,8 @@ import {
   Subheading,
   TextInput,
   TextLink,
+  Text,
+  Spacing,
 } from '@contentful/f36-components';
 import { useSDK } from '@contentful/react-apps-toolkit';
 import { useCallback, useEffect, useState } from 'react';
@@ -20,8 +22,11 @@ export interface AppInstallationParameters {
   apiKey: string;
 }
 
-export const BRAZE_DOCUMENTATION =
+export const BRAZE_CONNECTED_CONTENT_DOCUMENTATION =
   'https://braze.com/docs/user_guide/personalization_and_dynamic_content/connected_content';
+export const BRAZE_APP_DOCUMENTATION = 'https://www.contentful.com/help/apps/braze-app/';
+export const CONTENT_TYPE_DOCUMENTATION =
+  'https://www.contentful.com/help/content-types/configure-content-type/';
 
 export async function callToContentful(url: string, newApiKey: string) {
   return await fetch(url, {
@@ -92,36 +97,27 @@ const ConfigScreen = () => {
     <Flex justifyContent="center" alignContent="center">
       <Box className={styles.body} marginTop="spacingL" padding="spacingL">
         <Heading marginBottom="spacingS">Set up Braze</Heading>
-        <Paragraph marginBottom="spacing2Xs">
+        <InformationSection
+          url={BRAZE_CONNECTED_CONTENT_DOCUMENTATION}
+          linkText="Braze's Connected Content feature">
           The Braze app allows editors to connect content stored in Contentful to Braze campaigns
-          through{' '}
-        </Paragraph>
-        <TextLink
-          icon={<ExternalLinkIcon />}
-          alignIcon="end"
-          href={BRAZE_DOCUMENTATION}
-          target="_blank"
-          rel="noopener noreferrer">
-          Braze's Connected Content feature
-        </TextLink>
+          through
+        </InformationSection>
+        <InformationSection url={BRAZE_APP_DOCUMENTATION} linkText="here" marginTop="spacingL">
+          Learn more about how to connect Contentful with Braze and configure the Braze app
+        </InformationSection>
         <Splitter marginTop="spacingL" marginBottom="spacingL" />
-        <Subheading className={styles.subheading}>Connected Content configuration</Subheading>
-        <Paragraph marginBottom="spacing2Xs">
-          {' '}
-          Select the Contentful API key that Braze will use to request your content via API at send
+        <Heading marginBottom="spacingL">Connected Content configuration</Heading>
+        <Subheading className={styles.subheading}>Input the Contentful Delivery API</Subheading>
+        <InformationSection
+          url={`https://app.contentful.com/spaces/${spaceId}/api/keys`}
+          linkText="Manage API Keys">
+          Input the Contentful API key that Braze will use to request your content via API at send
           time.
-        </Paragraph>
-        <TextLink
-          icon={<ExternalLinkIcon />}
-          alignIcon="end"
-          href={`https://app.contentful.com/spaces/${spaceId}/api/keys`}
-          target="_blank"
-          rel="noopener noreferrer">
-          Manage API
-        </TextLink>
-        <Box marginTop="spacingM">
+        </InformationSection>
+        <Box marginTop="spacingM" marginBottom="spacingM">
           <Form>
-            <FormControl.Label>Contentful API key</FormControl.Label>
+            <FormControl.Label>Contentful Delivery API - access token</FormControl.Label>
             <TextInput
               value={parameters.apiKey}
               name="apiKey"
@@ -136,9 +132,42 @@ const ConfigScreen = () => {
             )}
           </Form>
         </Box>
+        <Subheading className={styles.subheading}>Add Braze to your content types</Subheading>
+        <InformationSection url={CONTENT_TYPE_DOCUMENTATION} linkText="here" marginTop="spacing2Xs">
+          Navigate to the content type you would like to use under the Content model tab in the main
+          navigation. Select the content type and adjust the sidebar settings on the Sidebar tab.
+          Learn more about configuring your content type
+        </InformationSection>
       </Box>
     </Flex>
   );
 };
+
+type InformationSectionProps = {
+  url: string;
+  children: string;
+  linkText: string;
+  marginTop?: Spacing;
+  marginBottom?: Spacing;
+};
+function InformationSection(props: InformationSectionProps) {
+  return (
+    <Paragraph
+      marginBottom={props.marginBottom ? props.marginBottom : 'spacing2Xs'}
+      marginTop={props.marginTop ? props.marginTop : 'spacingXs'}>
+      {`${props.children} `}
+      <TextLink
+        icon={<ExternalLinkIcon />}
+        alignIcon="end"
+        href={props.url}
+        target="_blank"
+        data-testid={props.url}
+        rel="noopener noreferrer">
+        {props.linkText}
+      </TextLink>
+      <Text> .</Text>
+    </Paragraph>
+  );
+}
 
 export default ConfigScreen;

--- a/apps/braze/test/locations/ConfigScreen.spec.tsx
+++ b/apps/braze/test/locations/ConfigScreen.spec.tsx
@@ -1,7 +1,11 @@
 import { fireEvent, screen, render, cleanup, RenderResult } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mockCma, mockSdk } from '../mocks';
-import ConfigScreen, { BRAZE_DOCUMENTATION } from '../../src/locations/ConfigScreen';
+import ConfigScreen, {
+  BRAZE_APP_DOCUMENTATION,
+  BRAZE_CONNECTED_CONTENT_DOCUMENTATION,
+  CONTENT_TYPE_DOCUMENTATION,
+} from '../../src/locations/ConfigScreen';
 import userEvent from '@testing-library/user-event';
 import { queries } from '@testing-library/dom';
 import React from 'react';
@@ -39,16 +43,32 @@ describe('Config Screen component', () => {
       const brazeLink = configScreen.getByText("Braze's Connected Content feature");
 
       expect(brazeLink).toBeTruthy();
-      expect(brazeLink.closest('a')?.getAttribute('href')).toBe(BRAZE_DOCUMENTATION);
+      expect(brazeLink.closest('a')?.getAttribute('href')).toBe(
+        BRAZE_CONNECTED_CONTENT_DOCUMENTATION
+      );
     });
 
     it('renders the link to manage api keys', () => {
-      const brazeLink = configScreen.getByText('Manage API');
+      const brazeLink = configScreen.getByText('Manage API Keys');
 
       expect(brazeLink).toBeTruthy();
       expect(brazeLink.closest('a')?.getAttribute('href')).toBe(
         `https://app.contentful.com/spaces/${mockSdk.spaceId}/api/keys`
       );
+    });
+
+    it('renders the braze app link correctly', () => {
+      const brazeLink = configScreen.getByTestId(BRAZE_APP_DOCUMENTATION);
+
+      expect(brazeLink).toBeTruthy();
+      expect(brazeLink.closest('a')?.getAttribute('href')).toBe(BRAZE_APP_DOCUMENTATION);
+    });
+
+    it('renders the braze app link correctly', () => {
+      const brazeLink = configScreen.getByTestId(CONTENT_TYPE_DOCUMENTATION);
+
+      expect(brazeLink).toBeTruthy();
+      expect(brazeLink.closest('a')?.getAttribute('href')).toBe(CONTENT_TYPE_DOCUMENTATION);
     });
 
     it('has an input that sets api key correctly', () => {


### PR DESCRIPTION
## Purpose

There were some sections missing in the config screen, such as:
- The content type section which has a link to the corresponding configuration doc
- The reference to the braze app documentation

## Approach

Now the config screen looks like the figma design for v1, with clean ups included.

Braze App Config Screen:
<img width="954" alt="Captura de pantalla 2025-04-15 a la(s) 2 02 18 p  m" src="https://github.com/user-attachments/assets/1cb23e79-3b31-4eba-857b-4e6c95622a5e" />

## Testing steps

Automated test were added to check:
- The link to the braze app documentation
- The link to the content type configuration documentation

## Dependencies and/or References

Link to [INTEG-2534](https://contentful.atlassian.net/browse/INTEG-2534)
Link to [figma desing](https://www.figma.com/design/6tRjfI7DK70Ol38nby7cBd/Braze?node-id=840-6848&t=SxtuZjwNHN2qhyKH-0)
