### PR TITLE
Braze app: Page modal adjustment to be more inline with the design [INTEG-2825]

### DIFF
--- a/apps/braze/src/locations/Page.tsx
+++ b/apps/braze/src/locations/Page.tsx
@@ -170,14 +170,6 @@ function ConnectedFieldsModal({
                     {entry.title}
                   </Text>
                 </Flex>
-                <Flex flexDirection="column">
-                  <Text fontColor="gray600" marginBottom="spacing2Xs">
-                    Connected fields
-                  </Text>
-                  <Text data-testid="modal-fields-length" fontWeight="fontWeightDemiBold">
-                    {entryConnectedFields.length}
-                  </Text>
-                </Flex>
                 <Button
                   variant="secondary"
                   size="small"
@@ -211,7 +203,9 @@ function ConnectedFieldsModal({
                       />
                     </Table.Cell>
                     <Table.Cell className={styles.baseCell}>
-                      <Text>Select all fields</Text>
+                      <Text fontColor="gray600">
+                        Select all fields ({entryConnectedFields.length})
+                      </Text>
                     </Table.Cell>
                   </Table.Row>
                 </Table.Head>

--- a/apps/braze/test/locations/Page.spec.tsx
+++ b/apps/braze/test/locations/Page.spec.tsx
@@ -154,9 +154,7 @@ describe('Page Location', () => {
       await screen.findByRole('dialog');
 
       expect(screen.getByTestId('modal-entry-title')).toBeTruthy();
-      expect(screen.getByTestId('modal-fields-length')).toBeTruthy();
-      expect(screen.getByText('Select all fields')).toBeTruthy();
-      expect(screen.getByText('View entry')).toBeTruthy();
+      expect(screen.getByText((content) => content.startsWith('Select all fields'))).toBeTruthy();
       expect(screen.getByText('View entry')).toBeTruthy();
     });
 


### PR DESCRIPTION
## Purpose

Page: Change position of number of connected field to be more inline with the design and avoid issues with longer title names

## Approach

- Change position of number of connected field to the select all checkbox label between “()”

## Testing steps
Before 
<img width="625" alt="Screenshot 2025-06-13 at 3 57 51 PM" src="https://github.com/user-attachments/assets/7d9ee2ba-cb98-4a0d-a5c7-6b67bc5cdb28" />


After

<img width="739" alt="Captura de pantalla 2025-06-25 a la(s) 3 15 26 p  m" src="https://github.com/user-attachments/assets/d62abd3a-c05b-419f-b46a-29083a29d874" />


