### PR TITLE
Braze: Handle empty sidebar []

### DIFF
--- a/apps/braze/functions/appEventHandler.ts
+++ b/apps/braze/functions/appEventHandler.ts
@@ -48,6 +48,10 @@ export const handler: FunctionEventHandler<FunctionTypeEnum.AppEventHandler> = a
     return;
   }
 
+  if (entryConnectedFields.length === 0) {
+    return;
+  }
+
   if (contentfulTopic.includes('Entry.delete')) {
     await entryDeletedHandler(cma, entryId, configEntry, connectedFields);
   } else if (

--- a/apps/braze/functions/common.ts
+++ b/apps/braze/functions/common.ts
@@ -37,9 +37,6 @@ export async function getConfigAndConnectedFields(
     throw new Error(`Configuration field ${CONFIG_FIELD_ID} not found`);
   }
   const connectedFields = Object.values(configField)[0] as ConnectedFields;
-  const entryConnectedFields = connectedFields[entryId];
-  if (!entryConnectedFields) {
-    throw new Error(`Configuration field ${CONFIG_FIELD_ID} not found`);
-  }
+  const entryConnectedFields = connectedFields[entryId] || [];
   return { configEntry, connectedFields, entryConnectedFields };
 }

--- a/apps/braze/functions/getContentBlocks.ts
+++ b/apps/braze/functions/getContentBlocks.ts
@@ -22,6 +22,12 @@ export const handler: FunctionEventHandler<
 
   const { entryConnectedFields } = await getConfigAndConnectedFields(cma, entryId);
 
+  if (entryConnectedFields.length === 0) {
+    return {
+      contentBlocks: [],
+    };
+  }
+
   const contentBlocks = await Promise.all(
     entryConnectedFields.map((field) => getContentBlock(brazeEndpoint, brazeApiKey, field))
   );

--- a/apps/braze/src/locations/Sidebar.tsx
+++ b/apps/braze/src/locations/Sidebar.tsx
@@ -20,12 +20,12 @@ import InformationWithLink from '../components/InformationWithLink';
 import Splitter from '../components/Splitter';
 import { createClient } from 'contentful-management';
 import { useEffect, useState } from 'react';
+import React from 'react';
 
 const Sidebar = () => {
   const sdk = useSDK<SidebarAppSDK>();
   useAutoResizer();
   const [entryConnectedFields, setEntryConnectedFields] = useState<SidebarContentBlockInfo[]>([]);
-  const currentEntryId = sdk.ids.entry;
 
   const cma = createClient(
     { apiAdapter: sdk.cmaAdapter },
@@ -161,7 +161,7 @@ const Sidebar = () => {
               <Splitter />
               <div className={styles.stack}>
                 {entryConnectedFields.map((fieldMapping, index) => (
-                  <>
+                  <React.Fragment key={`${fieldMapping.fieldId}-${index}`}>
                     <Text as="div" fontSize="fontSizeS" className={styles.listItem}>
                       Field name
                     </Text>
@@ -177,7 +177,7 @@ const Sidebar = () => {
                       {fieldMapping.contentBlockName}
                     </Text>
                     <Splitter />
-                  </>
+                  </React.Fragment>
                 ))}
               </div>
             </Card>


### PR DESCRIPTION
## Purpose

An error was being thrown in the Sidebar if the entry did not have any connected fields. We now return an empty array since it's a valid scenario.