### PR TITLE
Braze: Fix creating content blocks from draft entry [INTEG-2686]

### DIFF
--- a/apps/braze/src/components/create/CreateFlow.tsx
+++ b/apps/braze/src/components/create/CreateFlow.tsx
@@ -141,6 +141,8 @@ const CreateFlow = (props: CreateFlowProps) => {
     if (entry.state !== EntryStatus.Published && step === CREATE_STEP) {
       setStep(DRAFT_STEP);
       return;
+    } else if (step === DRAFT_STEP) {
+      setStep(CREATE_STEP);
     }
 
     setIsSubmitting(true);
@@ -185,6 +187,9 @@ const CreateFlow = (props: CreateFlowProps) => {
 
       setStep(SUCCESS_STEP);
     } catch (error) {
+      if (step === DRAFT_STEP) {
+        setStep(CREATE_STEP);
+      }
       console.error('Error creating content blocks: ', error);
     } finally {
       setIsSubmitting(false);


### PR DESCRIPTION
The errors are displayed in the Create Step. If the Draft Step was shown and there were errors, go back to the Create Step in order to show them

https://github.com/user-attachments/assets/f93f80cf-75d1-4f63-8edf-03df54bb36de