### PR TITLE
Braze: Fixes in error handling [INTEG-2540]

### DIFF
--- a/apps/braze/functions/createContentBlocks.ts
+++ b/apps/braze/functions/createContentBlocks.ts
@@ -73,7 +73,7 @@ export const handler: FunctionEventHandler<
       results.push({
         fieldId,
         success: false,
-        statusCode: 400,
+        statusCode: 600,
         message: `Field ${fieldId} does not exist or is empty`,
       });
       continue;

--- a/apps/braze/src/components/create/CreateFlow.tsx
+++ b/apps/braze/src/components/create/CreateFlow.tsx
@@ -148,11 +148,10 @@ const CreateFlow = (props: CreateFlowProps) => {
       setCreationResultFields(newCreationResultFields);
 
       const errors = responseData.results.filter((result: any) => !result.success);
-      if (
-        errors.length > 0 &&
-        !errors.some((error: any) => error.message?.includes(BRAZE_NAME_EXISTS_ERROR))
-      ) {
-        setStep(ERROR_STEP);
+      if (errors.length > 0) {
+        if (!errors.some((error: any) => error.message?.includes(BRAZE_NAME_EXISTS_ERROR))) {
+          setStep(ERROR_STEP);
+        }
         return;
       }
 

--- a/apps/braze/src/components/create/ErrorStep.tsx
+++ b/apps/braze/src/components/create/ErrorStep.tsx
@@ -19,11 +19,14 @@ const ErrorStep = ({
   handleCreate,
 }: ClientErrorStepProps) => {
   const createdFields = creationResultFields.filter((field) => field.success);
-  const clientErrors = creationResultFields.filter(
-    (field) => !field.success && field.statusCode !== 500
+  const customerErrors = creationResultFields.filter(
+    (field) => !field.success && field.statusCode === 600
   );
   const serverErrors = creationResultFields.filter(
     (field) => !field.success && field.statusCode === 500
+  );
+  const clientErrors = creationResultFields.filter(
+    (field) => !field.success && field.statusCode !== 500 && field.statusCode !== 600
   );
   const correctlyCreatedFields = creationResultFields.filter((field) => field.success);
   const containsServerError = serverErrors.length > 0;
@@ -51,6 +54,12 @@ const ErrorStep = ({
       </Subheading>
       <Text>The following errors occurred:</Text>
       <List>
+        {customerErrors.map((field, index) => (
+          <List.Item key={`${field.fieldId}-${index}`}>
+            <Text fontWeight="fontWeightDemiBold">{field.fieldId}</Text> - error code{' '}
+            {field.statusCode} - {field.message}. Please fix the errors and retry sending to Braze.
+          </List.Item>
+        ))}
         {serverErrors.map((field, index) => (
           <List.Item key={`${field.fieldId}-${index}`}>
             <Text fontWeight="fontWeightDemiBold">{field.fieldId}</Text> - error code{' '}
@@ -69,19 +78,25 @@ const ErrorStep = ({
               url={'https://support.contentful.com/hc/en-us'}
               linkText="Get support here"
               marginTop="spacing2Xs"
-              marginBottom="spacingL"
             />
           </List.Item>
         )}
       </List>
-      <Text>The following Content Blocks were created successfully:</Text>
-      <List>
-        {createdFields.map((field, index) => (
-          <List.Item key={`${field.fieldId}-${index}`}>
-            <Text fontWeight="fontWeightDemiBold">{field.fieldId}</Text>
-          </List.Item>
-        ))}
-      </List>
+      {createdFields.length > 0 && (
+        <>
+          <br />
+          <Text>The following Content Blocks were created successfully:</Text>
+          <List>
+            {createdFields.map((field, index) => (
+              <List.Item key={`${field.fieldId}-${index}`}>
+                <Text fontWeight="fontWeightDemiBold">
+                  {contentBlocksData.names[field.fieldId]}
+                </Text>
+              </List.Item>
+            ))}
+          </List>
+        </>
+      )}
       <WizardFooter>
         {containsServerError ? (
           <Button isLoading={isSubmitting} variant="primary" size="small" onClick={handleRetry}>


### PR DESCRIPTION
## Purpose

- Differentiate between customer errors (e.g. when a field is empty, we don't even call Braze in that case) and client errors (when we call Braze and get a 4xx error). In the first one we don't want to show the "get support" link.
- Small fix in the `CreateFlow` file: if errors had happened there were cases in which we would still go to the "success step".
- Only display the "Content Blocks were successfully created" in the error step if that's the case (we when displaying it in all cases).
- Use content block name instead of field name in the error step when displaying correctly created content blocks