### PR TITLE
Braze app: Fix long loading time [INTEG-2822]

### DIFF
--- a/apps/braze/src/fields/FieldsFactory.ts
+++ b/apps/braze/src/fields/FieldsFactory.ts
@@ -21,12 +21,19 @@ export class FieldsFactory {
   private entryId: string;
   private entryContentTypeId: string;
   private cma: PlainClientAPI;
+  private defaultLocale: string;
   NESTED_DEPTH = 5;
 
-  public constructor(entryId: string, entryContentTypeId: string, cma: PlainClientAPI) {
+  public constructor(
+    entryId: string,
+    entryContentTypeId: string,
+    cma: PlainClientAPI,
+    defaultLocale: string
+  ) {
     this.entryId = entryId;
     this.entryContentTypeId = entryContentTypeId;
     this.cma = cma;
+    this.defaultLocale = defaultLocale;
     this.contentTypes = {};
   }
 
@@ -191,6 +198,6 @@ export class FieldsFactory {
     if (!displayFieldValue || typeof displayFieldValue !== 'object' || displayFieldValue === null)
       return 'Untitled';
 
-    return Object.values(displayFieldValue)[0] as string;
+    return displayFieldValue[this.defaultLocale] || 'Untitled';
   }
 }

--- a/apps/braze/src/fields/FieldsFactory.ts
+++ b/apps/braze/src/fields/FieldsFactory.ts
@@ -188,11 +188,9 @@ export class FieldsFactory {
   private getDisplayFieldValue(fieldValue: any, displayField: string | undefined): string {
     if (!displayField) return 'Untitled';
     const displayFieldValue = fieldValue.fields?.[displayField];
-    if (!displayFieldValue || displayFieldValue === null) return 'Untitled';
-    if (typeof displayFieldValue === 'object') {
-      return Object.values(displayFieldValue)[0] as string;
-    }
+    if (!displayFieldValue || typeof displayFieldValue !== 'object' || displayFieldValue === null)
+      return 'Untitled';
 
-    return String(displayFieldValue);
+    return Object.values(displayFieldValue)[0] as string;
   }
 }

--- a/apps/braze/src/fields/FieldsFactory.ts
+++ b/apps/braze/src/fields/FieldsFactory.ts
@@ -140,9 +140,7 @@ export class FieldsFactory {
     currentDepth: number
   ): Promise<ReferenceField> {
     const fieldContentType = await this.getContentType(fieldValue.sys.contentType.sys.id);
-    const title = !!fieldContentType.displayField
-      ? Object.values(fieldValue.fields[fieldContentType.displayField] as { [key: string]: any })[0]
-      : 'Untitled';
+    const title = this.getDisplayFieldValue(fieldValue, fieldContentType.displayField);
 
     return new ReferenceField(
       fieldInfo.id,
@@ -169,7 +167,7 @@ export class FieldsFactory {
           crypto.randomUUID(),
           `${fieldInfo.name} item #${index + 1}`,
           contentType.sys.id,
-          Object.values(f.fields[fieldContentType.displayField] as { [key: string]: any })[0],
+          this.getDisplayFieldValue(f, fieldContentType.displayField),
           fieldInfo.localized,
           fieldContentType.sys.id,
           fieldContentType.name,
@@ -185,5 +183,16 @@ export class FieldsFactory {
       fieldInfo.localized,
       items
     );
+  }
+
+  private getDisplayFieldValue(fieldValue: any, displayField: string | undefined): string {
+    if (!displayField) return 'Untitled';
+    const displayFieldValue = fieldValue.fields?.[displayField];
+    if (!displayFieldValue || displayFieldValue === null) return 'Untitled';
+    if (typeof displayFieldValue === 'object') {
+      return Object.values(displayFieldValue)[0] as string;
+    }
+
+    return String(displayFieldValue);
   }
 }

--- a/apps/braze/src/locations/Dialog.tsx
+++ b/apps/braze/src/locations/Dialog.tsx
@@ -56,7 +56,8 @@ const Dialog = () => {
       const fieldsFactory = new FieldsFactory(
         invocationParams.entryId!,
         invocationParams.contentTypeId!,
-        cma
+        cma,
+        sdk.locales.default
       );
       const cmaEntry = await fieldsFactory.getEntry();
       fieldsRef.current = await fieldsFactory.createFieldsForEntry(cmaEntry.fields);

--- a/apps/braze/src/utils/fetchBrazeConnectedEntries.ts
+++ b/apps/braze/src/utils/fetchBrazeConnectedEntries.ts
@@ -37,7 +37,7 @@ export async function fetchBrazeConnectedEntries(
       const entryConnectedFields: EntryConnectedFields = entries[entryId];
       const connectedFieldIds = entryConnectedFields.map((f) => f.fieldId);
 
-      const fieldsFactory = new FieldsFactory(entryId, entryContentTypeId, cma);
+      const fieldsFactory = new FieldsFactory(entryId, entryContentTypeId, cma, defaultLocale);
       const fields = await fieldsFactory.createFieldsForConnectedEntry(connectedFieldIds);
       const entryTitle = rawEntry.fields[fields.title]?.[defaultLocale] || 'Untitled';
 

--- a/apps/braze/test/fields/FieldsFactory.spec.ts
+++ b/apps/braze/test/fields/FieldsFactory.spec.ts
@@ -418,6 +418,70 @@ describe('FieldsFactory', () => {
       level++;
     }
   });
+
+  describe('getDisplayFieldValue', () => {
+    let fieldsFactory: FieldsFactory;
+
+    beforeEach(() => {
+      fieldsFactory = new FieldsFactory(entryId, entryContentTypeId, mockCma as any);
+    });
+
+    it('should return "Untitled" when displayField is invalid (undefined, null, or empty string)', () => {
+      const fieldValue = { fields: { name: { 'en-US': 'John Doe' } } };
+
+      expect((fieldsFactory as any).getDisplayFieldValue(fieldValue, undefined)).toBe('Untitled');
+      expect((fieldsFactory as any).getDisplayFieldValue(fieldValue, null)).toBe('Untitled');
+      expect((fieldsFactory as any).getDisplayFieldValue(fieldValue, '')).toBe('Untitled');
+    });
+
+    it('should return "Untitled" when displayField does not exist in fields', () => {
+      const fieldValue = { fields: { name: { 'en-US': 'John Doe' } } };
+
+      expect((fieldsFactory as any).getDisplayFieldValue(fieldValue, 'nonexistent')).toBe(
+        'Untitled'
+      );
+    });
+
+    it('should return "Untitled" when displayField value is null, undefined, empty object, or object with only null values', () => {
+      const fieldValueNull = { fields: { name: null } };
+      const fieldValueUndef = { fields: { name: undefined } };
+      const fieldValueEmptyObj = { fields: { name: {} } };
+      const fieldValueNulls = { fields: { name: { 'en-US': null } } };
+
+      expect((fieldsFactory as any).getDisplayFieldValue(fieldValueNull, 'name')).toBe('Untitled');
+      expect((fieldsFactory as any).getDisplayFieldValue(fieldValueUndef, 'name')).toBe('Untitled');
+      expect((fieldsFactory as any).getDisplayFieldValue(fieldValueEmptyObj, 'name')).toBe(
+        undefined
+      );
+      expect((fieldsFactory as any).getDisplayFieldValue(fieldValueNulls, 'name')).toBe(null);
+    });
+
+    it('should return first locale value when displayField is a localized object (single or multiple locales)', () => {
+      const fieldValueSingle = { fields: { name: { 'en-US': 'John Doe' } } };
+      const fieldValueMulti = {
+        fields: {
+          title: {
+            'fr-FR': 'Titre Français',
+            'de-DE': 'Deutscher Titel',
+            'en-US': 'English Title',
+          },
+        },
+      };
+
+      expect((fieldsFactory as any).getDisplayFieldValue(fieldValueSingle, 'name')).toBe(
+        'John Doe'
+      );
+      expect((fieldsFactory as any).getDisplayFieldValue(fieldValueMulti, 'title')).toBe(
+        'Titre Français'
+      );
+    });
+
+    it('should return string value when displayField is a direct string', () => {
+      const fieldValue = { fields: { name: 'John Doe' } };
+
+      expect((fieldsFactory as any).getDisplayFieldValue(fieldValue, 'name')).toBe('John Doe');
+    });
+  });
 });
 
 async function createFields(

--- a/apps/braze/test/fields/FieldsFactory.spec.ts
+++ b/apps/braze/test/fields/FieldsFactory.spec.ts
@@ -423,7 +423,7 @@ describe('FieldsFactory', () => {
     let fieldsFactory: FieldsFactory;
 
     beforeEach(() => {
-      fieldsFactory = new FieldsFactory(entryId, entryContentTypeId, mockCma as any);
+      fieldsFactory = new FieldsFactory(entryId, entryContentTypeId, mockCma as any, 'en-US');
     });
 
     it('should return "Untitled" when displayField is invalid (undefined, null, or empty string)', () => {
@@ -451,12 +451,12 @@ describe('FieldsFactory', () => {
       expect((fieldsFactory as any).getDisplayFieldValue(fieldValueNull, 'name')).toBe('Untitled');
       expect((fieldsFactory as any).getDisplayFieldValue(fieldValueUndef, 'name')).toBe('Untitled');
       expect((fieldsFactory as any).getDisplayFieldValue(fieldValueEmptyObj, 'name')).toBe(
-        undefined
+        'Untitled'
       );
-      expect((fieldsFactory as any).getDisplayFieldValue(fieldValueNulls, 'name')).toBe(null);
+      expect((fieldsFactory as any).getDisplayFieldValue(fieldValueNulls, 'name')).toBe('Untitled');
     });
 
-    it('should return first locale value when displayField is a localized object (single or multiple locales)', () => {
+    it('should return default locale value when displayField is a localized object (single or multiple locales)', () => {
       const fieldValueSingle = { fields: { name: { 'en-US': 'John Doe' } } };
       const fieldValueMulti = {
         fields: {
@@ -472,7 +472,7 @@ describe('FieldsFactory', () => {
         'John Doe'
       );
       expect((fieldsFactory as any).getDisplayFieldValue(fieldValueMulti, 'title')).toBe(
-        'Titre Français'
+        'English Title'
       );
     });
   });
@@ -486,7 +486,7 @@ async function createFields(
     entry: { references: Mock };
   }
 ) {
-  const fieldsFactory = new FieldsFactory(entryId, entryContentTypeId, mockCma as any);
+  const fieldsFactory = new FieldsFactory(entryId, entryContentTypeId, mockCma as any, 'en-US');
   const cmaEntry = await fieldsFactory.getEntry();
   return await fieldsFactory.createFieldsForEntry(cmaEntry.fields);
 }

--- a/apps/braze/test/fields/FieldsFactory.spec.ts
+++ b/apps/braze/test/fields/FieldsFactory.spec.ts
@@ -475,12 +475,6 @@ describe('FieldsFactory', () => {
         'Titre Français'
       );
     });
-
-    it('should return string value when displayField is a direct string', () => {
-      const fieldValue = { fields: { name: 'John Doe' } };
-
-      expect((fieldsFactory as any).getDisplayFieldValue(fieldValue, 'name')).toBe('John Doe');
-    });
   });
 });
 


### PR DESCRIPTION
## Purpose

We want to fix a bug that causes an infinite loader.

## Approach
### Bug cause
The way we were getting the displayName(title) for references and arrays of references with no displayName(title) was undefined when doing` Object.values(f.fields[fieldContentType.displayField] as { [key: string]: any })[0] `and that cause it to infinite load.

### What was done to fix this
- Fix the logic for getting a name for references and array references
- Encapsulate logic
- Added tests

## Testing steps
Automated testing

Use a duplicated entry for the one that failed. This reference is untitle and has no content

https://github.com/user-attachments/assets/ea05fe52-cccf-44ad-9c7f-509618bb8ba1

Testing everything still works


https://github.com/user-attachments/assets/75af5758-3b5e-47ee-a970-3a3739bc5b10


