### PR TITLE
Bulk Edit App: Fix value carried over when opening modal [INTEG-2799]

### DIFF
--- a/apps/bulk-edit/src/locations/Page/components/BulkEditModal.tsx
+++ b/apps/bulk-edit/src/locations/Page/components/BulkEditModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Modal, Button, TextInput, Text, Flex, FormControl } from '@contentful/f36-components';
 import type { Entry, ContentTypeField } from '../types';
 import { getEntryFieldValue } from '../utils/entryUtils';
@@ -33,6 +33,10 @@ export const BulkEditModal: React.FC<BulkEditModalProps> = ({
 
   const isNumber = selectedField?.type === 'Number' || selectedField?.type === 'Integer';
   const isInvalid = selectedField?.type === 'Integer' && !Number.isInteger(Number(value));
+
+  useEffect(() => {
+    setValue('');
+  }, [isOpen]);
 
   return (
     <Modal isShown={isOpen} onClose={onClose} size="medium" aria-label={title}>

--- a/apps/bulk-edit/test/locations/Page/BulkEditModal.test.tsx
+++ b/apps/bulk-edit/test/locations/Page/BulkEditModal.test.tsx
@@ -109,7 +109,6 @@ describe('BulkEditModal', () => {
         onSave={vi.fn()}
         selectedEntries={[entry1]}
         selectedField={integerField}
-        fields={fields}
         defaultLocale="en-US"
         isSaving={false}
       />
@@ -118,5 +117,34 @@ describe('BulkEditModal', () => {
     fireEvent.change(input, { target: { value: '1.5' } });
     expect(screen.getByText('Integer field does not allow decimal')).toBeInTheDocument();
     expect(screen.getByTestId('bulk-edit-save')).toBeDisabled();
+  });
+
+  it('resets the input value when the modal is reopened', () => {
+    const onClose = vi.fn();
+    const onSave = vi.fn();
+    const modalComponent = (isOpened: boolean) => {
+      return (
+        <BulkEditModal
+          isOpen={isOpened}
+          onClose={onClose}
+          onSave={onSave}
+          selectedEntries={[entry1]}
+          selectedField={field}
+          defaultLocale="en-US"
+          isSaving={false}
+        />
+      );
+    };
+    const { rerender } = render(modalComponent(true));
+
+    const input = screen.getByPlaceholderText('Enter your new value');
+    fireEvent.change(input, { target: { value: '999' } });
+    expect(input).toHaveValue(999);
+
+    rerender(modalComponent(false));
+
+    rerender(modalComponent(true));
+
+    expect(screen.getByPlaceholderText('Enter your new value')).toHaveValue(null);
   });
 });

--- a/apps/bulk-edit/test/locations/Page/BulkEditModal.test.tsx
+++ b/apps/bulk-edit/test/locations/Page/BulkEditModal.test.tsx
@@ -119,7 +119,7 @@ describe('BulkEditModal', () => {
     expect(screen.getByTestId('bulk-edit-save')).toBeDisabled();
   });
 
-  it('resets the input value when the modal is reopened', () => {
+  it('resets the input value when the modal is re-opened', () => {
     const onClose = vi.fn();
     const onSave = vi.fn();
     const modalComponent = (isOpened: boolean) => {


### PR DESCRIPTION
## Purpose

Value from previous updated field gets carried over when opening the modal for editing a different field.
https://github.com/contentful/apps/pull/9910#issuecomment-2967741763

## Approach

Used a useEffect to clean the modal value every time it's reopened, since it toggles between visible and hidden without re-rendering.

## Testing steps

Added an automated test to check this edge case. You can check it manually if wanted:

https://github.com/user-attachments/assets/95c6c376-1cee-44af-ad77-9bb2054c7f35

Now the modal value is always empty when opened.

## Breaking Changes

N/A

## Dependencies and/or References

Link to [INTEG-2799](https://contentful.atlassian.net/browse/INTEG-2799) ticket.

## Deployment

N/A

[INTEG-2799]: https://contentful.atlassian.net/browse/INTEG-2799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ