### PR TITLE
feat: derive image field ID from focal point field ID for dynamic fie…

### DIFF
--- a/apps/image-focal-point/src/index.jsx
+++ b/apps/image-focal-point/src/index.jsx
@@ -8,9 +8,7 @@ import './index.css';
 import { AppView } from './components/AppView';
 import { FocalPointView } from './components/FocalPointView';
 import { FocalPointDialog } from './components/FocalPointDialog';
-import { getField, isCompatibleImageField } from './utils';
-
-const IMAGE_FIELD_ID = 'image';
+import { getField, isCompatibleImageField, deriveImageFieldId } from './utils';
 
 export class App extends React.Component {
   static propTypes = {
@@ -57,7 +55,9 @@ export class App extends React.Component {
   };
 
   findProperLocale() {
-    const imageField = this.props.sdk.entry.fields[IMAGE_FIELD_ID];
+    const currentFieldId = this.props.sdk.field.id;
+    const imageFieldId = deriveImageFieldId(currentFieldId);
+    const imageField = this.props.sdk.entry.fields[imageFieldId];
 
     return imageField.locales.includes(this.props.sdk.field.locale)
       ? this.props.sdk.field.locale
@@ -87,7 +87,9 @@ export class App extends React.Component {
     } = this.props;
 
     try {
-      const imageField = entry.fields[IMAGE_FIELD_ID];
+      const currentFieldId = this.props.sdk.field.id;
+      const imageFieldId = deriveImageFieldId(currentFieldId);
+      const imageField = entry.fields[imageFieldId];
       const asset = await space.getAsset(imageField.getValue(this.findProperLocale()).sys.id);
       const file =
         asset.fields.file[this.findProperLocale()] ??
@@ -124,7 +126,9 @@ export class App extends React.Component {
 
   render() {
     const { sdk } = this.props;
-    const imageField = getField(sdk.contentType, IMAGE_FIELD_ID);
+    const currentFieldId = sdk.field.id;
+    const imageFieldId = deriveImageFieldId(currentFieldId);
+    const imageField = getField(sdk.contentType, imageFieldId);
     const isImageField = isCompatibleImageField(imageField);
 
     if (isImageField) {
@@ -139,7 +143,7 @@ export class App extends React.Component {
 
     return (
       <Note variant="negative">
-        Could not find a field of type Asset with the ID &quot;{IMAGE_FIELD_ID}&quot;
+        Could not find a field of type Asset with the ID &quot;{imageFieldId}&quot;
       </Note>
     );
   }

--- a/apps/image-focal-point/src/utils.js
+++ b/apps/image-focal-point/src/utils.js
@@ -6,3 +6,29 @@ export const getField = (contentType, fieldId) =>
   contentType.fields.find((field) => field.id === fieldId);
 
 export const isCompatibleImageField = (field) => !!(field && field.linkType === 'Asset');
+
+/**
+ * Derives the associated image field ID from the focal point field ID
+ * Examples:
+ * - focalPoint -> image
+ * - focalPointLarge -> imageLarge
+ * - focalPointSomeThing -> imageSomeThing
+ *
+ * @param {string} focalPointFieldId - The ID of the focal point field
+ * @returns {string} The derived image field ID
+ */
+export const deriveImageFieldId = (focalPointFieldId) => {
+  // Default to 'image' if the field ID doesn't start with 'focalPoint'
+  if (!focalPointFieldId.startsWith('focalPoint')) {
+    return 'image';
+  }
+  
+  // If it's exactly 'focalPoint', return 'image'
+  if (focalPointFieldId === 'focalPoint') {
+    return 'image';
+  }
+  
+  // For cases like 'focalPointLarge', extract 'Large' and return 'imageLarge'
+  const suffix = focalPointFieldId.substring('focalPoint'.length);
+  return 'image' + suffix;
+};


### PR DESCRIPTION
# Dynamic Image Field Association for Focal Point App

- Fixes #9898

## Purpose

The Image Focal Point app was previously hardcoded to only work with a sibling field named "image". This limitation made it difficult to use the app with multiple image fields in the same content type. This change enables more flexible field configurations by dynamically deriving the target image field ID from the focal point field's own ID.

## Approach

We implemented a new [deriveImageFieldId](cci:1://file:///Users/dvanbrunt/Projects/apps/apps/image-focal-point/src/utils.js:9:0-33:2) utility function that follows a consistent naming pattern:
- `focalPoint` → `image` (maintains backward compatibility)
- `focalPointLarge` → `imageLarge`
- `focalPointSomeThing` → `imageSomeThing`

All references to the hardcoded `IMAGE_FIELD_ID` constant were updated to use this dynamic approach, while ensuring backward compatibility for existing implementations.

## Testing steps

1. Add a field of type JSON with ID "focalPoint" and configure the focal point app - verify it works with an "image" field
2. Add a field of type JSON with ID "focalPointLarge" and configure the focal point app - verify it works with an "imageLarge" field
3. Add a field of type JSON with ID "focalPointCustom" and configure the focal point app - verify it works with an "imageCustom" field
4. Check that error handling shows the correct field ID in error messages when target image fields are not found

## Breaking Changes

None. This change is fully backward compatible:
- Existing fields named exactly "focalPoint" will continue to associate with "image" fields
- The default fallback remains "image" for any unexpected field naming patterns
- No configuration changes are required for existing implementations

## Dependencies and/or References

N/A

## Deployment

Standard deployment process applies; no special deployment steps required.