### PR TITLE
Mux app: select video quality

### DIFF
--- a/apps/mux/frontend/src/components/UploadArea/UploadArea.module.css
+++ b/apps/mux/frontend/src/components/UploadArea/UploadArea.module.css
@@ -1,0 +1,40 @@
+.dropzone {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 2em;
+  min-height: 250px;
+  border: 2px dashed #aaa;
+  border-radius: 12px;
+  background: #fff;
+}
+
+.title {
+  font-size: 2.2rem;
+  font-weight: 500;
+  margin: 0;
+  text-align: center;
+}
+
+.or {
+  margin: 1.5em 0 1em 0;
+  font-size: 1.3rem;
+  color: #444;
+}
+
+.uploadButton {
+  font-size: 1.2rem;
+  padding: 0.8em 2em;
+  border: 2px solid #222;
+}
+
+.muxUploaderContainer {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 1em;
+  min-height: 250px;
+} 

--- a/apps/mux/frontend/src/components/UploadArea/UploadArea.module.css.d.ts
+++ b/apps/mux/frontend/src/components/UploadArea/UploadArea.module.css.d.ts
@@ -1,0 +1,8 @@
+declare const styles: {
+  dropzone: string;
+  title: string;
+  or: string;
+  uploadButton: string;
+  muxUploaderContainer: string;
+};
+export default styles; 

--- a/apps/mux/frontend/src/components/UploadArea/UploadArea.tsx
+++ b/apps/mux/frontend/src/components/UploadArea/UploadArea.tsx
@@ -1,0 +1,77 @@
+import React, { useRef } from 'react';
+import { Box, Button } from '@contentful/f36-components';
+import MuxUploader from '@mux/mux-uploader-react';
+import styles from './UploadArea.module.css';
+
+interface UploadAreaProps {
+  showMuxUploaderUI: boolean;
+  muxUploaderRef: React.RefObject<any>;
+  onSuccess: () => void;
+  onDrop: (e: React.DragEvent<HTMLDivElement>) => void;
+  onFileChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  fileInputRef?: React.RefObject<HTMLInputElement>;
+}
+
+const UploadArea: React.FC<UploadAreaProps> = ({
+  showMuxUploaderUI,
+  muxUploaderRef,
+  onSuccess,
+  onDrop,
+  onFileChange,
+  fileInputRef,
+}) => {
+  const internalFileInputRef = useRef<HTMLInputElement>(null);
+  const inputRef = fileInputRef || internalFileInputRef;
+
+  const handleButtonClick = () => {
+    inputRef.current?.click();
+  };
+
+  return (
+    <Box marginBottom="spacingM">
+      <div
+        id="uploaderDropzone"
+        className={styles.dropzone}
+        style={{ display: showMuxUploaderUI ? 'none' : 'flex' }}
+        onDrop={onDrop}
+        onDragOver={(e) => e.preventDefault()}
+      >
+        <h2 className={styles.title}>
+          Drop a video file here to upload
+        </h2>
+        <span className={styles.or}>or</span>
+        <Button
+          variant="secondary"
+          size="large"
+          className={styles.uploadButton}
+          onClick={handleButtonClick}
+        >
+          Upload a video
+        </Button>
+        <input
+          ref={inputRef}
+          type="file"
+          style={{ display: 'none' }}
+          onChange={onFileChange}
+        />
+      </div>
+      <MuxUploader
+        id="muxuploader"
+        ref={muxUploaderRef}
+        type="bar"
+        onSuccess={onSuccess}
+        noDrop
+        className={styles.muxUploaderContainer}
+        style={{
+          '--uploader-background-color': 'rgb(247, 249, 250)',
+          '--button-border-radius': '4px',
+          '--button-border': '1px solid rgb(207, 217, 224)',
+          '--button-padding': '0.5rem 1rem',
+          display: showMuxUploaderUI ? 'flex' : 'none',
+        } as React.CSSProperties}
+      />
+    </Box>
+  );
+};
+
+export default UploadArea; 

--- a/apps/mux/frontend/src/components/UploadArea/UploadArea.tsx
+++ b/apps/mux/frontend/src/components/UploadArea/UploadArea.tsx
@@ -34,23 +34,20 @@ const UploadArea: React.FC<UploadAreaProps> = ({
         className={styles.dropzone}
         style={{ display: showMuxUploaderUI ? 'none' : 'flex' }}
         onDrop={onDrop}
-        onDragOver={(e) => e.preventDefault()}
-      >
-        <h2 className={styles.title}>
-          Drop a video file here to upload
-        </h2>
+        onDragOver={(e) => e.preventDefault()}>
+        <h2 className={styles.title}>Drop a video file here to upload</h2>
         <span className={styles.or}>or</span>
         <Button
           variant="secondary"
           size="large"
           className={styles.uploadButton}
-          onClick={handleButtonClick}
-        >
+          onClick={handleButtonClick}>
           Upload a video
         </Button>
         <input
           ref={inputRef}
           type="file"
+          accept="video/*,audio/*"
           style={{ display: 'none' }}
           onChange={onFileChange}
         />
@@ -62,16 +59,18 @@ const UploadArea: React.FC<UploadAreaProps> = ({
         onSuccess={onSuccess}
         noDrop
         className={styles.muxUploaderContainer}
-        style={{
-          '--uploader-background-color': 'rgb(247, 249, 250)',
-          '--button-border-radius': '4px',
-          '--button-border': '1px solid rgb(207, 217, 224)',
-          '--button-padding': '0.5rem 1rem',
-          display: showMuxUploaderUI ? 'flex' : 'none',
-        } as React.CSSProperties}
+        style={
+          {
+            '--uploader-background-color': 'rgb(247, 249, 250)',
+            '--button-border-radius': '4px',
+            '--button-border': '1px solid rgb(207, 217, 224)',
+            '--button-padding': '0.5rem 1rem',
+            display: showMuxUploaderUI ? 'flex' : 'none',
+          } as React.CSSProperties
+        }
       />
     </Box>
   );
 };
 
-export default UploadArea; 
+export default UploadArea;

--- a/apps/mux/frontend/src/components/modalUploadAsset.tsx
+++ b/apps/mux/frontend/src/components/modalUploadAsset.tsx
@@ -1,5 +1,13 @@
 import { FC, useState } from 'react';
-import { Modal, Button, Radio, Stack, FormControl, TextLink } from '@contentful/f36-components';
+import {
+  Modal,
+  Button,
+  Radio,
+  Stack,
+  FormControl,
+  TextLink,
+  Flex,
+} from '@contentful/f36-components';
 import { ExternalLinkIcon } from '@contentful/f36-icons';
 
 export interface ModalData {
@@ -12,76 +20,64 @@ type ModalProps = {
   onConfirm: (options: ModalData) => void;
 };
 
-const options: Record<string,string> = {
-  basic: 'Lower video quality with no encoding cost. Ideal for simple video needs. ',
-  plus: 'High-quality video with smart encoding that adapts to content complexity. ',
-  premium: 'Top-tier quality for high-end content like live sports or movies. ',
+const options: Record<string, string> = {
+  basic: 'Lower video quality with no encoding cost. Ideal for simple video needs.',
+  plus: 'High-quality video with smart encoding that adapts to content complexity.',
+  premium: 'Top-tier quality for high-end content like live sports or movies.',
 };
 
-const ModalUploadAsset: FC<ModalProps> = ({isShown = false, onClose, onConfirm}) => {
+const videoQualityBaseLink = 'https://www.mux.com/docs/guides/use-video-quality-levels';
+
+const ModalUploadAsset: FC<ModalProps> = ({ isShown = false, onClose, onConfirm }) => {
   const [videoQuality, setVideoQuality] = useState('plus');
 
   return (
     <>
-      <Modal
-        isShown={isShown}
-        onClose={onClose}
-      >
-        <Modal.Header 
-          title='Configure Mux Upload'
-          onClose={onClose}
-        />
+      <Modal isShown={isShown} onClose={onClose}>
+        <Modal.Header title="Configure Mux Upload" onClose={onClose} />
         <Modal.Content>
           <FormControl>
             <FormControl.Label>Video Quality</FormControl.Label>
-            <Stack flexDirection="row">
-              {Object.entries(options).map(([id]) => (
-                <Radio
-                  key={id}
-                  id={`radio${id}`}
-                  name="radio-controlled"
-                  value={id}
-                  isChecked={videoQuality === id}
-                  onChange={() => setVideoQuality(id)}
-                >
-                  {String(id[0]).toUpperCase() + String(id).slice(1)}
-                </Radio>
+            <Stack flexDirection="column" spacing="spacingXs">
+              {Object.entries(options).map(([id, description]) => (
+                <Flex key={id} flexDirection="column" fullWidth>
+                  <Flex alignItems="flex-start" fullWidth>
+                    <Radio
+                      id={`radio${id}`}
+                      name="radio-controlled"
+                      value={id}
+                      isChecked={videoQuality === id}
+                      onChange={() => setVideoQuality(id)}>
+                      {String(id[0]).toUpperCase() + String(id).slice(1)}
+                    </Radio>
+                  </Flex>
+                  <FormControl.HelpText>
+                    {description}
+                    <TextLink
+                      icon={<ExternalLinkIcon />}
+                      variant="secondary"
+                      href={`${videoQualityBaseLink}#${id}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    />
+                  </FormControl.HelpText>
+                </Flex>
               ))}
             </Stack>
-            <FormControl.HelpText>
-              {options[videoQuality]}
-              <TextLink
-                icon={<ExternalLinkIcon />}
-                alignIcon="end"
-                href="https://www.mux.com/docs/guides/use-video-quality-levels#introducing-video-quality-levels"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Learn more
-              </TextLink>
-            </FormControl.HelpText>
           </FormControl>
         </Modal.Content>
 
         <Modal.Controls>
-          <Button
-            size="small"
-            variant="transparent"
-            onClick={onClose}
-          >
+          <Button size="small" variant="transparent" onClick={onClose}>
             Cancel
           </Button>
-          <Button
-            size="small"
-            variant="positive"
-            onClick={() => onConfirm({videoQuality})}
-          >
+          <Button size="small" variant="positive" onClick={() => onConfirm({ videoQuality })}>
             Upload
           </Button>
         </Modal.Controls>
       </Modal>
     </>
   );
-}
+};
 
 export default ModalUploadAsset;

--- a/apps/mux/frontend/src/components/modalUploadAsset.tsx
+++ b/apps/mux/frontend/src/components/modalUploadAsset.tsx
@@ -1,5 +1,6 @@
 import { FC, useState } from 'react';
-import { Modal, Button, Radio, Stack, FormControl } from '@contentful/f36-components';
+import { Modal, Button, Radio, Stack, FormControl, TextLink } from '@contentful/f36-components';
+import { ExternalLinkIcon } from '@contentful/f36-icons';
 
 export interface ModalData {
   videoQuality: string;
@@ -56,6 +57,18 @@ const ModalUploadAsset: FC<ModalProps> = ({isShown = false, onClose, onConfirm})
                 Premium
               </Radio>
             </Stack>
+            <FormControl.HelpText>
+              The video quality level informs the quality, cost, and available platform features for the asset.
+              <TextLink
+                icon={<ExternalLinkIcon />}
+                alignIcon="end"
+                href="https://www.mux.com/docs/guides/use-video-quality-levels#introducing-video-quality-levels"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Learn more
+              </TextLink>
+            </FormControl.HelpText>
           </FormControl>
         </Modal.Content>
 

--- a/apps/mux/frontend/src/components/modalUploadAsset.tsx
+++ b/apps/mux/frontend/src/components/modalUploadAsset.tsx
@@ -12,8 +12,14 @@ type ModalProps = {
   onConfirm: (options: ModalData) => void;
 };
 
+const options: Record<string,string> = {
+  basic: 'Lower video quality with no encoding cost. Ideal for simple video needs. ',
+  plus: 'High-quality video with smart encoding that adapts to content complexity. ',
+  premium: 'Top-tier quality for high-end content like live sports or movies. ',
+};
+
 const ModalUploadAsset: FC<ModalProps> = ({isShown = false, onClose, onConfirm}) => {
-  const [videoQuality, setVideoQuality] = useState('basic');
+  const [videoQuality, setVideoQuality] = useState('plus');
 
   return (
     <>
@@ -29,36 +35,21 @@ const ModalUploadAsset: FC<ModalProps> = ({isShown = false, onClose, onConfirm})
           <FormControl>
             <FormControl.Label>Video Quality</FormControl.Label>
             <Stack flexDirection="row">
-              <Radio
-                id="radioBasic"
-                name="radio-controlled"
-                value="basic"
-                isChecked={videoQuality === 'basic'}
-                onChange={() => setVideoQuality('basic')}
-              >
-                Basic
-              </Radio>
-              <Radio
-                id="radioPlus"
-                name="radio-controlled"
-                value="plus"
-                isChecked={videoQuality === 'plus'}
-                onChange={() => setVideoQuality('plus')}
-              >
-                Plus
-              </Radio>
-              <Radio
-                id="radioPremium"
-                name="radio-controlled"
-                value="basic"
-                isChecked={videoQuality === 'premium'}
-                onChange={() => setVideoQuality('premium')}
-              >
-                Premium
-              </Radio>
+              {Object.entries(options).map(([id]) => (
+                <Radio
+                  key={id}
+                  id={`radio${id}`}
+                  name="radio-controlled"
+                  value={id}
+                  isChecked={videoQuality === id}
+                  onChange={() => setVideoQuality(id)}
+                >
+                  {String(id[0]).toUpperCase() + String(id).slice(1)}
+                </Radio>
+              ))}
             </Stack>
             <FormControl.HelpText>
-              The video quality level informs the quality, cost, and available platform features for the asset.
+              {options[videoQuality]}
               <TextLink
                 icon={<ExternalLinkIcon />}
                 alignIcon="end"

--- a/apps/mux/frontend/src/components/modalUploadAsset.tsx
+++ b/apps/mux/frontend/src/components/modalUploadAsset.tsx
@@ -1,0 +1,83 @@
+import { FC, useState } from 'react';
+import { Modal, Button, Radio, Stack, FormControl } from '@contentful/f36-components';
+
+export interface ModalData {
+  videoQuality: string;
+}
+
+type ModalProps = {
+  isShown: boolean;
+  onClose: () => void;
+  onConfirm: (options: ModalData) => void;
+};
+
+const ModalUploadAsset: FC<ModalProps> = ({isShown = false, onClose, onConfirm}) => {
+  const [videoQuality, setVideoQuality] = useState('basic');
+
+  return (
+    <>
+      <Modal
+        isShown={isShown}
+        onClose={onClose}
+      >
+        <Modal.Header 
+          title='Configure Mux Upload'
+          onClose={onClose}
+        />
+        <Modal.Content>
+          <FormControl>
+            <FormControl.Label>Video Quality</FormControl.Label>
+            <Stack flexDirection="row">
+              <Radio
+                id="radioBasic"
+                name="radio-controlled"
+                value="basic"
+                isChecked={videoQuality === 'basic'}
+                onChange={() => setVideoQuality('basic')}
+              >
+                Basic
+              </Radio>
+              <Radio
+                id="radioPlus"
+                name="radio-controlled"
+                value="plus"
+                isChecked={videoQuality === 'plus'}
+                onChange={() => setVideoQuality('plus')}
+              >
+                Plus
+              </Radio>
+              <Radio
+                id="radioPremium"
+                name="radio-controlled"
+                value="basic"
+                isChecked={videoQuality === 'premium'}
+                onChange={() => setVideoQuality('premium')}
+              >
+                Premium
+              </Radio>
+            </Stack>
+          </FormControl>
+        </Modal.Content>
+
+        <Modal.Controls>
+          <Button
+            size="small"
+            variant="transparent"
+            onClick={onClose}
+          >
+            Cancel
+          </Button>
+          <Button
+            size="small"
+            variant="positive"
+            onClick={() => onConfirm({videoQuality})}
+          >
+            Upload
+          </Button>
+        </Modal.Controls>
+      </Modal>
+    </>
+  );
+}
+
+export default ModalUploadAsset;

--- a/apps/mux/frontend/src/index.test.tsx
+++ b/apps/mux/frontend/src/index.test.tsx
@@ -87,11 +87,11 @@ describe('Mux frontend app', () => {
     expect(error.innerText || error.textContent).toContain('No signing key');
   });
 
-  it('Displays Mux Uploader before user does anything.', () => {
+  it('Displays Uploader dropzone before user does anything and Mux Uploader is hidden.', () => {
     const mockedSdk = { ...SDK_MOCK };
-
     const dom = render(<App sdk={mockedSdk as any} />);
-    expect(getById(dom.container, 'muxuploader')).toBeVisible(); // Add prop to Note
+    expect(getById(dom.container, 'muxuploader')).not.toBeVisible(); // Add prop to Note
+    expect(getById(dom.container, 'uploaderDropzone')).toBeVisible();
     expect(getByName(dom.container, 'muxvideoinput')).toBeVisible(); // Add prop to Note
   });
 

--- a/apps/mux/frontend/src/index.tsx
+++ b/apps/mux/frontend/src/index.tsx
@@ -27,7 +27,7 @@ import Menu from './components/menu';
 import PlayerCode from './components/playercode';
 import CountryDatalist from './components/countryDatalist';
 import CaptionsList from './components/captionsList';
-import ModalUploadAsset, { ModalData } from './components/modalUploadAsset';
+import ModalUploadAsset, { ModalData } from './components/ModalUploadAsset';
 import UploadArea from './components/UploadArea/UploadArea';
 
 import {

--- a/apps/mux/frontend/src/index.tsx
+++ b/apps/mux/frontend/src/index.tsx
@@ -18,8 +18,6 @@ import {
 import { Form, FormControl, Checkbox, TextInput } from '@contentful/f36-forms';
 
 import MuxPlayer from '@mux/mux-player-react';
-import MuxUploader from '@mux/mux-uploader-react';
-import { MuxUploaderDrop } from '@mux/mux-uploader-react';
 
 import Config from './locations/config';
 import ApiClient from './util/apiClient';
@@ -30,6 +28,7 @@ import PlayerCode from './components/playercode';
 import CountryDatalist from './components/countryDatalist';
 import CaptionsList from './components/captionsList';
 import ModalUploadAsset, { ModalData } from './components/modalUploadAsset';
+import UploadArea from './components/UploadArea/UploadArea';
 
 import {
   type InstallationParams,
@@ -54,6 +53,7 @@ export class App extends React.Component<AppProps, AppState> {
   cmaClient: PlainClientAPI;
   resolveRef = createRef<(value: string|null) => void>();
   muxUploaderRef = createRef<any>();
+  fileInputRef = React.createRef<HTMLInputElement>();
 
   constructor(props: AppProps) {
     super(props);
@@ -362,6 +362,9 @@ export class App extends React.Component<AppProps, AppState> {
     this.resolveRef.current?.(null)
     this.setState({ file: null }); 
     this.setState({ modalUploadAssetVisible: false }); 
+    if (this.fileInputRef.current) {
+      this.fileInputRef.current.value = '';
+    }
   }
 
   getUploadUrl = async (options: ModalData) => {
@@ -398,13 +401,6 @@ export class App extends React.Component<AppProps, AppState> {
 
     return muxUpload.url;
   }
-
-  // openModal = async () => {
-  //   return new Promise<string>((resolve, reject) => {
-  //     (this.resolveRef.current as unknown as (value: string) => void) = resolve;
-  //     this.setState({ modalUploadAssetVisible: true });
-  //   });
-  // };
 
   onUploadError = (progress: CustomEvent) => {
     this.setState({ error: progress.detail });
@@ -1156,48 +1152,14 @@ export class App extends React.Component<AppProps, AppState> {
     return (
       <section>
         <ModalUploadAsset isShown={this.state.modalUploadAssetVisible} onClose={this.onCloseModal} onConfirm={this.onConfirmModal}/>
-        <Box marginBottom="spacingM">
-          <div className="uploader_area">
-            <div
-              style={
-                {
-                  width: '100%',
-                  display: this.state.showMuxUploaderUI ? 'none' : 'flex',
-                  justifyContent: 'center',
-                  alignItems: 'center',
-                  padding: '1em',
-                  minHeight: '250px',
-                } as React.CSSProperties
-              }
-              onDrop={this.handleDrop}
-              onDragOver={(e) => e.preventDefault()}
-            >
-              <input type="file" onChange={this.handleFile} />
-              <p>Drop a video file or select one here</p>
-            </div>
-            <MuxUploader
-              id="muxuploader"
-              ref={this.muxUploaderRef}
-              type="bar"
-              onSuccess={this.onUploadSuccess}
-              noDrop
-
-              style={
-                {
-                  '--uploader-background-color': 'rgb(247, 249, 250)',
-                  '--button-border-radius': '4px',
-                  '--button-border': '1px solid rgb(207, 217, 224)',
-                  '--button-padding': '0.5rem 1rem',
-                  width: '100%',
-                  display: this.state.showMuxUploaderUI ? 'flex' : 'none',
-                  justifyContent: 'center',
-                  alignItems: 'center',
-                  padding: '1em',
-                  minHeight: '250px',
-                } as React.CSSProperties
-              }></MuxUploader>
-          </div>
-        </Box>
+        <UploadArea
+          showMuxUploaderUI={this.state.showMuxUploaderUI}
+          muxUploaderRef={this.muxUploaderRef}
+          onSuccess={this.onUploadSuccess}
+          onDrop={this.handleDrop}
+          onFileChange={this.handleFile}
+          fileInputRef={this.fileInputRef}
+        />
 
         <Form onSubmit={this.addVideoByInput}>
           <FormControl>

--- a/apps/mux/frontend/src/util/types.tsx
+++ b/apps/mux/frontend/src/util/types.tsx
@@ -31,6 +31,7 @@ export interface AppState {
   modalUploadAssetVisible: boolean;
   file: File | null;
   showMuxUploaderUI: boolean;
+  pendingUploadURL: string | null;
 }
 
 export interface MuxContentfulObject {

--- a/apps/mux/frontend/src/util/types.tsx
+++ b/apps/mux/frontend/src/util/types.tsx
@@ -28,6 +28,9 @@ export interface AppState {
   playerPlaybackId?: string;
   // eslint-disable-next-line  @typescript-eslint/no-explicit-any
   raw?: any;
+  modalUploadAssetVisible: boolean;
+  file: File | null;
+  showMuxUploaderUI: boolean;
 }
 
 export interface MuxContentfulObject {


### PR DESCRIPTION
## Purpose

We are currently working on integrating the latest features provided by Mux into the plugin. This PR adds support for selecting the video quality level of an asset, which was not previously possible.
More information can be found [here](https://www.mux.com/docs/guides/use-video-quality-levels#introducing-video-quality-levels).

## Approach

Currently, the asset is uploaded as soon as it is loaded into the container. Adding options outside of this flow felt unintuitive, so we opted to introduce a modal that allows users to select options when uploading an asset to Mux.
We implemented a pre-upload modal to let users choose the video quality level. This approach also sets the groundwork for supporting additional options in the future, such as MP4 renditions or captions.

A new drag-and-drop component had to be created because Mux provides its own implementation, which doesn't allow modifying the upload behavior to show the modal beforehand. The design closely follows Mux's original style.

### Screenshots

![image](https://github.com/user-attachments/assets/5a375390-93fd-4db2-9771-13b3017e0f76)
![image](https://github.com/user-attachments/assets/a20e9c04-f0a9-4b6a-ab64-ed3badf8a268)
![image](https://github.com/user-attachments/assets/052e1996-5e93-4e87-a830-d9c9d1c9e14c)

## Testing steps

Create a content model with the Mux JSON Object. Then, create a new entry for that content type, and you’ll be able to test uploading assets while selecting the desired video quality.

Another case to test is by providing a URL of an existing video, for example [this one](http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4). In this case, the modal should appear to allow the user to select the desired quality.

If an Asset ID is provided instead, the modal **should not** appear, as this flow is intended for associating an existing Mux video.

## Breaking Changes

None.

## Dependencies and/or References

More information can be found [here](https://www.mux.com/docs/guides/use-video-quality-levels#introducing-video-quality-levels).

## Deployment

None.
