### PR TITLE
Braze app: Improve error message for empty fields[INTEG-2824]

### DIFF
--- a/apps/braze/functions/createContentBlocks.ts
+++ b/apps/braze/functions/createContentBlocks.ts
@@ -94,10 +94,7 @@ const createContentBlock = async (
       ...(locale ? { locale } : {}),
       success: false,
       statusCode: 600,
-      message:
-        `Field ${fieldId}` +
-        (locale ? ` with locale ${locale}` : '') +
-        ' does not exist or is empty',
+      message: `Field ${fieldId}` + (locale ? ` with locale ${locale}` : '') + ' is empty',
     };
   }
 

--- a/apps/braze/test/functions/createContentBlocks.spec.ts
+++ b/apps/braze/test/functions/createContentBlocks.spec.ts
@@ -230,13 +230,13 @@ describe('createContentBlocks', () => {
           locale: 'en-US',
           success: false,
           statusCode: 600,
-          message: 'Field title with locale en-US does not exist or is empty',
+          message: 'Field title with locale en-US is empty',
         },
         {
           fieldId: 'author',
           success: false,
           statusCode: 600,
-          message: 'Field author does not exist or is empty',
+          message: 'Field author is empty',
         },
       ],
     });
@@ -1075,7 +1075,7 @@ describe('createContentBlocks', () => {
 
       expect(result.results[0].success).toBe(false);
       expect(result.results[0].statusCode).toBe(600);
-      expect(result.results[0].message).toBe('Field nonexistent does not exist or is empty');
+      expect(result.results[0].message).toBe('Field nonexistent is empty');
       expect(global.fetch).not.toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
## Purpose

Improve error message for empty fields

## Approach

- Improve readability by updating error message
- Update tests

## Testing steps


https://github.com/user-attachments/assets/422438c1-4955-4fcd-b8e5-729954a9e668

