### PR TITLE
very-simple-editor-assistant (example entry editor location app)

### DIFF
--- a/examples/very-simple-editor-assistant/.gitignore
+++ b/examples/very-simple-editor-assistant/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/very-simple-editor-assistant/README.md
+++ b/examples/very-simple-editor-assistant/README.md
@@ -1,0 +1,35 @@
+# branch very-simple-editor-assistant
+
+- EntryEditor running on localhost port 3023
+
+This is a very simple Entry Editor location app (https://www.contentful.com/developers/docs/extensibility/app-framework/locations/#entry-editor) with the following functionalities:
+- it handles two simple content type (it's enough that they have two short text fields each)
+- it gets configured by reading a JSON object (**)
+- for each content type the app re-labels all fields in the UI, using values specified in its JSON configuration
+- PLEASE NOTE: we are not talking about renaming the fields in the content type !!!
+- we are merely displaying the fields in the UI using as labels some values different from the real field names
+
+-----------------------------------------
+Tips for the exercise:
+- as field editor use the SingleLineEditor provided in the Contentful SDK (NPM package '@contentful/field-editor-single-line')
+- in order to display the renamed label of the field, it will be enough to prepend a Forma36 Heading before the SingleLineEditor
+
+(**) Example JSON configuration object:
+{
+  "todo": {
+    "what": "Quando",
+    "why": "Motivo",
+  },
+  "article": {
+    "title": "Titolo",
+    "text": "Testo",
+  }
+}
+
+In this case the content types have id 'todo' and 'article'
+- todo has two short text fields with ids 'what' & 'why' that must be re-labeled as 'Quando' and 'Motivo' in the UI
+- article has two short text fields with ids 'title' & 'text' that must be re-labeled as 'Titolo' and 'Testo' in the UI
+
+This JSON object could be found inside a JSON file in the codebase. This would require a rebuild each time that the configuration file gets updated.
+
+A more complex version could find the configuration inside a JSON media file stored in the environment where the app is running; this media should be loaded inside a useEffect of the EntryEditor.

--- a/examples/very-simple-editor-assistant/index.html
+++ b/examples/very-simple-editor-assistant/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+    <script type="module" src="/src/index.jsx"></script>
+    <!--
+      This HTML file is a template.
+      If you open it directly in the browser, you will see an empty page.
+      You can add webfonts, meta tags, or analytics to this file.
+      The build step will place the bundled scripts into the <body> tag.
+      To begin the development, run `npm start`.
+      To create a production bundle, use `npm run build`.
+    -->
+  </body>
+</html>

--- a/examples/very-simple-editor-assistant/package.json
+++ b/examples/very-simple-editor-assistant/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "very-simple-editor-assistant",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "@contentful/app-sdk": "^4.29.1",
+    "@contentful/f36-components": "^4.78.0",
+    "@contentful/f36-tokens": "4.2.0",
+    "@contentful/react-apps-toolkit": "1.2.16",
+    "@contentful/field-editor-single-line": "^1.6.1",
+    "contentful-management": "10.46.4",
+    "emotion": "10.0.27",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "scripts": {
+    "start": "vite",
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "vitest",
+    "create-app-definition": "contentful-app-scripts create-app-definition",
+    "add-locations": "contentful-app-scripts add-locations",
+    "upload": "contentful-app-scripts upload --bundle-dir ./build",
+    "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN"
+  },
+  "eslintConfig": {
+    "extends": "react-app"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  },
+  "devDependencies": {
+    "@contentful/app-scripts": "^2.3.0",
+    "@testing-library/jest-dom": "^5.17.0",
+    "@testing-library/react": "^14.3.1",
+    "@vitejs/plugin-react": "^4.0.3",
+    "cross-env": "7.0.3",
+    "jsdom": "^26.0.0",
+    "vite": "^6.2.2",
+    "vitest": "^3.0.9"
+  },
+  "homepage": "."
+}

--- a/examples/very-simple-editor-assistant/src/App.jsx
+++ b/examples/very-simple-editor-assistant/src/App.jsx
@@ -1,0 +1,24 @@
+import React, { useMemo } from 'react';
+import { locations } from '@contentful/app-sdk';
+import EntryEditor from './locations/EntryEditor';
+import { useSDK } from '@contentful/react-apps-toolkit';
+
+const ComponentLocationSettings = {
+  [locations.LOCATION_ENTRY_EDITOR]: EntryEditor,
+};
+
+const App = () => {
+  const sdk = useSDK();
+
+  const Component = useMemo(() => {
+    for (const [location, component] of Object.entries(ComponentLocationSettings)) {
+      if (sdk.location.is(location)) {
+        return component;
+      }
+    }
+  }, [sdk.location]);
+
+  return Component ? <Component /> : null;
+};
+
+export default App;

--- a/examples/very-simple-editor-assistant/src/components/LocalhostWarning.jsx
+++ b/examples/very-simple-editor-assistant/src/components/LocalhostWarning.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Paragraph, TextLink, Note, Flex } from '@contentful/f36-components';
+
+const LocalhostWarning = () => {
+  return (
+    <Flex marginTop="spacingXl" justifyContent="center">
+      <Note title="App running outside of Contentful" style={{ maxWidth: '800px' }}>
+        <Paragraph>
+          Contentful Apps need to run inside the Contentful web app to function properly. Install
+          the app into a space and render your app into one of the{' '}
+          <TextLink href="https://www.contentful.com/developers/docs/extensibility/ui-extensions/sdk-reference/#locations">
+            available locations
+          </TextLink>
+          .
+        </Paragraph>
+        <br />
+
+        <Paragraph>
+          Follow{' '}
+          <TextLink href="https://www.contentful.com/developers/docs/extensibility/app-framework/tutorial/#embed-your-app-in-the-contentful-web-app">
+            our guide
+          </TextLink>{' '}
+          to get started or{' '}
+          <TextLink href="https://app.contentful.com/deeplink?link=apps">open Contentful</TextLink>{' '}
+          to manage your app.
+        </Paragraph>
+      </Note>
+    </Flex>
+  );
+};
+
+export default LocalhostWarning;

--- a/examples/very-simple-editor-assistant/src/config/vsea.json
+++ b/examples/very-simple-editor-assistant/src/config/vsea.json
@@ -1,0 +1,10 @@
+{
+  "aaaChild": {
+    "name": "Il mio Nome",
+    "markdownString": "Il mio Cognome"
+  },
+  "aaaParent": {
+    "name": "Nome del mio Papà",
+    "title": "Cognome del mio Papà"
+  }
+}

--- a/examples/very-simple-editor-assistant/src/index.jsx
+++ b/examples/very-simple-editor-assistant/src/index.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+
+import { GlobalStyles } from '@contentful/f36-components';
+import { SDKProvider } from '@contentful/react-apps-toolkit';
+
+import LocalhostWarning from './components/LocalhostWarning';
+import App from './App';
+
+const container = document.getElementById('root');
+const root = createRoot(container);
+
+if (process.env.NODE_ENV === 'development' && window.self === window.top) {
+  // You can remove this if block before deploying your app
+  root.render(<LocalhostWarning />);
+} else {
+  root.render(
+    <SDKProvider>
+      <GlobalStyles />
+      <App />
+    </SDKProvider>
+  );
+}

--- a/examples/very-simple-editor-assistant/src/locations/EntryEditor.jsx
+++ b/examples/very-simple-editor-assistant/src/locations/EntryEditor.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import {
+  Box,
+  Heading,
+} from '@contentful/f36-components';
+import {
+  useSDK,
+} from '@contentful/react-apps-toolkit';
+import { SingleLineEditor } from '@contentful/field-editor-single-line';
+import jsonConfigFileInCodebase from '../config/vsea.json';
+
+const Entry = () => {
+  const sdk = useSDK();
+  const locale = sdk.locales.default;
+  const locales = sdk.locales;
+  const contentTypeId = sdk.contentType.sys.id;
+
+  const jsonConfig = jsonConfigFileInCodebase;
+  const contentTypeConfig = jsonConfig[contentTypeId];
+
+  return <Box>
+    {Object.keys(contentTypeConfig).map(key => {
+
+      const newFieldName = contentTypeConfig[key];
+
+      return <div key={Math.random()}>
+        <Heading marginTop='spacingS'>{newFieldName}</Heading>
+        <SingleLineEditor
+          field={sdk.entry.fields[key].getForLocale(locale)}
+          locales={locales}
+          currentLocale={locale}
+        />
+      </div>
+    })}
+
+  </Box>;
+};
+
+export default Entry;

--- a/examples/very-simple-editor-assistant/vite.config.mjs
+++ b/examples/very-simple-editor-assistant/vite.config.mjs
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true, // Enables Jest-like global test functions (test, expect)
+    environment: 'jsdom', // Simulates a browser for component tests
+    setupFiles: './src/setupTests.js', // Equivalent to Jest's setup file
+  },
+  base: '',
+  build: {
+    outDir: 'build',
+  },
+  server: {
+    host: 'localhost',
+    port: 3023,
+  },
+});


### PR DESCRIPTION
## Purpose

I have created a very simple entry location app that solves a common problem not yet documented.

It is often necessary to re-label the fields in the editor's page: **our editors ask us to see fields labeled in a different manner depending on the context in which a given content type is used**. We don't aim to rename the field, but just to label it differently for the editor's sake. Please see the new labels indicated by the red arrows:

![image](https://github.com/user-attachments/assets/2f7253f5-335e-4116-b20b-3822a68d372b)

## Approach

The new labels are specified inside a JSON file, depending on the contentTypeId. The app can be easily expanded to include all sorts of process information besides the editor label.

All the details + an example JSON config file are provided in the README.md file.

## Testing steps

This app is very, very simple. I haven't seen the need for writing tests.

PLEASE NOTE that in the past I have submitted [another pull request](https://github.com/contentful/apps/pull/8831) for another example app of mine. I was informed that your automated tests did not run initially; therefore I spent a considerable amount of time trying to please them, without success. At the end the tests were successfully run by one of your engineers.

## Breaking Changes

No breaking changes. Just vanilla JS in the vanilla Apps Framework.

## Dependencies and/or References

This app uses the SingleLineEditor from package '@contentful/field-editor-single-line'

## Deployment

No special deployment care is needed. The app is meant to run on localhost.
