### PR TITLE
Braze: Modal Layout for page location [INTEG-2548]

### DIFF
--- a/apps/braze/src/locations/Page.styles.ts
+++ b/apps/braze/src/locations/Page.styles.ts
@@ -1,6 +1,11 @@
 import tokens from '@contentful/f36-tokens';
 import { css } from 'emotion';
 
+const baseTableCell = {
+  paddingTop: tokens.spacingXs,
+  paddingBottom: tokens.spacingXs,
+};
+
 export const styles = {
   container: css({
     background: tokens.colorWhite,
@@ -19,5 +24,37 @@ export const styles = {
   }),
   loading: css({
     height: '80vh',
+  }),
+  modalMainContainer: css({
+    minWidth: 400,
+  }),
+  modalEntryContainer: css({
+    border: `1px solid ${tokens.gray300}`,
+    borderRadius: tokens.borderRadiusMedium,
+    background: tokens.colorWhite,
+    padding: tokens.spacingS,
+    marginBottom: tokens.spacingM,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: tokens.spacingM,
+  }),
+  modalConnectedFieldsContainer: css({
+    border: `1px solid ${tokens.gray300}`,
+    boxShadow: 'none',
+  }),
+  viewEntryButton: css({
+    marginLeft: tokens.spacingL,
+  }),
+  baseCell: css({
+    ...baseTableCell,
+  }),
+  checkboxCell: css({
+    ...baseTableCell,
+    width: 40,
+  }),
+  boldCell: css({
+    ...baseTableCell,
+    fontWeight: 'bold',
   }),
 };

--- a/apps/braze/test/locations/Page.spec.tsx
+++ b/apps/braze/test/locations/Page.spec.tsx
@@ -1,94 +1,199 @@
+import React from 'react';
 import { useSDK } from '@contentful/react-apps-toolkit';
-import { render, waitFor, screen } from '@testing-library/react';
+import { render, waitFor, screen, cleanup } from '@testing-library/react';
 import { vi, describe, beforeEach, it, expect, Mock, afterEach } from 'vitest';
 import Page from '../../src/locations/Page';
 import { fetchBrazeConnectedEntries } from '../../src/utils/fetchBrazeConnectedEntries';
 import { BasicField } from '../../src/fields/BasicField';
 import { Entry } from '../../src/fields/Entry';
-import { mockSdk } from '../mocks/mockSdk';
+import { mockSdk } from '../mocks';
 
-vi.mock('@contentful/react-apps-toolkit');
-vi.mock('../../src/utils/fetchBrazeConnectedEntries');
-vi.mock('contentful-management', () => ({
-  createClient: vi.fn(() => ({})),
-}));
+describe('Page Location', () => {
+  vi.mock('@contentful/react-apps-toolkit');
+  vi.mock('../../src/utils/fetchBrazeConnectedEntries');
+  vi.mock('contentful-management', () => ({
+    createClient: vi.fn(() => ({})),
+  }));
 
-describe('Page', () => {
-  const title = new BasicField('title', 'Title', 'content-type-id', true);
-  const author = new BasicField('author', 'Author', 'content-type-id', true);
   beforeEach(() => {
     vi.clearAllMocks();
-    (useSDK as unknown as Mock).mockReturnValue(mockSdk);
   });
+
   afterEach(() => {
-    vi.clearAllMocks();
+    cleanup();
   });
 
-  it('renders loading state initially', () => {
-    (fetchBrazeConnectedEntries as Mock).mockReturnValue(new Promise(() => {}));
-    render(<Page />);
-    expect(screen.getByText(/Loading.../i)).toBeTruthy();
-  });
+  describe('Page component', () => {
+    const title = new BasicField('title', 'Title', 'content-type-id', true);
+    const author = new BasicField('author', 'Author', 'content-type-id', true);
 
-  it('renders error state if fetch fails', async () => {
-    (fetchBrazeConnectedEntries as Mock).mockRejectedValue(new Error('fail'));
-    render(<Page />);
-    await waitFor(() => {
-      expect(screen.getByText(/There was an error/i)).toBeTruthy();
-      expect(screen.getByText(/Please contact support/i)).toBeTruthy();
+    beforeEach(() => {
+      (useSDK as unknown as Mock).mockReturnValue(mockSdk);
+    });
+
+    it('renders loading state initially', () => {
+      (fetchBrazeConnectedEntries as Mock).mockReturnValue(new Promise(() => {}));
+      render(<Page />);
+      expect(screen.getByText(/Loading.../i)).toBeTruthy();
+    });
+
+    it('renders error state if fetch fails', async () => {
+      (fetchBrazeConnectedEntries as Mock).mockRejectedValue(new Error('fail'));
+      render(<Page />);
+      await waitFor(() => {
+        expect(screen.getByText(/There was an error/i)).toBeTruthy();
+        expect(screen.getByText(/Please contact support/i)).toBeTruthy();
+      });
+    });
+
+    it('renders empty state if no entries', async () => {
+      (fetchBrazeConnectedEntries as Mock).mockResolvedValue([]);
+      render(<Page />);
+      await waitFor(() => {
+        expect(screen.getByText(/No active Braze Content Blocks/i)).toBeTruthy();
+        expect(
+          screen.getByText(/Once you have created Content Blocks, they will display here./i)
+        ).toBeTruthy();
+      });
+    });
+
+    it('renders connected entries table if entries exist', async () => {
+      const publishEntry = new Entry(
+        'entry-id',
+        'content-type-id',
+        'Title',
+        [title, author],
+        'space-id',
+        'environment-id',
+        'valid-contentful-api-key',
+        '2025-05-15T16:49:16.367Z',
+        '2025-05-15T16:49:16.367Z'
+      );
+      (fetchBrazeConnectedEntries as Mock).mockResolvedValue([publishEntry]);
+      render(<Page />);
+      await waitFor(() => {
+        expect(screen.getByText(/Content connected to Braze/i)).toBeTruthy();
+        expect(screen.getByText(/Title/i)).toBeTruthy();
+        expect(screen.getByText(/Published/i)).toBeTruthy();
+        expect(screen.getByRole('button', { name: /View fields/i })).toBeTruthy();
+      });
+    });
+
+    it('shows correct badge for draft status', async () => {
+      const draftEntry = new Entry(
+        'entry-id',
+        'content-type-id',
+        'Title',
+        [title, author],
+        'space-id',
+        'environment-id',
+        'valid-contentful-api-key',
+        '',
+        '2025-05-15T16:49:16.367Z'
+      );
+      (fetchBrazeConnectedEntries as Mock).mockResolvedValue([draftEntry]);
+
+      render(<Page />);
+      await waitFor(() => {
+        expect(screen.getByText(/Draft/i)).toBeTruthy();
+      });
     });
   });
 
-  it('renders empty state if no entries', async () => {
-    (fetchBrazeConnectedEntries as Mock).mockResolvedValue([]);
-    render(<Page />);
-    await waitFor(() => {
-      expect(screen.getByText(/No active Braze Content Blocks/i)).toBeTruthy();
-      expect(
-        screen.getByText(/Once you have created Content Blocks, they will display here./i)
-      ).toBeTruthy();
-    });
-  });
-
-  it('renders connected entries table if entries exist', async () => {
-    const publishEntry = new Entry(
+  describe('Connected Fields Modal', () => {
+    const title = new BasicField('title', 'Title', 'content-type-id', true);
+    const description = new BasicField('description', 'Description', 'content-type-id', false);
+    const checkbox = new BasicField('checkbox', 'Checkbox', 'content-type-id', false);
+    const entry = new Entry(
       'entry-id',
       'content-type-id',
-      'Title',
-      [title, author],
+      'title',
+      [title, description, checkbox],
       'space-id',
       'environment-id',
       'valid-contentful-api-key',
       '2025-05-15T16:49:16.367Z',
       '2025-05-15T16:49:16.367Z'
     );
-    (fetchBrazeConnectedEntries as Mock).mockResolvedValue([publishEntry]);
-    render(<Page />);
-    await waitFor(() => {
-      expect(screen.getByText(/Content connected to Braze/i)).toBeTruthy();
-      expect(screen.getByText(/Title/i)).toBeTruthy();
-      expect(screen.getByText(/Published/i)).toBeTruthy();
-      expect(screen.getByRole('button', { name: /View fields/i })).toBeTruthy();
+
+    beforeEach(() => {
+      (useSDK as unknown as Mock).mockReturnValue(mockSdk);
+      (fetchBrazeConnectedEntries as Mock).mockResolvedValue([entry]);
     });
-  });
 
-  it('shows correct badge for draft status', async () => {
-    const draftEntry = new Entry(
-      'entry-id',
-      'content-type-id',
-      'Title',
-      [title, author],
-      'space-id',
-      'environment-id',
-      'valid-contentful-api-key',
-      '',
-      '2025-05-15T16:49:16.367Z'
-    );
-    (fetchBrazeConnectedEntries as Mock).mockResolvedValue([draftEntry]);
+    it('opens modal when View fields is clicked', async () => {
+      render(<Page />);
+      const viewFieldsButton = (await screen.findAllByRole('button', { name: /View fields/i }))[0];
+      viewFieldsButton.click();
+      const modal = await screen.findByRole('dialog');
 
-    render(<Page />);
-    await waitFor(() => {
-      expect(screen.getByText(/Draft/i)).toBeTruthy();
+      expect(modal).toBeTruthy();
+      expect(screen.getByText('View entry')).toBeTruthy();
+    });
+
+    it('displays entry name, connected fields count, and View entry button', async () => {
+      render(<Page />);
+      const viewFieldsButton = (await screen.findAllByRole('button', { name: /View fields/i }))[0];
+      viewFieldsButton.click();
+      await screen.findByRole('dialog');
+
+      expect(screen.getByTestId('modal-entry-title')).toBeTruthy();
+      expect(screen.getByTestId('modal-fields-length')).toBeTruthy();
+      expect(screen.getByText('View entry')).toBeTruthy();
+    });
+
+    it('lists all connected fields with checkboxes', async () => {
+      render(<Page />);
+      const viewFieldsButton = (await screen.findAllByRole('button', { name: /View fields/i }))[0];
+      viewFieldsButton.click();
+      await screen.findByRole('dialog');
+      expect(screen.getByText('Title')).toBeTruthy();
+      expect(screen.getByText('Description')).toBeTruthy();
+      expect(screen.getByText('Checkbox')).toBeTruthy();
+      // Checkboxes for each field
+      expect(screen.getByLabelText('Title')).toBeTruthy();
+      expect(screen.getByLabelText('Description')).toBeTruthy();
+      expect(screen.getByLabelText('Checkbox')).toBeTruthy();
+    });
+
+    it('selects/deselects all fields with header checkbox', async () => {
+      render(<Page />);
+      const viewFieldsButton = (await screen.findAllByRole('button', { name: /View fields/i }))[0];
+      viewFieldsButton.click();
+      await screen.findByRole('dialog');
+      const selectAll = screen.getByTestId('select-all-fields');
+      // Select all
+      selectAll.click();
+      expect((screen.getByLabelText('Title') as HTMLInputElement).checked).toBe(true);
+      expect((screen.getByLabelText('Description') as HTMLInputElement).checked).toBe(true);
+      expect((screen.getByLabelText('Checkbox') as HTMLInputElement).checked).toBe(true);
+      // Deselect all
+      selectAll.click();
+      expect((screen.getByLabelText('Title') as HTMLInputElement).checked).toBe(false);
+      expect((screen.getByLabelText('Description') as HTMLInputElement).checked).toBe(false);
+      expect((screen.getByLabelText('Checkbox') as HTMLInputElement).checked).toBe(false);
+    });
+
+    it('toggles individual field selection', async () => {
+      render(<Page />);
+      const viewFieldsButton = (await screen.findAllByRole('button', { name: /View fields/i }))[0];
+      viewFieldsButton.click();
+      await screen.findByRole('dialog');
+      const titleCheckbox = screen.getByLabelText('Title') as HTMLInputElement;
+      expect(titleCheckbox.checked).toBe(false);
+      titleCheckbox.click();
+      expect(titleCheckbox.checked).toBe(true);
+      titleCheckbox.click();
+      expect(titleCheckbox.checked).toBe(false);
+    });
+
+    it('calls navigation when View entry is clicked', async () => {
+      render(<Page />);
+      const viewFieldsButton = (await screen.findAllByRole('button', { name: /View fields/i }))[0];
+      viewFieldsButton.click();
+      await screen.findByRole('dialog');
+      screen.getByRole('button', { name: /View entry/i }).click();
+      expect(mockSdk.navigator.openEntry).toHaveBeenCalledWith('entry-id');
     });
   });
 });

--- a/apps/braze/test/mocks/mockSdk.ts
+++ b/apps/braze/test/mocks/mockSdk.ts
@@ -48,6 +48,7 @@ const mockSdk: any = {
     delivery: 'cdn.contentful.com',
   },
   navigator: {
+    openEntry: vi.fn(),
     openCurrentAppPage: vi.fn(),
     openAppConfig: vi.fn(),
   },


### PR DESCRIPTION
## Purpose

This update includes the base modal structure for the page view location when the user clicks a `view fields` button.

## Approach

Added a new component in the `Page.tsx` location to show the modal. For now, the modal just show you the connected fields and let you select them. The disconnection will be done in another ticket.

Now the page view location has the following modal:

https://github.com/user-attachments/assets/acf46386-9d1d-4e36-9097-17991a94b4eb

## Testing steps

Automated tests were added. To see the modal and test it manually, you can follow the video steps.

## Breaking Changes

N/A

## Dependencies and/or References

Link to [INTEG-2548](https://contentful.atlassian.net/jira/software/c/projects/INTEG/boards/454?selectedIssue=INTEG-2548) ticket.

## Deployment

N/A

[INTEG-2548]: https://contentful.atlassian.net/browse/INTEG-2548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ