### PR TITLE
Braze app: change width of Dialog for last step [INTEG-2506]

### DIFF
--- a/apps/braze/src/components/FieldsSelectionStep.tsx
+++ b/apps/braze/src/components/FieldsSelectionStep.tsx
@@ -10,12 +10,13 @@ import tokens from '@contentful/f36-tokens';
 
 type FieldsSelectionStepProps = {
   entry: Entry;
+  selectedFields: Set<string>;
+  setSelectedFields: React.Dispatch<React.SetStateAction<Set<string>>>;
   handleNextStep: () => void;
 };
 
 const FieldsSelectionStep = (props: FieldsSelectionStepProps) => {
-  const { entry, handleNextStep } = props;
-  const [selectedFields, setSelectedFields] = useState<Set<string>>(new Set());
+  const { entry, selectedFields, setSelectedFields, handleNextStep } = props;
   const [entrySelected, setEntrySelected] = useState(false);
 
   const fields = entry.fields;

--- a/apps/braze/src/components/FieldsSelectionStep.tsx
+++ b/apps/braze/src/components/FieldsSelectionStep.tsx
@@ -17,10 +17,10 @@ type FieldsSelectionStepProps = {
 
 const FieldsSelectionStep = (props: FieldsSelectionStepProps) => {
   const { entry, selectedFields, setSelectedFields, handleNextStep } = props;
-  const [entrySelected, setEntrySelected] = useState(false);
 
   const fields = entry.fields;
   const allFields = entry.getAllFields();
+  const [entrySelected, setEntrySelected] = useState(selectedFields.size === allFields.length);
 
   const handleToggle = (event: React.ChangeEvent<HTMLInputElement>): void => {
     const { checked, id } = event.target;
@@ -34,7 +34,7 @@ const FieldsSelectionStep = (props: FieldsSelectionStepProps) => {
 
     updateSelectedFields(checked, newSelectedFields, field.uniqueId());
     toggleNestedFields(field, checked, newSelectedFields);
-    toggleParentField(field, newSelectedFields, allFields);
+    toggleParentField(field, newSelectedFields);
 
     setSelectedFields(newSelectedFields);
     setEntrySelected(newSelectedFields.size === allFields.length);
@@ -58,7 +58,7 @@ const FieldsSelectionStep = (props: FieldsSelectionStepProps) => {
     }
   };
 
-  const toggleParentField = (field: Field, selectedSet: Set<string>, allFields: any[]): void => {
+  const toggleParentField = (field: Field, selectedSet: Set<string>): void => {
     if (!field.parent) return;
     const children = field.parent.getChildren();
 
@@ -69,7 +69,7 @@ const FieldsSelectionStep = (props: FieldsSelectionStepProps) => {
       selectedSet.delete(field.parent.uniqueId());
     }
 
-    toggleParentField(field.parent, selectedSet, allFields);
+    toggleParentField(field.parent, selectedSet);
   };
 
   const toggleEntry = (event: React.ChangeEvent<HTMLInputElement>): void => {

--- a/apps/braze/src/fields/AssetArrayField.ts
+++ b/apps/braze/src/fields/AssetArrayField.ts
@@ -1,5 +1,6 @@
 import { ASSET_FIELDS, ASSET_FIELDS_QUERY } from '../utils';
 import { Field } from './Field';
+import { FieldRegistry } from './fieldRegistry';
 
 export class AssetArrayField extends Field {
   constructor(id: string, name: string, entryContentTypeId: string, localized: boolean) {
@@ -35,3 +36,5 @@ ${items.join('\n')}
     ];
   }
 }
+
+FieldRegistry.registerFieldType('AssetArrayField', AssetArrayField.fromSerialized);

--- a/apps/braze/src/fields/AssetArrayField.ts
+++ b/apps/braze/src/fields/AssetArrayField.ts
@@ -4,8 +4,21 @@ import { Field } from './Field';
 export class AssetArrayField extends Field {
   constructor(id: string, name: string, entryContentTypeId: string, localized: boolean) {
     super(id, name, entryContentTypeId, localized);
-    this.id = id;
-    this.localized = localized;
+  }
+
+  get type(): string {
+    return 'AssetArrayField';
+  }
+
+  static fromSerialized(serializedField: any): AssetArrayField {
+    const field = new AssetArrayField(
+      serializedField.id,
+      serializedField.name,
+      serializedField.entryContentTypeId,
+      serializedField.localized
+    );
+    field.selected = serializedField.selected;
+    return field;
   }
 
   generateQuery(): string {

--- a/apps/braze/src/fields/AssetField.ts
+++ b/apps/braze/src/fields/AssetField.ts
@@ -6,6 +6,21 @@ export class AssetField extends Field {
     super(id, name, entryContentTypeId, localized);
   }
 
+  get type(): string {
+    return 'AssetField';
+  }
+
+  static fromSerialized(serializedField: any): AssetField {
+    const field = new AssetField(
+      serializedField.id,
+      serializedField.name,
+      serializedField.entryContentTypeId,
+      serializedField.localized
+    );
+    field.selected = serializedField.selected;
+    return field;
+  }
+
   generateQuery(): string {
     return `${this.id} {${ASSET_FIELDS_QUERY.join(' ')}}`;
   }

--- a/apps/braze/src/fields/AssetField.ts
+++ b/apps/braze/src/fields/AssetField.ts
@@ -1,5 +1,6 @@
 import { ASSET_FIELDS, ASSET_FIELDS_QUERY } from '../utils';
 import { Field } from './Field';
+import { FieldRegistry } from './fieldRegistry';
 
 export class AssetField extends Field {
   constructor(id: string, name: string, entryContentTypeId: string, localized: boolean) {
@@ -29,3 +30,5 @@ export class AssetField extends Field {
     return ASSET_FIELDS.map((assetField) => `{{${template}.${this.id}.${assetField}}}`);
   }
 }
+
+FieldRegistry.registerFieldType('AssetField', AssetField.fromSerialized);

--- a/apps/braze/src/fields/BasicField.ts
+++ b/apps/braze/src/fields/BasicField.ts
@@ -1,4 +1,5 @@
 import { Field } from './Field';
+import { FieldRegistry } from './fieldRegistry';
 
 // Used for all types (see FieldType from contentful-management) except for arrays, links, rich text and location
 export class BasicField extends Field {
@@ -29,3 +30,5 @@ export class BasicField extends Field {
     return [`{{${template}.${this.id}}}`];
   }
 }
+
+FieldRegistry.registerFieldType('BasicField', BasicField.fromSerialized);

--- a/apps/braze/src/fields/BasicField.ts
+++ b/apps/braze/src/fields/BasicField.ts
@@ -6,6 +6,21 @@ export class BasicField extends Field {
     super(id, name, entryContentTypeId, localized);
   }
 
+  get type(): string {
+    return 'BasicField';
+  }
+
+  static fromSerialized(serializedField: any): BasicField {
+    const field = new BasicField(
+      serializedField.id,
+      serializedField.name,
+      serializedField.entryContentTypeId,
+      serializedField.localized
+    );
+    field.selected = serializedField.selected;
+    return field;
+  }
+
   generateQuery(): string {
     return this.id;
   }

--- a/apps/braze/src/fields/Entry.ts
+++ b/apps/braze/src/fields/Entry.ts
@@ -1,14 +1,6 @@
 import { removeHypens, firstLetterToLowercase, SAVED_RESPONSE } from '../utils';
-import { AssetArrayField } from './AssetArrayField';
-import { AssetField } from './AssetField';
-import { BasicField } from './BasicField';
 import { Field } from './Field';
-import { LocationField } from './LocationField';
-import { ReferenceArrayField } from './ReferenceArrayField';
-import { ReferenceField } from './ReferenceField';
-import { ReferenceItem } from './ReferenceItem';
-import { RichTextField } from './RichTextField';
-import { TextArrayField } from './TextArrayField';
+import { FieldRegistry } from './fieldRegistry';
 
 export class Entry {
   public id: string;
@@ -41,36 +33,11 @@ export class Entry {
       serializedEntry['id'],
       serializedEntry['contentType'],
       serializedEntry['title'],
-      serializedEntry['fields'].map((field: any) => this.deserializeField(field)),
+      serializedEntry['fields'].map((field: any) => FieldRegistry.deserializeField(field)),
       serializedEntry['spaceId'],
       serializedEntry['environment'],
       serializedEntry['contentfulToken']
     );
-  }
-
-  static deserializeField(serializedField: any): Field {
-    switch (serializedField.type) {
-      case 'BasicField':
-        return BasicField.fromSerialized(serializedField);
-      case 'AssetField':
-        return AssetField.fromSerialized(serializedField);
-      case 'AssetArrayField':
-        return AssetArrayField.fromSerialized(serializedField);
-      case 'LocationField':
-        return LocationField.fromSerialized(serializedField);
-      case 'ReferenceField':
-        return ReferenceField.fromSerialized(serializedField);
-      case 'ReferenceArrayField':
-        return ReferenceArrayField.fromSerialized(serializedField);
-      case 'ReferenceItem':
-        return ReferenceItem.fromSerialized(serializedField);
-      case 'RichTextField':
-        return RichTextField.fromSerialized(serializedField);
-      case 'TextArrayField':
-        return TextArrayField.fromSerialized(serializedField);
-      default:
-        throw new Error(`Unknown field type: ${serializedField.type}`);
-    }
   }
 
   serialize() {

--- a/apps/braze/src/fields/Entry.ts
+++ b/apps/braze/src/fields/Entry.ts
@@ -1,5 +1,14 @@
 import { removeHypens, firstLetterToLowercase, SAVED_RESPONSE } from '../utils';
+import { AssetArrayField } from './AssetArrayField';
+import { AssetField } from './AssetField';
+import { BasicField } from './BasicField';
 import { Field } from './Field';
+import { LocationField } from './LocationField';
+import { ReferenceArrayField } from './ReferenceArrayField';
+import { ReferenceField } from './ReferenceField';
+import { ReferenceItem } from './ReferenceItem';
+import { RichTextField } from './RichTextField';
+import { TextArrayField } from './TextArrayField';
 
 export class Entry {
   public id: string;
@@ -27,8 +36,53 @@ export class Entry {
     this.contentfulToken = contentfulToken;
   }
 
+  static fromSerialized(serializedEntry: any): Entry {
+    return new Entry(
+      serializedEntry['id'],
+      serializedEntry['contentType'],
+      serializedEntry['title'],
+      serializedEntry['fields'].map((field: any) => this.deserializeField(field)),
+      serializedEntry['spaceId'],
+      serializedEntry['environment'],
+      serializedEntry['contentfulToken']
+    );
+  }
+
+  static deserializeField(serializedField: any): Field {
+    switch (serializedField.type) {
+      case 'BasicField':
+        return BasicField.fromSerialized(serializedField);
+      case 'AssetField':
+        return AssetField.fromSerialized(serializedField);
+      case 'AssetArrayField':
+        return AssetArrayField.fromSerialized(serializedField);
+      case 'LocationField':
+        return LocationField.fromSerialized(serializedField);
+      case 'ReferenceField':
+        return ReferenceField.fromSerialized(serializedField);
+      case 'ReferenceArrayField':
+        return ReferenceArrayField.fromSerialized(serializedField);
+      case 'ReferenceItem':
+        return ReferenceItem.fromSerialized(serializedField);
+      case 'RichTextField':
+        return RichTextField.fromSerialized(serializedField);
+      case 'TextArrayField':
+        return TextArrayField.fromSerialized(serializedField);
+      default:
+        throw new Error(`Unknown field type: ${serializedField.type}`);
+    }
+  }
+
   serialize() {
-    return {};
+    return {
+      id: this.id,
+      contentType: this.contentType,
+      title: this.title,
+      fields: this.fields.map((field) => field.serialize()),
+      spaceId: this.spaceId,
+      environment: this.environment,
+      contentfulToken: this.contentfulToken,
+    };
   }
 
   generateConnectedContentCall(locales: string[]) {

--- a/apps/braze/src/fields/Entry.ts
+++ b/apps/braze/src/fields/Entry.ts
@@ -27,6 +27,10 @@ export class Entry {
     this.contentfulToken = contentfulToken;
   }
 
+  serialize() {
+    return {};
+  }
+
   generateConnectedContentCall(locales: string[]) {
     return `{% capture body %}
   ${this.assembleQuery(locales)}

--- a/apps/braze/src/fields/Field.ts
+++ b/apps/braze/src/fields/Field.ts
@@ -1,6 +1,3 @@
-import { ReferenceArrayField } from './ReferenceArrayField';
-import { ReferenceField } from './ReferenceField';
-import { ReferenceItem } from './ReferenceItem';
 import { removeHypens, firstLetterToLowercase, SAVED_RESPONSE } from '../utils';
 
 export abstract class Field {
@@ -8,8 +5,8 @@ export abstract class Field {
   public name: string;
   public localized: boolean;
   public entryContentTypeId: string;
-  public selected: boolean = false;
-  public parent: ReferenceField | ReferenceArrayField | ReferenceItem | null = null;
+  private _selected: boolean = false;
+  public parent: Field | null = null;
 
   constructor(id: string, name: string, entryContentTypeId: string, localized: boolean) {
     this.id = firstLetterToLowercase(id);
@@ -18,8 +15,28 @@ export abstract class Field {
     this.localized = localized;
   }
 
+  public get selected(): boolean {
+    return this._selected;
+  }
+
+  public set selected(value: boolean) {
+    this._selected = value;
+  }
+
   abstract generateQuery(): string;
   public abstract generateLiquidTagForType(template: string): string[];
+  abstract get type(): string;
+
+  serialize(): any {
+    return {
+      id: this.id,
+      name: this.name,
+      entryContentTypeId: this.entryContentTypeId,
+      localized: this.localized,
+      selected: this.selected,
+      type: this.type,
+    };
+  }
 
   generateLiquidTag(locale?: string): string[] {
     let template = `${SAVED_RESPONSE}.data.${this.entryContentTypeId}`;
@@ -48,6 +65,8 @@ export abstract class Field {
   getChildren(): Field[] {
     return [];
   }
+
+  childToggled(selected: boolean) {}
 
   isEnabled(): boolean {
     return true;

--- a/apps/braze/src/fields/FieldsFactory.ts
+++ b/apps/braze/src/fields/FieldsFactory.ts
@@ -14,25 +14,26 @@ import { ReferenceField } from './ReferenceField';
 import { ReferenceItem } from './ReferenceItem';
 import { RichTextField } from './RichTextField';
 import { TextArrayField } from './TextArrayField';
-import { EntryInfo } from '../locations/Dialog';
 import resolveResponse from 'contentful-resolve-response';
 
 export class FieldsFactory {
   private contentTypes: { [key: string]: ContentTypeProps };
-  private entryInfo: EntryInfo;
+  private entryId: string;
+  private entryContentTypeId: string;
   private cma: PlainClientAPI;
   NESTED_DEPTH = 5;
 
-  public constructor(entryInfo: EntryInfo, cma: PlainClientAPI) {
-    this.entryInfo = entryInfo;
+  public constructor(entryId: string, entryContentTypeId: string, cma: PlainClientAPI) {
+    this.entryId = entryId;
+    this.entryContentTypeId = entryContentTypeId;
     this.cma = cma;
     this.contentTypes = {};
   }
 
   public async createFields() {
-    const response = await this.cma.entry.references({ entryId: this.entryInfo.id, include: 5 });
+    const response = await this.cma.entry.references({ entryId: this.entryId, include: 5 });
     const items = resolveResponse(response);
-    const contentType = await this.getContentType(this.entryInfo.contentTypeId);
+    const contentType = await this.getContentType(this.entryContentTypeId);
     return this.createFieldsForEntry(items[0].fields, contentType);
   }
 

--- a/apps/braze/src/fields/LocationField.ts
+++ b/apps/braze/src/fields/LocationField.ts
@@ -8,6 +8,21 @@ export class LocationField extends Field {
     super(id, name, entryContentTypeId, localized);
   }
 
+  get type(): string {
+    return 'LocationField';
+  }
+
+  static fromSerialized(serializedField: any): LocationField {
+    const field = new LocationField(
+      serializedField.id,
+      serializedField.name,
+      serializedField.entryContentTypeId,
+      serializedField.localized
+    );
+    field.selected = serializedField.selected;
+    return field;
+  }
+
   generateQuery(): string {
     return `${this.id} {lat lon}`;
   }

--- a/apps/braze/src/fields/LocationField.ts
+++ b/apps/braze/src/fields/LocationField.ts
@@ -1,4 +1,5 @@
 import { Field } from './Field';
+import { FieldRegistry } from './fieldRegistry';
 
 export class LocationField extends Field {
   LOCATION_LAT = 'lat';
@@ -34,3 +35,5 @@ export class LocationField extends Field {
     ];
   }
 }
+
+FieldRegistry.registerFieldType('LocationField', LocationField.fromSerialized);

--- a/apps/braze/src/fields/ReferenceArrayField.ts
+++ b/apps/braze/src/fields/ReferenceArrayField.ts
@@ -16,6 +16,35 @@ export class ReferenceArrayField extends Field {
     this.items = items;
   }
 
+  get type(): string {
+    return 'ReferenceArrayField';
+  }
+
+  serialize(): any {
+    const base = super.serialize();
+    return {
+      ...base,
+      items: this.items.map((item) => item.serialize()),
+    };
+  }
+
+  static fromSerialized(serializedField: any): ReferenceArrayField {
+    const deserializedItems = serializedField.items.map((item: any) =>
+      ReferenceItem.fromSerialized(item)
+    );
+
+    const field = new ReferenceArrayField(
+      serializedField.id,
+      serializedField.name,
+      serializedField.entryContentTypeId,
+      serializedField.localized,
+      deserializedItems
+    );
+    field.selected = serializedField.selected;
+    deserializedItems.forEach((item: ReferenceItem) => (item.parent = field));
+    return field;
+  }
+
   generateQuery(): string {
     const fragments = this.selectedItems().map((item) => item.generateQuery());
     return `${this.id}Collection {items {${fragments.join(' ')}}}`;

--- a/apps/braze/src/fields/ReferenceArrayField.ts
+++ b/apps/braze/src/fields/ReferenceArrayField.ts
@@ -1,4 +1,5 @@
 import { Field } from './Field';
+import { FieldRegistry } from './fieldRegistry';
 import { ReferenceItem } from './ReferenceItem';
 
 export class ReferenceArrayField extends Field {
@@ -88,3 +89,5 @@ export class ReferenceArrayField extends Field {
     return this.items.filter((item) => item.selected);
   }
 }
+
+FieldRegistry.registerFieldType('ReferenceArrayField', ReferenceArrayField.fromSerialized);

--- a/apps/braze/src/fields/ReferenceField.ts
+++ b/apps/braze/src/fields/ReferenceField.ts
@@ -1,6 +1,6 @@
 import { capitalize } from '../utils';
-import { Entry } from './Entry';
 import { Field } from './Field';
+import { FieldRegistry } from './fieldRegistry';
 
 export class ReferenceField extends Field {
   public referenceContentTypeId: string;
@@ -22,8 +22,8 @@ export class ReferenceField extends Field {
     this.referenceContentTypeId = referenceContentTypeId;
     this.referenceContentTypeName = referenceContentTypeName;
     this.title = title;
-    fields.forEach((field) => (field.parent = this));
     this.fields = fields;
+    this.fields.forEach((field) => (field.parent = this));
   }
 
   get type(): string {
@@ -42,7 +42,9 @@ export class ReferenceField extends Field {
   }
 
   static fromSerialized(serializedField: any): ReferenceField {
-    const deserializedFields = serializedField.fields.map((f: any) => Entry.deserializeField(f));
+    const deserializedFields = serializedField.fields.map((f: any) =>
+      FieldRegistry.deserializeField(f)
+    );
 
     const field = new ReferenceField(
       serializedField.id,
@@ -108,3 +110,5 @@ export class ReferenceField extends Field {
     return this.fields.filter((field) => field.selected);
   }
 }
+
+FieldRegistry.registerFieldType('ReferenceField', ReferenceField.fromSerialized);

--- a/apps/braze/src/fields/ReferenceField.ts
+++ b/apps/braze/src/fields/ReferenceField.ts
@@ -1,4 +1,5 @@
 import { capitalize } from '../utils';
+import { Entry } from './Entry';
 import { Field } from './Field';
 
 export class ReferenceField extends Field {
@@ -23,6 +24,39 @@ export class ReferenceField extends Field {
     this.title = title;
     fields.forEach((field) => (field.parent = this));
     this.fields = fields;
+  }
+
+  get type(): string {
+    return 'ReferenceField';
+  }
+
+  serialize(): any {
+    const base = super.serialize();
+    return {
+      ...base,
+      referenceContentTypeId: this.referenceContentTypeId,
+      referenceContentTypeName: this.referenceContentTypeName,
+      title: this.title,
+      fields: this.fields.map((f) => f.serialize()),
+    };
+  }
+
+  static fromSerialized(serializedField: any): ReferenceField {
+    const deserializedFields = serializedField.fields.map((f: any) => Entry.deserializeField(f));
+
+    const field = new ReferenceField(
+      serializedField.id,
+      serializedField.name,
+      serializedField.entryContentTypeId,
+      serializedField.title,
+      serializedField.localized,
+      serializedField.referenceContentTypeId,
+      serializedField.referenceContentTypeName,
+      deserializedFields
+    );
+    field.selected = serializedField.selected;
+    deserializedFields.forEach((f: Field) => (f.parent = field));
+    return field;
   }
 
   generateQuery(): string {
@@ -70,7 +104,7 @@ export class ReferenceField extends Field {
     return fields;
   }
 
-  protected selectedFields(): Field[] {
+  selectedFields(): Field[] {
     return this.fields.filter((field) => field.selected);
   }
 }

--- a/apps/braze/src/fields/ReferenceItem.ts
+++ b/apps/braze/src/fields/ReferenceItem.ts
@@ -1,4 +1,5 @@
 import { capitalize } from '../utils';
+import { Entry } from './Entry';
 import { Field } from './Field';
 import { ReferenceField } from './ReferenceField';
 
@@ -26,6 +27,28 @@ export class ReferenceItem extends ReferenceField {
     this.referenceContentTypeName = referenceContentTypeName;
     this.title = title;
     fields.forEach((field) => (field.parent = this));
+  }
+
+  get type(): string {
+    return 'ReferenceItem';
+  }
+
+  static fromSerialized(serializedField: any): ReferenceItem {
+    const deserializedFields = serializedField.fields.map((f: any) => Entry.deserializeField(f));
+
+    const item = new ReferenceItem(
+      serializedField.id,
+      serializedField.name,
+      serializedField.entryContentTypeId,
+      serializedField.title,
+      serializedField.localized,
+      serializedField.referenceContentTypeId,
+      serializedField.referenceContentTypeName,
+      deserializedFields
+    );
+    item.selected = serializedField.selected;
+    deserializedFields.forEach((f: Field) => (f.parent = item));
+    return item;
   }
 
   generateQuery(): string {

--- a/apps/braze/src/fields/ReferenceItem.ts
+++ b/apps/braze/src/fields/ReferenceItem.ts
@@ -1,7 +1,7 @@
 import { capitalize } from '../utils';
-import { Entry } from './Entry';
 import { Field } from './Field';
 import { ReferenceField } from './ReferenceField';
+import { FieldRegistry } from './fieldRegistry';
 
 export class ReferenceItem extends ReferenceField {
   constructor(
@@ -24,9 +24,6 @@ export class ReferenceItem extends ReferenceField {
       referenceContentTypeName,
       fields
     );
-    this.referenceContentTypeName = referenceContentTypeName;
-    this.title = title;
-    fields.forEach((field) => (field.parent = this));
   }
 
   get type(): string {
@@ -34,7 +31,9 @@ export class ReferenceItem extends ReferenceField {
   }
 
   static fromSerialized(serializedField: any): ReferenceItem {
-    const deserializedFields = serializedField.fields.map((f: any) => Entry.deserializeField(f));
+    const deserializedFields = serializedField.fields.map((f: any) =>
+      FieldRegistry.deserializeField(f)
+    );
 
     const item = new ReferenceItem(
       serializedField.id,
@@ -63,3 +62,5 @@ export class ReferenceItem extends ReferenceField {
     return this.selectedFields().flatMap((field) => field.generateLiquidTagForType(`${template}`));
   }
 }
+
+FieldRegistry.registerFieldType('ReferenceItem', ReferenceItem.fromSerialized);

--- a/apps/braze/src/fields/RichTextField.ts
+++ b/apps/braze/src/fields/RichTextField.ts
@@ -1,4 +1,5 @@
 import { Field } from './Field';
+import { FieldRegistry } from './fieldRegistry';
 
 // We are not supporting rich text fields for now
 export class RichTextField extends Field {
@@ -41,3 +42,5 @@ export class RichTextField extends Field {
     return `${this.name} (Support for rich text fields coming soon)`;
   }
 }
+
+FieldRegistry.registerFieldType('RichTextField', RichTextField.fromSerialized);

--- a/apps/braze/src/fields/RichTextField.ts
+++ b/apps/braze/src/fields/RichTextField.ts
@@ -6,6 +6,25 @@ export class RichTextField extends Field {
     super(id, name, entryContentTypeId, localized);
   }
 
+  get type(): string {
+    return 'RichTextField';
+  }
+
+  public override set selected(value: boolean) {
+    return;
+  }
+
+  static fromSerialized(serializedField: any): RichTextField {
+    const field = new RichTextField(
+      serializedField.id,
+      serializedField.name,
+      serializedField.entryContentTypeId,
+      serializedField.localized
+    );
+    field.selected = serializedField.selected;
+    return field;
+  }
+
   generateQuery(): string {
     throw new Error('Rich text not supported');
   }

--- a/apps/braze/src/fields/TextArrayField.ts
+++ b/apps/braze/src/fields/TextArrayField.ts
@@ -5,6 +5,21 @@ export class TextArrayField extends Field {
     super(id, name, entryContentTypeId, localized);
   }
 
+  get type(): string {
+    return 'TextArrayField';
+  }
+
+  static fromSerialized(serializedField: any): TextArrayField {
+    const field = new TextArrayField(
+      serializedField.id,
+      serializedField.name,
+      serializedField.entryContentTypeId,
+      serializedField.localized
+    );
+    field.selected = serializedField.selected;
+    return field;
+  }
+
   generateQuery(): string {
     return this.id;
   }

--- a/apps/braze/src/fields/TextArrayField.ts
+++ b/apps/braze/src/fields/TextArrayField.ts
@@ -1,4 +1,5 @@
 import { Field } from './Field';
+import { FieldRegistry } from './fieldRegistry';
 
 export class TextArrayField extends Field {
   constructor(id: string, name: string, entryContentTypeId: string, localized: boolean) {
@@ -32,3 +33,5 @@ export class TextArrayField extends Field {
     ];
   }
 }
+
+FieldRegistry.registerFieldType('TextArrayField', TextArrayField.fromSerialized);

--- a/apps/braze/src/fields/fieldRegistry.ts
+++ b/apps/braze/src/fields/fieldRegistry.ts
@@ -1,0 +1,17 @@
+import { Field } from './Field';
+
+type FieldDeserializer = (serializedField: any) => Field;
+
+export class FieldRegistry {
+  private static registry: Record<string, FieldDeserializer> = {};
+
+  public static registerFieldType(type: string, deserializer: FieldDeserializer): void {
+    FieldRegistry.registry[type] = deserializer;
+  }
+
+  public static deserializeField(serializedField: any): Field {
+    const type = serializedField.type;
+    const deserializer = FieldRegistry.registry[type];
+    return deserializer(serializedField);
+  }
+}

--- a/apps/braze/src/locations/Dialog.tsx
+++ b/apps/braze/src/locations/Dialog.tsx
@@ -10,10 +10,13 @@ import { FieldsFactory } from '../fields/FieldsFactory';
 import { Entry } from '../fields/Entry';
 import { Field } from '../fields/Field';
 
-export type EntryInfo = {
-  id: string;
-  contentTypeId: string;
-  title: string;
+export type InvocationParams = {
+  step: string;
+  entryId?: string;
+  contentTypeId?: string;
+  title?: string;
+  selectedLocales?: string[];
+  serializedEntry?: {};
 };
 
 const FIELDS_STEP = 'fields';
@@ -23,31 +26,47 @@ const CODE_BLOCKS_STEP = 'codeBlocks';
 const Dialog = () => {
   const sdk = useSDK<DialogAppSDK>();
   useAutoResizer();
-  const locales = sdk.locales.available;
-  const entryInfo = sdk.parameters.invocation as EntryInfo;
-  const [step, setStep] = useState('fields');
-  const [selectedLocales, setSelectedLocales] = useState<string[]>([]);
-  const [entry, setEntry] = useState<Entry | undefined>(undefined);
-  const fieldsRef = useRef<Field[]>([]);
 
-  const cma = createClient(
-    { apiAdapter: sdk.cmaAdapter },
-    {
-      type: 'plain',
-      defaults: {
-        environmentId: sdk.ids.environmentAlias ?? sdk.ids.environment,
-        spaceId: sdk.ids.space,
-      },
-    }
-  );
+  const invocationParams = sdk.parameters.invocation as InvocationParams;
+  const currentStep = invocationParams.step;
+  const currentSelectedLocales = invocationParams.selectedLocales || [];
+  const currentEntry = invocationParams.serializedEntry
+    ? Entry.fromSerialized(invocationParams.serializedEntry)
+    : undefined;
+
+  const locales = sdk.locales.available;
+
+  const [step, setStep] = useState(currentStep);
+  const [selectedLocales, setSelectedLocales] = useState<string[]>(currentSelectedLocales);
+  const [entry, setEntry] = useState<Entry | undefined>(currentEntry);
+  const fieldsRef = useRef<Field[]>(currentEntry ? currentEntry.fields : []);
+
   useEffect(() => {
+    if (entry) {
+      return;
+    }
+    const cma = createClient(
+      { apiAdapter: sdk.cmaAdapter },
+      {
+        type: 'plain',
+        defaults: {
+          environmentId: sdk.ids.environmentAlias ?? sdk.ids.environment,
+          spaceId: sdk.ids.space,
+        },
+      }
+    );
+
     const fetchEntry = async () => {
-      const fields = await new FieldsFactory(entryInfo, cma).createFields();
+      const fields = await new FieldsFactory(
+        invocationParams.entryId!,
+        invocationParams.contentTypeId!,
+        cma
+      ).createFields();
       fieldsRef.current = fields;
-      const entry = new Entry(
-        entryInfo.id,
-        entryInfo.contentTypeId,
-        entryInfo.title,
+      const entry = new Entry( // TODO: check if we can remove the !
+        invocationParams.entryId!,
+        invocationParams.contentTypeId!,
+        invocationParams.title!,
         fieldsRef.current,
         sdk.ids.space,
         sdk.ids.environment,
@@ -77,7 +96,14 @@ const Dialog = () => {
       {step === FIELDS_STEP && (
         <FieldsSelectionStep
           entry={entry}
-          handleNextStep={() => setStep(shouldChooseLocales ? LOCALES_STEP : CODE_BLOCKS_STEP)}
+          handleNextStep={() =>
+            shouldChooseLocales
+              ? setStep(LOCALES_STEP)
+              : sdk.close({
+                  step: CODE_BLOCKS_STEP,
+                  serializedEntry: entry.serialize(),
+                })
+          }
         />
       )}
       {step === LOCALES_STEP && (
@@ -86,15 +112,27 @@ const Dialog = () => {
           selectedLocales={selectedLocales}
           setSelectedLocales={setSelectedLocales}
           handlePreviousStep={() => setStep(FIELDS_STEP)}
-          handleNextStep={() => setStep(CODE_BLOCKS_STEP)}
+          handleNextStep={() =>
+            sdk.close({
+              step: CODE_BLOCKS_STEP,
+              serializedEntry: entry.serialize(),
+              selectedLocales: selectedLocales,
+            })
+          }
         />
       )}
       {step === CODE_BLOCKS_STEP && (
         <CodeBlocksStep
           entry={entry}
           selectedLocales={selectedLocales}
-          handlePreviousStep={() => setStep(shouldChooseLocales ? LOCALES_STEP : FIELDS_STEP)}
-          handleClose={() => sdk.close()}
+          handlePreviousStep={() =>
+            sdk.close({
+              step: shouldChooseLocales ? LOCALES_STEP : FIELDS_STEP,
+              selectedLocales: selectedLocales,
+              serializedEntry: entry.serialize(),
+            })
+          }
+          handleClose={() => sdk.close({ step: 'close' })}
         />
       )}
     </Box>

--- a/apps/braze/src/locations/Dialog.tsx
+++ b/apps/braze/src/locations/Dialog.tsx
@@ -11,10 +11,11 @@ import { Entry } from '../fields/Entry';
 import { Field } from '../fields/Field';
 
 export type InvocationParams = {
-  step: string;
+  step?: string;
   entryId?: string;
   contentTypeId?: string;
   title?: string;
+  selectedFields?: string[];
   selectedLocales?: string[];
   serializedEntry?: {};
 };
@@ -28,7 +29,8 @@ const Dialog = () => {
   useAutoResizer();
 
   const invocationParams = sdk.parameters.invocation as InvocationParams;
-  const currentStep = invocationParams.step;
+  const currentStep = invocationParams.step || FIELDS_STEP;
+  const currentSelectedFields = invocationParams.selectedFields || [];
   const currentSelectedLocales = invocationParams.selectedLocales || [];
   const currentEntry = invocationParams.serializedEntry
     ? Entry.fromSerialized(invocationParams.serializedEntry)
@@ -37,6 +39,7 @@ const Dialog = () => {
   const locales = sdk.locales.available;
 
   const [step, setStep] = useState(currentStep);
+  const [selectedFields, setSelectedFields] = useState<Set<string>>(new Set(currentSelectedFields));
   const [selectedLocales, setSelectedLocales] = useState<string[]>(currentSelectedLocales);
   const [entry, setEntry] = useState<Entry | undefined>(currentEntry);
   const fieldsRef = useRef<Field[]>(currentEntry ? currentEntry.fields : []);
@@ -96,6 +99,8 @@ const Dialog = () => {
       {step === FIELDS_STEP && (
         <FieldsSelectionStep
           entry={entry}
+          selectedFields={selectedFields}
+          setSelectedFields={setSelectedFields}
           handleNextStep={() =>
             shouldChooseLocales
               ? setStep(LOCALES_STEP)
@@ -116,6 +121,7 @@ const Dialog = () => {
             sdk.close({
               step: CODE_BLOCKS_STEP,
               serializedEntry: entry.serialize(),
+              selectedFields: selectedFields,
               selectedLocales: selectedLocales,
             })
           }
@@ -128,6 +134,7 @@ const Dialog = () => {
           handlePreviousStep={() =>
             sdk.close({
               step: shouldChooseLocales ? LOCALES_STEP : FIELDS_STEP,
+              selectedFields: selectedFields,
               selectedLocales: selectedLocales,
               serializedEntry: entry.serialize(),
             })

--- a/apps/braze/src/locations/Dialog.tsx
+++ b/apps/braze/src/locations/Dialog.tsx
@@ -12,9 +12,9 @@ import { Field } from '../fields/Field';
 
 export type InvocationParams = {
   step?: string;
-  entryId?: string;
-  contentTypeId?: string;
-  title?: string;
+  entryId: string;
+  contentTypeId: string;
+  title: string;
   selectedFields?: string[];
   selectedLocales?: string[];
   serializedEntry?: {};
@@ -66,10 +66,10 @@ const Dialog = () => {
         cma
       ).createFields();
       fieldsRef.current = fields;
-      const entry = new Entry( // TODO: check if we can remove the !
-        invocationParams.entryId!,
-        invocationParams.contentTypeId!,
-        invocationParams.title!,
+      const entry = new Entry(
+        invocationParams.entryId,
+        invocationParams.contentTypeId,
+        invocationParams.title,
         fieldsRef.current,
         sdk.ids.space,
         sdk.ids.environment,
@@ -106,6 +106,9 @@ const Dialog = () => {
               ? setStep(LOCALES_STEP)
               : sdk.close({
                   step: CODE_BLOCKS_STEP,
+                  entryId: invocationParams.entryId,
+                  contentTypeId: invocationParams.contentTypeId,
+                  title: invocationParams.title,
                   serializedEntry: entry.serialize(),
                 })
           }
@@ -120,6 +123,9 @@ const Dialog = () => {
           handleNextStep={() =>
             sdk.close({
               step: CODE_BLOCKS_STEP,
+              entryId: invocationParams.entryId,
+              contentTypeId: invocationParams.contentTypeId,
+              title: invocationParams.title,
               serializedEntry: entry.serialize(),
               selectedFields: selectedFields,
               selectedLocales: selectedLocales,
@@ -134,6 +140,9 @@ const Dialog = () => {
           handlePreviousStep={() =>
             sdk.close({
               step: shouldChooseLocales ? LOCALES_STEP : FIELDS_STEP,
+              entryId: invocationParams.entryId,
+              contentTypeId: invocationParams.contentTypeId,
+              title: invocationParams.title,
               selectedFields: selectedFields,
               selectedLocales: selectedLocales,
               serializedEntry: entry.serialize(),

--- a/apps/braze/src/locations/Sidebar.tsx
+++ b/apps/braze/src/locations/Sidebar.tsx
@@ -9,7 +9,6 @@ const Sidebar = () => {
   useAutoResizer();
 
   const initialInvocationParams: InvocationParams = {
-    step: 'fields',
     entryId: sdk.ids.entry,
     contentTypeId: sdk.ids.contentType,
     title: sdk.entry.fields[sdk.contentType.displayField].getValue(),

--- a/apps/braze/src/locations/Sidebar.tsx
+++ b/apps/braze/src/locations/Sidebar.tsx
@@ -20,10 +20,10 @@ const Sidebar = () => {
   ) => {
     const width = step === 'codeBlocks' ? 'fullWidth' : 'large';
     const result = await openDialog(parameters, width);
-    const nextStep = result['step'];
-    if (nextStep !== 'close') {
-      await openDialogLogic(nextStep, result);
+    if (!result || result['step'] === 'close') {
+      return;
     }
+    await openDialogLogic(result['step'], result);
   };
 
   const openDialog = async (parameters: InvocationParams, width: 'fullWidth' | 'large') => {

--- a/apps/braze/src/locations/Sidebar.tsx
+++ b/apps/braze/src/locations/Sidebar.tsx
@@ -1,30 +1,42 @@
 import { SidebarAppSDK } from '@contentful/app-sdk';
 import { Button } from '@contentful/f36-components';
 import { useAutoResizer, useSDK } from '@contentful/react-apps-toolkit';
-import { EntryInfo } from './Dialog';
 import { DIALOG_TITLE, SIDEBAR_BUTTON_TEXT } from '../utils';
+import { InvocationParams } from './Dialog';
 
 const Sidebar = () => {
   const sdk = useSDK<SidebarAppSDK>();
   useAutoResizer();
 
-  const invocationParams: EntryInfo = {
-    id: sdk.ids.entry,
+  const initialInvocationParams: InvocationParams = {
+    step: 'fields',
+    entryId: sdk.ids.entry,
     contentTypeId: sdk.ids.contentType,
     title: sdk.entry.fields[sdk.contentType.displayField].getValue(),
   };
 
+  const openDialogLogic = async (
+    step: string,
+    parameters: InvocationParams = initialInvocationParams
+  ) => {
+    const width = step === 'codeBlocks' ? 'fullWidth' : 'large';
+    const result = await openDialog(parameters, width);
+    const nextStep = result['step'];
+    if (nextStep !== 'close') {
+      await openDialogLogic(nextStep, result);
+    }
+  };
+
+  const openDialog = async (parameters: InvocationParams, width: 'fullWidth' | 'large') => {
+    return sdk.dialogs.openCurrentApp({
+      title: DIALOG_TITLE,
+      parameters: parameters,
+      width: width,
+    });
+  };
+
   return (
-    <Button
-      variant="primary"
-      isFullWidth={true}
-      onClick={() => {
-        sdk.dialogs.openCurrentApp({
-          title: DIALOG_TITLE,
-          parameters: invocationParams,
-          width: 'fullWidth',
-        });
-      }}>
+    <Button variant="primary" isFullWidth={true} onClick={() => openDialogLogic('fields')}>
       {SIDEBAR_BUTTON_TEXT}
     </Button>
   );

--- a/apps/braze/test/components/CodeBlock.spec.tsx
+++ b/apps/braze/test/components/CodeBlock.spec.tsx
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { mockCma, mockSdk } from '../../test/mocks';
-import CodeBlock from './CodeBlock';
+import { mockCma, mockSdk } from '../mocks';
+import CodeBlock from '../../src/components/CodeBlock';
 import { screen, render, cleanup } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/apps/braze/test/fields/FieldsFactory.spec.ts
+++ b/apps/braze/test/fields/FieldsFactory.spec.ts
@@ -28,11 +28,8 @@ describe('FieldsFactory', () => {
     },
   };
 
-  const mockEntryInfo = {
-    id: 'entryId',
-    contentTypeId: 'article',
-    title: 'entryTitle',
-  };
+  const entryId = 'entryId';
+  const entryContentTypeId = 'article';
 
   beforeEach(() => {
     vi.resetAllMocks();
@@ -56,7 +53,11 @@ describe('FieldsFactory', () => {
       },
     });
 
-    const result = await new FieldsFactory(mockEntryInfo, mockCma as any).createFields();
+    const result = await new FieldsFactory(
+      entryId,
+      entryContentTypeId,
+      mockCma as any
+    ).createFields();
 
     expect(result).toHaveLength(1);
     expect(result[0]).toBeInstanceOf(BasicField);
@@ -87,7 +88,11 @@ describe('FieldsFactory', () => {
       },
     });
 
-    const result = await new FieldsFactory(mockEntryInfo, mockCma as any).createFields();
+    const result = await new FieldsFactory(
+      entryId,
+      entryContentTypeId,
+      mockCma as any
+    ).createFields();
     expect(result).toHaveLength(1);
     expect(result[0]).toBeInstanceOf(AssetField);
     const fieldInstance = result[0] as AssetField;
@@ -148,7 +153,11 @@ describe('FieldsFactory', () => {
       }
     });
 
-    const result = await new FieldsFactory(mockEntryInfo, mockCma as any).createFields();
+    const result = await new FieldsFactory(
+      entryId,
+      entryContentTypeId,
+      mockCma as any
+    ).createFields();
     expect(result).toHaveLength(1);
     expect(result[0]).toBeInstanceOf(ReferenceField);
     const fieldInstance = result[0] as ReferenceField;
@@ -181,7 +190,11 @@ describe('FieldsFactory', () => {
       },
     });
 
-    const result = await new FieldsFactory(mockEntryInfo, mockCma as any).createFields();
+    const result = await new FieldsFactory(
+      entryId,
+      entryContentTypeId,
+      mockCma as any
+    ).createFields();
 
     expect(result).toHaveLength(1);
     expect(result[0]).toBeInstanceOf(TextArrayField);
@@ -220,7 +233,11 @@ describe('FieldsFactory', () => {
       },
     });
 
-    const result = await new FieldsFactory(mockEntryInfo, mockCma as any).createFields();
+    const result = await new FieldsFactory(
+      entryId,
+      entryContentTypeId,
+      mockCma as any
+    ).createFields();
     expect(result).toHaveLength(1);
     expect(result[0]).toBeInstanceOf(AssetArrayField);
     const fieldInstance = result[0] as AssetArrayField;
@@ -295,7 +312,11 @@ describe('FieldsFactory', () => {
       }
     });
 
-    const result = await new FieldsFactory(mockEntryInfo, mockCma as any).createFields();
+    const result = await new FieldsFactory(
+      entryId,
+      entryContentTypeId,
+      mockCma as any
+    ).createFields();
     expect(result).toHaveLength(1);
     expect(result[0]).toBeInstanceOf(ReferenceArrayField);
     const fieldInstance = result[0] as ReferenceArrayField;
@@ -361,7 +382,11 @@ describe('FieldsFactory', () => {
       };
     });
 
-    const result = await new FieldsFactory(mockEntryInfo, mockCma as any).createFields();
+    const result = await new FieldsFactory(
+      entryId,
+      entryContentTypeId,
+      mockCma as any
+    ).createFields();
 
     expect(result).toHaveLength(2); // name and nestedRef
     expect(result[0].id).toEqual('name');

--- a/apps/braze/test/locations/Dialog.spec.tsx
+++ b/apps/braze/test/locations/Dialog.spec.tsx
@@ -1,14 +1,101 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { mockCma, mockSdk } from '../mocks';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import Dialog from '../../src/locations/Dialog';
+import React from 'react';
+import { Entry } from '../../src/fields/Entry';
+import { BasicField } from '../../src/fields/BasicField';
 
 vi.mock('@contentful/react-apps-toolkit', () => ({
   useSDK: () => mockSdk,
-  useCMA: () => mockCma,
   useAutoResizer: () => {},
 }));
 
+vi.mock('contentful-management', () => ({
+  createClient: () => mockCma,
+}));
+
+const mockCreateFields = vi.fn();
+vi.mock('../../src/fields/FieldsFactory', () => ({
+  FieldsFactory: vi.fn().mockImplementation(() => ({
+    createFields: mockCreateFields,
+  })),
+}));
+
+const mockField = new BasicField('fieldId', 'fieldName', 'contentTypeId', false);
+mockField.selected = true;
+
+const mockEntry = new Entry(
+  'entryId',
+  'contentTypeId',
+  'title',
+  [mockField],
+  mockSdk.ids.space,
+  mockSdk.ids.environemnt,
+  mockSdk.parameters.installation.apiKey
+);
+
+const FIELDS_STEP_TEXT = 'Select which fields';
+const CODE_BLOCKS_STEP_TEXT = 'Braze Connected Content Call';
+
 describe('Dialog component', () => {
-  it('Component text exists', () => {
-    expect(true).toBeTruthy(); // TODO: replace
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateFields.mockResolvedValue([mockField]);
+    vi.spyOn(mockEntry, 'getGraphQLResponse').mockImplementation(async () => 'graphql response');
+    vi.spyOn(Entry, 'fromSerialized').mockImplementation(() => mockEntry);
+    mockSdk.parameters.invocation = undefined;
+    mockSdk.close = vi.fn();
+  });
+  afterEach(cleanup);
+
+  it('navigates through steps and closes', async () => {
+    mockSdk.parameters.invocation = {
+      entryId: 'entryId',
+      contentTypeId: 'contentTypeId',
+      title: 'title',
+    };
+    render(<Dialog />);
+
+    await screen.findByText(FIELDS_STEP_TEXT, { exact: false });
+
+    expect(screen.getByLabelText<HTMLInputElement>(mockField.name).checked).toBe(false);
+
+    fireEvent.click(screen.getByLabelText(mockField.name));
+    expect(screen.getByLabelText<HTMLInputElement>(mockField.name).checked).toBe(true);
+
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+
+    expect(mockSdk.close).toHaveBeenCalledWith({
+      step: 'codeBlocks',
+      serializedEntry: mockEntry.serialize(),
+    });
+  });
+
+  it('opens directly to Code Blocks step when specified in parameters', async () => {
+    mockSdk.parameters.invocation = {
+      step: 'codeBlocks',
+      selectedFields: new Set([mockField.uniqueId()]),
+      serializedEntry: mockEntry.serialize(),
+    };
+    render(<Dialog />);
+
+    await screen.findByText(CODE_BLOCKS_STEP_TEXT);
+    expect(screen.getByText(mockField.uniqueId())).toBeTruthy();
+    expect(screen.queryByText(FIELDS_STEP_TEXT)).toBeFalsy();
+  });
+
+  it('opens with pre-selected fields when specified in parameters', async () => {
+    mockSdk.parameters.invocation = {
+      step: 'fields',
+      selectedFields: new Set([mockField.uniqueId()]),
+      serializedEntry: mockEntry.serialize(),
+    };
+    render(<Dialog />);
+
+    await screen.findByText(FIELDS_STEP_TEXT, { exact: false });
+    expect(screen.getByText(mockField.name)).toBeTruthy();
+
+    expect(screen.getByLabelText<HTMLInputElement>(mockField.name).checked).toBe(true);
   });
 });

--- a/apps/braze/test/locations/Dialog.spec.tsx
+++ b/apps/braze/test/locations/Dialog.spec.tsx
@@ -68,6 +68,9 @@ describe('Dialog component', () => {
 
     expect(mockSdk.close).toHaveBeenCalledWith({
       step: 'codeBlocks',
+      entryId: 'entryId',
+      contentTypeId: 'contentTypeId',
+      title: 'title',
       serializedEntry: mockEntry.serialize(),
     });
   });

--- a/apps/braze/test/locations/Sidebar.spec.tsx
+++ b/apps/braze/test/locations/Sidebar.spec.tsx
@@ -1,6 +1,6 @@
-import { render } from '@testing-library/react';
+import { render, fireEvent, cleanup, waitFor } from '@testing-library/react'; // Import waitFor
 import React from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { SIDEBAR_BUTTON_TEXT, DIALOG_TITLE } from '../../src/utils';
 import { mockSdk, mockCma } from '../mocks';
 import Sidebar from '../../src/locations/Sidebar';
@@ -15,22 +15,85 @@ vi.mock('contentful-management', () => ({
 }));
 
 describe('Sidebar component', () => {
-  const { getByText } = render(<Sidebar />);
+  beforeEach(() => {
+    vi.clearAllMocks(); // Clear mocks before each test
+  });
+
+  afterEach(cleanup);
 
   it('Component text exists', () => {
+    const { getByText } = render(<Sidebar />);
     expect(getByText(SIDEBAR_BUTTON_TEXT)).toBeTruthy();
   });
 
-  it('Button opens a dialog', () => {
-    getByText(SIDEBAR_BUTTON_TEXT).click();
-    expect(mockSdk.dialogs.openCurrentApp).toBeCalledWith({
+  it('Button opens a dialog initially', async () => {
+    const { getByText } = render(<Sidebar />);
+    const button = getByText(SIDEBAR_BUTTON_TEXT);
+    await fireEvent.click(button);
+
+    expect(mockSdk.dialogs.openCurrentApp).toHaveBeenCalledTimes(1);
+    expect(mockSdk.dialogs.openCurrentApp).toHaveBeenCalledWith({
       title: DIALOG_TITLE,
       parameters: {
-        id: mockSdk.ids.entry,
+        entryId: mockSdk.ids.entry,
         contentTypeId: mockSdk.ids.contentType,
         title: 'Title',
       },
+      width: 'large',
+    });
+  });
+
+  it('Button opens dialog again if parameters are returned', async () => {
+    const result = { step: 'codeBlocks', otherParam: 'value' };
+    vi.mocked(mockSdk.dialogs.openCurrentApp).mockResolvedValueOnce(result);
+
+    const { getByText } = render(<Sidebar />);
+    const button = getByText(SIDEBAR_BUTTON_TEXT);
+    await fireEvent.click(button);
+
+    expect(mockSdk.dialogs.openCurrentApp).toHaveBeenCalledTimes(1);
+    expect(mockSdk.dialogs.openCurrentApp).toHaveBeenCalledWith({
+      title: DIALOG_TITLE,
+      parameters: {
+        entryId: mockSdk.ids.entry,
+        contentTypeId: mockSdk.ids.contentType,
+        title: 'Title',
+      },
+      width: 'large',
+    });
+
+    await waitFor(() => {
+      expect(mockSdk.dialogs.openCurrentApp).toHaveBeenCalledTimes(2);
+    });
+
+    expect(mockSdk.dialogs.openCurrentApp).toHaveBeenNthCalledWith(2, {
+      title: DIALOG_TITLE,
+      parameters: result,
       width: 'fullWidth',
+    });
+  });
+
+  it('Button does not open dialog again if step is close', async () => {
+    const result = { step: 'close' };
+    vi.mocked(mockSdk.dialogs.openCurrentApp).mockResolvedValueOnce(result);
+
+    const { getByText } = render(<Sidebar />);
+    const button = getByText(SIDEBAR_BUTTON_TEXT);
+    await fireEvent.click(button);
+
+    expect(mockSdk.dialogs.openCurrentApp).toHaveBeenCalledTimes(1);
+    expect(mockSdk.dialogs.openCurrentApp).toHaveBeenCalledWith({
+      title: DIALOG_TITLE,
+      parameters: {
+        entryId: mockSdk.ids.entry,
+        contentTypeId: mockSdk.ids.contentType,
+        title: 'Title',
+      },
+      width: 'large',
+    });
+
+    await waitFor(() => {
+      expect(mockSdk.dialogs.openCurrentApp).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
## Purpose

Until now we were using `fullWidth` for all three steps of the app, but we needed to use the `large` width for the first two steps.

## Approach

Since the width of the Dialog cannot be changed once open, it has to be closed and reopened before the last step. So we had to serialize and deserialize all information from the entry and the fields.

## Testing steps

Automated tests were added.
To test manually, just use the app and get to the last step, the Dialog should close and reopen in the last step.

https://github.com/user-attachments/assets/7683965b-75a3-48f3-8daa-fb37b5255f5e

## Breaking Changes

N/A

## Dependencies and/or References

N/A

## Deployment

 N/A
