### PR TITLE
Braze integ 2534

### DIFF
--- a/apps/braze/test/functions/createContentBlocks.test.ts
+++ b/apps/braze/test/functions/createContentBlocks.test.ts
@@ -178,11 +178,9 @@ describe('createContentBlocks', () => {
   });
 
   it('should handle missing fields', async () => {
-    // Mock Entry data
     const entry = createEntry({});
     const contentType = createContentType(['title', 'author']);
 
-    // Mock API responses
     vi.mocked(mockCma.entry.get).mockResolvedValue(entry);
     vi.mocked(mockCma.contentType.get).mockResolvedValue(contentType);
 
@@ -210,13 +208,13 @@ describe('createContentBlocks', () => {
         {
           fieldId: 'title',
           success: false,
-          statusCode: 400,
+          statusCode: 600,
           message: 'Field title does not exist or is empty',
         },
         {
           fieldId: 'author',
           success: false,
-          statusCode: 400,
+          statusCode: 600,
           message: 'Field author does not exist or is empty',
         },
       ],


### PR DESCRIPTION
## Purpose

Adding the possibility to add the app to the sidebar of several content types right in the config screen

## Approach

Added an autocomplete component to select content types. The app is added to the selected content types when the app gets installed

## Testing steps

Configure the app, select content types and verify the app appears on their sidebars.
Automated tests were added.

https://github.com/user-attachments/assets/31cf2e10-0234-47f0-b2dd-46a813e7cffd