### PR TITLE
Mux: Fixed signed tokens in Entry preview []

### DIFF
--- a/apps/mux/frontend/src/index.tsx
+++ b/apps/mux/frontend/src/index.tsx
@@ -1222,6 +1222,7 @@ export class App extends React.Component<AppProps, AppState> {
               <div>
                 <section className="player" style={this.getPlayerAspectRatio()}>
                   {this.state.playerPlaybackId !== 'playback-test-123' &&
+                  (!this.isUsingSigned() || !this.state.isTokenLoading) &&
                   (this.state.value.playbackId || this.state.playbackToken) ? (
                     <MuxPlayer
                       ref={this.muxPlayerRef}


### PR DESCRIPTION
## Purpose

When an Entry contains the Mux plugin and the Asset is protected (or signed), an error occurred when trying to display the player because it attempted to play the video without the required tokens. This happened because the token retrieval call was made after rendering the player.

## Approach

We now ensure that the token is retrieved before rendering the player. This change guarantees that the player has the necessary credentials at render time.

## Testing steps

1. Create an Entry with a protected Asset.
2. Refresh the page.
3. The player should now render correctly without errors.

## Breaking Changes

None.

## Dependencies and/or References

No additional dependencies or references.

## Deployment

No deployment-related changes or concerns.
