### PR TITLE
Braze: Config screen issues [INTEG-2685]

### DIFF
--- a/apps/braze/test/locations/ConfigScreen.spec.tsx
+++ b/apps/braze/test/locations/ConfigScreen.spec.tsx
@@ -162,6 +162,9 @@ describe('Config Screen component', () => {
           brazeApiKey: 'valid-api-key-321',
           brazeEndpoint: BRAZE_ENDPOINTS[0].url,
         },
+        targetState: {
+          EditorInterface: {},
+        },
       });
     });
 


### PR DESCRIPTION
- If a content type already has the app in the sidebar and we configure the app again, the app gets removed: we weren't keeping the current state, now we do
- We should display the content types that already have the app in the sidebar: done
- Do not display the “brazeConfig” content type as an option: done

https://github.com/user-attachments/assets/5a7191e0-e32c-4d79-9c1a-39aa580bdba7