### PR TITLE
Hubspot: Config screen base structure [INTEG-2769]

### DIFF
--- a/apps/hubspot/src/components/Splitter.tsx
+++ b/apps/hubspot/src/components/Splitter.tsx
@@ -1,0 +1,26 @@
+import { Box, CommonProps, MarginProps, PaddingProps } from '@contentful/f36-components';
+import { cx, css } from 'emotion';
+import tokens from '@contentful/f36-tokens';
+
+interface SplitterProps extends CommonProps, MarginProps, PaddingProps {}
+
+const Splitter = (props: SplitterProps) => {
+  const { className, ...otherProps } = props;
+
+  return (
+    <Box
+      {...otherProps}
+      as="hr"
+      className={cx(
+        css({
+          border: 0,
+          height: '1px',
+          backgroundColor: tokens.gray300,
+        }),
+        className
+      )}
+    />
+  );
+};
+
+export default Splitter;

--- a/apps/hubspot/src/locations/ConfigScreen.styles.ts
+++ b/apps/hubspot/src/locations/ConfigScreen.styles.ts
@@ -1,0 +1,13 @@
+import { css } from 'emotion';
+import tokens from '@contentful/f36-tokens';
+
+export const styles = {
+  body: css({
+    height: 'auto',
+    minHeight: '40vh',
+    maxWidth: '900px',
+    marginTop: tokens.spacing2Xl,
+  }),
+  orderList: css({ paddingLeft: 20, marginBottom: 0, marginTop: 0, color: tokens.gray500 }),
+  listItem: css({ marginBottom: 4 }),
+};

--- a/apps/hubspot/src/locations/ConfigScreen.tsx
+++ b/apps/hubspot/src/locations/ConfigScreen.tsx
@@ -12,6 +12,7 @@ import {
   IconButton,
   Subheading,
   TextLink,
+  List,
 } from '@contentful/f36-components';
 import { ChevronDownIcon, ChevronUpIcon, ExternalLinkIcon } from '@contentful/f36-icons';
 import { useSDK } from '@contentful/react-apps-toolkit';
@@ -26,7 +27,7 @@ import {
 
 const ConfigScreen = () => {
   const sdk = useSDK<ConfigAppSDK>();
-  const [isExpanded, setIsExpanded] = useState(true);
+  const [isExpanded, setIsExpanded] = useState(false);
   const [isHubspotTokenInvalid, setIsHubspotTokenInvalid] = useState(false);
   const [parameters, setParameters] = useState<AppInstallationParameters>({
     hubspotAccessToken: '',
@@ -66,9 +67,7 @@ const ConfigScreen = () => {
       const currentParameters: AppInstallationParameters | null = await sdk.app.getParameters();
 
       if (currentParameters) {
-        setParameters({
-          hubspotAccessToken: currentParameters.hubspotAccessToken ?? '',
-        });
+        setParameters(currentParameters);
       }
       sdk.app.setReady();
     })();
@@ -126,13 +125,13 @@ const ConfigScreen = () => {
             <Paragraph marginBottom="none" fontColor="gray500">
               To create a private app access token:
             </Paragraph>
-            <ol className={styles.orderList}>
+            <List as="ol" className={styles.orderList}>
               {CONFIG_SCREEN_INSTRUCTIONS.map((step, i) => (
-                <li key={i} className={styles.listItem}>
+                <List.Item key={i} className={styles.listItem}>
                   {step}
-                </li>
+                </List.Item>
               ))}
-            </ol>
+            </List>
             <Box marginTop="spacingS">
               <TextLink
                 href={HUBSPOT_PRIVATE_APPS_URL}

--- a/apps/hubspot/src/utils.ts
+++ b/apps/hubspot/src/utils.ts
@@ -1,0 +1,13 @@
+export const HUBSPOT_PRIVATE_APPS_URL = 'https://developers.hubspot.com/docs/api/private-apps';
+
+export const CONFIG_SCREEN_INSTRUCTIONS = [
+  'Navigate to your Hubspot account settings',
+  "In the left hand navigation, click 'Integrations' and select 'Private apps' from the sub menu",
+  'Create a new private app',
+  "Within your private app, navigate to the 'Auth' tab. There, you can view and copy your private app access token.",
+  'Paste your private app access token in the field above',
+];
+
+export type AppInstallationParameters = {
+  hubspotAccessToken: string;
+};

--- a/apps/hubspot/test/locations/ConfigScreen.spec.tsx
+++ b/apps/hubspot/test/locations/ConfigScreen.spec.tsx
@@ -1,22 +1,76 @@
+import React from 'react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mockSdk } from '../mocks';
 import ConfigScreen from '../../src/locations/ConfigScreen';
-import { render } from '@testing-library/react';
-import { mockCma, mockSdk } from '../mocks';
-import { vi } from 'vitest';
 
 vi.mock('@contentful/react-apps-toolkit', () => ({
   useSDK: () => mockSdk,
-  useCMA: () => mockCma,
 }));
 
-describe('Config Screen component', () => {
-  it('Component text exists', async () => {
-    const { getByText } = render(<ConfigScreen />);
+describe('Config Screen component (Hubspot)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    render(<ConfigScreen />);
+  });
 
-    // simulate the user clicking the install button
-    await mockSdk.app.onConfigure.mock.calls[0][0]();
+  afterEach(() => {
+    cleanup();
+  });
 
-    expect(
-      getByText('Welcome to your contentful app. This is your config page.')
-    ).toBeInTheDocument();
+  describe('components', () => {
+    it('renders the main heading and description', () => {
+      expect(screen.getByRole('heading', { name: /Set up Hubspot/i })).toBeTruthy();
+      expect(
+        screen.getByText(/Seamlessly sync Contentful entry content to email campaigns in Hubspot/i)
+      ).toBeTruthy();
+    });
+
+    it('renders the Configure access section and input', () => {
+      expect(screen.getByText(/Configure access/i)).toBeTruthy();
+      expect(
+        screen.getByText(
+          /To connect your organization's Hubspot account, enter the private app access token/i
+        )
+      ).toBeTruthy();
+      expect(screen.getByLabelText(/Private app access token/i)).toBeTruthy();
+      expect(screen.getByPlaceholderText(/Enter your access token/i)).toBeTruthy();
+    });
+
+    it('shows the input as required', () => {
+      const input = screen.getByPlaceholderText(/Enter your access token/i);
+      expect(input).toBeRequired();
+    });
+    /*
+    it('shows validation message if token is invalid', async () => {
+      const input = screen.getByPlaceholderText(/Enter your access token/i);
+      fireEvent.change(input, { target: { value: '' } });
+      // Wait for the validation message to appear
+      expect(await screen.findByText(/Invalid API key/i)).toBeTruthy();
+    });
+
+    it('renders the instructions section and can expand/collapse', () => {
+      expect(
+        screen.getByText(/Instructions to create a private app access token in Hubspot/i)
+      ).toBeTruthy();
+      // Should be expanded by default
+      expect(screen.getByText(/To create a private app access token:/i)).toBeTruthy();
+      // Collapse
+      const toggleBtn = screen.getByLabelText(/Collapse instructions|Expand instructions/i);
+      fireEvent.click(toggleBtn);
+      expect(screen.queryByText(/To create a private app access token:/i)).toBeFalsy();
+      // Expand again
+      fireEvent.click(toggleBtn);
+      expect(screen.getByText(/To create a private app access token:/i)).toBeTruthy();
+    });*/
+
+    it('renders the external link with icon', () => {
+      const link = screen.getByRole('link', {
+        name: /Read about creating private apps in Hubspot/i,
+      });
+      expect(link).toBeTruthy();
+      expect(link).toHaveAttribute('href');
+      expect(link.querySelector('svg')).toBeTruthy();
+    });
   });
 });

--- a/apps/hubspot/test/mocks/mockSdk.ts
+++ b/apps/hubspot/test/mocks/mockSdk.ts
@@ -7,6 +7,9 @@ const mockSdk: any = {
     setReady: vi.fn(),
     getCurrentState: vi.fn(),
   },
+  notifier: {
+    error: vi.fn(),
+  },
   ids: {
     app: 'test-app',
   },


### PR DESCRIPTION
## Purpose

This update introduce the first version of the config screen with the base structure:
- the hubspot access token (with empty check validation)
- the instructions expandable section

Note: Deeper validations are handled in another ticket.

## Approach

The config screen location was modified so the UI matches the figma design.

## Testing steps

Automated tests added. Manual check:

https://github.com/user-attachments/assets/ae323ced-623a-43db-a34a-5981f2ebcc17

## Breaking Changes

N/A

## Dependencies and/or References

Link to [INTEG-2769](https://contentful.atlassian.net/jira/software/c/projects/INTEG/boards/3109?issueParent=367108%2C365033%2C346554&selectedIssue=INTEG-2769) ticket

## Deployment

N/A

[INTEG-2769]: https://contentful.atlassian.net/browse/INTEG-2769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ