### PR TITLE
Config screen: Update helper text with no link [INTEG-2835]

### DIFF
--- a/apps/braze/src/locations/ConfigScreen.tsx
+++ b/apps/braze/src/locations/ConfigScreen.tsx
@@ -457,13 +457,10 @@ function ContentBlockSection({
           )}
         </Form>
       </Box>
-      <InformationWithLink
-        marginBottom="spacingL"
-        fontColor="gray500"
-        linkText="Braze REST API Keys page"
-        url={BRAZE_API_KEY_DOCUMENTATION}>
-        Enter your Braze REST API key. If you need to generate a key, visit your
-      </InformationWithLink>
+      <Paragraph fontColor={'gray500'} marginBottom={'spacingL'} marginTop={'spacingXs'}>
+        Enter your Braze REST API key. If you need to generate a key, visit the APIs and Identifiers
+        page under Settings on your Braze dashboard.
+      </Paragraph>
       <Subheading className={styles.subheading}>Select your Braze REST endpoint</Subheading>
       <InformationWithLink
         linkText="here"

--- a/apps/braze/test/locations/ConfigScreen.spec.tsx
+++ b/apps/braze/test/locations/ConfigScreen.spec.tsx
@@ -102,13 +102,6 @@ describe('Config Screen component', () => {
       );
     });
 
-    it('renders the braze api key link correctly', () => {
-      const brazeLink = configScreen.getByText('Braze REST API Keys page');
-
-      expect(brazeLink).toBeTruthy();
-      expect(brazeLink.closest('a')?.getAttribute('href')).toBe(BRAZE_API_KEY_DOCUMENTATION);
-    });
-
     it('renders the braze content block link correctly', () => {
       const brazeLink = configScreen.getByText("Braze's Content Block feature");
 


### PR DESCRIPTION
## Purpose
Update copy to: “Enter your Braze REST API key. If you need to generate a key, visit the APIs and Identifiers page under Settings on your Braze dashboard.” (without a link)

## Approach
- Changed used components
- Remove link test

## Testing steps

Before
<img width="871" alt="Screenshot 2025-06-10 at 4 25 39 PM" src="https://github.com/user-attachments/assets/02eab5a8-f926-4b7b-ba67-e71f6b6767af" />

After
<img width="1113" alt="Captura de pantalla 2025-06-25 a la(s) 4 08 41 p  m" src="https://github.com/user-attachments/assets/bbc17134-d4eb-4528-a2af-351807624eea" />

