### PR TITLE
Hubspot: Fix localization default names for modules issue [INTEG-2936]

### DIFF
--- a/apps/hubspot/src/locations/Dialog.tsx
+++ b/apps/hubspot/src/locations/Dialog.tsx
@@ -51,8 +51,9 @@ const Dialog = () => {
     selectedFieldObjects.forEach((field) => {
       const updatedEntryTitle = entryTitle.replace(/\s+/g, '-').replace(/[^A-Za-z0-9_-]/g, '');
       const updatedFieldName = field.name.replace(/\s+/g, '-').replace(/[^A-Za-z0-9_-]/g, '');
+      const locale = field.locale ? `-${field.locale}` : '';
       initialNameMapping[field.uniqueId] =
-        moduleNameMapping[field.uniqueId] ?? `${updatedEntryTitle}_${updatedFieldName}`;
+        moduleNameMapping[field.uniqueId] ?? `${updatedEntryTitle}-${updatedFieldName}${locale}`;
     });
     setModuleNameMapping(initialNameMapping);
   };

--- a/apps/hubspot/test/locations/Dialog.spec.tsx
+++ b/apps/hubspot/test/locations/Dialog.spec.tsx
@@ -205,7 +205,7 @@ describe('Dialog component', () => {
             },
             {
               ...expectedFields[1],
-              moduleName: 'test-entry-title_Description',
+              moduleName: 'test-entry-title-Description-en-US',
             },
           ]),
         },


### PR DESCRIPTION
## Purpose
Localize and non-localized fields have the same default name when creating a module. We want to change that.

## Approach

- Improve naming convention to include localization. 
- Every whitespace is now a hypen

## Testing steps


https://github.com/user-attachments/assets/ed2cffee-d1cd-4375-b6c7-6b26824fce8f


