### PR TITLE
Hubspot: Delete custom content type when uninstalling the app [INTEG-2966]

### DIFF
--- a/apps/hubspot/test/mocks/mockCma.ts
+++ b/apps/hubspot/test/mocks/mockCma.ts
@@ -6,6 +6,8 @@ const mockCma = {
     createWithId: vi.fn(),
     publish: vi.fn(),
     getMany: vi.fn(),
+    unpublish: vi.fn(),
+    delete: vi.fn(),
   },
   entry: {
     get: vi.fn(),


### PR DESCRIPTION
## Purpose

We want to remove the custom content type and entry when uninstalling the app.

## Approach

Add the ability to the app event handler to remove the content type at uninstall time.

## Testing steps

Install the app, check the content type and entry are created, uninstall it and verify they are deleted.

https://github.com/user-attachments/assets/fa93973b-af89-49ba-b0d9-99f08247fe17
