### PR TITLE
Hubspot: Move tooltip for syncing not supported [INTEG-2937]

### DIFF
--- a/apps/hubspot/src/components/FieldSelection.tsx
+++ b/apps/hubspot/src/components/FieldSelection.tsx
@@ -76,27 +76,27 @@ const FieldCheckbox = (props: FieldCheckboxProps) => {
   };
 
   return (
-    <Tooltip isDisabled={field.supported} content="Syncing not supported" placement="auto-start">
-      <Box
-        paddingLeft="spacingS"
-        paddingTop="spacingXs"
-        paddingBottom="spacingXs"
-        className={css({
-          borderTop: `1px solid ${tokens.gray300}`,
-        })}>
-        <Checkbox
-          key={field.uniqueId}
-          id={field.uniqueId}
-          isChecked={checked}
-          onChange={onFieldSelected}
-          isDisabled={!field.supported}>
+    <Box
+      paddingLeft="spacingS"
+      paddingTop="spacingXs"
+      paddingBottom="spacingXs"
+      className={css({
+        borderTop: `1px solid ${tokens.gray300}`,
+      })}>
+      <Checkbox
+        key={field.uniqueId}
+        id={field.uniqueId}
+        isChecked={checked}
+        onChange={onFieldSelected}
+        isDisabled={!field.supported}>
+        <Tooltip isDisabled={field.supported} content="Syncing not supported" placement="right">
           <Text fontColor={field.supported ? 'gray900' : 'gray500'} fontWeight="fontWeightMedium">
-            {displayName}
+            {displayName}{' '}
           </Text>
           <Text fontColor="gray500">({displayType(field.type, field.linkType, field.items)})</Text>
-        </Checkbox>
-      </Box>
-    </Tooltip>
+        </Tooltip>
+      </Checkbox>
+    </Box>
   );
 };
 


### PR DESCRIPTION
## Purpose

Move tooltip for syncing not supported to look similar to Figma

## Approach
- Move tooltip

## Testing steps

<img width="1549" height="858" alt="Captura de pantalla 2025-07-21 a la(s) 10 16 05 a  m" src="https://github.com/user-attachments/assets/3b3c15a4-75fd-4ac1-ad3c-a35ca62decfe" />


