### PR TITLE
Braze: Add locale support [INTEG-2619]

### DIFF
--- a/apps/braze/contentful-app-manifest.json
+++ b/apps/braze/contentful-app-manifest.json
@@ -6,8 +6,12 @@
       "description": "Function to create content blocks from App Action.",
       "path": "functions/createContentBlocks.js",
       "entryFile": "functions/createContentBlocks.ts",
-      "allowNetworks": ["https://*.braze.com"],
-      "accepts": ["appaction.call"]
+      "allowNetworks": [
+        "https://*.braze.com"
+      ],
+      "accepts": [
+        "appaction.call"
+      ]
     },
     {
       "id": "appEventHandler",
@@ -15,8 +19,12 @@
       "description": "Function to handle App Events.",
       "path": "functions/appEventHandler.js",
       "entryFile": "functions/appEventHandler.ts",
-      "allowNetworks": ["https://*.braze.com"],
-      "accepts": ["appevent.handler"]
+      "allowNetworks": [
+        "https://*.braze.com"
+      ],
+      "accepts": [
+        "appevent.handler"
+      ]
     }
   ],
   "actions": [
@@ -34,20 +42,8 @@
           "required": true
         },
         {
-          "id": "fieldIds",
-          "name": "Field IDs",
-          "type": "Symbol",
-          "required": true
-        },
-        {
-          "id": "contentBlockNames",
-          "name": "Content Block Names",
-          "type": "Symbol",
-          "required": true
-        },
-        {
-          "id": "contentBlockDescriptions",
-          "name": "Content Block Descriptions",
+          "id": "fieldsData",
+          "name": "Fields data",
           "type": "Symbol",
           "required": true
         }

--- a/apps/braze/functions/createContentBlocks.ts
+++ b/apps/braze/functions/createContentBlocks.ts
@@ -7,12 +7,19 @@ import type {
 import { documentToHtmlString } from '@contentful/rich-text-html-renderer';
 import { AppInstallationParameters } from '../src/utils';
 import { initContentfulManagementClient } from './common';
+import { ContentTypeProps, EntryProps } from 'contentful-management';
+import { KeyValueMap } from 'contentful-management';
 
 export type AppActionParameters = {
   entryId: string;
-  fieldIds: string;
-  contentBlockNames: string;
-  contentBlockDescriptions: string;
+  fieldsData: string;
+};
+
+type FieldData = {
+  fieldId: string;
+  locale?: string;
+  contentBlockName: string;
+  contentBlockDescription: string;
 };
 
 export const handler: FunctionEventHandler<
@@ -24,19 +31,12 @@ export const handler: FunctionEventHandler<
 ) => {
   const cma = initContentfulManagementClient(context);
 
-  const { entryId, fieldIds, contentBlockNames, contentBlockDescriptions } = event.body;
-  const parsedContentBlockNames = JSON.parse(contentBlockNames) as Record<string, string>;
-  const parsedContentBlockDescriptions = JSON.parse(contentBlockDescriptions) as Record<
-    string,
-    string
-  >;
+  const { entryId, fieldsData } = event.body;
+  const parsedFieldData = JSON.parse(fieldsData);
   const entry = await cma.entry.get({ entryId });
   const contentType = await cma.contentType.get({
     contentTypeId: entry.sys.contentType.sys.id,
   });
-  const locale = entry.sys.locale || 'en-US'; // TODO: define what to do here
-
-  const fieldIdArray = fieldIds.split(',').map((id) => id.trim());
 
   const { brazeApiKey, brazeEndpoint } =
     context.appInstallationParameters as AppInstallationParameters;
@@ -47,80 +47,103 @@ export const handler: FunctionEventHandler<
 
   const results = [];
 
-  for (const fieldId of fieldIdArray) {
-    const fieldValue = entry.fields[fieldId]?.[locale];
-
-    if (!fieldValue) {
-      results.push({
-        fieldId,
-        success: false,
-        statusCode: 600,
-        message: `Field ${fieldId} does not exist or is empty`,
-      });
-      continue;
-    }
-
-    if (!parsedContentBlockNames[fieldId]) {
-      results.push({
-        fieldId,
-        success: false,
-        statusCode: 400,
-        message: `Unexpected error: Content block name not found for field ${fieldId}`,
-      });
-      continue;
-    }
-
-    try {
-      const field = contentType.fields.find((f) => f.id === fieldId);
-      let content = fieldValue;
-
-      if (field?.type === 'RichText') {
-        content = documentToHtmlString(fieldValue);
-      }
-
-      const response = await fetch(`${brazeEndpoint}/content_blocks/create`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${brazeApiKey}`,
-        },
-        body: JSON.stringify({
-          name: parsedContentBlockNames[fieldId],
-          content: content,
-          state: 'draft',
-          description: parsedContentBlockDescriptions[fieldId] || '',
-        }),
-      });
-
-      const data = await response.json();
-
-      if (!response.ok) {
-        results.push({
-          fieldId,
-          success: false,
-          statusCode: response.status,
-          message: `Error creating content block for field ${fieldId}: ${data.message}`,
-        });
-        continue;
-      }
-
-      results.push({
-        fieldId,
-        success: true,
-        statusCode: 201,
-        contentBlockId: data.content_block_id,
-      });
-    } catch (error) {
-      results.push({
-        fieldId,
-        success: false,
-        statusCode: 500,
-        message: error instanceof Error ? error.message : 'Unknown error',
-      });
-    }
+  for (const fieldData of parsedFieldData) {
+    results.push(
+      await createContentBlock(entry, fieldData, contentType, brazeApiKey, brazeEndpoint)
+    );
   }
 
   return {
     results,
   };
+};
+
+const createContentBlock = async (
+  entry: EntryProps<KeyValueMap>,
+  fieldData: FieldData,
+  contentType: ContentTypeProps,
+  brazeApiKey: string,
+  brazeEndpoint: string
+) => {
+  const { fieldId, locale, contentBlockName, contentBlockDescription } = fieldData;
+  if (!fieldId || !contentBlockName) {
+    return {
+      fieldId: fieldId || '',
+      success: false,
+      statusCode: 601,
+      message: `Unexpected error: Information missing. Field ID: ${fieldId} - Content block name: ${contentBlockName}`,
+    };
+  }
+
+  let fieldValue = entry.fields[fieldId] ? entry.fields[fieldId] : undefined;
+  if (fieldValue) {
+    fieldValue = locale ? fieldValue[locale] : Object.values(fieldValue)[0];
+  }
+
+  if (!fieldValue) {
+    return {
+      fieldId,
+      ...(locale ? { locale } : {}),
+      success: false,
+      statusCode: 600,
+      message:
+        `Field ${fieldId}` +
+        (locale ? ` with locale ${locale}` : '') +
+        ' does not exist or is empty',
+    };
+  }
+
+  try {
+    const field = contentType.fields.find((f) => f.id === fieldId);
+    let content = fieldValue;
+
+    if (field?.type === 'RichText') {
+      content = documentToHtmlString(fieldValue);
+    }
+
+    const response = await fetch(`${brazeEndpoint}/content_blocks/create`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${brazeApiKey}`,
+      },
+      body: JSON.stringify({
+        name: contentBlockName,
+        content: content,
+        state: 'draft',
+        description: contentBlockDescription || '',
+      }),
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      return {
+        fieldId,
+        ...(locale ? { locale } : {}),
+        success: false,
+        statusCode: response.status,
+        message:
+          `Error creating content block for field ${fieldId}` +
+          (locale ? ` and locale ${locale}` : '') +
+          `: ${data.message}`,
+      };
+    }
+
+    return {
+      fieldId,
+      ...(locale ? { locale } : {}),
+      success: true,
+      statusCode: 201,
+      contentBlockId: data.content_block_id,
+    };
+  } catch (error) {
+    return {
+      fieldId,
+      ...(locale ? { locale } : {}),
+      success: false,
+      statusCode: 500,
+      message: error instanceof Error ? error.message : 'Unknown error',
+    };
+  }
 };

--- a/apps/braze/src/components/create/CreateFlow.tsx
+++ b/apps/braze/src/components/create/CreateFlow.tsx
@@ -13,13 +13,16 @@ import {
   FIELDS_STEP,
   getConfigEntry,
   updateConfig,
+  localizeFieldId,
 } from '../../utils';
 import { createClient } from 'contentful-management';
 import DraftStep from './DraftStep';
 import ErrorStep from './ErrorStep';
+import LocalesSelectionStep from '../generate/LocalesSelectionStep';
 
 const CREATE_STEP = 'create';
 const DRAFT_STEP = 'draft';
+const LOCALES_STEP = 'locales';
 const ERROR_STEP = 'error';
 const SUCCESS_STEP = 'success';
 const BRAZE_NAME_EXISTS_ERROR = 'name already exists';
@@ -29,6 +32,7 @@ type CreateFlowProps = {
   entry: Entry;
   invocationParams: InvocationParams;
   initialSelectedFields?: string[];
+  initialSelectedLocales?: string[];
 };
 
 export type ContentBlockData = {
@@ -38,21 +42,33 @@ export type ContentBlockData = {
 
 export type CreationResultField = {
   fieldId: string;
+  locale: string;
   success: boolean;
   statusCode: number;
   message: string;
 };
 
 const CreateFlow = (props: CreateFlowProps) => {
-  const { sdk, entry, initialSelectedFields = [] } = props;
+  const { sdk, entry, initialSelectedFields = [], initialSelectedLocales = [] } = props;
   const [step, setStep] = useState(FIELDS_STEP);
   const [selectedFields, setSelectedFields] = useState<Set<string>>(new Set(initialSelectedFields));
+  const [selectedLocales, setSelectedLocales] = useState<string[]>(initialSelectedLocales);
   const [creationResultFields, setCreationResultFields] = useState<CreationResultField[]>([]);
   const [contentBlocksData, setContentBlocksData] = useState<ContentBlockData>({
     names: {},
     descriptions: {},
   });
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const locales = sdk.locales.available;
+
+  const shouldChooseLocales = (selectedFields: Set<string>): boolean => {
+    return (
+      locales.length > 1 &&
+      Array.from(selectedFields).some(
+        (fieldId) => entry.fields.find((f) => f.id === fieldId)?.localized
+      )
+    );
+  };
 
   const cma = createClient(
     { apiAdapter: sdk.cmaAdapter },
@@ -73,26 +89,39 @@ const CreateFlow = (props: CreateFlowProps) => {
 
     setIsSubmitting(true);
 
-    const names: Record<string, string> = {};
-    const descriptions: Record<string, string> = {};
-    Object.entries(data.names)
-      .filter(
-        ([fieldId, fieldName]) =>
-          !creationResultFields.some((result) => result.fieldId === fieldId && result.success)
-      )
-      .forEach(([fieldId, fieldName]) => (names[fieldId] = fieldName));
-    Object.entries(data.descriptions)
-      .filter(
-        ([fieldId, fieldDescription]) =>
-          !creationResultFields.some((result) => result.fieldId === fieldId && result.success)
-      )
-      .forEach(([fieldId, fieldDescription]) => (descriptions[fieldId] = fieldDescription));
-    const fieldsIds = Array.from(selectedFields)
-      .filter(
-        (fieldId) =>
-          !creationResultFields.some((result) => result.fieldId === fieldId && result.success)
-      )
-      .join(',');
+    const fieldsToCreate = [];
+
+    for (const fieldId of Array.from(selectedFields)) {
+      const fieldIsLocalized = entry.fields.find((f) => f.id === fieldId)?.localized;
+      if (shouldChooseLocales(selectedFields) && fieldIsLocalized) {
+        for (const locale of selectedLocales) {
+          if (
+            creationResultFields.some(
+              (result) => result.success && result.fieldId === fieldId && result.locale === locale
+            )
+          ) {
+            continue;
+          }
+
+          const localizedFieldId = localizeFieldId(fieldId, locale);
+          fieldsToCreate.push({
+            fieldId,
+            locale,
+            contentBlockName: data.names[localizedFieldId],
+            contentBlockDescription: data.descriptions[localizedFieldId],
+          });
+        }
+      } else {
+        if (creationResultFields.some((result) => result.success && result.fieldId === fieldId)) {
+          continue;
+        }
+        fieldsToCreate.push({
+          fieldId,
+          contentBlockName: data.names[fieldId],
+          contentBlockDescription: data.descriptions[fieldId],
+        });
+      }
+    }
 
     try {
       const configEntry = await getConfigEntry(cma);
@@ -109,9 +138,7 @@ const CreateFlow = (props: CreateFlowProps) => {
         {
           parameters: {
             entryId: entry.id,
-            fieldIds: fieldsIds,
-            contentBlockNames: JSON.stringify(names),
-            contentBlockDescriptions: JSON.stringify(descriptions),
+            fieldsData: JSON.stringify(fieldsToCreate),
           },
         }
       );
@@ -122,6 +149,7 @@ const CreateFlow = (props: CreateFlowProps) => {
         .map((result: any) => {
           return {
             fieldId: result.fieldId,
+            locale: result.locale,
             contentBlockId: result.contentBlockId,
           };
         });
@@ -166,6 +194,17 @@ const CreateFlow = (props: CreateFlowProps) => {
           entry={entry}
           selectedFields={selectedFields}
           setSelectedFields={setSelectedFields}
+          handleNextStep={() =>
+            setStep(shouldChooseLocales(selectedFields) ? LOCALES_STEP : CREATE_STEP)
+          }
+        />
+      )}
+      {step === LOCALES_STEP && (
+        <LocalesSelectionStep
+          locales={locales}
+          selectedLocales={selectedLocales}
+          setSelectedLocales={setSelectedLocales}
+          handlePreviousStep={() => setStep(FIELDS_STEP)}
           handleNextStep={() => setStep(CREATE_STEP)}
         />
       )}
@@ -173,8 +212,11 @@ const CreateFlow = (props: CreateFlowProps) => {
         <CreateStep
           entry={entry}
           selectedFields={selectedFields}
+          selectedLocales={shouldChooseLocales(selectedFields) ? selectedLocales : undefined}
           isSubmitting={isSubmitting}
-          handlePreviousStep={() => setStep(FIELDS_STEP)}
+          handlePreviousStep={() =>
+            setStep(shouldChooseLocales(selectedFields) ? LOCALES_STEP : FIELDS_STEP)
+          }
           contentBlocksData={contentBlocksData}
           setContentBlocksData={setContentBlocksData}
           handleNextStep={handleCreate}
@@ -201,7 +243,7 @@ const CreateFlow = (props: CreateFlowProps) => {
       {step === SUCCESS_STEP && (
         <SuccessStep
           entry={entry}
-          selectedFields={selectedFields}
+          createdFields={creationResultFields.filter((result) => result.success).length}
           handleClose={() => sdk.close({ step: 'close' })}
         />
       )}

--- a/apps/braze/src/components/create/ErrorStep.tsx
+++ b/apps/braze/src/components/create/ErrorStep.tsx
@@ -2,6 +2,7 @@ import { Button, Subheading, Text, List } from '@contentful/f36-components';
 import WizardFooter from '../WizardFooter';
 import { ContentBlockData, CreationResultField } from './CreateFlow';
 import InformationWithLink from '../InformationWithLink';
+import { localizeFieldId } from '../../utils';
 
 type ClientErrorStepProps = {
   isSubmitting: boolean;
@@ -28,19 +29,18 @@ const ErrorStep = ({
   const clientErrors = creationResultFields.filter(
     (field) => !field.success && field.statusCode !== 500 && field.statusCode !== 600
   );
-  const correctlyCreatedFields = creationResultFields.filter((field) => field.success);
   const containsServerError = serverErrors.length > 0;
 
   function handleRetry() {
     const filteredContentBlocksData = {
       names: Object.fromEntries(
         Object.entries(contentBlocksData.names).filter(
-          ([fieldId]) => !correctlyCreatedFields.some((field) => field.fieldId === fieldId)
+          ([fieldId]) => !createdFields.some((field) => field.fieldId === fieldId)
         )
       ),
       descriptions: Object.fromEntries(
         Object.entries(contentBlocksData.descriptions).filter(
-          ([fieldId]) => !correctlyCreatedFields.some((field) => field.fieldId === fieldId)
+          ([fieldId]) => !createdFields.some((field) => field.fieldId === fieldId)
         )
       ),
     };
@@ -90,7 +90,7 @@ const ErrorStep = ({
             {createdFields.map((field, index) => (
               <List.Item key={`${field.fieldId}-${index}`}>
                 <Text fontWeight="fontWeightDemiBold">
-                  {contentBlocksData.names[field.fieldId]}
+                  {contentBlocksData.names[localizeFieldId(field.fieldId, field.locale)]}
                 </Text>
               </List.Item>
             ))}

--- a/apps/braze/src/components/create/SuccessStep.tsx
+++ b/apps/braze/src/components/create/SuccessStep.tsx
@@ -4,20 +4,20 @@ import WizardFooter from '../WizardFooter';
 
 type SuccessStepProps = {
   entry: Entry;
-  selectedFields: Set<string>;
+  createdFields: number;
   handleClose: () => void;
 };
 
-const SuccessStep = ({ selectedFields, handleClose }: SuccessStepProps) => {
+const SuccessStep = ({ createdFields, handleClose }: SuccessStepProps) => {
   return (
     <>
       <Subheading fontWeight="fontWeightDemiBold" fontSize="fontSizeXl" lineHeight="lineHeightL">
         Success!
       </Subheading>
       <Paragraph>
-        {selectedFields.size || 0} {selectedFields.size === 1 ? 'field was' : 'fields were'}{' '}
-        successfully sent to Braze. You can view them from your Braze dashboard by navigating to
-        Templates {'>'} Content Blocks.
+        {createdFields || 0} {createdFields === 1 ? 'field was' : 'fields were'} successfully sent
+        to Braze. You can view them from your Braze dashboard by navigating to Templates {'>'}{' '}
+        Content Blocks.
       </Paragraph>
       <WizardFooter>
         <Button variant="primary" size="small" onClick={handleClose}>

--- a/apps/braze/src/components/generate/GenerateFlow.tsx
+++ b/apps/braze/src/components/generate/GenerateFlow.tsx
@@ -15,7 +15,6 @@ type GenerateFlowProps = {
   sdk: DialogAppSDK;
   entry: Entry;
   invocationParams: InvocationParams;
-  locales: string[];
   initialStep?: string;
   initialSelectedFields?: string[];
   initialSelectedLocales?: string[];
@@ -26,7 +25,6 @@ const GenerateFlow = (props: GenerateFlowProps) => {
     sdk,
     entry,
     invocationParams,
-    locales,
     initialStep = FIELDS_STEP,
     initialSelectedFields = [],
     initialSelectedLocales = [],
@@ -36,6 +34,7 @@ const GenerateFlow = (props: GenerateFlowProps) => {
   const [selectedFields, setSelectedFields] = useState<Set<string>>(new Set(initialSelectedFields));
   const [selectedLocales, setSelectedLocales] = useState<string[]>(initialSelectedLocales);
 
+  const locales = sdk.locales.available;
   const shouldChooseLocales = locales.length > 1 && entry.anyFieldIsLocalized();
 
   return (

--- a/apps/braze/src/locations/Dialog.tsx
+++ b/apps/braze/src/locations/Dialog.tsx
@@ -89,7 +89,6 @@ const Dialog = () => {
       sdk={sdk}
       entry={entry}
       invocationParams={invocationParams}
-      locales={sdk.locales.available}
       initialStep={currentStep}
       initialSelectedFields={currentSelectedFields}
       initialSelectedLocales={currentSelectedLocales}

--- a/apps/braze/src/locations/Sidebar.tsx
+++ b/apps/braze/src/locations/Sidebar.tsx
@@ -21,6 +21,7 @@ import {
   GENERATE_DIALOG_MODE,
   GENERATE_DIALOG_TITLE,
   getConfigEntry,
+  localizeFieldId,
   SIDEBAR_CONNECTED_ENTRIES_BUTTON_TEXT,
   SIDEBAR_CREATE_BUTTON_TEXT,
   SIDEBAR_GENERATE_BUTTON_TEXT,
@@ -165,7 +166,7 @@ const Sidebar = () => {
                 className={styles.stack}>
                 {entryConnectedFields.map((fieldMapping, index) => (
                   <Text key={`${currentEntryId}-${index}`} className={styles.listItem}>
-                    {fieldMapping.fieldId}
+                    {localizeFieldId(fieldMapping.fieldId, fieldMapping.locale)}
                   </Text>
                 ))}
               </Stack>

--- a/apps/braze/src/utils.ts
+++ b/apps/braze/src/utils.ts
@@ -104,6 +104,7 @@ export type AppInstallationParameters = {
 
 export type EntryConnectedFields = {
   fieldId: string;
+  locale: string;
   contentBlockId: string;
 }[];
 
@@ -151,3 +152,7 @@ export async function updateConfig(
 export async function getConfigEntry(cma: PlainClientAPI): Promise<EntryProps<KeyValueMap>> {
   return await cma.entry.get({ entryId: CONFIG_ENTRY_ID });
 }
+
+export const localizeFieldId = (fieldId: string, locale?: string) => {
+  return locale ? `${fieldId}-${locale}` : fieldId;
+};

--- a/apps/braze/test/functions/createContentBlocks.test.ts
+++ b/apps/braze/test/functions/createContentBlocks.test.ts
@@ -64,15 +64,18 @@ describe('createContentBlocks', () => {
       type: FunctionTypeEnum.AppActionCall,
       body: {
         entryId: 'entry-id',
-        fieldIds: 'title,author',
-        contentBlockNames: JSON.stringify({
-          title: 'custom-title-name',
-          author: 'custom-author-name',
-        }),
-        contentBlockDescriptions: JSON.stringify({
-          title: 'custom-title-description',
-          author: 'custom-author-description',
-        }),
+        fieldsData: JSON.stringify([
+          {
+            fieldId: 'title',
+            contentBlockName: 'custom-title-name',
+            contentBlockDescription: 'custom-title-description',
+          },
+          {
+            fieldId: 'author',
+            contentBlockName: 'custom-author-name',
+            contentBlockDescription: 'custom-author-description',
+          },
+        ]),
       },
       headers: {},
     };
@@ -143,9 +146,13 @@ describe('createContentBlocks', () => {
       type: FunctionTypeEnum.AppActionCall,
       body: {
         entryId: 'entry-id',
-        fieldIds: 'content',
-        contentBlockNames: JSON.stringify({ content: 'custom-content-name' }),
-        contentBlockDescriptions: JSON.stringify({ content: 'custom-content-description' }),
+        fieldsData: JSON.stringify([
+          {
+            fieldId: 'content',
+            contentBlockName: 'custom-content-name',
+            contentBlockDescription: 'custom-content-description',
+          },
+        ]),
       },
       headers: {},
     };
@@ -190,15 +197,18 @@ describe('createContentBlocks', () => {
       type: FunctionTypeEnum.AppActionCall,
       body: {
         entryId: 'entry-id',
-        fieldIds: 'title,author',
-        contentBlockNames: JSON.stringify({
-          title: 'custom-title-name',
-          author: 'custom-author-name',
-        }),
-        contentBlockDescriptions: JSON.stringify({
-          title: 'custom-title-description',
-          author: 'custom-author-description',
-        }),
+        fieldsData: JSON.stringify([
+          {
+            fieldId: 'title',
+            contentBlockName: 'custom-title-name',
+            contentBlockDescription: 'custom-title-description',
+          },
+          {
+            fieldId: 'author',
+            contentBlockName: 'custom-author-name',
+            contentBlockDescription: 'custom-author-description',
+          },
+        ]),
       },
       headers: {},
     };
@@ -210,13 +220,13 @@ describe('createContentBlocks', () => {
         {
           fieldId: 'title',
           success: false,
-          statusCode: 400,
+          statusCode: 600,
           message: 'Field title does not exist or is empty',
         },
         {
           fieldId: 'author',
           success: false,
-          statusCode: 400,
+          statusCode: 600,
           message: 'Field author does not exist or is empty',
         },
       ],
@@ -246,15 +256,18 @@ describe('createContentBlocks', () => {
       type: FunctionTypeEnum.AppActionCall,
       body: {
         entryId: 'entry-id',
-        fieldIds: 'title,author',
-        contentBlockNames: JSON.stringify({
-          title: 'custom-title-name',
-          author: 'custom-author-name',
-        }),
-        contentBlockDescriptions: JSON.stringify({
-          title: 'custom-title-description',
-          author: 'custom-author-description',
-        }),
+        fieldsData: JSON.stringify([
+          {
+            fieldId: 'title',
+            contentBlockName: 'custom-title-name',
+            contentBlockDescription: 'custom-title-description',
+          },
+          {
+            fieldId: 'author',
+            contentBlockName: 'custom-author-name',
+            contentBlockDescription: 'custom-author-description',
+          },
+        ]),
       },
       headers: {},
     };
@@ -301,15 +314,18 @@ describe('createContentBlocks', () => {
       type: FunctionTypeEnum.AppActionCall,
       body: {
         entryId: 'entry-id',
-        fieldIds: 'title,author',
-        contentBlockNames: JSON.stringify({
-          title: 'custom-title-name',
-          author: 'custom-author-name',
-        }),
-        contentBlockDescriptions: JSON.stringify({
-          title: 'custom-title-description',
-          author: 'custom-author-description',
-        }),
+        fieldsData: JSON.stringify([
+          {
+            fieldId: 'title',
+            contentBlockName: 'custom-title-name',
+            contentBlockDescription: 'custom-title-description',
+          },
+          {
+            fieldId: 'author',
+            contentBlockName: 'custom-author-name',
+            contentBlockDescription: 'custom-author-description',
+          },
+        ]),
       },
       headers: {},
     };
@@ -360,7 +376,7 @@ describe('createContentBlocks', () => {
     );
   });
 
-  it('should handle invalid contentBlockNames JSON', async () => {
+  it('should handle invalid fieldsData JSON', async () => {
     // Mock Entry data
     const entry = createEntry({ title: 'Test Title', author: 'Test Author' });
     const contentType = createContentType(['title', 'author']);
@@ -373,12 +389,7 @@ describe('createContentBlocks', () => {
       type: FunctionTypeEnum.AppActionCall,
       body: {
         entryId: 'entry-id',
-        fieldIds: 'title,author',
-        contentBlockNames: 'invalid-json',
-        contentBlockDescriptions: JSON.stringify({
-          title: 'custom-title-description',
-          author: 'custom-author-description',
-        }),
+        fieldsData: 'invalid-json',
       },
       headers: {},
     };
@@ -404,15 +415,18 @@ describe('createContentBlocks', () => {
       type: FunctionTypeEnum.AppActionCall,
       body: {
         entryId: 'entry-id',
-        fieldIds: 'title,author',
-        contentBlockNames: JSON.stringify({
-          title: 'custom-title-name',
-          // author name is missing
-        }),
-        contentBlockDescriptions: JSON.stringify({
-          title: 'custom-title-description',
-          author: 'custom-author-description',
-        }),
+        fieldsData: JSON.stringify([
+          {
+            fieldId: 'title',
+            contentBlockName: 'custom-title-name',
+            contentBlockDescription: 'custom-title-description',
+          },
+          {
+            fieldId: 'author',
+            // author name is missing
+            contentBlockDescription: 'custom-author-description',
+          },
+        ]),
       },
       headers: {},
     };
@@ -430,8 +444,9 @@ describe('createContentBlocks', () => {
         {
           fieldId: 'author',
           success: false,
-          statusCode: 400,
-          message: 'Unexpected error: Content block name not found for field author',
+          statusCode: 601,
+          message:
+            'Unexpected error: Information missing. Field ID: author - Content block name: undefined',
         },
       ],
     });

--- a/apps/braze/test/locations/Dialog.spec.tsx
+++ b/apps/braze/test/locations/Dialog.spec.tsx
@@ -36,7 +36,7 @@ vi.mock('../../src/fields/FieldsFactory', () => ({
 }));
 
 const mockCMAEntryItemResponse = createEntry({
-  title: 'Some Title',
+  title: { 'en-US': 'Some Title' },
   fieldId: {
     sys: {
       id: 'referencedEntryId',

--- a/apps/braze/test/locations/Sidebar.spec.tsx
+++ b/apps/braze/test/locations/Sidebar.spec.tsx
@@ -37,6 +37,7 @@ describe('Sidebar component', () => {
             [mockSdk.ids.entry]: [
               {
                 fieldId: 'fieldA',
+                locale: 'en-US',
                 contentBlockId: 'contentBlockA',
               },
             ],
@@ -160,7 +161,7 @@ describe('Sidebar component', () => {
   it('renders the "Connected Content Block entries" section when connectedFields are present', async () => {
     const { getByText } = render(<Sidebar />);
     await screen.findByText('Connected Content Block entries', { exact: false });
-    expect(getByText('fieldA')).toBeTruthy();
+    expect(getByText('fieldA-en-US')).toBeTruthy();
   });
 
   it('renders the Connected Entries button and triggers navigation when clicked', async () => {

--- a/apps/braze/test/mocks/mocksForFunctions.ts
+++ b/apps/braze/test/mocks/mocksForFunctions.ts
@@ -35,9 +35,7 @@ export function createEntry(fields: Record<string, any>): EntryProps {
       updatedAt: '2024-01-01T00:00:00Z',
       automationTags: [],
     },
-    fields: Object.fromEntries(
-      Object.entries(fields).map(([key, value]) => [key, { 'en-US': value }])
-    ),
+    fields: Object.fromEntries(Object.entries(fields).map(([key, value]) => [key, value])),
   } as EntryProps;
 }
 


### PR DESCRIPTION
## Purpose

We can now create multiple content blocks per field if it's localized

## Approach

- Changed the format of the parameters sent to the action that creates the content block (from several parameters to just one stringified json). One object is sent per combination of field and locale
- Only display andnsend multiple objects if the field is localized, otherwise display only one

## Testing steps

Generate content blocks for fields that are localized. Automated tests have also been added