### PR TITLE
Bulk-Edit-App: Adding progress note in undo update [INTEG-3112]

### DIFF
--- a/apps/bulk-edit/src/locations/Page/components/UndoBulkEditModal.tsx
+++ b/apps/bulk-edit/src/locations/Page/components/UndoBulkEditModal.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Modal, Button, Text, Flex } from '@contentful/f36-components';
+import { Modal, Button, Text, Flex, Note } from '@contentful/f36-components';
 import { truncate } from '../utils/entryUtils';
+import { ClockIcon } from '@contentful/f36-icons';
 
 interface UndoBulkEditModalProps {
   isOpen: boolean;
@@ -9,6 +10,7 @@ interface UndoBulkEditModalProps {
   firstEntryFieldValue: string;
   isSaving: boolean;
   entryCount: number;
+  editionCount?: number;
 }
 
 export const UndoBulkEditModal: React.FC<UndoBulkEditModalProps> = ({
@@ -18,6 +20,7 @@ export const UndoBulkEditModal: React.FC<UndoBulkEditModalProps> = ({
   firstEntryFieldValue,
   isSaving,
   entryCount,
+  editionCount,
 }) => {
   const title = entryCount === 1 ? 'Edit' : 'Bulk edit';
 
@@ -30,7 +33,10 @@ export const UndoBulkEditModal: React.FC<UndoBulkEditModalProps> = ({
       key={`undo-bulk-edit-modal-${isOpen ? 'open' : 'closed'}`}>
       <Modal.Header title={title} />
       <Modal.Content>
-        <Flex gap="spacingS" flexDirection="column">
+        <Flex
+          gap="spacingS"
+          flexDirection="column"
+          marginBottom={isSaving ? 'spacingM' : undefined}>
           <Text>
             {entryCount === 1 ? (
               <>
@@ -44,6 +50,11 @@ export const UndoBulkEditModal: React.FC<UndoBulkEditModalProps> = ({
             )}
           </Text>
         </Flex>
+        {entryCount > 0 && isSaving && (
+          <Note title="Updating entries" variant="neutral" icon={<ClockIcon variant="muted" />}>
+            {`${editionCount} of ${entryCount} completed`}
+          </Note>
+        )}
       </Modal.Content>
       <Modal.Controls>
         <Button

--- a/apps/bulk-edit/src/locations/Page/index.tsx
+++ b/apps/bulk-edit/src/locations/Page/index.tsx
@@ -311,6 +311,9 @@ const Page = () => {
   };
 
   const undoUpdates = async (backupToUse: Record<string, EntryProps>) => {
+    setTotalUpdateCount(0);
+    setEditionCount(0);
+
     if (Object.keys(backupToUse).length === 0) return;
 
     setIsSaving(true);
@@ -347,6 +350,9 @@ const Page = () => {
               fields: backupEntry.fields,
             }
           );
+
+          setEditionCount((editionCount) => editionCount + 1);
+
           return { success: true, entry: restoredEntry };
         } catch {
           return { success: false, entry: currentEntry };
@@ -485,6 +491,7 @@ const Page = () => {
         firstEntryFieldValue={undoFirstEntryFieldValue}
         isSaving={isSaving}
         entryCount={selectedEntryIds.length}
+        editionCount={editionCount}
       />
     </Flex>
   );


### PR DESCRIPTION
## Purpose

Adding progress note in the `undo update function`.

## Approach

Same way as the `onSave` function using the `editionCount` and `totalCount` states.

## Testing steps

https://github.com/user-attachments/assets/00c69f6f-f612-42c1-95d3-b1b6b5c5be13

## Breaking Changes

N/A

## Dependencies and/or References

Link to [INTEG-3112](https://contentful.atlassian.net/jira/software/c/projects/INTEG/boards/3109?selectedIssue=INTEG-3112)

## Deployment

N/A