### PR TITLE
Iterable: Use single entry endpoint []

### DIFF
--- a/apps/iterable/src/locations/Sidebar.tsx
+++ b/apps/iterable/src/locations/Sidebar.tsx
@@ -27,7 +27,7 @@ const Sidebar = () => {
 
   const link = hasError
     ? ''
-    : `https://cdn.contentful.com/spaces/${space}/environments/master/entries?access_token=${apiKey}&sys.id=${entryId}${localization}&include=10`;
+    : `https://cdn.contentful.com/spaces/${space}/environments/master/entries/${sdk.ids.entry}?access_token=${apiKey}${localization}`;
 
   return (
     <Flex flexDirection="column">

--- a/apps/iterable/test/mocks/locations/Sidebar.spec.tsx
+++ b/apps/iterable/test/mocks/locations/Sidebar.spec.tsx
@@ -60,7 +60,7 @@ describe('Sidebar', () => {
     };
     render(<Sidebar />);
     const input = screen.getByDisplayValue(
-      /https:\/\/cdn\.contentful\.com\/spaces\/space-id\/environments\/master\/entries\?access_token=.+&sys\.id=entry-id&locale=\*&include=2/
+      /https:\/\/cdn\.contentful\.com\/spaces\/space-id\/environments\/master\/entries\/entry-id\?access_token=.+&locale=\*/
     );
     expect(input).toBeTruthy();
   });


### PR DESCRIPTION
## Purpose

Change the link generation so it uses the single entry endpoint instead of the entries collection endpoint.
The single entry endpoint is simpler and the usage of the entries collection will be documented in the app documentation.