### PR TITLE
Braze: Allow to retry when name already in use [INTEG-2540]

### DIFF
--- a/apps/braze/functions/createContentBlocks.ts
+++ b/apps/braze/functions/createContentBlocks.ts
@@ -74,7 +74,7 @@ export const handler: FunctionEventHandler<
         fieldId,
         success: false,
         statusCode: 400,
-        message: `Field ${fieldId} not found or has no value`,
+        message: `Field ${fieldId} does not exist or is empty`,
       });
       continue;
     }
@@ -84,7 +84,7 @@ export const handler: FunctionEventHandler<
         fieldId,
         success: false,
         statusCode: 400,
-        message: `Content block name not found or has no value for field ${fieldId}`,
+        message: `Unexpected error: Content block name not found for field ${fieldId}`,
       });
       continue;
     }

--- a/apps/braze/src/components/InformationWithLink.tsx
+++ b/apps/braze/src/components/InformationWithLink.tsx
@@ -5,7 +5,7 @@ import { ExternalLinkIcon } from '@contentful/f36-icons';
 
 type InformationSectionProps = {
   url: string;
-  children: string;
+  children?: string;
   linkText: string;
   marginTop?: Spacing;
   marginBottom?: Spacing;

--- a/apps/braze/src/components/create/CreateFlow.tsx
+++ b/apps/braze/src/components/create/CreateFlow.tsx
@@ -148,10 +148,11 @@ const CreateFlow = (props: CreateFlowProps) => {
       setCreationResultFields(newCreationResultFields);
 
       const errors = responseData.results.filter((result: any) => !result.success);
-      if (errors.length > 0) {
-        if (!errors.some((error: any) => error.message?.includes(BRAZE_NAME_EXISTS_ERROR))) {
-          setStep(ERROR_STEP);
-        }
+      if (
+        errors.length > 0 &&
+        !errors.some((error: any) => error.message?.includes(BRAZE_NAME_EXISTS_ERROR))
+      ) {
+        setStep(ERROR_STEP);
         return;
       }
 

--- a/apps/braze/src/components/create/CreateFlow.tsx
+++ b/apps/braze/src/components/create/CreateFlow.tsx
@@ -21,6 +21,7 @@ const CREATE_STEP = 'create';
 const DRAFT_STEP = 'draft';
 const ERROR_STEP = 'error';
 const SUCCESS_STEP = 'success';
+const BRAZE_NAME_EXISTS_ERROR = 'name already exists';
 
 type CreateFlowProps = {
   sdk: DialogAppSDK;
@@ -80,6 +81,27 @@ const CreateFlow = (props: CreateFlowProps) => {
 
     setIsSubmitting(true);
 
+    const names: Record<string, string> = {};
+    const descriptions: Record<string, string> = {};
+    Object.entries(data.names)
+      .filter(
+        ([fieldId, fieldName]) =>
+          !creationResultFields.some((result) => result.fieldId === fieldId && result.success)
+      )
+      .forEach(([fieldId, fieldName]) => (names[fieldId] = fieldName));
+    Object.entries(data.descriptions)
+      .filter(
+        ([fieldId, fieldDescription]) =>
+          !creationResultFields.some((result) => result.fieldId === fieldId && result.success)
+      )
+      .forEach(([fieldId, fieldDescription]) => (descriptions[fieldId] = fieldDescription));
+    const fieldsIds = Array.from(selectedFields)
+      .filter(
+        (fieldId) =>
+          !creationResultFields.some((result) => result.fieldId === fieldId && result.success)
+      )
+      .join(',');
+
     try {
       const configEntry = await getConfigEntry(cma);
       const connectedFields = configEntry.fields[CONFIG_FIELD_ID]?.[sdk.locales.default] || {};
@@ -95,13 +117,13 @@ const CreateFlow = (props: CreateFlowProps) => {
         {
           parameters: {
             entryId: entry.id,
-            fieldIds: Array.from(selectedFields).join(','),
-            contentBlockNames: JSON.stringify(data.names),
-            contentBlockDescriptions: JSON.stringify(data.descriptions),
+            fieldIds: fieldsIds,
+            contentBlockNames: JSON.stringify(names),
+            contentBlockDescriptions: JSON.stringify(descriptions),
           },
         }
       );
-      const responseData = JSON.parse(response.response.body);
+      const responseData: { results: CreationResultField[] } = JSON.parse(response.response.body);
 
       const newFields = responseData.results
         .filter((result: any) => result.success)
@@ -116,20 +138,27 @@ const CreateFlow = (props: CreateFlowProps) => {
 
       await updateConfig(configEntry, sdk.locales.default, connectedFields, cma);
 
-      setCreationResultFields(responseData.results);
+      const newCreationResultFields: CreationResultField[] = [
+        ...creationResultFields.filter(
+          (newResult: CreationResultField) =>
+            !responseData.results.some((oldResult) => oldResult.fieldId === newResult.fieldId)
+        ),
+        ...responseData.results,
+      ];
+      setCreationResultFields(newCreationResultFields);
 
       const errors = responseData.results.filter((result: any) => !result.success);
       if (errors.length > 0) {
-        setStep(ERROR_STEP);
-        setIsSubmitting(false);
+        if (!errors.some((error: any) => error.message?.includes(BRAZE_NAME_EXISTS_ERROR))) {
+          setStep(ERROR_STEP);
+        }
         return;
       }
 
-      setIsSubmitting(false);
       setStep(SUCCESS_STEP);
     } catch (error) {
-      // TODO: handle errors
-      console.error(error);
+      console.error('Error creating content blocks: ', error);
+    } finally {
       setIsSubmitting(false);
     }
   };
@@ -157,6 +186,7 @@ const CreateFlow = (props: CreateFlowProps) => {
           contentBlocksData={contentBlocksData}
           setContentBlocksData={setContentBlocksData}
           handleNextStep={handleCreate}
+          creationResultFields={creationResultFields}
         />
       )}
       {step === DRAFT_STEP && (

--- a/apps/braze/src/components/create/CreateStep.tsx
+++ b/apps/braze/src/components/create/CreateStep.tsx
@@ -11,12 +11,13 @@ import {
   FormControl,
   Textarea,
   Skeleton,
+  Icon,
 } from '@contentful/f36-components';
 import { Entry } from '../../fields/Entry';
 import WizardFooter from '../WizardFooter';
 import { useState, useEffect, Dispatch, SetStateAction } from 'react';
 import { editButton } from './CreateStep.styles';
-import { PencilSimple, Check } from '@phosphor-icons/react';
+import { PencilSimple, CheckCircle, Warning } from '@phosphor-icons/react';
 import tokens from '@contentful/f36-tokens';
 import CreateButton from './CreateButton';
 import { CreationResultField } from './CreateFlow';
@@ -45,7 +46,7 @@ type ContentBlockViewProps = {
   name: string;
   description: string;
   onEdit: () => void;
-  isDisabled?: boolean;
+  isCreated?: boolean;
   error?: string;
 };
 
@@ -61,7 +62,7 @@ type ContentBlockCardProps = {
   onCancel: () => void;
   onSave: (fieldId: string) => void;
   isNameValid: boolean;
-  isDisabled?: boolean;
+  isCreated?: boolean;
   error?: string;
 };
 
@@ -157,7 +158,7 @@ const ContentBlockView = ({
   name,
   description,
   onEdit,
-  isDisabled,
+  isCreated,
   error,
 }: ContentBlockViewProps) => {
   return (
@@ -169,9 +170,13 @@ const ContentBlockView = ({
         style={{ width: '100%' }}>
         <Stack spacing="spacingXs" flexDirection="column" alignItems="flex-start">
           <Text>Content Block name</Text>
-          <Text fontWeight="fontWeightDemiBold">{name}</Text>
+          <Flex alignItems="center" style={{ gap: tokens.spacing2Xs }}>
+            {isCreated && <Icon as={CheckCircle} variant="positive" size="tiny" />}
+            {error && <Icon as={Warning} variant="negative" size="tiny" />}
+            <Text fontWeight="fontWeightDemiBold">{name}</Text>
+          </Flex>
           {error && (
-            <Text fontColor="red600" fontSize="fontSizeS">
+            <Text as="span" fontColor="gray700" fontSize="fontSizeS">
               {error}
             </Text>
           )}
@@ -183,17 +188,7 @@ const ContentBlockView = ({
           </Stack>
         )}
       </Stack>
-      {isDisabled ? (
-        <IconButton
-          size="small"
-          variant="positive"
-          icon={<Check size={16} />}
-          aria-label="Content block created successfully"
-          className={editButton}
-          withTooltip
-          tooltipProps={{ content: 'Content block created successfully' }}
-        />
-      ) : (
+      {!isCreated && (
         <IconButton
           size="small"
           variant="secondary"
@@ -221,9 +216,9 @@ const ContentBlockCard = ({
   onCancel,
   onSave,
   isNameValid,
-  isDisabled,
+  isCreated,
   error,
-}: ContentBlockCardProps & { isDisabled?: boolean; error?: string }) => {
+}: ContentBlockCardProps & { isCreated?: boolean; error?: string }) => {
   return (
     <Card
       margin="none"
@@ -249,7 +244,7 @@ const ContentBlockCard = ({
           name={contentBlocksData.names[fieldId] || ''}
           description={contentBlocksData.descriptions[fieldId] || ''}
           onEdit={() => onEdit(fieldId)}
-          isDisabled={isDisabled}
+          isCreated={isCreated}
           error={error}
         />
       )}
@@ -367,7 +362,7 @@ const CreateStep = ({
               onCancel={handleCancel}
               onSave={handleSave}
               isNameValid={isNameValid}
-              isDisabled={creationResultFields.some(
+              isCreated={creationResultFields.some(
                 (result) => result.fieldId === fieldId && result.success
               )}
               error={creationResultFields.find((result) => result.fieldId === fieldId)?.message}

--- a/apps/braze/src/components/create/CreateStep.tsx
+++ b/apps/braze/src/components/create/CreateStep.tsx
@@ -17,7 +17,7 @@ import { Entry } from '../../fields/Entry';
 import WizardFooter from '../WizardFooter';
 import { useState, useEffect, Dispatch, SetStateAction } from 'react';
 import { editButton } from './CreateStep.styles';
-import { PencilSimple, CheckCircle, Warning } from '@phosphor-icons/react';
+import { PencilSimple, CheckCircle, WarningOctagon } from '@phosphor-icons/react';
 import tokens from '@contentful/f36-tokens';
 import CreateButton from './CreateButton';
 import { CreationResultField } from './CreateFlow';
@@ -172,11 +172,11 @@ const ContentBlockView = ({
           <Text>Content Block name</Text>
           <Flex alignItems="center" style={{ gap: tokens.spacing2Xs }}>
             {isCreated && <Icon as={CheckCircle} variant="positive" size="tiny" />}
-            {error && <Icon as={Warning} variant="negative" size="tiny" />}
-            <Text fontWeight="fontWeightDemiBold">{name}</Text>
+            {error && <Icon as={WarningOctagon} variant="negative" size="tiny" />}
+            <Text fontWeight="fontWeightMedium">{name}</Text>
           </Flex>
           {error && (
-            <Text as="span" fontColor="gray700" fontSize="fontSizeS">
+            <Text fontColor="red600" fontSize="fontSizeS">
               {error}
             </Text>
           )}
@@ -227,6 +227,7 @@ const ContentBlockCard = ({
         paddingBottom: tokens.spacingS,
         paddingLeft: tokens.spacingXs,
         paddingRight: tokens.spacingXs,
+        borderColor: error ? tokens.red600 : undefined,
       }}>
       {isEditing ? (
         <ContentBlockForm

--- a/apps/braze/src/components/create/ErrorStep.tsx
+++ b/apps/braze/src/components/create/ErrorStep.tsx
@@ -54,7 +54,7 @@ const ErrorStep = ({
         {serverErrors.map((field, index) => (
           <List.Item key={`${field.fieldId}-${index}`}>
             <Text fontWeight="fontWeightDemiBold">{field.fieldId}</Text> - error code{' '}
-            {field.statusCode} - {field.message} . Please retry sending to Braze.
+            {field.statusCode} - {field.message}. Please retry sending to Braze.
           </List.Item>
         ))}
         {clientErrors.map((field, index) => (

--- a/apps/braze/src/components/create/ErrorStep.tsx
+++ b/apps/braze/src/components/create/ErrorStep.tsx
@@ -1,8 +1,7 @@
-import { Stack, Button, Subheading, Text } from '@contentful/f36-components';
+import { Button, Subheading, Text, List } from '@contentful/f36-components';
 import WizardFooter from '../WizardFooter';
-import { styles } from './ErrorStep.styles';
 import { ContentBlockData, CreationResultField } from './CreateFlow';
-import React from 'react';
+import InformationWithLink from '../InformationWithLink';
 
 type ClientErrorStepProps = {
   isSubmitting: boolean;
@@ -19,6 +18,7 @@ const ErrorStep = ({
   handleClose,
   handleCreate,
 }: ClientErrorStepProps) => {
+  const createdFields = creationResultFields.filter((field) => field.success);
   const clientErrors = creationResultFields.filter(
     (field) => !field.success && field.statusCode !== 500
   );
@@ -47,20 +47,41 @@ const ErrorStep = ({
   return (
     <>
       <Subheading fontWeight="fontWeightDemiBold" fontSize="fontSizeXl" lineHeight="lineHeightL">
-        There was an issue
+        There was an issue with some Content Blocks
       </Subheading>
-      <Stack flexDirection="column" alignItems="flex-start" className={styles.stack}>
+      <Text>The following errors occurred:</Text>
+      <List>
         {serverErrors.map((field, index) => (
-          <Text key={`${field.fieldId}-${index}`}>
-            Error code [{field.statusCode}] - [{field.message}] . Please retry sending to Braze.
-          </Text>
+          <List.Item key={`${field.fieldId}-${index}`}>
+            <Text fontWeight="fontWeightDemiBold">{field.fieldId}</Text> - error code{' '}
+            {field.statusCode} - {field.message} . Please retry sending to Braze.
+          </List.Item>
         ))}
         {clientErrors.map((field, index) => (
-          <Text key={`${field.fieldId}-${index}`}>
-            Error code [{field.statusCode}] - [{field.message}]
-          </Text>
+          <List.Item key={`${field.fieldId}-${index}`}>
+            <Text fontWeight="fontWeightDemiBold">{field.fieldId}</Text> - error code{' '}
+            {field.statusCode} - {field.message}
+          </List.Item>
         ))}
-      </Stack>
+        {clientErrors.length > 0 && (
+          <List.Item>
+            <InformationWithLink
+              url={'https://support.contentful.com/hc/en-us'}
+              linkText="Get support here"
+              marginTop="spacing2Xs"
+              marginBottom="spacingL"
+            />
+          </List.Item>
+        )}
+      </List>
+      <Text>The following Content Blocks were created successfully:</Text>
+      <List>
+        {createdFields.map((field, index) => (
+          <List.Item key={`${field.fieldId}-${index}`}>
+            <Text fontWeight="fontWeightDemiBold">{field.fieldId}</Text>
+          </List.Item>
+        ))}
+      </List>
       <WizardFooter>
         {containsServerError ? (
           <Button isLoading={isSubmitting} variant="primary" size="small" onClick={handleRetry}>

--- a/apps/braze/test/components/create/CreateStep.spec.tsx
+++ b/apps/braze/test/components/create/CreateStep.spec.tsx
@@ -34,6 +34,7 @@ describe('CreateStep', () => {
         isSubmitting={false}
         handlePreviousStep={mockHandlePreviousStep}
         handleNextStep={mockHandleNextStep}
+        creationResultFields={[]}
         {...props}
       />
     );
@@ -120,6 +121,38 @@ describe('CreateStep', () => {
     it('returns the correct default name', () => {
       const defaultName = getDefaultContentBlockName(mockEntry, 'field1');
       expect(defaultName).toBe('Test-Entry-field1');
+    });
+  });
+
+  describe('when handling creation results', () => {
+    it('shows success state for successful fields and error message for failed fields', () => {
+      const creationResultFields = [
+        {
+          fieldId: 'field1',
+          success: true,
+          statusCode: 200,
+          message: '',
+        },
+        {
+          fieldId: 'field2',
+          success: false,
+          statusCode: 400,
+          message: 'Content Block name already exists',
+        },
+      ];
+
+      renderComponent({ creationResultFields });
+
+      const successIcon = screen.getAllByRole('button', {
+        name: 'Content block created successfully',
+      });
+      expect(successIcon).toHaveLength(1);
+
+      const errorMessage = screen.getByText('Content Block name already exists');
+      expect(errorMessage).toBeTruthy();
+
+      const editButtons = screen.getAllByRole('button', { name: /Edit content block/i });
+      expect(editButtons).toHaveLength(1);
     });
   });
 });

--- a/apps/braze/test/components/create/CreateStep.spec.tsx
+++ b/apps/braze/test/components/create/CreateStep.spec.tsx
@@ -125,7 +125,7 @@ describe('CreateStep', () => {
   });
 
   describe('when handling creation results', () => {
-    it('shows success state for successful fields and error message for failed fields', () => {
+    it('shows success state and error message for fields', () => {
       const creationResultFields = [
         {
           fieldId: 'field1',
@@ -142,11 +142,6 @@ describe('CreateStep', () => {
       ];
 
       renderComponent({ creationResultFields });
-
-      const successIcon = screen.getAllByRole('button', {
-        name: 'Content block created successfully',
-      });
-      expect(successIcon).toHaveLength(1);
 
       const errorMessage = screen.getByText('Content Block name already exists');
       expect(errorMessage).toBeTruthy();

--- a/apps/braze/test/functions/createContentBlocks.test.ts
+++ b/apps/braze/test/functions/createContentBlocks.test.ts
@@ -211,13 +211,13 @@ describe('createContentBlocks', () => {
           fieldId: 'title',
           success: false,
           statusCode: 400,
-          message: 'Field title not found or has no value',
+          message: 'Field title does not exist or is empty',
         },
         {
           fieldId: 'author',
           success: false,
           statusCode: 400,
-          message: 'Field author not found or has no value',
+          message: 'Field author does not exist or is empty',
         },
       ],
     });
@@ -431,7 +431,7 @@ describe('createContentBlocks', () => {
           fieldId: 'author',
           success: false,
           statusCode: 400,
-          message: 'Content block name not found or has no value for field author',
+          message: 'Unexpected error: Content block name not found for field author',
         },
       ],
     });

--- a/apps/braze/test/locations/Dialog.spec.tsx
+++ b/apps/braze/test/locations/Dialog.spec.tsx
@@ -209,17 +209,17 @@ describe('Dialog component', () => {
 
     await navigateToFinalStep();
 
-    await screen.findByText('There was an issue');
+    await screen.findByText('There was an issue with some Content Blocks');
 
     expect(
-      screen.getByText(
-        'Error code [400] - [Content block name not found or has no value for field name]'
-      )
+      screen.getByText('Content block name not found or has no value for field name', {
+        exact: false,
+      })
     ).toBeTruthy();
     expect(
-      screen.getByText(
-        'Error code [400] - [Content block name not found or has no value for field lastname]'
-      )
+      screen.getByText('Content block name not found or has no value for field lastname', {
+        exact: false,
+      })
     ).toBeTruthy();
   });
 
@@ -256,10 +256,11 @@ describe('Dialog component', () => {
 
     await navigateToFinalStep();
 
-    await screen.findByText('There was an issue');
+    await screen.findByText('There was an issue with some Content Blocks');
 
     const errorMessages = screen.getAllByText(
-      'Error code [500] - [Internal server error] . Please retry sending to Braze.'
+      'Internal server error. Please retry sending to Braze.',
+      { exact: false }
     );
     expect(errorMessages.length).toBeGreaterThan(0);
     errorMessages.forEach((message) => {
@@ -311,7 +312,7 @@ describe('Dialog component', () => {
 
     await navigateToFinalStep();
 
-    await screen.findByText('There was an issue');
+    await screen.findByText('There was an issue with some Content Blocks');
 
     const retryButton = screen.getByRole('button', { name: /retry/i });
     expect(retryButton).toBeTruthy();


### PR DESCRIPTION
## Purpose

If the chosen content block name for a field is already in use in Braze, the creation will fail. We now allow to edit the name and retry.

## Approach

Instead of going directly into the ErrorStep, we first check if any of the errors were caused by the name of the content block already existing in Braze. If that's the case, we return to the CreateStep showing the errors and allowing to edit the names for the content blocks.
The main change in the implementation is that now the `creationResultFields` **accumulates** all results instead of having only the results for the last call. That way we can now the status of all the selected fields.

If there are errors but none of them are from the name already existing, we do display the ErrorStep as we used to do.

## Testing steps

Try to create a content block using a name that already exists in Braze.

> [!WARNING]
> Some visual adjustements were donde after the recording of the video, see screenshots below for the final versions 

https://github.com/user-attachments/assets/b126ff73-a152-49e3-b794-61b762d9ad00

![image](https://github.com/user-attachments/assets/f830c4dd-4426-4f18-9edf-4553a34bf12d)
![image](https://github.com/user-attachments/assets/a3fd87cf-2395-4188-9a46-3dc0b2742cc7)