### PR TITLE
Hubspot: Update modules on entry save [INTEG-2785]

### DIFF
--- a/apps/hubspot/functions/appEventHandler.ts
+++ b/apps/hubspot/functions/appEventHandler.ts
@@ -24,6 +24,12 @@ export const handler: FunctionEventHandler<FunctionTypeEnum.AppEventHandler> = a
 
   const configService = new ConfigEntryService(cma);
 
+  const entryConnectedFields = await configService.getEntryConnectedFields(entryId);
+  if (!entryConnectedFields || entryConnectedFields.length === 0) {
+    // Entry is not tracked in config, skip the function
+    return;
+  }
+
   if (contentfulTopic.includes('Entry.delete')) {
     await callAndRetry(() => configService.removeEntryConnectedFields(entryId));
   } else if (

--- a/apps/hubspot/functions/appEventHandler.ts
+++ b/apps/hubspot/functions/appEventHandler.ts
@@ -30,7 +30,7 @@ export const handler: FunctionEventHandler<FunctionTypeEnum.AppEventHandler> = a
     contentfulTopic.includes('Entry.save') ||
     contentfulTopic.includes('Entry.auto_save')
   ) {
-    await entrySavedHandler(cma, context, body, configService);
+    await callAndRetry(() => entrySavedHandler(cma, context, body, configService));
   }
 };
 
@@ -69,8 +69,11 @@ const entrySavedHandler = async (
 
     try {
       const { fieldsFile } = getFiles(fieldInfo.type, fieldValue);
-      await callAndRetry(() =>
-        createModuleFile(fieldsFile, 'fields.json', connectedField.moduleName, hubspotAccessToken)
+      await createModuleFile(
+        fieldsFile,
+        'fields.json',
+        connectedField.moduleName,
+        hubspotAccessToken
       );
     } catch (error: any) {
       updateResult = {

--- a/apps/hubspot/functions/appEventHandler.ts
+++ b/apps/hubspot/functions/appEventHandler.ts
@@ -30,18 +30,18 @@ export const handler: FunctionEventHandler<FunctionTypeEnum.AppEventHandler> = a
     contentfulTopic.includes('Entry.save') ||
     contentfulTopic.includes('Entry.auto_save')
   ) {
-    await callAndRetry(() => entrySavedHandler(cma, context, body, configService));
+    const { hubspotAccessToken } = context.appInstallationParameters as AppInstallationParameters;
+    await callAndRetry(() => entrySavedHandler(cma, hubspotAccessToken, body, configService));
   }
 };
 
 const entrySavedHandler = async (
   cma: PlainClientAPI,
-  context: FunctionEventContext,
+  hubspotAccessToken: string,
   body: any,
   configService: ConfigEntryService
 ) => {
   const entryConnectedFields = await configService.getEntryConnectedFields(body.sys.id);
-  const { hubspotAccessToken } = context.appInstallationParameters as AppInstallationParameters;
 
   const contentType = await cma.contentType.get({
     contentTypeId: body.sys.contentType.sys.id,

--- a/apps/hubspot/functions/appEventHandler.ts
+++ b/apps/hubspot/functions/appEventHandler.ts
@@ -6,10 +6,7 @@ import {
 } from '@contentful/node-apps-toolkit';
 import ConfigEntryService from '../src/utils/ConfigEntryService';
 import { createModuleFile, getFiles, initContentfulManagementClient } from './common';
-import {
-  AppInstallationParameters,
-  ConnectedField,
-} from '../src/utils/utils';
+import { AppInstallationParameters, ConnectedField } from '../src/utils/utils';
 import { PlainClientAPI } from 'contentful-management';
 
 const WAIT_TIMES = [1000, 2000];

--- a/apps/hubspot/functions/common.ts
+++ b/apps/hubspot/functions/common.ts
@@ -1,5 +1,21 @@
 import { FunctionEventContext } from '@contentful/node-apps-toolkit';
-import { createClient, PlainClientAPI } from 'contentful-management';
+import { ContentFields, createClient, KeyValueMap, PlainClientAPI } from 'contentful-management';
+import { documentToHtmlString } from '@contentful/rich-text-html-renderer';
+import { InvalidHubspotTokenError, MissingHubspotScopesError } from './exceptions';
+import {
+  DATE_FIELD_TEMPLATE,
+  DATE_MODULE_TEMPLATE,
+  DATETIME_FIELD_TEMPLATE,
+  DATETIME_MODULE_TEMPLATE,
+  IMAGE_FIELD_TEMPLATE,
+  IMAGE_MODULE_TEMPLATE,
+  NUMBER_FIELD_TEMPLATE,
+  NUMBER_MODULE_TEMPLATE,
+  RICH_TEXT_FIELD_TEMPLATE,
+  RICH_TEXT_MODULE_TEMPLATE,
+  TEXT_FIELD_TEMPLATE,
+  TEXT_MODULE_TEMPLATE,
+} from './templates';
 
 export function initContentfulManagementClient(context: FunctionEventContext): PlainClientAPI {
   if (!context.cmaClientOptions) {
@@ -15,3 +31,121 @@ export function initContentfulManagementClient(context: FunctionEventContext): P
     },
   });
 }
+
+export const createModuleFile = async (
+  file: string,
+  fileName: string,
+  moduleName: string,
+  token: string
+) => {
+  const fileBuffer = Buffer.from(file);
+  const url = `https://api.hubapi.com/cms/v3/source-code/published/content/${moduleName}.module/${fileName}`;
+  const formData = new FormData();
+  const type = fileName.endsWith('json') ? 'application/json' : 'text/html';
+  formData.append('file', new Blob([fileBuffer], { type: type }), fileName);
+
+  const response = await fetch(url, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+    body: formData,
+  });
+
+  if (!response.ok) {
+    const error = await response.json();
+    if (error?.category === 'INVALID_AUTHENTICATION') {
+      throw new InvalidHubspotTokenError(error.message);
+    }
+    if (error?.category === 'MISSING_SCOPES') {
+      throw new MissingHubspotScopesError(error.message);
+    }
+    const errorData = await response.text();
+    throw new Error(
+      `HubSpot API request failed: ${response.status} ${response.statusText} - ${errorData}`
+    );
+  }
+};
+
+export const stringifyFieldValue = (fieldValue: any, field: ContentFields<KeyValueMap>): string => {
+  switch (field.type) {
+    case 'Symbol':
+    case 'Text':
+    case 'Integer':
+    case 'Number':
+    case 'Boolean':
+      return String(fieldValue);
+
+    case 'Date':
+      return new Date(fieldValue).toISOString();
+
+    case 'Object':
+      return JSON.stringify(fieldValue);
+
+    case 'RichText':
+      return documentToHtmlString(fieldValue);
+
+    case 'Location':
+      return `lat:${fieldValue.lat},long:${fieldValue.lon}`;
+
+    default:
+      throw new Error(`Field type '${field.type}' is not supported`);
+  }
+};
+
+export const getFiles = (type: string, value: any): { fieldsFile: string; moduleFile: string } => {
+  let fieldsFile;
+  let moduleFile;
+  switch (type) {
+    case 'Symbol':
+    case 'Text':
+      fieldsFile = structuredClone(TEXT_FIELD_TEMPLATE);
+      if (value) fieldsFile[0].default = value;
+      moduleFile = TEXT_MODULE_TEMPLATE;
+      break;
+    case 'RichText':
+      fieldsFile = structuredClone(RICH_TEXT_FIELD_TEMPLATE);
+      if (value) fieldsFile[0].default = documentToHtmlString(value);
+      moduleFile = RICH_TEXT_MODULE_TEMPLATE;
+      break;
+    case 'Number':
+    case 'Integer':
+      fieldsFile = structuredClone(NUMBER_FIELD_TEMPLATE);
+      if (value) fieldsFile[0].default = value;
+      moduleFile = NUMBER_MODULE_TEMPLATE;
+      break;
+    case 'Date':
+      const stringValue = value as string;
+      if (!stringValue || stringValue.includes('T')) {
+        fieldsFile = structuredClone(DATETIME_FIELD_TEMPLATE);
+        moduleFile = DATETIME_MODULE_TEMPLATE;
+      } else {
+        fieldsFile = structuredClone(DATE_FIELD_TEMPLATE);
+        moduleFile = DATE_MODULE_TEMPLATE;
+      }
+      fieldsFile[0].default = new Date(stringValue).getTime();
+      break;
+    case 'Location':
+      fieldsFile = structuredClone(TEXT_FIELD_TEMPLATE);
+      if (value) fieldsFile[0].default = `lat:${value.lat}, long:${value.lon}`;
+      moduleFile = TEXT_MODULE_TEMPLATE;
+      break;
+    case 'Array':
+      fieldsFile = structuredClone(TEXT_FIELD_TEMPLATE);
+      if (value) fieldsFile[0].default = value.join(', ');
+      moduleFile = TEXT_MODULE_TEMPLATE;
+      break;
+    case 'Link':
+      fieldsFile = structuredClone(IMAGE_FIELD_TEMPLATE);
+      if (value) {
+        fieldsFile[0].default.src = value.url;
+        fieldsFile[0].default.width = value.width;
+        fieldsFile[0].default.height = value.height;
+      }
+      moduleFile = IMAGE_MODULE_TEMPLATE;
+      break;
+    default:
+      throw new Error(`Unsupported field type: ${type}`);
+  }
+  return { fieldsFile: JSON.stringify(fieldsFile), moduleFile };
+};

--- a/apps/hubspot/functions/createModules.ts
+++ b/apps/hubspot/functions/createModules.ts
@@ -5,26 +5,14 @@ import type {
   AppActionRequest,
 } from '@contentful/node-apps-toolkit';
 import {
-  DATE_FIELD_TEMPLATE,
-  DATE_MODULE_TEMPLATE,
-  DATETIME_FIELD_TEMPLATE,
-  DATETIME_MODULE_TEMPLATE,
-  IMAGE_FIELD_TEMPLATE,
-  IMAGE_MODULE_TEMPLATE,
   META_JSON_TEMPLATE,
-  NUMBER_FIELD_TEMPLATE,
-  NUMBER_MODULE_TEMPLATE,
-  RICH_TEXT_FIELD_TEMPLATE,
-  RICH_TEXT_MODULE_TEMPLATE,
-  TEXT_FIELD_TEMPLATE,
-  TEXT_MODULE_TEMPLATE,
 } from './templates';
 import { SelectedSdkField } from '../src/utils/fieldsProcessing';
-import { documentToHtmlString } from '@contentful/rich-text-html-renderer';
 import { EntryConnectedFields } from '../src/utils/utils';
 import { PlainClientAPI } from 'contentful-management';
 import ConfigEntryService from '../src/utils/ConfigEntryService';
-import { initContentfulManagementClient } from './common';
+import { createModuleFile, getFiles, initContentfulManagementClient } from './common';
+import { InvalidHubspotTokenError, MissingHubspotScopesError } from './exceptions';
 
 type AppActionParameters = {
   entryId: string;
@@ -95,116 +83,9 @@ export const handler: FunctionEventHandler<FunctionTypeEnum.AppActionCall> = asy
 };
 
 const createModule = async (field: SelectedSdkField, token: string) => {
-  const { fieldsFile, moduleFile } = getFiles(field);
+  const { fieldsFile, moduleFile } = getFiles(field.type, field.value);
   const moduleName = field.moduleName;
   await createModuleFile(JSON.stringify(META_JSON_TEMPLATE), 'meta.json', moduleName, token);
   await createModuleFile(fieldsFile, 'fields.json', moduleName, token);
   await createModuleFile(moduleFile, 'module.html', moduleName, token);
 };
-
-const createModuleFile = async (
-  file: string,
-  fileName: string,
-  moduleName: string,
-  token: string
-) => {
-  const fileBuffer = Buffer.from(file);
-  const url = `https://api.hubapi.com/cms/v3/source-code/published/content/${moduleName}.module/${fileName}`;
-  const formData = new FormData();
-  const type = fileName.endsWith('json') ? 'application/json' : 'text/html';
-  formData.append('file', new Blob([fileBuffer], { type: type }), fileName);
-
-  const response = await fetch(url, {
-    method: 'PUT',
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-    body: formData,
-  });
-
-  if (!response.ok) {
-    const error = await response.json();
-    if (error?.category === 'INVALID_AUTHENTICATION') {
-      throw new InvalidHubspotTokenError(error.message);
-    }
-    if (error?.category === 'MISSING_SCOPES') {
-      throw new MissingHubspotScopesError(error.message);
-    }
-    const errorData = await response.text();
-    throw new Error(
-      `HubSpot API request failed: ${response.status} ${response.statusText} - ${errorData}`
-    );
-  }
-};
-
-const getFiles = (field: SelectedSdkField): { fieldsFile: string; moduleFile: string } => {
-  const { type } = field;
-  let fieldsFile;
-  let moduleFile;
-  switch (type) {
-    case 'Symbol':
-    case 'Text':
-      fieldsFile = structuredClone(TEXT_FIELD_TEMPLATE);
-      if (field.value) fieldsFile[0].default = field.value;
-      moduleFile = TEXT_MODULE_TEMPLATE;
-      break;
-    case 'RichText':
-      fieldsFile = structuredClone(RICH_TEXT_FIELD_TEMPLATE);
-      if (field.value) fieldsFile[0].default = documentToHtmlString(field.value);
-      moduleFile = RICH_TEXT_MODULE_TEMPLATE;
-      break;
-    case 'Number':
-    case 'Integer':
-      fieldsFile = structuredClone(NUMBER_FIELD_TEMPLATE);
-      if (field.value) fieldsFile[0].default = field.value;
-      moduleFile = NUMBER_MODULE_TEMPLATE;
-      break;
-    case 'Date':
-      const value = field.value as string;
-      if (!value || value.includes('T')) {
-        fieldsFile = structuredClone(DATETIME_FIELD_TEMPLATE);
-        moduleFile = DATETIME_MODULE_TEMPLATE;
-      } else {
-        fieldsFile = structuredClone(DATE_FIELD_TEMPLATE);
-        moduleFile = DATE_MODULE_TEMPLATE;
-      }
-      fieldsFile[0].default = new Date(value).getTime();
-      break;
-    case 'Location':
-      fieldsFile = structuredClone(TEXT_FIELD_TEMPLATE);
-      if (field.value) fieldsFile[0].default = `lat:${field.value.lat}, long:${field.value.lon}`;
-      moduleFile = TEXT_MODULE_TEMPLATE;
-      break;
-    case 'Array':
-      fieldsFile = structuredClone(TEXT_FIELD_TEMPLATE);
-      if (field.value) fieldsFile[0].default = field.value.join(', ');
-      moduleFile = TEXT_MODULE_TEMPLATE;
-      break;
-    case 'Link':
-      fieldsFile = structuredClone(IMAGE_FIELD_TEMPLATE);
-      if (field.value) {
-        fieldsFile[0].default.src = field.value.url;
-        fieldsFile[0].default.width = field.value.width;
-        fieldsFile[0].default.height = field.value.height;
-      }
-      moduleFile = IMAGE_MODULE_TEMPLATE;
-      break;
-    default:
-      throw new Error(`Unsupported field type: ${type}`);
-  }
-  return { fieldsFile: JSON.stringify(fieldsFile), moduleFile };
-};
-
-class InvalidHubspotTokenError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'InvalidHubspotTokenError';
-  }
-}
-
-class MissingHubspotScopesError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'MissingHubspotScopesError';
-  }
-}

--- a/apps/hubspot/functions/createModules.ts
+++ b/apps/hubspot/functions/createModules.ts
@@ -4,9 +4,7 @@ import type {
   FunctionTypeEnum,
   AppActionRequest,
 } from '@contentful/node-apps-toolkit';
-import {
-  META_JSON_TEMPLATE,
-} from './templates';
+import { META_JSON_TEMPLATE } from './templates';
 import { SelectedSdkField } from '../src/utils/fieldsProcessing';
 import { EntryConnectedFields } from '../src/utils/utils';
 import { PlainClientAPI } from 'contentful-management';

--- a/apps/hubspot/functions/exceptions.ts
+++ b/apps/hubspot/functions/exceptions.ts
@@ -1,0 +1,13 @@
+export class InvalidHubspotTokenError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidHubspotTokenError';
+  }
+}
+
+export class MissingHubspotScopesError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MissingHubspotScopesError';
+  }
+}

--- a/apps/hubspot/test/functions/appEventHandler.spec.ts
+++ b/apps/hubspot/test/functions/appEventHandler.spec.ts
@@ -26,8 +26,9 @@ vi.mock('contentful-management', () => ({
 }));
 
 vi.mock('../../functions/common', async () => {
-  const actual =
-    await vi.importActual<typeof import('../../functions/common')>('../../functions/common');
+  const actual = await vi.importActual<typeof import('../../functions/common')>(
+    '../../functions/common'
+  );
   return {
     ...actual,
     createModuleFile: vi.fn(),

--- a/apps/hubspot/test/functions/appEventHandler.spec.ts
+++ b/apps/hubspot/test/functions/appEventHandler.spec.ts
@@ -97,7 +97,7 @@ describe('app event handler', () => {
         updatedAt: new Date().toISOString(),
       },
     ];
-    const cma = makeCmaWithContentType([{ id: 'textField', type: 'Text' }]);
+    const cma = getCmaWithContentType([{ id: 'textField', type: 'Text' }]);
 
     mockConfigEntryServiceMethods(connectedFields);
     vi.spyOn(common, 'createModuleFile').mockResolvedValue(undefined);
@@ -137,7 +137,7 @@ describe('app event handler', () => {
         updatedAt: new Date().toISOString(),
       },
     ];
-    const cma = makeCmaWithContentType([{ id: 'richTextField', type: 'RichText' }]);
+    const cma = getCmaWithContentType([{ id: 'richTextField', type: 'RichText' }]);
 
     mockConfigEntryServiceMethods(connectedFields);
     vi.spyOn(common, 'createModuleFile').mockResolvedValue(undefined);
@@ -181,7 +181,7 @@ describe('app event handler', () => {
         updatedAt: new Date().toISOString(),
       },
     ];
-    const cma = makeCmaWithContentType([{ id: 'textField', type: 'Text' }]);
+    const cma = getCmaWithContentType([{ id: 'textField', type: 'Text' }]);
 
     const { updateEntryConnectedFieldsMock } = mockConfigEntryServiceMethods(connectedFields);
     mockCommonMethods(cma, true);
@@ -199,7 +199,7 @@ describe('app event handler', () => {
   });
 });
 
-function makeCmaWithContentType(contentTypeFields: { id: string; type: string }[]) {
+function getCmaWithContentType(contentTypeFields: { id: string; type: string }[]) {
   const contentType = { fields: contentTypeFields };
   return {
     contentType: {

--- a/apps/hubspot/test/functions/appEventHandler.spec.ts
+++ b/apps/hubspot/test/functions/appEventHandler.spec.ts
@@ -1,8 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { handler } from '../../functions/appEventHandler';
 import ConfigEntryService from '../../src/utils/ConfigEntryService';
-import { TEXT_FIELD_TEMPLATE, RICH_TEXT_FIELD_TEMPLATE } from '../../functions/templates';
+import { RICH_TEXT_FIELD_TEMPLATE, TEXT_FIELD_TEMPLATE } from '../../functions/templates';
 import { documentToHtmlString } from '@contentful/rich-text-html-renderer';
+import { BLOCKS, Document } from '@contentful/rich-text-types';
 import * as common from '../../functions/common';
 
 const mockCma = {
@@ -30,7 +31,6 @@ vi.mock('../../functions/common', async () => {
   return {
     ...actual,
     createModuleFile: vi.fn(),
-    getFiles: vi.fn(),
     initContentfulManagementClient: vi.fn(), // <-- add this line
   };
 });
@@ -89,7 +89,6 @@ describe('app event handler', () => {
         },
       },
     };
-
     const connectedFields = [
       {
         fieldId: 'textField',
@@ -98,30 +97,10 @@ describe('app event handler', () => {
         updatedAt: new Date().toISOString(),
       },
     ];
+    const cma = makeCmaWithContentType([{ id: 'textField', type: 'Text' }]);
 
-    const contentType = {
-      fields: [{ id: 'textField', type: 'Text' }],
-    };
-
-    vi.spyOn(ConfigEntryService.prototype, 'getEntryConnectedFields').mockResolvedValue(
-      connectedFields
-    );
-    vi.spyOn(ConfigEntryService.prototype, 'updateEntryConnectedFields').mockResolvedValue(
-      undefined as any
-    );
-    (common.createModuleFile as jest.Mock).mockResolvedValue(undefined as any);
-    vi.spyOn(common, 'getFiles').mockImplementation((type, value) => {
-      const fieldsFile = structuredClone(TEXT_FIELD_TEMPLATE);
-      fieldsFile[0].default = String(value);
-      return { fieldsFile: JSON.stringify(fieldsFile), moduleFile: '' };
-    });
-
-    const cma = {
-      contentType: {
-        get: vi.fn().mockResolvedValue(contentType as any),
-      },
-    };
-
+    mockConfigEntryServiceMethods(connectedFields);
+    vi.spyOn(common, 'createModuleFile').mockResolvedValue(undefined);
     vi.spyOn(common, 'initContentfulManagementClient').mockReturnValue(cma as any);
 
     await handler(event as any, mockContext as any);
@@ -135,6 +114,7 @@ describe('app event handler', () => {
   });
 
   it('should update a module on entry save with RichText field', async () => {
+    const minimalDocument: Document = { nodeType: BLOCKS.DOCUMENT, content: [], data: {} };
     const event = {
       headers: {
         'X-Contentful-Topic': 'Entry.save',
@@ -145,11 +125,10 @@ describe('app event handler', () => {
           contentType: { sys: { id: 'test-content-type' } },
         },
         fields: {
-          richTextField: { 'en-US': { nodeType: 'document' as any, content: [] } },
+          richTextField: { 'en-US': minimalDocument },
         },
       },
     };
-
     const connectedFields = [
       {
         fieldId: 'richTextField',
@@ -158,28 +137,10 @@ describe('app event handler', () => {
         updatedAt: new Date().toISOString(),
       },
     ];
+    const cma = makeCmaWithContentType([{ id: 'richTextField', type: 'RichText' }]);
 
-    const contentType = {
-      fields: [{ id: 'richTextField', type: 'RichText' }],
-    };
-
-    vi.spyOn(ConfigEntryService.prototype, 'getEntryConnectedFields').mockResolvedValue(
-      connectedFields
-    );
-    vi.spyOn(ConfigEntryService.prototype, 'updateEntryConnectedFields').mockResolvedValue(
-      undefined as any
-    );
-    (common.createModuleFile as jest.Mock).mockResolvedValue(undefined as any);
-    vi.spyOn(common, 'getFiles').mockImplementation((type, value) => {
-      const fieldsFile = structuredClone(RICH_TEXT_FIELD_TEMPLATE);
-      fieldsFile[0].default = documentToHtmlString(value as any);
-      return { fieldsFile: JSON.stringify(fieldsFile), moduleFile: '' };
-    });
-    const cma = {
-      contentType: {
-        get: vi.fn().mockResolvedValue(contentType as any),
-      },
-    };
+    mockConfigEntryServiceMethods(connectedFields);
+    vi.spyOn(common, 'createModuleFile').mockResolvedValue(undefined);
     vi.spyOn(common, 'initContentfulManagementClient').mockReturnValue(cma as any);
 
     await handler(event as any, mockContext as any);
@@ -188,7 +149,7 @@ describe('app event handler', () => {
       JSON.stringify([
         {
           ...RICH_TEXT_FIELD_TEMPLATE[0],
-          default: documentToHtmlString({ nodeType: 'document', content: [] }),
+          default: documentToHtmlString(minimalDocument),
         },
       ]),
       'fields.json',
@@ -212,7 +173,6 @@ describe('app event handler', () => {
         },
       },
     };
-
     const connectedFields = [
       {
         fieldId: 'textField',
@@ -221,29 +181,10 @@ describe('app event handler', () => {
         updatedAt: new Date().toISOString(),
       },
     ];
+    const cma = makeCmaWithContentType([{ id: 'textField', type: 'Text' }]);
 
-    const contentType = {
-      fields: [{ id: 'textField', type: 'Text' }],
-    };
-
-    vi.spyOn(ConfigEntryService.prototype, 'getEntryConnectedFields').mockResolvedValue(
-      connectedFields
-    );
-    const updateEntryConnectedFieldsMock = vi
-      .spyOn(ConfigEntryService.prototype, 'updateEntryConnectedFields')
-      .mockResolvedValue(undefined as any);
-    (common.createModuleFile as jest.Mock).mockRejectedValue(new Error('Failed to update'));
-    vi.spyOn(common, 'getFiles').mockImplementation((type, value) => {
-      const fieldsFile = structuredClone(TEXT_FIELD_TEMPLATE);
-      fieldsFile[0].default = String(value);
-      return { fieldsFile: JSON.stringify(fieldsFile), moduleFile: '' };
-    });
-    const cma = {
-      contentType: {
-        get: vi.fn().mockResolvedValue(contentType as any),
-      },
-    };
-    vi.spyOn(common, 'initContentfulManagementClient').mockReturnValue(cma as any);
+    const { updateEntryConnectedFieldsMock } = mockConfigEntryServiceMethods(connectedFields);
+    mockCommonMethods(cma, true);
 
     await handler(event as any, mockContext as any);
 
@@ -257,3 +198,31 @@ describe('app event handler', () => {
     ]);
   });
 });
+
+function makeCmaWithContentType(contentTypeFields: { id: string; type: string }[]) {
+  const contentType = { fields: contentTypeFields };
+  return {
+    contentType: {
+      get: vi.fn().mockResolvedValue(contentType as any),
+    },
+  };
+}
+
+function mockConfigEntryServiceMethods(
+  connectedFields1: { fieldId: string; locale: string; moduleName: string; updatedAt: string }[]
+) {
+  const getEntryConnectedFieldsMock = vi
+    .spyOn(ConfigEntryService.prototype, 'getEntryConnectedFields')
+    .mockResolvedValue(connectedFields1);
+  const updateEntryConnectedFieldsMock = vi
+    .spyOn(ConfigEntryService.prototype, 'updateEntryConnectedFields')
+    .mockResolvedValue(undefined as any);
+  return { getEntryConnectedFieldsMock, updateEntryConnectedFieldsMock };
+}
+
+function mockCommonMethods(cma: { contentType: any }, createFileWithError: boolean) {
+  vi.spyOn(common, 'createModuleFile').mockRejectedValue(
+    createFileWithError ? new Error('Failed to update') : undefined
+  );
+  vi.spyOn(common, 'initContentfulManagementClient').mockReturnValue(cma as any);
+}

--- a/apps/hubspot/test/functions/appEventHandler.spec.ts
+++ b/apps/hubspot/test/functions/appEventHandler.spec.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { handler } from '../../functions/appEventHandler';
 import ConfigEntryService from '../../src/utils/ConfigEntryService';
+import { TEXT_FIELD_TEMPLATE, RICH_TEXT_FIELD_TEMPLATE } from '../../functions/templates';
+import { documentToHtmlString } from '@contentful/rich-text-html-renderer';
+import * as common from '../../functions/common';
 
 const mockCma = {
   entry: {
@@ -20,6 +23,17 @@ const mockCma = {
 vi.mock('contentful-management', () => ({
   createClient: () => mockCma,
 }));
+
+vi.mock('../../functions/common', async () => {
+  const actual =
+    await vi.importActual<typeof import('../../functions/common')>('../../functions/common');
+  return {
+    ...actual,
+    createModuleFile: vi.fn(),
+    getFiles: vi.fn(),
+    initContentfulManagementClient: vi.fn(), // <-- add this line
+  };
+});
 
 describe('app event handler', () => {
   const mockContext = {
@@ -52,9 +66,194 @@ describe('app event handler', () => {
       'removeEntryConnectedFields'
     );
 
+    vi.spyOn(common, 'initContentfulManagementClient').mockReturnValue(mockCma as any);
+
     await handler(event as any, mockContext as any);
 
     expect(removeEntryConnectedFieldsMock).toHaveBeenCalled();
     expect(removeEntryConnectedFieldsMock).toHaveBeenCalledWith(event.body.sys.id);
+  });
+
+  it('should update a module on entry save with text field', async () => {
+    const event = {
+      headers: {
+        'X-Contentful-Topic': 'Entry.save',
+      },
+      body: {
+        sys: {
+          id: 'test-entry-id',
+          contentType: { sys: { id: 'test-content-type' } },
+        },
+        fields: {
+          textField: { 'en-US': 'Hello World' },
+        },
+      },
+    };
+
+    const connectedFields = [
+      {
+        fieldId: 'textField',
+        locale: 'en-US',
+        moduleName: 'test-module',
+        updatedAt: new Date().toISOString(),
+      },
+    ];
+
+    const contentType = {
+      fields: [{ id: 'textField', type: 'Text' }],
+    };
+
+    vi.spyOn(ConfigEntryService.prototype, 'getEntryConnectedFields').mockResolvedValue(
+      connectedFields
+    );
+    vi.spyOn(ConfigEntryService.prototype, 'updateEntryConnectedFields').mockResolvedValue(
+      undefined as any
+    );
+    (common.createModuleFile as jest.Mock).mockResolvedValue(undefined as any);
+    vi.spyOn(common, 'getFiles').mockImplementation((type, value) => {
+      const fieldsFile = structuredClone(TEXT_FIELD_TEMPLATE);
+      fieldsFile[0].default = String(value);
+      return { fieldsFile: JSON.stringify(fieldsFile), moduleFile: '' };
+    });
+
+    const cma = {
+      contentType: {
+        get: vi.fn().mockResolvedValue(contentType as any),
+      },
+    };
+
+    vi.spyOn(common, 'initContentfulManagementClient').mockReturnValue(cma as any);
+
+    await handler(event as any, mockContext as any);
+
+    expect(common.createModuleFile).toHaveBeenCalledWith(
+      JSON.stringify([{ ...TEXT_FIELD_TEMPLATE[0], default: 'Hello World' }]),
+      'fields.json',
+      'test-module',
+      'test-api-key'
+    );
+  });
+
+  it('should update a module on entry save with RichText field', async () => {
+    const event = {
+      headers: {
+        'X-Contentful-Topic': 'Entry.save',
+      },
+      body: {
+        sys: {
+          id: 'test-entry-id',
+          contentType: { sys: { id: 'test-content-type' } },
+        },
+        fields: {
+          richTextField: { 'en-US': { nodeType: 'document' as any, content: [] } },
+        },
+      },
+    };
+
+    const connectedFields = [
+      {
+        fieldId: 'richTextField',
+        locale: 'en-US',
+        moduleName: 'test-module',
+        updatedAt: new Date().toISOString(),
+      },
+    ];
+
+    const contentType = {
+      fields: [{ id: 'richTextField', type: 'RichText' }],
+    };
+
+    vi.spyOn(ConfigEntryService.prototype, 'getEntryConnectedFields').mockResolvedValue(
+      connectedFields
+    );
+    vi.spyOn(ConfigEntryService.prototype, 'updateEntryConnectedFields').mockResolvedValue(
+      undefined as any
+    );
+    (common.createModuleFile as jest.Mock).mockResolvedValue(undefined as any);
+    vi.spyOn(common, 'getFiles').mockImplementation((type, value) => {
+      const fieldsFile = structuredClone(RICH_TEXT_FIELD_TEMPLATE);
+      fieldsFile[0].default = documentToHtmlString(value as any);
+      return { fieldsFile: JSON.stringify(fieldsFile), moduleFile: '' };
+    });
+    const cma = {
+      contentType: {
+        get: vi.fn().mockResolvedValue(contentType as any),
+      },
+    };
+    vi.spyOn(common, 'initContentfulManagementClient').mockReturnValue(cma as any);
+
+    await handler(event as any, mockContext as any);
+
+    expect(common.createModuleFile).toHaveBeenCalledWith(
+      JSON.stringify([
+        {
+          ...RICH_TEXT_FIELD_TEMPLATE[0],
+          default: documentToHtmlString({ nodeType: 'document', content: [] }),
+        },
+      ]),
+      'fields.json',
+      'test-module',
+      'test-api-key'
+    );
+  });
+
+  it('should update the config on save failure', async () => {
+    const event = {
+      headers: {
+        'X-Contentful-Topic': 'Entry.save',
+      },
+      body: {
+        sys: {
+          id: 'test-entry-id',
+          contentType: { sys: { id: 'test-content-type' } },
+        },
+        fields: {
+          textField: { 'en-US': 'Hello World' },
+        },
+      },
+    };
+
+    const connectedFields = [
+      {
+        fieldId: 'textField',
+        locale: 'en-US',
+        moduleName: 'test-module',
+        updatedAt: new Date().toISOString(),
+      },
+    ];
+
+    const contentType = {
+      fields: [{ id: 'textField', type: 'Text' }],
+    };
+
+    vi.spyOn(ConfigEntryService.prototype, 'getEntryConnectedFields').mockResolvedValue(
+      connectedFields
+    );
+    const updateEntryConnectedFieldsMock = vi
+      .spyOn(ConfigEntryService.prototype, 'updateEntryConnectedFields')
+      .mockResolvedValue(undefined as any);
+    (common.createModuleFile as jest.Mock).mockRejectedValue(new Error('Failed to update'));
+    vi.spyOn(common, 'getFiles').mockImplementation((type, value) => {
+      const fieldsFile = structuredClone(TEXT_FIELD_TEMPLATE);
+      fieldsFile[0].default = String(value);
+      return { fieldsFile: JSON.stringify(fieldsFile), moduleFile: '' };
+    });
+    const cma = {
+      contentType: {
+        get: vi.fn().mockResolvedValue(contentType as any),
+      },
+    };
+    vi.spyOn(common, 'initContentfulManagementClient').mockReturnValue(cma as any);
+
+    await handler(event as any, mockContext as any);
+
+    expect(updateEntryConnectedFieldsMock).toHaveBeenCalledWith('test-entry-id', [
+      expect.objectContaining({
+        fieldId: 'textField',
+        locale: 'en-US',
+        moduleName: 'test-module',
+        error: expect.objectContaining({ message: expect.stringContaining('Failed to update') }),
+      }),
+    ]);
   });
 });

--- a/apps/hubspot/test/functions/appEventHandler.spec.ts
+++ b/apps/hubspot/test/functions/appEventHandler.spec.ts
@@ -92,6 +92,15 @@ describe('app event handler', () => {
       },
     };
 
+    vi.spyOn(ConfigEntryService.prototype, 'getEntryConnectedFields').mockResolvedValue([
+      {
+        fieldId: 'someField',
+        locale: 'en-US',
+        moduleName: 'test-module',
+        updatedAt: new Date().toISOString(),
+      },
+    ]);
+
     const removeEntryConnectedFieldsMock = vi.spyOn(
       ConfigEntryService.prototype,
       'removeEntryConnectedFields'

--- a/apps/hubspot/test/functions/appEventHandler.spec.ts
+++ b/apps/hubspot/test/functions/appEventHandler.spec.ts
@@ -50,6 +50,36 @@ describe('app event handler', () => {
     vi.clearAllMocks();
   });
 
+  it('should return early if entry is not tracked in config (no connected fields)', async () => {
+    const event = {
+      headers: {
+        'X-Contentful-Topic': 'Entry.save',
+      },
+      body: {
+        sys: {
+          id: 'untracked-entry-id',
+          contentType: { sys: { id: 'test-content-type' } },
+        },
+        fields: {},
+      },
+    };
+    vi.spyOn(ConfigEntryService.prototype, 'getEntryConnectedFields').mockResolvedValue([]);
+    const removeEntryConnectedFieldsMock = vi.spyOn(
+      ConfigEntryService.prototype,
+      'removeEntryConnectedFields'
+    );
+    const updateEntryConnectedFieldsMock = vi.spyOn(
+      ConfigEntryService.prototype,
+      'updateEntryConnectedFields'
+    );
+    vi.spyOn(common, 'initContentfulManagementClient').mockReturnValue({} as any);
+
+    await handler(event as any, mockContext as any);
+
+    expect(removeEntryConnectedFieldsMock).not.toHaveBeenCalled();
+    expect(updateEntryConnectedFieldsMock).not.toHaveBeenCalled();
+  });
+
   it('should remove the entry id from the config on entry deletion', async () => {
     const event = {
       headers: {

--- a/apps/hubspot/test/locations/Sidebar.spec.tsx
+++ b/apps/hubspot/test/locations/Sidebar.spec.tsx
@@ -52,6 +52,7 @@ describe('Sidebar component', () => {
       title: 'Sync entry fields to Hubspot',
       parameters: {
         entryTitle: 'title value',
+        entryId: 'test-entry-id',
         fields: expectedFields,
       },
     });


### PR DESCRIPTION
## Purpose

This update includes the second part of the [Update modules on entry save](https://contentful.atlassian.net/jira/software/c/projects/INTEG/boards/3109?issueParent=367108&label=10-Pines&selectedIssue=INTEG-2785) ticket pending in this [PR](https://github.com/contentful/apps/pull/9972).
- Logic to update a module on Hubspot was added inside the `appEventHandler` function when the user change a connected field in Contentful.
- Refactors were added, specially to extract the repeated logic between the `createModule` and `appEventHandler` functions

## Approach

Changes in the appEventHandler and createModule functions.

## Testing steps

Automated tests were added. You can check this update manually by creating a module through the app and then modifying the field and going to Hubspot to check the update:

https://github.com/user-attachments/assets/f1f89026-bd17-4075-9cf6-54504969b536

## Breaking Changes

N/A

## Dependencies and/or References

Link to [INTEG-2785](https://contentful.atlassian.net/jira/software/c/projects/INTEG/boards/3109?issueParent=367108&label=10-Pines&selectedIssue=INTEG-2785) ticket.

## Deployment

N/A

[INTEG-2785]: https://contentful.atlassian.net/browse/INTEG-2785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ