### PR TITLE
Trim whitespaces for access token in Config Screen []

### DIFF
--- a/apps/hubspot/src/locations/ConfigScreen.tsx
+++ b/apps/hubspot/src/locations/ConfigScreen.tsx
@@ -150,7 +150,7 @@ const ConfigScreen = () => {
                 placeholder="Enter your access token"
                 value={parameters.hubspotAccessToken}
                 onChange={(e) =>
-                  setParameters({ ...parameters, hubspotAccessToken: e.target.value })
+                  setParameters({ ...parameters, hubspotAccessToken: e.target.value.trim() })
                 }
                 isRequired
                 type="password"


### PR DESCRIPTION
## Purpose

Found this can happen in Iterable

## Approach
- Trim leading and trailing whitespaces

## Tests 

First add white spaces => Add trim => User no longer can leave white spaces as lead or trail:

https://github.com/user-attachments/assets/cc8f6825-a015-416f-bf6b-95e21d14a48c



