### PR TITLE
Braze app: Error modal for 4XX errors [INTEG-2544]

### DIFF
--- a/apps/braze/functions/createContentBlocks.ts
+++ b/apps/braze/functions/createContentBlocks.ts
@@ -105,17 +105,17 @@ export const handler: FunctionEventHandler<
         }),
       });
 
+      const data = await response.json();
+
       if (!response.ok) {
         results.push({
           fieldId,
           success: false,
           statusCode: response.status,
-          message: `Error creating content block for field ${fieldId}: ${response.statusText}`,
+          message: `Error creating content block for field ${fieldId}: ${data.message}`,
         });
         continue;
       }
-
-      const data = await response.json();
 
       results.push({
         fieldId,

--- a/apps/braze/functions/createContentBlocks.ts
+++ b/apps/braze/functions/createContentBlocks.ts
@@ -110,7 +110,7 @@ export const handler: FunctionEventHandler<
           fieldId,
           success: false,
           statusCode: response.status,
-          message: `Error creating content block: ${response.statusText}`,
+          message: `Error creating content block for field ${fieldId}: ${response.statusText}`,
         });
         continue;
       }

--- a/apps/braze/functions/createContentBlocks.ts
+++ b/apps/braze/functions/createContentBlocks.ts
@@ -68,6 +68,7 @@ export const handler: FunctionEventHandler<
       results.push({
         fieldId,
         success: false,
+        statusCode: 404,
         message: `Field ${fieldId} not found or has no value`,
       });
       continue;
@@ -107,6 +108,7 @@ export const handler: FunctionEventHandler<
         results.push({
           fieldId,
           success: false,
+          statusCode: response.status,
           message: `Error creating content block: ${response.statusText}`,
         });
         continue;
@@ -117,12 +119,14 @@ export const handler: FunctionEventHandler<
       results.push({
         fieldId,
         success: true,
+        statusCode: 201,
         contentBlockId: data.content_block_id,
       });
     } catch (error) {
       results.push({
         fieldId,
         success: false,
+        statusCode: 500,
         message: error instanceof Error ? error.message : 'Unknown error',
       });
     }

--- a/apps/braze/functions/createContentBlocks.ts
+++ b/apps/braze/functions/createContentBlocks.ts
@@ -78,6 +78,7 @@ export const handler: FunctionEventHandler<
       results.push({
         fieldId,
         success: false,
+        statusCode: 404,
         message: `Content block name not found or has no value for field ${fieldId}`,
       });
       continue;

--- a/apps/braze/src/components/create/ClientErrorStep.styles.ts
+++ b/apps/braze/src/components/create/ClientErrorStep.styles.ts
@@ -1,0 +1,8 @@
+import { css } from 'emotion';
+
+export const styles = {
+  stack: css({
+    maxHeight: '160px',
+    overflowY: 'auto',
+  }),
+};

--- a/apps/braze/src/components/create/ClientErrorStep.tsx
+++ b/apps/braze/src/components/create/ClientErrorStep.tsx
@@ -24,7 +24,7 @@ const ClientErrorStep = ({ fieldsWithErrors, handleClose }: ClientErrorStepProps
         {fieldsWithErrors
           .filter((field) => field.statusCode !== 500)
           .map((field) => (
-            <Text key={`${field.id}-index`}>
+            <Text key={`${field.fieldId}-index`}>
               Error code [{field.statusCode}] - [{field.message}]
             </Text>
           ))}

--- a/apps/braze/src/components/create/ClientErrorStep.tsx
+++ b/apps/braze/src/components/create/ClientErrorStep.tsx
@@ -1,0 +1,41 @@
+import { Stack, Button, Subheading, Text } from '@contentful/f36-components';
+import WizardFooter from '../WizardFooter';
+import { styles } from './ClientErrorStep.styles';
+
+type FieldError = {
+  fieldId: string;
+  success: boolean;
+  statusCode: number;
+  message: string;
+};
+
+type ClientErrorStepProps = {
+  fieldsWithErrors: FieldError[];
+  handleClose: () => void;
+};
+
+const ClientErrorStep = ({ fieldsWithErrors, handleClose }: ClientErrorStepProps) => {
+  return (
+    <>
+      <Subheading fontWeight="fontWeightDemiBold" fontSize="fontSizeXl" lineHeight="lineHeightL">
+        There was an issue
+      </Subheading>
+      <Stack flexDirection="column" alignItems="flex-start" className={styles.stack}>
+        {fieldsWithErrors
+          .filter((field) => field.statusCode !== 500)
+          .map((field) => (
+            <Text key={`${field.id}-index`}>
+              Error code [{field.statusCode}] - [{field.message}]
+            </Text>
+          ))}
+      </Stack>
+      <WizardFooter>
+        <Button variant="primary" size="small" onClick={handleClose}>
+          Done
+        </Button>
+      </WizardFooter>
+    </>
+  );
+};
+
+export default ClientErrorStep;

--- a/apps/braze/src/components/create/CreateFlow.tsx
+++ b/apps/braze/src/components/create/CreateFlow.tsx
@@ -9,9 +9,11 @@ import SuccessStep from './SuccessStep';
 import { EntryStatus, FIELDS_STEP } from '../../utils';
 import { createClient } from 'contentful-management';
 import DraftStep from './DraftStep';
+import ClientErrorStep from './ClientErrorStep';
 
 const CREATE_STEP = 'create';
 const DRAFT_STEP = 'draft';
+const CLIENT_ERROR_STEP = 'client-error';
 const SUCCESS_STEP = 'success';
 
 type CreateFlowProps = {
@@ -21,10 +23,18 @@ type CreateFlowProps = {
   initialSelectedFields?: string[];
 };
 
+type FieldError = {
+  fieldId: string;
+  success: boolean;
+  statusCode: number;
+  message: string;
+};
+
 const CreateFlow = (props: CreateFlowProps) => {
   const { sdk, entry, initialSelectedFields = [] } = props;
   const [step, setStep] = useState(FIELDS_STEP);
   const [selectedFields, setSelectedFields] = useState<Set<string>>(new Set(initialSelectedFields));
+  const [fieldsWithErrors, setFieldsWithErrors] = useState<FieldError[]>([]);
   const [contentBlockNames, setContentBlockNames] = useState<Record<string, string>>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -67,6 +77,7 @@ const CreateFlow = (props: CreateFlowProps) => {
         }
       );
       const data = JSON.parse(response.response.body);
+
       // TODO: define type returned by the action
       const newFields = data.results
         .filter((result: any) => result.success)
@@ -74,6 +85,14 @@ const CreateFlow = (props: CreateFlowProps) => {
 
       connectedFields[entry.id] = [...entryConnectedFields, ...newFields];
       sdk.parameters.installation.brazeConnectedFields = JSON.stringify(connectedFields);
+
+      const errors = newFields.filter((result: any) => !result.success);
+      const clientErrors = errors.filter((result: any) => result.statusCode !== 500);
+      if (errors.length > 0 && clientErrors.length > 0) {
+        setFieldsWithErrors(errors);
+        setStep(CLIENT_ERROR_STEP);
+        return;
+      }
 
       setIsSubmitting(false);
       setStep(SUCCESS_STEP);
@@ -114,6 +133,12 @@ const CreateFlow = (props: CreateFlowProps) => {
           handlePreviousStep={() => setStep(CREATE_STEP)}
           contentBlockNames={contentBlockNames}
           handleNextStep={handleCreate}
+        />
+      )}
+      {step === CLIENT_ERROR_STEP && (
+        <ClientErrorStep
+          fieldsWithErrors={fieldsWithErrors}
+          handleClose={() => sdk.close({ step: 'close' })}
         />
       )}
       {step === SUCCESS_STEP && (

--- a/apps/braze/src/components/create/CreateFlow.tsx
+++ b/apps/braze/src/components/create/CreateFlow.tsx
@@ -86,7 +86,7 @@ const CreateFlow = (props: CreateFlowProps) => {
       connectedFields[entry.id] = [...entryConnectedFields, ...newFields];
       sdk.parameters.installation.brazeConnectedFields = JSON.stringify(connectedFields);
 
-      const errors = newFields.filter((result: any) => !result.success);
+      const errors = data.results.filter((result: any) => !result.success);
       const clientErrors = errors.filter((result: any) => result.statusCode !== 500);
       if (errors.length > 0 && clientErrors.length > 0) {
         setFieldsWithErrors(errors);

--- a/apps/braze/src/components/create/DraftStep.tsx
+++ b/apps/braze/src/components/create/DraftStep.tsx
@@ -1,7 +1,7 @@
 import { Paragraph, Button, Subheading } from '@contentful/f36-components';
 import WizardFooter from '../WizardFooter';
 
-type CreateStepProps = {
+type DraftStepProps = {
   isSubmitting: boolean;
   contentBlockNames: Record<string, string>;
   handlePreviousStep: () => void;
@@ -13,7 +13,7 @@ const DraftStep = ({
   contentBlockNames,
   handlePreviousStep,
   handleNextStep,
-}: CreateStepProps) => {
+}: DraftStepProps) => {
   return (
     <>
       <Subheading fontWeight="fontWeightDemiBold" fontSize="fontSizeXl" lineHeight="lineHeightL">

--- a/apps/braze/test/fields/FieldsFactory.spec.ts
+++ b/apps/braze/test/fields/FieldsFactory.spec.ts
@@ -311,7 +311,7 @@ describe('FieldsFactory', () => {
     expect(fieldInstance.items[1].fields[0].id).toBe('name');
   });
 
-  it('should limit the recursion depth for nested references based on NESTED_DEPTH constant', async () => {
+  it('qences based on NESTED_DEPTH constant', async () => {
     const max_depth = 5;
 
     // Create mock entries with deep nesting structure

--- a/apps/braze/test/fields/FieldsFactory.spec.ts
+++ b/apps/braze/test/fields/FieldsFactory.spec.ts
@@ -311,7 +311,7 @@ describe('FieldsFactory', () => {
     expect(fieldInstance.items[1].fields[0].id).toBe('name');
   });
 
-  it('qences based on NESTED_DEPTH constant', async () => {
+  it('should limit the recursion depth for nested references based on NESTED_DEPTH constant', async () => {
     const max_depth = 5;
 
     // Create mock entries with deep nesting structure

--- a/apps/braze/test/functions/createContentBlocks.test.ts
+++ b/apps/braze/test/functions/createContentBlocks.test.ts
@@ -6,7 +6,7 @@ import {
   FunctionTypeEnum,
 } from '@contentful/node-apps-toolkit';
 
-import type { PlainClientAPI, EntryProps, ContentTypeProps } from 'contentful-management';
+import type { PlainClientAPI } from 'contentful-management';
 import { documentToHtmlString } from '@contentful/rich-text-html-renderer';
 import { createContentType, createEntry, mockFetchSuccess } from '../mocks/mocksForFunctions';
 
@@ -77,6 +77,7 @@ describe('createContentBlocks', () => {
         {
           fieldId: 'title',
           success: true,
+          statusCode: 201,
           contentBlockId: 'block-id',
         },
       ],
@@ -127,6 +128,7 @@ describe('createContentBlocks', () => {
         {
           fieldId: 'content',
           success: true,
+          statusCode: 201,
           contentBlockId: 'block-id',
         },
       ],
@@ -171,6 +173,7 @@ describe('createContentBlocks', () => {
         {
           fieldId: 'title',
           success: false,
+          statusCode: 404,
           message: 'Field title not found or has no value',
         },
       ],
@@ -189,8 +192,9 @@ describe('createContentBlocks', () => {
     vi.mocked(mockCma.contentType.get).mockResolvedValue(contentType);
     vi.mocked(global.fetch).mockResolvedValue({
       ok: false,
+      status: 400,
       statusText: 'Unauthorized',
-    } as Response);
+    } as Partial<Response> as Response);
 
     const event: AppActionRequest<'Custom', AppActionParameters> = {
       type: FunctionTypeEnum.AppActionCall,
@@ -209,7 +213,8 @@ describe('createContentBlocks', () => {
         {
           fieldId: 'title',
           success: false,
-          message: 'Error creating content block: Unauthorized',
+          statusCode: 400,
+          message: 'Error creating content block for field title: Unauthorized',
         },
       ],
     });
@@ -253,11 +258,13 @@ describe('createContentBlocks', () => {
         {
           fieldId: 'title',
           success: true,
+          statusCode: 201,
           contentBlockId: 'block-id-1',
         },
         {
           fieldId: 'description',
           success: true,
+          statusCode: 201,
           contentBlockId: 'block-id-2',
         },
       ],
@@ -344,11 +351,13 @@ describe('createContentBlocks', () => {
         {
           fieldId: 'title',
           success: true,
+          statusCode: 201,
           contentBlockId: 'block-id',
         },
         {
           fieldId: 'description',
           success: false,
+          statusCode: 404,
           message: 'Content block name not found or has no value for field description',
         },
       ],

--- a/apps/braze/test/functions/createContentBlocks.test.ts
+++ b/apps/braze/test/functions/createContentBlocks.test.ts
@@ -192,8 +192,11 @@ describe('createContentBlocks', () => {
     vi.mocked(mockCma.contentType.get).mockResolvedValue(contentType);
     vi.mocked(global.fetch).mockResolvedValue({
       ok: false,
-      status: 400,
-      statusText: 'Unauthorized',
+      status: 500,
+      json: () =>
+        Promise.resolve({
+          message: 'Unauthorized',
+        }),
     } as Partial<Response> as Response);
 
     const event: AppActionRequest<'Custom', AppActionParameters> = {
@@ -213,7 +216,7 @@ describe('createContentBlocks', () => {
         {
           fieldId: 'title',
           success: false,
-          statusCode: 400,
+          statusCode: 500,
           message: 'Error creating content block for field title: Unauthorized',
         },
       ],

--- a/apps/braze/test/functions/createContentBlocks.test.ts
+++ b/apps/braze/test/functions/createContentBlocks.test.ts
@@ -192,7 +192,7 @@ describe('createContentBlocks', () => {
     vi.mocked(mockCma.contentType.get).mockResolvedValue(contentType);
     vi.mocked(global.fetch).mockResolvedValue({
       ok: false,
-      status: 500,
+      status: 401,
       json: () =>
         Promise.resolve({
           message: 'Unauthorized',
@@ -216,7 +216,7 @@ describe('createContentBlocks', () => {
         {
           fieldId: 'title',
           success: false,
-          statusCode: 500,
+          statusCode: 401,
           message: 'Error creating content block for field title: Unauthorized',
         },
       ],


### PR DESCRIPTION
## Purpose

This update was needed to display the user the 4xx class errors in the creation of the content blocks.

## Approach

The following changes were introduced:
- We added status codes in the app function to identify the types of the errors.
- We added a new modal step that is showed when the creation of the content blocks fails due to a 4xx class error.
- Testing to validate this changes.

Here is an example of the result when the creation fails and when it is successfull:

https://github.com/user-attachments/assets/bbeb186c-96da-42c2-b697-b16ff346b3df


## Testing steps

- `createContentBlocks.ts` function tests were updated and one more automated test was added into `Dialog.spec.tsx`

## Breaking Changes

N/A

## Dependencies and/or References

Link to [INTEG-2544](https://contentful.atlassian.net/jira/software/c/projects/INTEG/boards/454?selectedIssue=INTEG-2544) ticket.

## Deployment

N/A

[INTEG-2544]: https://contentful.atlassian.net/browse/INTEG-2544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ