### PR TITLE
Hubspot: Setup custom content type for configuration [INTEG-2784]

### DIFF
--- a/apps/hubspot/src/locations/ConfigScreen.tsx
+++ b/apps/hubspot/src/locations/ConfigScreen.tsx
@@ -1,18 +1,18 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import {
   Box,
+  Collapse,
   Flex,
-  Heading,
-  Text,
   Form,
   FormControl,
-  TextInput,
-  Paragraph,
-  Collapse,
+  Heading,
   IconButton,
-  Subheading,
-  TextLink,
   List,
+  Paragraph,
+  Subheading,
+  Text,
+  TextInput,
+  TextLink,
 } from '@contentful/f36-components';
 import { ChevronDownIcon, ChevronUpIcon, ExternalLinkIcon } from '@contentful/f36-icons';
 import { useSDK } from '@contentful/react-apps-toolkit';
@@ -23,6 +23,7 @@ import {
   AppInstallationParameters,
   CONFIG_SCREEN_INSTRUCTIONS,
   ContentType,
+  createConfig,
   HUBSPOT_PRIVATE_APPS_URL,
 } from '../utils/utils';
 import { createClient } from 'contentful-management';
@@ -48,22 +49,29 @@ const ConfigScreen = () => {
     }
   );
 
-  function checkIfHasValue(value: string, setError: (error: string | null) => void) {
+  function checkIfHasValue(
+    value: string,
+    setError: (error: string | null) => void,
+    errorMessage: string
+  ) {
     const hasValue = !!value?.trim();
-    setError(hasValue ? null : 'Some fields are missing or invalid');
+    setError(hasValue ? null : errorMessage);
     return hasValue;
   }
 
   const validateAccessToken = async () => {
+    const emptyMessage = 'Some fields are missing';
+
     setHubspotTokenError(null);
 
     const hubspotTokenHasValue = checkIfHasValue(
       parameters.hubspotAccessToken,
-      setHubspotTokenError
+      setHubspotTokenError,
+      emptyMessage
     );
 
     if (!hubspotTokenHasValue) {
-      sdk.notifier.error('Some fields are missing or invalid');
+      sdk.notifier.error(emptyMessage);
       return false;
     }
 
@@ -100,6 +108,14 @@ const ConfigScreen = () => {
   const onConfigure = useCallback(async () => {
     const isTokenValid = await validateAccessToken();
     if (!isTokenValid) {
+      return false;
+    }
+
+    try {
+      await createConfig(cma);
+    } catch (e) {
+      console.error(e);
+      sdk.notifier.error('Error creating config entry');
       return false;
     }
 

--- a/apps/hubspot/test/locations/ConfigScreen.spec.tsx
+++ b/apps/hubspot/test/locations/ConfigScreen.spec.tsx
@@ -15,6 +15,25 @@ async function saveAppInstallation() {
   return await mockSdk.app.onConfigure.mock.calls.at(-1)[0]();
 }
 
+const selectContentTypes = async (user: UserEvent, contentTypeName: string | RegExp) => {
+  const autocomplete = await screen.findByText('Select one or more');
+  await user.click(autocomplete);
+  const checkbox = await screen.findByRole('checkbox', { name: contentTypeName });
+  await user.click(checkbox);
+};
+
+const fillInHubspotAccessToken = async (user: UserEvent, value: string) => {
+  const hubspotAccessTokenInput = await screen.findByPlaceholderText('Enter your access token');
+  await user.clear(hubspotAccessTokenInput);
+  await user.type(hubspotAccessTokenInput, value);
+};
+
+function mockSuccessTokenValidation() {
+  mockCma.appActionCall.createWithResponse.mockResolvedValue({
+    response: { body: JSON.stringify({ valid: true, hasContentScope: true, error: null }) },
+  });
+}
+
 describe('Hubspot Config Screen ', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -63,28 +82,24 @@ describe('Hubspot Config Screen ', () => {
 
     it('shows a toast error if the hubspot api key is not set', async () => {
       render(<ConfigScreen />);
-
       expect(await screen.findByPlaceholderText(/Enter your access token/i)).toBeTruthy();
 
       const input = screen.getByPlaceholderText(/Enter your access token/i);
       expect(input).toHaveValue('');
-
       await act(async () => {
         await saveAppInstallation();
       });
 
-      expect(mockSdk.notifier.error).toHaveBeenCalledWith('Some fields are missing or invalid');
+      expect(mockSdk.notifier.error).toHaveBeenCalledWith('Some fields are missing');
     });
 
     it('renders the external link with icon', async () => {
       render(<ConfigScreen />);
-
       expect(await screen.findByLabelText('Expand instructions')).toBeTruthy();
-
       const user = userEvent.setup();
+
       const expandButton = screen.getByLabelText('Expand instructions');
       await user.click(expandButton);
-
       const link = await screen.findByRole('link', {
         name: /Read about creating private apps in Hubspot/i,
       });
@@ -102,29 +117,15 @@ describe('Hubspot Config Screen ', () => {
   });
 
   describe('Content type installation', () => {
-    const selectContentTypes = async (user: UserEvent, contentTypeName: string | RegExp) => {
-      const autocomplete = await screen.findByText('Select one or more');
-      await user.click(autocomplete);
-      const checkbox = await screen.findByRole('checkbox', { name: contentTypeName });
-      await user.click(checkbox);
-    };
-
-    const fillInHubspotAccessToken = async (user: UserEvent) => {
-      const hubspotAccessTokenInput = await screen.findByPlaceholderText('Enter your access token');
-      await user.type(hubspotAccessTokenInput, 'valid-api-key-123');
-    };
-
     it('adds and removes app from sidebar for each content type', async () => {
       render(<ConfigScreen />);
-
       expect(await screen.findByText('Select one or more')).toBeTruthy();
-
       const user = userEvent.setup();
       // Always mock the token validation as valid for this test
       mockCma.appActionCall.createWithResponse.mockResolvedValue({
         response: { body: JSON.stringify({ valid: true, hasContentScope: true }) },
       });
-      await fillInHubspotAccessToken(user);
+      await fillInHubspotAccessToken(user, 'valid-token');
 
       // adding the app for the content type
       await selectContentTypes(user, 'Blog Post');
@@ -152,15 +153,8 @@ describe('Hubspot Config Screen ', () => {
   });
 
   describe('HubSpot access token validation', () => {
-    const fillInHubspotAccessToken = async (user: UserEvent, value: string) => {
-      const hubspotAccessTokenInput = await screen.findByPlaceholderText('Enter your access token');
-      await user.clear(hubspotAccessTokenInput);
-      await user.type(hubspotAccessTokenInput, value);
-    };
-
     it('shows the input as required', async () => {
       render(<ConfigScreen />);
-
       expect(await screen.findByPlaceholderText(/Enter your access token/i)).toBeTruthy();
 
       const input = screen.getByPlaceholderText(/Enter your access token/i);
@@ -169,9 +163,7 @@ describe('Hubspot Config Screen ', () => {
 
     it('blocks saving and shows error if the access token is invalid', async () => {
       render(<ConfigScreen />);
-
       expect(await screen.findByPlaceholderText(/Enter your access token/i)).toBeTruthy();
-
       const user = userEvent.setup();
       mockCma.appActionCall.createWithResponse.mockResolvedValueOnce({
         response: {
@@ -194,9 +186,7 @@ describe('Hubspot Config Screen ', () => {
 
     it('blocks saving and shows error if the access token is missing the content scope', async () => {
       render(<ConfigScreen />);
-
       expect(await screen.findByPlaceholderText(/Enter your access token/i)).toBeTruthy();
-
       const user = userEvent.setup();
       mockCma.appActionCall.createWithResponse.mockResolvedValueOnce({
         response: {
@@ -221,13 +211,9 @@ describe('Hubspot Config Screen ', () => {
 
     it('allows saving if the access token is valid and has content scope', async () => {
       render(<ConfigScreen />);
-
       expect(await screen.findByPlaceholderText(/Enter your access token/i)).toBeTruthy();
-
       const user = userEvent.setup();
-      mockCma.appActionCall.createWithResponse.mockResolvedValueOnce({
-        response: { body: JSON.stringify({ valid: true, hasContentScope: true }) },
-      });
+      mockSuccessTokenValidation();
 
       await fillInHubspotAccessToken(user, 'valid-token');
       const result = await act(async () => {
@@ -240,6 +226,42 @@ describe('Hubspot Config Screen ', () => {
       expect(mockSdk.notifier.error).not.toHaveBeenCalledWith(
         'The HubSpot token is missing the required "content" scope.'
       );
+    });
+  });
+
+  describe('createContentType', () => {
+    it('creates content type and entry if they do not exist', async () => {
+      render(<ConfigScreen />);
+      expect(await screen.findByPlaceholderText(/Enter your access token/i)).toBeTruthy();
+      mockSuccessTokenValidation();
+      const user = userEvent.setup();
+      await fillInHubspotAccessToken(user, 'valid-token');
+
+      await saveAppInstallation();
+
+      expect(mockCma.contentType.createWithId).toHaveBeenCalled();
+      expect(mockCma.contentType.publish).toHaveBeenCalled();
+      expect(mockCma.entry.createWithId).toHaveBeenCalled();
+    });
+
+    it('does not create content type if it already exists', async () => {
+      render(<ConfigScreen />);
+      expect(await screen.findByPlaceholderText(/Enter your access token/i)).toBeTruthy();
+      mockSuccessTokenValidation();
+      // Mock content type and entry creation to throw VersionMismatch error
+      const versionMismatchError = { code: 'VersionMismatch' };
+      mockCma.contentType.createWithId.mockResolvedValue(versionMismatchError);
+      mockCma.contentType.publish.mockResolvedValue(versionMismatchError);
+      mockCma.entry.createWithId.mockResolvedValue(versionMismatchError);
+      const user = userEvent.setup();
+      await fillInHubspotAccessToken(user, 'valid-token');
+
+      await saveAppInstallation();
+
+      expect(mockCma.contentType.createWithId).toHaveBeenCalled();
+      expect(mockCma.contentType.publish).toHaveBeenCalled();
+      expect(mockCma.entry.createWithId).toHaveBeenCalled();
+      expect(mockSdk.notifier.error).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/hubspot/test/mocks/mockCma.ts
+++ b/apps/hubspot/test/mocks/mockCma.ts
@@ -8,6 +8,7 @@ const mockCma = {
     getMany: vi.fn(),
   },
   entry: {
+    get: vi.fn(),
     createWithId: vi.fn(),
   },
   editorInterface: {


### PR DESCRIPTION
## Purpose

We needed to store which fields are being synced to Hubspot. For that we create a custom content type with a single json field and one single entry to store that information. This is setup when configuring the app.

## Approach

When we install the app, we create the config content type and entry. We catch and ignore the "already existing" content type or entry error, but the other kind of errors are thrown and we make the installation fail. By doing this, we are able to do one less call since we can avoid making the get (to check if it exists or not).

## Testing steps

Automated test were added. To validate this manually you should delete the config entry and content type (if existent) and save or install the app, you will see that the config entry and content type are created again.

https://github.com/user-attachments/assets/e5a20a37-88dc-4e80-9025-9b86232f6252

## Breaking Changes

N/A

## Dependencies and/or References

N/A

## Deployment

N/A