### PR TITLE
Hubspot: no duplicated names in module selection [INTEG-2967]

### DIFF
--- a/apps/hubspot/src/components/FieldModuleNameMapping.tsx
+++ b/apps/hubspot/src/components/FieldModuleNameMapping.tsx
@@ -21,11 +21,8 @@ const FieldModuleNameMapping = ({
 }: FieldModuleNameMappingProps) => {
   const [fieldValidations, setFieldValidations] = useState<{ [fieldId: string]: boolean }>({});
 
-  // Check if all fields are valid and notify parent
   useEffect(() => {
-    const allFieldsValid = selectedFields.every(
-      (field) => fieldValidations[field.uniqueId]
-    );
+    const allFieldsValid = selectedFields.every((field) => fieldValidations[field.uniqueId]);
     onValidationChange(allFieldsValid);
   }, [fieldValidations, selectedFields, onValidationChange]);
 

--- a/apps/hubspot/src/components/FieldModuleNameMapping.tsx
+++ b/apps/hubspot/src/components/FieldModuleNameMapping.tsx
@@ -1,7 +1,7 @@
 import { Box, Flex, FormControl, Paragraph, TextInput } from '@contentful/f36-components';
 import { SdkField } from '../utils/fieldsProcessing';
 import tokens from '@contentful/f36-tokens';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { MODULE_NAME_PATTERN } from '../utils/utils';
 
 interface FieldModuleNameMappingProps {
@@ -60,12 +60,10 @@ const FieldModuleNameMapping = ({
     });
 
     setFieldErrors(newErrors);
-  };
 
-  useEffect(() => {
     const allFieldsValid = selectedFields.every((field) => !fieldErrors[field.uniqueId]);
-    onValidationChange(allFieldsValid);
-  }, [fieldErrors, selectedFields, onValidationChange]);
+    onValidationChange(!allFieldsValid);
+  };
 
   return (
     <Box>

--- a/apps/hubspot/src/components/FieldModuleNameMapping.tsx
+++ b/apps/hubspot/src/components/FieldModuleNameMapping.tsx
@@ -40,7 +40,8 @@ const FieldModuleNameMapping = ({
 
     const isDuplicate = selectedFields.some(
       (otherField) =>
-        otherField.uniqueId !== fieldId && currentMapping[otherField.uniqueId] === value
+        otherField.uniqueId !== fieldId &&
+        currentMapping[otherField.uniqueId].toLowerCase() === value.toLowerCase()
     );
 
     return isDuplicate ? 'Module name already exists' : '';
@@ -61,8 +62,7 @@ const FieldModuleNameMapping = ({
 
     setFieldErrors(newErrors);
 
-    const allFieldsValid = selectedFields.every((field) => !fieldErrors[field.uniqueId]);
-    onValidationChange(!allFieldsValid);
+    onValidationChange(Object.keys(newErrors).length > 0);
   };
 
   return (

--- a/apps/hubspot/src/locations/Dialog.tsx
+++ b/apps/hubspot/src/locations/Dialog.tsx
@@ -7,7 +7,6 @@ import FieldModuleNameMapping from '../components/FieldModuleNameMapping';
 import { createClient } from 'contentful-management';
 import { SdkField, SelectedSdkField } from '../utils/fieldsProcessing';
 import { styles } from './Dialog.styles';
-import { MODULE_NAME_PATTERN } from '../utils/utils';
 import ConfigEntryService from '../utils/ConfigEntryService';
 
 export type InvocationParams = {
@@ -42,6 +41,7 @@ const Dialog = () => {
   const [moduleNameMapping, setModuleNameMapping] = useState<{ [fieldId: string]: string }>({});
   const [isSending, setIsSending] = useState(false);
   const [connectedFieldIds, setConnectedFieldIds] = useState<string[]>([]);
+  const [hasValidationErrors, setHasValidationErrors] = useState(false);
 
   useEffect(() => {
     const fetchConnectedFields = async () => {
@@ -185,6 +185,7 @@ const Dialog = () => {
             moduleNameMapping={moduleNameMapping}
             setModuleNameMapping={setModuleNameMapping}
             inputDisabled={isSending}
+            onValidationChange={(isValid) => setHasValidationErrors(!isValid)}
           />
           <Flex
             paddingTop="spacingM"
@@ -206,12 +207,7 @@ const Dialog = () => {
               variant="primary"
               size="small"
               onClick={handleSaveAndSync}
-              isDisabled={
-                isSending ||
-                Object.values(moduleNameMapping).some(
-                  (moduleName) => !MODULE_NAME_PATTERN.test(moduleName)
-                )
-              }
+              isDisabled={isSending || hasValidationErrors}
               isLoading={isSending}>
               Save and sync
             </Button>

--- a/apps/hubspot/src/locations/Dialog.tsx
+++ b/apps/hubspot/src/locations/Dialog.tsx
@@ -185,7 +185,7 @@ const Dialog = () => {
             moduleNameMapping={moduleNameMapping}
             setModuleNameMapping={setModuleNameMapping}
             inputDisabled={isSending}
-            onValidationChange={(isValid) => setHasValidationErrors(!isValid)}
+            onValidationChange={(isValid) => setHasValidationErrors(isValid)}
           />
           <Flex
             paddingTop="spacingM"


### PR DESCRIPTION
## Purpose

This update includes the validation of the no duplicate names in the naming module selection step.

## Approach

- The `Dialog.tsx` and `FieldModuleNameMapping.tsx` components were updated so the components doesn't allow duplicated names.
- Some modifications were made in the components, so the validations are re-triggered when the user changes the name again.
- The "Save and sync" button of the modal was modified: now it is disabled when there are errors in the naming validations

## Testing steps

Automated tests were added. Manual test:

https://github.com/user-attachments/assets/54dc8504-f160-440f-8c1d-6de05a1e0ba1

## Breaking Changes

N/A

## Dependencies and/or References

Link to [INTEG-2967](https://contentful.atlassian.net/jira/software/c/projects/INTEG/boards/3109?issueParent=367108&selectedIssue=INTEG-2967) ticket. This ticket came from the mob QA.

## Deployment

N/A

[INTEG-2967]: https://contentful.atlassian.net/browse/INTEG-2967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ