### PR TITLE
Braze: Disable resource link fields

### DIFF
--- a/apps/braze/src/fields/ExternalResourceField.ts
+++ b/apps/braze/src/fields/ExternalResourceField.ts
@@ -1,22 +1,21 @@
 import { Field } from './Field';
 import { FieldRegistry } from './fieldRegistry';
 
-// We are not supporting rich text fields for now
-export class RichTextField extends Field {
+export class ExternalResourceField extends Field {
   constructor(id: string, name: string, entryContentTypeId: string, localized: boolean) {
     super(id, name, entryContentTypeId, localized);
   }
 
   get type(): string {
-    return 'RichTextField';
+    return 'ExternalResourceField';
   }
 
   public override set selected(value: boolean) {
     return;
   }
 
-  static fromSerialized(serializedField: any): RichTextField {
-    const field = new RichTextField(
+  static fromSerialized(serializedField: any): ExternalResourceField {
+    const field = new ExternalResourceField(
       serializedField.id,
       serializedField.name,
       serializedField.entryContentTypeId,
@@ -26,16 +25,20 @@ export class RichTextField extends Field {
   }
 
   generateQuery(): string {
-    throw new Error('Rich text not supported');
+    throw new Error('External resource not supported');
   }
 
   generateLiquidTagForType(template: string): string[] {
-    throw new Error('Rich text not supported');
+    throw new Error('External resource not supported');
   }
 
   isEnabledForGenerate(): boolean {
     return false;
   }
+
+  isEnabledForCreate(): boolean {
+    return false;
+  }
 }
 
-FieldRegistry.registerFieldType('RichTextField', RichTextField.fromSerialized);
+FieldRegistry.registerFieldType('ExternalResourceField', ExternalResourceField.fromSerialized);

--- a/apps/braze/src/fields/FieldsFactory.ts
+++ b/apps/braze/src/fields/FieldsFactory.ts
@@ -15,6 +15,7 @@ import { ReferenceItem } from './ReferenceItem';
 import { RichTextField } from './RichTextField';
 import { TextArrayField } from './TextArrayField';
 import resolveResponse from 'contentful-resolve-response';
+import { ExternalResourceField } from './ExternalResourceField';
 
 export class FieldsFactory {
   private contentTypes: { [key: string]: ContentTypeProps };
@@ -134,6 +135,8 @@ export class FieldsFactory {
       fieldClass = RichTextField;
     } else if (fieldInfo.type === 'Location') {
       fieldClass = LocationField;
+    } else if (fieldInfo.type === 'ResourceLink') {
+      fieldClass = ExternalResourceField;
     } else {
       fieldClass = BasicField;
     }

--- a/apps/braze/test/fields/FieldsFactory.spec.ts
+++ b/apps/braze/test/fields/FieldsFactory.spec.ts
@@ -17,6 +17,7 @@ vi.mock('contentful-resolve-response', () => {
 
 // Import the mocked function for use in tests
 import resolveResponse from 'contentful-resolve-response';
+import { ExternalResourceField } from '../../src/fields/ExternalResourceField';
 
 describe('FieldsFactory', () => {
   const mockCma = {
@@ -474,6 +475,34 @@ describe('FieldsFactory', () => {
       expect((fieldsFactory as any).getDisplayFieldValue(fieldValueMulti, 'title')).toBe(
         'English Title'
       );
+    });
+
+    it('should create an ExternalResourceField instance with correct properties', async () => {
+      const mockEntry = [
+        {
+          fields: {
+            externalReference: {
+              sys: { type: 'ResourceLink', linkType: 'Contentful:Entry', urn: 'an-id' },
+            },
+          },
+        },
+      ];
+      (resolveResponse as any).mockReturnValue(mockEntry);
+
+      mockCma.contentType.get.mockResolvedValue({
+        fields: [{ id: 'externalReference', type: 'ResourceLink', localized: false }],
+        sys: {
+          id: 'externalArticle',
+        },
+      });
+
+      const result = await createFields(entryId, entryContentTypeId, mockCma);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBeInstanceOf(ExternalResourceField);
+      const fieldInstance = result[0] as ExternalResourceField;
+      expect(fieldInstance.id).toBe('externalReference');
+      expect(fieldInstance.entryContentTypeId).toBe('externalArticle');
+      expect(fieldInstance.localized).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Purpose

The ResourceLink field type is not supported in the Braze app. However, users were able to select them. This PR disables those fields.

## Approach

The FieldFactory wasn't aware of the existance of the ResourceLink type, so it created a BasicField. Now it creates a ExternalResourceField, which is disabled for both versions of the app.

## Testing steps

Try to use both versions of the app with an entry that has a ResourceLink field.