### PR TITLE
Braze app: create and generate sidebar buttons [INTEG-2535]

### DIFF
--- a/apps/braze/src/components/InformationLinkComponent.tsx
+++ b/apps/braze/src/components/InformationLinkComponent.tsx
@@ -1,0 +1,36 @@
+import { Text, Spacing, Paragraph, TextLink } from '@contentful/f36-components';
+import { ColorTokens } from '@contentful/f36-tokens';
+import React from 'react';
+import { ExternalLinkIcon } from '@contentful/f36-icons';
+
+type InformationSectionProps = {
+  url: string;
+  children: string;
+  linkText: string;
+  marginTop?: Spacing;
+  marginBottom?: Spacing;
+  fontColor?: ColorTokens | undefined;
+  dataTestId?: string;
+};
+function InformationLinkComponent(props: InformationSectionProps) {
+  return (
+    <Paragraph
+      fontColor={props.fontColor}
+      marginBottom={props.marginBottom ? props.marginBottom : 'spacing2Xs'}
+      marginTop={props.marginTop ? props.marginTop : 'spacingXs'}>
+      {props.children}{' '}
+      <TextLink
+        icon={<ExternalLinkIcon />}
+        alignIcon="end"
+        href={props.url}
+        target="_blank"
+        data-testid={props.dataTestId}
+        rel="noopener noreferrer">
+        {props.linkText}
+      </TextLink>
+      <Text> .</Text>
+    </Paragraph>
+  );
+}
+
+export default InformationLinkComponent;

--- a/apps/braze/src/components/InformationWithLink.tsx
+++ b/apps/braze/src/components/InformationWithLink.tsx
@@ -12,19 +12,20 @@ type InformationSectionProps = {
   fontColor?: ColorTokens | undefined;
   dataTestId?: string;
 };
-function InformationLinkComponent(props: InformationSectionProps) {
+function InformationWithLink(props: InformationSectionProps) {
   return (
     <Paragraph
       fontColor={props.fontColor}
       marginBottom={props.marginBottom ? props.marginBottom : 'spacing2Xs'}
-      marginTop={props.marginTop ? props.marginTop : 'spacingXs'}>
+      marginTop={props.marginTop ? props.marginTop : 'spacingXs'}
+      data-testid={props.dataTestId}>
       {props.children}{' '}
       <TextLink
         icon={<ExternalLinkIcon />}
         alignIcon="end"
         href={props.url}
         target="_blank"
-        data-testid={props.dataTestId}
+        data-testid={`link-${props.dataTestId}`}
         rel="noopener noreferrer">
         {props.linkText}
       </TextLink>
@@ -33,4 +34,4 @@ function InformationLinkComponent(props: InformationSectionProps) {
   );
 }
 
-export default InformationLinkComponent;
+export default InformationWithLink;

--- a/apps/braze/src/locations/ConfigScreen.tsx
+++ b/apps/braze/src/locations/ConfigScreen.tsx
@@ -1,34 +1,21 @@
 import { ConfigAppSDK } from '@contentful/app-sdk';
-import {
-  Box,
-  Flex,
-  Form,
-  FormControl,
-  Heading,
-  Paragraph,
-  TextInput,
-  TextLink,
-  Text,
-  Spacing,
-} from '@contentful/f36-components';
+import { Box, Flex, Form, FormControl, Heading, TextInput, Text } from '@contentful/f36-components';
 import { useSDK } from '@contentful/react-apps-toolkit';
 import { useCallback, useEffect, useState } from 'react';
-import { ExternalLinkIcon } from '@contentful/f36-icons';
 import { styles } from './ConfigScreen.styles';
 import Splitter from '../components/Splitter';
-import { ColorTokens } from '@contentful/f36-tokens';
+import {
+  BRAZE_API_KEY_DOCUMENTATION,
+  BRAZE_APP_DOCUMENTATION,
+  BRAZE_CONTENT_BLOCK_DOCUMENTATION,
+  CONTENT_TYPE_DOCUMENTATION,
+} from '../utils';
+import InformationLinkComponent from '../components/InformationLinkComponent';
 
 export interface AppInstallationParameters {
   contentfulApiKey: string;
   brazeApiKey: string;
 }
-
-export const BRAZE_APP_DOCUMENTATION = 'https://www.contentful.com/help/apps/braze-app/';
-export const BRAZE_API_KEY_DOCUMENTATION = `https://dashboard.braze.com/app_settings/developer_console/apisettings#apikeys`;
-export const CONTENT_TYPE_DOCUMENTATION =
-  'https://www.contentful.com/help/content-types/configure-content-type/';
-export const BRAZE_CONTENT_BLOCK_DOCUMENTATION =
-  'https://www.braze.com/docs/api/endpoints/templates/content_blocks_templates/post_create_email_content_block';
 
 export async function callTo(url: string, newApiKey: string) {
   return await fetch(url, {
@@ -109,12 +96,12 @@ const ConfigScreen = () => {
     <Flex justifyContent="center" alignContent="center">
       <Box className={styles.body} marginTop="spacingS" marginBottom="spacingS" padding="spacingL">
         <Heading marginBottom="spacingXs">Set up Braze</Heading>
-        <InformationSection
+        <InformationLinkComponent
           url={BRAZE_APP_DOCUMENTATION}
           linkText="here"
           dataTestId="braze-app-docs-here-link">
           Learn more about how to connect Contentful with Braze and configure the Braze app
-        </InformationSection>
+        </InformationLinkComponent>
         <Splitter marginTop="spacingL" marginBottom="spacingL" />
         <ContentTypeSection />
         <Splitter marginTop="spacingL" marginBottom="spacingL" />
@@ -144,12 +131,12 @@ function ConnectedContentSection(props: {
   return (
     <>
       <Heading marginBottom="spacing2Xs">Connected Content configuration</Heading>
-      <InformationSection
+      <InformationLinkComponent
         url={`https://app.contentful.com/spaces/${props.spaceId}/api/keys`}
         linkText="Manage API Keys">
         Input the Contentful API key that Braze will use to request your content via API at send
         time.
-      </InformationSection>
+      </InformationLinkComponent>
       <Box marginTop="spacingM">
         <Form>
           <FormControl.Label>Contentful Delivery API - access token</FormControl.Label>
@@ -176,7 +163,7 @@ function ContentTypeSection() {
   return (
     <>
       <Heading marginBottom="spacing2Xs">Add Braze to your content types</Heading>
-      <InformationSection
+      <InformationLinkComponent
         url={CONTENT_TYPE_DOCUMENTATION}
         linkText="here"
         marginTop="spacing2Xs"
@@ -184,7 +171,7 @@ function ContentTypeSection() {
         Navigate to the content type you would like to use under the Content model tab in the main
         navigation. Select the content type and adjust the sidebar settings on the Sidebar tab.
         Learn more about configuring your content type
-      </InformationSection>
+      </InformationLinkComponent>
     </>
   );
 }
@@ -197,11 +184,11 @@ function ContentBlockSection(props: {
   return (
     <>
       <Heading marginBottom="spacing2Xs">Content Blocks configuration</Heading>
-      <InformationSection
+      <InformationLinkComponent
         url={BRAZE_CONTENT_BLOCK_DOCUMENTATION}
         linkText="Braze's Content Block feature">
         Connect specific entry fields stored in Contentful to create Content Blocks in Braze through
-      </InformationSection>
+      </InformationLinkComponent>
       <Box marginTop="spacingM">
         <Form>
           <FormControl.Label>Braze REST API key</FormControl.Label>
@@ -220,43 +207,13 @@ function ContentBlockSection(props: {
           )}
         </Form>
       </Box>
-      <InformationSection
+      <InformationLinkComponent
         fontColor="gray500"
         linkText="Braze REST API Keys page"
         url={BRAZE_API_KEY_DOCUMENTATION}>
         Enter your Braze REST API key. If you need to generate a key, visit your
-      </InformationSection>
+      </InformationLinkComponent>
     </>
-  );
-}
-
-type InformationSectionProps = {
-  url: string;
-  children: string;
-  linkText: string;
-  marginTop?: Spacing;
-  marginBottom?: Spacing;
-  fontColor?: ColorTokens | undefined;
-  dataTestId?: string;
-};
-function InformationSection(props: InformationSectionProps) {
-  return (
-    <Paragraph
-      fontColor={props.fontColor}
-      marginBottom={props.marginBottom ? props.marginBottom : 'spacing2Xs'}
-      marginTop={props.marginTop ? props.marginTop : 'spacingXs'}>
-      {props.children}{' '}
-      <TextLink
-        icon={<ExternalLinkIcon />}
-        alignIcon="end"
-        href={props.url}
-        target="_blank"
-        data-testid={props.dataTestId}
-        rel="noopener noreferrer">
-        {props.linkText}
-      </TextLink>
-      <Text> .</Text>
-    </Paragraph>
   );
 }
 

--- a/apps/braze/src/locations/ConfigScreen.tsx
+++ b/apps/braze/src/locations/ConfigScreen.tsx
@@ -10,7 +10,7 @@ import {
   BRAZE_CONTENT_BLOCK_DOCUMENTATION,
   CONTENT_TYPE_DOCUMENTATION,
 } from '../utils';
-import InformationLinkComponent from '../components/InformationLinkComponent';
+import InformationWithLink from '../components/InformationWithLink';
 
 export interface AppInstallationParameters {
   contentfulApiKey: string;
@@ -96,12 +96,12 @@ const ConfigScreen = () => {
     <Flex justifyContent="center" alignContent="center">
       <Box className={styles.body} marginTop="spacingS" marginBottom="spacingS" padding="spacingL">
         <Heading marginBottom="spacingXs">Set up Braze</Heading>
-        <InformationLinkComponent
+        <InformationWithLink
           url={BRAZE_APP_DOCUMENTATION}
           linkText="here"
-          dataTestId="braze-app-docs-here-link">
+          dataTestId="braze-app-docs-here">
           Learn more about how to connect Contentful with Braze and configure the Braze app
-        </InformationLinkComponent>
+        </InformationWithLink>
         <Splitter marginTop="spacingL" marginBottom="spacingL" />
         <ContentTypeSection />
         <Splitter marginTop="spacingL" marginBottom="spacingL" />
@@ -131,12 +131,12 @@ function ConnectedContentSection(props: {
   return (
     <>
       <Heading marginBottom="spacing2Xs">Connected Content configuration</Heading>
-      <InformationLinkComponent
+      <InformationWithLink
         url={`https://app.contentful.com/spaces/${props.spaceId}/api/keys`}
         linkText="Manage API Keys">
         Input the Contentful API key that Braze will use to request your content via API at send
         time.
-      </InformationLinkComponent>
+      </InformationWithLink>
       <Box marginTop="spacingM">
         <Form>
           <FormControl.Label>Contentful Delivery API - access token</FormControl.Label>
@@ -163,15 +163,15 @@ function ContentTypeSection() {
   return (
     <>
       <Heading marginBottom="spacing2Xs">Add Braze to your content types</Heading>
-      <InformationLinkComponent
+      <InformationWithLink
         url={CONTENT_TYPE_DOCUMENTATION}
         linkText="here"
         marginTop="spacing2Xs"
-        dataTestId="content-type-docs-here-link">
+        dataTestId="content-type-docs-here">
         Navigate to the content type you would like to use under the Content model tab in the main
         navigation. Select the content type and adjust the sidebar settings on the Sidebar tab.
         Learn more about configuring your content type
-      </InformationLinkComponent>
+      </InformationWithLink>
     </>
   );
 }
@@ -184,11 +184,11 @@ function ContentBlockSection(props: {
   return (
     <>
       <Heading marginBottom="spacing2Xs">Content Blocks configuration</Heading>
-      <InformationLinkComponent
+      <InformationWithLink
         url={BRAZE_CONTENT_BLOCK_DOCUMENTATION}
         linkText="Braze's Content Block feature">
         Connect specific entry fields stored in Contentful to create Content Blocks in Braze through
-      </InformationLinkComponent>
+      </InformationWithLink>
       <Box marginTop="spacingM">
         <Form>
           <FormControl.Label>Braze REST API key</FormControl.Label>
@@ -207,12 +207,12 @@ function ContentBlockSection(props: {
           )}
         </Form>
       </Box>
-      <InformationLinkComponent
+      <InformationWithLink
         fontColor="gray500"
         linkText="Braze REST API Keys page"
         url={BRAZE_API_KEY_DOCUMENTATION}>
         Enter your Braze REST API key. If you need to generate a key, visit your
-      </InformationLinkComponent>
+      </InformationWithLink>
     </>
   );
 }

--- a/apps/braze/src/locations/Sidebar.styles.ts
+++ b/apps/braze/src/locations/Sidebar.styles.ts
@@ -1,0 +1,10 @@
+import tokens from '@contentful/f36-tokens';
+import { css } from 'emotion';
+
+export const styles = {
+  subheading: css({
+    margin: 0,
+    color: tokens.gray500,
+    fontSize: tokens.fontSizeM,
+  }),
+};

--- a/apps/braze/src/locations/Sidebar.tsx
+++ b/apps/braze/src/locations/Sidebar.tsx
@@ -9,7 +9,6 @@ import {
   SIDEBAR_CREATE_BUTTON_TEXT,
   SIDEBAR_GENERATE_BUTTON_TEXT,
 } from '../utils';
-import tokens from '@contentful/f36-tokens';
 import { styles } from './Sidebar.styles';
 import { KeyValueMap } from 'contentful-management';
 import InformationWithLink from '../components/InformationWithLink';
@@ -52,7 +51,7 @@ const Sidebar = () => {
           Generate a Connected Content call to copy and paste into Braze.
         </InformationWithLink>
         <Button
-          color={tokens.gray500}
+          variant="secondary"
           isFullWidth={true}
           onClick={() => {
             openDialog(sdk, invocationParams);
@@ -71,7 +70,7 @@ const Sidebar = () => {
           Send individual entry fields to Braze to create Content Blocks.
         </InformationWithLink>
         <Button
-          color={tokens.gray500}
+          variant="secondary"
           isFullWidth={true}
           onClick={() => {
             openDialog(sdk, invocationParams);

--- a/apps/braze/src/locations/Sidebar.tsx
+++ b/apps/braze/src/locations/Sidebar.tsx
@@ -12,7 +12,7 @@ import {
 import tokens from '@contentful/f36-tokens';
 import { styles } from './Sidebar.styles';
 import { KeyValueMap } from 'contentful-management';
-import InformationLinkComponent from '../components/InformationLinkComponent';
+import InformationWithLink from '../components/InformationWithLink';
 
 function openDialog(
   sdk: Omit<BaseAppSDK<KeyValueMap, KeyValueMap, never>, 'ids'> &
@@ -43,14 +43,14 @@ const Sidebar = () => {
     <>
       <Box>
         <Subheading className={styles.subheading}>Connected Content</Subheading>
-        <InformationLinkComponent
+        <InformationWithLink
           url={CONNECTED_CONTENT_DOCUMENTATION}
           linkText={'Learn more'}
           fontColor="gray500"
           marginTop="spacing2Xs"
           marginBottom="spacingS">
           Generate a Connected Content call to copy and paste into Braze.
-        </InformationLinkComponent>
+        </InformationWithLink>
         <Button
           color={tokens.gray500}
           isFullWidth={true}
@@ -62,14 +62,14 @@ const Sidebar = () => {
       </Box>
       <Box marginTop="spacingS">
         <Subheading className={styles.subheading}>Content Blocks</Subheading>
-        <InformationLinkComponent
+        <InformationWithLink
           url={BRAZE_CONTENT_BLOCK_DOCUMENTATION}
           linkText={'Learn more'}
           fontColor="gray500"
           marginTop="spacing2Xs"
           marginBottom="spacingS">
           Send individual entry fields to Braze to create Content Blocks.
-        </InformationLinkComponent>
+        </InformationWithLink>
         <Button
           color={tokens.gray500}
           isFullWidth={true}

--- a/apps/braze/src/locations/Sidebar.tsx
+++ b/apps/braze/src/locations/Sidebar.tsx
@@ -1,8 +1,33 @@
-import { SidebarAppSDK } from '@contentful/app-sdk';
-import { Button } from '@contentful/f36-components';
+import { BaseAppSDK, IdsAPI, SharedEditorSDK, SidebarAppSDK, WindowAPI } from '@contentful/app-sdk';
+import { Box, Button, Subheading } from '@contentful/f36-components';
 import { useAutoResizer, useSDK } from '@contentful/react-apps-toolkit';
 import { EntryInfo } from './Dialog';
-import { DIALOG_TITLE, SIDEBAR_BUTTON_TEXT } from '../utils';
+import {
+  BRAZE_CONTENT_BLOCK_DOCUMENTATION,
+  CONNECTED_CONTENT_DOCUMENTATION,
+  DIALOG_TITLE,
+  SIDEBAR_CREATE_BUTTON_TEXT,
+  SIDEBAR_GENERATE_BUTTON_TEXT,
+} from '../utils';
+import tokens from '@contentful/f36-tokens';
+import { styles } from './Sidebar.styles';
+import { KeyValueMap } from 'contentful-management';
+import InformationLinkComponent from '../components/InformationLinkComponent';
+
+function openDialog(
+  sdk: Omit<BaseAppSDK<KeyValueMap, KeyValueMap, never>, 'ids'> &
+    SharedEditorSDK & {
+      ids: Omit<IdsAPI, 'field'>;
+      window: WindowAPI;
+    },
+  invocationParams: EntryInfo
+) {
+  sdk.dialogs.openCurrentApp({
+    title: DIALOG_TITLE,
+    parameters: invocationParams,
+    width: 'fullWidth',
+  });
+}
 
 const Sidebar = () => {
   const sdk = useSDK<SidebarAppSDK>();
@@ -15,18 +40,46 @@ const Sidebar = () => {
   };
 
   return (
-    <Button
-      variant="primary"
-      isFullWidth={true}
-      onClick={() => {
-        sdk.dialogs.openCurrentApp({
-          title: DIALOG_TITLE,
-          parameters: invocationParams,
-          width: 'fullWidth',
-        });
-      }}>
-      {SIDEBAR_BUTTON_TEXT}
-    </Button>
+    <>
+      <Box>
+        <Subheading className={styles.subheading}>Connected Content</Subheading>
+        <InformationLinkComponent
+          url={CONNECTED_CONTENT_DOCUMENTATION}
+          linkText={'Learn more'}
+          fontColor="gray500"
+          marginTop="spacing2Xs"
+          marginBottom="spacingS">
+          Generate a Connected Content call to copy and paste into Braze.
+        </InformationLinkComponent>
+        <Button
+          color={tokens.gray500}
+          isFullWidth={true}
+          onClick={() => {
+            openDialog(sdk, invocationParams);
+          }}>
+          {SIDEBAR_GENERATE_BUTTON_TEXT}
+        </Button>
+      </Box>
+      <Box marginTop="spacingS">
+        <Subheading className={styles.subheading}>Content Blocks</Subheading>
+        <InformationLinkComponent
+          url={BRAZE_CONTENT_BLOCK_DOCUMENTATION}
+          linkText={'Learn more'}
+          fontColor="gray500"
+          marginTop="spacing2Xs"
+          marginBottom="spacingS">
+          Send individual entry fields to Braze to create Content Blocks.
+        </InformationLinkComponent>
+        <Button
+          color={tokens.gray500}
+          isFullWidth={true}
+          onClick={() => {
+            openDialog(sdk, invocationParams);
+          }}>
+          {SIDEBAR_CREATE_BUTTON_TEXT}
+        </Button>
+      </Box>
+    </>
   );
 };
 

--- a/apps/braze/src/utils.ts
+++ b/apps/braze/src/utils.ts
@@ -11,7 +11,17 @@ export const ASSET_FIELDS_QUERY = [
 ];
 export const ASSET_FIELDS = ['title', 'description', 'url'];
 export const DIALOG_TITLE = 'Generate Braze Connected Content Call';
-export const SIDEBAR_BUTTON_TEXT = 'Generate Braze Connected Content';
+export const SIDEBAR_GENERATE_BUTTON_TEXT = 'Generate';
+export const SIDEBAR_CREATE_BUTTON_TEXT = 'Create';
+
+export const CONNECTED_CONTENT_DOCUMENTATION =
+  'https://www.braze.com/docs/user_guide/personalization_and_dynamic_content/connected_content';
+export const CONTENT_TYPE_DOCUMENTATION =
+  'https://www.contentful.com/help/content-types/configure-content-type/';
+export const BRAZE_APP_DOCUMENTATION = 'https://www.contentful.com/help/apps/braze-app/';
+export const BRAZE_API_KEY_DOCUMENTATION = `https://dashboard.braze.com/app_settings/developer_console/apisettings#apikeys`;
+export const BRAZE_CONTENT_BLOCK_DOCUMENTATION =
+  'https://www.braze.com/docs/api/endpoints/templates/content_blocks_templates/post_create_email_content_block';
 
 export function capitalize(s: string): string {
   return s.charAt(0).toUpperCase() + s.slice(1);

--- a/apps/braze/test/components/InformationWithLink.spec.tsx
+++ b/apps/braze/test/components/InformationWithLink.spec.tsx
@@ -1,0 +1,41 @@
+import { cleanup, render, RenderResult } from '@testing-library/react';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { queries } from '@testing-library/dom';
+import InformationWithLink from '../../src/components/InformationWithLink';
+
+describe('InformationWithLink component', () => {
+  let infromationWithLinkComponent: RenderResult<typeof queries, HTMLElement, HTMLElement>;
+  beforeEach(() => {
+    infromationWithLinkComponent = render(
+      <InformationWithLink url={'https://example.com'} linkText={'Learn more'} dataTestId="test-id">
+        A random description.
+      </InformationWithLink>
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the link correctly', () => {
+    const brazeLink = infromationWithLinkComponent.getByTestId('link-test-id');
+
+    expect(brazeLink).toBeTruthy();
+    expect(brazeLink.closest('a')?.getAttribute('href')).toBe('https://example.com');
+  });
+
+  it('renders the text correctly', () => {
+    const brazeParagraph = infromationWithLinkComponent.getByTestId('test-id');
+
+    expect(brazeParagraph).toBeTruthy();
+    expect(brazeParagraph.innerText).toBe('A random description. Learn more .');
+  });
+
+  it('renders the icon correctly', () => {
+    const brazeLink = infromationWithLinkComponent.getByTestId('link-test-id');
+    const icon = brazeLink.querySelector('svg');
+
+    expect(icon).toBeTruthy();
+  });
+});

--- a/apps/braze/test/locations/ConfigScreen.spec.tsx
+++ b/apps/braze/test/locations/ConfigScreen.spec.tsx
@@ -1,15 +1,16 @@
 import { cleanup, fireEvent, render, RenderResult, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mockCma, mockSdk } from '../mocks';
-import ConfigScreen, {
+import ConfigScreen from '../../src/locations/ConfigScreen';
+import userEvent from '@testing-library/user-event';
+import { queries } from '@testing-library/dom';
+import React from 'react';
+import {
   BRAZE_API_KEY_DOCUMENTATION,
   BRAZE_APP_DOCUMENTATION,
   BRAZE_CONTENT_BLOCK_DOCUMENTATION,
   CONTENT_TYPE_DOCUMENTATION,
-} from '../../src/locations/ConfigScreen';
-import userEvent from '@testing-library/user-event';
-import { queries } from '@testing-library/dom';
-import React from 'react';
+} from '../../src/utils';
 
 vi.mock('@contentful/react-apps-toolkit', () => ({
   useSDK: () => mockSdk,

--- a/apps/braze/test/locations/ConfigScreen.spec.tsx
+++ b/apps/braze/test/locations/ConfigScreen.spec.tsx
@@ -42,7 +42,7 @@ describe('Config Screen component', () => {
 
   describe('components', () => {
     it('renders the braze app link correctly', () => {
-      const brazeLink = configScreen.getByTestId('braze-app-docs-here-link');
+      const brazeLink = configScreen.getByTestId('link-braze-app-docs-here');
 
       expect(brazeLink).toBeTruthy();
       expect(brazeLink.closest('a')?.getAttribute('href')).toBe(BRAZE_APP_DOCUMENTATION);
@@ -72,7 +72,7 @@ describe('Config Screen component', () => {
     });
 
     it('renders the content type link correctly', () => {
-      const brazeLink = configScreen.getByTestId('content-type-docs-here-link');
+      const brazeLink = configScreen.getByTestId('link-content-type-docs-here');
 
       expect(brazeLink).toBeTruthy();
       expect(brazeLink.closest('a')?.getAttribute('href')).toBe(CONTENT_TYPE_DOCUMENTATION);

--- a/apps/braze/test/locations/Sidebar.spec.tsx
+++ b/apps/braze/test/locations/Sidebar.spec.tsx
@@ -1,7 +1,11 @@
 import { render } from '@testing-library/react';
 import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
-import { SIDEBAR_BUTTON_TEXT, DIALOG_TITLE } from '../../src/utils';
+import {
+  DIALOG_TITLE,
+  SIDEBAR_GENERATE_BUTTON_TEXT,
+  SIDEBAR_CREATE_BUTTON_TEXT,
+} from '../../src/utils';
 import { mockSdk, mockCma } from '../mocks';
 import Sidebar from '../../src/locations/Sidebar';
 
@@ -16,21 +20,39 @@ vi.mock('contentful-management', () => ({
 
 describe('Sidebar component', () => {
   const { getByText } = render(<Sidebar />);
+  const dialogParameters = {
+    title: DIALOG_TITLE,
+    parameters: {
+      id: mockSdk.ids.entry,
+      contentTypeId: mockSdk.ids.contentType,
+      title: 'Title',
+    },
+    width: 'fullWidth',
+  };
 
-  it('Component text exists', () => {
-    expect(getByText(SIDEBAR_BUTTON_TEXT)).toBeTruthy();
+  it('Generate button text exists', () => {
+    const button = getByText(SIDEBAR_GENERATE_BUTTON_TEXT);
+
+    expect(button).toBeTruthy();
+    expect(button.innerText).toBe(SIDEBAR_GENERATE_BUTTON_TEXT);
   });
 
-  it('Button opens a dialog', () => {
-    getByText(SIDEBAR_BUTTON_TEXT).click();
-    expect(mockSdk.dialogs.openCurrentApp).toBeCalledWith({
-      title: DIALOG_TITLE,
-      parameters: {
-        id: mockSdk.ids.entry,
-        contentTypeId: mockSdk.ids.contentType,
-        title: 'Title',
-      },
-      width: 'fullWidth',
-    });
+  it('Create button text exists', () => {
+    const button = getByText(SIDEBAR_CREATE_BUTTON_TEXT);
+
+    expect(button).toBeTruthy();
+    expect(button.innerText).toBe(SIDEBAR_CREATE_BUTTON_TEXT);
+  });
+
+  it('Generate button opens a dialog', () => {
+    getByText(SIDEBAR_GENERATE_BUTTON_TEXT).click();
+
+    expect(mockSdk.dialogs.openCurrentApp).toBeCalledWith(dialogParameters);
+  });
+
+  it('Create button opens a dialog', () => {
+    getByText(SIDEBAR_CREATE_BUTTON_TEXT).click();
+
+    expect(mockSdk.dialogs.openCurrentApp).toBeCalledWith(dialogParameters);
   });
 });


### PR DESCRIPTION
## Purpose

This update adds a Create button to the sidebar, renames the existing one to Generate, and includes descriptions for each option.

## Approach

In addition of the changes mentioned above, this update also adds a new component to reuse some repeated logic between the config screen and the sidebar.

With these changes now the sidebar looks like this:
<img width="1495" alt="Captura de pantalla 2025-04-22 a la(s) 12 47 40 p  m" src="https://github.com/user-attachments/assets/6fb7e872-d6b1-4035-ad08-7bf9a8fc706e" />

## Testing steps

Automated tests were added for the new component and the new sidebar button. Additionally, some updates were made to existing ones.

## Dependencies and/or References

Link to the [ticket](https://contentful.atlassian.net/browse/INTEG-2535).

**Important note:** This PR doesn’t include the logic in the dialog to distinguish which button was clicked. That will be handled in a separate ticket.