### PR TITLE
Braze: Update callAndRetry implementation []

### DIFF
--- a/apps/braze/functions/appEventHandler.ts
+++ b/apps/braze/functions/appEventHandler.ts
@@ -20,7 +20,7 @@ import { documentToHtmlString } from '@contentful/rich-text-html-renderer';
 import { getConfigAndConnectedFields, initContentfulManagementClient } from './common';
 import { CustomError } from './customError';
 
-const WAIT_TIMES = [0, 5000, 10000];
+const WAIT_TIMES = [1000, 2000];
 
 export const handler: FunctionEventHandler<FunctionTypeEnum.AppEventHandler> = async (
   event: AppEventRequest,
@@ -105,12 +105,8 @@ const entrySavedHandler = async (
     };
 
     try {
-      // TODO : add callAndRetry
-      await updateContentBlock(
-        brazeEndpoint,
-        brazeApiKey,
-        connectedField.contentBlockId,
-        fieldValue
+      await callAndRetry(() =>
+        updateContentBlock(brazeEndpoint, brazeApiKey, connectedField.contentBlockId, fieldValue)
       );
     } catch (error: any) {
       updateResult = {
@@ -130,16 +126,20 @@ const entrySavedHandler = async (
   }
 };
 
-async function callAndRetry(fn: () => Promise<any>, waitTimeIndex: number = 0): Promise<void> {
-  try {
-    await fn();
-  } catch (error) {
-    if (waitTimeIndex < WAIT_TIMES.length) {
-      await new Promise((resolve) => setTimeout(resolve, WAIT_TIMES[waitTimeIndex]));
-      return callAndRetry(fn, waitTimeIndex + 1);
+async function callAndRetry(fn: () => Promise<any>): Promise<void> {
+  let lastError: any;
+  for (let i = 0; i <= WAIT_TIMES.length; i++) {
+    try {
+      await fn();
+      return;
+    } catch (error) {
+      lastError = error;
+      if (i < WAIT_TIMES.length) {
+        await new Promise((resolve) => setTimeout(resolve, WAIT_TIMES[i]));
+      }
     }
-    throw error;
   }
+  throw lastError;
 }
 
 async function deleteConfigEntry(cma: PlainClientAPI) {

--- a/apps/braze/test/functions/appEventHandler.spec.ts
+++ b/apps/braze/test/functions/appEventHandler.spec.ts
@@ -171,6 +171,9 @@ describe('updateContentBlocks', () => {
         },
       ],
     });
+    vi.mocked(global.fetch).mockResolvedValue(
+      new Response(JSON.stringify({ success: true }), { status: 200 })
+    );
 
     await handler(event as any, mockContext as any);
 
@@ -249,8 +252,16 @@ describe('updateContentBlocks', () => {
 
     await handler(event as any, mockContext as any);
 
-    expect(global.fetch).toHaveBeenCalledTimes(1);
-    expect(vi.mocked(updateConfig)).toHaveBeenCalledOnce();
+    expect(global.fetch).toHaveBeenCalledTimes(3);
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://test.braze.com/content_blocks/update',
+      expect.objectContaining({
+        body: JSON.stringify({
+          content_block_id: 'test-block-id',
+          content: 'test value',
+        }),
+      })
+    );
   });
 
   it('should update content block for each locale on entry save', async () => {


### PR DESCRIPTION
Change the callAndRetry method (to retry actions in the app event function) implementation of the Braze app from recursive to iterative and update the wait times in between