### PR TITLE
 Braze app: Use freshest title for ContentBlocks [INTEG-2823]

### DIFF
--- a/apps/braze/src/locations/Sidebar.tsx
+++ b/apps/braze/src/locations/Sidebar.tsx
@@ -62,16 +62,18 @@ const Sidebar = () => {
     getContentBlocksData();
   }, []);
 
-  const initialInvocationParams: InvocationParams = {
-    mode: GENERATE_DIALOG_MODE,
-    entryId: sdk.ids.entry,
-    contentTypeId: sdk.ids.contentType,
-    title: sdk.entry.fields[sdk.contentType.displayField].getValue(),
+  const initialInvocationParams = (): InvocationParams => {
+    return {
+      mode: GENERATE_DIALOG_MODE,
+      entryId: sdk.ids.entry,
+      contentTypeId: sdk.ids.contentType,
+      title: sdk.entry.fields[sdk.contentType.displayField].getValue(),
+    };
   };
 
   const openDialogLogic = async (
     step: string,
-    parameters: InvocationParams = initialInvocationParams,
+    parameters: InvocationParams = initialInvocationParams(),
     mode: string
   ) => {
     const width = step === 'codeBlocks' ? 'fullWidth' : 'large';


### PR DESCRIPTION
## Purpose

We want to fix a bug in which when a user changes the title of the entry, the modal shows a default content block name that is stale

## Approach

- Make sure we are calculating the initialInvocationParams everytime by making it into a function

## Testing steps

Make sure automated tests are working and:

https://github.com/user-attachments/assets/d7db9d89-9014-48c3-b9a8-5eefda7fbac2


## Collaborators
Thanks to @joaquincasal for this easy and elegant solution.
