### PR TITLE
Hubspot app:Add sidebar []

### DIFF
--- a/apps/hubspot/src/locations/Sidebar.tsx
+++ b/apps/hubspot/src/locations/Sidebar.tsx
@@ -1,16 +1,28 @@
-import { Paragraph } from '@contentful/f36-components';
+import { Button, Flex } from '@contentful/f36-components';
 import { SidebarAppSDK } from '@contentful/app-sdk';
-import { /* useCMA, */ useSDK } from '@contentful/react-apps-toolkit';
+import { useAutoResizer, useSDK } from '@contentful/react-apps-toolkit';
 
 const Sidebar = () => {
   const sdk = useSDK<SidebarAppSDK>();
-  /*
-     To use the cma, inject it as follows.
-     If it is not needed, you can remove the next line.
-  */
-  // const cma = useCMA();
+  useAutoResizer();
 
-  return <Paragraph>Hello Sidebar Component (AppId: {sdk.ids.app})</Paragraph>;
+  return (
+    <Flex gap="spacingM" flexDirection="column">
+      <Button
+        variant="secondary"
+        isFullWidth={true}
+        onClick={() => sdk.dialogs.openCurrentApp({ title: 'Sync entry fields to Hubspot' })}>
+        Sync entry fields to Hubspot
+      </Button>
+
+      <Button
+        variant="secondary"
+        isFullWidth={true}
+        onClick={() => sdk.navigator.openCurrentAppPage()}>
+        View all connected entries
+      </Button>
+    </Flex>
+  );
 };
 
 export default Sidebar;

--- a/apps/hubspot/test/locations/Sidebar.spec.tsx
+++ b/apps/hubspot/test/locations/Sidebar.spec.tsx
@@ -1,17 +1,39 @@
 import Sidebar from '../../src/locations/Sidebar';
-import { render } from '@testing-library/react';
-import { mockCma, mockSdk } from '../mocks';
-import { vi } from 'vitest';
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import { mockSdk } from '../mocks';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import React from 'react';
 
 vi.mock('@contentful/react-apps-toolkit', () => ({
   useSDK: () => mockSdk,
-  useCMA: () => mockCma,
+  useAutoResizer: () => {},
 }));
 
 describe('Sidebar component', () => {
-  it('Component text exists', () => {
+  beforeEach(() => {
+    vi.clearAllMocks(); // Clear mocks before each test
+  });
+
+  afterEach(cleanup);
+
+  it('Sync button opens dialog', () => {
     const { getByText } = render(<Sidebar />);
 
-    expect(getByText('Hello Sidebar Component (AppId: test-app)')).toBeInTheDocument();
+    const syncButton = getByText('Sync entry fields to Hubspot');
+    fireEvent.click(syncButton);
+
+    expect(mockSdk.dialogs.openCurrentApp).toHaveBeenCalledTimes(1);
+    expect(mockSdk.dialogs.openCurrentApp).toHaveBeenCalledWith({
+      title: 'Sync entry fields to Hubspot',
+    });
+  });
+
+  it('Page button opens page', () => {
+    const { getByText } = render(<Sidebar />);
+
+    const pageButton = getByText('View all connected entries');
+    fireEvent.click(pageButton);
+
+    expect(mockSdk.navigator.openCurrentAppPage).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/hubspot/test/mocks/mockSdk.ts
+++ b/apps/hubspot/test/mocks/mockSdk.ts
@@ -13,6 +13,12 @@ const mockSdk: any = {
   ids: {
     app: 'test-app',
   },
+  dialogs: {
+    openCurrentApp: vi.fn(),
+  },
+  navigator: {
+    openCurrentAppPage: vi.fn(),
+  },
 };
 
 export { mockSdk };


### PR DESCRIPTION
## Purpose

Adding the sidebar location for the Hubspot app.
It consists of two buttons: one opens the dialog location and the other one redirects to the page location.

## Testing steps

- Add app to the sidebar of a content type
- Go to an entry of that content type
- Use both buttons

https://github.com/user-attachments/assets/53648082-6fca-4ca7-8189-0c5820dba948