### PR TITLE
Bulk-Edit-App: Making the status column sticky [INTEG-3107]

### DIFF
--- a/apps/bulk-edit/src/locations/Page/components/TableHeader.tsx
+++ b/apps/bulk-edit/src/locations/Page/components/TableHeader.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Table, Checkbox, Flex, Text } from '@contentful/f36-components';
+import { Table, Checkbox, Flex, Text, Box } from '@contentful/f36-components';
 import { Tooltip } from '@contentful/f36-tooltip';
 import { QuestionIcon } from '@phosphor-icons/react';
 import { ContentTypeField } from '../types';
@@ -23,19 +23,21 @@ export const TableHeader: React.FC<TableHeaderProps> = ({
   return (
     <Table.Head style={styles.tableHead}>
       <Table.Row style={styles.stickyTableRow}>
-        {fields.length > 0 && (
-          <Table.Cell as="th" key={DISPLAY_NAME_COLUMN} style={styles.stickyTableHeader}>
-            Display name
+        <Box style={styles.stickyMainColumnsOrFields}>
+          {fields.length > 0 && (
+            <Table.Cell as="th" key={DISPLAY_NAME_COLUMN} style={styles.tableHeader}>
+              Display name
+            </Table.Cell>
+          )}
+          <Table.Cell as="th" key={ENTRY_STATUS_COLUMN} style={styles.tableHeader}>
+            <Flex gap="spacingXs" alignItems="center" justifyContent="flex-start">
+              Status
+              <Tooltip content="Bulk editing is not supported for Status" placement="top">
+                <QuestionIcon size={16} aria-label="Bulk editing not supported for Status" />
+              </Tooltip>
+            </Flex>
           </Table.Cell>
-        )}
-        <Table.Cell as="th" key={ENTRY_STATUS_COLUMN} style={styles.tableHeader}>
-          <Flex gap="spacingXs" alignItems="center" justifyContent="flex-start">
-            Status
-            <Tooltip content="Bulk editing is not supported for Status" placement="top">
-              <QuestionIcon size={16} aria-label="Bulk editing not supported for Status" />
-            </Tooltip>
-          </Flex>
-        </Table.Cell>
+        </Box>
         {fields.map((field) => {
           const isAllowed = isCheckboxAllowed(field);
           const isDisabled = checkboxesDisabled[field.uniqueId];

--- a/apps/bulk-edit/src/locations/Page/components/TableRow.tsx
+++ b/apps/bulk-edit/src/locations/Page/components/TableRow.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Table, TextLink, Badge, Checkbox, Flex, Text } from '@contentful/f36-components';
+import { Table, TextLink, Badge, Checkbox, Flex, Text, Box } from '@contentful/f36-components';
 import { ExternalLinkIcon } from '@contentful/f36-icons';
 import { Entry, ContentTypeField } from '../types';
 import { ContentTypeProps } from 'contentful-management';
@@ -44,20 +44,22 @@ export const TableRow: React.FC<TableRowProps> = ({
 
   return (
     <Table.Row key={entry.sys.id}>
-      <Table.Cell testId="display-name-cell" style={styles.stickyCell} isTruncated>
-        <TextLink
-          href={getEntryUrl(entry, spaceId, environmentId)}
-          target="_blank"
-          rel="noopener noreferrer"
-          testId="entry-link"
-          icon={<ExternalLinkIcon />}
-          alignIcon="end">
-          {getEntryTitle(entry, contentType, defaultLocale)}
-        </TextLink>
-      </Table.Cell>
-      <Table.Cell testId="status-cell" style={styles.cell}>
-        <Badge variant={status.color}>{status.label}</Badge>
-      </Table.Cell>
+      <Box style={styles.stickyMainColumnsOrFields}>
+        <Table.Cell testId="display-name-cell" style={styles.cell}>
+          <TextLink
+            href={getEntryUrl(entry, spaceId, environmentId)}
+            target="_blank"
+            rel="noopener noreferrer"
+            testId="entry-link"
+            icon={<ExternalLinkIcon />}
+            alignIcon="end">
+            {getEntryTitle(entry, contentType, defaultLocale)}
+          </TextLink>
+        </Table.Cell>
+        <Table.Cell testId="status-cell" style={styles.cell}>
+          <Badge variant={status.color}>{status.label}</Badge>
+        </Table.Cell>
+      </Box>
       {fields.map((field) => {
         const isAllowed = isCheckboxAllowed(field);
         const isDisabled = cellCheckboxesDisabled[field.uniqueId];

--- a/apps/bulk-edit/src/locations/Page/styles.ts
+++ b/apps/bulk-edit/src/locations/Page/styles.ts
@@ -1,6 +1,6 @@
 import tokens from '@contentful/f36-tokens';
 
-const SIDEBAR_WIDTH = 220;
+const SIDEBAR_WIDTH = 205;
 const STICKY_SPACER_SPACING = 24;
 const CELL_WIDTH = 200;
 const TABLE_WIDTH = CELL_WIDTH * 4;
@@ -43,10 +43,10 @@ export const styles = {
     left: 0,
     borderTop: `transparent`,
   },
-  stickyTableHeader: {
+  stickyMainColumnsOrFields: {
     background: tokens.gray200,
     position: 'sticky',
-    left: SIDEBAR_WIDTH + STICKY_SPACER_SPACING,
+    left: STICKY_SPACER_SPACING + CELL_WIDTH,
     zIndex: 1,
     borderRight: `1px solid ${tokens.gray300}`,
     minWidth: `${CELL_WIDTH}px`,
@@ -85,6 +85,7 @@ export const styles = {
     width: STICKY_SPACER_SPACING,
     height: '100vh',
     display: 'block',
+    marginRight: tokens.spacing2Xs,
   },
   sortMenu: {
     position: 'sticky',


### PR DESCRIPTION
## Purpose

Needed to include the `status` as a sticky column, same way as the `display name`.

## Approach

Both columns (display name and status) header and field values has the correct sticky css styles.

## Testing steps

https://github.com/user-attachments/assets/6eb7bea4-9048-41a8-a25c-4b06348586ca

## Breaking Changes

N/A

## Dependencies and/or References

Link to [INTEG-3107](https://contentful.atlassian.net/jira/software/c/projects/INTEG/boards/3109?selectedIssue=INTEG-3107)

## Deployment

N/A