### PR TITLE
Braze app autocomplete fixes [INTEG-2688]

### DIFF
--- a/apps/braze/test/locations/ConfigScreen.spec.tsx
+++ b/apps/braze/test/locations/ConfigScreen.spec.tsx
@@ -13,6 +13,7 @@ import {
   BRAZE_ENDPOINTS,
   CONTENT_TYPE_DOCUMENTATION,
 } from '../../src/utils';
+import { createContentTypeResponse } from '../mocks/contentTypeResponse';
 
 const mockCma = {
   contentType: {
@@ -256,6 +257,7 @@ describe('Config Screen component', () => {
     };
 
     it('loads and displays available content types', async () => {
+      await fillScreen();
       const user = userEvent.setup();
 
       const autocomplete = screen.getByPlaceholderText('Search');
@@ -278,6 +280,7 @@ describe('Config Screen component', () => {
       });
       mockCma.editorInterface.update.mockResolvedValueOnce({});
 
+      await fillScreen();
       const user = userEvent.setup();
       await fillScreen(user);
       await selectContentTypes(user);


### PR DESCRIPTION
## Purpose

- Wrap autocomplete pills

- Fix multiple selection 

- Select all placeholder when selecting all contentTypes and disable dropdown


## Testing steps
Updated tests: now we wait for the screen to fill so we have the content types and the autocomplete is not disabled

Tests:


https://github.com/user-attachments/assets/5e1a1877-d71c-4671-a848-4c2ad1456637


