### PR TITLE
Rich text versioning: Asset support [INTEG-3019]

### DIFF
--- a/apps/rich-text-versioning/src/components/HtmlDiffViewer.tsx
+++ b/apps/rich-text-versioning/src/components/HtmlDiffViewer.tsx
@@ -5,8 +5,7 @@ import { styles } from './HtmlDiffViewer.styles';
 import { documentToReactComponents } from '@contentful/rich-text-react-renderer';
 import { Skeleton } from '@contentful/f36-components';
 import { renderToString } from 'react-dom/server';
-import React from 'react';
-import { ContentTypeProps, EntryProps } from 'contentful-management';
+import { AssetProps, ContentTypeProps, EntryProps } from 'contentful-management';
 import { createOptions } from './createOptions';
 interface HtmlDiffViewerProps {
   currentField: Document;
@@ -14,7 +13,8 @@ interface HtmlDiffViewerProps {
   onChangeCount: (count: number) => void;
   entries: EntryProps[];
   entryContentTypes: Record<string, ContentTypeProps>;
-  defaultLocale: string;
+  locale: string;
+  assets: AssetProps[];
 }
 
 const HtmlDiffViewer = ({
@@ -23,7 +23,8 @@ const HtmlDiffViewer = ({
   onChangeCount,
   entries,
   entryContentTypes,
-  defaultLocale,
+  locale,
+  assets,
 }: HtmlDiffViewerProps) => {
   const [diffHtml, setDiffHtml] = useState<string>('');
 
@@ -32,11 +33,11 @@ const HtmlDiffViewer = ({
       // Convert current field to React components with embedded entry renderers
       const currentComponents = documentToReactComponents(
         currentField,
-        createOptions(entries, entryContentTypes, defaultLocale)
+        createOptions(entries, entryContentTypes, assets, locale)
       );
       const publishedComponents = documentToReactComponents(
         publishedField,
-        createOptions(entries, entryContentTypes, defaultLocale)
+        createOptions(entries, entryContentTypes, assets, locale)
       );
 
       // Convert React components to HTML strings
@@ -44,7 +45,7 @@ const HtmlDiffViewer = ({
       const publishedHtml = renderToString(<>{publishedComponents}</>);
 
       // Perform diff
-      const diff = Diff.execute(publishedHtml, currentHtml);
+      const diff = Diff.execute(publishedHtml, currentHtml, { combineWords: true });
       setDiffHtml(diff);
 
       const diffString = diff || '';

--- a/apps/rich-text-versioning/src/components/createOptions.tsx
+++ b/apps/rich-text-versioning/src/components/createOptions.tsx
@@ -1,16 +1,19 @@
-import { Box, EntryCard, InlineEntryCard } from '@contentful/f36-components';
-import { EntryProps, ContentTypeProps } from 'contentful-management';
-import { getEntryStatus, getEntryTitle } from '../utils';
-import { BLOCKS, INLINES } from '@contentful/rich-text-types';
+import { AssetCard, Box, EntryCard, InlineEntryCard } from '@contentful/f36-components';
+import { EntryProps, ContentTypeProps, AssetProps } from 'contentful-management';
+import { getEntryTitle } from '../utils';
+import { Block, BLOCKS, Inline, INLINES } from '@contentful/rich-text-types';
 import { Options } from '@contentful/rich-text-react-renderer';
+import { css } from 'emotion';
 
 const UNKNOWN = 'Unknown';
-const NOT_FOUND = 'Entry not found';
+const ENTRY_NOT_FOUND = 'Entry not found';
+const ASSET_NOT_FOUND = 'Asset not found';
 const DELETED = 'deleted';
 
 export const createOptions = (
   entries: EntryProps[],
   entryContentTypes: Record<string, ContentTypeProps>,
+  assets: AssetProps[],
   locale: string
 ): Options => ({
   renderNode: {
@@ -19,7 +22,7 @@ export const createOptions = (
       if (!entry) {
         return (
           <Box marginBottom="spacingM">
-            <EntryCard contentType={UNKNOWN} title={NOT_FOUND} status={DELETED} />
+            <EntryCard contentType={UNKNOWN} title={ENTRY_NOT_FOUND} status={DELETED} />
           </Box>
         );
       }
@@ -38,7 +41,11 @@ export const createOptions = (
       const entry = entries.find((e) => e.sys.id === node.data.target.sys.id);
 
       if (!entry) {
-        return <InlineEntryCard contentType={UNKNOWN} title={NOT_FOUND} status={DELETED} />;
+        return (
+          <InlineEntryCard contentType={UNKNOWN} status={DELETED}>
+            {ENTRY_NOT_FOUND}
+          </InlineEntryCard>
+        );
       }
 
       const contentType = entryContentTypes[entry.sys.id];
@@ -47,9 +54,29 @@ export const createOptions = (
       const status = entry.sys.fieldStatus?.['*']?.[locale];
 
       return (
-        <InlineEntryCard contentType={contentTypeName} title={title} status={status}>
+        <InlineEntryCard contentType={contentTypeName} status={status}>
           {title}
         </InlineEntryCard>
+      );
+    },
+    [BLOCKS.EMBEDDED_ASSET]: (node: Block | Inline) => {
+      const asset = assets.find((a) => a.sys.id === node.data.target.sys.id);
+
+      if (!asset) {
+        return (
+          <Box margin="spacingM">
+            <AssetCard title={ASSET_NOT_FOUND} status={DELETED} size="small" />
+          </Box>
+        );
+      }
+
+      const status = asset.sys?.fieldStatus?.['*']?.[locale];
+      const title = asset.fields.title[locale];
+
+      return (
+        <Box margin="spacingM">
+          <AssetCard status={status} title={title} size="small" />
+        </Box>
       );
     },
   },

--- a/apps/rich-text-versioning/src/components/createOptions.tsx
+++ b/apps/rich-text-versioning/src/components/createOptions.tsx
@@ -1,7 +1,7 @@
 import { AssetCard, Box, EntryCard, InlineEntryCard } from '@contentful/f36-components';
 import { EntryProps, ContentTypeProps, AssetProps } from 'contentful-management';
 import { getEntryTitle } from '../utils';
-import { Block, BLOCKS, Inline, INLINES } from '@contentful/rich-text-types';
+import { BLOCKS, INLINES } from '@contentful/rich-text-types';
 import { Options } from '@contentful/rich-text-react-renderer';
 
 const UNKNOWN = 'Unknown';

--- a/apps/rich-text-versioning/src/components/createOptions.tsx
+++ b/apps/rich-text-versioning/src/components/createOptions.tsx
@@ -3,7 +3,6 @@ import { EntryProps, ContentTypeProps, AssetProps } from 'contentful-management'
 import { getEntryTitle } from '../utils';
 import { Block, BLOCKS, Inline, INLINES } from '@contentful/rich-text-types';
 import { Options } from '@contentful/rich-text-react-renderer';
-import { css } from 'emotion';
 
 const UNKNOWN = 'Unknown';
 const ENTRY_NOT_FOUND = 'Entry not found';
@@ -59,7 +58,7 @@ export const createOptions = (
         </InlineEntryCard>
       );
     },
-    [BLOCKS.EMBEDDED_ASSET]: (node: Block | Inline) => {
+    [BLOCKS.EMBEDDED_ASSET]: (node: any) => {
       const asset = assets.find((a) => a.sys.id === node.data.target.sys.id);
 
       if (!asset) {

--- a/apps/rich-text-versioning/src/locations/Dialog.tsx
+++ b/apps/rich-text-versioning/src/locations/Dialog.tsx
@@ -122,7 +122,6 @@ const Dialog = () => {
           console.error('Error fetching assets:', error);
         }
       }
-      setEntryContentTypes(contentTypes);
       setLoading(false);
     };
 

--- a/apps/rich-text-versioning/src/locations/Dialog.tsx
+++ b/apps/rich-text-versioning/src/locations/Dialog.tsx
@@ -13,11 +13,11 @@ import {
 } from '@contentful/f36-components';
 import { useAutoResizer, useSDK } from '@contentful/react-apps-toolkit';
 import { documentToReactComponents } from '@contentful/rich-text-react-renderer';
-import { Block, BLOCKS, Document, Inline, INLINES } from '@contentful/rich-text-types';
+import { BLOCKS, Document, INLINES } from '@contentful/rich-text-types';
 import { useState, useEffect } from 'react';
 import { styles } from './Dialog.styles';
 import HtmlDiffViewer from '../components/HtmlDiffViewer';
-import { ContentTypeProps, EntryProps } from 'contentful-management';
+import { AssetProps, ContentTypeProps, EntryProps } from 'contentful-management';
 import { createOptions } from '../components/createOptions';
 import { ErrorInfo } from '../utils';
 
@@ -34,7 +34,7 @@ const Dialog = () => {
   const [changeCount, setChangeCount] = useState(0);
   const [entries, setEntries] = useState<EntryProps[]>([]);
   const [entryContentTypes, setEntryContentTypes] = useState<Record<string, ContentTypeProps>>({});
-
+  const [assets, setAssets] = useState<AssetProps[]>([]);
   const [loading, setLoading] = useState(true);
 
   useAutoResizer();
@@ -43,10 +43,10 @@ const Dialog = () => {
   const publishedField = invocationParams?.publishedField || { content: [] };
   const locale = invocationParams?.locale;
 
-  const getEntryIdsFromDocument = (doc: Document): string[] => {
+  const getReferenceIdsFromDocument = (doc: Document, types: string[]): string[] => {
     const ids: string[] = [];
     const getEntryIdsFromNode = (node: any) => {
-      if (node.nodeType === BLOCKS.EMBEDDED_ENTRY || node.nodeType === INLINES.EMBEDDED_ENTRY) {
+      if (types.includes(node.nodeType)) {
         ids.push(node.data.target.sys.id);
       }
       if ('content' in node) {
@@ -62,9 +62,21 @@ const Dialog = () => {
       setLoading(true);
       const contentTypes: Record<string, ContentTypeProps> = {};
 
-      const currentEntryIds = getEntryIdsFromDocument(currentField);
-      const publishedEntryIds = getEntryIdsFromDocument(publishedField);
+      const currentEntryIds = getReferenceIdsFromDocument(currentField, [
+        BLOCKS.EMBEDDED_ENTRY,
+        INLINES.EMBEDDED_ENTRY,
+      ]);
+      const publishedEntryIds = getReferenceIdsFromDocument(publishedField, [
+        BLOCKS.EMBEDDED_ENTRY,
+        INLINES.EMBEDDED_ENTRY,
+      ]);
+      const currentAssetIds = getReferenceIdsFromDocument(currentField, [BLOCKS.EMBEDDED_ASSET]);
+      const publishedAssetIds = getReferenceIdsFromDocument(publishedField, [
+        BLOCKS.EMBEDDED_ASSET,
+      ]);
       const allEntryIds = [...new Set([...currentEntryIds, ...publishedEntryIds])];
+      const allAssetIds = [...new Set([...currentAssetIds, ...publishedAssetIds])];
+
       if (allEntryIds.length > 0) {
         let entries: EntryProps[] = [];
         try {
@@ -98,6 +110,19 @@ const Dialog = () => {
         }
         setEntryContentTypes(contentTypes);
       }
+      if (allAssetIds.length > 0) {
+        try {
+          const fetchedAssets = await sdk.cma.asset.getMany({
+            query: {
+              'sys.id[in]': allAssetIds.join(','),
+            },
+          });
+          setAssets(fetchedAssets.items);
+        } catch (error) {
+          console.error('Error fetching assets:', error);
+        }
+      }
+      setEntryContentTypes(contentTypes);
       setLoading(false);
     };
 
@@ -166,7 +191,8 @@ const Dialog = () => {
               onChangeCount={setChangeCount}
               entries={entries}
               entryContentTypes={entryContentTypes}
-              defaultLocale={sdk.locales.default}
+              locale={sdk.locales.default}
+              assets={assets}
             />
           )}
         </GridItem>
@@ -175,7 +201,7 @@ const Dialog = () => {
           <Box className={styles.diff}>
             {documentToReactComponents(
               publishedField,
-              createOptions(entries, entryContentTypes, locale)
+              createOptions(entries, entryContentTypes, assets, locale)
             )}
           </Box>
         </GridItem>

--- a/apps/rich-text-versioning/src/locations/Field.tsx
+++ b/apps/rich-text-versioning/src/locations/Field.tsx
@@ -20,6 +20,7 @@ const Field = () => {
 
     const detachValueChangeHandler = sdk.field.onValueChanged(async (value: Document) => {
       setFieldValue(value);
+      sdk.entry.save();
     });
 
     return detachValueChangeHandler;

--- a/apps/rich-text-versioning/src/utils.ts
+++ b/apps/rich-text-versioning/src/utils.ts
@@ -72,17 +72,3 @@ export const getEntryTitle = (
   }
   return String(value);
 };
-
-export const getEntryStatus = (entry: EntryProps): EntityStatus | undefined => {
-  const { sys } = entry;
-  if (!sys.publishedVersion) {
-    return 'draft';
-  }
-  if (sys.version >= sys.publishedVersion + 2) {
-    return 'changed';
-  }
-  if (sys.version === sys.publishedVersion + 1) {
-    return 'published';
-  }
-  return undefined;
-};

--- a/apps/rich-text-versioning/test/locations/ConfigScreen.spec.tsx
+++ b/apps/rich-text-versioning/test/locations/ConfigScreen.spec.tsx
@@ -6,7 +6,6 @@ import { OnConfigureHandlerReturn } from '@contentful/app-sdk';
 
 vi.mock('@contentful/react-apps-toolkit', () => ({
   useSDK: () => mockSdk,
-  useCMA: () => mockCma,
 }));
 
 async function saveAppInstallation() {

--- a/apps/rich-text-versioning/test/locations/Dialog.spec.tsx
+++ b/apps/rich-text-versioning/test/locations/Dialog.spec.tsx
@@ -233,8 +233,6 @@ describe('Dialog component', () => {
               contentType: { sys: { id: 'fruits' } },
               updatedAt: new Date().toISOString(),
               publishedAt: new Date().toISOString(),
-              publishedVersion: 2,
-              version: 1,
             },
             fields: {
               title: { 'en-US': 'Banana' },
@@ -338,8 +336,6 @@ describe('Dialog component', () => {
               contentType: { sys: { id: 'fruits' } },
               updatedAt: new Date().toISOString(),
               publishedAt: new Date().toISOString(),
-              publishedVersion: 2,
-              version: 1,
             },
             fields: {
               title: { 'en-US': 'Banana' },
@@ -440,8 +436,6 @@ describe('Dialog component', () => {
               id: 'asset-id',
               updatedAt: new Date().toISOString(),
               publishedAt: new Date().toISOString(),
-              publishedVersion: 2,
-              version: 1,
             },
             fields: {
               title: { 'en-US': 'Banana' },

--- a/apps/rich-text-versioning/test/locations/Field.spec.tsx
+++ b/apps/rich-text-versioning/test/locations/Field.spec.tsx
@@ -76,7 +76,6 @@ const mockPublishedField = {
 
 vi.mock('@contentful/react-apps-toolkit', () => ({
   useSDK: () => fieldMockSdk,
-  useCMA: () => mockCma,
   useAutoResizer: vi.fn(),
 }));
 

--- a/apps/rich-text-versioning/test/locations/Field.spec.tsx
+++ b/apps/rich-text-versioning/test/locations/Field.spec.tsx
@@ -1,14 +1,8 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
-import { mockCma, mockSdk } from '../mocks';
+import { mockSdk } from '../mocks';
 import Field from '../../src/locations/Field';
 import { Document, BLOCKS } from '@contentful/rich-text-types';
-
-vi.mock('contentful', () => ({
-  createClient: vi.fn(() => ({
-    getEntry: vi.fn(),
-  })),
-}));
 
 vi.mock('@contentful/field-editor-rich-text', () => ({
   RichTextEditor: ({ sdk }: { sdk: any }) => (
@@ -23,6 +17,7 @@ const fieldMockSdk = {
   field: {
     getValue: vi.fn(),
     onValueChanged: vi.fn(),
+    locale: 'en-US',
   },
   entry: {
     getSys: vi.fn(),
@@ -89,8 +84,11 @@ describe('Field component', () => {
     });
     fieldMockSdk.entry.getSys.mockReturnValue({
       id: 'test-entry',
-      version: 3,
-      publishedVersion: 1,
+      fieldStatus: {
+        '*': {
+          'en-US': 'changed',
+        },
+      },
     });
   });
 
@@ -109,8 +107,11 @@ describe('Field component', () => {
   it('disables View Diff button when entry is not changed', async () => {
     fieldMockSdk.entry.getSys.mockReturnValue({
       id: 'test-entry',
-      version: 1,
-      publishedVersion: 1,
+      fieldStatus: {
+        '*': {
+          'en-US': 'published',
+        },
+      },
     });
 
     render(<Field />);
@@ -122,8 +123,11 @@ describe('Field component', () => {
   it('disables View Diff button when entry is in draft', async () => {
     fieldMockSdk.entry.getSys.mockReturnValue({
       id: 'test-entry',
-      version: 1,
-      publishedVersion: 1,
+      fieldStatus: {
+        '*': {
+          'en-US': 'draft',
+        },
+      },
     });
 
     render(<Field />);
@@ -135,26 +139,17 @@ describe('Field component', () => {
   it('enables View Diff button when entry has changes', () => {
     fieldMockSdk.entry.getSys.mockReturnValue({
       id: 'test-entry',
-      version: 3,
-      publishedVersion: 1,
+      fieldStatus: {
+        '*': {
+          'en-US': 'changed',
+        },
+      },
     });
 
     render(<Field />);
     const button = screen.getByTestId('view-diff-button');
 
     expect(button).not.toBeDisabled();
-  });
-
-  it('disables View Diff button when entry has no publishedVersion', () => {
-    fieldMockSdk.entry.getSys.mockReturnValue({
-      id: 'test-entry',
-      version: 1,
-    });
-
-    render(<Field />);
-    const button = screen.getByTestId('view-diff-button');
-
-    expect(button).toBeDisabled();
   });
 
   it('opens dialog when View Diff button is clicked', async () => {
@@ -173,6 +168,7 @@ describe('Field component', () => {
         parameters: {
           currentField: mockFieldValue,
           publishedField: undefined,
+          locale: 'en-US',
           errorInfo: {
             hasError: false,
           },
@@ -196,6 +192,7 @@ describe('Field component', () => {
         parameters: {
           currentField: mockFieldValue,
           publishedField: undefined,
+          locale: 'en-US',
           errorInfo: {
             hasError: true,
             errorCode: '500',

--- a/apps/rich-text-versioning/test/mocks/mockCma.ts
+++ b/apps/rich-text-versioning/test/mocks/mockCma.ts
@@ -8,6 +8,10 @@ const mockCma: any = {
   entry: {
     getMany: vi.fn(),
     get: vi.fn(),
+    getPublished: vi.fn(),
+  },
+  asset: {
+    getMany: vi.fn(),
   },
 };
 

--- a/apps/rich-text-versioning/test/mocks/mockSdk.ts
+++ b/apps/rich-text-versioning/test/mocks/mockSdk.ts
@@ -1,4 +1,5 @@
 import { vi } from 'vitest';
+import { mockCma } from './mockCma';
 
 const mockSdk: any = {
   app: {
@@ -15,15 +16,7 @@ const mockSdk: any = {
     space: 'test-space',
     environment: 'test-environment',
   },
-  cma: {
-    contentType: {
-      getMany: vi.fn(),
-      get: vi.fn(),
-    },
-    entry: {
-      getPublished: vi.fn(),
-    },
-  },
+  cma: mockCma,
   notifier: {
     error: vi.fn(),
   },


### PR DESCRIPTION
## Purpose

Display added or removed assets in the diff

## Approach

Same approach as with references: add options to the renderer so it displays an AssetCard when it finds an asset node

## Testing steps

Add or remove assets from a rich text and verify the diff

<img width="735" height="661" alt="image" src="https://github.com/user-attachments/assets/9cdb69e7-75a3-48ce-a4b6-ecf96a27535c" />
