### PR TITLE
Hubspot: Address QA comments [INTEG-2907]

### DIFF
--- a/apps/hubspot/src/components/FieldSelection.tsx
+++ b/apps/hubspot/src/components/FieldSelection.tsx
@@ -87,11 +87,7 @@ const FieldCheckbox = (props: FieldCheckboxProps) => {
   };
 
   return (
-    <Tooltip
-      isDisabled={field.supported}
-      isVisible={!field.supported}
-      content="Syncing not supported"
-      placement="auto-start">
+    <Tooltip isDisabled={field.supported} content="Syncing not supported" placement="auto-start">
       <Box
         paddingLeft="spacingS"
         paddingTop="spacingXs"

--- a/apps/hubspot/src/components/FieldSelection.tsx
+++ b/apps/hubspot/src/components/FieldSelection.tsx
@@ -1,4 +1,4 @@
-import { Box, Checkbox, Paragraph, Text } from '@contentful/f36-components';
+import { Box, Checkbox, Paragraph, Text, Tooltip } from '@contentful/f36-components';
 import { css } from 'emotion';
 import tokens from '@contentful/f36-tokens';
 import { useMemo } from 'react';
@@ -87,25 +87,31 @@ const FieldCheckbox = (props: FieldCheckboxProps) => {
   };
 
   return (
-    <Box
-      paddingLeft="spacingS"
-      paddingTop="spacingXs"
-      paddingBottom="spacingXs"
-      className={css({
-        borderTop: `1px solid ${tokens.gray300}`,
-      })}>
-      <Checkbox
-        key={field.uniqueId}
-        id={field.uniqueId}
-        isChecked={checked}
-        onChange={onFieldSelected}
-        isDisabled={!field.supported}>
-        <Text fontColor={field.supported ? 'gray900' : 'gray500'} fontWeight="fontWeightMedium">
-          {displayName}
-        </Text>
-        <Text fontColor="gray500">({displayType(field)})</Text>
-      </Checkbox>
-    </Box>
+    <Tooltip
+      isDisabled={field.supported}
+      isVisible={!field.supported}
+      content="Syncing not supported"
+      placement="auto-start">
+      <Box
+        paddingLeft="spacingS"
+        paddingTop="spacingXs"
+        paddingBottom="spacingXs"
+        className={css({
+          borderTop: `1px solid ${tokens.gray300}`,
+        })}>
+        <Checkbox
+          key={field.uniqueId}
+          id={field.uniqueId}
+          isChecked={checked}
+          onChange={onFieldSelected}
+          isDisabled={!field.supported}>
+          <Text fontColor={field.supported ? 'gray900' : 'gray500'} fontWeight="fontWeightMedium">
+            {displayName}
+          </Text>
+          <Text fontColor="gray500">({displayType(field)})</Text>
+        </Checkbox>
+      </Box>
+    </Tooltip>
   );
 };
 

--- a/apps/hubspot/src/utils/ConfigEntryService.ts
+++ b/apps/hubspot/src/utils/ConfigEntryService.ts
@@ -119,7 +119,7 @@ class ConfigEntryService {
         { contentTypeId: CONFIG_CONTENT_TYPE_ID, entryId: CONFIG_ENTRY_ID },
         {
           fields: {
-            title: { [await this.getDefaultLocale()]: 'Hubspot App Configuration' },
+            title: { [await this.getDefaultLocale()]: 'Hubspot App Configuration (Do not delete)' },
           },
         }
       );

--- a/apps/hubspot/src/utils/utils.ts
+++ b/apps/hubspot/src/utils/utils.ts
@@ -5,11 +5,13 @@ export const CONFIG_FIELD_ID = 'connectedFields';
 export const HUBSPOT_PRIVATE_APPS_URL = 'https://developers.hubspot.com/docs/api/private-apps';
 
 export const CONFIG_SCREEN_INSTRUCTIONS = [
-  'Navigate to your Hubspot account settings',
-  "In the left hand navigation, click 'Integrations' and select 'Private apps' from the sub menu",
+  'Navigate to your Hubspot account settings and select ‘Profile and Preferences’',
+  'In the left hand navigation, click ‘Integrations’ and select ‘Private apps’ from the sub menu',
   'Create a new private app',
-  "Your private app must include the scope 'content'",
-  "Within your private app, navigate to the 'Auth' tab. There, you can view and copy your private app access token.",
+  'Within the ‘Scopes’ tab, add a new scope: ‘content’. Your app must include this scope.',
+  'After you finish and click ‘Create’ you will see a confirmation modal, and then a modal with your private app access token.',
+  'In the private app access token modal, show the token, and then copy it. ',
+  'At any time, within your private app, navigate to the ‘Auth’ tab. There, you can view and copy your private app access token.',
   'Paste your private app access token in the field above',
 ];
 


### PR DESCRIPTION
## Purpose

Address several comments that rose up during QA.
Out of scope: This doesn't include the Get's started section. We'll take care of that after the Page view is ready

## Approach
In the config screen:
- Updated instructions for creation
- Remove sound from the Hubspot's video 

In the Dialog:
- Added tooltip for unsupported fields during Field Selection

When creating the configEntry:  
- Updated the title so it says do not delete

## Testing steps

Config:

https://github.com/user-attachments/assets/ade24c57-6a3d-43af-95e6-b9c7688950d3

Dialog:

https://github.com/user-attachments/assets/47b03167-0862-4cdf-a667-852b1030f96d

ConfigEntry title modification

https://github.com/user-attachments/assets/c2c44a39-da64-4df0-a5a3-20945a47740c





