### PR TITLE
Braze: Handle undefined c-type for ref and array of ref [INTEG-2705]

### DIFF
--- a/apps/braze/src/fields/FieldsFactory.ts
+++ b/apps/braze/src/fields/FieldsFactory.ts
@@ -70,14 +70,25 @@ export class FieldsFactory {
           continue;
         }
         const fieldValue = Object.values(field as { [key: string]: any })[0];
-        if (this.isReferenceField(fieldInfo)) {
+        const hasReference = fieldValue?.sys?.contentType;
+        if (this.isReferenceField(fieldInfo) && hasReference) {
           fields.push(
             await this.createReferenceField(fieldInfo, fieldValue, contentType, currentDepth)
           );
-        } else if (this.isReferenceArrayField(fieldInfo)) {
-          fields.push(
-            await this.createReferenceArrayField(fieldInfo, fieldValue, contentType, currentDepth)
-          );
+        } else {
+          if (this.isReferenceArrayField(fieldInfo)) {
+            const hasReferences = fieldValue.every((f: any) => f?.sys?.contentType);
+            if (hasReferences) {
+              fields.push(
+                await this.createReferenceArrayField(
+                  fieldInfo,
+                  fieldValue,
+                  contentType,
+                  currentDepth
+                )
+              );
+            }
+          }
         }
       }
     }

--- a/apps/braze/test/fields/FieldsFactory.spec.ts
+++ b/apps/braze/test/fields/FieldsFactory.spec.ts
@@ -185,9 +185,7 @@ describe('FieldsFactory', () => {
     (resolveResponse as any).mockReturnValue(mockEntry);
 
     mockCma.contentType.get.mockResolvedValue({
-      fields: [
-        { id: 'author', type: 'Link', linkType: 'Entry', localized: false },
-      ],
+      fields: [{ id: 'author', type: 'Link', linkType: 'Entry', localized: false }],
       displayField: '',
       sys: {
         id: 'article',
@@ -196,7 +194,7 @@ describe('FieldsFactory', () => {
 
     const result = await createFields(entryId, entryContentTypeId, mockCma);
     expect(result).toHaveLength(0);
-    expect(result.find(f => f instanceof ReferenceField)).toBeUndefined();
+    expect(result.find((f) => f instanceof ReferenceField)).toBeUndefined();
   });
 
   it('should create a BasicArrayField instance with correct properties', async () => {

--- a/apps/braze/test/fields/FieldsFactory.spec.ts
+++ b/apps/braze/test/fields/FieldsFactory.spec.ts
@@ -160,6 +160,45 @@ describe('FieldsFactory', () => {
     expect(fieldInstance.fields[1].id).toBe('bio');
   });
 
+  it('should skip reference fields with null content type', async () => {
+    const mockReferencedEntry = {
+      sys: {
+        contentType: null,
+      },
+      fields: {},
+    };
+
+    const mockEntry = [
+      {
+        sys: {
+          contentType: {
+            sys: { id: 'article' },
+          },
+        },
+        fields: {
+          author: {
+            'en-US': mockReferencedEntry,
+          },
+        },
+      },
+    ];
+    (resolveResponse as any).mockReturnValue(mockEntry);
+
+    mockCma.contentType.get.mockResolvedValue({
+      fields: [
+        { id: 'author', type: 'Link', linkType: 'Entry', localized: false },
+      ],
+      displayField: '',
+      sys: {
+        id: 'article',
+      },
+    });
+
+    const result = await createFields(entryId, entryContentTypeId, mockCma);
+    expect(result).toHaveLength(0);
+    expect(result.find(f => f instanceof ReferenceField)).toBeUndefined();
+  });
+
   it('should create a BasicArrayField instance with correct properties', async () => {
     const mockEntry = [
       {


### PR DESCRIPTION
## Purpose

When the user deletes an entry that is being referenced from another which has a `reference or array reference` field, the fetch from the Dialog failed because the content types were undefined.

## Approach

The proper validation to skip the references and array of references, which doesn't have content type, were added.

## Testing steps

An automated test to validate this edge case was added.

## Breaking Changes

N/A

## Dependencies and/or References

Link to [INTEG-2705](https://contentful.atlassian.net/browse/INTEG-2705)

## Deployment

N/A

[INTEG-2705]: https://contentful.atlassian.net/browse/INTEG-2705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ