### PR TITLE
[WIP] Braze app: create content blocks [INTEG-2541]

### DIFF
--- a/apps/braze/contentful-app-manifest.json
+++ b/apps/braze/contentful-app-manifest.json
@@ -6,7 +6,9 @@
       "description": "Function to create content blocks from App Action.",
       "path": "functions/createContentBlocks.js",
       "entryFile": "functions/createContentBlocks.ts",
-      "allowNetworks": [],
+      "allowNetworks": [
+        "https://*.braze.com"
+      ],
       "accepts": ["appaction.call"]
     },
     {
@@ -15,7 +17,9 @@
       "description": "Function to update content blocks from App Events.",
       "path": "functions/updateContentBlocks.js",
       "entryFile": "functions/updateContentBlocks.ts",
-      "allowNetworks": [],
+      "allowNetworks": [
+        "https://*.braze.com"
+      ],
       "accepts": ["appevent.handler"]
     }
   ],
@@ -26,7 +30,20 @@
       "type": "function-invocation",
       "functionId": "createContentBlocksFunction",
       "category": "Custom",
-      "parameters": []
+      "parameters": [
+        {
+          "id": "entryId",
+          "name": "Entry ID",
+          "type": "Symbol",
+          "required": true
+        },
+        {
+          "id": "fieldIds",
+          "name": "Field IDs",
+          "type": "Symbol",
+          "required": true
+        }
+      ]
     }
   ]
 }

--- a/apps/braze/functions/createContentBlocks.ts
+++ b/apps/braze/functions/createContentBlocks.ts
@@ -44,9 +44,11 @@ export const handler: FunctionEventHandler<FunctionTypeEnum.AppActionCall> = asy
     contentTypeId: entry.sys.contentType.sys.id,
   });
   const locale = entry.sys.locale || 'en-US'; // TODO: define what to do here
+
   const entryTitle = !!contentType.displayField
     ? entry.fields[contentType.displayField]?.[locale] || 'Untitled'
     : 'Untitled';
+  const entryTitleWithoutSpaces = entryTitle.replace(/\s+/g, '-');
 
   const fieldIdArray = fieldIds.split(',').map((id) => id.trim());
 
@@ -86,7 +88,7 @@ export const handler: FunctionEventHandler<FunctionTypeEnum.AppActionCall> = asy
           Authorization: `Bearer ${brazeApiKey}`,
         },
         body: JSON.stringify({
-          name: `${entryTitle}-${fieldId}`,
+          name: `${entryTitleWithoutSpaces}-${fieldId}`,
           content: content,
           state: 'draft',
         }),

--- a/apps/braze/package-lock.json
+++ b/apps/braze/package-lock.json
@@ -13,6 +13,7 @@
         "@contentful/f36-multiselect": "^4.26.0",
         "@contentful/f36-tokens": "4.0.2",
         "@contentful/react-apps-toolkit": "1.2.16",
+        "@contentful/rich-text-html-renderer": "^17.0.0",
         "@testing-library/user-event": "^14.6.1",
         "contentful-management": "11.48.3",
         "contentful-resolve-response": "^1.9.2",
@@ -1265,6 +1266,43 @@
       "peerDependencies": {
         "@contentful/app-sdk": ">=4.0.0",
         "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@contentful/rich-text-html-renderer": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-html-renderer/-/rich-text-html-renderer-17.0.0.tgz",
+      "integrity": "sha512-mJXZALvCbc9T4vVUN288xdWraio1n4dPZEkFbRjef3yXbVZBDALL/Ld3WY3saaNmn9AR9XOhnt4sOU8UxXy1AQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/rich-text-types": "^17.0.0",
+        "escape-html": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@contentful/rich-text-html-renderer/node_modules/@contentful/rich-text-types": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-17.0.0.tgz",
+      "integrity": "sha512-x50t6sILzFHBdFpAo0foJRnH8fHWyidheWhAv3uwt9aOnNqTh893gxyoc3Q0RVEZxXfHpTi+O9gmakHcdlRdTA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@contentful/rich-text-html-renderer/node_modules/is-plain-obj": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
+      "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@contentful/rich-text-types": {
@@ -3915,6 +3953,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",

--- a/apps/braze/package.json
+++ b/apps/braze/package.json
@@ -8,6 +8,7 @@
     "@contentful/f36-multiselect": "^4.26.0",
     "@contentful/f36-tokens": "4.0.2",
     "@contentful/react-apps-toolkit": "1.2.16",
+    "@contentful/rich-text-html-renderer": "^17.0.0",
     "@testing-library/user-event": "^14.6.1",
     "contentful-management": "11.48.3",
     "contentful-resolve-response": "^1.9.2",

--- a/apps/braze/test/functions/createContentBlocks.test.ts
+++ b/apps/braze/test/functions/createContentBlocks.test.ts
@@ -90,7 +90,7 @@ describe('createContentBlocks', () => {
           Authorization: 'Bearer test-api-key',
         },
         body: JSON.stringify({
-          name: 'Test Title-title',
+          name: 'Test-Title-title',
           content: 'Test Title',
           state: 'draft',
         }),

--- a/apps/braze/test/functions/createContentBlocks.test.ts
+++ b/apps/braze/test/functions/createContentBlocks.test.ts
@@ -1,0 +1,417 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handler } from '../../functions/createContentBlocks';
+import {
+  AppActionRequest,
+  FunctionEventContext,
+  FunctionTypeEnum,
+} from '@contentful/node-apps-toolkit';
+import type { PlainClientAPI, EntryProps, ContentTypeProps } from 'contentful-management';
+import { documentToHtmlString } from '@contentful/rich-text-html-renderer';
+
+const mockCma = {
+  entry: {
+    get: vi.fn(),
+  },
+  contentType: {
+    get: vi.fn(),
+  },
+} as unknown as PlainClientAPI;
+
+// Mock the contentful-management client
+vi.mock('contentful-management', () => ({
+  createClient: () => mockCma,
+}));
+
+// Mock the rich-text-html-renderer
+vi.mock('@contentful/rich-text-html-renderer', () => ({
+  documentToHtmlString: vi.fn(),
+}));
+
+describe('createContentBlocks', () => {
+  const mockContext: FunctionEventContext = {
+    spaceId: 'space-id',
+    environmentId: 'environment-id',
+    appInstallationParameters: {
+      brazeApiKey: 'test-api-key',
+      brazeEndpoint: 'https://test.braze.com',
+    },
+    cmaClientOptions: {
+      accessToken: 'test-token',
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn();
+  });
+
+  it('should create content blocks for text fields', async () => {
+    // Mock entry data
+    const mockEntry = {
+      sys: {
+        id: 'entry-id',
+        type: 'Entry',
+        space: { sys: { type: 'Link', linkType: 'Space', id: 'space-id' } },
+        environment: { sys: { type: 'Link', linkType: 'Environment', id: 'environment-id' } },
+        contentType: {
+          sys: {
+            type: 'Link',
+            linkType: 'ContentType',
+            id: 'content-type-id',
+          },
+        },
+        locale: 'en-US',
+        version: 1,
+        createdAt: '2024-01-01T00:00:00Z',
+        updatedAt: '2024-01-01T00:00:00Z',
+        automationTags: [],
+      },
+      fields: {
+        title: {
+          'en-US': 'Test Title',
+        },
+      },
+    } as unknown as EntryProps;
+
+    // Mock contentType data
+    const mockContentType = {
+      sys: {
+        type: 'ContentType',
+        id: 'content-type-id',
+        version: 1,
+        createdAt: '2024-01-01T00:00:00Z',
+        updatedAt: '2024-01-01T00:00:00Z',
+        space: { sys: { type: 'Link', linkType: 'Space', id: 'space-id' } },
+        environment: { sys: { type: 'Link', linkType: 'Environment', id: 'environment-id' } },
+      },
+      name: 'Test Content Type',
+      description: 'Test Description',
+      displayField: 'title',
+      fields: [
+        {
+          id: 'title',
+          name: 'Title',
+          type: 'Text',
+          localized: true,
+          required: true,
+          validations: [],
+          disabled: false,
+          omitted: false,
+        },
+      ],
+    } as ContentTypeProps;
+
+    // Mock API responses
+    vi.mocked(mockCma.entry.get).mockResolvedValue(mockEntry);
+    vi.mocked(mockCma.contentType.get).mockResolvedValue(mockContentType);
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ content_block_id: 'block-id' }),
+    } as Response);
+
+    const event: AppActionRequest<'Custom', { entryId: string; fieldIds: string }> = {
+      type: FunctionTypeEnum.AppActionCall,
+      body: {
+        entryId: 'entry-id',
+        fieldIds: 'title',
+      },
+      headers: {},
+    };
+
+    const result = await handler(event, mockContext);
+
+    expect(result).toEqual({
+      results: [
+        {
+          fieldId: 'title',
+          success: true,
+          contentBlockId: 'block-id',
+        },
+      ],
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://test.braze.com/content_blocks/create',
+      expect.objectContaining({
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer test-api-key',
+        },
+        body: JSON.stringify({
+          name: 'Test Title-title',
+          content: 'Test Title',
+          state: 'draft',
+        }),
+      })
+    );
+  });
+
+  it('should convert rich text fields to HTML', async () => {
+    // Mock entry data
+    const mockEntry = {
+      sys: {
+        id: 'entry-id',
+        type: 'Entry',
+        space: { sys: { type: 'Link', linkType: 'Space', id: 'space-id' } },
+        environment: { sys: { type: 'Link', linkType: 'Environment', id: 'environment-id' } },
+        contentType: {
+          sys: {
+            type: 'Link',
+            linkType: 'ContentType',
+            id: 'content-type-id',
+          },
+        },
+        locale: 'en-US',
+        version: 1,
+        createdAt: '2024-01-01T00:00:00Z',
+        updatedAt: '2024-01-01T00:00:00Z',
+        automationTags: [],
+      },
+      fields: {
+        content: {
+          'en-US': {
+            nodeType: 'document',
+            content: [],
+          },
+        },
+      },
+    } as unknown as EntryProps;
+
+    // Mock contentType data
+    const mockContentType = {
+      sys: {
+        type: 'ContentType',
+        id: 'content-type-id',
+        version: 1,
+        createdAt: '2024-01-01T00:00:00Z',
+        updatedAt: '2024-01-01T00:00:00Z',
+        space: { sys: { type: 'Link', linkType: 'Space', id: 'space-id' } },
+        environment: { sys: { type: 'Link', linkType: 'Environment', id: 'environment-id' } },
+      },
+      name: 'Test Content Type',
+      description: 'Test Description',
+      displayField: 'title',
+      fields: [
+        {
+          id: 'content',
+          name: 'Content',
+          type: 'RichText',
+          localized: true,
+          required: true,
+          validations: [],
+          disabled: false,
+          omitted: false,
+        },
+      ],
+    } as ContentTypeProps;
+
+    // Mock API responses
+    vi.mocked(mockCma.entry.get).mockResolvedValue(mockEntry);
+    vi.mocked(mockCma.contentType.get).mockResolvedValue(mockContentType);
+    vi.mocked(documentToHtmlString).mockReturnValue('<p>Test HTML</p>');
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ content_block_id: 'block-id' }),
+    } as Response);
+
+    const event: AppActionRequest<'Custom', { entryId: string; fieldIds: string }> = {
+      type: FunctionTypeEnum.AppActionCall,
+      body: {
+        entryId: 'entry-id',
+        fieldIds: 'content',
+      },
+      headers: {},
+    };
+
+    const result = await handler(event, mockContext);
+
+    expect(result).toEqual({
+      results: [
+        {
+          fieldId: 'content',
+          success: true,
+          contentBlockId: 'block-id',
+        },
+      ],
+    });
+
+    expect(documentToHtmlString).toHaveBeenCalledWith(mockEntry.fields.content['en-US']);
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://test.braze.com/content_blocks/create',
+      expect.objectContaining({
+        body: JSON.stringify({
+          name: 'Untitled-content',
+          content: '<p>Test HTML</p>',
+          state: 'draft',
+        }),
+      })
+    );
+  });
+
+  it('should handle missing fields', async () => {
+    // Mock entry data
+    const mockEntry = {
+      sys: {
+        id: 'entry-id',
+        type: 'Entry',
+        space: { sys: { type: 'Link', linkType: 'Space', id: 'space-id' } },
+        environment: { sys: { type: 'Link', linkType: 'Environment', id: 'environment-id' } },
+        contentType: {
+          sys: {
+            type: 'Link',
+            linkType: 'ContentType',
+            id: 'content-type-id',
+          },
+        },
+        locale: 'en-US',
+        version: 1,
+        createdAt: '2024-01-01T00:00:00Z',
+        updatedAt: '2024-01-01T00:00:00Z',
+        automationTags: [],
+      },
+      fields: {},
+    } as unknown as EntryProps;
+
+    // Mock contentType data
+    const mockContentType = {
+      sys: {
+        type: 'ContentType',
+        id: 'content-type-id',
+        version: 1,
+        createdAt: '2024-01-01T00:00:00Z',
+        updatedAt: '2024-01-01T00:00:00Z',
+        space: { sys: { type: 'Link', linkType: 'Space', id: 'space-id' } },
+        environment: { sys: { type: 'Link', linkType: 'Environment', id: 'environment-id' } },
+      },
+      name: 'Test Content Type',
+      description: 'Test Description',
+      displayField: 'title',
+      fields: [
+        {
+          id: 'title',
+          name: 'Title',
+          type: 'Text',
+          localized: true,
+          required: true,
+          validations: [],
+          disabled: false,
+          omitted: false,
+        },
+      ],
+    } as ContentTypeProps;
+
+    // Mock API responses
+    vi.mocked(mockCma.entry.get).mockResolvedValue(mockEntry);
+    vi.mocked(mockCma.contentType.get).mockResolvedValue(mockContentType);
+
+    const event: AppActionRequest<'Custom', { entryId: string; fieldIds: string }> = {
+      type: FunctionTypeEnum.AppActionCall,
+      body: {
+        entryId: 'entry-id',
+        fieldIds: 'title',
+      },
+      headers: {},
+    };
+
+    const result = await handler(event, mockContext);
+
+    expect(result).toEqual({
+      results: [
+        {
+          fieldId: 'title',
+          success: false,
+          message: 'Field title not found or has no value',
+        },
+      ],
+    });
+
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('should handle API errors', async () => {
+    // Mock entry data
+    const mockEntry = {
+      sys: {
+        id: 'entry-id',
+        type: 'Entry',
+        space: { sys: { type: 'Link', linkType: 'Space', id: 'space-id' } },
+        environment: { sys: { type: 'Link', linkType: 'Environment', id: 'environment-id' } },
+        contentType: {
+          sys: {
+            type: 'Link',
+            linkType: 'ContentType',
+            id: 'content-type-id',
+          },
+        },
+        locale: 'en-US',
+        version: 1,
+        createdAt: '2024-01-01T00:00:00Z',
+        updatedAt: '2024-01-01T00:00:00Z',
+        automationTags: [],
+      },
+      fields: {
+        title: {
+          'en-US': 'Test Title',
+        },
+      },
+    } as unknown as EntryProps;
+
+    // Mock contentType data
+    const mockContentType = {
+      sys: {
+        type: 'ContentType',
+        id: 'content-type-id',
+        version: 1,
+        createdAt: '2024-01-01T00:00:00Z',
+        updatedAt: '2024-01-01T00:00:00Z',
+        space: { sys: { type: 'Link', linkType: 'Space', id: 'space-id' } },
+        environment: { sys: { type: 'Link', linkType: 'Environment', id: 'environment-id' } },
+      },
+      name: 'Test Content Type',
+      description: 'Test Description',
+      displayField: 'title',
+      fields: [
+        {
+          id: 'title',
+          name: 'Title',
+          type: 'Text',
+          localized: true,
+          required: true,
+          validations: [],
+          disabled: false,
+          omitted: false,
+        },
+      ],
+    } as ContentTypeProps;
+
+    // Mock API responses
+    vi.mocked(mockCma.entry.get).mockResolvedValue(mockEntry);
+    vi.mocked(mockCma.contentType.get).mockResolvedValue(mockContentType);
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: false,
+      statusText: 'Unauthorized',
+    } as Response);
+
+    const event: AppActionRequest<'Custom', { entryId: string; fieldIds: string }> = {
+      type: FunctionTypeEnum.AppActionCall,
+      body: {
+        entryId: 'entry-id',
+        fieldIds: 'title',
+      },
+      headers: {},
+    };
+
+    const result = await handler(event, mockContext);
+
+    expect(result).toEqual({
+      results: [
+        {
+          fieldId: 'title',
+          success: false,
+          message: 'Error creating content block: Unauthorized',
+        },
+      ],
+    });
+  });
+});

--- a/apps/braze/test/locations/Dialog.spec.tsx
+++ b/apps/braze/test/locations/Dialog.spec.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { mockCma, mockSdk } from '../mocks';
+import { mockSdk } from '../mocks';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import Dialog from '../../src/locations/Dialog';
 import React from 'react';
@@ -10,6 +10,12 @@ vi.mock('@contentful/react-apps-toolkit', () => ({
   useSDK: () => mockSdk,
   useAutoResizer: () => {},
 }));
+
+const mockCma = {
+  appActionCall: {
+    createWithResponse: vi.fn(),
+  },
+};
 
 vi.mock('contentful-management', () => ({
   createClient: () => mockCma,
@@ -113,6 +119,13 @@ describe('Dialog component', () => {
       contentTypeId: 'contentTypeId',
       title: 'title',
     };
+    mockCma.appActionCall.createWithResponse.mockResolvedValue({
+      response: {
+        body: JSON.stringify({
+          results: [['fieldId', 'contentBlockId']],
+        }),
+      },
+    });
 
     render(<Dialog />);
 

--- a/apps/braze/test/mocks/mocksForFunctions.ts
+++ b/apps/braze/test/mocks/mocksForFunctions.ts
@@ -1,0 +1,79 @@
+import type { EntryProps, ContentTypeProps, PlainClientAPI } from 'contentful-management';
+import type { FunctionEventContext } from '@contentful/node-apps-toolkit';
+import { vi } from 'vitest';
+
+export const mockCma = {
+  entry: { get: vi.fn() },
+  contentType: { get: vi.fn() },
+} as unknown as PlainClientAPI;
+
+export const mockContext: FunctionEventContext = {
+  spaceId: 'space-id',
+  environmentId: 'environment-id',
+  appInstallationParameters: {
+    brazeApiKey: 'test-api-key',
+    brazeEndpoint: 'https://test.braze.com',
+  },
+  cmaClientOptions: {
+    accessToken: 'test-token',
+  },
+};
+
+export function createEntry(fields: Record<string, any>): EntryProps {
+  return {
+    sys: {
+      id: 'entry-id',
+      type: 'Entry',
+      space: { sys: { type: 'Link', linkType: 'Space', id: 'space-id' } },
+      environment: { sys: { type: 'Link', linkType: 'Environment', id: 'environment-id' } },
+      contentType: {
+        sys: { type: 'Link', linkType: 'ContentType', id: 'content-type-id' },
+      },
+      locale: 'en-US',
+      version: 1,
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-01T00:00:00Z',
+      automationTags: [],
+    },
+    fields: Object.fromEntries(
+      Object.entries(fields).map(([key, value]) => [key, { 'en-US': value }])
+    ),
+  } as EntryProps;
+}
+
+export function createContentType(
+  fieldIds: string[],
+  type: 'Text' | 'RichText' = 'Text'
+): ContentTypeProps {
+  return {
+    sys: {
+      type: 'ContentType',
+      id: 'content-type-id',
+      version: 1,
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-01T00:00:00Z',
+      space: { sys: { type: 'Link', linkType: 'Space', id: 'space-id' } },
+      environment: { sys: { type: 'Link', linkType: 'Environment', id: 'environment-id' } },
+    },
+    name: 'Test Content Type',
+    description: 'Test Description',
+    displayField: 'title',
+    fields: fieldIds.map((id) => ({
+      id,
+      name: id.charAt(0).toUpperCase() + id.slice(1),
+      type,
+      localized: true,
+      required: true,
+      validations: [],
+      disabled: false,
+      omitted: false,
+    })),
+  };
+}
+
+export function mockFetchSuccess(responseData: object) {
+  vi.mocked(global.fetch).mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(responseData),
+  } as Response);
+}


### PR DESCRIPTION
## Purpose

Implement content block creation

## Approach

Add implementation to existing function and call it from the frontend using an action.
For each connected field, this saves the id of the field and the newly created content block id in an installation parameters called "brazeConnectedFields".

## Testing steps

Configure the app with all required params and follow the 'create' flow. A content block should be created in Braze. Note that the name of the content block can't be repeated. Content blocks cannot be deleted but the name can be changed

## Breaking Changes

N/A

## Dependencies and/or References

N/A

## Deployment

N/A