### PR TITLE
Hubspot: Avoid duplicated module creation [INTEG-2935]

### DIFF
--- a/apps/hubspot/src/locations/Dialog.tsx
+++ b/apps/hubspot/src/locations/Dialog.tsx
@@ -57,7 +57,7 @@ const Dialog = () => {
       setConnectedFieldIds(ids);
     };
     fetchConnectedFields();
-  }, [invocationParams.entryId]);
+  }, []);
 
   const selectedFieldObjects = useMemo(
     () => fields.filter((f) => selectedFields.includes(f.uniqueId)),


### PR DESCRIPTION
## Purpose

We want to avoid creating the same module for a field in an entry twice

## Approach

- Call the Config entry service to get Connected fields for that entry 
- Block selection from Field Selection
- Add tooltip to warn the user that field is already Connected 

## Testing steps

https://github.com/user-attachments/assets/8e94bc57-b172-41ea-b8de-1d47a5696447



