### PR TITLE
Braze app : Update config screen edge case [INTEG-2610]

### DIFF
--- a/apps/braze/src/locations/Sidebar.tsx
+++ b/apps/braze/src/locations/Sidebar.tsx
@@ -1,5 +1,14 @@
 import { SidebarAppSDK } from '@contentful/app-sdk';
-import { Box, Button, Subheading, Card, Text, Stack } from '@contentful/f36-components';
+import {
+  Box,
+  Button,
+  Subheading,
+  Card,
+  Text,
+  Stack,
+  Note,
+  TextLink,
+} from '@contentful/f36-components';
 import { useAutoResizer, useSDK } from '@contentful/react-apps-toolkit';
 import {
   BRAZE_CONTENT_BLOCK_DOCUMENTATION,
@@ -54,9 +63,32 @@ const Sidebar = () => {
     });
   };
 
+  const handleOpenAppConfig = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    await sdk.navigator.openAppConfig();
+  };
+
+  const hasUpdatedConfig =
+    sdk.parameters.installation.contentfulApiKey &&
+    sdk.parameters.installation.brazeApiKey &&
+    sdk.parameters.installation.brazeEndpoint;
+
   return (
     <>
       <Box>
+        {!hasUpdatedConfig && (
+          <Note variant="warning">
+            <Text>Update your app configuration </Text>
+            <TextLink
+              alignIcon="end"
+              href="#"
+              onClick={handleOpenAppConfig}
+              target="_blank"
+              rel="noopener noreferrer">
+              here
+            </TextLink>
+          </Note>
+        )}
         <Subheading className={styles.subheading}>Connected Content</Subheading>
         <InformationWithLink
           url={CONNECTED_CONTENT_DOCUMENTATION}
@@ -69,7 +101,8 @@ const Sidebar = () => {
         <Button
           variant="secondary"
           isFullWidth={true}
-          onClick={() => openDialogLogic(FIELDS_STEP, undefined, GENERATE_DIALOG_MODE)}>
+          onClick={() => openDialogLogic(FIELDS_STEP, undefined, GENERATE_DIALOG_MODE)}
+          isDisabled={!hasUpdatedConfig}>
           {SIDEBAR_GENERATE_BUTTON_TEXT}
         </Button>
       </Box>
@@ -86,7 +119,8 @@ const Sidebar = () => {
         <Button
           variant="secondary"
           isFullWidth={true}
-          onClick={() => openDialogLogic(FIELDS_STEP, undefined, CREATE_DIALOG_MODE)}>
+          onClick={() => openDialogLogic(FIELDS_STEP, undefined, CREATE_DIALOG_MODE)}
+          isDisabled={!hasUpdatedConfig}>
           {SIDEBAR_CREATE_BUTTON_TEXT}
         </Button>
       </Box>

--- a/apps/braze/test/locations/Sidebar.spec.tsx
+++ b/apps/braze/test/locations/Sidebar.spec.tsx
@@ -1,4 +1,4 @@
-import { render, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import { render, fireEvent, cleanup, waitFor, getByRole } from '@testing-library/react';
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import {
   GENERATE_DIALOG_TITLE,
@@ -9,9 +9,11 @@ import {
 } from '../../src/utils';
 import { mockSdk, mockCma } from '../mocks';
 import Sidebar from '../../src/locations/Sidebar';
+import { useSDK } from '@contentful/react-apps-toolkit';
+import React from 'react';
 
 vi.mock('@contentful/react-apps-toolkit', () => ({
-  useSDK: () => mockSdk,
+  useSDK: vi.fn(() => mockSdk),
   useAutoResizer: () => {},
 }));
 
@@ -22,6 +24,7 @@ vi.mock('contentful-management', () => ({
 describe('Sidebar component', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    (useSDK as any).mockReturnValue(mockSdk);
   });
 
   afterEach(cleanup);
@@ -116,11 +119,13 @@ describe('Sidebar component', () => {
     });
   });
 
-  it('Create button opens a dialog', () => {
+  it('Create button opens a dialog', async () => {
+    vi.mocked(mockSdk.dialogs.openCurrentApp).mockResolvedValueOnce({ step: 'close' });
     const { getByText } = render(<Sidebar />);
-    getByText(SIDEBAR_CREATE_BUTTON_TEXT).click();
+    const button = getByText(SIDEBAR_CREATE_BUTTON_TEXT);
+    await fireEvent.click(button);
 
-    expect(mockSdk.dialogs.openCurrentApp).toBeCalledWith({
+    expect(mockSdk.dialogs.openCurrentApp).toHaveBeenCalledWith({
       title: CREATE_DIALOG_TITLE,
       parameters: {
         entryId: mockSdk.ids.entry,
@@ -150,5 +155,104 @@ describe('Sidebar component', () => {
     fireEvent.click(button);
 
     expect(mockSdk.navigator.openCurrentAppPage).toHaveBeenCalledTimes(1);
+  });
+
+  describe('Configuration validation', () => {
+    it('shows warning when all config values are empty', () => {
+      const sdkWithEmptyConfig = {
+        ...mockSdk,
+        parameters: {
+          ...mockSdk.parameters,
+          installation: {
+            contentfulApiKey: '',
+            brazeApiKey: '',
+            brazeEndpoint: '',
+            brazeConnectedFields: '{}',
+          },
+        },
+      };
+      (useSDK as any).mockReturnValue(sdkWithEmptyConfig);
+
+      const { getByText } = render(<Sidebar />);
+      expect(getByText('Update your app configuration')).toBeTruthy();
+    });
+
+    it('shows warning when contentfulApiKey is missing', () => {
+      const sdkWithMissingContentfulKey = {
+        ...mockSdk,
+        parameters: {
+          ...mockSdk.parameters,
+          installation: {
+            ...mockSdk.parameters.installation,
+            contentfulApiKey: '',
+          },
+        },
+      };
+      (useSDK as any).mockReturnValue(sdkWithMissingContentfulKey);
+
+      const { getByText } = render(<Sidebar />);
+      expect(getByText('Update your app configuration')).toBeTruthy();
+    });
+
+    it('shows warning when brazeApiKey is missing', () => {
+      const sdkWithMissingBrazeKey = {
+        ...mockSdk,
+        parameters: {
+          ...mockSdk.parameters,
+          installation: {
+            ...mockSdk.parameters.installation,
+            brazeApiKey: '',
+          },
+        },
+      };
+      (useSDK as any).mockReturnValue(sdkWithMissingBrazeKey);
+
+      const { getByText } = render(<Sidebar />);
+      expect(getByText('Update your app configuration')).toBeTruthy();
+    });
+
+    it('shows warning when brazeEndpoint is missing', () => {
+      const sdkWithMissingEndpoint = {
+        ...mockSdk,
+        parameters: {
+          ...mockSdk.parameters,
+          installation: {
+            ...mockSdk.parameters.installation,
+            brazeEndpoint: '',
+          },
+        },
+      };
+      (useSDK as any).mockReturnValue(sdkWithMissingEndpoint);
+
+      const { getByText } = render(<Sidebar />);
+      expect(getByText('Update your app configuration')).toBeTruthy();
+    });
+
+    it('disables buttons when config is incomplete', () => {
+      const sdkWithIncompleteConfig = {
+        ...mockSdk,
+        parameters: {
+          ...mockSdk.parameters,
+          installation: {
+            contentfulApiKey: '',
+            brazeApiKey: 'test-braze-key',
+            brazeEndpoint: 'test-endpoint',
+            brazeConnectedFields: '{}',
+          },
+        },
+      };
+      (useSDK as any).mockReturnValue(sdkWithIncompleteConfig);
+
+      const { getByText, getByRole } = render(<Sidebar />);
+      const generateButton = getByRole('button', {
+        name: SIDEBAR_GENERATE_BUTTON_TEXT,
+      }) as HTMLButtonElement;
+      const createButton = getByRole('button', {
+        name: SIDEBAR_CREATE_BUTTON_TEXT,
+      }) as HTMLButtonElement;
+
+      expect(generateButton?.disabled).toBe(true);
+      expect(createButton?.disabled).toBe(true);
+    });
   });
 });

--- a/apps/braze/test/mocks/mockSdk.ts
+++ b/apps/braze/test/mocks/mockSdk.ts
@@ -1,4 +1,5 @@
 import { vi } from 'vitest';
+import { BRAZE_ENDPOINTS_LIST } from '../../src/utils';
 
 const mockSdk: any = {
   app: {
@@ -19,6 +20,7 @@ const mockSdk: any = {
     installation: {
       contentfulApiKey: 'test-contentful-apiKey',
       brazeApiKey: 'test-braze-apiKey',
+      brazeEndpoint: BRAZE_ENDPOINTS_LIST[0],
       brazeConnectedFields: JSON.stringify({
         testEntryId: [
           ['fieldA', 'brazeIdA'],
@@ -54,6 +56,7 @@ const mockSdk: any = {
   },
   navigator: {
     openCurrentAppPage: vi.fn(),
+    openAppConfig: vi.fn(),
   },
 };
 


### PR DESCRIPTION
## Purpose

Handle edge case in which we don't have available the installation parameters. This can happen if the user was already using the v1 version of the app.

## Approach
In this PR:
- Added warning note
- Added link to config page 
- Disable buttons of the app, until the user re-configures the page
## Testing steps
Added test to handle edge cases. Tested using the v1


https://github.com/user-attachments/assets/0b33892a-a7ba-47a2-a267-8af24bb184a5

