### PR TITLE
Braze app: Adding dropdown to config screen for Braze Endpoint [INTEG-2655]

### DIFF
--- a/apps/braze/src/locations/ConfigScreen.tsx
+++ b/apps/braze/src/locations/ConfigScreen.tsx
@@ -94,7 +94,7 @@ const ConfigScreen = () => {
 
     const isContentfulKeyValid = await checkContentfulApiKey(parameters.contentfulApiKey);
     const isBrazeKeyValid = checkIfHasValue(parameters.brazeApiKey, setBrazeApiKeyIsValid);
-    console.log('parameters.brazeEndpoint', parameters.brazeEndpoint);
+
     const isBrazeEndpointValid = checkIfHasValue(parameters.brazeEndpoint, setBrazeEndpointIsValid);
 
     if (!isContentfulKeyValid || !isBrazeKeyValid || !isBrazeEndpointValid) {
@@ -123,7 +123,6 @@ const ConfigScreen = () => {
   useEffect(() => {
     (async () => {
       const currentParameters: AppInstallationParameters | null = await sdk.app.getParameters();
-      console.log('currentParameters', currentParameters);
 
       if (currentParameters) {
         setParameters(currentParameters);

--- a/apps/braze/src/utils.ts
+++ b/apps/braze/src/utils.ts
@@ -30,8 +30,68 @@ export const BRAZE_APP_DOCUMENTATION = 'https://www.contentful.com/help/apps/bra
 export const BRAZE_API_KEY_DOCUMENTATION = `https://dashboard.braze.com/app_settings/developer_console/apisettings#apikeys`;
 export const BRAZE_CONTENT_BLOCK_DOCUMENTATION =
   'https://www.braze.com/docs/api/endpoints/templates/content_blocks_templates/post_create_email_content_block';
-export const BRAZE_ENDPOINTS_LIST =
+export const BRAZE_ENDPOINTS_DOCUMENTATION =
   'https://www.braze.com/docs/api/basics#braze-rest-api-collection';
+
+export type BrazeEndpoint = {
+  name: string;
+  url: string;
+};
+
+export const BRAZE_ENDPOINTS: BrazeEndpoint[] = [
+  {
+    name: 'rest.iad-01.braze.com',
+    url: 'https://rest.iad-01.braze.com',
+  },
+  {
+    name: 'rest.iad-02.braze.com',
+    url: 'https://rest.iad-02.braze.com',
+  },
+  {
+    name: 'rest.iad-03.braze.com',
+    url: 'https://rest.iad-03.braze.com',
+  },
+  {
+    name: 'rest.iad-04.braze.com',
+    url: 'https://rest.iad-04.braze.com',
+  },
+  {
+    name: 'rest.iad-05.braze.com',
+    url: 'https://rest.iad-05.braze.com',
+  },
+  {
+    name: 'rest.iad-06.braze.com',
+    url: 'https://rest.iad-06.braze.com',
+  },
+  {
+    name: 'rest.iad-07.braze.com',
+    url: 'https://rest.iad-07.braze.com',
+  },
+  {
+    name: 'rest.iad-08.braze.com',
+    url: 'https://rest.iad-08.braze.com',
+  },
+  {
+    name: 'rest.us-10.braze.com',
+    url: 'https://rest.us-10.braze.com',
+  },
+  {
+    name: 'rest.fra-01.braze.eu',
+    url: 'https://rest.fra-01.braze.eu',
+  },
+  {
+    name: 'rest.fra-02.braze.eu',
+    url: 'https://rest.fra-02.braze.eu',
+  },
+  {
+    name: 'rest.au-01.braze.com',
+    url: 'https://rest.au-01.braze.com',
+  },
+  {
+    name: 'rest.id-01.braze.com',
+    url: 'https://rest.id-01.braze.com',
+  },
+];
 
 export const CONFIG_CONTENT_TYPE_ID = 'brazeConfig';
 export const CONFIG_FIELD_ID = 'connectedFields';

--- a/apps/braze/test/locations/ConfigScreen.spec.tsx
+++ b/apps/braze/test/locations/ConfigScreen.spec.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { cleanup, fireEvent, render, RenderResult, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mockSdk } from '../mocks';
@@ -12,7 +13,6 @@ import {
   BRAZE_ENDPOINTS,
   CONTENT_TYPE_DOCUMENTATION,
 } from '../../src/utils';
-import React from 'react';
 
 const mockCma = {
   contentType: {
@@ -132,15 +132,20 @@ describe('Config Screen component', () => {
       const contentfulApiKeyInput = screen.getAllByTestId('contentfulApiKey')[0];
       const brazeApiKeyInput = screen.getAllByTestId('brazeApiKey')[0];
       const brazeEndpointInput = screen.getByPlaceholderText('ex. rest.iad-01.braze.com');
+
       await user.type(contentfulApiKeyInput, 'valid-api-key-123');
       await user.type(brazeApiKeyInput, 'valid-api-key-321');
-      await user.type(brazeEndpointInput, BRAZE_ENDPOINTS[0].url);
+
+      // Simulate selecting an item from the Autocomplete
+      fireEvent.change(brazeEndpointInput, { target: { value: BRAZE_ENDPOINTS[0].name } });
+      const menuItem = screen.getByText(BRAZE_ENDPOINTS[0].name);
+      fireEvent.click(menuItem);
+
       vi.spyOn(window, 'fetch').mockImplementationOnce((): any => {
         return { ok: true, status: 200 };
       });
 
       const result = await saveAppInstallation();
-      console.log('result', result);
 
       expect(result).toEqual({
         parameters: {
@@ -205,12 +210,20 @@ describe('Config Screen component', () => {
       const contentfulApiKeyInput = screen.getAllByTestId('contentfulApiKey')[0];
       const brazeApiKeyInput = screen.getAllByTestId('brazeApiKey')[0];
       const brazeEndpointInput = screen.getByPlaceholderText('ex. rest.iad-01.braze.com');
+
       await user.type(contentfulApiKeyInput, 'valid-api-key-123');
       await user.type(brazeApiKeyInput, 'valid-api-key-321');
-      await user.type(brazeEndpointInput, BRAZE_ENDPOINTS[0].url);
+
+      // Simulate selecting an item from the Autocomplete
+      fireEvent.change(brazeEndpointInput, { target: { value: BRAZE_ENDPOINTS[0].name } });
+      const menuItem = screen.getByText(BRAZE_ENDPOINTS[0].name);
+      fireEvent.click(menuItem);
+
       vi.spyOn(window, 'fetch').mockImplementationOnce((): any => {
         return { ok: true, status: 200 };
       });
+
+      // Mock contentType.get to throw an error to trigger content type creation
       mockCma.contentType.get.mockRejectedValueOnce(new Error('Content type not found'));
 
       await saveAppInstallation();

--- a/apps/braze/test/locations/ConfigScreen.spec.tsx
+++ b/apps/braze/test/locations/ConfigScreen.spec.tsx
@@ -8,7 +8,8 @@ import {
   BRAZE_API_KEY_DOCUMENTATION,
   BRAZE_APP_DOCUMENTATION,
   BRAZE_CONTENT_BLOCK_DOCUMENTATION,
-  BRAZE_ENDPOINTS_LIST,
+  BRAZE_ENDPOINTS_DOCUMENTATION,
+  BRAZE_ENDPOINTS,
   CONTENT_TYPE_DOCUMENTATION,
 } from '../../src/utils';
 import React from 'react';
@@ -98,7 +99,7 @@ describe('Config Screen component', () => {
       const brazeLink = configScreen.getByTestId('link-rest-endpoints-here');
 
       expect(brazeLink).toBeTruthy();
-      expect(brazeLink.closest('a')?.getAttribute('href')).toBe(BRAZE_ENDPOINTS_LIST);
+      expect(brazeLink.closest('a')?.getAttribute('href')).toBe(BRAZE_ENDPOINTS_DOCUMENTATION);
     });
 
     it('has an input that sets contentful api key correctly', () => {
@@ -111,24 +112,17 @@ describe('Config Screen component', () => {
       expect(inputExpected.value).toEqual(`A test value for input`);
     });
 
-    it('has an input that sets braze api key correctly', () => {
-      const input = screen.getAllByTestId('brazeApiKey')[0];
+    it('has an input that sets braze rest endpoint key correctly', async () => {
+      const input = screen.getByPlaceholderText('ex. rest.iad-01.braze.com');
       fireEvent.change(input, {
-        target: { value: `A test value for input` },
+        target: { value: BRAZE_ENDPOINTS[0].url },
       });
 
-      const inputExpected = screen.getAllByTestId('brazeApiKey')[0] as HTMLInputElement;
-      expect(inputExpected.value).toEqual(`A test value for input`);
-    });
+      const inputExpected = screen.getByPlaceholderText(
+        'ex. rest.iad-01.braze.com'
+      ) as HTMLInputElement;
 
-    it('has an input that sets braze rest endpoint key correctly', () => {
-      const input = screen.getAllByTestId('brazeEndpoint')[0];
-      fireEvent.change(input, {
-        target: { value: `A test value for input` },
-      });
-
-      const inputExpected = screen.getAllByTestId('brazeEndpoint')[0] as HTMLInputElement;
-      expect(inputExpected.value).toEqual(`A test value for input`);
+      expect(inputExpected.value).toEqual(BRAZE_ENDPOINTS[0].url);
     });
   });
 
@@ -137,21 +131,22 @@ describe('Config Screen component', () => {
       const user = userEvent.setup();
       const contentfulApiKeyInput = screen.getAllByTestId('contentfulApiKey')[0];
       const brazeApiKeyInput = screen.getAllByTestId('brazeApiKey')[0];
-      const brazeEndpointInput = screen.getAllByTestId('brazeEndpoint')[0];
+      const brazeEndpointInput = screen.getByPlaceholderText('ex. rest.iad-01.braze.com');
       await user.type(contentfulApiKeyInput, 'valid-api-key-123');
       await user.type(brazeApiKeyInput, 'valid-api-key-321');
-      await user.type(brazeEndpointInput, 'valid-rest-endpoint-132');
+      await user.type(brazeEndpointInput, BRAZE_ENDPOINTS[0].url);
       vi.spyOn(window, 'fetch').mockImplementationOnce((): any => {
         return { ok: true, status: 200 };
       });
 
       const result = await saveAppInstallation();
+      console.log('result', result);
 
       expect(result).toEqual({
         parameters: {
           contentfulApiKey: 'valid-api-key-123',
           brazeApiKey: 'valid-api-key-321',
-          brazeEndpoint: 'valid-rest-endpoint-132',
+          brazeEndpoint: BRAZE_ENDPOINTS[0].url,
         },
       });
     });
@@ -159,7 +154,7 @@ describe('Config Screen component', () => {
     it('shows a toast error if the contentful api key is not set or invalid', async () => {
       const user = userEvent.setup();
       const contentfulApiKeyInput = screen.getAllByTestId('contentfulApiKey')[0];
-      const brazeEndpointInput = screen.getAllByTestId('brazeEndpoint')[0];
+      const brazeEndpointInput = screen.getByPlaceholderText('ex. rest.iad-01.braze.com');
       const brazeApiKeyInput = screen.getAllByTestId('brazeApiKey')[0];
       await user.type(brazeEndpointInput, 'valid-rest-endpoint-123');
       await user.type(brazeApiKeyInput, 'valid-api-key-123');
@@ -176,7 +171,7 @@ describe('Config Screen component', () => {
     it('shows a toast error if the braze api key is not set', async () => {
       const user = userEvent.setup();
       const contentfulApiKeyInput = screen.getAllByTestId('contentfulApiKey')[0];
-      const brazeEndpointInput = screen.getAllByTestId('brazeEndpoint')[0];
+      const brazeEndpointInput = screen.getByPlaceholderText('ex. rest.iad-01.braze.com');
       await user.type(contentfulApiKeyInput, 'valid-api-key-123');
       await user.type(brazeEndpointInput, 'valid-rest-endpoint-123');
       vi.spyOn(window, 'fetch').mockImplementationOnce((): any => {
@@ -209,10 +204,10 @@ describe('Config Screen component', () => {
       const user = userEvent.setup();
       const contentfulApiKeyInput = screen.getAllByTestId('contentfulApiKey')[0];
       const brazeApiKeyInput = screen.getAllByTestId('brazeApiKey')[0];
-      const brazeEndpointInput = screen.getAllByTestId('brazeEndpoint')[0];
+      const brazeEndpointInput = screen.getByPlaceholderText('ex. rest.iad-01.braze.com');
       await user.type(contentfulApiKeyInput, 'valid-api-key-123');
       await user.type(brazeApiKeyInput, 'valid-api-key-321');
-      await user.type(brazeEndpointInput, 'valid-rest-endpoint-132');
+      await user.type(brazeEndpointInput, BRAZE_ENDPOINTS[0].url);
       vi.spyOn(window, 'fetch').mockImplementationOnce((): any => {
         return { ok: true, status: 200 };
       });
@@ -229,10 +224,10 @@ describe('Config Screen component', () => {
       const user = userEvent.setup();
       const contentfulApiKeyInput = screen.getAllByTestId('contentfulApiKey')[0];
       const brazeApiKeyInput = screen.getAllByTestId('brazeApiKey')[0];
-      const brazeEndpointInput = screen.getAllByTestId('brazeEndpoint')[0];
+      const brazeEndpointInput = screen.getByPlaceholderText('ex. rest.iad-01.braze.com');
       await user.type(contentfulApiKeyInput, 'valid-api-key-123');
       await user.type(brazeApiKeyInput, 'valid-api-key-321');
-      await user.type(brazeEndpointInput, 'valid-rest-endpoint-132');
+      await user.type(brazeEndpointInput, BRAZE_ENDPOINTS[0].url);
       vi.spyOn(window, 'fetch').mockImplementationOnce((): any => {
         return { ok: true, status: 200 };
       });

--- a/apps/braze/test/mocks/mockSdk.ts
+++ b/apps/braze/test/mocks/mockSdk.ts
@@ -1,5 +1,5 @@
 import { vi } from 'vitest';
-import { BRAZE_ENDPOINTS_LIST } from '../../src/utils';
+import { BRAZE_ENDPOINTS } from '../../src/utils';
 
 const mockSdk: any = {
   app: {
@@ -20,7 +20,7 @@ const mockSdk: any = {
     installation: {
       contentfulApiKey: 'test-contentful-apiKey',
       brazeApiKey: 'test-braze-apiKey',
-      brazeEndpoint: BRAZE_ENDPOINTS_LIST[0],
+      brazeEndpoint: BRAZE_ENDPOINTS[0].url,
     },
     invocation: {
       id: 'test-entryId',


### PR DESCRIPTION
## Purpose

Add dropdown to braze endpoint to avoid user error in config screen

## Approach

- Added Autocomplete component to Config screen
- Added list of braze endpoints
- Refactor tests to use the endpoint

## Testing steps
When an app is installed and has to update

https://github.com/user-attachments/assets/8d22cd7e-d49b-40ce-83ed-5915ce1c4271

When app is not installed

https://github.com/user-attachments/assets/a02480f8-a804-426d-a093-1ced826f8fec

When app is missing every config parameter

https://github.com/user-attachments/assets/ad1622ec-a456-41c3-b9f2-cc086419ead0

