### PR TITLE
Braze: Display correct error when content for locale is empty [INTEG-2687]

### DIFF
--- a/apps/braze/functions/createContentBlocks.ts
+++ b/apps/braze/functions/createContentBlocks.ts
@@ -75,7 +75,10 @@ const createContentBlock = async (
     };
   }
 
-  let fieldValue = entry.fields[fieldId] ? entry.fields[fieldId] : undefined;
+  let fieldValue;
+  if (entry.fields[fieldId]) {
+    fieldValue = locale ? entry.fields[fieldId][locale] : Object.values(entry.fields[fieldId])[0];
+  }
 
   if (!fieldValue) {
     return {
@@ -89,8 +92,6 @@ const createContentBlock = async (
         ' does not exist or is empty',
     };
   }
-
-  fieldValue = locale ? fieldValue[locale] : Object.values(fieldValue)[0];
 
   try {
     const field = contentType.fields.find((f) => f.id === fieldId);

--- a/apps/braze/src/components/create/ErrorStep.tsx
+++ b/apps/braze/src/components/create/ErrorStep.tsx
@@ -56,20 +56,27 @@ const ErrorStep = ({
       <List>
         {customerErrors.map((field, index) => (
           <List.Item key={`${field.fieldId}-${index}`}>
-            <Text fontWeight="fontWeightDemiBold">{field.fieldId}</Text> - error code{' '}
-            {field.statusCode} - {field.message}. Please fix the errors and retry sending to Braze.
+            <Text fontWeight="fontWeightDemiBold">
+              {localizeFieldId(field.fieldId, field.locale)}
+            </Text>{' '}
+            - error code {field.statusCode} - {field.message}. Please fix the errors and retry
+            sending to Braze.
           </List.Item>
         ))}
         {serverErrors.map((field, index) => (
           <List.Item key={`${field.fieldId}-${index}`}>
-            <Text fontWeight="fontWeightDemiBold">{field.fieldId}</Text> - error code{' '}
-            {field.statusCode} - {field.message}. Please retry sending to Braze.
+            <Text fontWeight="fontWeightDemiBold">
+              {localizeFieldId(field.fieldId, field.locale)}
+            </Text>{' '}
+            - error code {field.statusCode} - {field.message}. Please retry sending to Braze.
           </List.Item>
         ))}
         {clientErrors.map((field, index) => (
           <List.Item key={`${field.fieldId}-${index}`}>
-            <Text fontWeight="fontWeightDemiBold">{field.fieldId}</Text> - error code{' '}
-            {field.statusCode} - {field.message}
+            <Text fontWeight="fontWeightDemiBold">
+              {localizeFieldId(field.fieldId, field.locale)}
+            </Text>{' '}
+            - error code {field.statusCode} - {field.message}
           </List.Item>
         ))}
         {clientErrors.length > 0 && (

--- a/apps/braze/test/functions/createContentBlocks.spec.ts
+++ b/apps/braze/test/functions/createContentBlocks.spec.ts
@@ -192,7 +192,9 @@ describe('createContentBlocks', () => {
   });
 
   it('should handle missing fields', async () => {
-    const entry = createEntryResponse({});
+    const entry = createEntryResponse({
+      title: { 'es-AR': 'Test Title' },
+    });
     const contentType = createContentTypeResponse(['title', 'author']);
 
     vi.mocked(mockCma.entry.get).mockResolvedValue(entry);
@@ -205,6 +207,7 @@ describe('createContentBlocks', () => {
         fieldsData: JSON.stringify([
           {
             fieldId: 'title',
+            locale: 'en-US',
             contentBlockName: 'custom-title-name',
             contentBlockDescription: 'custom-title-description',
           },
@@ -224,9 +227,10 @@ describe('createContentBlocks', () => {
       results: [
         {
           fieldId: 'title',
+          locale: 'en-US',
           success: false,
           statusCode: 600,
-          message: 'Field title does not exist or is empty',
+          message: 'Field title with locale en-US does not exist or is empty',
         },
         {
           fieldId: 'author',


### PR DESCRIPTION
We were showing a 400 error and the link to contact support when a field that is localized is empty instead of displaying that it's a custom error

https://github.com/user-attachments/assets/2f9770d4-eab8-4fac-a9e1-8948a0e5cc70