### PR TITLE
Reuse apikey after upgrade to v2

### DIFF
--- a/apps/braze/src/locations/ConfigScreen.tsx
+++ b/apps/braze/src/locations/ConfigScreen.tsx
@@ -138,7 +138,9 @@ const ConfigScreen = () => {
 
   useEffect(() => {
     (async () => {
-      const currentParameters: AppInstallationParameters | null = await sdk.app.getParameters();
+      const currentParameters: AppInstallationParameters =
+        (await sdk.app.getParameters()) || parameters;
+      currentParameters.contentfulApiKey ||= currentParameters?.apiKey || '';
 
       if (currentParameters) {
         setParameters(currentParameters);

--- a/apps/braze/src/utils.ts
+++ b/apps/braze/src/utils.ts
@@ -97,6 +97,7 @@ export const CONFIG_ENTRY_ID = 'brazeConfig';
 export const CONFIG_FIELD_ID = 'connectedFields';
 
 export type AppInstallationParameters = {
+  apiKey?: string;
   contentfulApiKey: string;
   brazeApiKey: string;
   brazeEndpoint: string;

--- a/apps/braze/test/locations/ConfigScreen.spec.tsx
+++ b/apps/braze/test/locations/ConfigScreen.spec.tsx
@@ -6,14 +6,12 @@ import ConfigScreen from '../../src/locations/ConfigScreen';
 import userEvent, { UserEvent } from '@testing-library/user-event';
 import { queries, waitFor } from '@testing-library/dom';
 import {
-  BRAZE_API_KEY_DOCUMENTATION,
   BRAZE_APP_DOCUMENTATION,
   BRAZE_CONTENT_BLOCK_DOCUMENTATION,
   BRAZE_ENDPOINTS_DOCUMENTATION,
   BRAZE_ENDPOINTS,
   CONTENT_TYPE_DOCUMENTATION,
 } from '../../src/utils';
-import { createContentTypeResponse } from '../mocks/contentTypeResponse';
 
 const mockCma = {
   contentType: {
@@ -160,6 +158,22 @@ describe('Config Screen component', () => {
           EditorInterface: {},
         },
       });
+    });
+
+    it('uses apiKey if contentfulApiKey is empty', async () => {
+      // Clear the existing mock and set up a new one
+      mockSdk.app.getParameters.mockReset();
+      mockSdk.app.getParameters.mockResolvedValue({ apiKey: 'contentful-key' });
+
+      // Re-render the component after setting up the mock
+      cleanup();
+      render(<ConfigScreen />);
+
+      const contentfulApiKeyInput = screen.getAllByTestId('contentfulApiKey')[0];
+
+      await waitFor(() =>
+        expect((contentfulApiKeyInput as HTMLInputElement).value).toEqual('contentful-key')
+      );
     });
 
     it('shows a toast error if the contentful api key is not set or invalid', async () => {


### PR DESCRIPTION
## Purpose

The contentful api key parameter changed names from v1 to v2. We still want to reuse it if customers were already using the app.

## Approach

If the new contentfulApiKey parameter is empty, set the value to the apiKey parameters (if it is set). 

## Testing steps

Set the app parameters so only apiKey has a value and go to the config screen. The contentful api key input should be set.