### PR TITLE
Braze app: fix space in config screen [INTEG-2534]

### DIFF
--- a/apps/braze/src/locations/ConfigScreen.tsx
+++ b/apps/braze/src/locations/ConfigScreen.tsx
@@ -164,7 +164,7 @@ function InformationSection(props: InformationSectionProps) {
     <Paragraph
       marginBottom={props.marginBottom ? props.marginBottom : 'spacing2Xs'}
       marginTop={props.marginTop ? props.marginTop : 'spacingXs'}>
-      {props.children}
+      {props.children}{' '}
       <TextLink
         icon={<ExternalLinkIcon />}
         alignIcon="end"


### PR DESCRIPTION
## Purpose

I missed a white space that was needed in the https://github.com/contentful/apps/pull/9699 pr.

## Approach

Adding a space in the InformationSection component.

Before:
<img width="914" alt="Captura de pantalla 2025-04-16 a la(s) 2 43 18 p  m" src="https://github.com/user-attachments/assets/9cd07994-d86e-4ee4-bb84-48d8fe3fcb70" />

After:
<img width="923" alt="Captura de pantalla 2025-04-16 a la(s) 2 42 51 p  m" src="https://github.com/user-attachments/assets/e463fa68-0cb4-47f2-b81a-73fc5f69e65b" />
