### PR TITLE
Braze: Page view connected entries table [INTEG-2547] 

### DIFF
--- a/apps/braze/.gitignore
+++ b/apps/braze/.gitignore
@@ -12,6 +12,9 @@
 .env.*
 !.env*.example
 
+# cursor rules
+/.cursor
+
 # misc
 .DS_Store
 

--- a/apps/braze/src/components/create/CreateFlow.tsx
+++ b/apps/braze/src/components/create/CreateFlow.tsx
@@ -41,10 +41,12 @@ export type CreationResultField = {
   message: string;
 };
 
-export type EntryConnectedFields = {
+export type EntryConnectedField = {
   fieldId: string;
   contentBlockId: string;
-}[];
+};
+
+export type EntryConnectedFields = EntryConnectedField[];
 
 export type ConnectedFields = {
   [entryId: string]: EntryConnectedFields;

--- a/apps/braze/src/fields/Entry.ts
+++ b/apps/braze/src/fields/Entry.ts
@@ -10,6 +10,7 @@ export class Entry {
   private spaceId: string;
   private environment: string;
   private contentfulToken: string;
+  public updatedAt: string | undefined;
   public state: EntryStatus;
   constructor(
     id: string,
@@ -29,6 +30,7 @@ export class Entry {
     this.spaceId = spaceId;
     this.environment = environment;
     this.contentfulToken = contentfulToken;
+    this.updatedAt = updatedAt;
     this.state = this.getEntryState(publishedAt, updatedAt);
   }
 
@@ -41,6 +43,7 @@ export class Entry {
       serializedEntry['spaceId'],
       serializedEntry['environment'],
       serializedEntry['contentfulToken'],
+      serializedEntry['updatedAt'],
       serializedEntry['state']
     );
   }
@@ -54,6 +57,7 @@ export class Entry {
       spaceId: this.spaceId,
       environment: this.environment,
       contentfulToken: this.contentfulToken,
+      updatedAt: this.updatedAt,
       state: this.state,
     };
   }

--- a/apps/braze/src/fields/FieldsFactory.ts
+++ b/apps/braze/src/fields/FieldsFactory.ts
@@ -45,8 +45,12 @@ export class FieldsFactory {
     }
 
     const fields = [];
-    // const newContentType = entryFields.map((field) => {})
-    for (const fieldInfo of contentType.fields) {
+    const entryFieldIds = entryFields.map((field: any) => field.fieldId);
+    const newContentTypeFields = contentType.fields.filter((field) =>
+      entryFieldIds.includes(field.id)
+    );
+    console.log('NEW CONTENT TYPE: ', newContentTypeFields);
+    for (const fieldInfo of newContentTypeFields) {
       fields.push(this.createSimpleField(fieldInfo, contentType));
     }
     return fields;

--- a/apps/braze/src/fields/FieldsFactory.ts
+++ b/apps/braze/src/fields/FieldsFactory.ts
@@ -35,21 +35,16 @@ export class FieldsFactory {
     return resolveResponse(response)[0];
   }
 
-  public async createFieldsForEntryLALALA(
-    entryFields: any,
-    contentType?: ContentTypeProps
-  ): Promise<any> {
-    if (!contentType) {
-      contentType = await this.getContentType(this.entryContentTypeId);
-    }
+  public async createFieldsForConnectedFields(connectedFieldsIds: string[]): Promise<any> {
+    // Connected entries do not have referece fields, so we can skip the nested depth check
+    const contentType = await this.getContentType(this.entryContentTypeId);
 
     const fields = [];
-    const entryFieldIds = entryFields.map((field: any) => field.fieldId);
-    const newContentTypeFields = contentType.fields.filter((field) =>
-      entryFieldIds.includes(field.id)
-    );
-    for (const fieldInfo of newContentTypeFields) {
-      fields.push(this.createSimpleField(fieldInfo, contentType));
+    for (const field of contentType.fields) {
+      // We also need to filter the fields that are connected to the entry
+      if (connectedFieldsIds.includes(field.id)) {
+        fields.push(this.createSimpleField(field, contentType));
+      }
     }
     return { title: contentType.displayField, fields };
   }

--- a/apps/braze/src/fields/FieldsFactory.ts
+++ b/apps/braze/src/fields/FieldsFactory.ts
@@ -112,6 +112,7 @@ export class FieldsFactory {
     contentType: ContentTypeProps,
     currentDepth: number
   ): Promise<ReferenceField> {
+    console.log('FIELD VALUE: ', fieldValue);
     const fieldContentType = await this.getContentType(fieldValue.sys.contentType.sys.id);
     const title = !!fieldContentType.displayField
       ? Object.values(fieldValue.fields[fieldContentType.displayField] as { [key: string]: any })[0]

--- a/apps/braze/src/fields/FieldsFactory.ts
+++ b/apps/braze/src/fields/FieldsFactory.ts
@@ -35,6 +35,23 @@ export class FieldsFactory {
     return resolveResponse(response)[0];
   }
 
+  public async createFieldsForEntryLALALA(
+    entryFields: any,
+    contentType?: ContentTypeProps,
+    currentDepth: number = 1
+  ): Promise<Field[]> {
+    if (!contentType) {
+      contentType = await this.getContentType(this.entryContentTypeId);
+    }
+
+    const fields = [];
+    // const newContentType = entryFields.map((field) => {})
+    for (const fieldInfo of contentType.fields) {
+      fields.push(this.createSimpleField(fieldInfo, contentType));
+    }
+    return fields;
+  }
+
   public async createFieldsForEntry(
     entryFields: any,
     contentType?: ContentTypeProps,

--- a/apps/braze/src/fields/FieldsFactory.ts
+++ b/apps/braze/src/fields/FieldsFactory.ts
@@ -48,7 +48,6 @@ export class FieldsFactory {
     const newContentTypeFields = contentType.fields.filter((field) =>
       entryFieldIds.includes(field.id)
     );
-    console.log('NEW CONTENT TYPE: ', newContentTypeFields);
     for (const fieldInfo of newContentTypeFields) {
       fields.push(this.createSimpleField(fieldInfo, contentType));
     }
@@ -132,7 +131,6 @@ export class FieldsFactory {
     contentType: ContentTypeProps,
     currentDepth: number
   ): Promise<ReferenceField> {
-    console.log('FIELD VALUE: ', fieldValue);
     const fieldContentType = await this.getContentType(fieldValue.sys.contentType.sys.id);
     const title = !!fieldContentType.displayField
       ? Object.values(fieldValue.fields[fieldContentType.displayField] as { [key: string]: any })[0]

--- a/apps/braze/src/fields/FieldsFactory.ts
+++ b/apps/braze/src/fields/FieldsFactory.ts
@@ -37,9 +37,8 @@ export class FieldsFactory {
 
   public async createFieldsForEntryLALALA(
     entryFields: any,
-    contentType?: ContentTypeProps,
-    currentDepth: number = 1
-  ): Promise<Field[]> {
+    contentType?: ContentTypeProps
+  ): Promise<any> {
     if (!contentType) {
       contentType = await this.getContentType(this.entryContentTypeId);
     }
@@ -53,7 +52,7 @@ export class FieldsFactory {
     for (const fieldInfo of newContentTypeFields) {
       fields.push(this.createSimpleField(fieldInfo, contentType));
     }
-    return fields;
+    return { title: contentType.displayField, fields };
   }
 
   public async createFieldsForEntry(

--- a/apps/braze/src/locations/Page.styles.ts
+++ b/apps/braze/src/locations/Page.styles.ts
@@ -4,15 +4,18 @@ import { css } from 'emotion';
 export const styles = {
   container: css({
     background: tokens.colorWhite,
-    height: 'auto',
-    boxShadow: tokens.boxShadowDefault,
-    minHeight: '40vh',
+    minHeight: '100vh',
+    height: '100vh',
+    width: '100%',
     border: `1px solid ${tokens.gray300}`,
     borderRadius: tokens.borderRadiusMedium,
-    width: '100%',
   }),
   subheading: css({
     margin: 0,
     fontSize: tokens.fontSizeM,
+  }),
+  emptyComponentContainer: css({ minHeight: '80vh' }),
+  buttonCell: css({
+    width: '6rem',
   }),
 };

--- a/apps/braze/src/locations/Page.styles.ts
+++ b/apps/braze/src/locations/Page.styles.ts
@@ -5,7 +5,6 @@ export const styles = {
   container: css({
     background: tokens.colorWhite,
     minHeight: '100vh',
-    height: '100vh',
     width: '100%',
     border: `1px solid ${tokens.gray300}`,
     borderRadius: tokens.borderRadiusMedium,
@@ -17,5 +16,8 @@ export const styles = {
   emptyComponentContainer: css({ minHeight: '80vh' }),
   buttonCell: css({
     width: '6rem',
+  }),
+  loading: css({
+    height: '80vh',
   }),
 };

--- a/apps/braze/src/locations/Page.styles.ts
+++ b/apps/braze/src/locations/Page.styles.ts
@@ -3,6 +3,7 @@ import { css } from 'emotion';
 
 export const styles = {
   container: css({
+    background: tokens.colorWhite,
     height: 'auto',
     boxShadow: tokens.boxShadowDefault,
     minHeight: '40vh',

--- a/apps/braze/src/locations/Page.styles.ts
+++ b/apps/braze/src/locations/Page.styles.ts
@@ -1,0 +1,17 @@
+import tokens from '@contentful/f36-tokens';
+import { css } from 'emotion';
+
+export const styles = {
+  container: css({
+    height: 'auto',
+    boxShadow: tokens.boxShadowDefault,
+    minHeight: '40vh',
+    border: `1px solid ${tokens.gray300}`,
+    borderRadius: tokens.borderRadiusMedium,
+    width: '100%',
+  }),
+  subheading: css({
+    margin: 0,
+    fontSize: tokens.fontSizeM,
+  }),
+};

--- a/apps/braze/src/locations/Page.tsx
+++ b/apps/braze/src/locations/Page.tsx
@@ -30,7 +30,10 @@ const getStatusBadge = (status: string) => {
   return <Badge variant="warning">Draft</Badge>;
 };
 
-const getUpdatedLabel = (dateString: string) => {
+const getUpdatedLabel = (dateString: string | undefined) => {
+  if (!dateString) {
+    return '-';
+  }
   const date = new Date(dateString);
   const now = new Date();
   const diffMs = now.getTime() - date.getTime();
@@ -69,7 +72,12 @@ const Page = () => {
   useEffect(() => {
     setLoading(true);
     setError(null);
-    fetchBrazeConnectedEntries(cma, sdk.ids.space, sdk.ids.environment || 'master')
+    fetchBrazeConnectedEntries(
+      cma,
+      sdk.parameters?.installation?.contentfulApiKey,
+      sdk.ids.space,
+      sdk.ids.environment || 'master'
+    )
       .then((entries) => {
         setEntries(entries);
         setLoading(false);
@@ -107,13 +115,13 @@ const Page = () => {
                 <Text marginLeft="spacingM">Loading...</Text>
               </Flex>
             ) : error ? (
-              <Box marginBottom="spacingL">
+              <Box marginTop="spacingL">
                 <Note variant="negative" title="Error">
                   {error}
                 </Note>
               </Box>
             ) : entries.length === 0 ? (
-              <Box marginBottom="spacingL">
+              <Box marginTop="spacingL">
                 <Note variant="warning" title="No connected entries">
                   There are no entries connected to Braze Content Blocks.
                 </Note>
@@ -142,7 +150,7 @@ const Page = () => {
                       const contentType = entry.contentType;
                       const updated = getUpdatedLabel(entry.updatedAt);
                       const status = entry.state;
-                      const connectedCount = getConnectedFieldsCount(entry.fields); // Todo : this are not the real connected fields
+                      const connectedCount = getConnectedFieldsCount(entry.fields);
                       return (
                         <Table.Row key={entry.id}>
                           <Table.Cell>{name}</Table.Cell>

--- a/apps/braze/src/locations/Page.tsx
+++ b/apps/braze/src/locations/Page.tsx
@@ -1,15 +1,174 @@
-import React from 'react';
-import { Paragraph, Box } from '@contentful/f36-components';
-import { /* useCMA, */ useSDK } from '@contentful/react-apps-toolkit';
+import React, { useEffect, useState } from 'react';
+import {
+  Paragraph,
+  Box,
+  Table,
+  Text,
+  Badge,
+  Spinner,
+  Button,
+  Note,
+  Flex,
+  Heading,
+  Subheading,
+} from '@contentful/f36-components';
+import { useSDK } from '@contentful/react-apps-toolkit';
 import { PageAppSDK } from '@contentful/app-sdk';
+import { fetchBrazeConnectedEntries } from '../utils/fetchBrazeConnectedEntries';
+import InformationWithLink from '../components/InformationWithLink';
+import { styles } from './Page.styles';
+import Splitter from '../components/Splitter';
+import { createClient } from 'contentful-management';
+
+const HELP_URL =
+  'https://www.braze.com/docs/api/endpoints/templates/content_blocks_templates/post_create_email_content_block';
+
+const getStatusBadge = (status: string) => {
+  if (status.toLowerCase() === 'published') {
+    return <Badge variant="positive">Published</Badge>;
+  }
+  return <Badge variant="warning">Draft</Badge>;
+};
+
+const getUpdatedLabel = (dateString: string) => {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+  if (diffHours < 24) {
+    return `${diffHours} hour${diffHours === 1 ? '' : 's'} ago`;
+  }
+  return date.toLocaleDateString('en-GB', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  });
+};
+
+const getConnectedFieldsCount = (connectedFields: any) => {
+  return connectedFields.length;
+};
 
 const Page = () => {
   const sdk = useSDK<PageAppSDK>();
+  const [entries, setEntries] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const cma = createClient(
+    { apiAdapter: sdk.cmaAdapter },
+    {
+      type: 'plain',
+      defaults: {
+        environmentId: sdk.ids.environment,
+        spaceId: sdk.ids.space,
+      },
+    }
+  );
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+    fetchBrazeConnectedEntries(cma, sdk.ids.space, sdk.ids.environment || 'master')
+      .then((entries) => {
+        setEntries(entries);
+        setLoading(false);
+      })
+      .catch((e) => {
+        console.log('Error: ', e);
+        setError('Error loading connected entries');
+        setLoading(false);
+      });
+  }, []);
 
   return (
-    <Box marginTop="spacingM">
-      <Paragraph>Hello Page Component (AppId: {sdk.ids.app})</Paragraph>
-    </Box>
+    <Flex justifyContent="center" padding="spacing2Xl">
+      <Box className={styles.container}>
+        <Heading
+          as="h1"
+          marginTop="spacingS"
+          marginBottom="spacingS"
+          marginRight="spacingM"
+          marginLeft="spacingM">
+          Braze Content Blocks
+        </Heading>
+        <Splitter />
+        <Box padding="spacingL">
+          <Subheading className={styles.subheading}>
+            Content connected to Braze through Content Blocks
+          </Subheading>
+          <InformationWithLink url={HELP_URL} linkText="here" dataTestId="help-here">
+            Learn more about Braze Content Blocks
+          </InformationWithLink>
+          <Box>
+            {loading ? (
+              <Flex alignItems="center" justifyContent="center" padding="spacingL">
+                <Spinner size="large" />
+                <Text marginLeft="spacingM">Loading...</Text>
+              </Flex>
+            ) : error ? (
+              <Box marginBottom="spacingL">
+                <Note variant="negative" title="Error">
+                  {error}
+                </Note>
+              </Box>
+            ) : entries.length === 0 ? (
+              <Box marginBottom="spacingL">
+                <Note variant="warning" title="No connected entries">
+                  There are no entries connected to Braze Content Blocks.
+                </Note>
+              </Box>
+            ) : (
+              <Box marginTop="spacingXl">
+                <Flex justifyContent="end" alignItems="center" marginBottom="spacingXs">
+                  <Text fontColor="gray600" fontSize="fontSizeS">
+                    Connected entries: {entries.length}/25
+                  </Text>
+                </Flex>
+                <Table>
+                  <Table.Head>
+                    <Table.Row>
+                      <Table.Cell as="th">Entry name</Table.Cell>
+                      <Table.Cell as="th">Content type</Table.Cell>
+                      <Table.Cell as="th">Updated</Table.Cell>
+                      <Table.Cell as="th">Status</Table.Cell>
+                      <Table.Cell as="th">Connected fields</Table.Cell>
+                      <Table.Cell as="th" />
+                    </Table.Row>
+                  </Table.Head>
+                  <Table.Body>
+                    {entries.map((entry) => {
+                      const name = entry.title;
+                      const contentType = entry.contentType;
+                      const updated = getUpdatedLabel(entry.updatedAt);
+                      const status = entry.getStatus();
+                      const connectedCount = getConnectedFieldsCount(entry.fields); // Todo : this are not the real connected fields
+                      return (
+                        <Table.Row key={entry.sys.id}>
+                          <Table.Cell>{name}</Table.Cell>
+                          <Table.Cell>{contentType}</Table.Cell>
+                          <Table.Cell>{updated}</Table.Cell>
+                          <Table.Cell>{getStatusBadge(status)}</Table.Cell>
+                          <Table.Cell>{connectedCount}</Table.Cell>
+                          <Table.Cell>
+                            <Button
+                              variant="secondary"
+                              size="small"
+                              onClick={() => sdk.navigator.openEntry(entry.sys.id)}>
+                              View fields
+                            </Button>
+                          </Table.Cell>
+                        </Table.Row>
+                      );
+                    })}
+                  </Table.Body>
+                </Table>
+              </Box>
+            )}
+          </Box>
+        </Box>
+      </Box>
+    </Flex>
   );
 };
 

--- a/apps/braze/src/locations/Page.tsx
+++ b/apps/braze/src/locations/Page.tsx
@@ -10,6 +10,7 @@ import {
   Flex,
   Heading,
   Subheading,
+  Paragraph,
 } from '@contentful/f36-components';
 import { useSDK } from '@contentful/react-apps-toolkit';
 import { PageAppSDK } from '@contentful/app-sdk';
@@ -52,6 +53,96 @@ const getConnectedFieldsCount = (connectedFields: any) => {
   return connectedFields.length;
 };
 
+// Loading state component
+function LoadingState() {
+  return (
+    <Flex alignItems="center" justifyContent="center" padding="spacingL">
+      <Spinner size="large" />
+      <Text marginLeft="spacingM">Loading...</Text>
+    </Flex>
+  );
+}
+
+// Error state component
+function ErrorState({ error }: { error: string }) {
+  return (
+    <Box marginTop="spacingL">
+      <Note variant="negative" title="Error">
+        {error}
+      </Note>
+    </Box>
+  );
+}
+
+// Empty state component
+function EmptyState() {
+  return (
+    <Flex
+      flexDirection="column"
+      alignItems="center"
+      justifyContent="center"
+      className={styles.emptyComponentContainer}>
+      <Text fontSize="fontSizeL" fontWeight="fontWeightDemiBold" marginBottom="spacingXs">
+        No active Braze Content Blocks
+      </Text>
+      <Text fontColor="gray600">Once you have created Content Blocks, they will display here.</Text>
+    </Flex>
+  );
+}
+
+// Table component
+function ConnectedEntriesTable({ entries }: { entries: Entry[] }) {
+  return (
+    <Box marginTop="spacingXl">
+      <Flex justifyContent="end" alignItems="center" marginBottom="spacingXs">
+        <Text fontColor="gray600" fontSize="fontSizeS">
+          Connected entries: {entries.length}/25
+        </Text>
+      </Flex>
+      <Table>
+        <Table.Head>
+          <Table.Row>
+            <Table.Cell>Entry name</Table.Cell>
+            <Table.Cell>Content type</Table.Cell>
+            <Table.Cell>Updated</Table.Cell>
+            <Table.Cell>Status</Table.Cell>
+            <Table.Cell>Connected fields</Table.Cell>
+            <Table.Cell align="center" className={styles.buttonCell} />
+          </Table.Row>
+        </Table.Head>
+        <Table.Body>
+          {entries.map((entry) => {
+            const name = entry.title;
+            const contentType = entry.contentType;
+            const updated = getUpdatedLabel(entry.updatedAt);
+            const status = entry.state;
+            const connectedCount = getConnectedFieldsCount(entry.fields);
+            return (
+              <Table.Row key={entry.id}>
+                <Table.Cell>{name}</Table.Cell>
+                <Table.Cell>{contentType}</Table.Cell>
+                <Table.Cell>{updated}</Table.Cell>
+                <Table.Cell>{getStatusBadge(status)}</Table.Cell>
+                <Table.Cell>{connectedCount}</Table.Cell>
+                <Table.Cell align="center" className={styles.buttonCell}>
+                  <Button
+                    variant="secondary"
+                    size="small"
+                    onClick={() => {
+                      // Todo : implement
+                    }}>
+                    View fields
+                  </Button>
+                </Table.Cell>
+              </Table.Row>
+            );
+          })}
+        </Table.Body>
+      </Table>
+    </Box>
+  );
+}
+
 const Page = () => {
   const sdk = useSDK<PageAppSDK>();
   const [entries, setEntries] = useState<Entry[]>([]);
@@ -90,8 +181,12 @@ const Page = () => {
       });
   }, []);
 
+  const hasConnectedEntries = () => {
+    return entries.length > 0;
+  };
+
   return (
-    <Flex justifyContent="center" padding="spacing2Xl">
+    <Flex justifyContent="center" paddingLeft="spacing2Xl" paddingRight="spacing2Xl">
       <Box className={styles.container}>
         <Heading
           as="h1"
@@ -103,78 +198,25 @@ const Page = () => {
         </Heading>
         <Splitter />
         <Box padding="spacingL">
-          <Subheading className={styles.subheading}>
-            Content connected to Braze through Content Blocks
-          </Subheading>
-          <InformationWithLink url={HELP_URL} linkText="here" dataTestId="help-here">
-            Learn more about Braze Content Blocks
-          </InformationWithLink>
+          {hasConnectedEntries() && (
+            <>
+              <Subheading className={styles.subheading}>
+                Content connected to Braze through Content Blocks
+              </Subheading>
+              <InformationWithLink url={HELP_URL} linkText="here" dataTestId="help-here">
+                Learn more about Braze Content Blocks
+              </InformationWithLink>
+            </>
+          )}
           <Box>
             {loading ? (
-              <Flex alignItems="center" justifyContent="center" padding="spacingL">
-                <Spinner size="large" />
-                <Text marginLeft="spacingM">Loading...</Text>
-              </Flex>
+              <LoadingState />
             ) : error ? (
-              <Box marginTop="spacingL">
-                <Note variant="negative" title="Error">
-                  {error}
-                </Note>
-              </Box>
+              <ErrorState error={error} />
             ) : entries.length === 0 ? (
-              <Box marginTop="spacingL">
-                <Note variant="warning" title="No connected entries">
-                  There are no entries connected to Braze Content Blocks.
-                </Note>
-              </Box>
+              <EmptyState />
             ) : (
-              <Box marginTop="spacingXl">
-                <Flex justifyContent="end" alignItems="center" marginBottom="spacingXs">
-                  <Text fontColor="gray600" fontSize="fontSizeS">
-                    Connected entries: {entries.length}/25
-                  </Text>
-                </Flex>
-                <Table>
-                  <Table.Head>
-                    <Table.Row>
-                      <Table.Cell as="th">Entry name</Table.Cell>
-                      <Table.Cell as="th">Content type</Table.Cell>
-                      <Table.Cell as="th">Updated</Table.Cell>
-                      <Table.Cell as="th">Status</Table.Cell>
-                      <Table.Cell as="th">Connected fields</Table.Cell>
-                      <Table.Cell as="th" />
-                    </Table.Row>
-                  </Table.Head>
-                  <Table.Body>
-                    {entries.map((entry) => {
-                      const name = entry.title;
-                      const contentType = entry.contentType;
-                      const updated = getUpdatedLabel(entry.updatedAt);
-                      const status = entry.state;
-                      const connectedCount = getConnectedFieldsCount(entry.fields);
-                      return (
-                        <Table.Row key={entry.id}>
-                          <Table.Cell>{name}</Table.Cell>
-                          <Table.Cell>{contentType}</Table.Cell>
-                          <Table.Cell>{updated}</Table.Cell>
-                          <Table.Cell>{getStatusBadge(status)}</Table.Cell>
-                          <Table.Cell>{connectedCount}</Table.Cell>
-                          <Table.Cell>
-                            <Button
-                              variant="secondary"
-                              size="small"
-                              onClick={() => {
-                                // Todo : implement
-                              }}>
-                              View fields
-                            </Button>
-                          </Table.Cell>
-                        </Table.Row>
-                      );
-                    })}
-                  </Table.Body>
-                </Table>
-              </Box>
+              <ConnectedEntriesTable entries={entries} />
             )}
           </Box>
         </Box>

--- a/apps/braze/src/locations/Page.tsx
+++ b/apps/braze/src/locations/Page.tsx
@@ -76,7 +76,8 @@ const Page = () => {
       cma,
       sdk.parameters?.installation?.contentfulApiKey,
       sdk.ids.space,
-      sdk.ids.environment || 'master'
+      sdk.ids.environment || 'master',
+      sdk.locales.default || 'en-US'
     )
       .then((entries) => {
         setEntries(entries);

--- a/apps/braze/src/locations/Page.tsx
+++ b/apps/braze/src/locations/Page.tsx
@@ -6,11 +6,9 @@ import {
   Badge,
   Spinner,
   Button,
-  Note,
   Flex,
   Heading,
   Subheading,
-  Paragraph,
 } from '@contentful/f36-components';
 import { useSDK } from '@contentful/react-apps-toolkit';
 import { PageAppSDK } from '@contentful/app-sdk';
@@ -20,9 +18,7 @@ import { styles } from './Page.styles';
 import Splitter from '../components/Splitter';
 import { createClient } from 'contentful-management';
 import { Entry } from '../fields/Entry';
-
-const HELP_URL =
-  'https://www.braze.com/docs/api/endpoints/templates/content_blocks_templates/post_create_email_content_block';
+import { BRAZE_CONTENT_BLOCK_DOCUMENTATION } from '../utils';
 
 const getStatusBadge = (status: string) => {
   if (status.toLowerCase() === 'published') {
@@ -53,29 +49,20 @@ const getConnectedFieldsCount = (connectedFields: any) => {
   return connectedFields.length;
 };
 
-// Loading state component
 function LoadingState() {
   return (
-    <Flex alignItems="center" justifyContent="center" padding="spacingL">
+    <Flex alignItems="center" justifyContent="center" className={styles.loading}>
       <Spinner size="large" />
       <Text marginLeft="spacingM">Loading...</Text>
     </Flex>
   );
 }
 
-// Error state component
-function ErrorState({ error }: { error: string }) {
-  return (
-    <Box marginTop="spacingL">
-      <Note variant="negative" title="Error">
-        {error}
-      </Note>
-    </Box>
-  );
-}
-
-// Empty state component
-function EmptyState() {
+type MessageProps = {
+  title: string;
+  message: string;
+};
+function DisplayMessage({ title, message }: MessageProps) {
   return (
     <Flex
       flexDirection="column"
@@ -83,14 +70,13 @@ function EmptyState() {
       justifyContent="center"
       className={styles.emptyComponentContainer}>
       <Text fontSize="fontSizeL" fontWeight="fontWeightDemiBold" marginBottom="spacingXs">
-        No active Braze Content Blocks
+        {title}
       </Text>
-      <Text fontColor="gray600">Once you have created Content Blocks, they will display here.</Text>
+      <Text fontColor="gray600">{message}</Text>
     </Flex>
   );
 }
 
-// Table component
 function ConnectedEntriesTable({ entries }: { entries: Entry[] }) {
   return (
     <Box marginTop="spacingXl">
@@ -203,7 +189,10 @@ const Page = () => {
               <Subheading className={styles.subheading}>
                 Content connected to Braze through Content Blocks
               </Subheading>
-              <InformationWithLink url={HELP_URL} linkText="here" dataTestId="help-here">
+              <InformationWithLink
+                url={BRAZE_CONTENT_BLOCK_DOCUMENTATION}
+                linkText="here"
+                dataTestId="help-here">
                 Learn more about Braze Content Blocks
               </InformationWithLink>
             </>
@@ -212,9 +201,12 @@ const Page = () => {
             {loading ? (
               <LoadingState />
             ) : error ? (
-              <ErrorState error={error} />
-            ) : entries.length === 0 ? (
-              <EmptyState />
+              <DisplayMessage title="There was an error" message="Please contact support" />
+            ) : !hasConnectedEntries() ? (
+              <DisplayMessage
+                title="No active Braze Content Blocks"
+                message="Once you have created Content Blocks, they will display here."
+              />
             ) : (
               <ConnectedEntriesTable entries={entries} />
             )}

--- a/apps/braze/src/locations/Page.tsx
+++ b/apps/braze/src/locations/Page.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import {
-  Paragraph,
   Box,
   Table,
   Text,
@@ -19,6 +18,7 @@ import InformationWithLink from '../components/InformationWithLink';
 import { styles } from './Page.styles';
 import Splitter from '../components/Splitter';
 import { createClient } from 'contentful-management';
+import { Entry } from '../fields/Entry';
 
 const HELP_URL =
   'https://www.braze.com/docs/api/endpoints/templates/content_blocks_templates/post_create_email_content_block';
@@ -51,7 +51,7 @@ const getConnectedFieldsCount = (connectedFields: any) => {
 
 const Page = () => {
   const sdk = useSDK<PageAppSDK>();
-  const [entries, setEntries] = useState<any[]>([]);
+  const [entries, setEntries] = useState<Entry[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -141,10 +141,10 @@ const Page = () => {
                       const name = entry.title;
                       const contentType = entry.contentType;
                       const updated = getUpdatedLabel(entry.updatedAt);
-                      const status = entry.getStatus();
+                      const status = entry.state;
                       const connectedCount = getConnectedFieldsCount(entry.fields); // Todo : this are not the real connected fields
                       return (
-                        <Table.Row key={entry.sys.id}>
+                        <Table.Row key={entry.id}>
                           <Table.Cell>{name}</Table.Cell>
                           <Table.Cell>{contentType}</Table.Cell>
                           <Table.Cell>{updated}</Table.Cell>
@@ -154,7 +154,9 @@ const Page = () => {
                             <Button
                               variant="secondary"
                               size="small"
-                              onClick={() => sdk.navigator.openEntry(entry.sys.id)}>
+                              onClick={() => {
+                                // Todo : implement
+                              }}>
                               View fields
                             </Button>
                           </Table.Cell>

--- a/apps/braze/src/utils/fetchBrazeConnectedEntries.ts
+++ b/apps/braze/src/utils/fetchBrazeConnectedEntries.ts
@@ -1,0 +1,65 @@
+import { PlainClientAPI } from 'contentful-management';
+import { getConfigEntry } from '../utils';
+import { Entry } from '../fields/Entry';
+import { FieldsFactory } from '../fields/FieldsFactory';
+
+/**
+ * Fetches entries from Contentful that have connectedFields (with at least one field).
+ * @param cma Contentful Management API client
+ * @param spaceId The space ID
+ * @param environmentId The environment ID
+ * @returns Array of entries with connectedFields
+ */
+export async function fetchBrazeConnectedEntries(
+  cma: PlainClientAPI,
+  spaceId: string,
+  environmentId: string
+): Promise<Entry[]> {
+  const configEntry = await getConfigEntry(cma);
+  console.log('GET CONGIG ENRTRY: ', configEntry);
+
+  const entrys = configEntry?.fields?.connectedFields?.['en-US'];
+  const entrysIds: string[] = [];
+  Object.entries(entrys).forEach(([key]) => {
+    entrysIds.push(key);
+  });
+
+  const entriesResponse = await cma.entry.getMany({
+    spaceId,
+    environmentId,
+    query: {
+      'sys.id[in]': entrysIds.join(','),
+      limit: 1000,
+    },
+  });
+
+  console.log('ENTRIES RESPONSE: ', entriesResponse);
+
+  if (!entriesResponse?.items) return [];
+
+  return await Promise.all(
+    entriesResponse.items.map(async (item: any) => {
+      const fieldsFactory = new FieldsFactory(
+        item.sys.id,
+        item.sys.contentType?.sys?.id || '',
+        cma
+      );
+      const cmaEntry = await fieldsFactory.getEntry();
+      console.log('CMA ENTRY: ', cmaEntry);
+      console.log('CMA PUB: ', cmaEntry.sys.publishedAt);
+      console.log('CMA UPD: ', cmaEntry.sys.updatedAt);
+      const fields = await fieldsFactory.createFieldsForEntry(cmaEntry.fields);
+      return new Entry(
+        item.sys.id,
+        item.sys.contentType?.sys?.id || '',
+        item.fields?.name?.['en-US'] || 'Untitled',
+        fields,
+        item.sys.space?.sys?.id || spaceId,
+        item.sys.environment?.sys?.id || environmentId,
+        '',
+        cmaEntry.sys.publishedAt,
+        cmaEntry.sys.updatedAt
+      );
+    })
+  );
+}

--- a/apps/braze/src/utils/fetchBrazeConnectedEntries.ts
+++ b/apps/braze/src/utils/fetchBrazeConnectedEntries.ts
@@ -50,9 +50,12 @@ export async function fetchBrazeConnectedEntries(
 
       console.log('ENTRY CONNECTED FIELDS: ', entryConnectedFields);
 
-      const rawFields = entryConnectedFields.map(
-        (contentBlockData: EntryConnectedField) => rawEntry.fields[contentBlockData.fieldId]
-      );
+      const rawFields = entryConnectedFields.map((contentBlockData: EntryConnectedField) => {
+        return {
+          fieldId: contentBlockData.fieldId,
+          ...rawEntry.fields[contentBlockData.fieldId],
+        };
+      });
 
       console.log('RAW FIELDS: ', rawFields);
 

--- a/apps/braze/src/utils/fetchBrazeConnectedEntries.ts
+++ b/apps/braze/src/utils/fetchBrazeConnectedEntries.ts
@@ -11,10 +11,11 @@ export async function fetchBrazeConnectedEntries(
   cma: PlainClientAPI,
   contentfulApiKey: string,
   spaceId: string,
-  environmentId: string
+  environmentId: string,
+  defaultLocale: string
 ): Promise<Entry[]> {
   const configEntry = await getConfigEntry(cma);
-  const entries = configEntry?.fields?.connectedFields?.['en-US'] || {};
+  const entries = configEntry?.fields?.connectedFields?.[defaultLocale] || {};
   const entryIds = Object.keys(entries);
 
   if (!entryIds.length) return [];
@@ -39,7 +40,7 @@ export async function fetchBrazeConnectedEntries(
 
       const fieldsFactory = new FieldsFactory(entryId, entryContentTypeId, cma);
       const fieldsAndTitle = await fieldsFactory.createFieldsForConnectedFields(connectedFieldIds);
-      const entryTitle = rawEntry.fields[fieldsAndTitle.title]?.['en-US'] || 'Untitled';
+      const entryTitle = rawEntry.fields[fieldsAndTitle.title]?.[defaultLocale] || 'Untitled';
 
       return new Entry(
         entryId,

--- a/apps/braze/src/utils/fetchBrazeConnectedEntries.ts
+++ b/apps/braze/src/utils/fetchBrazeConnectedEntries.ts
@@ -19,7 +19,6 @@ export async function fetchBrazeConnectedEntries(
   environmentId: string
 ): Promise<Entry[]> {
   const configEntry = await getConfigEntry(cma);
-  console.log('GET CONGIG ENRTRY: ', configEntry);
 
   const entrys = configEntry?.fields?.connectedFields?.['en-US'] || [];
   const entrysIds: string[] = [];
@@ -36,13 +35,10 @@ export async function fetchBrazeConnectedEntries(
     },
   });
 
-  console.log('ENTRIES RESPONSE: ', entriesResponse);
-
   if (!entriesResponse?.items) return [];
 
   return await Promise.all(
     entriesResponse.items.map(async (rawEntry: any) => {
-      console.log('RAW ENTRY: ', rawEntry);
       const fieldsFactory = new FieldsFactory(
         rawEntry.sys.id,
         rawEntry.sys.contentType?.sys?.id || '',
@@ -51,8 +47,6 @@ export async function fetchBrazeConnectedEntries(
       const rawEntryId = rawEntry.sys.id;
       const entryConnectedFields = entrys[rawEntryId];
 
-      console.log('ENTRY CONNECTED FIELDS: ', entryConnectedFields);
-
       const rawFields = entryConnectedFields.map((contentBlockData: EntryConnectedField) => {
         return {
           fieldId: contentBlockData.fieldId,
@@ -60,7 +54,6 @@ export async function fetchBrazeConnectedEntries(
         };
       });
 
-      console.log('RAW FIELDS: ', rawFields);
       const fieldsAndTitle = await fieldsFactory.createFieldsForEntryLALALA(rawFields);
       const entryTitle = rawEntry.fields[fieldsAndTitle.title]?.['en-US'] || 'Untitled';
       return new Entry(

--- a/apps/braze/test/functions/createContentBlocks.test.ts
+++ b/apps/braze/test/functions/createContentBlocks.test.ts
@@ -8,7 +8,9 @@ import {
 
 import type { PlainClientAPI } from 'contentful-management';
 import { documentToHtmlString } from '@contentful/rich-text-html-renderer';
-import { createContentType, createEntry, mockFetchSuccess } from '../mocks/mocksForFunctions';
+import { mockFetchSuccess } from '../mocks/mocksForFunctions';
+import { createGetEntryResponse } from '../mocks/entryResponse';
+import { createContentTypeResponse } from '../mocks/contentTypeResponse';
 
 const mockCma = {
   entry: {
@@ -49,8 +51,8 @@ describe('createContentBlocks', () => {
 
   it('should create content blocks for text fields', async () => {
     // Mock entry data
-    const mockEntry = createEntry({ title: 'Test Title', author: 'Test Author' });
-    const mockContentType = createContentType(['title', 'author']);
+    const mockEntry = createGetEntryResponse({ title: 'Test Title', author: 'Test Author' });
+    const mockContentType = createContentTypeResponse(['title', 'author']);
 
     // Mock API responses
     vi.mocked(mockCma.entry.get).mockResolvedValue(mockEntry);
@@ -130,8 +132,8 @@ describe('createContentBlocks', () => {
 
   it('should convert rich text fields to HTML', async () => {
     // Mock Entry data
-    const entry = createEntry({ content: { nodeType: 'document', content: [] } });
-    const contentType = createContentType(['content'], 'RichText');
+    const entry = createGetEntryResponse({ content: { nodeType: 'document', content: [] } });
+    const contentType = createContentTypeResponse(['content'], 'RichText');
 
     // Mock API responses
     vi.mocked(mockCma.entry.get).mockResolvedValue(entry);
@@ -179,8 +181,8 @@ describe('createContentBlocks', () => {
 
   it('should handle missing fields', async () => {
     // Mock Entry data
-    const entry = createEntry({});
-    const contentType = createContentType(['title', 'author']);
+    const entry = createGetEntryResponse({});
+    const contentType = createContentTypeResponse(['title', 'author']);
 
     // Mock API responses
     vi.mocked(mockCma.entry.get).mockResolvedValue(entry);
@@ -227,8 +229,8 @@ describe('createContentBlocks', () => {
 
   it('should handle API errors', async () => {
     // Mock Entry data
-    const entry = createEntry({ title: 'Test Title', author: 'Test Author' });
-    const contentType = createContentType(['title', 'author']);
+    const entry = createGetEntryResponse({ title: 'Test Title', author: 'Test Author' });
+    const contentType = createContentTypeResponse(['title', 'author']);
 
     // Mock API responses
     vi.mocked(mockCma.entry.get).mockResolvedValue(entry);
@@ -281,8 +283,8 @@ describe('createContentBlocks', () => {
 
   it('should handle multiple fields with custom names', async () => {
     // Mock Entry data
-    const entry = createEntry({ title: 'Test Title', author: 'Test Author' });
-    const contentType = createContentType(['title', 'author']);
+    const entry = createGetEntryResponse({ title: 'Test Title', author: 'Test Author' });
+    const contentType = createContentTypeResponse(['title', 'author']);
 
     // Mock API responses
     vi.mocked(mockCma.entry.get).mockResolvedValue(entry);
@@ -362,8 +364,8 @@ describe('createContentBlocks', () => {
 
   it('should handle invalid contentBlockNames JSON', async () => {
     // Mock Entry data
-    const entry = createEntry({ title: 'Test Title', author: 'Test Author' });
-    const contentType = createContentType(['title', 'author']);
+    const entry = createGetEntryResponse({ title: 'Test Title', author: 'Test Author' });
+    const contentType = createContentTypeResponse(['title', 'author']);
 
     // Mock API responses
     vi.mocked(mockCma.entry.get).mockResolvedValue(entry);
@@ -389,8 +391,8 @@ describe('createContentBlocks', () => {
 
   it('should handle missing contentBlockNames for a field', async () => {
     // Mock Entry data
-    const entry = createEntry({ title: 'Test Title', author: 'Test Author' });
-    const contentType = createContentType(['title', 'author']);
+    const entry = createGetEntryResponse({ title: 'Test Title', author: 'Test Author' });
+    const contentType = createContentTypeResponse(['title', 'author']);
 
     // Mock API responses
     vi.mocked(mockCma.entry.get).mockResolvedValue(entry);

--- a/apps/braze/test/locations/Dialog.spec.tsx
+++ b/apps/braze/test/locations/Dialog.spec.tsx
@@ -56,7 +56,9 @@ const mockEntry = new Entry(
   [mockField],
   mockSdk.ids.space,
   mockSdk.ids.environemnt,
-  mockSdk.parameters.installation.contentfulApiKey
+  mockSdk.parameters.installation.contentfulApiKey,
+  undefined,
+  '2024-01-01T00:00:00Z'
 );
 
 const GENERATE_FIELDS_STEP_TEXT = 'Select which fields';

--- a/apps/braze/test/locations/Dialog.spec.tsx
+++ b/apps/braze/test/locations/Dialog.spec.tsx
@@ -4,8 +4,8 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import Dialog from '../../src/locations/Dialog';
 import { Entry } from '../../src/fields/Entry';
 import { BasicField } from '../../src/fields/BasicField';
-import { createEntry } from '../mocks/mocksForFunctions';
 import React from 'react';
+import { createGetEntryResponse } from '../mocks/entryResponse';
 
 vi.mock('@contentful/react-apps-toolkit', () => ({
   useSDK: () => mockSdk,
@@ -35,7 +35,7 @@ vi.mock('../../src/fields/FieldsFactory', () => ({
   })),
 }));
 
-const mockCMAEntryItemResponse = createEntry({
+const mockCMAEntryItemResponse = createGetEntryResponse({
   title: 'Some Title',
   fieldId: {
     sys: {

--- a/apps/braze/test/locations/Page.spec.tsx
+++ b/apps/braze/test/locations/Page.spec.tsx
@@ -3,140 +3,52 @@ import { cleanup } from '@testing-library/react';
 import { fetchBrazeConnectedEntries } from '../../src/utils/fetchBrazeConnectedEntries';
 import { Entry } from '../../src/fields/Entry';
 import { BasicField } from '../../src/fields/BasicField';
-
-const mockCma = {
-  contentType: {
-    get: vi.fn(),
-  },
-  entry: {
-    getMany: vi.fn(),
-    get: vi.fn(),
-  },
-};
+import { mockConnectedFields, mockSingleConnectedField } from '../mocks/connectedFields';
+import { createContentTypeResponse } from '../mocks/contentTypeResponse';
+import { createGetManyEntryResponse } from '../mocks/entryResponse';
 
 describe('Page component', () => {
+  const mockCma = {
+    contentType: {
+      get: vi.fn().mockResolvedValue(createContentTypeResponse(['title', 'author'])),
+    },
+    entry: {
+      getMany: vi.fn().mockResolvedValue({
+        sys: { type: 'Array' },
+        total: 1,
+        skip: 0,
+        limit: 1000,
+        items: [createGetManyEntryResponse({ title: 'Title', author: 'Author' })],
+      }),
+      get: vi.fn(),
+    },
+  };
+
   beforeEach(() => {
     vi.clearAllMocks();
   });
+
   afterEach(cleanup);
 
-  it('when two field are connected, then it returns an entry', async () => {
-    mockCma.entry.get.mockResolvedValue({
-      fields: {
-        connectedFields: {
-          'en-US': {
-            ['entry-id']: [
-              {
-                fieldId: 'title',
-                contentBlockId: 'contentBlockA',
-              },
-              {
-                fieldId: 'author',
-                contentBlockId: 'contentBlockB',
-              },
-            ],
-          },
-        },
-      },
-    });
+  const createExpectedEntry = (fields: BasicField[]) => {
+    return new Entry(
+      'entry-id',
+      'content-type-id',
+      'Title',
+      fields,
+      'space-id',
+      'environment-id',
+      'valid-contentful-api-key',
+      '2025-05-15T16:49:16.367Z',
+      '2025-05-15T16:49:16.367Z'
+    );
+  };
 
-    mockCma.entry.getMany.mockResolvedValue({
-      sys: {
-        type: 'Array',
-      },
-      total: 1,
-      skip: 0,
-      limit: 1000,
-      items: [
-        {
-          metadata: {
-            tags: [],
-            concepts: [],
-          },
-          sys: {
-            space: {
-              sys: {
-                type: 'Link',
-                linkType: 'Space',
-                id: 'space-id',
-              },
-            },
-            id: 'entry-id',
-            type: 'Entry',
-            createdAt: '2025-05-08T16:04:58.212Z',
-            updatedAt: '2025-05-15T16:49:16.367Z',
-            environment: {
-              sys: {
-                id: 'environment-id',
-                type: 'Link',
-                linkType: 'Environment',
-              },
-            },
-            publishedVersion: 10,
-            publishedAt: '2025-05-15T16:49:16.367Z',
-            firstPublishedAt: '2025-05-08T16:05:05.759Z',
-            createdBy: {
-              sys: {
-                type: 'Link',
-                linkType: 'User',
-                id: 'user-id',
-              },
-            },
-            updatedBy: {
-              sys: {
-                type: 'Link',
-                linkType: 'User',
-                id: 'user-id',
-              },
-            },
-            publishedCounter: 3,
-            version: 11,
-            publishedBy: {
-              sys: {
-                type: 'Link',
-                linkType: 'User',
-                id: 'user-id',
-              },
-            },
-            fieldStatus: {
-              '*': {
-                'en-US': 'published',
-              },
-            },
-            automationTags: [],
-            contentType: {
-              sys: {
-                type: 'Link',
-                linkType: 'ContentType',
-                id: 'content-type-id',
-              },
-            },
-            urn: 'crn:contentful:::content:spaces/space-id/environments/environment-id/entries/entry-id',
-          },
-          fields: {
-            title: {
-              'en-US': 'Test Title',
-            },
-            author: {
-              'en-US': 'Test Author',
-            },
-          },
-        },
-      ],
-    });
-
-    mockCma.contentType.get.mockImplementation(() => {
-      return {
-        fields: [
-          { id: 'title', type: 'Symbol', localized: false, name: 'Test Title' },
-          { id: 'author', type: 'Symbol', localized: false, name: 'Test Author' },
-        ],
-        displayField: 'title',
-        sys: {
-          id: 'content-type-id',
-        },
-      };
-    });
+  it('returns an entry when two fields are connected', async () => {
+    mockCma.entry.get.mockResolvedValue(mockConnectedFields);
+    const title = new BasicField('title', 'Title', 'content-type-id', true);
+    const author = new BasicField('author', 'Author', 'content-type-id', true);
+    const expectedEntry = createExpectedEntry([title, author]);
 
     const result = await fetchBrazeConnectedEntries(
       mockCma as unknown as any,
@@ -144,135 +56,14 @@ describe('Page component', () => {
       'space-id',
       'environment-id'
     );
-    const title = new BasicField('title', 'Test Title', 'content-type-id', false);
-    const author = new BasicField('author', 'Test Author', 'content-type-id', false);
-    const entry = new Entry(
-      'entry-id',
-      'content-type-id',
-      'Test Title',
-      [title, author],
-      'space-id',
-      'environment-id',
-      'valid-contentful-api-key',
-      '2025-05-15T16:49:16.367Z',
-      '2025-05-15T16:49:16.367Z'
-    );
-    expect(result[0].serialize()).toEqual(entry.serialize());
+
+    expect(result[0].serialize()).toEqual(expectedEntry.serialize());
   });
 
-  it("when one field is connected and the other isn't, it returns an entry with only connected fields", async () => {
-    mockCma.entry.get.mockResolvedValue({
-      fields: {
-        connectedFields: {
-          'en-US': {
-            ['entry-id']: [
-              {
-                fieldId: 'title',
-                contentBlockId: 'contentBlockA',
-              },
-            ],
-          },
-        },
-      },
-    });
-
-    mockCma.entry.getMany.mockResolvedValue({
-      sys: {
-        type: 'Array',
-      },
-      total: 1,
-      skip: 0,
-      limit: 1000,
-      items: [
-        {
-          metadata: {
-            tags: [],
-            concepts: [],
-          },
-          sys: {
-            space: {
-              sys: {
-                type: 'Link',
-                linkType: 'Space',
-                id: 'space-id',
-              },
-            },
-            id: 'entry-id',
-            type: 'Entry',
-            createdAt: '2025-05-08T16:04:58.212Z',
-            updatedAt: '2025-05-15T16:49:16.367Z',
-            environment: {
-              sys: {
-                id: 'environment-id',
-                type: 'Link',
-                linkType: 'Environment',
-              },
-            },
-            publishedVersion: 10,
-            publishedAt: '2025-05-15T16:49:16.367Z',
-            firstPublishedAt: '2025-05-08T16:05:05.759Z',
-            createdBy: {
-              sys: {
-                type: 'Link',
-                linkType: 'User',
-                id: 'user-id',
-              },
-            },
-            updatedBy: {
-              sys: {
-                type: 'Link',
-                linkType: 'User',
-                id: 'user-id',
-              },
-            },
-            publishedCounter: 3,
-            version: 11,
-            publishedBy: {
-              sys: {
-                type: 'Link',
-                linkType: 'User',
-                id: 'user-id',
-              },
-            },
-            fieldStatus: {
-              '*': {
-                'en-US': 'published',
-              },
-            },
-            automationTags: [],
-            contentType: {
-              sys: {
-                type: 'Link',
-                linkType: 'ContentType',
-                id: 'content-type-id',
-              },
-            },
-            urn: 'crn:contentful:::content:spaces/space-id/environments/environment-id/entries/entry-id',
-          },
-          fields: {
-            title: {
-              'en-US': 'Test Title',
-            },
-            author: {
-              'en-US': 'Test Author',
-            },
-          },
-        },
-      ],
-    });
-
-    mockCma.contentType.get.mockImplementation(() => {
-      return {
-        fields: [
-          { id: 'title', type: 'Symbol', localized: false, name: 'Test Title' },
-          { id: 'author', type: 'Symbol', localized: false, name: 'Test Author' },
-        ],
-        displayField: 'title',
-        sys: {
-          id: 'content-type-id',
-        },
-      };
-    });
+  it('returns an entry with only connected fields when one field is connected', async () => {
+    mockCma.entry.get.mockResolvedValue(mockSingleConnectedField);
+    const title = new BasicField('title', 'Title', 'content-type-id', true);
+    const expectedEntry = createExpectedEntry([title]);
 
     const result = await fetchBrazeConnectedEntries(
       mockCma as unknown as any,
@@ -280,18 +71,7 @@ describe('Page component', () => {
       'space-id',
       'environment-id'
     );
-    const title = new BasicField('title', 'Test Title', 'content-type-id', false);
-    const entry = new Entry(
-      'entry-id',
-      'content-type-id',
-      'Test Title',
-      [title],
-      'space-id',
-      'environment-id',
-      'valid-contentful-api-key',
-      '2025-05-15T16:49:16.367Z',
-      '2025-05-15T16:49:16.367Z'
-    );
-    expect(result[0].serialize()).toEqual(entry.serialize());
+
+    expect(result[0].serialize()).toEqual(expectedEntry.serialize());
   });
 });

--- a/apps/braze/test/locations/Page.spec.tsx
+++ b/apps/braze/test/locations/Page.spec.tsx
@@ -140,6 +140,7 @@ describe('Page component', () => {
 
     const result = await fetchBrazeConnectedEntries(
       mockCma as unknown as any,
+      'valid-contentful-api-key',
       'space-id',
       'environment-id'
     );
@@ -148,11 +149,11 @@ describe('Page component', () => {
     const entry = new Entry(
       'entry-id',
       'content-type-id',
-      'Untitled',
+      'Test Title',
       [title, author],
       'space-id',
       'environment-id',
-      '',
+      'valid-contentful-api-key',
       '2025-05-15T16:49:16.367Z',
       '2025-05-15T16:49:16.367Z'
     );
@@ -275,6 +276,7 @@ describe('Page component', () => {
 
     const result = await fetchBrazeConnectedEntries(
       mockCma as unknown as any,
+      'valid-contentful-api-key',
       'space-id',
       'environment-id'
     );
@@ -282,11 +284,11 @@ describe('Page component', () => {
     const entry = new Entry(
       'entry-id',
       'content-type-id',
-      'Untitled',
+      'Test Title',
       [title],
       'space-id',
       'environment-id',
-      '',
+      'valid-contentful-api-key',
       '2025-05-15T16:49:16.367Z',
       '2025-05-15T16:49:16.367Z'
     );

--- a/apps/braze/test/locations/Page.spec.tsx
+++ b/apps/braze/test/locations/Page.spec.tsx
@@ -54,7 +54,8 @@ describe('Page component', () => {
       mockCma as unknown as any,
       'valid-contentful-api-key',
       'space-id',
-      'environment-id'
+      'environment-id',
+      'en-US'
     );
 
     expect(result[0].serialize()).toEqual(expectedEntry.serialize());
@@ -69,7 +70,8 @@ describe('Page component', () => {
       mockCma as unknown as any,
       'valid-contentful-api-key',
       'space-id',
-      'environment-id'
+      'environment-id',
+      'en-US'
     );
 
     expect(result[0].serialize()).toEqual(expectedEntry.serialize());

--- a/apps/braze/test/locations/Page.spec.tsx
+++ b/apps/braze/test/locations/Page.spec.tsx
@@ -1,191 +1,295 @@
-import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import React from 'react';
-import Page from '../../src/locations/Page';
-import { mockSdk, mockCma } from '../mocks';
+import { describe, vi, beforeEach, afterEach, it, expect } from 'vitest';
+import { cleanup } from '@testing-library/react';
+import { fetchBrazeConnectedEntries } from '../../src/utils/fetchBrazeConnectedEntries';
+import { Entry } from '../../src/fields/Entry';
+import { BasicField } from '../../src/fields/BasicField';
 
-vi.mock('@contentful/react-apps-toolkit', () => ({
-  useSDK: () => mockSdk,
-  useCMA: () => mockCma,
-}));
-
-const mockEntries = [
-  {
-    sys: { id: '1', updatedAt: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString() },
-    fields: {
-      name: { 'en-US': 'Banana' },
-      contentType: { 'en-US': 'Fruits' },
-      status: { 'en-US': 'published' },
-      connectedFields: {
-        'en-US': {
-          '2UaU3B1eRMxStWNQ1Pkv7f': [
-            { fieldId: 'name', contentBlockId: 'de9aacf2-7e95-4bf6-be3a-296380760ac0' },
-            { fieldId: 'name', contentBlockId: '875eb453-86cd-4cb8-a302-40e99cae6550' },
-          ],
-        },
-      },
-    },
+const mockCma = {
+  contentType: {
+    get: vi.fn(),
   },
-  {
-    sys: { id: '2', updatedAt: new Date(Date.now() - 10 * 60 * 60 * 1000).toISOString() },
-    fields: {
-      name: { 'en-US': 'Dogs' },
-      contentType: { 'en-US': 'Animals' },
-      status: { 'en-US': 'draft' },
-      connectedFields: {
-        'en-US': {
-          '2UaU3B1eRMxStWNQ1Pkv7f': [
-            { fieldId: 'name', contentBlockId: 'de9aacf2-7e95-4bf6-be3a-296380760ac0' },
-            { fieldId: 'lastname', contentBlockId: '572c6425-10cf-4fd5-aae1-84357e7c13cc' },
-            { fieldId: 'type', contentBlockId: '875eb453-86cd-4cb8-a302-40e99cae6550' },
-          ],
-        },
-      },
-    },
+  entry: {
+    getMany: vi.fn(),
+    get: vi.fn(),
   },
-  {
-    sys: { id: '3', updatedAt: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString() },
-    fields: {
-      name: { 'en-US': 'Cats' },
-      contentType: { 'en-US': 'Animals' },
-      status: { 'en-US': 'published' },
-      connectedFields: {
-        'en-US': {
-          '2UaU3B1eRMxStWNQ1Pkv7f': [
-            { fieldId: 'name', contentBlockId: 'de9aacf2-7e95-4bf6-be3a-296380760ac0' },
-            { fieldId: 'type', contentBlockId: '875eb453-86cd-4cb8-a302-40e99cae6550' },
-          ],
-        },
-      },
-    },
-  },
-  {
-    sys: { id: '4', updatedAt: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString() },
-    fields: {
-      name: { 'en-US': 'Cars' },
-      contentType: { 'en-US': 'Things that go' },
-      status: { 'en-US': 'published' },
-      connectedFields: {
-        'en-US': {
-          '2UaU3B1eRMxStWNQ1Pkv7f': [
-            { fieldId: 'name', contentBlockId: 'de9aacf2-7e95-4bf6-be3a-296380760ac0' },
-            { fieldId: 'type', contentBlockId: '875eb453-86cd-4cb8-a302-40e99cae6550' },
-            { fieldId: 'model', contentBlockId: '572c6425-10cf-4fd5-aae1-84357e7c13cc' },
-            { fieldId: 'brand', contentBlockId: '572c6425-10cf-4fd5-aae1-84357e7c13cc' },
-            { fieldId: 'year', contentBlockId: '572c6425-10cf-4fd5-aae1-84357e7c13cc' },
-            { fieldId: 'color', contentBlockId: '572c6425-10cf-4fd5-aae1-84357e7c13cc' },
-            { fieldId: 'doors', contentBlockId: '572c6425-10cf-4fd5-aae1-84357e7c13cc' },
-            { fieldId: 'wheels', contentBlockId: '572c6425-10cf-4fd5-aae1-84357e7c13cc' },
-            { fieldId: 'engine', contentBlockId: '572c6425-10cf-4fd5-aae1-84357e7c13cc' },
-            { fieldId: 'fuel', contentBlockId: '572c6425-10cf-4fd5-aae1-84357e7c13cc' },
-          ],
-        },
-      },
-    },
-  },
-  {
-    sys: { id: '5', updatedAt: '2025-02-26T00:00:00.000Z' },
-    fields: {
-      name: { 'en-US': 'Trucks' },
-      contentType: { 'en-US': 'Things that go' },
-      status: { 'en-US': 'draft' },
-      connectedFields: {
-        'en-US': {
-          '2UaU3B1eRMxStWNQ1Pkv7f': [
-            { fieldId: 'name', contentBlockId: 'de9aacf2-7e95-4bf6-be3a-296380760ac0' },
-            { fieldId: 'type', contentBlockId: '875eb453-86cd-4cb8-a302-40e99cae6550' },
-            { fieldId: 'model', contentBlockId: '572c6425-10cf-4fd5-aae1-84357e7c13cc' },
-            { fieldId: 'brand', contentBlockId: '572c6425-10cf-4fd5-aae1-84357e7c13cc' },
-            { fieldId: 'year', contentBlockId: '572c6425-10cf-4fd5-aae1-84357e7c13cc' },
-          ],
-        },
-      },
-    },
-  },
-];
-
-const fetchEntriesMock = vi.fn();
-
-vi.mock('../../src/utils/fetchBrazeConnectedEntries', () => ({
-  fetchBrazeConnectedEntries: fetchEntriesMock,
-}));
+};
 
 describe('Page component', () => {
   beforeEach(() => {
-    fetchEntriesMock.mockResolvedValue(mockEntries);
-  });
-  afterEach(() => {
     vi.clearAllMocks();
   });
+  afterEach(cleanup);
 
-  it('renders the title, description, and help link', async () => {
-    render(<Page />);
-    expect(await screen.findByText('Braze Content Blocks')).toBeTruthy();
-    expect(screen.getByText('Content connected to Braze through Content Blocks')).toBeTruthy();
-    const helpLink = screen.getByRole('link', { name: /here/i });
-    expect(helpLink.getAttribute('href')).toContain('braze.com');
+  it('when two field are connected, then it returns an entry', async () => {
+    mockCma.entry.get.mockResolvedValue({
+      fields: {
+        connectedFields: {
+          'en-US': {
+            ['entry-id']: [
+              {
+                fieldId: 'title',
+                contentBlockId: 'contentBlockA',
+              },
+              {
+                fieldId: 'author',
+                contentBlockId: 'contentBlockB',
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    mockCma.entry.getMany.mockResolvedValue({
+      sys: {
+        type: 'Array',
+      },
+      total: 1,
+      skip: 0,
+      limit: 1000,
+      items: [
+        {
+          metadata: {
+            tags: [],
+            concepts: [],
+          },
+          sys: {
+            space: {
+              sys: {
+                type: 'Link',
+                linkType: 'Space',
+                id: 'space-id',
+              },
+            },
+            id: 'entry-id',
+            type: 'Entry',
+            createdAt: '2025-05-08T16:04:58.212Z',
+            updatedAt: '2025-05-15T16:49:16.367Z',
+            environment: {
+              sys: {
+                id: 'environment-id',
+                type: 'Link',
+                linkType: 'Environment',
+              },
+            },
+            publishedVersion: 10,
+            publishedAt: '2025-05-15T16:49:16.367Z',
+            firstPublishedAt: '2025-05-08T16:05:05.759Z',
+            createdBy: {
+              sys: {
+                type: 'Link',
+                linkType: 'User',
+                id: 'user-id',
+              },
+            },
+            updatedBy: {
+              sys: {
+                type: 'Link',
+                linkType: 'User',
+                id: 'user-id',
+              },
+            },
+            publishedCounter: 3,
+            version: 11,
+            publishedBy: {
+              sys: {
+                type: 'Link',
+                linkType: 'User',
+                id: 'user-id',
+              },
+            },
+            fieldStatus: {
+              '*': {
+                'en-US': 'published',
+              },
+            },
+            automationTags: [],
+            contentType: {
+              sys: {
+                type: 'Link',
+                linkType: 'ContentType',
+                id: 'content-type-id',
+              },
+            },
+            urn: 'crn:contentful:::content:spaces/space-id/environments/environment-id/entries/entry-id',
+          },
+          fields: {
+            title: {
+              'en-US': 'Test Title',
+            },
+            author: {
+              'en-US': 'Test Author',
+            },
+          },
+        },
+      ],
+    });
+
+    mockCma.contentType.get.mockImplementation(() => {
+      return {
+        fields: [
+          { id: 'title', type: 'Symbol', localized: false, name: 'Test Title' },
+          { id: 'author', type: 'Symbol', localized: false, name: 'Test Author' },
+        ],
+        displayField: 'title',
+        sys: {
+          id: 'content-type-id',
+        },
+      };
+    });
+
+    const result = await fetchBrazeConnectedEntries(
+      mockCma as unknown as any,
+      'space-id',
+      'environment-id'
+    );
+    const title = new BasicField('title', 'Test Title', 'content-type-id', false);
+    const author = new BasicField('author', 'Test Author', 'content-type-id', false);
+    const entry = new Entry(
+      'entry-id',
+      'content-type-id',
+      'Untitled',
+      [title, author],
+      'space-id',
+      'environment-id',
+      '',
+      '2025-05-15T16:49:16.367Z',
+      '2025-05-15T16:49:16.367Z'
+    );
+    expect(result[0].serialize()).toEqual(entry.serialize());
   });
 
-  it('renders the table headers', async () => {
-    render(<Page />);
-    expect(await screen.findByText('Entry name')).toBeTruthy();
-    expect(screen.getByText('Content type')).toBeTruthy();
-    expect(screen.getByText('Updated')).toBeTruthy();
-    expect(screen.getByText('Status')).toBeTruthy();
-    expect(screen.getByText('Connected fields')).toBeTruthy();
-  });
+  it("when one field is connected and the other isn't, it returns an entry with only connected fields", async () => {
+    mockCma.entry.get.mockResolvedValue({
+      fields: {
+        connectedFields: {
+          'en-US': {
+            ['entry-id']: [
+              {
+                fieldId: 'title',
+                contentBlockId: 'contentBlockA',
+              },
+            ],
+          },
+        },
+      },
+    });
 
-  it('renders the correct number of rows and data', async () => {
-    render(<Page />);
-    for (const entry of mockEntries) {
-      expect(await screen.findByText(entry.fields.name['en-US'])).toBeTruthy();
-      expect(screen.getByText(entry.fields.contentType['en-US'])).toBeTruthy();
-    }
-    // Check connected fields count
-    expect(screen.getByText('2')).toBeTruthy(); // Banana
-    expect(screen.getByText('3')).toBeTruthy(); // Dogs
-    expect(screen.getByText('10')).toBeTruthy(); // Cars
-    expect(screen.getByText('5')).toBeTruthy(); // Trucks
-  });
+    mockCma.entry.getMany.mockResolvedValue({
+      sys: {
+        type: 'Array',
+      },
+      total: 1,
+      skip: 0,
+      limit: 1000,
+      items: [
+        {
+          metadata: {
+            tags: [],
+            concepts: [],
+          },
+          sys: {
+            space: {
+              sys: {
+                type: 'Link',
+                linkType: 'Space',
+                id: 'space-id',
+              },
+            },
+            id: 'entry-id',
+            type: 'Entry',
+            createdAt: '2025-05-08T16:04:58.212Z',
+            updatedAt: '2025-05-15T16:49:16.367Z',
+            environment: {
+              sys: {
+                id: 'environment-id',
+                type: 'Link',
+                linkType: 'Environment',
+              },
+            },
+            publishedVersion: 10,
+            publishedAt: '2025-05-15T16:49:16.367Z',
+            firstPublishedAt: '2025-05-08T16:05:05.759Z',
+            createdBy: {
+              sys: {
+                type: 'Link',
+                linkType: 'User',
+                id: 'user-id',
+              },
+            },
+            updatedBy: {
+              sys: {
+                type: 'Link',
+                linkType: 'User',
+                id: 'user-id',
+              },
+            },
+            publishedCounter: 3,
+            version: 11,
+            publishedBy: {
+              sys: {
+                type: 'Link',
+                linkType: 'User',
+                id: 'user-id',
+              },
+            },
+            fieldStatus: {
+              '*': {
+                'en-US': 'published',
+              },
+            },
+            automationTags: [],
+            contentType: {
+              sys: {
+                type: 'Link',
+                linkType: 'ContentType',
+                id: 'content-type-id',
+              },
+            },
+            urn: 'crn:contentful:::content:spaces/space-id/environments/environment-id/entries/entry-id',
+          },
+          fields: {
+            title: {
+              'en-US': 'Test Title',
+            },
+            author: {
+              'en-US': 'Test Author',
+            },
+          },
+        },
+      ],
+    });
 
-  it('renders status badges correctly', async () => {
-    render(<Page />);
-    expect(await screen.findByText('Published')).toBeTruthy();
-    expect(screen.getAllByText('Published').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('Draft').length).toBeGreaterThan(0);
-  });
+    mockCma.contentType.get.mockImplementation(() => {
+      return {
+        fields: [
+          { id: 'title', type: 'Symbol', localized: false, name: 'Test Title' },
+          { id: 'author', type: 'Symbol', localized: false, name: 'Test Author' },
+        ],
+        displayField: 'title',
+        sys: {
+          id: 'content-type-id',
+        },
+      };
+    });
 
-  it('renders the action button for each row', async () => {
-    render(<Page />);
-    const buttons = await screen.findAllByRole('button', { name: /View fields/i });
-    expect(buttons.length).toBe(mockEntries.length);
-  });
-
-  it('calls navigator when action button is clicked', async () => {
-    render(<Page />);
-    const buttons = await screen.findAllByRole('button', { name: /View fields/i });
-    fireEvent.click(buttons[0]);
-    expect(mockSdk.navigator.openCurrentAppPage).toHaveBeenCalled();
-  });
-
-  it('shows a message if there are no connected entries', async () => {
-    fetchEntriesMock.mockResolvedValueOnce([]);
-    render(<Page />);
-    expect(await screen.findByText(/no connected entries/i)).toBeTruthy();
-  });
-
-  /*it('shows a loading state while fetching', async () => {
-    let resolveFn;
-    fetchEntriesMock.mockReturnValue(new Promise((resolve) => { resolveFn = resolve; }));
-    render(<Page />);
-    expect(screen.getByText(/loading/i)).toBeTruthy();
-    resolveFn([]);
-    await waitFor(() => expect(screen.queryByText(/loading/i)).toBeNull());
-  });*/
-
-  it('shows an error state if fetch fails', async () => {
-    fetchEntriesMock.mockRejectedValueOnce(new Error('Failed to fetch'));
-    render(<Page />);
-    expect(await screen.findByText(/error/i)).toBeTruthy();
+    const result = await fetchBrazeConnectedEntries(
+      mockCma as unknown as any,
+      'space-id',
+      'environment-id'
+    );
+    const title = new BasicField('title', 'Test Title', 'content-type-id', false);
+    const entry = new Entry(
+      'entry-id',
+      'content-type-id',
+      'Untitled',
+      [title],
+      'space-id',
+      'environment-id',
+      '',
+      '2025-05-15T16:49:16.367Z',
+      '2025-05-15T16:49:16.367Z'
+    );
+    expect(result[0].serialize()).toEqual(entry.serialize());
   });
 });

--- a/apps/braze/test/locations/Page.spec.tsx
+++ b/apps/braze/test/locations/Page.spec.tsx
@@ -1,18 +1,191 @@
-import { describe, expect, it, vi } from 'vitest';
-import { mockCma, mockSdk } from '../mocks';
-import { render } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
 import Page from '../../src/locations/Page';
+import { mockSdk, mockCma } from '../mocks';
 
 vi.mock('@contentful/react-apps-toolkit', () => ({
   useSDK: () => mockSdk,
   useCMA: () => mockCma,
 }));
 
-describe('Page component', () => {
-  it('Component text exists', () => {
-    const { getByText } = render(<Page />);
+const mockEntries = [
+  {
+    sys: { id: '1', updatedAt: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString() },
+    fields: {
+      name: { 'en-US': 'Banana' },
+      contentType: { 'en-US': 'Fruits' },
+      status: { 'en-US': 'published' },
+      connectedFields: {
+        'en-US': {
+          '2UaU3B1eRMxStWNQ1Pkv7f': [
+            { fieldId: 'name', contentBlockId: 'de9aacf2-7e95-4bf6-be3a-296380760ac0' },
+            { fieldId: 'name', contentBlockId: '875eb453-86cd-4cb8-a302-40e99cae6550' },
+          ],
+        },
+      },
+    },
+  },
+  {
+    sys: { id: '2', updatedAt: new Date(Date.now() - 10 * 60 * 60 * 1000).toISOString() },
+    fields: {
+      name: { 'en-US': 'Dogs' },
+      contentType: { 'en-US': 'Animals' },
+      status: { 'en-US': 'draft' },
+      connectedFields: {
+        'en-US': {
+          '2UaU3B1eRMxStWNQ1Pkv7f': [
+            { fieldId: 'name', contentBlockId: 'de9aacf2-7e95-4bf6-be3a-296380760ac0' },
+            { fieldId: 'lastname', contentBlockId: '572c6425-10cf-4fd5-aae1-84357e7c13cc' },
+            { fieldId: 'type', contentBlockId: '875eb453-86cd-4cb8-a302-40e99cae6550' },
+          ],
+        },
+      },
+    },
+  },
+  {
+    sys: { id: '3', updatedAt: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString() },
+    fields: {
+      name: { 'en-US': 'Cats' },
+      contentType: { 'en-US': 'Animals' },
+      status: { 'en-US': 'published' },
+      connectedFields: {
+        'en-US': {
+          '2UaU3B1eRMxStWNQ1Pkv7f': [
+            { fieldId: 'name', contentBlockId: 'de9aacf2-7e95-4bf6-be3a-296380760ac0' },
+            { fieldId: 'type', contentBlockId: '875eb453-86cd-4cb8-a302-40e99cae6550' },
+          ],
+        },
+      },
+    },
+  },
+  {
+    sys: { id: '4', updatedAt: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString() },
+    fields: {
+      name: { 'en-US': 'Cars' },
+      contentType: { 'en-US': 'Things that go' },
+      status: { 'en-US': 'published' },
+      connectedFields: {
+        'en-US': {
+          '2UaU3B1eRMxStWNQ1Pkv7f': [
+            { fieldId: 'name', contentBlockId: 'de9aacf2-7e95-4bf6-be3a-296380760ac0' },
+            { fieldId: 'type', contentBlockId: '875eb453-86cd-4cb8-a302-40e99cae6550' },
+            { fieldId: 'model', contentBlockId: '572c6425-10cf-4fd5-aae1-84357e7c13cc' },
+            { fieldId: 'brand', contentBlockId: '572c6425-10cf-4fd5-aae1-84357e7c13cc' },
+            { fieldId: 'year', contentBlockId: '572c6425-10cf-4fd5-aae1-84357e7c13cc' },
+            { fieldId: 'color', contentBlockId: '572c6425-10cf-4fd5-aae1-84357e7c13cc' },
+            { fieldId: 'doors', contentBlockId: '572c6425-10cf-4fd5-aae1-84357e7c13cc' },
+            { fieldId: 'wheels', contentBlockId: '572c6425-10cf-4fd5-aae1-84357e7c13cc' },
+            { fieldId: 'engine', contentBlockId: '572c6425-10cf-4fd5-aae1-84357e7c13cc' },
+            { fieldId: 'fuel', contentBlockId: '572c6425-10cf-4fd5-aae1-84357e7c13cc' },
+          ],
+        },
+      },
+    },
+  },
+  {
+    sys: { id: '5', updatedAt: '2025-02-26T00:00:00.000Z' },
+    fields: {
+      name: { 'en-US': 'Trucks' },
+      contentType: { 'en-US': 'Things that go' },
+      status: { 'en-US': 'draft' },
+      connectedFields: {
+        'en-US': {
+          '2UaU3B1eRMxStWNQ1Pkv7f': [
+            { fieldId: 'name', contentBlockId: 'de9aacf2-7e95-4bf6-be3a-296380760ac0' },
+            { fieldId: 'type', contentBlockId: '875eb453-86cd-4cb8-a302-40e99cae6550' },
+            { fieldId: 'model', contentBlockId: '572c6425-10cf-4fd5-aae1-84357e7c13cc' },
+            { fieldId: 'brand', contentBlockId: '572c6425-10cf-4fd5-aae1-84357e7c13cc' },
+            { fieldId: 'year', contentBlockId: '572c6425-10cf-4fd5-aae1-84357e7c13cc' },
+          ],
+        },
+      },
+    },
+  },
+];
 
-    expect(getByText('Hello Page Component (AppId: test-app)')).toBeTruthy();
+const fetchEntriesMock = vi.fn();
+
+vi.mock('../../src/utils/fetchBrazeConnectedEntries', () => ({
+  fetchBrazeConnectedEntries: fetchEntriesMock,
+}));
+
+describe('Page component', () => {
+  beforeEach(() => {
+    fetchEntriesMock.mockResolvedValue(mockEntries);
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the title, description, and help link', async () => {
+    render(<Page />);
+    expect(await screen.findByText('Braze Content Blocks')).toBeTruthy();
+    expect(screen.getByText('Content connected to Braze through Content Blocks')).toBeTruthy();
+    const helpLink = screen.getByRole('link', { name: /here/i });
+    expect(helpLink.getAttribute('href')).toContain('braze.com');
+  });
+
+  it('renders the table headers', async () => {
+    render(<Page />);
+    expect(await screen.findByText('Entry name')).toBeTruthy();
+    expect(screen.getByText('Content type')).toBeTruthy();
+    expect(screen.getByText('Updated')).toBeTruthy();
+    expect(screen.getByText('Status')).toBeTruthy();
+    expect(screen.getByText('Connected fields')).toBeTruthy();
+  });
+
+  it('renders the correct number of rows and data', async () => {
+    render(<Page />);
+    for (const entry of mockEntries) {
+      expect(await screen.findByText(entry.fields.name['en-US'])).toBeTruthy();
+      expect(screen.getByText(entry.fields.contentType['en-US'])).toBeTruthy();
+    }
+    // Check connected fields count
+    expect(screen.getByText('2')).toBeTruthy(); // Banana
+    expect(screen.getByText('3')).toBeTruthy(); // Dogs
+    expect(screen.getByText('10')).toBeTruthy(); // Cars
+    expect(screen.getByText('5')).toBeTruthy(); // Trucks
+  });
+
+  it('renders status badges correctly', async () => {
+    render(<Page />);
+    expect(await screen.findByText('Published')).toBeTruthy();
+    expect(screen.getAllByText('Published').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Draft').length).toBeGreaterThan(0);
+  });
+
+  it('renders the action button for each row', async () => {
+    render(<Page />);
+    const buttons = await screen.findAllByRole('button', { name: /View fields/i });
+    expect(buttons.length).toBe(mockEntries.length);
+  });
+
+  it('calls navigator when action button is clicked', async () => {
+    render(<Page />);
+    const buttons = await screen.findAllByRole('button', { name: /View fields/i });
+    fireEvent.click(buttons[0]);
+    expect(mockSdk.navigator.openCurrentAppPage).toHaveBeenCalled();
+  });
+
+  it('shows a message if there are no connected entries', async () => {
+    fetchEntriesMock.mockResolvedValueOnce([]);
+    render(<Page />);
+    expect(await screen.findByText(/no connected entries/i)).toBeTruthy();
+  });
+
+  /*it('shows a loading state while fetching', async () => {
+    let resolveFn;
+    fetchEntriesMock.mockReturnValue(new Promise((resolve) => { resolveFn = resolve; }));
+    render(<Page />);
+    expect(screen.getByText(/loading/i)).toBeTruthy();
+    resolveFn([]);
+    await waitFor(() => expect(screen.queryByText(/loading/i)).toBeNull());
+  });*/
+
+  it('shows an error state if fetch fails', async () => {
+    fetchEntriesMock.mockRejectedValueOnce(new Error('Failed to fetch'));
+    render(<Page />);
+    expect(await screen.findByText(/error/i)).toBeTruthy();
   });
 });

--- a/apps/braze/test/mocks/connectedFields.ts
+++ b/apps/braze/test/mocks/connectedFields.ts
@@ -1,0 +1,33 @@
+export const mockConnectedFields = {
+  fields: {
+    connectedFields: {
+      'en-US': {
+        ['entry-id']: [
+          {
+            fieldId: 'title',
+            contentBlockId: 'contentBlockA',
+          },
+          {
+            fieldId: 'author',
+            contentBlockId: 'contentBlockB',
+          },
+        ],
+      },
+    },
+  },
+};
+
+export const mockSingleConnectedField = {
+  fields: {
+    connectedFields: {
+      'en-US': {
+        ['entry-id']: [
+          {
+            fieldId: 'title',
+            contentBlockId: 'contentBlockA',
+          },
+        ],
+      },
+    },
+  },
+};

--- a/apps/braze/test/mocks/contentTypeResponse.ts
+++ b/apps/braze/test/mocks/contentTypeResponse.ts
@@ -1,0 +1,31 @@
+import type { ContentTypeProps } from 'contentful-management';
+
+export function createContentTypeResponse(
+  fieldIds: string[],
+  type: 'Text' | 'RichText' = 'Text'
+): ContentTypeProps {
+  return {
+    sys: {
+      type: 'ContentType',
+      id: 'content-type-id',
+      version: 1,
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-01T00:00:00Z',
+      space: { sys: { type: 'Link', linkType: 'Space', id: 'space-id' } },
+      environment: { sys: { type: 'Link', linkType: 'Environment', id: 'environment-id' } },
+    },
+    name: 'Test Content Type',
+    description: 'Test Description',
+    displayField: 'title',
+    fields: fieldIds.map((id) => ({
+      id,
+      name: id.charAt(0).toUpperCase() + id.slice(1),
+      type,
+      localized: true,
+      required: true,
+      validations: [],
+      disabled: false,
+      omitted: false,
+    })),
+  };
+}

--- a/apps/braze/test/mocks/entryResponse.ts
+++ b/apps/braze/test/mocks/entryResponse.ts
@@ -1,0 +1,60 @@
+import { EntryProps } from 'contentful-management';
+
+export function createGetManyEntryResponse(fields: Record<string, any>): EntryProps {
+  return {
+    metadata: {
+      tags: [],
+      concepts: [],
+    },
+    sys: {
+      space: { sys: { type: 'Link', linkType: 'Space', id: 'space-id' } },
+      id: 'entry-id',
+      type: 'Entry',
+      createdAt: '2025-05-08T16:04:58.212Z',
+      updatedAt: '2025-05-15T16:49:16.367Z',
+      environment: { sys: { type: 'Link', linkType: 'Environment', id: 'environment-id' } },
+      publishedVersion: 10,
+      publishedAt: '2025-05-15T16:49:16.367Z',
+      firstPublishedAt: '2025-05-08T16:05:05.759Z',
+      createdBy: { sys: { type: 'Link', linkType: 'User', id: 'user-id' } },
+      updatedBy: { sys: { type: 'Link', linkType: 'User', id: 'user-id' } },
+      publishedCounter: 3,
+      version: 11,
+      publishedBy: {
+        sys: { type: 'Link', linkType: 'User', id: 'user-id' },
+      },
+      fieldStatus: {
+        '*': { 'en-US': 'published' },
+      },
+      automationTags: [],
+      contentType: {
+        sys: { type: 'Link', linkType: 'ContentType', id: 'content-type-id' },
+      },
+    },
+    fields: Object.fromEntries(
+      Object.entries(fields).map(([key, value]) => [key, { 'en-US': value }])
+    ),
+  };
+}
+
+export function createGetEntryResponse(fields: Record<string, any>): EntryProps {
+  return {
+    sys: {
+      id: 'entry-id',
+      type: 'Entry',
+      space: { sys: { type: 'Link', linkType: 'Space', id: 'space-id' } },
+      environment: { sys: { type: 'Link', linkType: 'Environment', id: 'environment-id' } },
+      contentType: {
+        sys: { type: 'Link', linkType: 'ContentType', id: 'content-type-id' },
+      },
+      locale: 'en-US',
+      version: 1,
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-01T00:00:00Z',
+      automationTags: [],
+    },
+    fields: Object.fromEntries(
+      Object.entries(fields).map(([key, value]) => [key, { 'en-US': value }])
+    ),
+  } as EntryProps;
+}

--- a/apps/braze/test/mocks/mocksForFunctions.ts
+++ b/apps/braze/test/mocks/mocksForFunctions.ts
@@ -1,4 +1,4 @@
-import type { EntryProps, ContentTypeProps, PlainClientAPI } from 'contentful-management';
+import type { PlainClientAPI } from 'contentful-management';
 import type { FunctionEventContext } from '@contentful/node-apps-toolkit';
 import { vi } from 'vitest';
 
@@ -18,58 +18,6 @@ export const mockContext: FunctionEventContext = {
     accessToken: 'test-token',
   },
 };
-
-export function createEntry(fields: Record<string, any>): EntryProps {
-  return {
-    sys: {
-      id: 'entry-id',
-      type: 'Entry',
-      space: { sys: { type: 'Link', linkType: 'Space', id: 'space-id' } },
-      environment: { sys: { type: 'Link', linkType: 'Environment', id: 'environment-id' } },
-      contentType: {
-        sys: { type: 'Link', linkType: 'ContentType', id: 'content-type-id' },
-      },
-      locale: 'en-US',
-      version: 1,
-      createdAt: '2024-01-01T00:00:00Z',
-      updatedAt: '2024-01-01T00:00:00Z',
-      automationTags: [],
-    },
-    fields: Object.fromEntries(
-      Object.entries(fields).map(([key, value]) => [key, { 'en-US': value }])
-    ),
-  } as EntryProps;
-}
-
-export function createContentType(
-  fieldIds: string[],
-  type: 'Text' | 'RichText' = 'Text'
-): ContentTypeProps {
-  return {
-    sys: {
-      type: 'ContentType',
-      id: 'content-type-id',
-      version: 1,
-      createdAt: '2024-01-01T00:00:00Z',
-      updatedAt: '2024-01-01T00:00:00Z',
-      space: { sys: { type: 'Link', linkType: 'Space', id: 'space-id' } },
-      environment: { sys: { type: 'Link', linkType: 'Environment', id: 'environment-id' } },
-    },
-    name: 'Test Content Type',
-    description: 'Test Description',
-    displayField: 'title',
-    fields: fieldIds.map((id) => ({
-      id,
-      name: id.charAt(0).toUpperCase() + id.slice(1),
-      type,
-      localized: true,
-      required: true,
-      validations: [],
-      disabled: false,
-      omitted: false,
-    })),
-  };
-}
 
 export function mockFetchSuccess(responseData: object) {
   vi.mocked(global.fetch).mockResolvedValue({


### PR DESCRIPTION
## Purpose

This updates includes the creation of the table which shows the connected entries in the Page location.

## Approach

We added the new structure in the Page.tsx location and a fetchBrazeConnectedEntries.ts file which contains the logic to get the connected entries from the config entry of the user.

if the user has connected entries, it should look like the following video (taking into account that it's only possible to have 25 connected entries):

https://github.com/user-attachments/assets/2305992c-5a93-44e8-ab14-ce79c26f87fc

if the user doesn't have connected entries, the following message will be displayed:

<img width="1512" alt="Captura de pantalla 2025-05-22 a la(s) 2 59 42 p  m" src="https://github.com/user-attachments/assets/37e13dfb-fc1f-4e91-af1a-d36850585d59" />

If there is an error, then: 

<img width="1510" alt="Captura de pantalla 2025-05-22 a la(s) 3 21 28 p  m" src="https://github.com/user-attachments/assets/78d9004c-9806-41ce-907e-385335f57db5" />


## Testing steps

- An automated test was added.
- You can test it manually by creating a new content block and going to the page location, there, a connected entry should be displayed.

## Breaking Changes

N/A

## Dependencies and/or References

Link to [INTEG-2547](https://contentful.atlassian.net/browse/INTEG-2547) ticket.

## Deployment

N/A