### PR TITLE
Fix null displayname bug- [INTEG-2708]

### DIFF
--- a/apps/bulk-edit/src/locations/Page/index.tsx
+++ b/apps/bulk-edit/src/locations/Page/index.tsx
@@ -65,12 +65,13 @@ const Page = () => {
     return allContentTypes;
   };
 
-  const buildQuery = (sortOption: string, displayField: string) => {
+  const buildQuery = (sortOption: string, displayField: string | null) => {
     const getOrder = (sortOption: string) => {
-      if (sortOption === 'displayName_asc') return `fields.${displayField}`;
-      else if (sortOption === 'displayName_desc') return `-fields.${displayField}`;
-      else if (sortOption === 'updatedAt_desc') return '-sys.updatedAt';
+      if (sortOption === 'updatedAt_desc') return '-sys.updatedAt';
       else if (sortOption === 'updatedAt_asc') return 'sys.updatedAt';
+      else if (displayField === null) return undefined;
+      else if (sortOption === 'displayName_asc') return `fields.${displayField}`;
+      else if (sortOption === 'displayName_desc') return `-fields.${displayField}`;
     };
 
     return {
@@ -139,7 +140,7 @@ const Page = () => {
           }
         });
         setFields(newFields);
-        const displayField = ct.displayField || 'displayName';
+        const displayField = ct.displayField || null;
 
         const { items, total } = await sdk.cma.entry.getMany({
           spaceId: sdk.ids.space,

--- a/apps/bulk-edit/test/locations/Page/Page.test.tsx
+++ b/apps/bulk-edit/test/locations/Page/Page.test.tsx
@@ -7,6 +7,7 @@ import { getManyContentTypes, getManyEntries } from '../../mocks/mockCma';
 import { condoAContentType } from '../../mocks/mockContentTypes';
 import { condoAEntry1, condoAEntry2 } from '../../mocks/mockEntries';
 import { Notification } from '@contentful/f36-components';
+import type { ContentTypeProps } from 'contentful-management';
 
 vi.mock('@contentful/react-apps-toolkit', () => ({
   useSDK: () => mockSdk,
@@ -178,5 +179,48 @@ describe('Bulk edit notification', () => {
       'Building one and 4 more entry fields were updated to Alpine',
       { title: 'Success!' }
     );
+  });
+});
+
+describe('Table display', () => {
+  beforeEach(() => {
+    // Mock content type fetch
+    mockSdk.cma.contentType.getMany = vi
+      .fn()
+      .mockResolvedValue(getManyContentTypes([condoAContentType]));
+
+    // Mock content type get for fields
+    mockSdk.cma.contentType.get = vi.fn().mockResolvedValue(condoAContentType);
+
+    // Mock entries fetch
+    mockSdk.cma.entry.getMany = vi
+      .fn()
+      .mockResolvedValue(getManyEntries([condoAEntry1, condoAEntry2]));
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('displays table correctly when displayField is null', async () => {
+    const contentTypeWithoutDisplayField = {
+      ...condoAContentType,
+      displayField: null,
+    } as unknown as ContentTypeProps;
+
+    mockSdk.cma.contentType.getMany = vi
+      .fn()
+      .mockResolvedValue(getManyContentTypes([contentTypeWithoutDisplayField]));
+    mockSdk.cma.contentType.get = vi.fn().mockResolvedValue(contentTypeWithoutDisplayField);
+
+    render(<Page />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('bulk-edit-table')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Condo A')).toBeInTheDocument();
+    expect(screen.getByTestId('cf-ui-table-body')).toBeInTheDocument();
+    expect(screen.getAllByText('Untitled').length).toBe(2);
   });
 });


### PR DESCRIPTION
## Purpose

Franco found an edge case: the content type can have null displayName. In the table shows as if the user doesn't have entries:
<img width="1783" alt="Captura de pantalla 2025-06-17 a la(s) 12 38 58 p  m" src="https://github.com/user-attachments/assets/e8f2bf6d-eac6-4341-a6c1-4872b4539cad" />

<img width="1785" alt="Captura de pantalla 2025-06-17 a la(s) 12 38 53 p  m" src="https://github.com/user-attachments/assets/10a3143a-9206-4829-8621-0e59d64450a0" />

## Approach
 - Added new tests
 - Updated query for order 
 - Allow for displayName to be null

## Testing steps
- Created a type with only a json field, this causes for the display name to be null
- Now it loads the entry

https://github.com/user-attachments/assets/78e8e423-85cf-4aef-9fa4-e84cb2c2387a



