### PR TITLE
Hubspot: add sync info to sidebar [INTEG-2773]

### DIFF
--- a/apps/hubspot/src/locations/Sidebar.tsx
+++ b/apps/hubspot/src/locations/Sidebar.tsx
@@ -1,8 +1,11 @@
-import { Button, Flex } from '@contentful/f36-components';
+import { Button, Flex, Text, RelativeDateTime } from '@contentful/f36-components';
 import { SidebarAppSDK } from '@contentful/app-sdk';
 import { useAutoResizer, useSDK } from '@contentful/react-apps-toolkit';
 import { processFields } from '../utils/fieldsProcessing';
 import { createClient } from 'contentful-management';
+import { useEffect, useState } from 'react';
+import ConfigEntryService from '../utils/ConfigEntryService';
+import { EntryConnectedFields } from '../utils/utils';
 
 const Sidebar = () => {
   const sdk = useSDK<SidebarAppSDK>();
@@ -39,14 +42,40 @@ const Sidebar = () => {
     };
   };
 
+  const [connectedFields, setConnectedFields] = useState<EntryConnectedFields | undefined>(
+    undefined
+  );
+
+  useEffect(() => {
+    const getConfig = async () => {
+      try {
+        const connectedFields = await new ConfigEntryService(
+          cma,
+          sdk.locales.default
+        ).getConnectedFields();
+        setConnectedFields(connectedFields[sdk.ids.entry]);
+      } catch (error) {}
+    };
+    getConfig();
+  }, []);
+
   return (
     <Flex gap="spacingM" flexDirection="column">
-      <Button
-        variant="secondary"
-        isFullWidth={true}
-        onClick={async () => sdk.dialogs.openCurrentApp(await dialogParams())}>
-        Sync entry fields to Hubspot
-      </Button>
+      <Flex gap="spacingXs" flexDirection="column">
+        <Button
+          variant="secondary"
+          isFullWidth={true}
+          onClick={async () => sdk.dialogs.openCurrentApp(await dialogParams())}>
+          Sync entry fields to Hubspot
+        </Button>
+
+        {connectedFields && connectedFields.length > 0 && (
+          <Text lineHeight="lineHeightCondensed" fontColor="gray500">
+            {`${connectedFields.length} field${connectedFields.length === 1 ? '' : 's'} synced `}
+            <RelativeDateTime date={connectedFields[0].updatedAt} />
+          </Text>
+        )}
+      </Flex>
 
       <Button
         variant="secondary"

--- a/apps/hubspot/src/locations/Sidebar.tsx
+++ b/apps/hubspot/src/locations/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { Button, Flex, Text, RelativeDateTime } from '@contentful/f36-components';
+import { Button, Flex, Text, RelativeDateTime, Note, TextLink } from '@contentful/f36-components';
 import { SidebarAppSDK } from '@contentful/app-sdk';
 import { useAutoResizer, useSDK } from '@contentful/react-apps-toolkit';
 import { processFields } from '../utils/fieldsProcessing';
@@ -6,6 +6,7 @@ import { createClient } from 'contentful-management';
 import { useEffect, useState } from 'react';
 import ConfigEntryService from '../utils/ConfigEntryService';
 import { EntryConnectedFields } from '../utils/utils';
+import { ErrorCircleOutlineIcon } from '@contentful/f36-icons';
 
 const Sidebar = () => {
   const sdk = useSDK<SidebarAppSDK>();
@@ -61,6 +62,17 @@ const Sidebar = () => {
 
   return (
     <Flex gap="spacingM" flexDirection="column">
+      {connectedFields &&
+        connectedFields.length > 0 &&
+        connectedFields.some((field) => field.error) && (
+          <Note variant="negative" icon={<ErrorCircleOutlineIcon />}>
+            <Text lineHeight="lineHeightCondensed" fontColor="gray800">
+              Unable to sync content. Review your connected or{' '}
+              <TextLink onClick={() => sdk.navigator.openAppConfig()}>app configuration</TextLink>.
+            </Text>
+          </Note>
+        )}
+
       <Flex gap="spacingXs" flexDirection="column">
         <Button
           variant="secondary"

--- a/apps/hubspot/src/locations/Sidebar.tsx
+++ b/apps/hubspot/src/locations/Sidebar.tsx
@@ -62,9 +62,7 @@ const Sidebar = () => {
 
   return (
     <Flex gap="spacingM" flexDirection="column">
-      {connectedFields &&
-        connectedFields.length > 0 &&
-        connectedFields.some((field) => field.error) && (
+      {connectedFields?.some(field => field.error) && (
           <Note variant="negative" icon={<ErrorCircleOutlineIcon />}>
             <Text lineHeight="lineHeightCondensed" fontColor="gray800">
               Unable to sync content. Review your connected or{' '}

--- a/apps/hubspot/src/locations/Sidebar.tsx
+++ b/apps/hubspot/src/locations/Sidebar.tsx
@@ -62,14 +62,14 @@ const Sidebar = () => {
 
   return (
     <Flex gap="spacingM" flexDirection="column">
-      {connectedFields?.some(field => field.error) && (
-          <Note variant="negative" icon={<ErrorCircleOutlineIcon />}>
-            <Text lineHeight="lineHeightCondensed" fontColor="gray800">
-              Unable to sync content. Review your connected or{' '}
-              <TextLink onClick={() => sdk.navigator.openAppConfig()}>app configuration</TextLink>.
-            </Text>
-          </Note>
-        )}
+      {connectedFields?.some((field) => field.error) && (
+        <Note variant="negative" icon={<ErrorCircleOutlineIcon />}>
+          <Text lineHeight="lineHeightCondensed" fontColor="gray800">
+            Unable to sync content. Review your connected or{' '}
+            <TextLink onClick={() => sdk.navigator.openAppConfig()}>app configuration</TextLink>.
+          </Text>
+        </Note>
+      )}
 
       <Flex gap="spacingXs" flexDirection="column">
         <Button

--- a/apps/hubspot/src/utils/ConfigEntryService.ts
+++ b/apps/hubspot/src/utils/ConfigEntryService.ts
@@ -16,11 +16,16 @@ class ConfigEntryService {
     await this.createEntry();
   }
 
-  async getConfigEntry(): Promise<EntryProps<KeyValueMap>> {
+  private async getConfigEntry(): Promise<EntryProps<KeyValueMap>> {
     if (!this.configEntry) {
       this.configEntry = await this.cma.entry.get({ entryId: CONFIG_ENTRY_ID });
     }
     return this.configEntry;
+  }
+
+  async getConnectedFields(): Promise<ConnectedFields> {
+    const configEntry = await this.getConfigEntry();
+    return configEntry.fields[CONFIG_FIELD_ID][this.getDefaultLocale()];
   }
 
   async updateConfig(connectedFields: ConnectedFields, cma: PlainClientAPI) {

--- a/apps/hubspot/test/mocks/mockSdk.ts
+++ b/apps/hubspot/test/mocks/mockSdk.ts
@@ -17,6 +17,7 @@ const mockSdk: any = {
     space: 'test-space',
     environment: 'test-environment',
     environmentAlias: 'test-environment-alias',
+    entry: 'test-entry-id',
   },
   cmaAdapter: {
     // Mock CMA adapter for testing


### PR DESCRIPTION
## Purpose

Add sync information in the Sidebar.

## Approach

- If there are errors in synced fields, we display an error note.
- If there are synced fields, display how long ago they were sinced.

## Testing steps

- Update the config entry with one connected field (make sure to include the `updatedAt` property), go to the entry and check the "Synced x time ago" appears
- Update the config entry with one connected field that includes the "error" property and check the warning appears in the sidebar

<img width="332" alt="Screenshot 2025-07-04 at 16 26 32" src="https://github.com/user-attachments/assets/a0d67067-79b6-41c7-93b6-0e279bde9342" />

