### PR TITLE
Braze app: Fixing dialog multiselect height [INTEG-2617]

### DIFF
--- a/apps/braze/src/components/create/FieldsStep.tsx
+++ b/apps/braze/src/components/create/FieldsStep.tsx
@@ -4,6 +4,7 @@ import { Entry } from '../../fields/Entry';
 import WizardFooter from '../WizardFooter';
 import React from 'react';
 import { Field } from '../../fields/Field';
+import { MULTISELECT_DIALOG_HEIGHT } from '../../utils';
 
 type FieldsStepProps = {
   entry: Entry;
@@ -57,11 +58,14 @@ const FieldsStep = ({
         Select the fields you would like to generate into Content Blocks. Referenced fields are not
         available in this list, but can be linked directly through the entry.
       </Paragraph>
-      <FormControl isRequired isInvalid={setSelectedFields.length === 0} marginBottom="spacing4Xl">
+      <FormControl
+        isRequired
+        isInvalid={setSelectedFields.length === 0}
+        style={{ marginBottom: '7rem' }}>
         <FormControl.Label>Select Fields</FormControl.Label>
         <Multiselect
           currentSelection={currentSelection}
-          popoverProps={{ isFullWidth: true, listMaxHeight: 108 }}
+          popoverProps={{ isFullWidth: true, listMaxHeight: MULTISELECT_DIALOG_HEIGHT }}
           placeholder="Select one or more">
           <Multiselect.SelectAll
             onSelectItem={handleSelectAll}

--- a/apps/braze/src/components/generate/LocalesSelectionStep.tsx
+++ b/apps/braze/src/components/generate/LocalesSelectionStep.tsx
@@ -1,7 +1,8 @@
-import { Button, FormControl, Paragraph } from '@contentful/f36-components';
+import { Box, Button, FormControl, Paragraph } from '@contentful/f36-components';
 import { Multiselect } from '@contentful/f36-multiselect';
 import { Dispatch, SetStateAction } from 'react';
 import WizardFooter from '../WizardFooter';
+import { MULTISELECT_DIALOG_HEIGHT } from '../../utils';
 
 type LocalesSelectionStepProps = {
   locales: string[];
@@ -30,12 +31,14 @@ const LocalesSelectionStep = (props: LocalesSelectionStepProps) => {
         Select the locales you want to reference in Braze messages.
       </Paragraph>
 
-      <FormControl isRequired isInvalid={selectedLocales.length === 0} marginBottom="spacing4Xl">
+      <FormControl
+        isRequired
+        isInvalid={selectedLocales.length === 0}
+        style={{ marginBottom: '7rem' }}>
         <FormControl.Label>Locales</FormControl.Label>
-
         <Multiselect
           currentSelection={selectedLocales}
-          popoverProps={{ isFullWidth: true, listMaxHeight: 108 }}
+          popoverProps={{ isFullWidth: true, listMaxHeight: MULTISELECT_DIALOG_HEIGHT }}
           placeholder="Select one or more">
           {locales.map((local) => {
             const val = local.toLowerCase().replace(/\s/g, '-');

--- a/apps/braze/src/utils.ts
+++ b/apps/braze/src/utils.ts
@@ -37,6 +37,8 @@ export const CONFIG_CONTENT_TYPE_ID = 'brazeConfig';
 export const CONFIG_FIELD_ID = 'connectedFields';
 export const CONFIG_ENTRY_ID = 'brazeConfig';
 
+export const MULTISELECT_DIALOG_HEIGHT = 144;
+
 export enum EntryStatus {
   Draft = 'DRAFT',
   Changed = 'CHANGED',


### PR DESCRIPTION
## Purpose

Fixing dialog multiselect height so it shows more options

## Approach
As we can't get out-of-bounds the dialog, we want to at least show more options when opening the multiselect for the user

## Testing steps

Befo
<img width="695" alt="Captura de pantalla 2025-05-20 a la(s) 11 47 04 a  m" src="https://github.com/user-attachments/assets/a5706e96-bfb7-40f3-914f-bb2642da1973" />
re:
<img width="767" alt="Captura de pantalla 2025-05-20 a la(s) 11 46 49 a  m" src="https://github.com/user-attachments/assets/0289ed7e-3bb9-4464-873f-ec8a0a5f3ce9" />

After:

https://github.com/user-attachments/assets/131e8b06-3c57-4fc0-a0e3-8f386dda2158



## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
