### PR TITLE
fix: use correct orgId for app actions [INTEG-3018]

### DIFF
--- a/apps/mux/frontend/src/index.tsx
+++ b/apps/mux/frontend/src/index.tsx
@@ -53,6 +53,7 @@ import {
   generateAutoCaptions,
 } from './util/muxApi';
 import Sidebar from './locations/Sidebar';
+import { APP_ORGANIZATION_ID, isMarketplaceVersion } from './util/constants';
 
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -207,7 +208,9 @@ export class App extends React.Component<AppProps, AppState> {
 
   async componentDidMount() {
     const appActionsResponse = await this.cmaClient.appAction.getMany({
-      organizationId: this.props.sdk.ids.organization,
+      organizationId: isMarketplaceVersion({ appId: this.props.sdk.ids.app })
+        ? APP_ORGANIZATION_ID
+        : this.props.sdk.ids.organization,
       appDefinitionId: this.props.sdk.ids.app!,
     });
     this.getSignedTokenActionId =
@@ -503,7 +506,9 @@ export class App extends React.Component<AppProps, AppState> {
         response: { body },
       } = await this.cmaClient.appActionCall.createWithResponse(
         {
-          organizationId: this.props.sdk.ids.organization,
+          organizationId: isMarketplaceVersion({ appId: this.props.sdk.ids.app })
+            ? APP_ORGANIZATION_ID
+            : this.props.sdk.ids.organization,
           appDefinitionId: this.props.sdk.ids.app!,
           appActionId: this.getSignedTokenActionId,
         },

--- a/apps/mux/frontend/src/index.tsx
+++ b/apps/mux/frontend/src/index.tsx
@@ -105,6 +105,7 @@ export class App extends React.Component<AppProps, AppState> {
   muxPlayerRef = React.createRef<any>(); // eslint-disable-line @typescript-eslint/no-explicit-any
   getSignedTokenActionId: string;
   private pollPending = false;
+  orgId: string;
 
   constructor(props: AppProps) {
     super(props);
@@ -152,6 +153,10 @@ export class App extends React.Component<AppProps, AppState> {
       storyboardToken: undefined,
       raw: undefined,
     };
+
+    this.orgId = isMarketplaceVersion({ appId: this.props.sdk.ids.app })
+      ? APP_ORGANIZATION_ID
+      : this.props.sdk.ids.organization;
   }
 
   // eslint-disable-next-line  @typescript-eslint/ban-types
@@ -208,9 +213,7 @@ export class App extends React.Component<AppProps, AppState> {
 
   async componentDidMount() {
     const appActionsResponse = await this.cmaClient.appAction.getMany({
-      organizationId: isMarketplaceVersion({ appId: this.props.sdk.ids.app })
-        ? APP_ORGANIZATION_ID
-        : this.props.sdk.ids.organization,
+      organizationId: this.orgId,
       appDefinitionId: this.props.sdk.ids.app!,
     });
     this.getSignedTokenActionId =
@@ -506,9 +509,7 @@ export class App extends React.Component<AppProps, AppState> {
         response: { body },
       } = await this.cmaClient.appActionCall.createWithResponse(
         {
-          organizationId: isMarketplaceVersion({ appId: this.props.sdk.ids.app })
-            ? APP_ORGANIZATION_ID
-            : this.props.sdk.ids.organization,
+          organizationId: this.orgId,
           appDefinitionId: this.props.sdk.ids.app!,
           appActionId: this.getSignedTokenActionId,
         },

--- a/apps/mux/frontend/src/util/constants.ts
+++ b/apps/mux/frontend/src/util/constants.ts
@@ -1,6 +1,6 @@
 export const APP_ORGANIZATION_ID = '5EJGHo8tYJcjnEhYWDxivp';
 const APP_DEFINITION_ID = '5l4WmuXdhJGcADHfCm1v4k';
 
-export const isMarketplaceVersion = ({ appId }: { appId: string }) => {
-  return appId === APP_DEFINITION_ID;
+export const isMarketplaceVersion = ({ appId }: { appId: string | undefined }) => {
+  return !!appId && appId === APP_DEFINITION_ID;
 };

--- a/apps/mux/frontend/src/util/constants.ts
+++ b/apps/mux/frontend/src/util/constants.ts
@@ -1,0 +1,6 @@
+export const APP_ORGANIZATION_ID = '5EJGHo8tYJcjnEhYWDxivp';
+const APP_DEFINITION_ID = '5l4WmuXdhJGcADHfCm1v4k';
+
+export const isMarketplaceVersion = ({ appId }: { appId: string }) => {
+  return appId === APP_DEFINITION_ID;
+};


### PR DESCRIPTION
the sdk.ids.orgId refers to the current orgId but when we search for app actions, we need to search for the org where the app action lives. This code makes sure we use the correct org - if the app is the marketplace version, use the marketplace apps org, if this is a custom version, use the current orgId.

I was worried about exposing the orgId but Tyler said they are already exposed in our api calls so whatevs
