### PR TITLE
Hubspot: Persist error in sidebar []

### DIFF
--- a/apps/hubspot/src/locations/Dialog.tsx
+++ b/apps/hubspot/src/locations/Dialog.tsx
@@ -100,25 +100,30 @@ const Dialog = () => {
     invalidToken: boolean,
     missingScopes: boolean
   ) => {
-    const successfullFields = `${success.length} entry field${success.length === 1 ? '' : 's'}`;
-    const failedFields = `${failed.length} entry field${failed.length === 1 ? '' : 's'}`;
+    const resultMessage = (fields: SelectedSdkField[]): string => {
+      return `${fields.length} entry field${fields.length === 1 ? '' : 's'}`;
+    };
+
+    const successMessage = `${resultMessage(success)} successfully synced.`;
+    const failedMessage = `${resultMessage(failed)} did not sync, please try again.`;
+    const errorMessage =
+      'There is an error with your Hubspot private app access token, and entry fields did not sync.';
 
     if (invalidToken || missingScopes) {
-      sdk.notifier.error(
-        'There is an error with your Hubspot private app access token, and entry fields did not sync.'
-      );
-      sdk.close(true);
-      return;
+      sdk.notifier.error(errorMessage);
     } else if (failed.length > 0 && success.length > 0) {
-      sdk.notifier.warning(
-        `${successfullFields} were successfully synced, but ${failedFields} did not sync.`
-      );
+      sdk.notifier.warning(`${successMessage} ${failedMessage}`);
     } else if (failed.length > 0) {
-      sdk.notifier.error(`${failedFields} did not sync, please try again.`);
+      sdk.notifier.error(failedMessage);
     } else {
-      sdk.notifier.success(`${successfullFields} successfully synced.`);
+      sdk.notifier.success(successMessage);
     }
-    sdk.close(false);
+
+    if (invalidToken || missingScopes) {
+      sdk.close(true);
+    } else {
+      sdk.close(false);
+    }
   };
 
   return (

--- a/apps/hubspot/src/locations/Dialog.tsx
+++ b/apps/hubspot/src/locations/Dialog.tsx
@@ -87,7 +87,6 @@ const Dialog = () => {
       );
       const { success, failed, invalidToken, missingScopes } = JSON.parse(response.response.body);
       showResults(success, failed, invalidToken, missingScopes);
-      sdk.close();
     } catch (error) {
       console.error('Error creating modules: ', error);
     } finally {
@@ -101,25 +100,25 @@ const Dialog = () => {
     invalidToken: boolean,
     missingScopes: boolean
   ) => {
-    const successMessage = `${success.length} entry field${
-      success.length === 1 ? '' : 's'
-    } successfully synced`;
-    const failedMessage = `${failed.length} entry field${
-      failed.length === 1 ? '' : 's'
-    } did not sync, please try again`;
-    const mixedMessage = `${successMessage} but ${failedMessage}`;
+    const successfullFields = `${success.length} entry field${success.length === 1 ? '' : 's'}`;
+    const failedFields = `${failed.length} entry field${failed.length === 1 ? '' : 's'}`;
 
-    if (invalidToken) {
-      sdk.notifier.error('Invalid Hubspot access token.');
-    } else if (missingScopes) {
-      sdk.notifier.error('The Hubspot token is missing the required "content" scope.');
+    if (invalidToken || missingScopes) {
+      sdk.notifier.error(
+        'There is an error with your Hubspot private app access token, and entry fields did not sync.'
+      );
+      sdk.close(true);
+      return;
     } else if (failed.length > 0 && success.length > 0) {
-      sdk.notifier.warning(mixedMessage);
+      sdk.notifier.warning(
+        `${successfullFields} were successfully synced, but ${failedFields} did not sync.`
+      );
     } else if (failed.length > 0) {
-      sdk.notifier.error(`${failedMessage}.`);
+      sdk.notifier.error(`${failedFields} did not sync, please try again.`);
     } else {
-      sdk.notifier.success(`${successMessage}.`);
+      sdk.notifier.success(`${successfullFields} successfully synced.`);
     }
+    sdk.close(false);
   };
 
   return (

--- a/apps/hubspot/src/locations/Sidebar.tsx
+++ b/apps/hubspot/src/locations/Sidebar.tsx
@@ -22,6 +22,11 @@ const Sidebar = () => {
   );
   useAutoResizer();
 
+  const [connectedFields, setConnectedFields] = useState<EntryConnectedFields | undefined>(
+    undefined
+  );
+  const [showTokenError, setShowTokenError] = useState(false);
+
   const getEntryTitle = (): string => {
     let displayFieldId = sdk.contentType.displayField;
     if (!displayFieldId) return 'Untitled';
@@ -43,9 +48,11 @@ const Sidebar = () => {
     };
   };
 
-  const [connectedFields, setConnectedFields] = useState<EntryConnectedFields | undefined>(
-    undefined
-  );
+  const openDialog = async () => {
+    const params = await dialogParams();
+    const showError = await sdk.dialogs.openCurrentApp(params);
+    setShowTokenError(showError);
+  };
 
   useEffect(() => {
     const getConfig = async () => {
@@ -65,17 +72,23 @@ const Sidebar = () => {
       {connectedFields?.some((field) => field.error) && (
         <Note variant="negative" icon={<ErrorCircleOutlineIcon />}>
           <Text lineHeight="lineHeightCondensed" fontColor="gray800">
-            Unable to sync content. Review your connected or{' '}
+            Unable to sync content. Review your connected fields or{' '}
+            <TextLink onClick={() => sdk.navigator.openAppConfig()}>app configuration</TextLink>.
+          </Text>
+        </Note>
+      )}
+      {showTokenError && (
+        <Note variant="negative" icon={<ErrorCircleOutlineIcon />}>
+          <Text lineHeight="lineHeightCondensed" fontColor="gray800">
+            There is an error with your Hubspot private app access token, and entry fields did not
+            sync. View instructions on the{' '}
             <TextLink onClick={() => sdk.navigator.openAppConfig()}>app configuration</TextLink>.
           </Text>
         </Note>
       )}
 
       <Flex gap="spacingXs" flexDirection="column">
-        <Button
-          variant="secondary"
-          isFullWidth={true}
-          onClick={async () => sdk.dialogs.openCurrentApp(await dialogParams())}>
+        <Button variant="secondary" isFullWidth={true} onClick={openDialog}>
           Sync entry fields to Hubspot
         </Button>
 

--- a/apps/hubspot/test/locations/Sidebar.spec.tsx
+++ b/apps/hubspot/test/locations/Sidebar.spec.tsx
@@ -105,4 +105,32 @@ describe('Sidebar component', () => {
 
     expect(await screen.findByText('2 fields synced', { exact: false })).toBeInTheDocument();
   });
+
+  it('displays error when dialog returns true', async () => {
+    mockCma.asset.get.mockResolvedValue({
+      fields: {
+        file: {
+          'en-US': {
+            url: 'https://example.com/image.jpg',
+            contentType: 'image/jpeg',
+            details: {
+              image: { width: 100, height: 100 },
+            },
+          },
+        },
+      },
+    });
+    mockSdk.dialogs.openCurrentApp.mockResolvedValue(true);
+    const { getByText } = render(<Sidebar />);
+
+    const syncButton = getByText('Sync entry fields to Hubspot');
+    fireEvent.click(syncButton);
+
+    expect(
+      await screen.findByText(
+        'There is an error with your Hubspot private app access token, and entry fields did not sync.',
+        { exact: false }
+      )
+    ).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Purpose

Give more details and a CTA if there's an error with the hubspot token when creating new modules.

## Approach

The Dialog returns a boolean indicating if there was an error related to the token so a note can be displayed in the sidebar.

## Testing steps

Paste an invalid token in the config screen and try to create new modules. An error should be displayed in the sidebar.

<img width="344" alt="image" src="https://github.com/user-attachments/assets/8d53ff33-c688-449c-b73b-7ffdf662845c" />