### PR TITLE
Bulk Edit App: fix condition to show spinner [INTEG-2728]

### DIFF
--- a/apps/bulk-edit/src/locations/Page/index.tsx
+++ b/apps/bulk-edit/src/locations/Page/index.tsx
@@ -11,7 +11,7 @@ import {
 } from '@contentful/f36-components';
 import { useSDK } from '@contentful/react-apps-toolkit';
 import { ContentFields, ContentTypeProps, KeyValueMap, EntryProps } from 'contentful-management';
-import { Entry, ContentTypeField } from './types';
+import { ContentTypeField } from './types';
 import { styles } from './styles';
 import { ContentTypeSidebar } from './components/ContentTypeSidebar';
 import { SortMenu, SORT_OPTIONS } from './components/SortMenu';
@@ -277,7 +277,7 @@ const Page = () => {
                 <Heading style={styles.stickyPageHeader}>
                   {selectedContentType ? `Bulk edit ${selectedContentType.name}` : 'Bulk Edit App'}
                 </Heading>
-                {entries.length === 0 || !selectedContentType ? (
+                {(entries.length === 0 && !entriesLoading) || !selectedContentType ? (
                   <Box style={styles.noEntriesText}>No entries found.</Box>
                 ) : (
                   <>


### PR DESCRIPTION
## Purpose

The spinner wasn't showing when fetching the entries.

https://github.com/user-attachments/assets/cedbd7ee-3c65-4d1c-8f85-a34f3914f661

## Approach

A minimal fix was made in the condition of the if that shows the spinner.

## Testing steps

Now the spinner works correctly:

https://github.com/user-attachments/assets/95a4f775-b4a7-4e3b-a9bb-e31c2e992228


## Breaking Changes

N/A

## Dependencies and/or References

N/A

## Deployment

N/A