### PR TITLE
chore(ci): [SECURITY-936] Enable CodeQL scans for GitHub workflow+customise for existing flows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,32 @@
+---
+name: "CodeQL Scan for GitHub Actions Workflows"
+
+on:
+  push:
+    branches: [master]
+    paths: [".github/workflows/**"]
+  pull_request:
+    branches: [master]
+    paths: [".github/workflows/**"]
+
+jobs:
+  analyze:
+    name: Analyze GitHub Actions workflows
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: actions
+
+      - name: Run CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: actions

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,5 +1,5 @@
 ---
-name: "CodeQL Scan: Actions + JS/TS"
+name: "CodeQL Scan: Actions+existing"
 
 on:
   push:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,17 +1,15 @@
 ---
-name: "CodeQL Scan for GitHub Actions Workflows"
+name: "CodeQL Scan: Actions + JS/TS"
 
 on:
   push:
     branches: [master]
-    paths: [".github/workflows/**"]
   pull_request:
     branches: [master]
-    paths: [".github/workflows/**"]
 
 jobs:
   analyze:
-    name: Analyze GitHub Actions workflows
+    name: Analyze workflows and JS/TS
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -24,9 +22,9 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
-          languages: actions
+          languages: |
+            actions
+            javascript-typescript
 
-      - name: Run CodeQL Analysis
+      - name: Autobuild and analyze
         uses: github/codeql-action/analyze@v3
-        with:
-          category: actions

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,9 +22,7 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
-          languages: |
-            actions
-            javascript-typescript
+          languages: actions, javascript-typescript
 
       - name: Autobuild and analyze
         uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
Enable CodeQL scans for GitHub workflow.

For more details on why we do this, please refer to https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/

After the merge, navigate to the code-scanning findings available under the security tab --> code-scanning