### PR TITLE
Rich-Text-Versioning: fix current content not showing [INTEG-3028]

### DIFF
--- a/apps/rich-text-versioning/src/locations/Dialog.tsx
+++ b/apps/rich-text-versioning/src/locations/Dialog.tsx
@@ -77,7 +77,7 @@ const Dialog = () => {
               {changeCount} change{changeCount !== 1 ? 's' : ''}
             </Badge>
           </Flex>
-          {publishedField && (
+          {(publishedField || currentField) && (
             <HtmlDiffViewer
               currentField={currentField}
               publishedField={publishedField}

--- a/apps/rich-text-versioning/test/locations/Dialog.spec.tsx
+++ b/apps/rich-text-versioning/test/locations/Dialog.spec.tsx
@@ -3,62 +3,69 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { mockCma, mockSdk } from '../mocks';
 import Dialog from '../../src/locations/Dialog';
 import { BLOCKS } from '@contentful/rich-text-types';
+import { useSDK, useCMA } from '@contentful/react-apps-toolkit';
 
 // Extend the existing mockSdk for Dialog-specific functionality
+const currentField = {
+  nodeType: BLOCKS.DOCUMENT,
+  data: {},
+  content: [
+    {
+      nodeType: BLOCKS.PARAGRAPH,
+      data: {},
+      content: [
+        {
+          nodeType: 'text',
+          value: 'Current content',
+          marks: [],
+          data: {},
+        },
+      ],
+    },
+  ],
+};
+
+const publishedField = {
+  nodeType: BLOCKS.DOCUMENT,
+  data: {},
+  content: [
+    {
+      nodeType: BLOCKS.PARAGRAPH,
+      data: {},
+      content: [
+        {
+          nodeType: 'text',
+          value: 'Published content',
+          marks: [],
+          data: {},
+        },
+      ],
+    },
+  ],
+};
+
 const dialogMockSdk = {
   ...mockSdk,
   close: vi.fn(),
   parameters: {
     invocation: {
-      currentField: {
-        nodeType: BLOCKS.DOCUMENT,
-        data: {},
-        content: [
-          {
-            nodeType: BLOCKS.PARAGRAPH,
-            data: {},
-            content: [
-              {
-                nodeType: 'text',
-                value: 'Current content',
-                marks: [],
-                data: {},
-              },
-            ],
-          },
-        ],
-      },
-      publishedField: {
-        nodeType: BLOCKS.DOCUMENT,
-        data: {},
-        content: [
-          {
-            nodeType: BLOCKS.PARAGRAPH,
-            data: {},
-            content: [
-              {
-                nodeType: 'text',
-                value: 'Published content',
-                marks: [],
-                data: {},
-              },
-            ],
-          },
-        ],
-      },
+      currentField: currentField,
+      publishedField: publishedField,
     },
   },
 };
 
 vi.mock('@contentful/react-apps-toolkit', () => ({
-  useSDK: () => dialogMockSdk,
-  useCMA: () => mockCma,
+  useSDK: vi.fn(),
+  useCMA: vi.fn(),
   useAutoResizer: vi.fn(),
 }));
 
 describe('Dialog component', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(useSDK).mockReturnValue(dialogMockSdk);
+    vi.mocked(useCMA).mockReturnValue(mockCma);
   });
 
   it('renders the dialog with correct layout', () => {
@@ -75,6 +82,32 @@ describe('Dialog component', () => {
     expect(screen.getByText('2 changes')).toBeInTheDocument();
   });
 
+  it('displays current change even though there is no published content', () => {
+    const emptyPublishedField = {
+      nodeType: BLOCKS.DOCUMENT,
+      data: {},
+      content: [],
+    };
+
+    const dialogMockSdkWithEmptyPublished = {
+      ...mockSdk,
+      close: vi.fn(),
+      parameters: {
+        invocation: {
+          currentField: currentField,
+          publishedField: emptyPublishedField,
+        },
+      },
+    };
+
+    vi.mocked(useSDK).mockReturnValue(dialogMockSdkWithEmptyPublished);
+
+    render(<Dialog />);
+
+    expect(screen.getByText('1 change')).toBeInTheDocument();
+    expect(screen.getByText('Current content')).toBeInTheDocument();
+  });
+
   it('renders crossed text for deleted content', async () => {
     render(<Dialog />);
 
@@ -86,11 +119,23 @@ describe('Dialog component', () => {
   });
 
   it('renders a note if there was an error loading the content', async () => {
-    dialogMockSdk.parameters.invocation.errorInfo = {
-      hasError: true,
-      errorCode: '500',
-      errorMessage: 'Error loading content',
+    const dialogMockSdkWithError = {
+      ...mockSdk,
+      close: vi.fn(),
+      parameters: {
+        invocation: {
+          currentField: currentField,
+          publishedField: publishedField,
+          errorInfo: {
+            hasError: true,
+            errorCode: '500',
+            errorMessage: 'Error loading content',
+          },
+        },
+      },
     };
+
+    vi.mocked(useSDK).mockReturnValue(dialogMockSdkWithError);
 
     render(<Dialog />);
 


### PR DESCRIPTION
## Purpose

This update was introduced because the current content was not being shown in the modal when the published content was empty.

## Approach

The conditional rendering to show the diff was updated, so now if there is current content the diff is going to be shown too.

## Testing steps

An automated test was added to validate this change.

**Before**:

> <img width="1512" height="852" alt="Captura de pantalla 2025-08-14 a la(s) 10 55 11 a  m" src="https://github.com/user-attachments/assets/267ce18c-5208-403c-bd0b-47f704edc7bd" />

**Now**:

> <img width="1512" height="852" alt="Captura de pantalla 2025-08-14 a la(s) 10 54 54 a  m" src="https://github.com/user-attachments/assets/f8b1a4ae-8c65-4130-84b7-1099d3d4f13b" />

## Breaking Changes

N/A

## Dependencies and/or References

Link to [INTEG-3028](https://contentful.atlassian.net/jira/software/c/projects/INTEG/boards/3109?label=10-Pines&selectedIssue=INTEG-3028)

## Deployment

N/A

[INTEG-3028]: https://contentful.atlassian.net/browse/INTEG-3028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ