### PR TITLE
Iterable: Sidebar [INTEG-2842]

### DIFF
--- a/apps/iterable/package-lock.json
+++ b/apps/iterable/package-lock.json
@@ -14,6 +14,7 @@
         "@contentful/f36-tokens": "4.2.0",
         "@contentful/field-editor-json": "^3.3.38",
         "@contentful/react-apps-toolkit": "1.2.16",
+        "@phosphor-icons/react": "^2.1.10",
         "contentful-management": "^11.52.0",
         "emotion": "10.0.27",
         "react": "18.3.1",
@@ -2063,6 +2064,19 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g=="
+    },
+    "node_modules/@phosphor-icons/react": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.1.10.tgz",
+      "integrity": "sha512-vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8",
+        "react-dom": ">= 16.8"
+      }
     },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",

--- a/apps/iterable/package.json
+++ b/apps/iterable/package.json
@@ -9,6 +9,7 @@
     "@contentful/f36-tokens": "4.2.0",
     "@contentful/field-editor-json": "^3.3.38",
     "@contentful/react-apps-toolkit": "1.2.16",
+    "@phosphor-icons/react": "^2.1.10",
     "contentful-management": "^11.52.0",
     "emotion": "10.0.27",
     "react": "18.3.1",

--- a/apps/iterable/src/components/ContentfulApiKeyInput.tsx
+++ b/apps/iterable/src/components/ContentfulApiKeyInput.tsx
@@ -43,7 +43,11 @@ const ContentfulApiKeyInput = ({
       type="password"
       isRequired
     />
-    {isInvalid && <FormControl.ValidationMessage>Invalid API key</FormControl.ValidationMessage>}
+    {isInvalid && (
+      <FormControl.ValidationMessage>
+        Invalid delivery API - access token
+      </FormControl.ValidationMessage>
+    )}
   </FormControl>
 );
 

--- a/apps/iterable/src/locations/ConfigScreen.tsx
+++ b/apps/iterable/src/locations/ConfigScreen.tsx
@@ -132,7 +132,6 @@ const ConfigScreen = () => {
             Learn more about how to connect Contentful with Iterable and configure the Iterable app{' '}
             {/* TODO: Add link to documentation */}
             <TextLink
-              href=""
               target="_blank"
               rel="noopener noreferrer"
               alignIcon="end"

--- a/apps/iterable/src/locations/ConfigScreen.tsx
+++ b/apps/iterable/src/locations/ConfigScreen.tsx
@@ -66,7 +66,7 @@ const ConfigScreen = () => {
   }, [sdk]);
 
   const handleApiKeyChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setParameters({ ...parameters, contentfulApiKey: e.target.value });
+    setParameters({ ...parameters, contentfulApiKey: e.target.value.trim() });
   };
 
   return (

--- a/apps/iterable/src/locations/Sidebar.tsx
+++ b/apps/iterable/src/locations/Sidebar.tsx
@@ -1,27 +1,23 @@
 import { CopyButton, Flex, Paragraph, TextInput, TextLink, Text } from '@contentful/f36-components';
 import { SidebarAppSDK } from '@contentful/app-sdk';
-import { /* useCMA, */ useAutoResizer, useSDK } from '@contentful/react-apps-toolkit';
-import { CopyIcon, ExternalLinkIcon } from '@contentful/f36-icons';
+import { useAutoResizer, useSDK } from '@contentful/react-apps-toolkit';
+import { ExternalLinkIcon } from '@contentful/f36-icons';
 import tokens from '@contentful/f36-tokens';
 
 const Sidebar = () => {
   const sdk = useSDK<SidebarAppSDK>();
   useAutoResizer();
-  /*
-     To use the cma, inject it as follows.
-     If it is not needed, you can remove the next line.
-  */
-  // const cma = useCMA();
 
-  const value = 'a link';
+  const link = `https://cdn.contentful.com/spaces/${sdk.ids.space}/environments/master/entries?access_token=${sdk.parameters.installation.contentfulApiKey}&sys.id=${sdk.ids.entry}&include=2`;
+
   return (
     <Flex flexDirection="column">
       <Text fontWeight="fontWeightDemiBold" marginBottom="spacingXs">
         Data feed link
       </Text>
       <TextInput.Group>
-        <TextInput isDisabled isReadOnly value={value} />
-        <CopyButton value={value} tooltipProps={{ placement: 'right', usePortal: true }} />
+        <TextInput isDisabled isReadOnly value={link} />
+        <CopyButton value={link} tooltipProps={{ placement: 'right', usePortal: true }} />
       </TextInput.Group>
       <Paragraph marginTop="spacingXs" fontColor={'gray500'}>
         Copy and paste this link into your Iterable data feed. Content automatically syncs when the

--- a/apps/iterable/src/locations/Sidebar.tsx
+++ b/apps/iterable/src/locations/Sidebar.tsx
@@ -1,14 +1,31 @@
-import { CopyButton, Flex, Paragraph, TextInput, TextLink, Text } from '@contentful/f36-components';
+import {
+  CopyButton,
+  Flex,
+  Paragraph,
+  TextInput,
+  TextLink,
+  Text,
+  IconButton,
+  Skeleton,
+} from '@contentful/f36-components';
 import { SidebarAppSDK } from '@contentful/app-sdk';
 import { useAutoResizer, useSDK } from '@contentful/react-apps-toolkit';
 import { ExternalLinkIcon } from '@contentful/f36-icons';
+import { WarningOctagonIcon } from '@phosphor-icons/react';
 import tokens from '@contentful/f36-tokens';
 
 const Sidebar = () => {
   const sdk = useSDK<SidebarAppSDK>();
   useAutoResizer();
 
-  const link = `https://cdn.contentful.com/spaces/${sdk.ids.space}/environments/master/entries?access_token=${sdk.parameters.installation.contentfulApiKey}&sys.id=${sdk.ids.entry}&include=2`;
+  const space = sdk.ids.space;
+  const apiKey = sdk.parameters.installation.contentfulApiKey;
+  const entryId = sdk.ids.entry;
+
+  const hasError = !space || !apiKey || !entryId;
+  const link = hasError
+    ? ''
+    : `https://cdn.contentful.com/spaces/${space}/environments/master/entries?access_token=${apiKey}&sys.id=${entryId}&include=2`;
 
   return (
     <Flex flexDirection="column">
@@ -16,14 +33,18 @@ const Sidebar = () => {
         Data feed link
       </Text>
       <TextInput.Group>
-        <TextInput isDisabled isReadOnly value={link} />
-        <CopyButton value={link} tooltipProps={{ placement: 'right', usePortal: true }} />
+        <TextInput isDisabled isReadOnly value={link} isInvalid={hasError} />
+        <CopyButton
+          value={link}
+          variant={hasError ? 'negative' : 'secondary'}
+          isDisabled={hasError}
+          tooltipProps={{ placement: 'right', usePortal: true }}
+        />
       </TextInput.Group>
-      <Paragraph marginTop="spacingXs" fontColor={'gray500'}>
+      <Paragraph marginTop="spacingXs" fontColor="gray500">
         Copy and paste this link into your Iterable data feed. Content automatically syncs when the
-        entry is published.{' '}
+        entry is published. {/* TODO: Add link to documentation */}
         <TextLink
-          href=""
           target="_blank"
           rel="noopener noreferrer"
           alignIcon="end"
@@ -31,6 +52,12 @@ const Sidebar = () => {
           Learn more
         </TextLink>
       </Paragraph>
+      {hasError && (
+        <Flex alignItems="center" gap="spacing2Xs">
+          <WarningOctagonIcon size={16} color={tokens.red600} />
+          <Text fontColor="red600">Link generation error</Text>
+        </Flex>
+      )}
     </Flex>
   );
 };

--- a/apps/iterable/src/locations/Sidebar.tsx
+++ b/apps/iterable/src/locations/Sidebar.tsx
@@ -1,16 +1,42 @@
-import { Paragraph } from '@contentful/f36-components';
+import { CopyButton, Flex, Paragraph, TextInput, TextLink, Text } from '@contentful/f36-components';
 import { SidebarAppSDK } from '@contentful/app-sdk';
-import { /* useCMA, */ useSDK } from '@contentful/react-apps-toolkit';
+import { /* useCMA, */ useAutoResizer, useSDK } from '@contentful/react-apps-toolkit';
+import { CopyIcon, ExternalLinkIcon } from '@contentful/f36-icons';
+import tokens from '@contentful/f36-tokens';
 
 const Sidebar = () => {
   const sdk = useSDK<SidebarAppSDK>();
+  useAutoResizer();
   /*
      To use the cma, inject it as follows.
      If it is not needed, you can remove the next line.
   */
   // const cma = useCMA();
 
-  return <Paragraph>Hello Sidebar Component (AppId: {sdk.ids.app})</Paragraph>;
+  const value = 'a link';
+  return (
+    <Flex flexDirection="column">
+      <Text fontWeight="fontWeightDemiBold" marginBottom="spacingXs">
+        Data feed link
+      </Text>
+      <TextInput.Group>
+        <TextInput isDisabled isReadOnly value={value} />
+        <CopyButton value={value} tooltipProps={{ placement: 'right', usePortal: true }} />
+      </TextInput.Group>
+      <Paragraph marginTop="spacingXs" fontColor={'gray500'}>
+        Copy and paste this link into your Iterable data feed. Content automatically syncs when the
+        entry is published.{' '}
+        <TextLink
+          href=""
+          target="_blank"
+          rel="noopener noreferrer"
+          alignIcon="end"
+          icon={<ExternalLinkIcon />}>
+          Learn more
+        </TextLink>
+      </Paragraph>
+    </Flex>
+  );
 };
 
 export default Sidebar;

--- a/apps/iterable/test/mocks/index.ts
+++ b/apps/iterable/test/mocks/index.ts
@@ -1,2 +1,2 @@
 export { mockCma } from './mockCma';
-export { mockSdk } from './mockSdk';
+export { mockSdk, defaultMockSdk } from './mockSdk';

--- a/apps/iterable/test/mocks/locations/Sidebar.spec.tsx
+++ b/apps/iterable/test/mocks/locations/Sidebar.spec.tsx
@@ -1,18 +1,67 @@
 import React from 'react';
-import { render } from '@testing-library/react';
-import { vi } from 'vitest';
-import { mockSdk, mockCma } from '..';
+import { render, screen, cleanup } from '@testing-library/react';
+import { vi, describe, it, beforeEach, afterEach, expect } from 'vitest';
 import Sidebar from '../../../src/locations/Sidebar';
+
+// Default mockSdk
+const defaultMockSdk = {
+  ids: {
+    space: 'space-id',
+    entry: 'entry-id',
+  },
+  parameters: {
+    installation: {
+      contentfulApiKey: 'api-key',
+    },
+  },
+};
+
+let mockSdk;
 
 vi.mock('@contentful/react-apps-toolkit', () => ({
   useSDK: () => mockSdk,
-  useCMA: () => mockCma,
+  useAutoResizer: () => {},
 }));
 
-describe('Sidebar component', () => {
-  it('Component text exists', async () => {
-    const { getByText } = render(<Sidebar />);
+describe('Sidebar', () => {
+  beforeEach(() => {
+    mockSdk = JSON.parse(JSON.stringify(defaultMockSdk)); // Deep clone for isolation
+  });
 
-    await expect(getByText('Hello Sidebar Component (AppId: test-app)')).toBeInTheDocument();
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the data feed link and enables copy when all values are present', () => {
+    render(<Sidebar />);
+    expect(screen.getByText('Data feed link')).toBeTruthy();
+    expect(
+      screen.getByDisplayValue(
+        /https:\/\/cdn\.contentful\.com\/spaces\/space-id\/environments\/master\/entries/
+      )
+    ).toBeTruthy();
+    expect(screen.getByRole('button', { name: /copy/i })).not.toHaveProperty('disabled', true);
+    expect(screen.queryByText('Link generation error')).toBeFalsy();
+  });
+
+  it('shows error and disables copy when API key is missing', () => {
+    mockSdk.parameters.installation.contentfulApiKey = '';
+    render(<Sidebar />);
+    expect(screen.getByText('Link generation error')).toBeTruthy();
+    expect(screen.getByRole('button', { name: /copy/i })).toHaveProperty('disabled', true);
+  });
+
+  it('shows error and disables copy when space is missing', () => {
+    mockSdk.ids.space = '';
+    render(<Sidebar />);
+    expect(screen.getByText('Link generation error')).toBeTruthy();
+    expect(screen.getByRole('button', { name: /copy/i })).toHaveProperty('disabled', true);
+  });
+
+  it('shows error and disables copy when entryId is missing', () => {
+    mockSdk.ids.entry = '';
+    render(<Sidebar />);
+    expect(screen.getByText('Link generation error')).toBeTruthy();
+    expect(screen.getByRole('button', { name: /copy/i })).toHaveProperty('disabled', true);
   });
 });

--- a/apps/iterable/test/mocks/locations/Sidebar.spec.tsx
+++ b/apps/iterable/test/mocks/locations/Sidebar.spec.tsx
@@ -2,22 +2,9 @@ import React from 'react';
 import { render, screen, cleanup } from '@testing-library/react';
 import { vi, describe, it, beforeEach, afterEach, expect } from 'vitest';
 import Sidebar from '../../../src/locations/Sidebar';
-
-// Default mockSdk
-const defaultMockSdk = {
-  ids: {
-    space: 'space-id',
-    entry: 'entry-id',
-  },
-  parameters: {
-    installation: {
-      contentfulApiKey: 'api-key',
-    },
-  },
-};
+import { defaultMockSdk } from '../mockSdk';
 
 let mockSdk;
-
 vi.mock('@contentful/react-apps-toolkit', () => ({
   useSDK: () => mockSdk,
   useAutoResizer: () => {},

--- a/apps/iterable/test/mocks/mockSdk.ts
+++ b/apps/iterable/test/mocks/mockSdk.ts
@@ -17,4 +17,16 @@ const mockSdk: any = {
   },
 };
 
-export { mockSdk };
+const defaultMockSdk = {
+  ids: {
+    space: 'space-id',
+    entry: 'entry-id',
+  },
+  parameters: {
+    installation: {
+      contentfulApiKey: 'api-key',
+    },
+  },
+};
+
+export { mockSdk, defaultMockSdk };


### PR DESCRIPTION
## Purpose
Add the sidebar part to Iterable 
Out of scope: Add link with information, as we need the tech doc

## Approach

- Add sidebar
- Add error handling
- Fix some whitespace error in the config screen (when the api key had spaces at the end or beginning, it affected the link creation)
-  Updated error handling in config screen to make it looks like the design
## Testing steps
Sidebar

<img width="454" alt="Captura de pantalla 2025-07-07 a la(s) 12 24 11 p  m" src="https://github.com/user-attachments/assets/5fe3887c-5935-4aed-b005-f0156ca1ad19" />

Using it to create a data feed with a 50 field content type

https://github.com/user-attachments/assets/d95f1886-660f-4357-b293-864906b2a97b

Using data feed to create email templates

https://github.com/user-attachments/assets/1b134ee0-1200-4756-9f4b-d2c09b781fa6

Using a reference


https://github.com/user-attachments/assets/354f0c9b-ac6d-4ec5-9d0f-496870040711


