### PR TITLE
Hubspot: storage on module creation [INTEG-2785]

### DIFF
--- a/apps/hubspot/contentful-app-manifest.json
+++ b/apps/hubspot/contentful-app-manifest.json
@@ -32,6 +32,12 @@
           "name": "Fields",
           "type": "Symbol",
           "required": true
+        },
+        {
+          "id": "entryId",
+          "name": "EntryId",
+          "type": "Symbol",
+          "required": true
         }
       ]
     }

--- a/apps/hubspot/functions/createModules.ts
+++ b/apps/hubspot/functions/createModules.ts
@@ -83,7 +83,7 @@ export const handler: FunctionEventHandler<FunctionTypeEnum.AppActionCall> = asy
   }
 
   if (successFields.length > 0 && !invalidToken && !missingScopes) {
-    updateConnectedFields(cma, event.body.entryId, successFields, new Date().toISOString());
+    await updateConnectedFields(cma, event.body.entryId, successFields, new Date().toISOString());
   }
 
   return {

--- a/apps/hubspot/src/locations/Dialog.tsx
+++ b/apps/hubspot/src/locations/Dialog.tsx
@@ -85,8 +85,10 @@ const Dialog = () => {
           },
         }
       );
-      const { success, failed, invalidToken, missingScopes } = JSON.parse(response.response.body);
-      showResults(success, failed, invalidToken, missingScopes);
+      const { successQuantity, failedQuantity, invalidToken, missingScopes } = JSON.parse(
+        response.response.body
+      );
+      showResults(successQuantity, failedQuantity, invalidToken, missingScopes);
     } catch (error) {
       console.error('Error creating modules: ', error);
     } finally {
@@ -95,25 +97,25 @@ const Dialog = () => {
   };
 
   const showResults = (
-    success: SelectedSdkField[] = [],
-    failed: SelectedSdkField[] = [],
+    successQuantity: number,
+    failedQuantity: number,
     invalidToken: boolean,
     missingScopes: boolean
   ) => {
-    const resultMessage = (fields: SelectedSdkField[]): string => {
-      return `${fields.length} entry field${fields.length === 1 ? '' : 's'}`;
+    const resultMessage = (fieldsQuantity: number): string => {
+      return `${fieldsQuantity} entry field${fieldsQuantity === 1 ? '' : 's'}`;
     };
 
-    const successMessage = `${resultMessage(success)} successfully synced.`;
-    const failedMessage = `${resultMessage(failed)} did not sync, please try again.`;
+    const successMessage = `${resultMessage(successQuantity)} successfully synced.`;
+    const failedMessage = `${resultMessage(failedQuantity)} did not sync, please try again.`;
     const errorMessage =
       'There is an error with your Hubspot private app access token, and entry fields did not sync.';
 
     if (invalidToken || missingScopes) {
       sdk.notifier.error(errorMessage);
-    } else if (failed.length > 0 && success.length > 0) {
+    } else if (failedQuantity > 0 && successQuantity > 0) {
       sdk.notifier.warning(`${successMessage} ${failedMessage}`);
-    } else if (failed.length > 0) {
+    } else if (failedQuantity > 0) {
       sdk.notifier.error(failedMessage);
     } else {
       sdk.notifier.success(successMessage);

--- a/apps/hubspot/src/locations/Dialog.tsx
+++ b/apps/hubspot/src/locations/Dialog.tsx
@@ -11,6 +11,7 @@ import { MODULE_NAME_PATTERN } from '../utils/utils';
 
 export type InvocationParams = {
   entryTitle: string;
+  entryId: string;
   fields: SdkField[];
 };
 
@@ -81,6 +82,7 @@ const Dialog = () => {
         },
         {
           parameters: {
+            entryId: invocationParams.entryId,
             fields: JSON.stringify(fieldsToSend),
           },
         }

--- a/apps/hubspot/src/locations/Sidebar.tsx
+++ b/apps/hubspot/src/locations/Sidebar.tsx
@@ -43,6 +43,7 @@ const Sidebar = () => {
       title: 'Sync entry fields to Hubspot',
       parameters: {
         entryTitle: getEntryTitle(),
+        entryId: sdk.ids.entry,
         fields: JSON.parse(
           JSON.stringify(
             await processFields(Object.values(sdk.entry.fields), cma, sdk.locales.default)

--- a/apps/hubspot/src/utils/utils.ts
+++ b/apps/hubspot/src/utils/utils.ts
@@ -26,8 +26,8 @@ export type AppInstallationParameters = {
 
 export type ConnectedField = {
   fieldId: string;
-  locale: string;
-  moduleId: string;
+  locale?: string;
+  moduleName: string;
   updatedAt: string;
   error?: { status: number; message: string };
 };

--- a/apps/hubspot/test/functions/createModules.spec.ts
+++ b/apps/hubspot/test/functions/createModules.spec.ts
@@ -20,6 +20,25 @@ import { documentToHtmlString } from '@contentful/rich-text-html-renderer';
 // Mock fetch globally
 global.fetch = vi.fn();
 
+const mockCma = {
+  entry: {
+    get: vi.fn().mockResolvedValue({
+      fields: {
+        connectedFields: {
+          'en-US': {
+            'test-entry-id': [],
+          },
+        },
+      },
+    }),
+    update: vi.fn(),
+  },
+};
+
+vi.mock('contentful-management', () => ({
+  createClient: () => mockCma,
+}));
+
 describe('createModules', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -38,6 +57,9 @@ describe('createModules', () => {
     appInstallationParameters: {
       hubspotAccessToken: token,
     },
+    cmaClientOptions: {},
+    spaceId: 'test-space',
+    environmentId: 'test-env',
   });
 
   it('should create three files for a module', async () => {
@@ -64,8 +86,8 @@ describe('createModules', () => {
 
     // Verify the result
     expect(result).toEqual({
-      success: [mockField.uniqueId],
-      failed: [],
+      successQuantity: 1,
+      failedQuantity: 0,
       invalidToken: false,
       missingScopes: false,
     });
@@ -141,8 +163,8 @@ describe('createModules', () => {
 
     // Verify the result
     expect(result).toEqual({
-      success: [],
-      failed: [mockField.uniqueId],
+      successQuantity: 0,
+      failedQuantity: 1,
       invalidToken: false,
       missingScopes: false,
     });
@@ -192,8 +214,8 @@ describe('createModules', () => {
 
     // Verify the result
     expect(result).toEqual({
-      success: [],
-      failed: [],
+      successQuantity: 0,
+      failedQuantity: 0,
       invalidToken: true,
       missingScopes: false,
     });
@@ -231,8 +253,8 @@ describe('createModules', () => {
 
     // Verify the result
     expect(result).toEqual({
-      success: [],
-      failed: [],
+      successQuantity: 0,
+      failedQuantity: 0,
       invalidToken: false,
       missingScopes: true,
     });
@@ -263,8 +285,8 @@ describe('createModules', () => {
 
     // Verify the result
     expect(result).toEqual({
-      success: [mockField.uniqueId],
-      failed: [],
+      successQuantity: 1,
+      failedQuantity: 0,
       invalidToken: false,
       missingScopes: false,
     });
@@ -325,8 +347,8 @@ describe('createModules', () => {
 
     // Verify the result
     expect(result).toEqual({
-      success: [mockField.uniqueId],
-      failed: [],
+      successQuantity: 1,
+      failedQuantity: 0,
       invalidToken: false,
       missingScopes: false,
     });
@@ -386,8 +408,8 @@ describe('createModules', () => {
 
     // Verify the result
     expect(result).toEqual({
-      success: [mockField.uniqueId],
-      failed: [],
+      successQuantity: 1,
+      failedQuantity: 0,
       invalidToken: false,
       missingScopes: false,
     });
@@ -445,8 +467,8 @@ describe('createModules', () => {
 
     // Verify the result
     expect(result).toEqual({
-      success: [mockField.uniqueId],
-      failed: [],
+      successQuantity: 1,
+      failedQuantity: 0,
       invalidToken: false,
       missingScopes: false,
     });
@@ -504,8 +526,8 @@ describe('createModules', () => {
 
     // Verify the result
     expect(result).toEqual({
-      success: [mockField.uniqueId],
-      failed: [],
+      successQuantity: 1,
+      failedQuantity: 0,
       invalidToken: false,
       missingScopes: false,
     });
@@ -563,8 +585,8 @@ describe('createModules', () => {
 
     // Verify the result
     expect(result).toEqual({
-      success: [mockField.uniqueId],
-      failed: [],
+      successQuantity: 1,
+      failedQuantity: 0,
       invalidToken: false,
       missingScopes: false,
     });
@@ -625,8 +647,8 @@ describe('createModules', () => {
 
     // Verify the result
     expect(result).toEqual({
-      success: [mockField.uniqueId],
-      failed: [],
+      successQuantity: 1,
+      failedQuantity: 0,
       invalidToken: false,
       missingScopes: false,
     });
@@ -689,8 +711,8 @@ describe('createModules', () => {
 
     // Verify the result
     expect(result).toEqual({
-      success: [mockField.uniqueId],
-      failed: [],
+      successQuantity: 1,
+      failedQuantity: 0,
       invalidToken: false,
       missingScopes: false,
     });

--- a/apps/hubspot/test/locations/Dialog.spec.tsx
+++ b/apps/hubspot/test/locations/Dialog.spec.tsx
@@ -154,7 +154,12 @@ describe('Dialog component', () => {
     const user = userEvent.setup();
     const mockCreateWithResponse = vi.fn().mockResolvedValue({
       response: {
-        body: JSON.stringify({ success: ['title', 'description-en-us'], failed: [] }),
+        body: JSON.stringify({
+          successQuantity: 2,
+          failedQuantity: 0,
+          invalidToken: false,
+          missingScopes: false,
+        }),
       },
     });
 

--- a/apps/hubspot/test/locations/Sidebar.spec.tsx
+++ b/apps/hubspot/test/locations/Sidebar.spec.tsx
@@ -71,7 +71,7 @@ describe('Sidebar component', () => {
       {
         fieldId: 'title',
         locale: 'en-US',
-        moduleId: 'test-module',
+        moduleName: 'test-module',
         updatedAt: '2024-01-01T00:00:00Z',
         error: { status: 400, message: 'Bad Request' },
       },
@@ -86,13 +86,13 @@ describe('Sidebar component', () => {
       {
         fieldId: 'title',
         locale: 'en-US',
-        moduleId: 'test-module',
+        moduleName: 'test-module',
         updatedAt: '2024-01-01T00:00:00Z',
       },
       {
         fieldId: 'description',
         locale: 'en-US',
-        moduleId: 'test-module',
+        moduleName: 'test-module',
         updatedAt: '2024-01-01T00:00:00Z',
       },
     ]);


### PR DESCRIPTION
## Purpose

- This update includes:
  - the storage on the config entry when the user create a module through the app
  - the addition of more methods for the config entry service that are used in the createModule function
  - the addition of some refactors for the Dialog and also for the createModule function
- The second part of the ticket will be contemplated on another PR: The update of the module when a user modifies a field

## Approach

We use the config entry service to update the config entry.

## Testing steps

Automated tests were added.

## Breaking Changes

N/A

## Dependencies and/or References

Link to [INTEG-2785](https://contentful.atlassian.net/jira/software/c/projects/INTEG/boards/3109?issueParent=367108&label=10-Pines&selectedIssue=INTEG-2785) ticket

## Deployment

N/A

[INTEG-2785]: https://contentful.atlassian.net/browse/INTEG-2785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ