### PR TITLE
mux: use getmanyforenv for app actions [INTEG-3018]

### DIFF
--- a/apps/mux/frontend/src/index.test.tsx
+++ b/apps/mux/frontend/src/index.test.tsx
@@ -9,7 +9,7 @@ import { vi } from 'vitest';
 vi.mock('contentful-management', () => ({
   createClient: vi.fn(() => ({
     appAction: {
-      getMany: vi.fn(() => Promise.resolve({ items: [] })),
+      getManyForEnvironment: vi.fn(() => Promise.resolve({ items: [] })),
     },
     appActionCall: {
       createWithResponse: vi.fn(() =>

--- a/apps/mux/frontend/src/index.tsx
+++ b/apps/mux/frontend/src/index.tsx
@@ -53,7 +53,6 @@ import {
   generateAutoCaptions,
 } from './util/muxApi';
 import Sidebar from './locations/Sidebar';
-import { APP_ORGANIZATION_ID, isMarketplaceVersion } from './util/constants';
 
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -105,7 +104,6 @@ export class App extends React.Component<AppProps, AppState> {
   muxPlayerRef = React.createRef<any>(); // eslint-disable-line @typescript-eslint/no-explicit-any
   getSignedTokenActionId: string;
   private pollPending = false;
-  orgId: string;
 
   constructor(props: AppProps) {
     super(props);
@@ -153,10 +151,6 @@ export class App extends React.Component<AppProps, AppState> {
       storyboardToken: undefined,
       raw: undefined,
     };
-
-    this.orgId = isMarketplaceVersion({ appId: this.props.sdk.ids.app })
-      ? APP_ORGANIZATION_ID
-      : this.props.sdk.ids.organization;
   }
 
   // eslint-disable-next-line  @typescript-eslint/ban-types
@@ -212,10 +206,7 @@ export class App extends React.Component<AppProps, AppState> {
   };
 
   async componentDidMount() {
-    const appActionsResponse = await this.cmaClient.appAction.getMany({
-      organizationId: this.orgId,
-      appDefinitionId: this.props.sdk.ids.app!,
-    });
+    const appActionsResponse = await this.cmaClient.appAction.getManyForEnvironment({});
     this.getSignedTokenActionId =
       appActionsResponse.items.find((x) => x.name === 'getSignedUrlTokens')?.sys.id ?? '';
 
@@ -509,7 +500,7 @@ export class App extends React.Component<AppProps, AppState> {
         response: { body },
       } = await this.cmaClient.appActionCall.createWithResponse(
         {
-          organizationId: this.orgId,
+          organizationId: this.props.sdk.ids.organization,
           appDefinitionId: this.props.sdk.ids.app!,
           appActionId: this.getSignedTokenActionId,
         },

--- a/apps/mux/frontend/src/index.tsx
+++ b/apps/mux/frontend/src/index.tsx
@@ -206,7 +206,10 @@ export class App extends React.Component<AppProps, AppState> {
   };
 
   async componentDidMount() {
-    const appActionsResponse = await this.cmaClient.appAction.getManyForEnvironment({});
+    const appActionsResponse = await this.cmaClient.appAction.getManyForEnvironment({
+      environmentId: this.props.sdk.ids.environment,
+      spaceId: this.props.sdk.ids.space,
+    });
     this.getSignedTokenActionId =
       appActionsResponse.items.find((x) => x.name === 'getSignedUrlTokens')?.sys.id ?? '';
 

--- a/apps/mux/frontend/src/util/constants.ts
+++ b/apps/mux/frontend/src/util/constants.ts
@@ -1,6 +1,0 @@
-export const APP_ORGANIZATION_ID = '5EJGHo8tYJcjnEhYWDxivp';
-const APP_DEFINITION_ID = '5l4WmuXdhJGcADHfCm1v4k';
-
-export const isMarketplaceVersion = ({ appId }: { appId: string | undefined }) => {
-  return !!appId && appId === APP_DEFINITION_ID;
-};


### PR DESCRIPTION
We were using the wrong method to get the app actions - we need to use getManyForEnvironement so that users can get the app actions, getMany only gets app actions the belong to that space, which when a user installs a marketplace app with actions, the action does not belong to their space it is just enabled.
