### PR TITLE
 Braze config screen fix: [INTEG-2643]

### DIFF
--- a/apps/braze/src/locations/ConfigScreen.tsx
+++ b/apps/braze/src/locations/ConfigScreen.tsx
@@ -28,11 +28,11 @@ export const BRAZE_APP_DOCUMENTATION = 'https://www.contentful.com/help/apps/bra
 export const CONTENT_TYPE_DOCUMENTATION =
   'https://www.contentful.com/help/content-types/configure-content-type/';
 
-export async function callToContentful(url: string, newApiKey: string) {
+export async function callToContentful(sdk: ConfigAppSDK, apiKey: string) {
+  const url = `https://${sdk.hostnames.delivery}/spaces/${sdk.ids.space}/environments/${sdk.ids.environment}/entries?access_token=${apiKey}`;
   return await fetch(url, {
     method: 'GET',
     headers: {
-      Authorization: `Bearer ${newApiKey}`,
       'Content-Type': 'application/json',
     },
   });
@@ -52,8 +52,7 @@ const ConfigScreen = () => {
       return false;
     }
 
-    const url = `https://${sdk.hostnames.delivery}/spaces/${sdk.ids.space}`;
-    const response: Response = await callToContentful(url, apiKey);
+    const response: Response = await callToContentful(sdk, apiKey);
 
     const isValid = response.ok;
     setApiKeyIsValid(isValid);


### PR DESCRIPTION
## Purpose

Fix a bug where a user attemps to install the braze app in an environment different to master.

## Approach

When we install the app, we make a request to contentful to check that the API key is valid, the previous call wasn't using the environment in which the app is being installed. Now it does to make sure that the API key has permissions on that environment.

## Testing steps

Install/Configure the app in an environment that isn't master with an API key that has permissions on the environment.

https://github.com/user-attachments/assets/869e7c14-7357-40f8-8f6d-7a7f0f1deb66