### PR TITLE
Fix errors and add test [INTEG-2819]

### DIFF
--- a/apps/braze/src/components/create/CreateFlow.tsx
+++ b/apps/braze/src/components/create/CreateFlow.tsx
@@ -142,6 +142,7 @@ const CreateFlow = (props: CreateFlowProps) => {
       setStep(DRAFT_STEP);
       return;
     } else if (step === DRAFT_STEP) {
+      setCreationResultFields([]);
       setStep(CREATE_STEP);
     }
 

--- a/apps/braze/src/components/create/CreateStep.tsx
+++ b/apps/braze/src/components/create/CreateStep.tsx
@@ -280,6 +280,8 @@ const CreateStep = ({
     description: '',
   });
   const [isNameValid, setIsNameValid] = useState(true);
+  // Track which errors should be cleared after save
+  const [clearedErrors, setClearedErrors] = useState<Set<string>>(new Set());
 
   const localizedFieldsIds = Array.from(selectedFields).flatMap((fieldId) => {
     const isLocalized = entry.fields.find((f) => f.id === fieldId)?.localized || false;
@@ -360,18 +362,53 @@ const CreateStep = ({
     }
   };
 
+  const hasNameChanged = (fieldId: string, newName: string): boolean => {
+    const previousName = contentBlocksData.names[fieldId];
+    return previousName !== newName;
+  };
+
   const handleSave = (fieldId: string) => {
     if (!isValidContentBlockName(editDraft.name)) {
       setIsNameValid(false);
       return;
     }
+
     setIsNameValid(true);
     setContentBlocksData((prev) => ({
       names: { ...prev.names, [fieldId]: editDraft.name },
       descriptions: { ...prev.descriptions, [fieldId]: editDraft.description },
     }));
+
+    // Only clear error if the name has actually changed
+    if (hasNameChanged(fieldId, editDraft.name)) {
+      setClearedErrors((prev) => new Set(prev).add(fieldId));
+    }
+
     setEditingField(null);
     setEditDraft({ name: '', description: '' });
+  };
+
+  const shouldShowError = (fieldId: string): boolean => {
+    const hasError = creationResultFields.some(
+      (result) => fieldId === localizeFieldId(result.fieldId, result.locale)
+    );
+    const isCleared = clearedErrors.has(fieldId);
+
+    return hasError && !isCleared;
+  };
+
+  const getErrorMessage = (fieldId: string): string | undefined => {
+    const errorResult = creationResultFields.find(
+      (result) => fieldId === localizeFieldId(result.fieldId, result.locale)
+    );
+
+    return shouldShowError(fieldId) ? errorResult?.message : undefined;
+  };
+
+  // Clear all errors when going back in the wizard
+  const handleBack = () => {
+    setClearedErrors(new Set());
+    handlePreviousStep();
   };
 
   return (
@@ -407,12 +444,7 @@ const CreateStep = ({
                         result.success &&
                         localizedFieldId === localizeFieldId(result.fieldId, result.locale)
                     )}
-                    error={
-                      creationResultFields.find(
-                        (result) =>
-                          localizedFieldId === localizeFieldId(result.fieldId, result.locale)
-                      )?.message
-                    }
+                    error={getErrorMessage(localizedFieldId)}
                   />
                 );
               });
@@ -434,18 +466,14 @@ const CreateStep = ({
                 isCreated={creationResultFields.some(
                   (result) => result.success && fieldId === result.fieldId
                 )}
-                error={creationResultFields.find((result) => fieldId === result.fieldId)?.message}
+                error={getErrorMessage(fieldId)}
               />,
             ];
           })}
         </Stack>
       </Box>
       <WizardFooter>
-        <Button
-          variant="secondary"
-          size="small"
-          onClick={handlePreviousStep}
-          data-testid="back-button">
+        <Button variant="secondary" size="small" onClick={handleBack} data-testid="back-button">
           Back
         </Button>
         <CreateButton

--- a/apps/braze/test/components/create/CreateStep.spec.tsx
+++ b/apps/braze/test/components/create/CreateStep.spec.tsx
@@ -218,5 +218,108 @@ describe('CreateStep', () => {
       const editButtons = screen.getAllByRole('button', { name: /Edit content block/i });
       expect(editButtons).toHaveLength(1);
     });
+
+    it('hides the error after saving a new value for the content block name', async () => {
+      const creationResultFields = [
+        {
+          fieldId: 'field1',
+          success: false,
+          statusCode: 400,
+          message: 'Content Block name already exists',
+        },
+      ];
+
+      await act(async () => {
+        render(<TestCreateStepWrapper creationResultFields={creationResultFields} />);
+      });
+
+      // Error is shown initially
+      expect(screen.getByText('Content Block name already exists')).toBeTruthy();
+
+      // Click edit button for the field with error
+      const editButtons = screen.getAllByRole('button', { name: /Edit content block/i });
+      fireEvent.click(editButtons[0]);
+
+      // Change the name to a new valid value
+      const inputName = screen.getByTestId('content-block-name-input') as HTMLInputElement;
+      fireEvent.change(inputName, { target: { value: 'NewName' } });
+
+      // Save the changes
+      const saveButton = screen.getByRole('button', { name: 'Save' });
+      fireEvent.click(saveButton);
+
+      // Error should no longer be shown
+      expect(screen.queryByText('Content Block name already exists')).toBeNull();
+    });
+
+    it('hides the error for a localized field after saving a new value', async () => {
+      const creationResultFields = [
+        {
+          fieldId: 'field2',
+          locale: 'en-US',
+          success: false,
+          statusCode: 400,
+          message: 'Content Block name already exists',
+        },
+      ];
+
+      await act(async () => {
+        render(<TestCreateStepWrapper creationResultFields={creationResultFields} />);
+      });
+
+      // Error is shown initially
+      expect(screen.getByText('Content Block name already exists')).toBeTruthy();
+
+      // Find and click edit button for the localized field with error
+      const editButtons = screen.getAllByRole('button', { name: /Edit content block/i });
+      // The second edit button corresponds to field2-en-US
+      fireEvent.click(editButtons[1]);
+
+      // Change the name to a new valid value
+      const inputName = screen.getByTestId('content-block-name-input') as HTMLInputElement;
+      fireEvent.change(inputName, { target: { value: 'NewLocalizedName' } });
+
+      // Save the changes
+      const saveButton = screen.getByRole('button', { name: 'Save' });
+      fireEvent.click(saveButton);
+
+      // Error should no longer be shown
+      expect(screen.queryByText('Content Block name already exists')).toBeNull();
+    });
+
+    it('calls handlePreviousStep when back button is clicked', async () => {
+      const creationResultFields = [
+        {
+          fieldId: 'field1',
+          success: false,
+          statusCode: 400,
+          message: 'Content Block name already exists',
+        },
+      ];
+
+      await act(async () => {
+        render(<TestCreateStepWrapper creationResultFields={creationResultFields} />);
+      });
+
+      // Error is shown initially
+      expect(screen.getByText('Content Block name already exists')).toBeTruthy();
+
+      // Click the back button
+      const backButton = screen.getByRole('button', { name: 'Back' });
+      fireEvent.click(backButton);
+
+      // Verify handlePreviousStep was called
+      expect(mockHandlePreviousStep).toHaveBeenCalled();
+    });
+
+    it('shows no errors when creationResultFields is empty', async () => {
+      await act(async () => {
+        render(<TestCreateStepWrapper creationResultFields={[]} />);
+      });
+
+      // No error messages should be shown
+      expect(screen.queryByText('Content Block name already exists')).toBeNull();
+      expect(screen.queryByText('Another error message')).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
## Purpose

We wanted to fix the following:
"When changed the name, the error doesn't go until we click again the create"

## Approach
- Clear errors after save instead of after onCreate
- Added more tests

## Testing steps

https://github.com/user-attachments/assets/250377dc-33c6-4a78-b602-1b17de556149
