### PR TITLE
Braze app: Edit card component [INTEG-2539]

### DIFF
--- a/apps/braze/contentful-app-manifest.json
+++ b/apps/braze/contentful-app-manifest.json
@@ -44,6 +44,12 @@
           "name": "Content Block Names",
           "type": "Symbol",
           "required": true
+        },
+        {
+          "id": "contentBlockDescriptions",
+          "name": "Content Block Descriptions",
+          "type": "Symbol",
+          "required": true
         }
       ]
     }

--- a/apps/braze/functions/createContentBlocks.ts
+++ b/apps/braze/functions/createContentBlocks.ts
@@ -12,10 +12,16 @@ type AppInstallationParameters = {
   brazeEndpoint: string;
 };
 
+type ContentBlockData = {
+  name: string;
+  description: string;
+};
+
 export type AppActionParameters = {
   entryId: string;
   fieldIds: string;
   contentBlockNames: string;
+  contentBlockDescriptions: string;
 };
 
 function initContentfulManagementClient(context: FunctionEventContext): PlainClientAPI {
@@ -42,8 +48,12 @@ export const handler: FunctionEventHandler<
 ) => {
   const cma = initContentfulManagementClient(context);
 
-  const { entryId, fieldIds, contentBlockNames } = event.body;
+  const { entryId, fieldIds, contentBlockNames, contentBlockDescriptions } = event.body;
   const parsedContentBlockNames = JSON.parse(contentBlockNames) as Record<string, string>;
+  const parsedContentBlockDescriptions = JSON.parse(contentBlockDescriptions) as Record<
+    string,
+    string
+  >;
   const entry = await cma.entry.get({ entryId });
   const contentType = await cma.contentType.get({
     contentTypeId: entry.sys.contentType.sys.id,
@@ -102,6 +112,7 @@ export const handler: FunctionEventHandler<
           name: parsedContentBlockNames[fieldId],
           content: content,
           state: 'draft',
+          description: parsedContentBlockDescriptions[fieldId] || '',
         }),
       });
 

--- a/apps/braze/package-lock.json
+++ b/apps/braze/package-lock.json
@@ -14,6 +14,7 @@
         "@contentful/f36-tokens": "4.0.2",
         "@contentful/react-apps-toolkit": "1.2.16",
         "@contentful/rich-text-html-renderer": "^17.0.0",
+        "@phosphor-icons/react": "^2.1.7",
         "@testing-library/user-event": "^14.6.1",
         "contentful-management": "11.48.3",
         "contentful-resolve-response": "^1.9.2",
@@ -312,9 +313,9 @@
       }
     },
     "node_modules/@contentful/app-scripts": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@contentful/app-scripts/-/app-scripts-2.3.1.tgz",
-      "integrity": "sha512-/IGTLSBbbGuLccGDKsrhksQz8/qer8RrM6vYgXvl6Sin/pNw+9mjPPhju2NI3Tkc3zTjAVdrqjzOdh3JIMPIwQ==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@contentful/app-scripts/-/app-scripts-2.5.1.tgz",
+      "integrity": "sha512-9AOvEAMmGGXIL0n7VU9xJVTUXDTmKqgumSHTHPPTuxG7IFu+THP838/hXuVlMhFOmqsDJU109k1I0xCI+jF2kw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -344,6 +345,19 @@
       "engines": {
         "node": ">=18",
         "npm": ">=9"
+      }
+    },
+    "node_modules/@contentful/app-scripts/node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/@contentful/app-sdk": {
@@ -1939,6 +1953,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@phosphor-icons/react": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.1.7.tgz",
+      "integrity": "sha512-g2e2eVAn1XG2a+LI09QU3IORLhnFNAFkNbo2iwbX6NOKSLOwvEMmTa7CgOzEbgNWR47z8i8kwjdvYZ5fkGx1mQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8",
+        "react-dom": ">= 16.8"
       }
     },
     "node_modules/@popperjs/core": {
@@ -3742,19 +3769,6 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "peer": true
-    },
-    "node_modules/dotenv": {
-      "version": "16.4.7",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
-      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
     },
     "node_modules/downshift": {
       "version": "6.1.12",

--- a/apps/braze/package.json
+++ b/apps/braze/package.json
@@ -9,6 +9,7 @@
     "@contentful/f36-tokens": "4.0.2",
     "@contentful/react-apps-toolkit": "1.2.16",
     "@contentful/rich-text-html-renderer": "^17.0.0",
+    "@phosphor-icons/react": "^2.1.7",
     "@testing-library/user-event": "^14.6.1",
     "contentful-management": "11.48.3",
     "contentful-resolve-response": "^1.9.2",
@@ -23,10 +24,10 @@
     "build": "tsc && vite build --outDir build && npm run build:functions",
     "test": "vitest",
     "create-app-definition": "contentful-app-scripts create-app-definition",
-    "deploy": "contentful-app-scripts upload --ci --bundle-dir ./dist --organization-id ${DEFINITIONS_ORG_ID} --definition-id gWLhC7MnK2rgcvifgE4do --token ${CONTENTFUL_CMA_TOKEN}",
+    "deploy": "source .env && contentful-app-scripts upload --ci --bundle-dir ./dist --organization-id \"$DEFINITIONS_ORG_ID\" --definition-id gWLhC7MnK2rgcvifgE4do --token \"$CONTENTFUL_CMA_TOKEN\"",
     "upload": "contentful-app-scripts upload --bundle-dir ./build",
-    "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN",
-    "upsert-actions": "contentful-app-scripts upsert-actions --ci --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN",
+    "upload-ci": "source .env && contentful-app-scripts upload --ci --bundle-dir ./build --organization-id \"$CONTENTFUL_ORG_ID\" --definition-id \"$CONTENTFUL_APP_DEF_ID\" --token \"$CONTENTFUL_ACCESS_TOKEN\"",
+    "upsert-actions": "source .env && contentful-app-scripts upsert-actions --ci --organization-id \"$CONTENTFUL_ORG_ID\" --definition-id \"$CONTENTFUL_APP_DEF_ID\" --token \"$CONTENTFUL_ACCESS_TOKEN\"",
     "build:functions": "contentful-app-scripts build-functions --ci"
   },
   "devDependencies": {

--- a/apps/braze/package.json
+++ b/apps/braze/package.json
@@ -24,11 +24,14 @@
     "build": "tsc && vite build --outDir build && npm run build:functions",
     "test": "vitest",
     "create-app-definition": "contentful-app-scripts create-app-definition",
-    "deploy": "source .env && contentful-app-scripts upload --ci --bundle-dir ./dist --organization-id \"$DEFINITIONS_ORG_ID\" --definition-id gWLhC7MnK2rgcvifgE4do --token \"$CONTENTFUL_CMA_TOKEN\"",
+    "deploy": "contentful-app-scripts upload --ci --bundle-dir ./dist --organization-id ${DEFINITIONS_ORG_ID} --definition-id gWLhC7MnK2rgcvifgE4do --token ${CONTENTFUL_CMA_TOKEN}",
     "upload": "contentful-app-scripts upload --bundle-dir ./build",
-    "upload-ci": "source .env && contentful-app-scripts upload --ci --bundle-dir ./build --organization-id \"$CONTENTFUL_ORG_ID\" --definition-id \"$CONTENTFUL_APP_DEF_ID\" --token \"$CONTENTFUL_ACCESS_TOKEN\"",
-    "upsert-actions": "source .env && contentful-app-scripts upsert-actions --ci --organization-id \"$CONTENTFUL_ORG_ID\" --definition-id \"$CONTENTFUL_APP_DEF_ID\" --token \"$CONTENTFUL_ACCESS_TOKEN\"",
-    "build:functions": "contentful-app-scripts build-functions --ci"
+    "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN",
+    "upsert-actions": "contentful-app-scripts upsert-actions --ci --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN",
+    "build:functions": "contentful-app-scripts build-functions --ci",
+    "deploy:dev": "source .env && contentful-app-scripts upload --ci --bundle-dir ./dist --organization-id \"$DEFINITIONS_ORG_ID\" --definition-id gWLhC7MnK2rgcvifgE4do --token \"$CONTENTFUL_CMA_TOKEN\"",
+    "upload-ci:dev": "source .env && contentful-app-scripts upload --ci --bundle-dir ./build --organization-id \"$CONTENTFUL_ORG_ID\" --definition-id \"$CONTENTFUL_APP_DEF_ID\" --token \"$CONTENTFUL_ACCESS_TOKEN\"",
+    "upsert-actions:dev": "source .env && contentful-app-scripts upsert-actions --ci --organization-id \"$CONTENTFUL_ORG_ID\" --definition-id \"$CONTENTFUL_APP_DEF_ID\" --token \"$CONTENTFUL_ACCESS_TOKEN\""
   },
   "devDependencies": {
     "@contentful/app-scripts": "^2.3.0",

--- a/apps/braze/src/components/create/CreateFlow.tsx
+++ b/apps/braze/src/components/create/CreateFlow.tsx
@@ -67,6 +67,15 @@ const CreateFlow = (props: CreateFlowProps) => {
     const connectedFields = JSON.parse(sdk.parameters.installation.brazeConnectedFields || '{}');
     const entryConnectedFields = connectedFields[entry.id] || [];
 
+    // Create a map of field IDs to their respective names and descriptions
+    const names: Record<string, string> = {};
+    const descriptions: Record<string, string> = {};
+
+    Object.entries(data).forEach(([fieldId, state]) => {
+      names[fieldId] = state.name;
+      descriptions[fieldId] = state.description;
+    });
+
     try {
       const response = await cma.appActionCall.createWithResponse(
         {
@@ -79,8 +88,8 @@ const CreateFlow = (props: CreateFlowProps) => {
           parameters: {
             entryId: entry.id,
             fieldIds: Array.from(selectedFields).join(','),
-            contentBlockNames: JSON.stringify(data.names),
-            contentBlockDescriptions: JSON.stringify(data.descriptions),
+            contentBlockNames: JSON.stringify(names),
+            contentBlockDescriptions: JSON.stringify(descriptions),
           },
         }
       );

--- a/apps/braze/src/components/create/CreateFlow.tsx
+++ b/apps/braze/src/components/create/CreateFlow.tsx
@@ -94,7 +94,7 @@ const CreateFlow = (props: CreateFlowProps) => {
       connectedFields[entry.id] = [...entryConnectedFields, ...newFields];
       sdk.parameters.installation.brazeConnectedFields = JSON.stringify(connectedFields);
 
-      const errors = data.results.filter((result: any) => !result.success);
+      const errors = responseData.results.filter((result: any) => !result.success);
       const clientErrors = errors.filter((result: any) => result.statusCode !== 500);
       if (errors.length > 0 && clientErrors.length > 0) {
         setFieldsWithErrors(errors);

--- a/apps/braze/src/components/create/CreateFlow.tsx
+++ b/apps/braze/src/components/create/CreateFlow.tsx
@@ -23,6 +23,11 @@ type CreateFlowProps = {
   initialSelectedFields?: string[];
 };
 
+export type ContentBlockState = {
+  name: string;
+  description: string;
+};
+
 type FieldError = {
   fieldId: string;
   success: boolean;
@@ -35,7 +40,9 @@ const CreateFlow = (props: CreateFlowProps) => {
   const [step, setStep] = useState(FIELDS_STEP);
   const [selectedFields, setSelectedFields] = useState<Set<string>>(new Set(initialSelectedFields));
   const [fieldsWithErrors, setFieldsWithErrors] = useState<FieldError[]>([]);
-  const [contentBlockNames, setContentBlockNames] = useState<Record<string, string>>({});
+  const [contentBlockStates, setContentBlockStates] = useState<Record<string, ContentBlockState>>(
+    {}
+  );
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const cma = createClient(
@@ -49,7 +56,7 @@ const CreateFlow = (props: CreateFlowProps) => {
     }
   );
 
-  const handleCreate = async (contentBlockNames: Record<string, string>) => {
+  const handleCreate = async (data: Record<string, ContentBlockState>) => {
     if (entry.state !== EntryStatus.Published && step === CREATE_STEP) {
       setStep(DRAFT_STEP);
       return;
@@ -72,14 +79,14 @@ const CreateFlow = (props: CreateFlowProps) => {
           parameters: {
             entryId: entry.id,
             fieldIds: Array.from(selectedFields).join(','),
-            contentBlockNames: JSON.stringify(contentBlockNames),
+            contentBlockNames: JSON.stringify(data.names),
+            contentBlockDescriptions: JSON.stringify(data.descriptions),
           },
         }
       );
-      const data = JSON.parse(response.response.body);
+      const responseData = JSON.parse(response.response.body);
 
-      // TODO: define type returned by the action
-      const newFields = data.results
+      const newFields = responseData.results
         .filter((result: any) => result.success)
         .map((result: any) => [result.fieldId, result.contentBlockId]);
 
@@ -122,8 +129,8 @@ const CreateFlow = (props: CreateFlowProps) => {
           selectedFields={selectedFields}
           isSubmitting={isSubmitting}
           handlePreviousStep={() => setStep(FIELDS_STEP)}
-          contentBlockNames={contentBlockNames}
-          setContentBlockNames={setContentBlockNames}
+          contentBlockStates={contentBlockStates}
+          setContentBlockStates={setContentBlockStates}
           handleNextStep={handleCreate}
         />
       )}
@@ -131,7 +138,7 @@ const CreateFlow = (props: CreateFlowProps) => {
         <DraftStep
           isSubmitting={isSubmitting}
           handlePreviousStep={() => setStep(CREATE_STEP)}
-          contentBlockNames={contentBlockNames}
+          contentBlockStates={contentBlockStates}
           handleNextStep={handleCreate}
         />
       )}

--- a/apps/braze/src/components/create/CreateFlow.tsx
+++ b/apps/braze/src/components/create/CreateFlow.tsx
@@ -23,7 +23,7 @@ type CreateFlowProps = {
   initialSelectedFields?: string[];
 };
 
-export type ContentBlockState = {
+export type ContentBlockData = {
   names: Record<string, string>;
   descriptions: Record<string, string>;
 };
@@ -40,7 +40,7 @@ const CreateFlow = (props: CreateFlowProps) => {
   const [step, setStep] = useState(FIELDS_STEP);
   const [selectedFields, setSelectedFields] = useState<Set<string>>(new Set(initialSelectedFields));
   const [fieldsWithErrors, setFieldsWithErrors] = useState<FieldError[]>([]);
-  const [contentBlockStates, setContentBlockStates] = useState<ContentBlockState>({
+  const [contentBlocksData, setContentBlocksData] = useState<ContentBlockData>({
     names: {},
     descriptions: {},
   });
@@ -57,7 +57,7 @@ const CreateFlow = (props: CreateFlowProps) => {
     }
   );
 
-  const handleCreate = async (data: ContentBlockState) => {
+  const handleCreate = async (data: ContentBlockData) => {
     if (entry.state !== EntryStatus.Published && step === CREATE_STEP) {
       setStep(DRAFT_STEP);
       return;
@@ -130,8 +130,8 @@ const CreateFlow = (props: CreateFlowProps) => {
           selectedFields={selectedFields}
           isSubmitting={isSubmitting}
           handlePreviousStep={() => setStep(FIELDS_STEP)}
-          contentBlockStates={contentBlockStates}
-          setContentBlockStates={setContentBlockStates}
+          contentBlocksData={contentBlocksData}
+          setContentBlocksData={setContentBlocksData}
           handleNextStep={handleCreate}
         />
       )}
@@ -139,7 +139,7 @@ const CreateFlow = (props: CreateFlowProps) => {
         <DraftStep
           isSubmitting={isSubmitting}
           handlePreviousStep={() => setStep(CREATE_STEP)}
-          contentBlockStates={contentBlockStates}
+          contentBlocksData={contentBlocksData}
           handleNextStep={handleCreate}
         />
       )}

--- a/apps/braze/src/components/create/CreateStep.tsx
+++ b/apps/braze/src/components/create/CreateStep.tsx
@@ -87,6 +87,7 @@ const ContentBlockForm = ({
         <FormControl.Label>Content Block name</FormControl.Label>
         <TextInput
           value={editDraft.name}
+          data-testid="content-block-name-input"
           onChange={(e) => onNameChange(e.target.value)}
           placeholder={getDefaultContentBlockName(entry, fieldId)}
           style={{ marginBottom: tokens.spacingS }}
@@ -102,6 +103,7 @@ const ContentBlockForm = ({
           maxLength={MAX_DESCRIPTION_LENGTH}
           rows={3}
           style={{ marginBottom: tokens.spacing2Xs }}
+          data-testid="content-block-description-input"
         />
         <Text fontColor="gray500" fontSize="fontSizeS">
           {editDraft.description.length} / {MAX_DESCRIPTION_LENGTH}
@@ -216,7 +218,7 @@ const CreateStep = ({
   if (Array.from(selectedFields).some((fieldId) => !contentBlockStates.names[fieldId])) {
     return (
       <Box padding="spacingM">
-        <Skeleton.Container>
+        <Skeleton.Container data-testid="cf-ui-skeleton-form">
           <Skeleton.BodyText numberOfLines={2} />
           <Skeleton.Image width={200} height={32} />
           <Skeleton.BodyText numberOfLines={1} />

--- a/apps/braze/src/components/create/CreateStep.tsx
+++ b/apps/braze/src/components/create/CreateStep.tsx
@@ -66,7 +66,7 @@ type CreateStepProps = {
 };
 
 // Utils
-const getDefaultContentBlockName = (entry: Entry, fieldId: string) => {
+export const getDefaultContentBlockName = (entry: Entry, fieldId: string) => {
   const entryTitle = entry.title || 'Untitled';
   return `${entryTitle.replace(/\s+/g, '-')}-${fieldId}`;
 };

--- a/apps/braze/src/components/create/CreateStep.tsx
+++ b/apps/braze/src/components/create/CreateStep.tsx
@@ -296,6 +296,7 @@ const CreateStep = ({
       setIsNameValid(false);
       return;
     }
+    setIsNameValid(true);
     setContentBlockStates((prev) => ({
       names: { ...prev.names, [fieldId]: editDraft.name },
       descriptions: { ...prev.descriptions, [fieldId]: editDraft.description },

--- a/apps/braze/src/components/create/CreateStep.tsx
+++ b/apps/braze/src/components/create/CreateStep.tsx
@@ -22,7 +22,7 @@ import tokens from '@contentful/f36-tokens';
 const MAX_DESCRIPTION_LENGTH = 250;
 
 // Types
-type ContentBlockState = {
+type ContentBlockData = {
   names: Record<string, string>;
   descriptions: Record<string, string>;
 };
@@ -47,7 +47,7 @@ type ContentBlockViewProps = {
 type ContentBlockCardProps = {
   fieldId: string;
   entry: Entry;
-  contentBlockState: ContentBlockState;
+  contentBlocksData: ContentBlockData;
   isEditing: boolean;
   editDraft: { name: string; description: string };
   onEdit: (fieldId: string) => void;
@@ -61,11 +61,11 @@ type ContentBlockCardProps = {
 type CreateStepProps = {
   entry: Entry;
   selectedFields: Set<string>;
-  contentBlockStates: ContentBlockState;
-  setContentBlockStates: Dispatch<SetStateAction<ContentBlockState>>;
+  contentBlocksData: ContentBlockData;
+  setContentBlocksData: Dispatch<SetStateAction<ContentBlockData>>;
   isSubmitting: boolean;
   handlePreviousStep: () => void;
-  handleNextStep: (contentBlockStates: ContentBlockState) => void;
+  handleNextStep: (contentBlocksData: ContentBlockData) => void;
 };
 
 // Utils
@@ -177,7 +177,7 @@ const ContentBlockView = ({ name, description, onEdit }: ContentBlockViewProps) 
 const ContentBlockCard = ({
   fieldId,
   entry,
-  contentBlockState,
+  contentBlocksData,
   isEditing,
   editDraft,
   onEdit,
@@ -209,8 +209,8 @@ const ContentBlockCard = ({
         />
       ) : (
         <ContentBlockView
-          name={contentBlockState.names[fieldId] || ''}
-          description={contentBlockState.descriptions[fieldId] || ''}
+          name={contentBlocksData.names[fieldId] || ''}
+          description={contentBlocksData.descriptions[fieldId] || ''}
           onEdit={() => onEdit(fieldId)}
         />
       )}
@@ -223,8 +223,8 @@ const CreateStep = ({
   entry,
   selectedFields,
   isSubmitting,
-  contentBlockStates,
-  setContentBlockStates,
+  contentBlocksData,
+  setContentBlocksData,
   handlePreviousStep,
   handleNextStep,
 }: CreateStepProps) => {
@@ -238,7 +238,7 @@ const CreateStep = ({
 
   // Effects
   useEffect(() => {
-    const initialStates: ContentBlockState = {
+    const initialStates: ContentBlockData = {
       names: {},
       descriptions: {},
     };
@@ -246,11 +246,11 @@ const CreateStep = ({
       initialStates.names[fieldId] = getDefaultContentBlockName(entry, fieldId);
       initialStates.descriptions[fieldId] = '';
     });
-    setContentBlockStates(initialStates);
+    setContentBlocksData(initialStates);
   }, [entry, selectedFields]);
 
   // Early return: show skeleton if any field state is missing
-  if (Array.from(selectedFields).some((fieldId) => !contentBlockStates.names[fieldId])) {
+  if (Array.from(selectedFields).some((fieldId) => !contentBlocksData.names[fieldId])) {
     return (
       <Box padding="spacingM">
         <Skeleton.Container data-testid="cf-ui-skeleton-form">
@@ -266,8 +266,8 @@ const CreateStep = ({
   const handleEdit = (fieldId: string) => {
     setEditingField(fieldId);
     setEditDraft({
-      name: contentBlockStates.names[fieldId] || '',
-      description: contentBlockStates.descriptions[fieldId] || '',
+      name: contentBlocksData.names[fieldId] || '',
+      description: contentBlocksData.descriptions[fieldId] || '',
     });
   };
 
@@ -285,8 +285,8 @@ const CreateStep = ({
     setEditingField(null);
     if (editingField) {
       setEditDraft({
-        name: contentBlockStates.names[editingField] || '',
-        description: contentBlockStates.descriptions[editingField] || '',
+        name: contentBlocksData.names[editingField] || '',
+        description: contentBlocksData.descriptions[editingField] || '',
       });
     }
   };
@@ -297,7 +297,7 @@ const CreateStep = ({
       return;
     }
     setIsNameValid(true);
-    setContentBlockStates((prev) => ({
+    setContentBlocksData((prev) => ({
       names: { ...prev.names, [fieldId]: editDraft.name },
       descriptions: { ...prev.descriptions, [fieldId]: editDraft.description },
     }));
@@ -318,7 +318,7 @@ const CreateStep = ({
               key={fieldId}
               fieldId={fieldId}
               entry={entry}
-              contentBlockState={contentBlockStates}
+              contentBlocksData={contentBlocksData}
               isEditing={editingField === fieldId}
               editDraft={editDraft}
               onEdit={handleEdit}
@@ -341,7 +341,7 @@ const CreateStep = ({
         </Button>
         <Button
           variant="primary"
-          onClick={() => handleNextStep(contentBlockStates)}
+          onClick={() => handleNextStep(contentBlocksData)}
           isDisabled={editingField !== null}>
           {isSubmitting ? 'Creating...' : 'Send to Braze'}
         </Button>

--- a/apps/braze/src/components/create/CreateStep.tsx
+++ b/apps/braze/src/components/create/CreateStep.tsx
@@ -102,10 +102,12 @@ const ContentBlockForm = ({
           autoFocus
         />
         <FormControl.HelpText>Name should be unique</FormControl.HelpText>
-        <FormControl.ValidationMessage>
-          Content Block name can only contain alphanumeric characters (A-Z, a-z, 0-9), dashes (-),
-          and underscores (_).
-        </FormControl.ValidationMessage>
+        {!isNameValid && (
+          <FormControl.ValidationMessage>
+            Content Block name can only contain alphanumeric characters (A-Z, a-z, 0-9), dashes (-),
+            and underscores (_).
+          </FormControl.ValidationMessage>
+        )}
       </FormControl>
       <FormControl style={{ width: '100%' }}>
         <FormControl.Label>Description</FormControl.Label>

--- a/apps/braze/src/components/create/DraftStep.tsx
+++ b/apps/braze/src/components/create/DraftStep.tsx
@@ -4,9 +4,9 @@ import { ContentBlockState } from './CreateFlow';
 
 type DraftStepProps = {
   isSubmitting: boolean;
-  contentBlockStates: Record<string, ContentBlockState>;
+  contentBlockStates: ContentBlockState;
   handlePreviousStep: () => void;
-  handleNextStep: (data: Record<string, ContentBlockState>) => void;
+  handleNextStep: (data: ContentBlockState) => void;
 };
 
 const DraftStep = ({

--- a/apps/braze/src/components/create/DraftStep.tsx
+++ b/apps/braze/src/components/create/DraftStep.tsx
@@ -1,23 +1,24 @@
 import { Paragraph, Button, Subheading } from '@contentful/f36-components';
 import WizardFooter from '../WizardFooter';
+import { ContentBlockState } from './CreateFlow';
 
 type DraftStepProps = {
   isSubmitting: boolean;
-  contentBlockNames: Record<string, string>;
+  contentBlockStates: Record<string, ContentBlockState>;
   handlePreviousStep: () => void;
-  handleNextStep: (contentBlockNames: Record<string, string>) => void;
+  handleNextStep: (data: Record<string, ContentBlockState>) => void;
 };
 
 const DraftStep = ({
   isSubmitting,
-  contentBlockNames,
+  contentBlockStates,
   handlePreviousStep,
   handleNextStep,
 }: DraftStepProps) => {
   return (
     <>
       <Subheading fontWeight="fontWeightDemiBold" fontSize="fontSizeXl" lineHeight="lineHeightL">
-        This entry is in a “Draft” state.
+        This entry is in a "Draft" state.
       </Subheading>
       <Paragraph marginBottom="spacing2Xs">
         This entry has not yet been published, and it's content may not have passed your
@@ -27,7 +28,7 @@ const DraftStep = ({
         <Button variant="secondary" size="small" onClick={handlePreviousStep}>
           Back
         </Button>
-        <Button variant="primary" size="small" onClick={() => handleNextStep(contentBlockNames)}>
+        <Button variant="primary" size="small" onClick={() => handleNextStep(contentBlockStates)}>
           {isSubmitting ? 'Creating...' : 'Send to Braze'}
         </Button>
       </WizardFooter>

--- a/apps/braze/src/components/create/DraftStep.tsx
+++ b/apps/braze/src/components/create/DraftStep.tsx
@@ -1,17 +1,17 @@
 import { Paragraph, Button, Subheading } from '@contentful/f36-components';
 import WizardFooter from '../WizardFooter';
-import { ContentBlockState } from './CreateFlow';
+import { ContentBlockData } from './CreateFlow';
 
 type DraftStepProps = {
   isSubmitting: boolean;
-  contentBlockStates: ContentBlockState;
+  contentBlocksData: ContentBlockData;
   handlePreviousStep: () => void;
-  handleNextStep: (data: ContentBlockState) => void;
+  handleNextStep: (data: ContentBlockData) => void;
 };
 
 const DraftStep = ({
   isSubmitting,
-  contentBlockStates,
+  contentBlocksData,
   handlePreviousStep,
   handleNextStep,
 }: DraftStepProps) => {
@@ -28,7 +28,7 @@ const DraftStep = ({
         <Button variant="secondary" size="small" onClick={handlePreviousStep}>
           Back
         </Button>
-        <Button variant="primary" size="small" onClick={() => handleNextStep(contentBlockStates)}>
+        <Button variant="primary" size="small" onClick={() => handleNextStep(contentBlocksData)}>
           {isSubmitting ? 'Creating...' : 'Send to Braze'}
         </Button>
       </WizardFooter>

--- a/apps/braze/test/components/create/CreateStep.spec.tsx
+++ b/apps/braze/test/components/create/CreateStep.spec.tsx
@@ -26,11 +26,11 @@ describe('CreateStep', () => {
       <CreateStep
         entry={mockEntry}
         selectedFields={mockSelectedFields}
-        contentBlockStates={{
+        contentBlocksData={{
           names: { field1: 'Field-1', field2: 'Field-2' },
           descriptions: { field1: 'Field 1 description', field2: 'Field 2 description' },
         }}
-        setContentBlockStates={() => {}}
+        setContentBlocksData={() => {}}
         isSubmitting={false}
         handlePreviousStep={mockHandlePreviousStep}
         handleNextStep={mockHandleNextStep}

--- a/apps/braze/test/components/create/CreateStep.spec.tsx
+++ b/apps/braze/test/components/create/CreateStep.spec.tsx
@@ -1,13 +1,6 @@
-import React from 'react';
-import {
-  render,
-  screen,
-  fireEvent,
-  cleanup,
-  waitForElementToBeRemoved,
-} from '@testing-library/react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import CreateStep from '../../../src/components/create/CreateStep';
+import CreateStep, { getDefaultContentBlockName } from '../../../src/components/create/CreateStep';
 import { Entry } from '../../../src/fields/Entry';
 import { BasicField } from '../../../src/fields/BasicField';
 
@@ -121,5 +114,12 @@ describe('CreateStep', () => {
     fireEvent.click(backButton);
 
     expect(mockHandlePreviousStep).toHaveBeenCalled();
+  });
+
+  describe('when trying to get the default name', () => {
+    it('returns the correct default name', () => {
+      const defaultName = getDefaultContentBlockName(mockEntry, 'field1');
+      expect(defaultName).toBe('Test-Entry-field1');
+    });
   });
 });

--- a/apps/braze/test/components/create/CreateStep.spec.tsx
+++ b/apps/braze/test/components/create/CreateStep.spec.tsx
@@ -65,7 +65,7 @@ describe('CreateStep', () => {
     fireEvent.click(editButtons[0]);
 
     // Check if form control elements appear
-    expect(screen.getByText('Name should be unique.')).toBeTruthy();
+    expect(screen.getByTestId('content-block-description-input')).toBeTruthy();
     expect(screen.getByText('Field 1 description')).toBeTruthy();
   });
 

--- a/apps/braze/test/components/create/CreateStep.test.tsx
+++ b/apps/braze/test/components/create/CreateStep.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import CreateStep from '../../../src/components/create/CreateStep';
+import { Entry } from '../../../src/fields/Entry';
+import { BasicField } from '../../../src/fields/BasicField';
+
+describe('CreateStep', () => {
+  const field1 = new BasicField('field1', 'Field 1', 'test', false);
+  const field2 = new BasicField('field2', 'Field 2', 'test', false);
+  const mockEntry = new Entry(
+    'entry-id',
+    'test',
+    'Test Entry',
+    [field1, field2],
+    'space-id',
+    'environment-id',
+    'api-token'
+  );
+
+  const mockSelectedFields = new Set(['field1', 'field2']);
+  const mockHandlePreviousStep = vi.fn();
+  const mockHandleNextStep = vi.fn();
+
+  const renderComponent = (props = {}) => {
+    return render(
+      <CreateStep
+        entry={mockEntry}
+        selectedFields={mockSelectedFields}
+        contentBlockStates={{}}
+        setContentBlockStates={() => {}}
+        isSubmitting={false}
+        handlePreviousStep={mockHandlePreviousStep}
+        handleNextStep={mockHandleNextStep}
+        {...props}
+      />
+    );
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the component with initial state', () => {
+    renderComponent();
+
+    // Check if main elements are rendered
+    expect(screen.getByText(/Edit each field/i)).toBeTruthy();
+    expect(screen.getAllByText('Name')).toHaveLength(mockSelectedFields.size);
+    expect(screen.getAllByRole('button', { name: /Edit content block/i })).toHaveLength(
+      mockSelectedFields.size
+    );
+  });
+
+  it('shows default content block names', () => {
+    renderComponent();
+
+    mockSelectedFields.forEach((fieldId) => {
+      const expectedName = `Test-Entry-${fieldId}`;
+      expect(screen.getByText(expectedName)).toBeTruthy();
+    });
+  });
+
+  it('enters edit mode when edit button is clicked', () => {
+    renderComponent();
+
+    const editButtons = screen.getAllByRole('button', { name: /Edit content block/i });
+    fireEvent.click(editButtons[0]);
+
+    // Check if form control elements appear
+    expect(screen.getByText('Name should be unique.')).toBeTruthy();
+    expect(screen.getByRole('textbox')).toBeTruthy();
+  });
+
+  it('updates content block name when edited', () => {
+    renderComponent();
+
+    // Click edit button for first field
+    const editButtons = screen.getAllByRole('button', { name: /Edit content block/i });
+    fireEvent.click(editButtons[0]);
+
+    // Type new name
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'New Name' } });
+
+    // Check if the new name is in the input
+    expect(input.value).toBe('New Name');
+  });
+
+  it('handles form submission', () => {
+    renderComponent();
+
+    // Click the submit button
+    const submitButton = screen.getByRole('button', { name: /Send to Braze/i });
+    fireEvent.click(submitButton);
+
+    expect(mockHandleNextStep).toHaveBeenCalled();
+  });
+
+  it('shows loading state when submitting', () => {
+    renderComponent({ isSubmitting: true });
+
+    expect(screen.getByText('Creating...')).toBeTruthy();
+  });
+
+  it('navigates back when back button is clicked', () => {
+    renderComponent();
+
+    const backButton = screen.getByRole('button', { name: 'Back' });
+    fireEvent.click(backButton);
+
+    expect(mockHandlePreviousStep).toHaveBeenCalled();
+  });
+});

--- a/apps/braze/test/functions/createContentBlocks.test.ts
+++ b/apps/braze/test/functions/createContentBlocks.test.ts
@@ -49,8 +49,8 @@ describe('createContentBlocks', () => {
 
   it('should create content blocks for text fields', async () => {
     // Mock entry data
-    const mockEntry = createEntry({ title: 'Test Title' });
-    const mockContentType = createContentType(['title']);
+    const mockEntry = createEntry({ title: 'Test Title', author: 'Test Author' });
+    const mockContentType = createContentType(['title', 'author']);
 
     // Mock API responses
     vi.mocked(mockCma.entry.get).mockResolvedValue(mockEntry);
@@ -64,8 +64,15 @@ describe('createContentBlocks', () => {
       type: FunctionTypeEnum.AppActionCall,
       body: {
         entryId: 'entry-id',
-        fieldIds: 'title',
-        contentBlockNames: JSON.stringify({ title: 'custom-title-name' }),
+        fieldIds: 'title,author',
+        contentBlockNames: JSON.stringify({
+          title: 'custom-title-name',
+          author: 'custom-author-name',
+        }),
+        contentBlockDescriptions: JSON.stringify({
+          title: 'custom-title-description',
+          author: 'custom-author-description',
+        }),
       },
       headers: {},
     };
@@ -80,10 +87,23 @@ describe('createContentBlocks', () => {
           statusCode: 201,
           contentBlockId: 'block-id',
         },
+        {
+          fieldId: 'author',
+          success: true,
+          statusCode: 201,
+          contentBlockId: 'block-id',
+        },
+        {
+          fieldId: 'author',
+          success: true,
+          contentBlockId: 'block-id',
+        },
       ],
     });
 
-    expect(global.fetch).toHaveBeenCalledWith(
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      1,
       'https://test.braze.com/content_blocks/create',
       expect.objectContaining({
         method: 'POST',
@@ -95,6 +115,19 @@ describe('createContentBlocks', () => {
           name: 'custom-title-name',
           content: 'Test Title',
           state: 'draft',
+          description: 'custom-title-description',
+        }),
+      })
+    );
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      2,
+      'https://test.braze.com/content_blocks/create',
+      expect.objectContaining({
+        body: JSON.stringify({
+          name: 'custom-author-name',
+          content: 'Test Author',
+          state: 'draft',
+          description: 'custom-author-description',
         }),
       })
     );
@@ -117,6 +150,7 @@ describe('createContentBlocks', () => {
         entryId: 'entry-id',
         fieldIds: 'content',
         contentBlockNames: JSON.stringify({ content: 'custom-content-name' }),
+        contentBlockDescriptions: JSON.stringify({ content: 'custom-content-description' }),
       },
       headers: {},
     };
@@ -142,6 +176,7 @@ describe('createContentBlocks', () => {
           name: 'custom-content-name',
           content: '<p>Test HTML</p>',
           state: 'draft',
+          description: 'custom-content-description',
         }),
       })
     );
@@ -150,7 +185,7 @@ describe('createContentBlocks', () => {
   it('should handle missing fields', async () => {
     // Mock Entry data
     const entry = createEntry({});
-    const contentType = createContentType(['title']);
+    const contentType = createContentType(['title', 'author']);
 
     // Mock API responses
     vi.mocked(mockCma.entry.get).mockResolvedValue(entry);
@@ -160,8 +195,15 @@ describe('createContentBlocks', () => {
       type: FunctionTypeEnum.AppActionCall,
       body: {
         entryId: 'entry-id',
-        fieldIds: 'title',
-        contentBlockNames: JSON.stringify({ title: 'custom-title-name' }),
+        fieldIds: 'title,author',
+        contentBlockNames: JSON.stringify({
+          title: 'custom-title-name',
+          author: 'custom-author-name',
+        }),
+        contentBlockDescriptions: JSON.stringify({
+          title: 'custom-title-description',
+          author: 'custom-author-description',
+        }),
       },
       headers: {},
     };
@@ -176,6 +218,11 @@ describe('createContentBlocks', () => {
           statusCode: 404,
           message: 'Field title not found or has no value',
         },
+        {
+          fieldId: 'author',
+          success: false,
+          message: 'Field author not found or has no value',
+        },
       ],
     });
 
@@ -184,8 +231,8 @@ describe('createContentBlocks', () => {
 
   it('should handle API errors', async () => {
     // Mock Entry data
-    const entry = createEntry({ title: 'Test Title' });
-    const contentType = createContentType(['title']);
+    const entry = createEntry({ title: 'Test Title', author: 'Test Author' });
+    const contentType = createContentType(['title', 'author']);
 
     // Mock API responses
     vi.mocked(mockCma.entry.get).mockResolvedValue(entry);
@@ -203,8 +250,15 @@ describe('createContentBlocks', () => {
       type: FunctionTypeEnum.AppActionCall,
       body: {
         entryId: 'entry-id',
-        fieldIds: 'title',
-        contentBlockNames: JSON.stringify({ title: 'custom-title-name' }),
+        fieldIds: 'title,author',
+        contentBlockNames: JSON.stringify({
+          title: 'custom-title-name',
+          author: 'custom-author-name',
+        }),
+        contentBlockDescriptions: JSON.stringify({
+          title: 'custom-title-description',
+          author: 'custom-author-description',
+        }),
       },
       headers: {},
     };
@@ -219,14 +273,25 @@ describe('createContentBlocks', () => {
           statusCode: 401,
           message: 'Error creating content block for field title: Unauthorized',
         },
+        {
+          fieldId: 'author',
+          success: false,
+          statusCode: 401,
+          message: 'Error creating content block for field title: Unauthorized',
+        },
+        {
+          fieldId: 'author',
+          success: false,
+          message: 'Error creating content block: Unauthorized',
+        },
       ],
     });
   });
 
   it('should handle multiple fields with custom names', async () => {
     // Mock Entry data
-    const entry = createEntry({ title: 'Test Title', description: 'Test Description' });
-    const contentType = createContentType(['title', 'description']);
+    const entry = createEntry({ title: 'Test Title', author: 'Test Author' });
+    const contentType = createContentType(['title', 'author']);
 
     // Mock API responses
     vi.mocked(mockCma.entry.get).mockResolvedValue(entry);
@@ -245,10 +310,14 @@ describe('createContentBlocks', () => {
       type: FunctionTypeEnum.AppActionCall,
       body: {
         entryId: 'entry-id',
-        fieldIds: 'title,description',
+        fieldIds: 'title,author',
         contentBlockNames: JSON.stringify({
           title: 'custom-title-name',
-          description: 'custom-description-name',
+          author: 'custom-author-name',
+        }),
+        contentBlockDescriptions: JSON.stringify({
+          title: 'custom-title-description',
+          author: 'custom-author-description',
         }),
       },
       headers: {},
@@ -265,7 +334,7 @@ describe('createContentBlocks', () => {
           contentBlockId: 'block-id-1',
         },
         {
-          fieldId: 'description',
+          fieldId: 'author',
           success: true,
           statusCode: 201,
           contentBlockId: 'block-id-2',
@@ -282,6 +351,7 @@ describe('createContentBlocks', () => {
           name: 'custom-title-name',
           content: 'Test Title',
           state: 'draft',
+          description: 'custom-title-description',
         }),
       })
     );
@@ -290,9 +360,10 @@ describe('createContentBlocks', () => {
       'https://test.braze.com/content_blocks/create',
       expect.objectContaining({
         body: JSON.stringify({
-          name: 'custom-description-name',
-          content: 'Test Description',
+          name: 'custom-author-name',
+          content: 'Test Author',
           state: 'draft',
+          description: 'custom-author-description',
         }),
       })
     );
@@ -300,8 +371,8 @@ describe('createContentBlocks', () => {
 
   it('should handle invalid contentBlockNames JSON', async () => {
     // Mock Entry data
-    const entry = createEntry({ title: 'Test Title' });
-    const contentType = createContentType(['title']);
+    const entry = createEntry({ title: 'Test Title', author: 'Test Author' });
+    const contentType = createContentType(['title', 'author']);
 
     // Mock API responses
     vi.mocked(mockCma.entry.get).mockResolvedValue(entry);
@@ -311,8 +382,12 @@ describe('createContentBlocks', () => {
       type: FunctionTypeEnum.AppActionCall,
       body: {
         entryId: 'entry-id',
-        fieldIds: 'title',
+        fieldIds: 'title,author',
         contentBlockNames: 'invalid-json',
+        contentBlockDescriptions: JSON.stringify({
+          title: 'custom-title-description',
+          author: 'custom-author-description',
+        }),
       },
       headers: {},
     };
@@ -323,8 +398,8 @@ describe('createContentBlocks', () => {
 
   it('should handle missing contentBlockNames for a field', async () => {
     // Mock Entry data
-    const entry = createEntry({ title: 'Test Title', description: 'Test Description' });
-    const contentType = createContentType(['title', 'description']);
+    const entry = createEntry({ title: 'Test Title', author: 'Test Author' });
+    const contentType = createContentType(['title', 'author']);
 
     // Mock API responses
     vi.mocked(mockCma.entry.get).mockResolvedValue(entry);
@@ -338,10 +413,14 @@ describe('createContentBlocks', () => {
       type: FunctionTypeEnum.AppActionCall,
       body: {
         entryId: 'entry-id',
-        fieldIds: 'title,description',
+        fieldIds: 'title,author',
         contentBlockNames: JSON.stringify({
           title: 'custom-title-name',
-          // description name is missing
+          // author name is missing
+        }),
+        contentBlockDescriptions: JSON.stringify({
+          title: 'custom-title-description',
+          author: 'custom-author-description',
         }),
       },
       headers: {},
@@ -358,10 +437,10 @@ describe('createContentBlocks', () => {
           contentBlockId: 'block-id',
         },
         {
-          fieldId: 'description',
+          fieldId: 'author',
           success: false,
           statusCode: 404,
-          message: 'Content block name not found or has no value for field description',
+          message: 'Content block name not found or has no value for field author',
         },
       ],
     });

--- a/apps/braze/test/functions/createContentBlocks.test.ts
+++ b/apps/braze/test/functions/createContentBlocks.test.ts
@@ -93,11 +93,6 @@ describe('createContentBlocks', () => {
           statusCode: 201,
           contentBlockId: 'block-id',
         },
-        {
-          fieldId: 'author',
-          success: true,
-          contentBlockId: 'block-id',
-        },
       ],
     });
 
@@ -221,6 +216,7 @@ describe('createContentBlocks', () => {
         {
           fieldId: 'author',
           success: false,
+          statusCode: 404,
           message: 'Field author not found or has no value',
         },
       ],
@@ -277,12 +273,7 @@ describe('createContentBlocks', () => {
           fieldId: 'author',
           success: false,
           statusCode: 401,
-          message: 'Error creating content block for field title: Unauthorized',
-        },
-        {
-          fieldId: 'author',
-          success: false,
-          message: 'Error creating content block: Unauthorized',
+          message: 'Error creating content block for field author: Unauthorized',
         },
       ],
     });

--- a/apps/braze/test/locations/Dialog.spec.tsx
+++ b/apps/braze/test/locations/Dialog.spec.tsx
@@ -2,7 +2,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mockSdk } from '../mocks';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import Dialog from '../../src/locations/Dialog';
-import React from 'react';
 import { Entry } from '../../src/fields/Entry';
 import { BasicField } from '../../src/fields/BasicField';
 import { createEntry } from '../mocks/mocksForFunctions';
@@ -154,6 +153,7 @@ describe('Dialog component', () => {
         exact: false,
       }
     );
+
     expect(successStepParagraph).toBeTruthy();
   });
 


### PR DESCRIPTION
## Purpose

We want users to be allowed to edit name and description of a contentblock when creating a new one
## Approach
The following changes were introduced:
- Introduce description to card component and to create content block action
- Add validations for name
- Enhance UI for editing name and description
- Updated package.json to better test in the dev environment

## Testing steps

Updated automatic testing.
Tested using my own app:

https://github.com/user-attachments/assets/88112a47-466c-4a4a-933e-ba2ddc545cae




