### PR TITLE
Braze app: Change approach for storing connected fields info [INTEG-2650]

### DIFF
--- a/apps/braze/src/locations/Sidebar.tsx
+++ b/apps/braze/src/locations/Sidebar.tsx
@@ -3,12 +3,14 @@ import { Box, Button, Subheading, Card, Text, Stack } from '@contentful/f36-comp
 import { useAutoResizer, useSDK } from '@contentful/react-apps-toolkit';
 import {
   BRAZE_CONTENT_BLOCK_DOCUMENTATION,
+  CONFIG_FIELD_ID,
   CONNECTED_CONTENT_DOCUMENTATION,
   CREATE_DIALOG_MODE,
   CREATE_DIALOG_TITLE,
   FIELDS_STEP,
   GENERATE_DIALOG_MODE,
   GENERATE_DIALOG_TITLE,
+  getConfigEntry,
   SIDEBAR_CONNECTED_ENTRIES_BUTTON_TEXT,
   SIDEBAR_CREATE_BUTTON_TEXT,
   SIDEBAR_GENERATE_BUTTON_TEXT,
@@ -17,14 +19,38 @@ import { InvocationParams } from './Dialog';
 import { styles } from './Sidebar.styles';
 import InformationWithLink from '../components/InformationWithLink';
 import Splitter from '../components/Splitter';
+import { createClient, QueryParams } from 'contentful-management';
+import { useEffect, useState } from 'react';
+import { EntryConnectedFields } from '../components/create/CreateFlow';
 
 const Sidebar = () => {
   const sdk = useSDK<SidebarAppSDK>();
-  const connectedFields = JSON.parse(sdk.parameters.installation.brazeConnectedFields || '{}');
-  const currentEntryId = sdk.ids.entry;
-  const connectedFieldsForCurrentEntry: [string, string][] = connectedFields[currentEntryId] || [];
-
   useAutoResizer();
+  const [entryConnectedFields, setEntryConnectedFields] = useState<
+    EntryConnectedFields | undefined
+  >(undefined);
+  const currentEntryId = sdk.ids.entry;
+
+  const cma = createClient(
+    { apiAdapter: sdk.cmaAdapter },
+    {
+      type: 'plain',
+      defaults: {
+        environmentId: sdk.ids.environment,
+        spaceId: sdk.ids.space,
+      },
+    }
+  );
+
+  useEffect(() => {
+    const getConfig = async () => {
+      const configEntry = await getConfigEntry(cma);
+      const connectedFields = configEntry.fields[CONFIG_FIELD_ID]?.[sdk.locales.default] || {};
+      const entryConnectedFields: EntryConnectedFields = connectedFields[sdk.ids.entry] || [];
+      setEntryConnectedFields(entryConnectedFields);
+    };
+    getConfig();
+  }, []);
 
   const initialInvocationParams: InvocationParams = {
     mode: GENERATE_DIALOG_MODE,
@@ -90,7 +116,7 @@ const Sidebar = () => {
           {SIDEBAR_CREATE_BUTTON_TEXT}
         </Button>
       </Box>
-      {Object.keys(connectedFieldsForCurrentEntry).length > 0 && (
+      {entryConnectedFields !== undefined && entryConnectedFields.length > 0 && (
         <>
           <Box marginTop="spacingM">
             <Card className={styles.card}>
@@ -103,9 +129,9 @@ const Sidebar = () => {
                 spacing="spacingXs"
                 alignItems="initial"
                 className={styles.stack}>
-                {connectedFieldsForCurrentEntry.map(([contentfulFieldId], index) => (
+                {entryConnectedFields.map((fieldMapping, index) => (
                   <Text key={`${currentEntryId}-${index}`} className={styles.listItem}>
-                    {contentfulFieldId}
+                    {fieldMapping.fieldId}
                   </Text>
                 ))}
               </Stack>

--- a/apps/braze/src/utils.ts
+++ b/apps/braze/src/utils.ts
@@ -1,3 +1,6 @@
+import { EntryProps, KeyValueMap, PlainClientAPI } from 'contentful-management';
+import { EntryConnectedFields } from './components/create/CreateFlow';
+
 export const SAVED_RESPONSE = 'response';
 export const ASSET_FIELDS_QUERY = [
   'title',
@@ -30,6 +33,10 @@ export const BRAZE_CONTENT_BLOCK_DOCUMENTATION =
 export const BRAZE_ENDPOINTS_LIST =
   'https://www.braze.com/docs/api/basics#braze-rest-api-collection';
 
+export const CONFIG_CONTENT_TYPE_ID = 'brazeConfig';
+export const CONFIG_FIELD_ID = 'connectedFields';
+export const CONFIG_ENTRY_ID = 'brazeConfig';
+
 export enum EntryStatus {
   Draft = 'DRAFT',
   Changed = 'CHANGED',
@@ -50,4 +57,21 @@ export function removeIndentation(str: string) {
 
 export function removeHypens(str: string) {
   return str.replace('-', '');
+}
+
+export async function updateConfig(
+  configEntry: EntryProps<KeyValueMap>,
+  locale: string,
+  connectedFields: EntryConnectedFields,
+  cma: PlainClientAPI
+) {
+  if (!configEntry.fields[CONFIG_FIELD_ID]) {
+    configEntry.fields[CONFIG_FIELD_ID] = {};
+  }
+  configEntry.fields[CONFIG_FIELD_ID][locale] = connectedFields;
+  await cma.entry.update({ entryId: CONFIG_ENTRY_ID }, configEntry);
+}
+
+export async function getConfigEntry(cma: PlainClientAPI): Promise<EntryProps<KeyValueMap>> {
+  return await cma.entry.get({ entryId: CONFIG_ENTRY_ID });
 }

--- a/apps/braze/test/locations/Dialog.spec.tsx
+++ b/apps/braze/test/locations/Dialog.spec.tsx
@@ -15,6 +15,10 @@ const mockCma = {
   appActionCall: {
     createWithResponse: vi.fn(),
   },
+  entry: {
+    get: vi.fn(),
+    update: vi.fn(),
+  },
 };
 
 vi.mock('contentful-management', () => ({
@@ -65,6 +69,20 @@ describe('Dialog component', () => {
     mockCreateFieldsForEntry.mockResolvedValue([mockField]);
     vi.spyOn(mockEntry, 'getGraphQLResponse').mockImplementation(async () => 'graphql response');
     vi.spyOn(Entry, 'fromSerialized').mockImplementation(() => mockEntry);
+    mockCma.entry.get.mockResolvedValue({
+      fields: {
+        connectedFields: {
+          'en-US': {
+            [mockSdk.ids.entry]: [
+              {
+                fieldId: 'fieldA',
+                contentBlockId: 'contentBlockA',
+              },
+            ],
+          },
+        },
+      },
+    });
     mockSdk.parameters.invocation = undefined;
     mockSdk.close = vi.fn();
   });

--- a/apps/braze/test/mocks/mockSdk.ts
+++ b/apps/braze/test/mocks/mockSdk.ts
@@ -19,13 +19,6 @@ const mockSdk: any = {
     installation: {
       contentfulApiKey: 'test-contentful-apiKey',
       brazeApiKey: 'test-braze-apiKey',
-      brazeConnectedFields: JSON.stringify({
-        testEntryId: [
-          ['fieldA', 'brazeIdA'],
-          ['fieldB', 'brazeIdB'],
-        ],
-        testEntryId2: [['fieldC', 'brazeIdC']],
-      }),
     },
     invocation: {
       id: 'test-entryId',


### PR DESCRIPTION
## Purpose

We were storing the information for connected fields in app installation parameters, but that's actually not possible (the parameters weren't actually persisted).

## Approach

The new solution is to create a content type specifically for storing this information, with one single entry with one single json field.

## Testing steps

- Configure app
- Check that content type and entry were created
- Connect fields and check they're visible in the sidebar

https://github.com/user-attachments/assets/a0e4774f-44bc-4433-b6bd-c1a60472949a