### PR TITLE
Hubspot: changing displaying field and content type id for name [INTEG-2971]

### DIFF
--- a/apps/hubspot/src/components/ConnectedEntriesTable.tsx
+++ b/apps/hubspot/src/components/ConnectedEntriesTable.tsx
@@ -1,8 +1,8 @@
-import {EntryProps, KeyValueMap} from 'contentful-management';
-import {ConnectedFields, EntryWithContentType, getEntryTitle} from '../utils/utils';
-import {Badge, Box, Button, Flex, Table, Text} from '@contentful/f36-components';
-import {styles} from './ConnectedEntriesTable.styles';
-import {WarningOctagonIcon} from '@phosphor-icons/react';
+import { EntryProps, KeyValueMap } from 'contentful-management';
+import { ConnectedFields, EntryWithContentType, getEntryTitle } from '../utils/utils';
+import { Badge, Box, Button, Flex, Table, Text } from '@contentful/f36-components';
+import { styles } from './ConnectedEntriesTable.styles';
+import { WarningOctagonIcon } from '@phosphor-icons/react';
 
 const getStatusBadge = (entry: EntryProps<KeyValueMap>) => {
   const isPublished = Boolean(entry.sys.publishedAt);

--- a/apps/hubspot/src/components/ConnectedEntriesTable.tsx
+++ b/apps/hubspot/src/components/ConnectedEntriesTable.tsx
@@ -1,8 +1,8 @@
-import { EntryProps, KeyValueMap } from 'contentful-management';
-import { ConnectedFields, EntryWithContentType, getEntryTitle } from '../utils/utils';
-import { Badge, Box, Button, Flex, Table, Text } from '@contentful/f36-components';
-import { styles } from './ConnectedEntriesTable.styles';
-import { WarningOctagonIcon } from '@phosphor-icons/react';
+import {EntryProps, KeyValueMap} from 'contentful-management';
+import {ConnectedFields, EntryWithContentType, getEntryTitle} from '../utils/utils';
+import {Badge, Box, Button, Flex, Table, Text} from '@contentful/f36-components';
+import {styles} from './ConnectedEntriesTable.styles';
+import {WarningOctagonIcon} from '@phosphor-icons/react';
 
 const getStatusBadge = (entry: EntryProps<KeyValueMap>) => {
   const isPublished = Boolean(entry.sys.publishedAt);
@@ -69,7 +69,6 @@ const ConnectedEntriesTable = ({
       <Table.Body>
         {entries.map(({ entry, contentType }) => {
           const name = getEntryTitle(entry, contentType, defaultLocale);
-          const contentTypeName = contentType.name;
           const updated = getLastUpdatedTime(entry.sys.updatedAt);
           const status = getStatusBadge(entry);
           const connected = connectedFields[entry.sys.id] || [];
@@ -79,7 +78,7 @@ const ConnectedEntriesTable = ({
           return (
             <Table.Row key={entry.sys.id}>
               <Table.Cell>{name}</Table.Cell>
-              <Table.Cell>{contentTypeName}</Table.Cell>
+              <Table.Cell>{contentType.name}</Table.Cell>
               <Table.Cell>{updated}</Table.Cell>
               <Table.Cell>{status}</Table.Cell>
               <Table.Cell>

--- a/apps/hubspot/src/components/ConnectedEntriesTable.tsx
+++ b/apps/hubspot/src/components/ConnectedEntriesTable.tsx
@@ -69,7 +69,7 @@ const ConnectedEntriesTable = ({
       <Table.Body>
         {entries.map(({ entry, contentType }) => {
           const name = getEntryTitle(entry, contentType, defaultLocale);
-          const contentTypeId = contentType.sys?.id;
+          const contentTypeName = contentType.name;
           const updated = getLastUpdatedTime(entry.sys.updatedAt);
           const status = getStatusBadge(entry);
           const connected = connectedFields[entry.sys.id] || [];
@@ -79,7 +79,7 @@ const ConnectedEntriesTable = ({
           return (
             <Table.Row key={entry.sys.id}>
               <Table.Cell>{name}</Table.Cell>
-              <Table.Cell>{contentTypeId}</Table.Cell>
+              <Table.Cell>{contentTypeName}</Table.Cell>
               <Table.Cell>{updated}</Table.Cell>
               <Table.Cell>{status}</Table.Cell>
               <Table.Cell>

--- a/apps/hubspot/src/components/ConnectedFieldsModal.tsx
+++ b/apps/hubspot/src/components/ConnectedFieldsModal.tsx
@@ -76,13 +76,22 @@ const ConnectedFieldsModal: React.FC<ConnectedFieldsModalProps> = ({
     onDisconnect(Array.from(selectedFields));
   }
 
+  function getContentTypeField(fieldId: string) {
+    return entryWithContentType.contentType.fields.find(
+      (contentTypeField) => contentTypeField.id === fieldId
+    );
+  }
+
   function getFieldDisplayName(fieldId: string, locale?: string) {
-    return locale ? `${fieldId} (${locale})` : `${fieldId}`;
+    const field = getContentTypeField(fieldId);
+
+    return locale ? `${field?.name} (${locale})` : `${field?.name}`;
   }
 
   function getFieldDisplayType(fieldId: string) {
-    const field = entryWithContentType.contentType.fields.find((f) => f.id === fieldId);
+    const field = getContentTypeField(fieldId);
     if (!field) return '';
+
     return displayType(field.type, field.linkType, field.items);
   }
 

--- a/apps/hubspot/test/locations/Page.spec.tsx
+++ b/apps/hubspot/test/locations/Page.spec.tsx
@@ -117,7 +117,7 @@ describe('Page Location', () => {
         {
           sys: {
             id: 'entry-1',
-            contentType: { sys: { id: 'Fruits' } },
+            contentType: { sys: { id: 'fruits' } },
             updatedAt: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
             publishedAt: new Date().toISOString(),
           },
@@ -128,7 +128,7 @@ describe('Page Location', () => {
         {
           sys: {
             id: 'entry-2',
-            contentType: { sys: { id: 'Animals' } },
+            contentType: { sys: { id: 'animals' } },
             updatedAt: new Date(Date.now() - 10 * 60 * 60 * 1000).toISOString(),
             publishedAt: undefined,
           },
@@ -138,19 +138,21 @@ describe('Page Location', () => {
     });
 
     mockCma.contentType.get = vi.fn().mockImplementation(({ contentTypeId }) => {
-      if (contentTypeId === 'Fruits') {
+      if (contentTypeId === 'fruits') {
         return Promise.resolve({
           displayField: 'title',
-          sys: { id: 'Fruits' },
+          name: 'Fruits',
+          sys: { id: 'fruits' },
           fields: [
             { id: 'title', name: 'Title', type: 'Text' },
             { id: 'description', name: 'Description', type: 'Text' },
           ],
         });
       }
-      if (contentTypeId === 'Animals') {
+      if (contentTypeId === 'animals') {
         return Promise.resolve({
-          sys: { id: 'Animals' },
+          name: 'Animals',
+          sys: { id: 'animals' },
           displayField: 'title',
           fields: [{ id: 'title', name: 'Title', type: 'Text' }],
         });
@@ -198,7 +200,7 @@ describe('Page Location', () => {
           {
             sys: {
               id: 'entry-id',
-              contentType: { sys: { id: 'Fruits' } },
+              contentType: { sys: { id: 'fruits' } },
               updatedAt: new Date().toISOString(),
               publishedAt: new Date().toISOString(),
             },
@@ -212,7 +214,8 @@ describe('Page Location', () => {
       });
       mockCma.contentType.get = vi.fn().mockResolvedValue({
         displayField: 'title',
-        sys: { id: 'Fruits' },
+        name: 'Fruits',
+        sys: { id: 'fruits' },
         fields: [
           { id: 'title', name: 'Title', type: 'Symbol' },
           { id: 'description', name: 'Description', type: 'Text' },

--- a/apps/hubspot/test/locations/Page.spec.tsx
+++ b/apps/hubspot/test/locations/Page.spec.tsx
@@ -232,11 +232,11 @@ describe('Page Location', () => {
       expect(screen.getByTestId('modal-entry-title')).toBeTruthy();
       expect(screen.getByText((content) => content.startsWith('Select all fields'))).toBeTruthy();
       expect(screen.getByText('View entry')).toBeTruthy();
-      expect(screen.getByText('title')).toBeTruthy();
+      expect(screen.getByText('Title')).toBeTruthy();
       expect(screen.getByText('(Short text)')).toBeTruthy();
-      expect(screen.getByText('description')).toBeTruthy();
-      expect(screen.getByText('greeting (en-US)')).toBeTruthy();
-      expect(screen.getByText('greeting (es-AR)')).toBeTruthy();
+      expect(screen.getByText('Description')).toBeTruthy();
+      expect(screen.getByText('Greeting (en-US)')).toBeTruthy();
+      expect(screen.getByText('Greeting (es-AR)')).toBeTruthy();
     });
 
     it('selects/deselects all fields with header checkbox', async () => {
@@ -247,10 +247,10 @@ describe('Page Location', () => {
       const selectAll = screen.getByTestId('select-all-fields');
       // Select all
       fireEvent.click(selectAll);
-      expect((screen.getByLabelText('description') as HTMLInputElement).checked).toBe(true);
+      expect((screen.getByLabelText('Description') as HTMLInputElement).checked).toBe(true);
       // Deselect all
       fireEvent.click(selectAll);
-      expect((screen.getByLabelText('description') as HTMLInputElement).checked).toBe(false);
+      expect((screen.getByLabelText('Description') as HTMLInputElement).checked).toBe(false);
     });
 
     it('toggles individual field selection', async () => {
@@ -258,7 +258,7 @@ describe('Page Location', () => {
       const btn = await screen.findByRole('button', { name: /Manage fields/i });
       fireEvent.click(btn);
       await screen.findByRole('dialog');
-      const descriptionCheckbox = screen.getByLabelText('description') as HTMLInputElement;
+      const descriptionCheckbox = screen.getByLabelText('Description') as HTMLInputElement;
       expect(descriptionCheckbox.checked).toBe(false);
       fireEvent.click(descriptionCheckbox);
       expect(descriptionCheckbox.checked).toBe(true);
@@ -285,7 +285,7 @@ describe('Page Location', () => {
       expect(screen.queryByRole('button', { name: /Disconnect/i })).toBeDisabled();
 
       // Select a field
-      const titleCheckbox = screen.getByLabelText('title') as HTMLInputElement;
+      const titleCheckbox = screen.getByLabelText('Title') as HTMLInputElement;
       fireEvent.click(titleCheckbox);
 
       // Disconnect button should be enabled
@@ -300,8 +300,8 @@ describe('Page Location', () => {
       await screen.findByRole('dialog');
 
       // Select multiple fields
-      const titleCheckbox = screen.getByLabelText('title') as HTMLInputElement;
-      const descriptionCheckbox = screen.getByLabelText('description') as HTMLInputElement;
+      const titleCheckbox = screen.getByLabelText('Title') as HTMLInputElement;
+      const descriptionCheckbox = screen.getByLabelText('Description') as HTMLInputElement;
       fireEvent.click(titleCheckbox);
       fireEvent.click(descriptionCheckbox);
 
@@ -362,10 +362,10 @@ describe('Page Location', () => {
       await waitFor(() => screen.findByRole('dialog'));
 
       // Select title field
-      const titleCheckbox = screen.getByLabelText('title') as HTMLInputElement;
+      const titleCheckbox = screen.getByLabelText('Title') as HTMLInputElement;
       fireEvent.click(titleCheckbox);
 
-      const greetingCheckbox = screen.getByLabelText('greeting (en-US)') as HTMLInputElement;
+      const greetingCheckbox = screen.getByLabelText('Greeting (en-US)') as HTMLInputElement;
       fireEvent.click(greetingCheckbox);
 
       // Click disconnect


### PR DESCRIPTION
## Purpose

- Use field name instead of id in the modal 
- Use content type name instead of id in the table

## Approach

The Page table and modal were modified so the name is displayed instead of the id.

## Testing steps

Automated tests were changed as well to match the field and content type name. Now it displays the name:
<img width="1512" height="884" alt="Captura de pantalla 2025-07-25 a la(s) 12 32 55 p  m" src="https://github.com/user-attachments/assets/d1346fb2-359d-4b2e-b8f4-6914929f296f" />

## Breaking Changes

N/A

## Dependencies and/or References

Link to [INTEG-2971](https://contentful.atlassian.net/jira/software/c/projects/INTEG/boards/3109?selectedIssue=INTEG-2971) ticket.

## Deployment

N/A

[INTEG-2971]: https://contentful.atlassian.net/browse/INTEG-2971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ