### PR TITLE
Braze: Fix uninstall handler [INTEG-2687]

### DIFF
--- a/apps/braze/functions/appEventHandler.ts
+++ b/apps/braze/functions/appEventHandler.ts
@@ -111,10 +111,18 @@ async function callAndRetry(fn: () => Promise<any>, waitTimeIndex: number = 0): 
 }
 
 async function deleteConfigEntry(cma: PlainClientAPI) {
-  await cma.entry.unpublish({ entryId: CONFIG_ENTRY_ID });
-  await cma.entry.delete({ entryId: CONFIG_ENTRY_ID });
-  await cma.contentType.unpublish({ contentTypeId: CONFIG_CONTENT_TYPE_ID });
-  await cma.contentType.delete({ contentTypeId: CONFIG_CONTENT_TYPE_ID });
+  try {
+    await cma.entry.unpublish({ entryId: CONFIG_ENTRY_ID });
+  } catch (e) {}
+  try {
+    await cma.entry.delete({ entryId: CONFIG_ENTRY_ID });
+  } catch (e) {}
+  try {
+    await cma.contentType.unpublish({ contentTypeId: CONFIG_CONTENT_TYPE_ID });
+  } catch (e) {}
+  try {
+    await cma.contentType.delete({ contentTypeId: CONFIG_CONTENT_TYPE_ID });
+  } catch (e) {}
 }
 
 async function updateContentBlock(

--- a/apps/braze/test/functions/appEventHandler.spec.ts
+++ b/apps/braze/test/functions/appEventHandler.spec.ts
@@ -62,6 +62,30 @@ describe('updateContentBlocks', () => {
     });
   });
 
+  it('should delete the custom entry and content type when they are not published', async () => {
+    const event = {
+      headers: {
+        'X-Contentful-Topic': ['AppInstallation.delete'],
+      },
+    };
+
+    mockCma.entry.unpublish.mockRejectedValue(new Error('Entry is already unpublished'));
+    mockCma.contentType.unpublish.mockRejectedValue(
+      new Error('Content type is already unpublished')
+    );
+
+    await handler(event as any, mockContext as any);
+
+    expect(mockCma.entry.unpublish).toHaveBeenCalledWith({ entryId: 'brazeConfig' });
+    expect(mockCma.entry.delete).toHaveBeenCalledWith({ entryId: 'brazeConfig' });
+    expect(mockCma.contentType.unpublish).toHaveBeenCalledWith({
+      contentTypeId: 'brazeConfig',
+    });
+    expect(mockCma.contentType.delete).toHaveBeenCalledWith({
+      contentTypeId: 'brazeConfig',
+    });
+  });
+
   it('should remove the entry id from the config on entry deletion', async () => {
     const event = {
       headers: {


### PR DESCRIPTION
- When the app gets uninstalled it tries to remove the config entry and its content type. Before deleting each of them, it tries to unpublish them, but if they aren't published, it fails. So we now wrap each call in a retry block in case the entry or the content type got unpublished