### PR TITLE
Bulk Edit App: Empty content type and entries handling [INTEG-2728]

### DIFF
--- a/apps/bulk-edit/src/locations/Page/components/ContentTypeSidebar.tsx
+++ b/apps/bulk-edit/src/locations/Page/components/ContentTypeSidebar.tsx
@@ -19,16 +19,20 @@ export const ContentTypeSidebar: React.FC<ContentTypeSidebarProps> = ({
     <Flex style={styles.sidebar} padding="spacingM" flexDirection="column" gap="spacingXs">
       <Text fontColor="gray600">Content types</Text>
       <NavList aria-label="Content types" testId="content-types-nav">
-        {contentTypes.map((ct) => (
-          <NavList.Item
-            as="button"
-            key={ct.sys.id}
-            isActive={ct.sys.id === selectedContentTypeId}
-            onClick={() => onContentTypeSelect(ct.sys.id)}
-            testId="content-type-nav-item">
-            {ct.name}
-          </NavList.Item>
-        ))}
+        {contentTypes.length === 0 ? (
+          <Text style={styles.noContentTypeText}>No content types found.</Text>
+        ) : (
+          contentTypes.map((ct) => (
+            <NavList.Item
+              as="button"
+              key={ct.sys.id}
+              isActive={ct.sys.id === selectedContentTypeId}
+              onClick={() => onContentTypeSelect(ct.sys.id)}
+              testId="content-type-nav-item">
+              {ct.name}
+            </NavList.Item>
+          ))
+        )}
       </NavList>
     </Flex>
   );

--- a/apps/bulk-edit/src/locations/Page/index.tsx
+++ b/apps/bulk-edit/src/locations/Page/index.tsx
@@ -153,38 +153,38 @@ const Page = () => {
             />
             <div style={styles.stickySpacer} />
             <Box>
-              {!selectedContentType ? (
-                <Spinner />
-              ) : (
-                <>
-                  <Heading style={styles.stickyPageHeader}>
-                    {selectedContentType
-                      ? `Bulk edit ${selectedContentType.name}`
-                      : 'Bulk Edit App'}
-                  </Heading>
+              <>
+                <Heading style={styles.stickyPageHeader}>
+                  {selectedContentType ? `Bulk edit ${selectedContentType.name}` : 'Bulk Edit App'}
+                </Heading>
+                {(entries.length === 0 && !entriesLoading) || !selectedContentType ? (
+                  <Box style={styles.noEntriesText}>No entries found.</Box>
+                ) : (
                   <>
-                    <SortMenu sortOption={sortOption} onSortChange={setSortOption} />
                     {entriesLoading ? (
                       <Spinner />
                     ) : (
-                      <EntryTable
-                        entries={entries}
-                        fields={fields}
-                        contentType={selectedContentType}
-                        spaceId={sdk.ids.space}
-                        environmentId={sdk.ids.environment}
-                        defaultLocale={defaultLocale}
-                        activePage={activePage}
-                        totalEntries={totalEntries}
-                        itemsPerPage={itemsPerPage}
-                        onPageChange={setActivePage}
-                        onItemsPerPageChange={setItemsPerPage}
-                        pageSizeOptions={PAGE_SIZE_OPTIONS}
-                      />
+                      <>
+                        <SortMenu sortOption={sortOption} onSortChange={setSortOption} />
+                        <EntryTable
+                          entries={entries}
+                          fields={fields}
+                          contentType={selectedContentType}
+                          spaceId={sdk.ids.space}
+                          environmentId={sdk.ids.environment}
+                          defaultLocale={defaultLocale}
+                          activePage={activePage}
+                          totalEntries={totalEntries}
+                          itemsPerPage={itemsPerPage}
+                          onPageChange={setActivePage}
+                          onItemsPerPageChange={setItemsPerPage}
+                          pageSizeOptions={PAGE_SIZE_OPTIONS}
+                        />
+                      </>
                     )}
                   </>
-                </>
-              )}
+                )}
+              </>
             </Box>
           </Flex>
         </Box>

--- a/apps/bulk-edit/src/locations/Page/styles.ts
+++ b/apps/bulk-edit/src/locations/Page/styles.ts
@@ -95,4 +95,12 @@ export const styles = {
     marginTop: tokens.spacingL,
     marginRight: tokens.spacingXs,
   },
+  noEntriesText: {
+    textAlign: 'start',
+    fontWeight: 'bold',
+    fontSize: tokens.fontSizeL,
+  },
+  noContentTypeText: {
+    fontWeight: 'bold',
+  },
 } as const;


### PR DESCRIPTION
## Purpose

There wasn't a handling when there weren't any content types or entries.

## Approach

Now a text is rendered depending if the fetch's of the content type and entries are done correctly:
- if there is no content types - a message is rendered
- if there is no entries of a content type - a message is rendered

## Testing steps

You can install the app on an empty state and you will see this messages:
<img width="1511" alt="Captura de pantalla 2025-06-12 a la(s) 10 01 41 a  m" src="https://github.com/user-attachments/assets/0b8fa227-a3d3-460c-a79b-c1feb3b0c57a" />

Then if you add a content type but no entries, you will see the following:
<img width="1510" alt="Captura de pantalla 2025-06-12 a la(s) 10 02 15 a  m" src="https://github.com/user-attachments/assets/44b4f66d-eca1-43fa-8e2c-5468547795a9" />

If you add entries then you will see them:
<img width="1511" alt="Captura de pantalla 2025-06-12 a la(s) 10 02 33 a  m" src="https://github.com/user-attachments/assets/aae8dfc9-bd1d-40fa-a9d8-49c0884a0be9" />


## Breaking Changes

N/A

## Dependencies and/or References

Link to [INTEG-2728](https://contentful.atlassian.net/browse/INTEG-2728) ticket

## Deployment

N/A

[INTEG-2728]: https://contentful.atlassian.net/browse/INTEG-2728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ