### PR TITLE
Fix: Netlify build button timeouts [ZEND-6481]

### DIFF
--- a/apps/netlify/frontend/src/sidebar/build-button.js
+++ b/apps/netlify/frontend/src/sidebar/build-button.js
@@ -60,7 +60,7 @@ export default class NeflifySidebarBuildButton extends React.Component {
         ok: false,
         info: 'Contentful lost connection to update the build status. Verify if the build has completed in the Netlify app.',
       });
-    }, 120000); // 2 minute timeout
+    }, 120000); // 2 minute timeout for the "Triggering..." button
   };
 
   createPubSub = async () => {
@@ -83,7 +83,7 @@ export default class NeflifySidebarBuildButton extends React.Component {
       if (inOrder && notDuplicate) {
         const newState = messageToState(msg);
 
-        // Clear timeout since we received a message - we're no longer stuck on triggering
+        // Clear timeout after receiving a message indicating we are not stuck on triggering
         this.clearBuildTimeout();
 
         this.setState(({ history }) => {
@@ -107,7 +107,7 @@ export default class NeflifySidebarBuildButton extends React.Component {
       const latestMessage = filteredHistory[0];
       const messageState = messageToState(latestMessage);
 
-      // Check if the latest message is a stale busy state (older than 10 minutes)
+      // Check if the latest message is in a stale busy state (older than 10 minutes)
       const isStale = this.isMessageStale(latestMessage, 10 * 60 * 1000); // 10 minutes
       const isStuck = messageState.busy && isStale;
 


### PR DESCRIPTION
https://contentful.atlassian.net/jira/software/c/projects/ZEND/boards/254?quickFilter=1321&selectedIssue=ZEND-6481

A customer reported that their Netlify build button is stuck on "Triggering..."  despite confirming that the build was successful on the Netlify side. We use Pubnub for these status updates from Netlify, that we use to update our button.

I was not able to reproduce, but I've had customers report of this before. It's not a widespread or persistent issue, but it seems that sometimes we lose that connection with Netlify and the button remains in a stuck state. This means they can't trigger any subsequent builds generally unless they reinstall the app.

Knowing we can't effectively replace pubnub with a native Netlify solution, I went ahead and tried to fix the scenario where the button just gets stuck forever with no recourse. 

If the button is stuck for over 2 minutes on the Triggering phase (Not the building phase, that can actually take a while) then we show this error:

![image](https://github.com/user-attachments/assets/aad977cb-d870-4628-bb55-65d7fbf046bc)

and surface a Reset button so a custom can get out of the triggering state after verifying if the build is actually done on Netlify.

I also solved the issue of the stale message that keeps triggering stuck for literal DAYS. 
