### PR TITLE
Fix localization edge cases []

### DIFF
--- a/apps/rich-text-versioning/src/locations/Field.tsx
+++ b/apps/rich-text-versioning/src/locations/Field.tsx
@@ -78,7 +78,7 @@ const Field = () => {
       parameters: {
         currentField: convertToSerializableJson(value),
         publishedField: publishedField
-          ? convertToSerializableJson(publishedField)[sdk.locales.default]
+          ? convertToSerializableJson(publishedField)[sdk.field.locale]
           : undefined,
         errorInfo: convertToSerializableJson(currentErrorInfo),
         locale: sdk.field.locale,


### PR DESCRIPTION
## Purpose

This PR wants to fix the following situations
When a field with localization changes, all diff buttons for the rest of the field localization get activated, even though no change happen.

Published is using default locale instead of the field locale

## Approach

We now look at the field status instead of the entry status

## Testing steps


https://github.com/user-attachments/assets/3c66a70d-1e12-4fff-b657-06f454639233





