### PR TITLE
Bulk edit: Use display field when showing update errors [INTEG-2801]

### DIFF
--- a/apps/bulk-edit/src/locations/Page/index.tsx
+++ b/apps/bulk-edit/src/locations/Page/index.tsx
@@ -17,7 +17,7 @@ import { ContentTypeSidebar } from './components/ContentTypeSidebar';
 import { SortMenu, SORT_OPTIONS } from './components/SortMenu';
 import { EntryTable } from './components/EntryTable';
 import { BulkEditModal } from './components/BulkEditModal';
-import { updateEntryFieldLocalized, getEntryFieldValue } from './utils/entryUtils';
+import { updateEntryFieldLocalized, getEntryFieldValue, getEntryTitle } from './utils/entryUtils';
 import { WarningOctagonIcon } from '@phosphor-icons/react';
 import tokens from '@contentful/f36-tokens';
 
@@ -299,9 +299,9 @@ const Page = () => {
                       <>
                         {failedUpdates.length > 0 &&
                           (() => {
-                            const firstFailedValue = getEntryFieldValue(
+                            const firstFailedValue = getEntryTitle(
                               failedUpdates[0],
-                              selectedField,
+                              selectedContentType,
                               defaultLocale
                             );
                             return (

--- a/apps/bulk-edit/test/locations/Page/ErrorNote.test.tsx
+++ b/apps/bulk-edit/test/locations/Page/ErrorNote.test.tsx
@@ -2,21 +2,13 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { ErrorNote } from '../../../src/locations/Page/components/ErrorNote';
 import { condoAEntry1, condoAEntry2 } from '../../mocks/mockEntries';
-import { condoAContentType } from '../../mocks/mockContentTypes';
 import { vi } from 'vitest';
-import { ContentTypeField } from '../../../src/locations/Page/types';
+import { condoAContentType } from '../../mocks/mockContentTypes';
 
 describe('ErrorNote', () => {
-  const mockField: ContentTypeField = {
-    id: 'description',
-    uniqueId: 'description',
-    name: 'Description',
-    type: 'Text',
-  };
-
   const defaultProps = {
     failedUpdates: [condoAEntry1],
-    selectedField: mockField,
+    selectedContentType: condoAContentType,
     defaultLocale: 'en-US',
     onClose: vi.fn(),
   };

--- a/apps/bulk-edit/test/locations/Page/Page.test.tsx
+++ b/apps/bulk-edit/test/locations/Page/Page.test.tsx
@@ -142,7 +142,7 @@ describe('Bulk edit functionality', () => {
 
     // Verify error note appears
     await waitFor(() => {
-      expect(screen.getByText(/did not update/)).toBeInTheDocument();
+      expect(screen.getByText(/did not update: Building one/)).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
When an error occurs after an update, we were displaying the previous value of the updated field for the failed entry. We now display the title of the entry so help the user recognize the entry that failed

<img width="1240" alt="image" src="https://github.com/user-attachments/assets/39a831be-4058-4444-ab9b-9a8ff05e10a5" />


