### PR TITLE
Braze: Do not set content blocks data if it already exists [INTEG-2686]

### DIFF
--- a/apps/braze/src/components/create/CreateStep.tsx
+++ b/apps/braze/src/components/create/CreateStep.tsx
@@ -291,6 +291,9 @@ const CreateStep = ({
 
   // Effects
   useEffect(() => {
+    if (Object.keys(contentBlocksData.names).length > 0) {
+      return;
+    }
     const initialStates: ContentBlockData = {
       names: {},
       descriptions: {},


### PR DESCRIPTION
The CreateStep was always setting the initial state for the ContentBlocksData, even if was already set