### PR TITLE
Hubspot: config entry warning note [INTEG-2769]

### DIFF
--- a/apps/hubspot/src/locations/ConfigScreen.tsx
+++ b/apps/hubspot/src/locations/ConfigScreen.tsx
@@ -8,6 +8,7 @@ import {
   Heading,
   IconButton,
   List,
+  Note,
   Paragraph,
   Subheading,
   Text,
@@ -153,11 +154,17 @@ const ConfigScreen = () => {
     <Flex justifyContent="center" alignItems="center">
       <Box className={styles.body}>
         <Heading marginBottom="spacingS">Set up Hubspot</Heading>
-        <Paragraph>
+        <Paragraph marginBottom="spacing2Xs">
           Seamlessly sync Contentful entry content to email campaigns in Hubspot. Map entry fields
           to custom email modules in Hubspot to continuously and automatically keep content
           consistent at scale.
         </Paragraph>
+        <Box marginTop="spacingS" marginBottom="spacing2Xl">
+          <Note variant="neutral">
+            The Hubspot app will create a content type labeled "hubspotConfig". Do not delete or
+            modify manually.
+          </Note>
+        </Box>
         <Box marginTop="spacingXl" marginBottom="spacingXs">
           <Subheading marginBottom="spacingXs">Configure access</Subheading>
           <Paragraph marginBottom="spacingL">


### PR DESCRIPTION
## Purpose

This update adds the warning note to let the user know that a config entry would be created if he installed the app (the same way as Braze does). And warn them to not delete or modify that entry.

## Approach

Adding the Note component to match the figma design.

## Testing steps

Now the config screen looks like this:
<img width="1510" alt="Captura de pantalla 2025-07-02 a la(s) 2 20 02 p  m" src="https://github.com/user-attachments/assets/8aedd7b5-de01-46e0-9d9f-60dd01d5deb0" />

## Breaking Changes

N/A

## Dependencies and/or References

Link to the original ticket [INTEG-2769](https://contentful.atlassian.net/jira/software/c/projects/INTEG/boards/3109?issueParent=367108&label=10-Pines&selectedIssue=INTEG-2769)

## Deployment

N/A

[INTEG-2769]: https://contentful.atlassian.net/browse/INTEG-2769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ