### PR TITLE
Hubspot: adding config entry service [INTEG-2785]

### DIFF
--- a/apps/hubspot/src/locations/ConfigScreen.tsx
+++ b/apps/hubspot/src/locations/ConfigScreen.tsx
@@ -112,7 +112,7 @@ const ConfigScreen = () => {
     }
 
     try {
-      const configService = new ConfigEntryService(cma);
+      const configService = new ConfigEntryService(cma, sdk.locales.default);
       await configService.createConfig();
     } catch (e) {
       sdk.notifier.error('The app configuration was not saved. Please try again.');

--- a/apps/hubspot/src/locations/ConfigScreen.tsx
+++ b/apps/hubspot/src/locations/ConfigScreen.tsx
@@ -23,11 +23,11 @@ import {
   AppInstallationParameters,
   CONFIG_SCREEN_INSTRUCTIONS,
   ContentType,
-  createConfig,
   HUBSPOT_PRIVATE_APPS_URL,
 } from '../utils/utils';
 import { createClient } from 'contentful-management';
 import ContentTypeMultiSelect from '../components/ContentTypeMultiSelect';
+import ConfigEntryService from '../utils/ConfigEntryService';
 
 export const EMPTY_MESSAGE = 'Some fields are missing';
 
@@ -112,10 +112,10 @@ const ConfigScreen = () => {
     }
 
     try {
-      await createConfig(cma);
+      const configService = new ConfigEntryService(cma);
+      await configService.createConfig();
     } catch (e) {
-      console.error(e);
-      sdk.notifier.error('Error creating configuration entry');
+      sdk.notifier.error('The app configuration was not saved. Please try again.');
       return false;
     }
 

--- a/apps/hubspot/src/utils/ConfigEntryService.ts
+++ b/apps/hubspot/src/utils/ConfigEntryService.ts
@@ -1,0 +1,86 @@
+import { EntryProps, KeyValueMap, PlainClientAPI } from 'contentful-management';
+import {
+  CONFIG_CONTENT_TYPE_ID,
+  CONFIG_ENTRY_ID,
+  CONFIG_FIELD_ID,
+  ConnectedFields,
+  getDefaultLocale,
+} from './utils';
+
+class ConfigEntryService {
+  private cma: PlainClientAPI;
+
+  constructor(cma: PlainClientAPI) {
+    this.cma = cma;
+  }
+
+  async createConfig() {
+    await this.createContentType();
+    await this.createEntry();
+  }
+
+  async createContentType() {
+    const contentTypeBody = {
+      name: CONFIG_CONTENT_TYPE_ID,
+      description: 'Content Type used by the Hubspot app. Do not delete or modify manually.',
+      fields: [
+        {
+          id: CONFIG_FIELD_ID,
+          name: CONFIG_FIELD_ID,
+          required: false,
+          localized: false,
+          type: 'Object',
+        },
+      ],
+    };
+    try {
+      const contentTypeProps = await this.cma.contentType.createWithId(
+        { contentTypeId: CONFIG_CONTENT_TYPE_ID },
+        contentTypeBody
+      );
+      await this.cma.contentType.publish(
+        { contentTypeId: CONFIG_CONTENT_TYPE_ID },
+        contentTypeProps
+      );
+    } catch (e: any) {
+      // Only ignore error if content type already exists
+      if (e?.code !== 'VersionMismatch') {
+        throw e;
+      }
+    }
+  }
+
+  async createEntry() {
+    try {
+      await this.cma.entry.createWithId(
+        { contentTypeId: CONFIG_CONTENT_TYPE_ID, entryId: CONFIG_ENTRY_ID },
+        { fields: {} }
+      );
+    } catch (e: any) {
+      // Only ignore error if entry already exists
+      if (e?.code !== 'VersionMismatch') {
+        throw e;
+      }
+    }
+  }
+
+  async getConfigEntry(): Promise<EntryProps<KeyValueMap>> {
+    return this.cma.entry.get({ entryId: CONFIG_ENTRY_ID });
+  }
+
+  async updateConfig(
+    configEntry: EntryProps<KeyValueMap>,
+    connectedFields: ConnectedFields,
+    cma: PlainClientAPI,
+    defaultLocale?: string
+  ) {
+    if (!configEntry.fields[CONFIG_FIELD_ID]) {
+      configEntry.fields[CONFIG_FIELD_ID] = {};
+    }
+    defaultLocale ||= await getDefaultLocale(cma);
+    configEntry.fields[CONFIG_FIELD_ID][defaultLocale] = connectedFields;
+    return await cma.entry.update({ entryId: CONFIG_ENTRY_ID }, configEntry);
+  }
+}
+
+export default ConfigEntryService;

--- a/apps/hubspot/src/utils/ConfigEntryService.ts
+++ b/apps/hubspot/src/utils/ConfigEntryService.ts
@@ -1,11 +1,5 @@
 import { EntryProps, KeyValueMap, PlainClientAPI } from 'contentful-management';
-import {
-  CONFIG_CONTENT_TYPE_ID,
-  CONFIG_ENTRY_ID,
-  CONFIG_FIELD_ID,
-  ConnectedFields,
-  getDefaultLocale,
-} from './utils';
+import { CONFIG_CONTENT_TYPE_ID, CONFIG_ENTRY_ID, CONFIG_FIELD_ID, ConnectedFields } from './utils';
 
 class ConfigEntryService {
   private cma: PlainClientAPI;
@@ -72,18 +66,13 @@ class ConfigEntryService {
     return this.configEntry;
   }
 
-  async updateConfig(
-    connectedFields: ConnectedFields,
-    cma: PlainClientAPI,
-    defaultLocale?: string
-  ) {
+  async updateConfig(connectedFields: ConnectedFields, cma: PlainClientAPI, defaultLocale: string) {
     const configEntry = await this.getConfigEntry();
 
     if (!configEntry.fields[CONFIG_FIELD_ID]) {
       configEntry.fields[CONFIG_FIELD_ID] = {};
     }
 
-    defaultLocale ||= await getDefaultLocale(cma);
     configEntry.fields[CONFIG_FIELD_ID][defaultLocale] = connectedFields;
     const updatedEntry = await cma.entry.update({ entryId: CONFIG_ENTRY_ID }, configEntry);
     this.configEntry = updatedEntry;

--- a/apps/hubspot/src/utils/utils.ts
+++ b/apps/hubspot/src/utils/utils.ts
@@ -23,49 +23,27 @@ export type AppInstallationParameters = {
   hubspotAccessToken: string;
 };
 
-export async function createConfig(cma: PlainClientAPI) {
-  await createContentType(cma);
-  await createEntry(cma);
-}
+export type ConnectedField = {
+  fieldId: string;
+  locale: string;
+  contentBlockId: string;
+  error?: { status: number; message: string };
+};
 
-export async function createContentType(cma: PlainClientAPI) {
-  const contentTypeBody = {
-    name: CONFIG_CONTENT_TYPE_ID,
-    description: 'Content Type used by the Hubspot app. Do not delete or modify manually.',
-    fields: [
-      {
-        id: CONFIG_FIELD_ID,
-        name: CONFIG_FIELD_ID,
-        required: false,
-        localized: false,
-        type: 'Object',
-      },
-    ],
-  };
-  try {
-    const contentTypeProps = await cma.contentType.createWithId(
-      { contentTypeId: CONFIG_CONTENT_TYPE_ID },
-      contentTypeBody
-    );
-    await cma.contentType.publish({ contentTypeId: CONFIG_CONTENT_TYPE_ID }, contentTypeProps);
-  } catch (e: any) {
-    // Only ignore error if content type already exists
-    if (e?.code !== 'VersionMismatch') {
-      throw e;
-    }
-  }
-}
+export type EntryConnectedFields = ConnectedField[];
 
-export async function createEntry(cma: PlainClientAPI) {
+export type ConnectedFields = {
+  [entryId: string]: EntryConnectedFields;
+};
+
+export async function getDefaultLocale(cma: PlainClientAPI): Promise<string> {
+  const fallbackLocale = 'en-US';
   try {
-    await cma.entry.createWithId(
-      { contentTypeId: CONFIG_CONTENT_TYPE_ID, entryId: CONFIG_ENTRY_ID },
-      { fields: {} }
-    );
-  } catch (e: any) {
-    // Only ignore error if entry already exists
-    if (e?.code !== 'VersionMismatch') {
-      throw e;
-    }
+    const locales = await cma.locale.getMany({ query: { limit: 1000 } });
+    const defaultLocale = locales.items.find((locale) => locale.default);
+    return defaultLocale?.code || fallbackLocale;
+  } catch (error) {
+    console.error('Error fetching default locale:', error);
+    return fallbackLocale;
   }
 }

--- a/apps/hubspot/src/utils/utils.ts
+++ b/apps/hubspot/src/utils/utils.ts
@@ -26,7 +26,8 @@ export type AppInstallationParameters = {
 export type ConnectedField = {
   fieldId: string;
   locale: string;
-  contentBlockId: string;
+  moduleId: string;
+  updatedAt: string;
   error?: { status: number; message: string };
 };
 

--- a/apps/hubspot/src/utils/utils.ts
+++ b/apps/hubspot/src/utils/utils.ts
@@ -1,5 +1,3 @@
-import { PlainClientAPI } from 'contentful-management';
-
 export const CONFIG_CONTENT_TYPE_ID = 'hubspotConfig';
 export const CONFIG_ENTRY_ID = 'hubspotConfig';
 export const CONFIG_FIELD_ID = 'connectedFields';
@@ -36,15 +34,3 @@ export type EntryConnectedFields = ConnectedField[];
 export type ConnectedFields = {
   [entryId: string]: EntryConnectedFields;
 };
-
-export async function getDefaultLocale(cma: PlainClientAPI): Promise<string> {
-  const fallbackLocale = 'en-US';
-  try {
-    const locales = await cma.locale.getMany({ query: { limit: 1000 } });
-    const defaultLocale = locales.items.find((locale) => locale.default);
-    return defaultLocale?.code || fallbackLocale;
-  } catch (error) {
-    console.error('Error fetching default locale:', error);
-    return fallbackLocale;
-  }
-}


### PR DESCRIPTION
## Purpose

This update includes a refactor to have a configuration entry service so we can fetch, update or create the config entry in a simpler way and more reusable.

## Approach

A ConfigEntryService was created and we now use that service in the config screen to create the config entry when the app is installed.

The methods of the service:
- getConfig
- updateConfig

Are not being used for the moment but are going to be needed later so they were also included to simplify the following tickets implementations.

## Testing steps

This was the use case:

https://github.com/user-attachments/assets/ac8e2848-5393-4a93-bf76-043f7dcd68f2

## Breaking Changes

N/A

## Dependencies and/or References

This PR is a refactor for this ticket: [App Events - Setup custom content type for configuration](https://contentful.atlassian.net/jira/software/c/projects/INTEG/boards/3109?issueParent=367108&label=10-Pines&selectedIssue=INTEG-2784)

## Deployment

N/A