### PR TITLE
Hubspot: page location table [INTEG-2780]

### DIFF
--- a/apps/hubspot/src/components/ConnectedEntriesTable.styles.ts
+++ b/apps/hubspot/src/components/ConnectedEntriesTable.styles.ts
@@ -1,0 +1,8 @@
+import { css } from 'emotion';
+
+export const styles = {
+  rightCell: css({
+    minWidth: 140,
+    textAlign: 'right',
+  }),
+};

--- a/apps/hubspot/src/components/ConnectedEntriesTable.tsx
+++ b/apps/hubspot/src/components/ConnectedEntriesTable.tsx
@@ -1,0 +1,107 @@
+import { EntryProps, KeyValueMap } from 'contentful-management';
+import { ConnectedFields } from '../utils/utils';
+import { Badge, Box, Button, Flex, Table, Text } from '@contentful/f36-components';
+import React from 'react';
+import { styles } from './ConnectedEntriesTable.styles';
+
+const getStatusBadge = (entry: EntryProps<KeyValueMap>) => {
+  const isPublished = Boolean(entry.sys.publishedAt);
+  return (
+    <Badge variant={isPublished ? 'positive' : 'warning'}>
+      {isPublished ? 'Published' : 'Draft'}
+    </Badge>
+  );
+};
+
+const getLastUpdatedTime = (dateString: string | undefined) => {
+  if (!dateString) return '-';
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+  if (diffHours < 24) {
+    return `${diffHours} hour${diffHours === 1 ? '' : 's'} ago`;
+  }
+  return date.toLocaleDateString('en-GB', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  });
+};
+
+const ConnectedEntriesTable = ({
+  entries,
+  connectedFields,
+  displayFieldId,
+  locale,
+  onManageFields,
+}: {
+  entries: EntryProps<KeyValueMap>[];
+  connectedFields: ConnectedFields;
+  displayFieldId: string;
+  locale: string;
+  onManageFields: (entry: EntryProps<KeyValueMap>) => void;
+}) => (
+  <Box marginTop="spacingXl">
+    <Table>
+      <Table.Head>
+        <Table.Row>
+          <Table.Cell>
+            <Text fontWeight="fontWeightDemiBold">Entry name</Text>
+          </Table.Cell>
+          <Table.Cell>
+            <Text fontWeight="fontWeightDemiBold">Content type</Text>
+          </Table.Cell>
+          <Table.Cell>
+            <Text fontWeight="fontWeightDemiBold">Updated</Text>
+          </Table.Cell>
+          <Table.Cell>
+            <Text fontWeight="fontWeightDemiBold">Status</Text>
+          </Table.Cell>
+          <Table.Cell>
+            <Text fontWeight="fontWeightDemiBold">Connected fields</Text>
+          </Table.Cell>
+          <Table.Cell className={styles.rightCell}>
+            <Text fontColor="gray600" fontSize="fontSizeS">
+              Connected entries: {entries.length}/25
+            </Text>
+          </Table.Cell>
+        </Table.Row>
+      </Table.Head>
+      <Table.Body>
+        {entries.map((entry) => {
+          const name = entry.fields?.[displayFieldId]?.[locale] || 'Untitled';
+          const contentType = entry.sys.contentType.sys.id;
+          const updated = getLastUpdatedTime(entry.sys.updatedAt);
+          const status = getStatusBadge(entry);
+          const connected = connectedFields[entry.sys.id] || [];
+          const connectedCount = connected.length;
+          return (
+            <Table.Row key={entry.sys.id}>
+              <Table.Cell>{name}</Table.Cell>
+              <Table.Cell>{contentType}</Table.Cell>
+              <Table.Cell>{updated}</Table.Cell>
+              <Table.Cell>{status}</Table.Cell>
+              <Table.Cell>
+                <Flex flexDirection="row" gap="spacingS" alignItems="center">
+                  <Text>{connectedCount}</Text>
+                </Flex>
+              </Table.Cell>
+              <Table.Cell className={styles.rightCell}>
+                <Button
+                  variant="secondary"
+                  size="small"
+                  onClick={() => onManageFields(entry)}
+                  testId={`manage-fields-${entry.sys.id}`}>
+                  Manage fields
+                </Button>
+              </Table.Cell>
+            </Table.Row>
+          );
+        })}
+      </Table.Body>
+    </Table>
+  </Box>
+);
+
+export default ConnectedEntriesTable;

--- a/apps/hubspot/src/components/DisplayMessage.tsx
+++ b/apps/hubspot/src/components/DisplayMessage.tsx
@@ -1,0 +1,24 @@
+import { Flex, Text } from '@contentful/f36-components';
+import { styles } from '../locations/Page.styles';
+import React from 'react';
+
+type MessageProps = {
+  title: string;
+  message: string;
+};
+function DisplayMessage({ title, message }: MessageProps) {
+  return (
+    <Flex
+      flexDirection="column"
+      alignItems="center"
+      justifyContent="center"
+      className={styles.emptyComponentContainer}>
+      <Text fontSize="fontSizeL" fontWeight="fontWeightDemiBold" marginBottom="spacingXs">
+        {title}
+      </Text>
+      <Text fontColor="gray600">{message}</Text>
+    </Flex>
+  );
+}
+
+export default DisplayMessage;

--- a/apps/hubspot/src/locations/Page.styles.ts
+++ b/apps/hubspot/src/locations/Page.styles.ts
@@ -1,11 +1,6 @@
 import tokens from '@contentful/f36-tokens';
 import { css } from 'emotion';
 
-const baseTableCell = {
-  paddingTop: tokens.spacingS,
-  paddingBottom: tokens.spacingXs,
-};
-
 export const styles = {
   container: css({
     background: tokens.colorWhite,
@@ -14,76 +9,8 @@ export const styles = {
     border: `1px solid ${tokens.gray300}`,
     borderRadius: tokens.borderRadiusMedium,
   }),
-  subheading: css({
-    margin: 0,
-    fontSize: tokens.fontSizeM,
-  }),
   emptyComponentContainer: css({ minHeight: '80vh' }),
-  buttonCell: css({
-    width: '6rem',
-  }),
   loading: css({
     height: '80vh',
-  }),
-  modalMainContainer: css({
-    minWidth: 400,
-    maxHeight: '50vh',
-  }),
-  modalEntryContainer: css({
-    border: `1px solid ${tokens.gray300}`,
-    borderRadius: tokens.borderRadiusMedium,
-    background: tokens.colorWhite,
-    padding: tokens.spacingS,
-    marginBottom: tokens.spacingM,
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    gap: tokens.spacingM,
-  }),
-  modalConnectedFieldsContainer: css({
-    border: `1px solid ${tokens.gray300}`,
-    boxShadow: 'none',
-  }),
-  viewEntryButton: css({
-    marginLeft: tokens.spacingL,
-  }),
-  baseCell: css({
-    ...baseTableCell,
-    paddingLeft: 0,
-    verticalAlign: 'middle',
-  }),
-  checkboxCell: css({
-    ...baseTableCell,
-    width: 40,
-    paddingRight: tokens.spacingXs,
-    verticalAlign: 'middle',
-  }),
-  boldCell: css({
-    fontWeight: 'bold',
-  }),
-  modalErrorBanner: css({
-    background: tokens.red100,
-    border: `1px solid ${tokens.red500}`,
-    borderRadius: tokens.borderRadiusMedium,
-    padding: tokens.spacingM,
-    marginBottom: tokens.spacingS,
-    color: tokens.red700,
-    display: 'flex',
-    flexDirection: 'column',
-    gap: tokens.spacing2Xs,
-  }),
-  modalErrorTitle: css({
-    color: tokens.red700,
-    fontWeight: 'bold',
-    fontSize: tokens.fontSizeM,
-    marginBottom: tokens.spacing2Xs,
-  }),
-  modalErrorMessage: css({
-    color: tokens.red700,
-    fontSize: tokens.fontSizeS,
-  }),
-  rightCell: css({
-    minWidth: 140,
-    textAlign: 'right',
   }),
 };

--- a/apps/hubspot/src/locations/Page.styles.ts
+++ b/apps/hubspot/src/locations/Page.styles.ts
@@ -1,0 +1,89 @@
+import tokens from '@contentful/f36-tokens';
+import { css } from 'emotion';
+
+const baseTableCell = {
+  paddingTop: tokens.spacingS,
+  paddingBottom: tokens.spacingXs,
+};
+
+export const styles = {
+  container: css({
+    background: tokens.colorWhite,
+    minHeight: '100vh',
+    width: '100%',
+    border: `1px solid ${tokens.gray300}`,
+    borderRadius: tokens.borderRadiusMedium,
+  }),
+  subheading: css({
+    margin: 0,
+    fontSize: tokens.fontSizeM,
+  }),
+  emptyComponentContainer: css({ minHeight: '80vh' }),
+  buttonCell: css({
+    width: '6rem',
+  }),
+  loading: css({
+    height: '80vh',
+  }),
+  modalMainContainer: css({
+    minWidth: 400,
+    maxHeight: '50vh',
+  }),
+  modalEntryContainer: css({
+    border: `1px solid ${tokens.gray300}`,
+    borderRadius: tokens.borderRadiusMedium,
+    background: tokens.colorWhite,
+    padding: tokens.spacingS,
+    marginBottom: tokens.spacingM,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: tokens.spacingM,
+  }),
+  modalConnectedFieldsContainer: css({
+    border: `1px solid ${tokens.gray300}`,
+    boxShadow: 'none',
+  }),
+  viewEntryButton: css({
+    marginLeft: tokens.spacingL,
+  }),
+  baseCell: css({
+    ...baseTableCell,
+    paddingLeft: 0,
+    verticalAlign: 'middle',
+  }),
+  checkboxCell: css({
+    ...baseTableCell,
+    width: 40,
+    paddingRight: tokens.spacingXs,
+    verticalAlign: 'middle',
+  }),
+  boldCell: css({
+    fontWeight: 'bold',
+  }),
+  modalErrorBanner: css({
+    background: tokens.red100,
+    border: `1px solid ${tokens.red500}`,
+    borderRadius: tokens.borderRadiusMedium,
+    padding: tokens.spacingM,
+    marginBottom: tokens.spacingS,
+    color: tokens.red700,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: tokens.spacing2Xs,
+  }),
+  modalErrorTitle: css({
+    color: tokens.red700,
+    fontWeight: 'bold',
+    fontSize: tokens.fontSizeM,
+    marginBottom: tokens.spacing2Xs,
+  }),
+  modalErrorMessage: css({
+    color: tokens.red700,
+    fontSize: tokens.fontSizeS,
+  }),
+  rightCell: css({
+    minWidth: 140,
+    textAlign: 'right',
+  }),
+};

--- a/apps/hubspot/src/locations/Page.tsx
+++ b/apps/hubspot/src/locations/Page.tsx
@@ -6,6 +6,7 @@ import ConfigEntryService from '../utils/ConfigEntryService';
 import { styles } from './Page.styles';
 import { ConnectedFields } from '../utils/utils';
 import ConnectedEntriesTable from '../components/ConnectedEntriesTable';
+import DisplayMessage from '../components/DisplayMessage';
 
 const Page = () => {
   const sdk = useSDK();
@@ -85,7 +86,10 @@ const Page = () => {
           content.
         </Text>
         {loading ? (
-          <EmptyState />
+          <Flex alignItems="center" justifyContent="center" className={styles.loading}>
+            <Spinner size="large" />
+            <Text marginLeft="spacingM">Loading...</Text>
+          </Flex>
         ) : error ? (
           <DisplayMessage
             title="The app cannot load content."
@@ -109,33 +113,5 @@ const Page = () => {
     </Flex>
   );
 };
-
-function EmptyState() {
-  return (
-    <Flex alignItems="center" justifyContent="center" className={styles.loading}>
-      <Spinner size="large" />
-      <Text marginLeft="spacingM">Loading...</Text>
-    </Flex>
-  );
-}
-
-type MessageProps = {
-  title: string;
-  message: string;
-};
-function DisplayMessage({ title, message }: MessageProps) {
-  return (
-    <Flex
-      flexDirection="column"
-      alignItems="center"
-      justifyContent="center"
-      className={styles.emptyComponentContainer}>
-      <Text fontSize="fontSizeL" fontWeight="fontWeightDemiBold" marginBottom="spacingXs">
-        {title}
-      </Text>
-      <Text fontColor="gray600">{message}</Text>
-    </Flex>
-  );
-}
 
 export default Page;

--- a/apps/hubspot/src/locations/Page.tsx
+++ b/apps/hubspot/src/locations/Page.tsx
@@ -1,48 +1,15 @@
 import React, { useEffect, useState } from 'react';
-import {
-  Box,
-  Table,
-  Text,
-  Spinner,
-  Flex,
-  Heading,
-  Button,
-  Badge,
-} from '@contentful/f36-components';
+import { Box, Text, Spinner, Flex, Heading } from '@contentful/f36-components';
 import { useSDK } from '@contentful/react-apps-toolkit';
-import { createClient } from 'contentful-management';
+import { createClient, EntryProps, KeyValueMap } from 'contentful-management';
 import ConfigEntryService from '../utils/ConfigEntryService';
 import { styles } from './Page.styles';
 import { ConnectedFields } from '../utils/utils';
-
-const getStatusBadge = (entry: any) => {
-  const isPublished = Boolean(entry.sys.publishedAt);
-  return (
-    <Badge variant={isPublished ? 'positive' : 'warning'}>
-      {isPublished ? 'Published' : 'Draft'}
-    </Badge>
-  );
-};
-
-const getLastUpdatedTime = (dateString: string | undefined) => {
-  if (!dateString) return '-';
-  const date = new Date(dateString);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
-  if (diffHours < 24) {
-    return `${diffHours} hour${diffHours === 1 ? '' : 's'} ago`;
-  }
-  return date.toLocaleDateString('en-GB', {
-    day: '2-digit',
-    month: 'short',
-    year: 'numeric',
-  });
-};
+import ConnectedEntriesTable from '../components/ConnectedEntriesTable';
 
 const Page = () => {
   const sdk = useSDK();
-  const [entries, setEntries] = useState<any[]>([]);
+  const [entries, setEntries] = useState<EntryProps<KeyValueMap>[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [connectedFields, setConnectedFields] = useState<ConnectedFields>({});
@@ -103,8 +70,8 @@ const Page = () => {
     fetchData();
   }, [sdk]);
 
-  const handleManageFields = (entry: any) => {
-    sdk.navigator.openEntry(entry.sys.id);
+  const handleManageFields = (entry: EntryProps<KeyValueMap>) => {
+    // todo : implement
   };
 
   return (
@@ -142,81 +109,6 @@ const Page = () => {
     </Flex>
   );
 };
-
-const ConnectedEntriesTable = ({
-  entries,
-  connectedFields,
-  displayFieldId,
-  locale,
-  onManageFields,
-}: {
-  entries: any[];
-  connectedFields: ConnectedFields;
-  displayFieldId: string;
-  locale: string;
-  onManageFields: (entry: any) => void;
-}) => (
-  <Box marginTop="spacingXl">
-    <Table>
-      <Table.Head>
-        <Table.Row>
-          <Table.Cell>
-            <Text fontWeight="fontWeightDemiBold">Entry name</Text>
-          </Table.Cell>
-          <Table.Cell>
-            <Text fontWeight="fontWeightDemiBold">Content type</Text>
-          </Table.Cell>
-          <Table.Cell>
-            <Text fontWeight="fontWeightDemiBold">Updated</Text>
-          </Table.Cell>
-          <Table.Cell>
-            <Text fontWeight="fontWeightDemiBold">Status</Text>
-          </Table.Cell>
-          <Table.Cell>
-            <Text fontWeight="fontWeightDemiBold">Connected fields</Text>
-          </Table.Cell>
-          <Table.Cell className={styles.rightCell}>
-            <Text fontColor="gray600" fontSize="fontSizeS">
-              Connected entries: {entries.length}/25
-            </Text>
-          </Table.Cell>
-        </Table.Row>
-      </Table.Head>
-      <Table.Body>
-        {entries.map((entry) => {
-          const name = entry.fields?.[displayFieldId]?.[locale] || 'Untitled';
-          const contentType = entry.sys.contentType.sys.name || entry.sys.contentType.sys.id;
-          const updated = getLastUpdatedTime(entry.sys.updatedAt);
-          const status = getStatusBadge(entry);
-          const connected = connectedFields[entry.sys.id] || [];
-          const connectedCount = connected.length;
-          return (
-            <Table.Row key={entry.sys.id}>
-              <Table.Cell>{name}</Table.Cell>
-              <Table.Cell>{contentType}</Table.Cell>
-              <Table.Cell>{updated}</Table.Cell>
-              <Table.Cell>{status}</Table.Cell>
-              <Table.Cell>
-                <Flex flexDirection="row" gap="spacingS" alignItems="center">
-                  <Text>{connectedCount}</Text>
-                </Flex>
-              </Table.Cell>
-              <Table.Cell className={styles.rightCell}>
-                <Button
-                  variant="secondary"
-                  size="small"
-                  onClick={() => onManageFields(entry)}
-                  testId={`manage-fields-${entry.sys.id}`}>
-                  Manage fields
-                </Button>
-              </Table.Cell>
-            </Table.Row>
-          );
-        })}
-      </Table.Body>
-    </Table>
-  </Box>
-);
 
 function EmptyState() {
   return (

--- a/apps/hubspot/src/locations/Page.tsx
+++ b/apps/hubspot/src/locations/Page.tsx
@@ -1,16 +1,249 @@
-import { Paragraph } from '@contentful/f36-components';
-import { PageAppSDK } from '@contentful/app-sdk';
-import { /* useCMA, */ useSDK } from '@contentful/react-apps-toolkit';
+import React, { useEffect, useState } from 'react';
+import {
+  Box,
+  Table,
+  Text,
+  Spinner,
+  Flex,
+  Heading,
+  Button,
+  Badge,
+} from '@contentful/f36-components';
+import { useSDK } from '@contentful/react-apps-toolkit';
+import { createClient } from 'contentful-management';
+import ConfigEntryService from '../utils/ConfigEntryService';
+import { styles } from './Page.styles';
+import { ConnectedFields } from '../utils/utils';
+
+const getStatusBadge = (entry: any) => {
+  const isPublished = Boolean(entry.sys.publishedAt);
+  return (
+    <Badge variant={isPublished ? 'positive' : 'warning'}>
+      {isPublished ? 'Published' : 'Draft'}
+    </Badge>
+  );
+};
+
+const getLastUpdatedTime = (dateString: string | undefined) => {
+  if (!dateString) return '-';
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+  if (diffHours < 24) {
+    return `${diffHours} hour${diffHours === 1 ? '' : 's'} ago`;
+  }
+  return date.toLocaleDateString('en-GB', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  });
+};
 
 const Page = () => {
-  const sdk = useSDK<PageAppSDK>();
-  /*
-     To use the cma, inject it as follows.
-     If it is not needed, you can remove the next line.
-  */
-  // const cma = useCMA();
+  const sdk = useSDK();
+  const [entries, setEntries] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [connectedFields, setConnectedFields] = useState<ConnectedFields>({});
+  const [displayFieldId, setDisplayFieldId] = useState('title');
+  const [locale, setLocale] = useState('en-US');
 
-  return <Paragraph>Hello Page Component (AppId: {sdk.ids.app})</Paragraph>;
+  useEffect(() => {
+    const fetchData = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const cma = createClient(
+          { apiAdapter: sdk.cmaAdapter },
+          {
+            type: 'plain',
+            defaults: {
+              environmentId: sdk.ids.environment,
+              spaceId: sdk.ids.space,
+            },
+          }
+        );
+        const configService = new ConfigEntryService(cma, sdk.locales.default);
+        const connected = await configService.getConnectedFields();
+        setConnectedFields(connected);
+        setLocale(sdk.locales.default);
+        let displayField = 'title';
+        const entryIds = Object.keys(connected);
+        if (entryIds.length === 0) {
+          setEntries([]);
+          setDisplayFieldId('title');
+          setLoading(false);
+          return;
+        }
+        const fetchedEntries = [];
+        for (const entryId of entryIds) {
+          try {
+            const entry = await cma.entry.get({ entryId });
+            fetchedEntries.push(entry);
+            if (fetchedEntries.length === 1) {
+              const ct = await cma.contentType.get({ contentTypeId: entry.sys.contentType.sys.id });
+              displayField = ct.displayField || 'title';
+            }
+          } catch (e) {
+            // skip missing entry
+          }
+        }
+        setEntries(fetchedEntries);
+        setDisplayFieldId(displayField);
+      } catch (e) {
+        setEntries([]);
+        setError(
+          'The app cannot load content. Try refreshing, or reviewing your app configuration.'
+        );
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, [sdk]);
+
+  const handleManageFields = (entry: any) => {
+    sdk.navigator.openEntry(entry.sys.id);
+  };
+
+  return (
+    <Flex justifyContent="center" paddingLeft="spacing2Xl" paddingRight="spacing2Xl">
+      <Box className={styles.container} padding="spacingL">
+        <Heading as="h1" marginBottom="spacingM">
+          Hubspot
+        </Heading>
+        <Text fontColor="gray600" marginBottom="spacingL">
+          View the details of your synced entry fields. Click Manage fields to connect or disconnect
+          content.
+        </Text>
+        {loading ? (
+          <EmptyState />
+        ) : error ? (
+          <DisplayMessage
+            title="The app cannot load content."
+            message="Try refreshing, or reviewing your app configuration"
+          />
+        ) : entries.length === 0 ? (
+          <DisplayMessage
+            title="No active Hubspot modules"
+            message="Once you have created modules, they will display here."
+          />
+        ) : (
+          <ConnectedEntriesTable
+            entries={entries}
+            connectedFields={connectedFields}
+            displayFieldId={displayFieldId}
+            locale={locale}
+            onManageFields={handleManageFields}
+          />
+        )}
+      </Box>
+    </Flex>
+  );
 };
+
+const ConnectedEntriesTable = ({
+  entries,
+  connectedFields,
+  displayFieldId,
+  locale,
+  onManageFields,
+}: {
+  entries: any[];
+  connectedFields: ConnectedFields;
+  displayFieldId: string;
+  locale: string;
+  onManageFields: (entry: any) => void;
+}) => (
+  <Box marginTop="spacingXl">
+    <Table>
+      <Table.Head>
+        <Table.Row>
+          <Table.Cell>
+            <Text fontWeight="fontWeightDemiBold">Entry name</Text>
+          </Table.Cell>
+          <Table.Cell>
+            <Text fontWeight="fontWeightDemiBold">Content type</Text>
+          </Table.Cell>
+          <Table.Cell>
+            <Text fontWeight="fontWeightDemiBold">Updated</Text>
+          </Table.Cell>
+          <Table.Cell>
+            <Text fontWeight="fontWeightDemiBold">Status</Text>
+          </Table.Cell>
+          <Table.Cell>
+            <Text fontWeight="fontWeightDemiBold">Connected fields</Text>
+          </Table.Cell>
+          <Table.Cell align="right" style={{ minWidth: 140 }}>
+            <Text fontColor="gray600" fontSize="fontSizeS">
+              Connected entries: {entries.length}/25
+            </Text>
+          </Table.Cell>
+        </Table.Row>
+      </Table.Head>
+      <Table.Body>
+        {entries.map((entry) => {
+          const name = entry.fields?.[displayFieldId]?.[locale] || 'Untitled';
+          const contentType = entry.sys.contentType.sys.name || entry.sys.contentType.sys.id;
+          const updated = getLastUpdatedTime(entry.sys.updatedAt);
+          const status = getStatusBadge(entry);
+          const connected = connectedFields[entry.sys.id] || [];
+          const connectedCount = connected.length;
+          return (
+            <Table.Row key={entry.sys.id}>
+              <Table.Cell>{name}</Table.Cell>
+              <Table.Cell>{contentType}</Table.Cell>
+              <Table.Cell>{updated}</Table.Cell>
+              <Table.Cell>{status}</Table.Cell>
+              <Table.Cell>
+                <Flex flexDirection="row" gap="spacingS" alignItems="center">
+                  <Text>{connectedCount}</Text>
+                </Flex>
+              </Table.Cell>
+              <Table.Cell align="right">
+                <Button
+                  variant="secondary"
+                  size="small"
+                  onClick={() => onManageFields(entry)}
+                  testId={`manage-fields-${entry.sys.id}`}>
+                  Manage fields
+                </Button>
+              </Table.Cell>
+            </Table.Row>
+          );
+        })}
+      </Table.Body>
+    </Table>
+  </Box>
+);
+
+function EmptyState() {
+  return (
+    <Flex alignItems="center" justifyContent="center" className={styles.loading}>
+      <Spinner size="large" />
+      <Text marginLeft="spacingM">Loading...</Text>
+    </Flex>
+  );
+}
+
+type MessageProps = {
+  title: string;
+  message: string;
+};
+function DisplayMessage({ title, message }: MessageProps) {
+  return (
+    <Flex
+      flexDirection="column"
+      alignItems="center"
+      justifyContent="center"
+      className={styles.emptyComponentContainer}>
+      <Text fontSize="fontSizeL" fontWeight="fontWeightDemiBold" marginBottom="spacingXs">
+        {title}
+      </Text>
+      <Text fontColor="gray600">{message}</Text>
+    </Flex>
+  );
+}
 
 export default Page;

--- a/apps/hubspot/src/locations/Page.tsx
+++ b/apps/hubspot/src/locations/Page.tsx
@@ -175,7 +175,7 @@ const ConnectedEntriesTable = ({
           <Table.Cell>
             <Text fontWeight="fontWeightDemiBold">Connected fields</Text>
           </Table.Cell>
-          <Table.Cell align="right" style={{ minWidth: 140 }}>
+          <Table.Cell className={styles.rightCell}>
             <Text fontColor="gray600" fontSize="fontSizeS">
               Connected entries: {entries.length}/25
             </Text>
@@ -201,7 +201,7 @@ const ConnectedEntriesTable = ({
                   <Text>{connectedCount}</Text>
                 </Flex>
               </Table.Cell>
-              <Table.Cell align="right">
+              <Table.Cell className={styles.rightCell}>
                 <Button
                   variant="secondary"
                   size="small"

--- a/apps/hubspot/test/locations/Page.spec.tsx
+++ b/apps/hubspot/test/locations/Page.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, waitFor, screen, cleanup, fireEvent } from '@testing-library/react';
+import { render, waitFor, screen, cleanup } from '@testing-library/react';
 import { vi, describe, beforeEach, it, expect, afterEach } from 'vitest';
 import Page from '../../src/locations/Page';
 
@@ -92,7 +92,7 @@ describe('Page Location', () => {
       .mockResolvedValueOnce({
         sys: {
           id: 'entry-1',
-          contentType: { sys: { id: 'ct1', name: 'Fruits' } },
+          contentType: { sys: { id: 'Fruits' } },
           updatedAt: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
           publishedAt: new Date().toISOString(),
         },
@@ -101,7 +101,7 @@ describe('Page Location', () => {
       .mockResolvedValueOnce({
         sys: {
           id: 'entry-2',
-          contentType: { sys: { id: 'ct2', name: 'Animals' } },
+          contentType: { sys: { id: 'Animals' } },
           updatedAt: new Date(Date.now() - 10 * 60 * 60 * 1000).toISOString(),
           publishedAt: undefined,
         },
@@ -122,26 +122,5 @@ describe('Page Location', () => {
       expect(screen.getByText('2')).toBeTruthy();
       expect(screen.getByText('1')).toBeTruthy();
     });
-  });
-
-  it('calls openEntry when Manage fields is clicked', async () => {
-    mockGetConnectedFields.mockResolvedValue({
-      'entry-1': [{ fieldId: 'title', moduleName: 'mod1', updatedAt: '2024-05-01T10:00:00Z' }],
-    });
-    mockCma.entry.get.mockResolvedValueOnce({
-      sys: {
-        id: 'entry-1',
-        contentType: { sys: { id: 'ct1', name: 'Fruits' } },
-        updatedAt: new Date().toISOString(),
-        publishedAt: new Date().toISOString(),
-      },
-      fields: { title: { 'en-US': 'Banana' } },
-    });
-    mockCma.contentType.get.mockResolvedValue({ displayField: 'title' });
-
-    render(<Page />);
-    const btn = await screen.findByRole('button', { name: /Manage fields/i });
-    fireEvent.click(btn);
-    expect(mockNavigator.openEntry).toHaveBeenCalledWith('entry-1');
   });
 });

--- a/apps/hubspot/test/locations/Page.spec.tsx
+++ b/apps/hubspot/test/locations/Page.spec.tsx
@@ -31,7 +31,6 @@ vi.mock('contentful-management', () => ({
 const mockGetConnectedFields = vi.fn();
 vi.mock('../../src/utils/ConfigEntryService', () => {
   return {
-    __esModule: true,
     default: vi.fn().mockImplementation(() => ({
       getConnectedFields: mockGetConnectedFields,
     })),

--- a/apps/hubspot/test/locations/Page.spec.tsx
+++ b/apps/hubspot/test/locations/Page.spec.tsx
@@ -1,16 +1,148 @@
+import React from 'react';
+import { render, waitFor, screen, cleanup, fireEvent } from '@testing-library/react';
+import { vi, describe, beforeEach, it, expect, afterEach } from 'vitest';
 import Page from '../../src/locations/Page';
-import { render } from '@testing-library/react';
-import { mockCma, mockSdk } from '../mocks';
+
+const mockNavigator = { openEntry: vi.fn() };
+const mockSdk = {
+  cmaAdapter: {},
+  ids: { environment: 'env', space: 'space' },
+  locales: { default: 'en-US' },
+  navigator: mockNavigator,
+};
+
+const mockCma = {
+  entry: {
+    get: vi.fn(),
+  },
+  contentType: {
+    get: vi.fn(),
+  },
+};
 
 vi.mock('@contentful/react-apps-toolkit', () => ({
   useSDK: () => mockSdk,
-  useCMA: () => mockCma,
 }));
 
-describe('Page component', () => {
-  it('Component text exists', () => {
-    const { getByText } = render(<Page />);
+vi.mock('contentful-management', () => ({
+  createClient: () => mockCma,
+}));
 
-    expect(getByText('Hello Page Component (AppId: test-app)')).toBeInTheDocument();
+const mockGetConnectedFields = vi.fn();
+vi.mock('../../src/utils/ConfigEntryService', () => {
+  return {
+    __esModule: true,
+    default: vi.fn().mockImplementation(() => ({
+      getConnectedFields: mockGetConnectedFields,
+    })),
+  };
+});
+
+describe('Page Location', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders loading state initially', () => {
+    mockGetConnectedFields.mockReturnValue(new Promise(() => {}));
+
+    render(<Page />);
+
+    expect(screen.getByText(/Loading.../i)).toBeTruthy();
+  });
+
+  it('renders empty table if no connected entries', async () => {
+    mockGetConnectedFields.mockResolvedValue({});
+
+    render(<Page />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Hubspot')).toBeTruthy();
+      expect(
+        screen.getByText(
+          /View the details of your synced entry fields. Click Manage fields to connect or disconnect content./i
+        )
+      ).toBeTruthy();
+      expect(screen.getByText('No active Hubspot modules')).toBeTruthy();
+      expect(
+        screen.getByText('Once you have created modules, they will display here.')
+      ).toBeTruthy();
+      expect(screen.queryByRole('row', { name: /Manage fields/i })).toBeNull();
+    });
+  });
+
+  it('renders connected entries table if entries exist', async () => {
+    mockGetConnectedFields.mockResolvedValue({
+      'entry-1': [
+        { fieldId: 'title', moduleName: 'mod1', updatedAt: '2024-05-01T10:00:00Z' },
+        { fieldId: 'desc', moduleName: 'mod2', updatedAt: '2024-05-01T10:00:00Z' },
+      ],
+      'entry-2': [
+        {
+          fieldId: 'title',
+          moduleName: 'mod1',
+          updatedAt: '2024-05-01T10:00:00Z',
+        },
+      ],
+    });
+    mockCma.entry.get
+      .mockResolvedValueOnce({
+        sys: {
+          id: 'entry-1',
+          contentType: { sys: { id: 'ct1', name: 'Fruits' } },
+          updatedAt: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
+          publishedAt: new Date().toISOString(),
+        },
+        fields: { title: { 'en-US': 'Banana' } },
+      })
+      .mockResolvedValueOnce({
+        sys: {
+          id: 'entry-2',
+          contentType: { sys: { id: 'ct2', name: 'Animals' } },
+          updatedAt: new Date(Date.now() - 10 * 60 * 60 * 1000).toISOString(),
+          publishedAt: undefined,
+        },
+        fields: { title: { 'en-US': 'Dog' } },
+      });
+    mockCma.contentType.get.mockResolvedValue({ displayField: 'title' });
+
+    render(<Page />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Banana')).toBeTruthy();
+      expect(screen.getByText('Dog')).toBeTruthy();
+      expect(screen.getByText('Fruits')).toBeTruthy();
+      expect(screen.getByText('Animals')).toBeTruthy();
+      expect(screen.getByText('Published')).toBeTruthy();
+      expect(screen.getByText('Draft')).toBeTruthy();
+      expect(screen.getAllByText('Manage fields').length).toBe(2);
+      expect(screen.getByText('2')).toBeTruthy();
+      expect(screen.getByText('1')).toBeTruthy();
+    });
+  });
+
+  it('calls openEntry when Manage fields is clicked', async () => {
+    mockGetConnectedFields.mockResolvedValue({
+      'entry-1': [{ fieldId: 'title', moduleName: 'mod1', updatedAt: '2024-05-01T10:00:00Z' }],
+    });
+    mockCma.entry.get.mockResolvedValueOnce({
+      sys: {
+        id: 'entry-1',
+        contentType: { sys: { id: 'ct1', name: 'Fruits' } },
+        updatedAt: new Date().toISOString(),
+        publishedAt: new Date().toISOString(),
+      },
+      fields: { title: { 'en-US': 'Banana' } },
+    });
+    mockCma.contentType.get.mockResolvedValue({ displayField: 'title' });
+
+    render(<Page />);
+    const btn = await screen.findByRole('button', { name: /Manage fields/i });
+    fireEvent.click(btn);
+    expect(mockNavigator.openEntry).toHaveBeenCalledWith('entry-1');
   });
 });


### PR DESCRIPTION
## Purpose

This update includes the table for the page location connected entries.

## Approach

The table was created and some edge cases were handled (such as "loading state", "no connected entries" and "error when fetching").

## Testing steps

Automated test were added.

https://github.com/user-attachments/assets/f81dce4c-0ab6-47c0-b201-0b4922809100

Error message:
<img width="1512" height="772" alt="Captura de pantalla 2025-07-15 a la(s) 9 46 02 a  m" src="https://github.com/user-attachments/assets/d1d3ee68-d541-404a-a065-6fbfb22b247f" />

## Breaking Changes

N/A

## Dependencies and/or References

Link to [INTEG-2780](https://contentful.atlassian.net/jira/software/c/projects/INTEG/boards/3109?issueParent=367108&label=10-Pines&selectedIssue=INTEG-2780) ticket.

## Deployment

N/A

[INTEG-2780]: https://contentful.atlassian.net/browse/INTEG-2780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ