### PR TITLE
Bulk Edit App: Pagination buttons adjustment [INTEG-2737] 

### DIFF
--- a/apps/bulk-edit/src/locations/Page/components/EntryTable.tsx
+++ b/apps/bulk-edit/src/locations/Page/components/EntryTable.tsx
@@ -156,7 +156,7 @@ export const EntryTable: React.FC<EntryTableProps> = ({
           ))}
         </Table.Body>
       </Table>
-      <Box marginTop="spacingM">
+      <Box style={styles.paginationContainer}>
         <Pagination
           activePage={activePage}
           onPageChange={onPageChange}

--- a/apps/bulk-edit/src/locations/Page/styles.ts
+++ b/apps/bulk-edit/src/locations/Page/styles.ts
@@ -85,4 +85,14 @@ export const styles = {
     zIndex: 1,
     width: 'fit-content',
   },
+  paginationContainer: {
+    position: 'sticky',
+    left: '18%',
+    zIndex: 1,
+    background: tokens.colorWhite,
+    paddingBottom: tokens.spacingM,
+    maxWidth: `80vw`,
+    marginTop: '20px',
+    marginRight: '10px',
+  },
 } as const;


### PR DESCRIPTION
## Purpose

The pagination buttons won't show while scrolling horizontally. This update fix this situation and now the user can always see the pagination buttons.

## Approach

The pagination is now sticky, following the same idea of the first column:

https://github.com/user-attachments/assets/228066df-5412-4079-a27a-6356e65ca2d5


## Testing steps

N/A

## Breaking Changes

N/A

## Dependencies and/or References

Link to [INTEG-2737](https://contentful.atlassian.net/browse/INTEG-2737) ticket.

## Deployment

N/A