### PR TITLE
Mux app: Fix render error while creating/removing captions

### DIFF
--- a/apps/mux/frontend/src/index.tsx
+++ b/apps/mux/frontend/src/index.tsx
@@ -730,11 +730,6 @@ export class App extends React.Component<AppProps, AppState> {
 
   reloadPlayer = async () => {
     if (!this.state || !this.state.value) return;
-    const currentPlaybackId = this.state.playerPlaybackId;
-    this.setState({ playerPlaybackId: undefined });
-    await new Promise((resolve) => setTimeout(resolve, 100));
-    this.setState({ playerPlaybackId: currentPlaybackId });
-    await new Promise((resolve) => setTimeout(resolve, 100));
     this.muxPlayerRef.current?.load();
   };
 

--- a/apps/mux/frontend/src/util/types.tsx
+++ b/apps/mux/frontend/src/util/types.tsx
@@ -19,7 +19,6 @@ export interface AppState {
   error: string | false;
   errorShowResetAction: boolean | false;
   isDeleting: boolean | false;
-  isReloading: boolean | false;
   isTokenLoading: boolean | false;
   playbackToken?: string;
   posterToken?: string;


### PR DESCRIPTION
## Purpose

Fixes #7808 
This PR fixes a re-render error that occurs when a captions is being added/removed.

## Approach

Currently, the plugin triggers a full re-render of the player, which causes issues with the Mux Player library and leads to CORS errors.
The approach taken in this PR is to reload the player's manifest with the updated captions, without requiring a full re-render.

### Recording

https://github.com/user-attachments/assets/bd7eafe0-5e23-4852-9133-2839c40252cd

## Testing steps

Create a content model with the Mux JSON Object. Then, create a new entry for that content type, and you’ll be able to test uploading assets.
After uploading an Asset, create a caption using the form in the field. Also test removing a caption.
The player should reload without errors.

## Breaking Changes

None.

## Dependencies and/or References

None.

## Deployment

None.
