### PR TITLE
Braze app v2: Handle other field types []

### DIFF
--- a/apps/braze/functions/appEventHandler.ts
+++ b/apps/braze/functions/appEventHandler.ts
@@ -16,8 +16,11 @@ import {
   ConnectedField,
 } from '../src/utils';
 import { EntryProps, KeyValueMap, PlainClientAPI } from 'contentful-management';
-import { documentToHtmlString } from '@contentful/rich-text-html-renderer';
-import { getConfigAndConnectedFields, initContentfulManagementClient } from './common';
+import {
+  getConfigAndConnectedFields,
+  initContentfulManagementClient,
+  stringifyFieldValue,
+} from './common';
 import { CustomError } from './customError';
 
 const WAIT_TIMES = [1000, 2000];
@@ -100,8 +103,6 @@ const entrySavedHandler = async (
       continue;
     }
 
-    fieldValue = fieldInfo.type === 'RichText' ? documentToHtmlString(fieldValue) : fieldValue;
-
     let updateResult: ConnectedField = {
       fieldId: connectedField.fieldId,
       locale,
@@ -109,8 +110,14 @@ const entrySavedHandler = async (
     };
 
     try {
+      const stringifiedValue = stringifyFieldValue(fieldValue, fieldInfo);
       await callAndRetry(() =>
-        updateContentBlock(brazeEndpoint, brazeApiKey, connectedField.contentBlockId, fieldValue)
+        updateContentBlock(
+          brazeEndpoint,
+          brazeApiKey,
+          connectedField.contentBlockId,
+          stringifiedValue
+        )
       );
     } catch (error: any) {
       updateResult = {

--- a/apps/braze/functions/common.ts
+++ b/apps/braze/functions/common.ts
@@ -52,17 +52,13 @@ export const stringifyFieldValue = (fieldValue: any, field: ContentFields<KeyVal
   switch (field.type) {
     case 'Symbol':
     case 'Text':
-      return String(fieldValue);
-
     case 'Integer':
     case 'Number':
+    case 'Boolean':
       return String(fieldValue);
 
     case 'Date':
       return new Date(fieldValue).toISOString();
-
-    case 'Boolean':
-      return String(fieldValue);
 
     case 'Object':
       return JSON.stringify(fieldValue);

--- a/apps/braze/functions/common.ts
+++ b/apps/braze/functions/common.ts
@@ -70,6 +70,9 @@ export const stringifyFieldValue = (fieldValue: any, field: ContentFields<KeyVal
     case 'RichText':
       return documentToHtmlString(fieldValue);
 
+    case 'Location':
+      return `lat:${fieldValue.lat},long:${fieldValue.lon}`;
+
     default:
       throw new Error(`Field type '${field.type}' is not supported`);
   }

--- a/apps/braze/functions/common.ts
+++ b/apps/braze/functions/common.ts
@@ -1,5 +1,12 @@
 import { FunctionEventContext } from '@contentful/node-apps-toolkit';
-import { createClient, EntryProps, KeyValueMap, PlainClientAPI } from 'contentful-management';
+import {
+  createClient,
+  EntryProps,
+  KeyValueMap,
+  PlainClientAPI,
+  ContentFields,
+} from 'contentful-management';
+import { documentToHtmlString } from '@contentful/rich-text-html-renderer';
 import {
   ConnectedFields,
   EntryConnectedFields,
@@ -40,3 +47,30 @@ export async function getConfigAndConnectedFields(
   const entryConnectedFields = connectedFields[entryId] || [];
   return { configEntry, connectedFields, entryConnectedFields };
 }
+
+export const stringifyFieldValue = (fieldValue: any, field: ContentFields<KeyValueMap>): string => {
+  switch (field.type) {
+    case 'Symbol':
+    case 'Text':
+      return String(fieldValue);
+
+    case 'Integer':
+    case 'Number':
+      return String(fieldValue);
+
+    case 'Date':
+      return new Date(fieldValue).toISOString();
+
+    case 'Boolean':
+      return String(fieldValue);
+
+    case 'Object':
+      return JSON.stringify(fieldValue);
+
+    case 'RichText':
+      return documentToHtmlString(fieldValue);
+
+    default:
+      throw new Error(`Field type '${field.type}' is not supported`);
+  }
+};

--- a/apps/braze/functions/createContentBlocks.ts
+++ b/apps/braze/functions/createContentBlocks.ts
@@ -4,9 +4,8 @@ import type {
   FunctionTypeEnum,
   AppActionRequest,
 } from '@contentful/node-apps-toolkit';
-import { documentToHtmlString } from '@contentful/rich-text-html-renderer';
 import { AppInstallationParameters } from '../src/utils';
-import { initContentfulManagementClient } from './common';
+import { initContentfulManagementClient, stringifyFieldValue } from './common';
 import { ContentTypeProps, EntryProps, ContentFields } from 'contentful-management';
 import { KeyValueMap } from 'contentful-management';
 
@@ -20,33 +19,6 @@ type FieldData = {
   locale?: string;
   contentBlockName: string;
   contentBlockDescription: string;
-};
-
-const stringifyFieldValue = (fieldValue: any, field: ContentFields<KeyValueMap>): string => {
-  switch (field.type) {
-    case 'Symbol':
-    case 'Text':
-      return String(fieldValue);
-
-    case 'Integer':
-    case 'Number':
-      return String(fieldValue);
-
-    case 'Date':
-      return new Date(fieldValue).toISOString();
-
-    case 'Boolean':
-      return String(fieldValue);
-
-    case 'Object':
-      return JSON.stringify(fieldValue);
-
-    case 'RichText':
-      return documentToHtmlString(fieldValue);
-
-    default:
-      throw new Error(`Field type '${field.type}' is not supported`);
-  }
 };
 
 const createBrazeErrorMessage = (
@@ -141,8 +113,7 @@ const createContentBlock = async (
       };
     }
 
-    let content: string;
-    content = stringifyFieldValue(fieldValue, field);
+    const content = stringifyFieldValue(fieldValue, field);
 
     const response = await fetch(`${brazeEndpoint}/content_blocks/create`, {
       method: 'POST',

--- a/apps/braze/test/functions/appEventHandler.spec.ts
+++ b/apps/braze/test/functions/appEventHandler.spec.ts
@@ -346,4 +346,645 @@ describe('updateContentBlocks', () => {
       })
     );
   });
+
+  describe('field stringification in updates', () => {
+    it('should stringify Symbol fields', async () => {
+      const event = {
+        headers: {
+          'X-Contentful-Topic': ['Entry.save'],
+        },
+        body: {
+          sys: {
+            id: 'test-entry-id',
+            contentType: {
+              sys: {
+                id: 'test-content-type',
+              },
+            },
+          },
+          fields: {
+            symbolField: {
+              'en-US': 'Test Symbol',
+            },
+          },
+        },
+      };
+
+      const mockConfigEntry = {
+        fields: {
+          connectedFields: {
+            'en-US': {
+              'test-entry-id': [
+                {
+                  fieldId: 'symbolField',
+                  contentBlockId: 'symbol-block-id',
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      vi.mocked(getConfigEntry).mockResolvedValue(mockConfigEntry as any);
+      mockCma.contentType.get.mockResolvedValue({
+        fields: [
+          {
+            id: 'symbolField',
+            type: 'Symbol',
+          },
+        ],
+      });
+      vi.mocked(global.fetch).mockResolvedValue(
+        new Response(JSON.stringify({ success: true }), { status: 200 })
+      );
+
+      await handler(event as any, mockContext as any);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://test.braze.com/content_blocks/update',
+        expect.objectContaining({
+          body: JSON.stringify({
+            content_block_id: 'symbol-block-id',
+            content: 'Test Symbol',
+          }),
+        })
+      );
+    });
+
+    it('should stringify Integer fields', async () => {
+      const event = {
+        headers: {
+          'X-Contentful-Topic': ['Entry.save'],
+        },
+        body: {
+          sys: {
+            id: 'test-entry-id',
+            contentType: {
+              sys: {
+                id: 'test-content-type',
+              },
+            },
+          },
+          fields: {
+            integerField: {
+              'en-US': 42,
+            },
+          },
+        },
+      };
+
+      const mockConfigEntry = {
+        fields: {
+          connectedFields: {
+            'en-US': {
+              'test-entry-id': [
+                {
+                  fieldId: 'integerField',
+                  contentBlockId: 'integer-block-id',
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      vi.mocked(getConfigEntry).mockResolvedValue(mockConfigEntry as any);
+      mockCma.contentType.get.mockResolvedValue({
+        fields: [
+          {
+            id: 'integerField',
+            type: 'Integer',
+          },
+        ],
+      });
+      vi.mocked(global.fetch).mockResolvedValue(
+        new Response(JSON.stringify({ success: true }), { status: 200 })
+      );
+
+      await handler(event as any, mockContext as any);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://test.braze.com/content_blocks/update',
+        expect.objectContaining({
+          body: JSON.stringify({
+            content_block_id: 'integer-block-id',
+            content: '42',
+          }),
+        })
+      );
+    });
+
+    it('should stringify Number fields', async () => {
+      const event = {
+        headers: {
+          'X-Contentful-Topic': ['Entry.save'],
+        },
+        body: {
+          sys: {
+            id: 'test-entry-id',
+            contentType: {
+              sys: {
+                id: 'test-content-type',
+              },
+            },
+          },
+          fields: {
+            numberField: {
+              'en-US': 99.99,
+            },
+          },
+        },
+      };
+
+      const mockConfigEntry = {
+        fields: {
+          connectedFields: {
+            'en-US': {
+              'test-entry-id': [
+                {
+                  fieldId: 'numberField',
+                  contentBlockId: 'number-block-id',
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      vi.mocked(getConfigEntry).mockResolvedValue(mockConfigEntry as any);
+      mockCma.contentType.get.mockResolvedValue({
+        fields: [
+          {
+            id: 'numberField',
+            type: 'Number',
+          },
+        ],
+      });
+      vi.mocked(global.fetch).mockResolvedValue(
+        new Response(JSON.stringify({ success: true }), { status: 200 })
+      );
+
+      await handler(event as any, mockContext as any);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://test.braze.com/content_blocks/update',
+        expect.objectContaining({
+          body: JSON.stringify({
+            content_block_id: 'number-block-id',
+            content: '99.99',
+          }),
+        })
+      );
+    });
+
+    it('should stringify Date fields', async () => {
+      const testDate = '2024-01-15T10:30:00Z';
+      const event = {
+        headers: {
+          'X-Contentful-Topic': ['Entry.save'],
+        },
+        body: {
+          sys: {
+            id: 'test-entry-id',
+            contentType: {
+              sys: {
+                id: 'test-content-type',
+              },
+            },
+          },
+          fields: {
+            dateField: {
+              'en-US': testDate,
+            },
+          },
+        },
+      };
+
+      const mockConfigEntry = {
+        fields: {
+          connectedFields: {
+            'en-US': {
+              'test-entry-id': [
+                {
+                  fieldId: 'dateField',
+                  contentBlockId: 'date-block-id',
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      vi.mocked(getConfigEntry).mockResolvedValue(mockConfigEntry as any);
+      mockCma.contentType.get.mockResolvedValue({
+        fields: [
+          {
+            id: 'dateField',
+            type: 'Date',
+          },
+        ],
+      });
+      vi.mocked(global.fetch).mockResolvedValue(
+        new Response(JSON.stringify({ success: true }), { status: 200 })
+      );
+
+      await handler(event as any, mockContext as any);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://test.braze.com/content_blocks/update',
+        expect.objectContaining({
+          body: JSON.stringify({
+            content_block_id: 'date-block-id',
+            content: '2024-01-15T10:30:00.000Z',
+          }),
+        })
+      );
+    });
+
+    it('should stringify Boolean fields', async () => {
+      const event = {
+        headers: {
+          'X-Contentful-Topic': ['Entry.save'],
+        },
+        body: {
+          sys: {
+            id: 'test-entry-id',
+            contentType: {
+              sys: {
+                id: 'test-content-type',
+              },
+            },
+          },
+          fields: {
+            booleanField: {
+              'en-US': true,
+            },
+          },
+        },
+      };
+
+      const mockConfigEntry = {
+        fields: {
+          connectedFields: {
+            'en-US': {
+              'test-entry-id': [
+                {
+                  fieldId: 'booleanField',
+                  contentBlockId: 'boolean-block-id',
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      vi.mocked(getConfigEntry).mockResolvedValue(mockConfigEntry as any);
+      mockCma.contentType.get.mockResolvedValue({
+        fields: [
+          {
+            id: 'booleanField',
+            type: 'Boolean',
+          },
+        ],
+      });
+      vi.mocked(global.fetch).mockResolvedValue(
+        new Response(JSON.stringify({ success: true }), { status: 200 })
+      );
+
+      await handler(event as any, mockContext as any);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://test.braze.com/content_blocks/update',
+        expect.objectContaining({
+          body: JSON.stringify({
+            content_block_id: 'boolean-block-id',
+            content: 'true',
+          }),
+        })
+      );
+    });
+
+    it('should stringify Object fields', async () => {
+      const objectValue = { key: 'value', number: 123, nested: { test: true } };
+      const event = {
+        headers: {
+          'X-Contentful-Topic': ['Entry.save'],
+        },
+        body: {
+          sys: {
+            id: 'test-entry-id',
+            contentType: {
+              sys: {
+                id: 'test-content-type',
+              },
+            },
+          },
+          fields: {
+            objectField: {
+              'en-US': objectValue,
+            },
+          },
+        },
+      };
+
+      const mockConfigEntry = {
+        fields: {
+          connectedFields: {
+            'en-US': {
+              'test-entry-id': [
+                {
+                  fieldId: 'objectField',
+                  contentBlockId: 'object-block-id',
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      vi.mocked(getConfigEntry).mockResolvedValue(mockConfigEntry as any);
+      mockCma.contentType.get.mockResolvedValue({
+        fields: [
+          {
+            id: 'objectField',
+            type: 'Object',
+          },
+        ],
+      });
+      vi.mocked(global.fetch).mockResolvedValue(
+        new Response(JSON.stringify({ success: true }), { status: 200 })
+      );
+
+      await handler(event as any, mockContext as any);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://test.braze.com/content_blocks/update',
+        expect.objectContaining({
+          body: JSON.stringify({
+            content_block_id: 'object-block-id',
+            content: JSON.stringify(objectValue),
+          }),
+        })
+      );
+    });
+
+    it('should skip Link fields', async () => {
+      const event = {
+        headers: {
+          'X-Contentful-Topic': ['Entry.save'],
+        },
+        body: {
+          sys: {
+            id: 'test-entry-id',
+            contentType: {
+              sys: {
+                id: 'test-content-type',
+              },
+            },
+          },
+          fields: {
+            linkField: {
+              'en-US': { sys: { type: 'Link', linkType: 'Asset', id: 'asset-id' } },
+            },
+          },
+        },
+      };
+
+      const mockConfigEntry = {
+        fields: {
+          connectedFields: {
+            'en-US': {
+              'test-entry-id': [
+                {
+                  fieldId: 'linkField',
+                  contentBlockId: 'link-block-id',
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      vi.mocked(getConfigEntry).mockResolvedValue(mockConfigEntry as any);
+      mockCma.contentType.get.mockResolvedValue({
+        fields: [
+          {
+            id: 'linkField',
+            type: 'Link',
+            linkType: 'Asset',
+          },
+        ],
+      });
+
+      await handler(event as any, mockContext as any);
+
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('should skip Location fields', async () => {
+      const event = {
+        headers: {
+          'X-Contentful-Topic': ['Entry.save'],
+        },
+        body: {
+          sys: {
+            id: 'test-entry-id',
+            contentType: {
+              sys: {
+                id: 'test-content-type',
+              },
+            },
+          },
+          fields: {
+            locationField: {
+              'en-US': { lat: 40.7128, lon: -74.006 },
+            },
+          },
+        },
+      };
+
+      const mockConfigEntry = {
+        fields: {
+          connectedFields: {
+            'en-US': {
+              'test-entry-id': [
+                {
+                  fieldId: 'locationField',
+                  contentBlockId: 'location-block-id',
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      vi.mocked(getConfigEntry).mockResolvedValue(mockConfigEntry as any);
+      mockCma.contentType.get.mockResolvedValue({
+        fields: [
+          {
+            id: 'locationField',
+            type: 'Location',
+          },
+        ],
+      });
+
+      await handler(event as any, mockContext as any);
+
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('should skip Array fields', async () => {
+      const event = {
+        headers: {
+          'X-Contentful-Topic': ['Entry.save'],
+        },
+        body: {
+          sys: {
+            id: 'test-entry-id',
+            contentType: {
+              sys: {
+                id: 'test-content-type',
+              },
+            },
+          },
+          fields: {
+            arrayField: {
+              'en-US': ['tag1', 'tag2', 'tag3'],
+            },
+          },
+        },
+      };
+
+      const mockConfigEntry = {
+        fields: {
+          connectedFields: {
+            'en-US': {
+              'test-entry-id': [
+                {
+                  fieldId: 'arrayField',
+                  contentBlockId: 'array-block-id',
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      vi.mocked(getConfigEntry).mockResolvedValue(mockConfigEntry as any);
+      mockCma.contentType.get.mockResolvedValue({
+        fields: [
+          {
+            id: 'arrayField',
+            type: 'Array',
+            items: {
+              type: 'Symbol',
+            },
+          },
+        ],
+      });
+
+      await handler(event as any, mockContext as any);
+
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('should handle mixed field types correctly', async () => {
+      const event = {
+        headers: {
+          'X-Contentful-Topic': ['Entry.save'],
+        },
+        body: {
+          sys: {
+            id: 'test-entry-id',
+            contentType: {
+              sys: {
+                id: 'test-content-type',
+              },
+            },
+          },
+          fields: {
+            textField: {
+              'en-US': 'Text value',
+            },
+            linkField: {
+              'en-US': { sys: { type: 'Link', linkType: 'Asset', id: 'asset-id' } },
+            },
+            numberField: {
+              'en-US': 42,
+            },
+          },
+        },
+      };
+
+      const mockConfigEntry = {
+        fields: {
+          connectedFields: {
+            'en-US': {
+              'test-entry-id': [
+                {
+                  fieldId: 'textField',
+                  contentBlockId: 'text-block-id',
+                },
+                {
+                  fieldId: 'linkField',
+                  contentBlockId: 'link-block-id',
+                },
+                {
+                  fieldId: 'numberField',
+                  contentBlockId: 'number-block-id',
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      vi.mocked(getConfigEntry).mockResolvedValue(mockConfigEntry as any);
+      mockCma.contentType.get.mockResolvedValue({
+        fields: [
+          {
+            id: 'textField',
+            type: 'Text',
+          },
+          {
+            id: 'linkField',
+            type: 'Link',
+            linkType: 'Asset',
+          },
+          {
+            id: 'numberField',
+            type: 'Number',
+          },
+        ],
+      });
+      vi.mocked(global.fetch).mockResolvedValue(
+        new Response(JSON.stringify({ success: true }), { status: 200 })
+      );
+
+      await handler(event as any, mockContext as any);
+
+      // Should only update supported fields (text and number)
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+      expect(global.fetch).toHaveBeenNthCalledWith(
+        1,
+        'https://test.braze.com/content_blocks/update',
+        expect.objectContaining({
+          body: JSON.stringify({
+            content_block_id: 'text-block-id',
+            content: 'Text value',
+          }),
+        })
+      );
+      expect(global.fetch).toHaveBeenNthCalledWith(
+        2,
+        'https://test.braze.com/content_blocks/update',
+        expect.objectContaining({
+          body: JSON.stringify({
+            content_block_id: 'number-block-id',
+            content: '42',
+          }),
+        })
+      );
+    });
+  });
 });

--- a/apps/braze/test/functions/createContentBlocks.spec.ts
+++ b/apps/braze/test/functions/createContentBlocks.spec.ts
@@ -692,4 +692,382 @@ describe('createContentBlocks', () => {
       })
     );
   });
+
+  describe('field stringification', () => {
+    it('should stringify Symbol fields', async () => {
+      const entry = createEntryResponse({
+        title: { 'en-US': 'Test Symbol' },
+      });
+      const contentType = createContentTypeResponse(['title'], 'Symbol');
+
+      vi.mocked(mockCma.entry.get).mockResolvedValue(entry);
+      vi.mocked(mockCma.contentType.get).mockResolvedValue(contentType);
+      mockFetchSuccess({ content_block_id: 'block-id' });
+
+      const event: AppActionRequest<'Custom', AppActionParameters> = {
+        type: FunctionTypeEnum.AppActionCall,
+        body: {
+          entryId: 'entry-id',
+          fieldsData: JSON.stringify([
+            {
+              fieldId: 'title',
+              contentBlockName: 'symbol-field',
+              contentBlockDescription: 'Symbol field test',
+            },
+          ]),
+        },
+        headers: {},
+      };
+
+      const result = await handler(event, mockContext);
+
+      expect(result.results[0].success).toBe(true);
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://test.braze.com/content_blocks/create',
+        expect.objectContaining({
+          body: JSON.stringify({
+            name: 'symbol-field',
+            content: 'Test Symbol',
+            state: 'draft',
+            description: 'Symbol field test',
+          }),
+        })
+      );
+    });
+
+    it('should stringify Integer fields', async () => {
+      const entry = createEntryResponse({
+        count: { 'en-US': 42 },
+      });
+      const contentType = createContentTypeResponse(['count'], 'Integer');
+
+      vi.mocked(mockCma.entry.get).mockResolvedValue(entry);
+      vi.mocked(mockCma.contentType.get).mockResolvedValue(contentType);
+      mockFetchSuccess({ content_block_id: 'block-id' });
+
+      const event: AppActionRequest<'Custom', AppActionParameters> = {
+        type: FunctionTypeEnum.AppActionCall,
+        body: {
+          entryId: 'entry-id',
+          fieldsData: JSON.stringify([
+            {
+              fieldId: 'count',
+              contentBlockName: 'integer-field',
+              contentBlockDescription: 'Integer field test',
+            },
+          ]),
+        },
+        headers: {},
+      };
+
+      const result = await handler(event, mockContext);
+
+      expect(result.results[0].success).toBe(true);
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://test.braze.com/content_blocks/create',
+        expect.objectContaining({
+          body: JSON.stringify({
+            name: 'integer-field',
+            content: '42',
+            state: 'draft',
+            description: 'Integer field test',
+          }),
+        })
+      );
+    });
+
+    it('should stringify Number fields', async () => {
+      const entry = createEntryResponse({
+        price: { 'en-US': 99.99 },
+      });
+      const contentType = createContentTypeResponse(['price'], 'Number');
+
+      vi.mocked(mockCma.entry.get).mockResolvedValue(entry);
+      vi.mocked(mockCma.contentType.get).mockResolvedValue(contentType);
+      mockFetchSuccess({ content_block_id: 'block-id' });
+
+      const event: AppActionRequest<'Custom', AppActionParameters> = {
+        type: FunctionTypeEnum.AppActionCall,
+        body: {
+          entryId: 'entry-id',
+          fieldsData: JSON.stringify([
+            {
+              fieldId: 'price',
+              contentBlockName: 'number-field',
+              contentBlockDescription: 'Number field test',
+            },
+          ]),
+        },
+        headers: {},
+      };
+
+      const result = await handler(event, mockContext);
+
+      expect(result.results[0].success).toBe(true);
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://test.braze.com/content_blocks/create',
+        expect.objectContaining({
+          body: JSON.stringify({
+            name: 'number-field',
+            content: '99.99',
+            state: 'draft',
+            description: 'Number field test',
+          }),
+        })
+      );
+    });
+
+    it('should stringify Date fields', async () => {
+      const testDate = '2024-01-15T10:30:00Z';
+      const entry = createEntryResponse({
+        publishedAt: { 'en-US': testDate },
+      });
+      const contentType = createContentTypeResponse(['publishedAt'], 'Date');
+
+      vi.mocked(mockCma.entry.get).mockResolvedValue(entry);
+      vi.mocked(mockCma.contentType.get).mockResolvedValue(contentType);
+      mockFetchSuccess({ content_block_id: 'block-id' });
+
+      const event: AppActionRequest<'Custom', AppActionParameters> = {
+        type: FunctionTypeEnum.AppActionCall,
+        body: {
+          entryId: 'entry-id',
+          fieldsData: JSON.stringify([
+            {
+              fieldId: 'publishedAt',
+              contentBlockName: 'date-field',
+              contentBlockDescription: 'Date field test',
+            },
+          ]),
+        },
+        headers: {},
+      };
+
+      const result = await handler(event, mockContext);
+
+      expect(result.results[0].success).toBe(true);
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://test.braze.com/content_blocks/create',
+        expect.objectContaining({
+          body: JSON.stringify({
+            name: 'date-field',
+            content: '2024-01-15T10:30:00.000Z',
+            state: 'draft',
+            description: 'Date field test',
+          }),
+        })
+      );
+    });
+
+    it('should stringify Boolean fields', async () => {
+      const entry = createEntryResponse({
+        isPublished: { 'en-US': true },
+      });
+      const contentType = createContentTypeResponse(['isPublished'], 'Boolean');
+
+      vi.mocked(mockCma.entry.get).mockResolvedValue(entry);
+      vi.mocked(mockCma.contentType.get).mockResolvedValue(contentType);
+      mockFetchSuccess({ content_block_id: 'block-id' });
+
+      const event: AppActionRequest<'Custom', AppActionParameters> = {
+        type: FunctionTypeEnum.AppActionCall,
+        body: {
+          entryId: 'entry-id',
+          fieldsData: JSON.stringify([
+            {
+              fieldId: 'isPublished',
+              contentBlockName: 'boolean-field',
+              contentBlockDescription: 'Boolean field test',
+            },
+          ]),
+        },
+        headers: {},
+      };
+
+      const result = await handler(event, mockContext);
+
+      expect(result.results[0].success).toBe(true);
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://test.braze.com/content_blocks/create',
+        expect.objectContaining({
+          body: JSON.stringify({
+            name: 'boolean-field',
+            content: 'true',
+            state: 'draft',
+            description: 'Boolean field test',
+          }),
+        })
+      );
+    });
+
+    it('should stringify Object fields', async () => {
+      const objectValue = { key: 'value', number: 123, nested: { test: true } };
+      const entry = createEntryResponse({
+        metadata: { 'en-US': objectValue },
+      });
+      const contentType = createContentTypeResponse(['metadata'], 'Object');
+
+      vi.mocked(mockCma.entry.get).mockResolvedValue(entry);
+      vi.mocked(mockCma.contentType.get).mockResolvedValue(contentType);
+      mockFetchSuccess({ content_block_id: 'block-id' });
+
+      const event: AppActionRequest<'Custom', AppActionParameters> = {
+        type: FunctionTypeEnum.AppActionCall,
+        body: {
+          entryId: 'entry-id',
+          fieldsData: JSON.stringify([
+            {
+              fieldId: 'metadata',
+              contentBlockName: 'object-field',
+              contentBlockDescription: 'Object field test',
+            },
+          ]),
+        },
+        headers: {},
+      };
+
+      const result = await handler(event, mockContext);
+
+      expect(result.results[0].success).toBe(true);
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://test.braze.com/content_blocks/create',
+        expect.objectContaining({
+          body: JSON.stringify({
+            name: 'object-field',
+            content: JSON.stringify(objectValue),
+            state: 'draft',
+            description: 'Object field test',
+          }),
+        })
+      );
+    });
+
+    it('should reject Link fields', async () => {
+      const entry = createEntryResponse({
+        asset: { 'en-US': { sys: { type: 'Link', linkType: 'Asset', id: 'asset-id' } } },
+      });
+      const contentType = createContentTypeResponse(['asset'], 'Link');
+
+      vi.mocked(mockCma.entry.get).mockResolvedValue(entry);
+      vi.mocked(mockCma.contentType.get).mockResolvedValue(contentType);
+
+      const event: AppActionRequest<'Custom', AppActionParameters> = {
+        type: FunctionTypeEnum.AppActionCall,
+        body: {
+          entryId: 'entry-id',
+          fieldsData: JSON.stringify([
+            {
+              fieldId: 'asset',
+              contentBlockName: 'link-field',
+              contentBlockDescription: 'Link field test',
+            },
+          ]),
+        },
+        headers: {},
+      };
+
+      const result = await handler(event, mockContext);
+
+      expect(result.results[0].success).toBe(false);
+      expect(result.results[0].statusCode).toBe(500);
+      expect(result.results[0].message).toBe("Field type 'Link' is not supported");
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('should reject Location fields', async () => {
+      const entry = createEntryResponse({
+        location: { 'en-US': { lat: 40.7128, lon: -74.006 } },
+      });
+      const contentType = createContentTypeResponse(['location'], 'Location');
+
+      vi.mocked(mockCma.entry.get).mockResolvedValue(entry);
+      vi.mocked(mockCma.contentType.get).mockResolvedValue(contentType);
+
+      const event: AppActionRequest<'Custom', AppActionParameters> = {
+        type: FunctionTypeEnum.AppActionCall,
+        body: {
+          entryId: 'entry-id',
+          fieldsData: JSON.stringify([
+            {
+              fieldId: 'location',
+              contentBlockName: 'location-field',
+              contentBlockDescription: 'Location field test',
+            },
+          ]),
+        },
+        headers: {},
+      };
+
+      const result = await handler(event, mockContext);
+
+      expect(result.results[0].success).toBe(false);
+      expect(result.results[0].statusCode).toBe(500);
+      expect(result.results[0].message).toBe("Field type 'Location' is not supported");
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('should reject Array fields', async () => {
+      const entry = createEntryResponse({
+        tags: { 'en-US': ['tag1', 'tag2', 'tag3'] },
+      });
+      const contentType = createContentTypeResponse(['tags'], 'Array');
+
+      vi.mocked(mockCma.entry.get).mockResolvedValue(entry);
+      vi.mocked(mockCma.contentType.get).mockResolvedValue(contentType);
+
+      const event: AppActionRequest<'Custom', AppActionParameters> = {
+        type: FunctionTypeEnum.AppActionCall,
+        body: {
+          entryId: 'entry-id',
+          fieldsData: JSON.stringify([
+            {
+              fieldId: 'tags',
+              contentBlockName: 'array-field',
+              contentBlockDescription: 'Array field test',
+            },
+          ]),
+        },
+        headers: {},
+      };
+
+      const result = await handler(event, mockContext);
+
+      expect(result.results[0].success).toBe(false);
+      expect(result.results[0].statusCode).toBe(500);
+      expect(result.results[0].message).toBe("Field type 'Array' is not supported");
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('should handle field not found in content type', async () => {
+      const entry = createEntryResponse({
+        title: { 'en-US': 'Test Title' },
+      });
+      const contentType = createContentTypeResponse(['title']);
+
+      vi.mocked(mockCma.entry.get).mockResolvedValue(entry);
+      vi.mocked(mockCma.contentType.get).mockResolvedValue(contentType);
+
+      const event: AppActionRequest<'Custom', AppActionParameters> = {
+        type: FunctionTypeEnum.AppActionCall,
+        body: {
+          entryId: 'entry-id',
+          fieldsData: JSON.stringify([
+            {
+              fieldId: 'nonexistent',
+              contentBlockName: 'nonexistent-field',
+              contentBlockDescription: 'Nonexistent field test',
+            },
+          ]),
+        },
+        headers: {},
+      };
+
+      const result = await handler(event, mockContext);
+
+      expect(result.results[0].success).toBe(false);
+      expect(result.results[0].statusCode).toBe(600);
+      expect(result.results[0].message).toBe('Field nonexistent does not exist or is empty');
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/apps/braze/test/mocks/contentTypeResponse.ts
+++ b/apps/braze/test/mocks/contentTypeResponse.ts
@@ -1,8 +1,21 @@
 import type { ContentTypeProps } from 'contentful-management';
 
+type FieldType =
+  | 'Symbol'
+  | 'Text'
+  | 'RichText'
+  | 'Integer'
+  | 'Number'
+  | 'Date'
+  | 'Boolean'
+  | 'Object'
+  | 'Link'
+  | 'Location'
+  | 'Array';
+
 export function createContentTypeResponse(
   fieldIds: string[],
-  type: 'Text' | 'RichText' = 'Text'
+  type: FieldType = 'Text'
 ): ContentTypeProps {
   return {
     sys: {
@@ -17,15 +30,43 @@ export function createContentTypeResponse(
     name: 'Test Content Type',
     description: 'Test Description',
     displayField: 'title',
-    fields: fieldIds.map((id) => ({
-      id,
-      name: id.charAt(0).toUpperCase() + id.slice(1),
-      type,
-      localized: true,
-      required: true,
-      validations: [],
-      disabled: false,
-      omitted: false,
-    })),
+    fields: fieldIds.map((id) => {
+      const baseField = {
+        id,
+        name: id.charAt(0).toUpperCase() + id.slice(1),
+        localized: true,
+        required: true,
+        validations: [],
+        disabled: false,
+        omitted: false,
+      };
+
+      switch (type) {
+        case 'Link':
+          return {
+            ...baseField,
+            type: 'Link',
+            linkType: 'Asset',
+          };
+        case 'Array':
+          return {
+            ...baseField,
+            type: 'Array',
+            items: {
+              type: 'Symbol',
+            },
+          };
+        case 'Location':
+          return {
+            ...baseField,
+            type: 'Location',
+          };
+        default:
+          return {
+            ...baseField,
+            type,
+          };
+      }
+    }),
   };
 }


### PR DESCRIPTION
## Purpose

Fix a bug from Braze that prevents the user to create contentblocks with field types different to text, symbol or rich text. Types we also want to handle:
- Integer
- Number
- Date
- Boolean
- Object
- Location

## Approach

- Stringify all allowed fields because braze API only accepts content that is a string
- Change create handler to accept types
- Change update handler to accept types
- Added more tests for this cases

## Testing steps
Automated testing and local testing
All fields except location:

https://github.com/user-attachments/assets/a095991e-7aaf-4053-8794-58fde016f2c0


Location field:

https://github.com/user-attachments/assets/55aea82b-dd1c-49ab-8435-22e9e1b0e77b

Boolean:
<img width="1191" alt="Captura de pantalla 2025-06-23 a la(s) 4 20 40 p  m" src="https://github.com/user-attachments/assets/d3d3dc33-a839-4c52-865f-ca3f38d94628" />


