### PR TITLE
Bulk Edit v1.1 []

### DIFF
--- a/apps/bulk-edit/.env.example
+++ b/apps/bulk-edit/.env.example
@@ -1,0 +1,25 @@
+# Content Management API token
+# Get this from: https://app.contentful.com/spaces/{SPACE_ID}/api/keys
+CONTENTFUL_ACCESS_TOKEN=your_content_management_api_token_here
+
+# Your Contentful Space ID
+# Found in the URL when you're in your Contentful space
+SPACE_ID=your_space_id_here
+
+# Your Contentful Environment ID
+# Usually 'master' for production, or your custom environment name
+ENVIRONMENT_ID=master
+
+# Your Contentful Organization ID
+# Found in the URL when you're in your organization settings
+CONTENTFUL_ORG_ID=your_organization_id_here
+
+# Your Contentful App Definition ID
+# Found under the title from the app definition in contentful
+CONTENTFUL_APP_DEF_ID=yout_app_definition_id
+
+# Set the amount of entries we want create (OPTIONAL)
+AMOUNT_OF_ENTRIES=5
+
+# Set the Content Type name of the entries you want to delete
+DELETE_CONTENT_TYPE_NAME="test-content-type"

--- a/apps/bulk-edit/.env.test
+++ b/apps/bulk-edit/.env.test
@@ -1,0 +1,25 @@
+# Content Management API token
+# Get this from: https://app.contentful.com/spaces/{SPACE_ID}/api/keys
+CONTENTFUL_ACCESS_TOKEN=access_token
+
+# Your Contentful Space ID
+# Found in the URL when you're in your Contentful space
+SPACE_ID=space_id
+
+# Your Contentful Environment ID
+# Usually 'master' for production, or your custom environment name
+ENVIRONMENT_ID=master
+
+# Your Contentful Organization ID
+# Found in the URL when you're in your organization settings
+CONTENTFUL_ORG_ID=org_id
+
+# Your Contentful App Definition ID
+# Found under the title from the app definition in contentful
+CONTENTFUL_APP_DEF_ID=app_deff_id
+
+# Set the amount of entries we want create
+AMOUNT_OF_ENTRIES=5
+
+# Set the Content Type name of the entries you want to delete
+DELETE_CONTENT_TYPE_NAME="test-content-type"

--- a/apps/bulk-edit/.gitignore
+++ b/apps/bulk-edit/.gitignore
@@ -15,6 +15,7 @@
 .env
 .env.*
 !.env*.example
+!.env.test
 
 # misc
 .DS_Store
@@ -23,3 +24,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+

--- a/apps/bulk-edit/package-lock.json
+++ b/apps/bulk-edit/package-lock.json
@@ -31,6 +31,7 @@
         "@vitejs/plugin-react": "^4.0.3",
         "cross-env": "7.0.3",
         "jsdom": "^26.0.0",
+        "tsx": "^4.7.0",
         "typescript": "4.9.5",
         "vite": "^6.2.2",
         "vitest": "^3.0.9"
@@ -4965,6 +4966,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -6876,6 +6890,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/restore-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
@@ -7675,6 +7699,26 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.20.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.4.tgz",
+      "integrity": "sha512-yyxBKfORQ7LuRt/BQKBXrpcq59ZvSW0XxwfjAt3w2/8PmdxaFzijtMhTawprSHhpzeM5BgU2hXHG3lklIERZXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-fest": {
       "version": "0.21.3",

--- a/apps/bulk-edit/package.json
+++ b/apps/bulk-edit/package.json
@@ -25,7 +25,8 @@
     "create-app-definition": "contentful-app-scripts create-app-definition",
     "add-locations": "contentful-app-scripts add-locations",
     "deploy": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEFINITIONS_ORG_ID} --definition-id 3bRpNGJb2qXeYUmMkDMAwh --token ${CONTENTFUL_CMA_TOKEN}",
-    "deploy:staging": "contentful-app-scripts upload --ci --bundle-dir ./dist --organization-id ${TEST_ORG_ID} --definition-id 75CMBc0rQykFfUPGGrECFF --token ${TEST_CMA_TOKEN}",
+    "deploy:staging": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${TEST_ORG_ID} --definition-id 75CMBc0rQykFfUPGGrECFF --token ${TEST_CMA_TOKEN}",
+    "upload": "contentful-app-scripts upload --bundle-dir ./build",
     "generate-entries": "tsx src/scripts/generateEntries.ts",
     "delete-entries": "tsx src/scripts/deleteEntries.ts"
   },

--- a/apps/bulk-edit/package.json
+++ b/apps/bulk-edit/package.json
@@ -25,7 +25,9 @@
     "create-app-definition": "contentful-app-scripts create-app-definition",
     "add-locations": "contentful-app-scripts add-locations",
     "deploy": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEFINITIONS_ORG_ID} --definition-id 3bRpNGJb2qXeYUmMkDMAwh --token ${CONTENTFUL_CMA_TOKEN}",
-    "deploy:staging": "contentful-app-scripts upload --ci --bundle-dir ./dist --organization-id ${TEST_ORG_ID} --definition-id 75CMBc0rQykFfUPGGrECFF --token ${TEST_CMA_TOKEN}"
+    "deploy:staging": "contentful-app-scripts upload --ci --bundle-dir ./dist --organization-id ${TEST_ORG_ID} --definition-id 75CMBc0rQykFfUPGGrECFF --token ${TEST_CMA_TOKEN}",
+    "generate-entries": "tsx src/scripts/generateEntries.ts",
+    "delete-entries": "tsx src/scripts/deleteEntries.ts"
   },
   "eslintConfig": {
     "extends": "react-app"
@@ -52,6 +54,7 @@
     "@vitejs/plugin-react": "^4.0.3",
     "cross-env": "7.0.3",
     "jsdom": "^26.0.0",
+    "tsx": "^4.7.0",
     "typescript": "4.9.5",
     "vite": "^6.2.2",
     "vitest": "^3.0.9"

--- a/apps/bulk-edit/src/locations/Page/components/BulkEditModal.styles.ts
+++ b/apps/bulk-edit/src/locations/Page/components/BulkEditModal.styles.ts
@@ -1,0 +1,10 @@
+import tokens from '@contentful/f36-tokens';
+
+export const styles = {
+  editProgress: {
+    background: tokens.gray100,
+    border: `1px solid ${tokens.gray300}`,
+    borderRadius: tokens.borderRadiusMedium,
+    padding: tokens.spacingM,
+  },
+} as const;

--- a/apps/bulk-edit/src/locations/Page/components/BulkEditModal.tsx
+++ b/apps/bulk-edit/src/locations/Page/components/BulkEditModal.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Modal, Button, TextInput, Text, Flex, FormControl } from '@contentful/f36-components';
 import type { Entry, ContentTypeField } from '../types';
-import { getEntryFieldValue } from '../utils/entryUtils';
+import { getEntryFieldValue, truncate } from '../utils/entryUtils';
 
 interface BulkEditModalProps {
   isOpen: boolean;
@@ -48,7 +48,7 @@ export const BulkEditModal: React.FC<BulkEditModalProps> = ({
           </Text>
           <Flex>
             <Text>
-              <Text fontWeight="fontWeightDemiBold">{firstValueToUpdate}</Text>{' '}
+              <Text fontWeight="fontWeightDemiBold">{truncate(firstValueToUpdate, 100)}</Text>{' '}
               {entryCount === 1 ? 'selected' : `selected and ${entryCount - 1} more`}
             </Text>
           </Flex>
@@ -71,7 +71,11 @@ export const BulkEditModal: React.FC<BulkEditModalProps> = ({
         </Flex>
       </Modal.Content>
       <Modal.Controls>
-        <Button variant="secondary" onClick={onClose} testId="bulk-edit-cancel">
+        <Button
+          variant="secondary"
+          onClick={onClose}
+          testId="bulk-edit-cancel"
+          isDisabled={isSaving}>
           Cancel
         </Button>
         <Button

--- a/apps/bulk-edit/src/locations/Page/components/BulkEditModal.tsx
+++ b/apps/bulk-edit/src/locations/Page/components/BulkEditModal.tsx
@@ -1,7 +1,16 @@
 import React, { useEffect, useState } from 'react';
-import { Modal, Button, TextInput, Text, Flex, FormControl } from '@contentful/f36-components';
+import {
+  Modal,
+  Button,
+  TextInput,
+  Text,
+  Flex,
+  FormControl,
+  Note,
+} from '@contentful/f36-components';
 import type { Entry, ContentTypeField } from '../types';
 import { getEntryFieldValue, truncate } from '../utils/entryUtils';
+import { ClockIcon } from '@contentful/f36-icons';
 
 interface BulkEditModalProps {
   isOpen: boolean;
@@ -11,6 +20,8 @@ interface BulkEditModalProps {
   selectedField: ContentTypeField | null;
   defaultLocale: string;
   isSaving: boolean;
+  totalUpdateCount: number;
+  editionCount: number;
 }
 
 export const BulkEditModal: React.FC<BulkEditModalProps> = ({
@@ -21,6 +32,8 @@ export const BulkEditModal: React.FC<BulkEditModalProps> = ({
   selectedField,
   defaultLocale,
   isSaving,
+  totalUpdateCount,
+  editionCount,
 }) => {
   const [value, setValue] = useState('');
   const entryCount = selectedEntries.length;
@@ -39,7 +52,12 @@ export const BulkEditModal: React.FC<BulkEditModalProps> = ({
   }, [isOpen]);
 
   return (
-    <Modal isShown={isOpen} onClose={onClose} size="medium" aria-label={title}>
+    <Modal
+      isShown={isOpen}
+      onClose={onClose}
+      size="medium"
+      aria-label={title}
+      key={`bulk-edit-modal-${isOpen ? 'open' : 'closed'}`}>
       <Modal.Header title={title} />
       <Modal.Content>
         <Flex gap="spacingS" flexDirection="column">
@@ -69,6 +87,11 @@ export const BulkEditModal: React.FC<BulkEditModalProps> = ({
             )}
           </FormControl>
         </Flex>
+        {totalUpdateCount > 0 && isSaving && (
+          <Note title="Updating entries" variant="neutral" icon={<ClockIcon variant="muted" />}>
+            {`${editionCount} of ${totalUpdateCount} completed`}
+          </Note>
+        )}
       </Modal.Content>
       <Modal.Controls>
         <Button

--- a/apps/bulk-edit/src/locations/Page/components/TableHeader.tsx
+++ b/apps/bulk-edit/src/locations/Page/components/TableHeader.tsx
@@ -22,7 +22,7 @@ export const TableHeader: React.FC<TableHeaderProps> = ({
 }) => {
   return (
     <Table.Head style={styles.tableHead}>
-      <Table.Row>
+      <Table.Row style={styles.stickyTableRow}>
         {fields.length > 0 && (
           <Table.Cell as="th" key={DISPLAY_NAME_COLUMN} style={styles.stickyTableHeader}>
             Display name

--- a/apps/bulk-edit/src/locations/Page/components/TableHeader.tsx
+++ b/apps/bulk-edit/src/locations/Page/components/TableHeader.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Table, Checkbox, Flex, Text } from '@contentful/f36-components';
+import { Table, Checkbox, Flex, Text, Box } from '@contentful/f36-components';
 import { Tooltip } from '@contentful/f36-tooltip';
 import { QuestionIcon } from '@phosphor-icons/react';
 import { ContentTypeField } from '../types';
@@ -23,19 +23,21 @@ export const TableHeader: React.FC<TableHeaderProps> = ({
   return (
     <Table.Head style={styles.tableHead}>
       <Table.Row style={styles.stickyTableRow}>
-        {fields.length > 0 && (
-          <Table.Cell as="th" key={DISPLAY_NAME_COLUMN} style={styles.stickyTableHeader}>
-            Display name
+        <Box style={styles.stickyMainColumnsOrFields}>
+          {fields.length > 0 && (
+            <Table.Cell as="th" key={DISPLAY_NAME_COLUMN} style={styles.tableHeader}>
+              Display name
+            </Table.Cell>
+          )}
+          <Table.Cell as="th" key={ENTRY_STATUS_COLUMN} style={styles.tableHeader}>
+            <Flex gap="spacingXs" alignItems="center" justifyContent="flex-start">
+              Status
+              <Tooltip content="Bulk editing is not supported for Status" placement="top">
+                <QuestionIcon size={16} aria-label="Bulk editing not supported for Status" />
+              </Tooltip>
+            </Flex>
           </Table.Cell>
-        )}
-        <Table.Cell as="th" key={ENTRY_STATUS_COLUMN} style={styles.tableHeader}>
-          <Flex gap="spacingXs" alignItems="center" justifyContent="flex-start">
-            Status
-            <Tooltip content="Bulk editing is not supported for Status" placement="top">
-              <QuestionIcon size={16} aria-label="Bulk editing not supported for Status" />
-            </Tooltip>
-          </Flex>
-        </Table.Cell>
+        </Box>
         {fields.map((field) => {
           const isAllowed = isCheckboxAllowed(field);
           const isDisabled = checkboxesDisabled[field.uniqueId];

--- a/apps/bulk-edit/src/locations/Page/components/TableRow.tsx
+++ b/apps/bulk-edit/src/locations/Page/components/TableRow.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Table, TextLink, Badge, Checkbox, Flex, Text } from '@contentful/f36-components';
+import { Table, TextLink, Badge, Checkbox, Flex, Text, Box } from '@contentful/f36-components';
 import { ExternalLinkIcon } from '@contentful/f36-icons';
 import { Entry, ContentTypeField } from '../types';
 import { ContentTypeProps } from 'contentful-management';
@@ -44,20 +44,22 @@ export const TableRow: React.FC<TableRowProps> = ({
 
   return (
     <Table.Row key={entry.sys.id}>
-      <Table.Cell testId="display-name-cell" style={styles.stickyCell} isTruncated>
-        <TextLink
-          href={getEntryUrl(entry, spaceId, environmentId)}
-          target="_blank"
-          rel="noopener noreferrer"
-          testId="entry-link"
-          icon={<ExternalLinkIcon />}
-          alignIcon="end">
-          {getEntryTitle(entry, contentType, defaultLocale)}
-        </TextLink>
-      </Table.Cell>
-      <Table.Cell testId="status-cell" style={styles.cell}>
-        <Badge variant={status.color}>{status.label}</Badge>
-      </Table.Cell>
+      <Box style={styles.stickyMainColumnsOrFields}>
+        <Table.Cell testId="display-name-cell" style={styles.cell}>
+          <TextLink
+            href={getEntryUrl(entry, spaceId, environmentId)}
+            target="_blank"
+            rel="noopener noreferrer"
+            testId="entry-link"
+            icon={<ExternalLinkIcon />}
+            alignIcon="end">
+            {getEntryTitle(entry, contentType, defaultLocale)}
+          </TextLink>
+        </Table.Cell>
+        <Table.Cell testId="status-cell" style={styles.cell}>
+          <Badge variant={status.color}>{status.label}</Badge>
+        </Table.Cell>
+      </Box>
       {fields.map((field) => {
         const isAllowed = isCheckboxAllowed(field);
         const isDisabled = cellCheckboxesDisabled[field.uniqueId];

--- a/apps/bulk-edit/src/locations/Page/components/UndoBulkEditModal.tsx
+++ b/apps/bulk-edit/src/locations/Page/components/UndoBulkEditModal.tsx
@@ -22,7 +22,12 @@ export const UndoBulkEditModal: React.FC<UndoBulkEditModalProps> = ({
   const title = entryCount === 1 ? 'Edit' : 'Bulk edit';
 
   return (
-    <Modal isShown={isOpen} onClose={onClose} size="medium" aria-label={title}>
+    <Modal
+      isShown={isOpen}
+      onClose={onClose}
+      size="medium"
+      aria-label={title}
+      key={`undo-bulk-edit-modal-${isOpen ? 'open' : 'closed'}`}>
       <Modal.Header title={title} />
       <Modal.Content>
         <Flex gap="spacingS" flexDirection="column">

--- a/apps/bulk-edit/src/locations/Page/components/UndoBulkEditModal.tsx
+++ b/apps/bulk-edit/src/locations/Page/components/UndoBulkEditModal.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Modal, Button, Text, Flex } from '@contentful/f36-components';
+import { truncate } from '../utils/entryUtils';
 
 interface UndoBulkEditModalProps {
   isOpen: boolean;
@@ -28,19 +29,23 @@ export const UndoBulkEditModal: React.FC<UndoBulkEditModalProps> = ({
           <Text>
             {entryCount === 1 ? (
               <>
-                The update for <b>{firstEntryFieldValue}</b> will be reverted.
+                The update for <b>{truncate(firstEntryFieldValue, 100)}</b> will be reverted.
               </>
             ) : (
               <>
-                The update for <b>{firstEntryFieldValue}</b> and <b>{entryCount - 1}</b> more entry
-                fields will be reverted.
+                The update for <b>{truncate(firstEntryFieldValue, 100)}</b> and{' '}
+                <b>{entryCount - 1}</b> more entry fields will be reverted.
               </>
             )}
           </Text>
         </Flex>
       </Modal.Content>
       <Modal.Controls>
-        <Button variant="secondary" onClick={onClose} testId="undo-bulk-cancel">
+        <Button
+          variant="secondary"
+          onClick={onClose}
+          testId="undo-bulk-cancel"
+          isDisabled={isSaving}>
           Cancel
         </Button>
         <Button variant="primary" onClick={onUndo} testId="undo-bulk-confirm" isLoading={isSaving}>

--- a/apps/bulk-edit/src/locations/Page/components/UndoBulkEditModal.tsx
+++ b/apps/bulk-edit/src/locations/Page/components/UndoBulkEditModal.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Modal, Button, Text, Flex } from '@contentful/f36-components';
+import { Modal, Button, Text, Flex, Note } from '@contentful/f36-components';
 import { truncate } from '../utils/entryUtils';
+import { ClockIcon } from '@contentful/f36-icons';
 
 interface UndoBulkEditModalProps {
   isOpen: boolean;
@@ -9,6 +10,7 @@ interface UndoBulkEditModalProps {
   firstEntryFieldValue: string;
   isSaving: boolean;
   entryCount: number;
+  editionCount: number;
 }
 
 export const UndoBulkEditModal: React.FC<UndoBulkEditModalProps> = ({
@@ -18,6 +20,7 @@ export const UndoBulkEditModal: React.FC<UndoBulkEditModalProps> = ({
   firstEntryFieldValue,
   isSaving,
   entryCount,
+  editionCount,
 }) => {
   const title = entryCount === 1 ? 'Edit' : 'Bulk edit';
 
@@ -30,7 +33,10 @@ export const UndoBulkEditModal: React.FC<UndoBulkEditModalProps> = ({
       key={`undo-bulk-edit-modal-${isOpen ? 'open' : 'closed'}`}>
       <Modal.Header title={title} />
       <Modal.Content>
-        <Flex gap="spacingS" flexDirection="column">
+        <Flex
+          gap="spacingS"
+          flexDirection="column"
+          marginBottom={isSaving ? 'spacingM' : undefined}>
           <Text>
             {entryCount === 1 ? (
               <>
@@ -44,6 +50,11 @@ export const UndoBulkEditModal: React.FC<UndoBulkEditModalProps> = ({
             )}
           </Text>
         </Flex>
+        {entryCount > 0 && isSaving && (
+          <Note title="Updating entries" variant="neutral" icon={<ClockIcon variant="muted" />}>
+            {`${editionCount} of ${entryCount} completed`}
+          </Note>
+        )}
       </Modal.Content>
       <Modal.Controls>
         <Button

--- a/apps/bulk-edit/src/locations/Page/index.tsx
+++ b/apps/bulk-edit/src/locations/Page/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Box,
   Heading,
@@ -7,6 +7,8 @@ import {
   Button,
   Text,
   Notification,
+  Skeleton,
+  Table,
 } from '@contentful/f36-components';
 import { useSDK } from '@contentful/react-apps-toolkit';
 import { ContentFields, ContentTypeProps, KeyValueMap, EntryProps } from 'contentful-management';
@@ -379,7 +381,11 @@ const Page = () => {
                       </Flex>
                     )}
                     {entriesLoading ? (
-                      <Spinner />
+                      <Table style={styles.loadingTableBorder}>
+                        <Table.Body>
+                          <Skeleton.Row rowCount={5} columnCount={5} />
+                        </Table.Body>
+                      </Table>
                     ) : (
                       <>
                         {failedUpdates.length > 0 && (

--- a/apps/bulk-edit/src/locations/Page/index.tsx
+++ b/apps/bulk-edit/src/locations/Page/index.tsx
@@ -57,6 +57,8 @@ const Page = () => {
   const [lastUpdateBackup, setLastUpdateBackup] = useState<Record<string, EntryProps>>({});
   const [isUndoModalOpen, setIsUndoModalOpen] = useState(false);
   const [undoFirstEntryFieldValue, setUndoFirstEntryFieldValue] = useState('');
+  const [totalUpdateCount, setTotalUpdateCount] = useState<number>(0);
+  const [editionCount, setEditionCount] = useState<number>(0);
 
   const getAllContentTypes = async (): Promise<ContentTypeProps[]> => {
     const allContentTypes: ContentTypeProps[] = [];
@@ -228,11 +230,16 @@ const Page = () => {
   };
 
   const onSave = async (val: string | number) => {
+    setTotalUpdateCount(0);
+    setEditionCount(0);
     setIsSaving(true);
     setFailedUpdates([]);
 
     try {
       if (!selectedField) return;
+
+      setTotalUpdateCount(selectedEntries.length);
+
       const backups: Record<string, EntryProps> = {};
 
       // Create update function for batch processing
@@ -257,6 +264,8 @@ const Page = () => {
             },
             { ...latestEntry, fields: updatedFields }
           );
+
+          setEditionCount((editionCount) => editionCount + 1);
 
           return { success: true, entry: updated };
         } catch {
@@ -463,6 +472,8 @@ const Page = () => {
         selectedField={selectedField}
         defaultLocale={defaultLocale}
         isSaving={isSaving}
+        totalUpdateCount={totalUpdateCount}
+        editionCount={editionCount}
       />
       <UndoBulkEditModal
         isOpen={isUndoModalOpen}

--- a/apps/bulk-edit/src/locations/Page/index.tsx
+++ b/apps/bulk-edit/src/locations/Page/index.tsx
@@ -311,6 +311,9 @@ const Page = () => {
   };
 
   const undoUpdates = async (backupToUse: Record<string, EntryProps>) => {
+    setTotalUpdateCount(0);
+    setEditionCount(0);
+
     if (Object.keys(backupToUse).length === 0) return;
 
     setIsSaving(true);
@@ -347,6 +350,9 @@ const Page = () => {
               fields: backupEntry.fields,
             }
           );
+
+          setEditionCount((editionCount) => editionCount + 1);
+
           return { success: true, entry: restoredEntry };
         } catch {
           return { success: false, entry: currentEntry };
@@ -485,6 +491,7 @@ const Page = () => {
         firstEntryFieldValue={undoFirstEntryFieldValue}
         isSaving={isSaving}
         entryCount={selectedEntryIds.length}
+        editionCount={editionCount}
       />
     </Flex>
   );

--- a/apps/bulk-edit/src/locations/Page/styles.ts
+++ b/apps/bulk-edit/src/locations/Page/styles.ts
@@ -1,6 +1,6 @@
 import tokens from '@contentful/f36-tokens';
 
-const SIDEBAR_WIDTH = 220;
+const SIDEBAR_WIDTH = 205;
 const STICKY_SPACER_SPACING = 24;
 const CELL_WIDTH = 200;
 const TABLE_WIDTH = CELL_WIDTH * 4;
@@ -43,10 +43,10 @@ export const styles = {
     left: 0,
     borderTop: `transparent`,
   },
-  stickyTableHeader: {
+  stickyMainColumnsOrFields: {
     background: tokens.gray200,
     position: 'sticky',
-    left: SIDEBAR_WIDTH + STICKY_SPACER_SPACING,
+    left: STICKY_SPACER_SPACING + CELL_WIDTH,
     zIndex: 1,
     borderRight: `1px solid ${tokens.gray300}`,
     minWidth: `${CELL_WIDTH}px`,
@@ -85,6 +85,7 @@ export const styles = {
     width: STICKY_SPACER_SPACING,
     height: '100vh',
     display: 'block',
+    marginRight: tokens.spacing2Xs,
   },
   sortMenu: {
     position: 'sticky',

--- a/apps/bulk-edit/src/locations/Page/styles.ts
+++ b/apps/bulk-edit/src/locations/Page/styles.ts
@@ -1,5 +1,4 @@
 import tokens from '@contentful/f36-tokens';
-import { SortMenu } from './components/SortMenu';
 
 const SIDEBAR_WIDTH = 220;
 const STICKY_SPACER_SPACING = 24;
@@ -14,7 +13,7 @@ export const styles = {
     position: 'sticky',
     left: 0,
     top: 0,
-    zIndex: 3,
+    zIndex: 4,
     background: tokens.colorWhite,
   },
   mainContent: {
@@ -52,6 +51,12 @@ export const styles = {
     borderRight: `1px solid ${tokens.gray300}`,
     minWidth: `${CELL_WIDTH}px`,
   },
+  stickyTableRow: {
+    background: tokens.colorWhite,
+    position: 'sticky',
+    top: 0,
+    zIndex: 2,
+  },
   cell: {
     borderRight: `1px solid ${tokens.gray300}`,
     minWidth: `${CELL_WIDTH}px`,
@@ -74,7 +79,7 @@ export const styles = {
   stickySpacer: {
     position: 'sticky',
     left: SIDEBAR_WIDTH,
-    zIndex: 1,
+    zIndex: 3,
     top: 0,
     background: tokens.colorWhite,
     width: STICKY_SPACER_SPACING,

--- a/apps/bulk-edit/src/locations/Page/styles.ts
+++ b/apps/bulk-edit/src/locations/Page/styles.ts
@@ -123,4 +123,7 @@ export const styles = {
     left: SIDEBAR_WIDTH + STICKY_SPACER_SPACING,
     zIndex: 1,
   },
+  loadingTableBorder: {
+    border: `1px solid ${tokens.gray200}`,
+  },
 } as const;

--- a/apps/bulk-edit/src/locations/Page/utils/constants.ts
+++ b/apps/bulk-edit/src/locations/Page/utils/constants.ts
@@ -3,7 +3,23 @@ export const ENTRY_STATUS_COLUMN = 'notfield_status';
 export const PAGE_TITLE = 'Bulk Edit';
 export const PAGE_DESCRIPTION = 'Bulk edit your content entries';
 
-export const ERROR_MESSAGES = {
-  LOADING_ERROR: 'Failed to load data',
-  SAVE_ERROR: 'Failed to save changes',
+export const BATCH_FETCHING = {
+  DEFAULT_BATCH_SIZE: 100,
+  MIN_BATCH_SIZE: 2,
 } as const;
+
+export const BATCH_PROCESSING = {
+  // Align with Contentful's bulk action limit of 200 items
+  DEFAULT_BATCH_SIZE: 50,
+  // Align with CMA rate limit: 10 calls per second = 100ms between calls
+  // Using 200ms to be conservative and account for network latency
+  DEFAULT_DELAY_MS: 200,
+} as const;
+
+// API limits - used in index.tsx
+export const API_LIMITS = {
+  DEFAULT_PAGINATION_LIMIT: 1000,
+  CORS_QUERY_PARAM_LIMIT: 300,
+} as const;
+
+export const PAGE_SIZE_OPTIONS = [25, 50, 100, 200, 300, 500];

--- a/apps/bulk-edit/src/locations/Page/utils/entryUtils.ts
+++ b/apps/bulk-edit/src/locations/Page/utils/entryUtils.ts
@@ -1,7 +1,8 @@
 import { documentToHtmlString } from '@contentful/rich-text-html-renderer';
 import { Document } from '@contentful/rich-text-types';
 import { Entry, ContentTypeField, Status, Fields } from '../types';
-import { ContentTypeProps } from 'contentful-management';
+import { ContentTypeProps, EntryProps, QueryOptions } from 'contentful-management';
+import { BATCH_FETCHING } from './constants';
 
 export const getStatus = (entry: Entry): Status => {
   const { sys } = entry;
@@ -147,4 +148,109 @@ export function getEntryFieldValue(
   if (fieldValue === undefined || fieldValue === null) return 'empty field';
 
   return String(fieldValue) || 'empty field';
+}
+
+/**
+ * Processes entries in batches with configurable delays to avoid rate limiting.
+ * @param entries - Array of entries to process
+ * @param updateFunction - Function to call for each entry
+ * @param batchSize - Number of entries to process in each batch
+ * @param delayMs - Delay in milliseconds between batches
+ * @returns Promise that resolves to array of results from updateFunction
+ */
+export async function processEntriesInBatches(
+  entries: EntryProps[],
+  updateFunction: (entry: EntryProps) => Promise<{
+    success: boolean;
+    entry: EntryProps;
+  }>,
+  batchSize: number,
+  delayMs: number
+): Promise<{ success: boolean; entry: EntryProps }[]> {
+  if (entries.length === 0) {
+    return [];
+  }
+
+  const results = [];
+
+  for (let i = 0; i < entries.length; i += batchSize) {
+    const batch = entries.slice(i, i + batchSize);
+
+    // Process current batch
+    const batchResults = await Promise.all(batch.map((entry) => updateFunction(entry)));
+    results.push(...batchResults);
+
+    // Add delay between batches (except for the last batch)
+    if (i + batchSize < entries.length) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+
+  return results;
+}
+
+// Fetch entries in batches to avoid response size limits
+export async function fetchEntriesWithBatching(
+  sdk: any,
+  query: QueryOptions,
+  batchSize: number
+): Promise<{ entries: EntryProps[]; total: number }> {
+  const allEntries: EntryProps[] = [];
+  const { skip, limit } = query;
+  let batchSkip = skip || 0;
+  let total = 0;
+  let hasMore = true;
+
+  while (hasMore) {
+    try {
+      const batchQuery = {
+        ...query,
+        skip: batchSkip,
+        limit: batchSize,
+      };
+
+      const response = await sdk.cma.entry.getMany({
+        spaceId: sdk.ids.space,
+        environmentId: sdk.ids.environment,
+        query: batchQuery,
+      });
+
+      const items = response.items as EntryProps[];
+      const batchTotal = response.total || 0;
+
+      // Set total on first batch
+      if (total === 0) {
+        total = batchTotal;
+      }
+
+      allEntries.push(...items);
+
+      // Check if we should continue
+      hasMore =
+        items.length === batchSize &&
+        (limit === undefined || allEntries.length < limit) &&
+        allEntries.length < total;
+
+      batchSkip += batchSize;
+    } catch (error: any) {
+      // If we hit response size limit, reduce batch size and retry
+      if (error.message && error.message.includes('Response size too big')) {
+        if (batchSize > BATCH_FETCHING.MIN_BATCH_SIZE) {
+          const newBatchSize = Math.floor(batchSize / 2);
+          console.warn(
+            `Response size limit hit, reducing batch size from ${batchSize} to ${newBatchSize}`
+          );
+          return fetchEntriesWithBatching(sdk, query, newBatchSize);
+        } else {
+          throw new Error(
+            'Unable to fetch entries: response size too large even with minimal batch size'
+          );
+        }
+      } else {
+        throw error;
+      }
+    }
+  }
+
+  return { entries: allEntries, total };
 }

--- a/apps/bulk-edit/src/scripts/deleteEntries.ts
+++ b/apps/bulk-edit/src/scripts/deleteEntries.ts
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+
+/*
+ * This script deletes all entries from a specific content type
+ * It uses the Content Management API to find and delete all entries of the specified content type
+ */
+
+import 'dotenv/config';
+import {
+  askForContentTypeName,
+  confirmDeletion,
+  createContentfulClient,
+  createReadlineInterface,
+  getContentTypeIdByName,
+  getEntriesByContentType,
+  validateEnvironment,
+} from './utils';
+import { PlainClientAPI } from 'contentful-management';
+import { Interface } from 'readline';
+
+export async function deleteEntry(entryId: string, client: PlainClientAPI): Promise<boolean> {
+  try {
+    try {
+      const entry = await client.entry.get({ entryId });
+      if (entry.sys.publishedVersion) {
+        await client.entry.unpublish({ entryId });
+        console.log(`   📤 Unpublished entry: ${entryId}`);
+      }
+    } catch (error) {}
+
+    await client.entry.delete({ entryId });
+    console.log(`   ✅ Deleted entry: ${entryId}`);
+    return true;
+  } catch (error) {
+    console.error(`   ❌ Failed to delete entry ${entryId}:`, error);
+    return false;
+  }
+}
+
+export async function deleteAllEntriesForContentType(
+  contentTypeId: string,
+  client: PlainClientAPI,
+  rl: Interface,
+  deleteContentTypeName: string | undefined
+): Promise<void> {
+  console.log(`\n🔍 Fetching all entries for content type: ${contentTypeId}`);
+
+  const entries = await getEntriesByContentType(client, contentTypeId);
+
+  if (entries.length === 0) {
+    console.log('✅ No entries found for this content type.');
+    return;
+  }
+
+  console.log(`📊 Found ${entries.length} entries to delete.`);
+
+  let confirmed: boolean;
+  if (deleteContentTypeName) {
+    confirmed = true;
+  } else {
+    confirmed = await confirmDeletion(rl, entries.length);
+  }
+
+  if (!confirmed) {
+    console.log('❌ Operation cancelled by user.');
+    return;
+  }
+
+  console.log('\n🗑️  Starting deletion process...');
+
+  let successCount = 0;
+  let failureCount = 0;
+
+  const batchSize = 10;
+  for (let i = 0; i < entries.length; i += batchSize) {
+    const batch = entries.slice(i, i + batchSize);
+
+    console.log(
+      `\n📦 Processing batch ${Math.floor(i / batchSize) + 1}/${Math.ceil(
+        entries.length / batchSize
+      )}`
+    );
+
+    const batchPromises = batch.map(async (entry) => {
+      return await deleteEntry(entry.sys.id, client);
+    });
+
+    const results = await Promise.all(batchPromises);
+
+    successCount += results.filter(Boolean).length;
+    failureCount += results.filter((r) => !r).length;
+
+    if (i + batchSize < entries.length) {
+      console.log('⏳ Waiting 2 seconds before next batch...');
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+    }
+  }
+
+  console.log('\n📋 Deletion Summary:');
+  console.log(`   ✅ Successfully deleted: ${successCount} entries`);
+  console.log(`   ❌ Failed to delete: ${failureCount} entries`);
+  console.log(`   📊 Total processed: ${entries.length} entries`);
+}
+
+export async function deleteEntries() {
+  validateEnvironment();
+  const client = createContentfulClient();
+  const rl = createReadlineInterface();
+  const { DELETE_CONTENT_TYPE_NAME } = process.env;
+
+  try {
+    console.log('🗑️  Contentful Entry Deletion Script\n');
+
+    const contentTypeName = await askForContentTypeName(rl, DELETE_CONTENT_TYPE_NAME);
+
+    if (!contentTypeName) {
+      console.log('❌ Content type name cannot be empty.');
+      return;
+    }
+
+    console.log(`\n🔍 Looking for content type: "${contentTypeName}"`);
+
+    const contentTypeId = await getContentTypeIdByName(client, contentTypeName);
+
+    if (!contentTypeId) {
+      console.log('\n❌ Content type not found. Please check the name and try again.');
+      return;
+    }
+
+    console.log(`✅ Found content type: ${contentTypeName} (ID: ${contentTypeId})`);
+
+    await deleteAllEntriesForContentType(contentTypeId, client, rl, DELETE_CONTENT_TYPE_NAME);
+
+    console.log('\n🎉 Script completed successfully!');
+  } catch (error) {
+    console.error('\n❌ Script failed:', error);
+    throw error;
+  } finally {
+    rl.close();
+  }
+}
+
+if (require.main === module) {
+  deleteEntries();
+}

--- a/apps/bulk-edit/src/scripts/generateEntries.ts
+++ b/apps/bulk-edit/src/scripts/generateEntries.ts
@@ -1,0 +1,289 @@
+#!/usr/bin/env node
+
+import 'dotenv/config';
+import {
+  validateEnvironment,
+  createContentfulClient,
+  createReadlineInterface,
+  askForEntryCount,
+} from './utils';
+import { KeyValueMap, PlainClientAPI } from 'contentful-management';
+
+const FIELD_TYPES = [
+  {
+    type: 'Symbol',
+    name: 'Short Text',
+    id: 'shortText',
+    description: 'A short text field (single line)',
+  },
+  {
+    type: 'Text',
+    name: 'Long Text',
+    id: 'longText',
+    description: 'A long text field (multi-line)',
+  },
+  {
+    type: 'RichText',
+    name: 'Rich Text',
+    id: 'richText',
+    description: 'A rich text field with formatting',
+  },
+  {
+    type: 'Integer',
+    name: 'Integer Number',
+    id: 'integerNumber',
+    description: 'A whole number field',
+  },
+  {
+    type: 'Number',
+    name: 'Decimal Number',
+    id: 'decimalNumber',
+    description: 'A decimal number field',
+  },
+  { type: 'Date', name: 'Date and Time', id: 'dateTime', description: 'A date and time field' },
+  { type: 'Boolean', name: 'Boolean', id: 'boolean', description: 'A true/false field' },
+  { type: 'Object', name: 'JSON Object', id: 'jsonObject', description: 'A JSON object field' },
+  {
+    type: 'Location',
+    name: 'Location',
+    id: 'location',
+    description: 'A geographic location field',
+  },
+  {
+    type: 'Link',
+    name: 'Asset',
+    id: 'asset',
+    linkType: 'Asset',
+    description: 'A link to an asset',
+  },
+  {
+    type: 'Link',
+    name: 'Reference',
+    id: 'reference',
+    linkType: 'Entry',
+    description: 'A link to an entry',
+  },
+  {
+    type: 'Array',
+    name: 'Symbol Array',
+    id: 'symbolArray',
+    items: { type: 'Symbol' },
+    description: 'An array of short text values',
+  },
+  {
+    type: 'Array',
+    name: 'Asset Array',
+    id: 'assetArray',
+    items: { type: 'Link', linkType: 'Asset' },
+    description: 'An array of asset links',
+  },
+  {
+    type: 'Array',
+    name: 'Entry Array',
+    id: 'entryArray',
+    items: { type: 'Link', linkType: 'Entry' },
+    description: 'An array of entry links',
+  },
+];
+
+export async function createContentTypeWithAllFields(client: PlainClientAPI) {
+  const contentTypeName = 'All Field Types';
+
+  console.log(`Creating content type: ${contentTypeName}`);
+
+  const fields = FIELD_TYPES.map((fieldType) => {
+    const baseField = {
+      id: fieldType.id,
+      name: fieldType.name,
+      required: false,
+      localized: false,
+      validations: [],
+      disabled: false,
+      omitted: false,
+    };
+
+    if (fieldType.type === 'Link') {
+      return {
+        ...baseField,
+        type: 'Link',
+        linkType: fieldType.linkType,
+      };
+    } else if (fieldType.type === 'Array') {
+      return {
+        ...baseField,
+        type: 'Array',
+        items: fieldType.items,
+      };
+    } else {
+      return {
+        ...baseField,
+        type: fieldType.type,
+      };
+    }
+  });
+
+  const body = {
+    name: contentTypeName,
+    displayField: 'shortText',
+    description:
+      'A comprehensive content type with all possible field types for testing the app integration',
+    fields,
+  };
+
+  try {
+    const contentTypeProps = await client.contentType.create({}, body);
+    console.log(`Created content type: ${contentTypeProps.sys.id}`);
+
+    await client.contentType.publish({ contentTypeId: contentTypeProps.sys.id }, contentTypeProps);
+
+    console.log(`✅ Created and published content type: ${contentTypeProps.sys.id}`);
+    return contentTypeProps.sys.id;
+  } catch (err) {
+    console.error(`❌ Content type creation failed: ${err instanceof Error ? err.message : err}`);
+    throw err;
+  }
+}
+
+export async function createSampleEntry(
+  contentTypeId: string,
+  index: number,
+  client: PlainClientAPI
+) {
+  console.log(`Creating sample entry ${index + 1}...`);
+
+  const fields: KeyValueMap = {
+    shortText: { 'en-US': 'Sample Short Text ' + (index + 1) },
+    longText: {
+      'en-US':
+        'This is a sample long text field with multiple lines.\nIt can contain paragraphs and formatting.',
+    },
+    richText: {
+      'en-US': {
+        nodeType: 'document',
+        data: {},
+        content: [
+          {
+            nodeType: 'paragraph',
+            data: {},
+            content: [
+              {
+                nodeType: 'text',
+                value: 'This is a sample rich text field with formatting.',
+                marks: [],
+                data: {},
+              },
+            ],
+          },
+        ],
+      },
+    },
+    integerNumber: { 'en-US': 42 },
+    decimalNumber: { 'en-US': 3.14159 },
+    dateTime: { 'en-US': '2024-01-15T10:30:00.000Z' },
+    boolean: { 'en-US': true },
+    jsonObject: { 'en-US': { key: 'value', nested: { data: 'example' } } },
+    location: { 'en-US': { lat: 40.7128, lon: -74.006 } },
+    symbolArray: { 'en-US': ['Item 1', 'Item 2', 'Item 3'] },
+  };
+
+  const body = {
+    title: { 'en-US': `Sample Entry ${index + 1}` },
+    fields,
+  };
+
+  try {
+    const entryResult = await client.entry.create({ contentTypeId }, body);
+    console.log(`✅ Created sample entry: ${entryResult.sys.id}`);
+
+    await client.entry.publish({ entryId: entryResult.sys.id }, entryResult);
+    console.log(`✅ Published sample entry ${index + 1}`);
+
+    return entryResult.sys.id;
+  } catch (err) {
+    console.error(
+      `❌ Entry ${index + 1} creation failed: ${err instanceof Error ? err.message : err}`
+    );
+    throw err;
+  }
+}
+
+export async function batchEntries(
+  numberOfEntries: number,
+  contentTypeId: string,
+  client: PlainClientAPI
+) {
+  console.log(`Creating ${numberOfEntries} entries in batches...`);
+
+  const batchSize = 10;
+  let successCount = 0;
+  let failureCount = 0;
+
+  for (let i = 0; i < numberOfEntries; i += batchSize) {
+    const batch = Array.from(
+      { length: Math.min(batchSize, numberOfEntries - i) },
+      (_, batchIndex) => createSampleEntry(contentTypeId, i + batchIndex, client)
+    );
+
+    console.log(
+      `\n📦 Processing batch ${Math.floor(i / batchSize) + 1}/${Math.ceil(
+        numberOfEntries / batchSize
+      )}`
+    );
+
+    try {
+      const batchResults = await Promise.all(batch);
+      successCount += batchResults.length;
+      console.log(`✅ Completed batch ${Math.floor(i / batchSize) + 1}`);
+    } catch (error) {
+      failureCount += batch.length;
+      console.error(`❌ Batch ${Math.floor(i / batchSize) + 1} failed:`, error);
+    }
+
+    if (i + batchSize < numberOfEntries) {
+      console.log('⏳ Waiting 1 second before next batch...');
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+    }
+  }
+
+  console.log(`\n📊 Creation Summary:`);
+  console.log(`   ✅ Successfully created: ${successCount} entries`);
+  console.log(`   ❌ Failed to create: ${failureCount} entries`);
+  console.log(`   📊 Total processed: ${numberOfEntries} entries`);
+
+  console.log('\n🎉 Success! Content type generation complete.');
+  console.log(`\n📋 Summary:`);
+  console.log(`   • Content Type ID: ${contentTypeId}`);
+  console.log(`   • Total Fields: ${FIELD_TYPES.length}`);
+  console.log(`   • Field Types: ${FIELD_TYPES.map((f) => f.type).join(', ')}`);
+  console.log(`\n🔗 You can now use this content type to test the app integration.`);
+  console.log(`   Visit your Contentful space to see the new content type and sample entry.`);
+}
+
+export async function generateEntries() {
+  validateEnvironment();
+  const client = createContentfulClient();
+  const rl = createReadlineInterface();
+  const { AMOUNT_OF_ENTRIES } = process.env;
+
+  const contentTypeId = await createContentTypeWithAllFields(client);
+
+  if (!AMOUNT_OF_ENTRIES) {
+    try {
+      const numberOfEntries = await askForEntryCount(rl);
+      await batchEntries(numberOfEntries, contentTypeId, client);
+    } catch (error) {
+      console.error('❌ Script failed:', error);
+      throw error;
+    } finally {
+      rl.close();
+    }
+  } else {
+    const numberOfEntries = parseInt(AMOUNT_OF_ENTRIES);
+
+    await batchEntries(numberOfEntries, contentTypeId, client);
+  }
+}
+
+if (require.main === module) {
+  generateEntries();
+}

--- a/apps/bulk-edit/src/scripts/utils.ts
+++ b/apps/bulk-edit/src/scripts/utils.ts
@@ -1,0 +1,133 @@
+import { createClient, EntryProps, PlainClientAPI } from 'contentful-management';
+import { Interface, createInterface } from 'readline';
+
+const { SPACE_ID, ENVIRONMENT_ID, CONTENTFUL_ACCESS_TOKEN } = process.env;
+
+export function validateEnvironment(): void {
+  if (!CONTENTFUL_ACCESS_TOKEN || !SPACE_ID || !ENVIRONMENT_ID) {
+    console.error(
+      'Missing required environment variables. Please set CONTENTFUL_ACCESS_TOKEN, SPACE_ID, and ENVIRONMENT_ID'
+    );
+    throw new Error('Missing required environment variables');
+  }
+}
+
+export function createContentfulClient() {
+  return createClient(
+    {
+      accessToken: CONTENTFUL_ACCESS_TOKEN!,
+    },
+    {
+      type: 'plain',
+      defaults: {
+        spaceId: SPACE_ID!,
+        environmentId: ENVIRONMENT_ID!,
+      },
+    }
+  );
+}
+
+export function createReadlineInterface(): Interface {
+  return createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+}
+
+export function askQuestion(rl: Interface, question: string): Promise<string> {
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      resolve(answer.trim());
+    });
+  });
+}
+
+export async function getContentTypeIdByName(
+  client: any,
+  contentTypeName: string
+): Promise<string | null> {
+  try {
+    const contentTypes = await client.contentType.getMany({});
+
+    const contentType = contentTypes.items.find(
+      (ct: any) => ct.name.toLowerCase() === contentTypeName.toLowerCase()
+    );
+
+    if (contentType) {
+      return contentType.sys.id;
+    }
+
+    console.log('\n❌ Content type not found. Available content types:');
+    contentTypes.items.forEach((ct: any) => {
+      console.log(`   • ${ct.name} (ID: ${ct.sys.id})`);
+    });
+
+    return null;
+  } catch (error) {
+    console.error('❌ Error fetching content types:', error);
+    return null;
+  }
+}
+
+export async function getEntriesByContentType(
+  client: PlainClientAPI,
+  contentTypeId: string
+): Promise<EntryProps[]> {
+  try {
+    console.log(`   📄 Fetching all entries for content type: ${contentTypeId}...`);
+
+    const response = await client.entry.getMany({
+      query: {
+        content_type: contentTypeId,
+        limit: 1000,
+      },
+    });
+
+    console.log(`   📊 Got ${response.items.length} entries for this content type`);
+    return response.items;
+  } catch (error) {
+    console.error('❌ Error fetching entries:', error);
+    return [];
+  }
+}
+
+export async function askForEntryCount(rl: Interface): Promise<number> {
+  const entriesInput = await askQuestion(rl, 'Enter the number of entries to create: ');
+  const numberOfEntries = Number.parseInt(entriesInput);
+
+  if (isNaN(numberOfEntries) || numberOfEntries <= 0) {
+    console.log('❌ Please enter a valid positive number.');
+    throw new Error('Invalid entry count');
+  }
+
+  return numberOfEntries;
+}
+
+export async function askForContentTypeName(
+  rl: Interface,
+  deleteContentTypeName: string | undefined
+): Promise<string> {
+  let contentTypeName: string | undefined;
+
+  if (deleteContentTypeName) {
+    contentTypeName = deleteContentTypeName;
+  } else {
+    contentTypeName = await askQuestion(rl, 'Enter the name of the content type: ');
+  }
+
+  if (!contentTypeName) {
+    console.log('❌ Content type name cannot be empty.');
+    throw new Error('Empty content type name');
+  }
+
+  return contentTypeName;
+}
+
+export async function confirmDeletion(rl: Interface, entryCount: number): Promise<boolean> {
+  const confirmation = await askQuestion(
+    rl,
+    `\n⚠️  Are you sure you want to delete ALL ${entryCount} entries? (yes/no): `
+  );
+
+  return confirmation.toLowerCase() === 'yes';
+}

--- a/apps/bulk-edit/test/locations/Page/BulkEditModal.test.tsx
+++ b/apps/bulk-edit/test/locations/Page/BulkEditModal.test.tsx
@@ -3,18 +3,9 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { vi } from 'vitest';
 import { BulkEditModal } from '../../../src/locations/Page/components/BulkEditModal';
 import { Entry, ContentTypeField } from '../../../src/locations/Page/types';
-import { ContentTypeProps } from 'contentful-management';
 
 describe('BulkEditModal', () => {
   const field: ContentTypeField = { id: 'size', uniqueId: 'size', name: 'Size', type: 'Number' };
-  const displayNameField: ContentTypeField = {
-    id: 'displayName',
-    uniqueId: 'displayName',
-    name: 'Display Name',
-    type: 'Symbol',
-  };
-  const fields: ContentTypeField[] = [displayNameField, field];
-  const contentType: Partial<ContentTypeProps> = { displayField: 'displayName' };
   const entry1: Entry = {
     sys: { id: '1', contentType: { sys: { id: 'condoA' } }, version: 1 },
     fields: { displayName: { 'en-US': 'Building one' }, size: { 'en-US': 1000 } },
@@ -34,6 +25,8 @@ describe('BulkEditModal', () => {
         selectedField={field}
         defaultLocale="en-US"
         isSaving={false}
+        totalUpdateCount={0}
+        editionCount={0}
       />
     );
     expect(screen.getByText('Edit')).toBeInTheDocument();
@@ -52,6 +45,8 @@ describe('BulkEditModal', () => {
         selectedField={field}
         defaultLocale="en-US"
         isSaving={false}
+        totalUpdateCount={0}
+        editionCount={0}
       />
     );
     expect(screen.getByText('Bulk edit')).toBeInTheDocument();
@@ -70,6 +65,8 @@ describe('BulkEditModal', () => {
         selectedField={field}
         defaultLocale="en-US"
         isSaving={false}
+        totalUpdateCount={0}
+        editionCount={0}
       />
     );
     fireEvent.click(screen.getByTestId('bulk-edit-cancel'));
@@ -87,6 +84,8 @@ describe('BulkEditModal', () => {
         selectedField={field}
         defaultLocale="en-US"
         isSaving={false}
+        totalUpdateCount={0}
+        editionCount={0}
       />
     );
     const input = screen.getByPlaceholderText('Enter your new value');
@@ -111,6 +110,8 @@ describe('BulkEditModal', () => {
         selectedField={integerField}
         defaultLocale="en-US"
         isSaving={false}
+        totalUpdateCount={0}
+        editionCount={0}
       />
     );
     const input = screen.getByPlaceholderText('Enter your new value');
@@ -132,6 +133,8 @@ describe('BulkEditModal', () => {
           selectedField={field}
           defaultLocale="en-US"
           isSaving={false}
+          totalUpdateCount={0}
+          editionCount={0}
         />
       );
     };
@@ -146,5 +149,48 @@ describe('BulkEditModal', () => {
     rerender(modalComponent(true));
 
     expect(screen.getByPlaceholderText('Enter your new value')).toHaveValue(null);
+  });
+
+  it('shows progress message during saving', () => {
+    const onClose = vi.fn();
+    const onSave = vi.fn();
+
+    render(
+      <BulkEditModal
+        isOpen={true}
+        onClose={onClose}
+        onSave={onSave}
+        selectedEntries={[entry1, entry2]}
+        selectedField={field}
+        defaultLocale="en-US"
+        isSaving={true}
+        totalUpdateCount={2}
+        editionCount={1}
+      />
+    );
+
+    expect(screen.getByText('1 of 2 completed')).toBeInTheDocument();
+    expect(screen.getByText('Updating entries')).toBeInTheDocument();
+  });
+
+  it('does not show progress message when not saving', () => {
+    const onClose = vi.fn();
+    const onSave = vi.fn();
+
+    render(
+      <BulkEditModal
+        isOpen={true}
+        onClose={onClose}
+        onSave={onSave}
+        selectedEntries={[entry1, entry2]}
+        selectedField={field}
+        defaultLocale="en-US"
+        isSaving={false}
+        totalUpdateCount={0}
+        editionCount={0}
+      />
+    );
+
+    expect(screen.queryByText('Updating entries')).not.toBeInTheDocument();
   });
 });

--- a/apps/bulk-edit/test/scripts/deleteEntries.spec.ts
+++ b/apps/bulk-edit/test/scripts/deleteEntries.spec.ts
@@ -1,0 +1,297 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createClient, PlainClientAPI } from 'contentful-management';
+import { deleteAllEntriesForContentType, deleteEntry } from '../../src/scripts/deleteEntries';
+import { getContentTypeIdByName } from '../../src/scripts/utils';
+
+// Mock contentful-management
+vi.mock('contentful-management', () => ({
+  createClient: vi.fn(),
+}));
+
+// Mock console methods
+const consoleSpy = {
+  log: vi.spyOn(console, 'log').mockImplementation(() => {}),
+  error: vi.spyOn(console, 'error').mockImplementation(() => {}),
+};
+
+// Mock process.env
+const originalEnv = process.env;
+
+// Mock readline interface
+const mockReadlineInterface = {
+  question: vi.fn(),
+  close: vi.fn(),
+} as any;
+
+async function mocksAndActionsForNormalDeletion(
+  mockEntry: any,
+  mockClient: Partial<PlainClientAPI>
+) {
+  const mockResponseWithEntries = {
+    items: [{ sys: { id: 'entry-1' } }, { sys: { id: 'entry-2' } }, { sys: { id: 'entry-3' } }],
+  };
+
+  mockEntry.getMany.mockResolvedValue(mockResponseWithEntries);
+  mockEntry.get.mockResolvedValue({ sys: { publishedVersion: undefined } });
+  mockEntry.delete.mockResolvedValue({});
+
+  await deleteAllEntriesForContentType(
+    'test-content-type',
+    mockClient as PlainClientAPI,
+    mockReadlineInterface,
+    process.env.DELETE_CONTENT_TYPE_NAME
+  );
+}
+
+describe('deleteEntries.ts', () => {
+  let mockClient: Partial<PlainClientAPI>;
+  let mockEntry: any;
+  let mockContentType: any;
+
+  beforeEach(() => {
+    // Reset mocks
+    vi.clearAllMocks();
+
+    // Reset environment variables to test values
+    process.env = { ...originalEnv };
+
+    // Setup mock entry with all required methods
+    mockEntry = {
+      get: vi.fn(),
+      getMany: vi.fn(),
+      unpublish: vi.fn(),
+      delete: vi.fn(),
+    };
+
+    // Setup mock content type
+    mockContentType = {
+      getMany: vi.fn(),
+    };
+
+    // Setup mock client
+    mockClient = {
+      entry: mockEntry,
+      contentType: mockContentType,
+    };
+
+    // Setup mocks for external dependencies
+    (createClient as any).mockReturnValue(mockClient);
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('should handle content type not found', async () => {
+    const contentTypeName = 'unknown-content-type';
+    mockContentType.getMany.mockRejectedValue('Content type not found');
+
+    await getContentTypeIdByName(mockClient as PlainClientAPI, contentTypeName);
+
+    expect(consoleSpy.error).toHaveBeenCalledWith(
+      '❌ Error fetching content types:',
+      'Content type not found'
+    );
+  });
+
+  describe('deleteEntry', () => {
+    it('should delete an unpublished entry successfully', async () => {
+      mockEntry.get.mockResolvedValue({ sys: { publishedVersion: undefined } });
+      mockEntry.delete.mockResolvedValue({});
+
+      const result = await deleteEntry('entry-1', mockClient as PlainClientAPI);
+
+      expect(mockEntry.get).toHaveBeenCalledWith({ entryId: 'entry-1' });
+      expect(mockEntry.delete).toHaveBeenCalledWith({ entryId: 'entry-1' });
+      expect(mockEntry.unpublish).not.toHaveBeenCalled();
+      expect(result).toBe(true);
+      expect(consoleSpy.log).toHaveBeenCalledWith('   ✅ Deleted entry: entry-1');
+    });
+
+    it('should unpublish and then delete a published entry', async () => {
+      mockEntry.get.mockResolvedValue({ sys: { publishedVersion: 1 } });
+      mockEntry.unpublish.mockResolvedValue({});
+      mockEntry.delete.mockResolvedValue({});
+
+      const result = await deleteEntry('entry-1', mockClient as PlainClientAPI);
+
+      expect(mockEntry.get).toHaveBeenCalledWith({ entryId: 'entry-1' });
+      expect(mockEntry.unpublish).toHaveBeenCalledWith({ entryId: 'entry-1' });
+      expect(mockEntry.delete).toHaveBeenCalledWith({ entryId: 'entry-1' });
+      expect(result).toBe(true);
+      expect(consoleSpy.log).toHaveBeenCalledWith('   📤 Unpublished entry: entry-1');
+      expect(consoleSpy.log).toHaveBeenCalledWith('   ✅ Deleted entry: entry-1');
+    });
+
+    it('should handle entry get errors gracefully', async () => {
+      mockEntry.get.mockRejectedValue(new Error('Entry not found'));
+      mockEntry.delete.mockResolvedValue({});
+
+      const result = await deleteEntry('entry-1', mockClient as PlainClientAPI);
+
+      expect(mockEntry.get).toHaveBeenCalledWith({ entryId: 'entry-1' });
+      expect(mockEntry.delete).toHaveBeenCalledWith({ entryId: 'entry-1' });
+      expect(result).toBe(true);
+      expect(consoleSpy.log).toHaveBeenCalledWith('   ✅ Deleted entry: entry-1');
+    });
+
+    it('should handle deletion errors gracefully', async () => {
+      mockEntry.get.mockResolvedValue({ sys: { publishedVersion: undefined } });
+      mockEntry.delete.mockRejectedValue(new Error('Deletion failed'));
+
+      const result = await deleteEntry('entry-1', mockClient as PlainClientAPI);
+
+      expect(mockEntry.get).toHaveBeenCalledWith({ entryId: 'entry-1' });
+      expect(mockEntry.delete).toHaveBeenCalledWith({ entryId: 'entry-1' });
+      expect(result).toBe(false);
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        '   ❌ Failed to delete entry entry-1:',
+        expect.any(Error)
+      );
+    });
+  });
+
+  describe('deleteAllEntriesForContentType', () => {
+    it('should fetch all the existing entries correctly', async () => {
+      await mocksAndActionsForNormalDeletion(mockEntry, mockClient);
+
+      expect(mockEntry.getMany).toHaveBeenCalledWith({
+        query: {
+          content_type: 'test-content-type',
+          limit: 1000,
+        },
+      });
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        '\n🔍 Fetching all entries for content type: test-content-type'
+      );
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        '   📄 Fetching all entries for content type: test-content-type...'
+      );
+      expect(consoleSpy.log).toHaveBeenCalledWith('   📊 Got 3 entries for this content type');
+      expect(consoleSpy.log).toHaveBeenCalledWith('📊 Found 3 entries to delete.');
+    });
+
+    it('should delete all entries from a content type', async () => {
+      await mocksAndActionsForNormalDeletion(mockEntry, mockClient);
+
+      expect(mockEntry.delete).toHaveBeenCalledTimes(3);
+      expect(mockEntry.delete).toHaveBeenCalledWith({ entryId: 'entry-1' });
+      expect(mockEntry.delete).toHaveBeenCalledWith({ entryId: 'entry-2' });
+      expect(mockEntry.delete).toHaveBeenCalledWith({ entryId: 'entry-3' });
+    });
+
+    it('should not delete content type', async () => {
+      const mockResponseWithEntries = {
+        items: [{ sys: { id: 'entry-1' } }, { sys: { id: 'entry-2' } }],
+      };
+
+      mockEntry.getMany.mockResolvedValue(mockResponseWithEntries);
+      mockEntry.get.mockResolvedValue({ sys: { publishedVersion: undefined } });
+      mockEntry.delete.mockResolvedValue({});
+
+      await deleteAllEntriesForContentType(
+        'test-content-type',
+        mockClient as PlainClientAPI,
+        mockReadlineInterface,
+        process.env.DELETE_CONTENT_TYPE_NAME
+      );
+
+      // Verify that only entries are deleted, not content types
+      expect(mockClient.contentType).toBeDefined();
+      expect(mockEntry.delete).toHaveBeenCalledTimes(2);
+    });
+
+    it('should log progress and summary information', async () => {
+      const mockEntries = Array.from({ length: 25 }, (_, i) => ({ sys: { id: `entry-${i + 1}` } }));
+      const mockResponseWithEntries = { items: mockEntries };
+
+      mockEntry.getMany.mockResolvedValue(mockResponseWithEntries);
+      mockEntry.get.mockResolvedValue({ sys: { publishedVersion: undefined } });
+      mockEntry.delete.mockResolvedValue({});
+
+      await deleteAllEntriesForContentType(
+        'test-content-type',
+        mockClient as PlainClientAPI,
+        mockReadlineInterface,
+        process.env.DELETE_CONTENT_TYPE_NAME
+      );
+
+      expect(consoleSpy.log).toHaveBeenCalledWith('\n🗑️  Starting deletion process...');
+      expect(consoleSpy.log).toHaveBeenCalledWith('\n📦 Processing batch 1/3');
+      expect(consoleSpy.log).toHaveBeenCalledWith('\n📦 Processing batch 2/3');
+      expect(consoleSpy.log).toHaveBeenCalledWith('\n📦 Processing batch 3/3');
+      expect(consoleSpy.log).toHaveBeenCalledWith('⏳ Waiting 2 seconds before next batch...');
+      expect(consoleSpy.log).toHaveBeenCalledWith('\n📋 Deletion Summary:');
+      expect(consoleSpy.log).toHaveBeenCalledWith('   ✅ Successfully deleted: 25 entries');
+      expect(consoleSpy.log).toHaveBeenCalledWith('   ❌ Failed to delete: 0 entries');
+      expect(consoleSpy.log).toHaveBeenCalledWith('   📊 Total processed: 25 entries');
+    });
+
+    it('should handle entry deletion errors gracefully', async () => {
+      const mockResponseWithEntries = {
+        items: [{ sys: { id: 'entry-1' } }, { sys: { id: 'entry-2' } }, { sys: { id: 'entry-3' } }],
+      };
+
+      mockEntry.getMany.mockResolvedValue(mockResponseWithEntries);
+      mockEntry.get.mockResolvedValue({ sys: { publishedVersion: undefined } });
+
+      // First entry succeeds, second fails, third succeeds
+      mockEntry.delete
+        .mockResolvedValueOnce({})
+        .mockRejectedValueOnce(new Error('Deletion failed'))
+        .mockResolvedValueOnce({});
+
+      await deleteAllEntriesForContentType(
+        'test-content-type',
+        mockClient as PlainClientAPI,
+        mockReadlineInterface,
+        process.env.DELETE_CONTENT_TYPE_NAME
+      );
+
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        '   ❌ Failed to delete entry entry-2:',
+        expect.any(Error)
+      );
+      expect(consoleSpy.log).toHaveBeenCalledWith('   ✅ Deleted entry: entry-1');
+      expect(consoleSpy.log).toHaveBeenCalledWith('   ✅ Deleted entry: entry-3');
+      expect(consoleSpy.log).toHaveBeenCalledWith('   ✅ Successfully deleted: 2 entries');
+      expect(consoleSpy.log).toHaveBeenCalledWith('   ❌ Failed to delete: 1 entries');
+    });
+
+    it('should delete entries in batches', async () => {
+      const mockEntries = Array.from({ length: 25 }, (_, i) => ({ sys: { id: `entry-${i + 1}` } }));
+      const mockResponseWithEntries = { items: mockEntries };
+
+      mockEntry.getMany.mockResolvedValue(mockResponseWithEntries);
+      mockEntry.get.mockResolvedValue({ sys: { publishedVersion: undefined } });
+      mockEntry.delete.mockResolvedValue({});
+
+      await deleteAllEntriesForContentType(
+        'test-content-type',
+        mockClient as PlainClientAPI,
+        mockReadlineInterface,
+        process.env.DELETE_CONTENT_TYPE_NAME
+      );
+
+      // Should process 25 entries in 3 batches: 10, 10, 5
+      expect(consoleSpy.log).toHaveBeenCalledWith('\n📦 Processing batch 1/3');
+      expect(consoleSpy.log).toHaveBeenCalledWith('\n📦 Processing batch 2/3');
+      expect(consoleSpy.log).toHaveBeenCalledWith('\n📦 Processing batch 3/3');
+      expect(consoleSpy.log).toHaveBeenCalledWith('⏳ Waiting 2 seconds before next batch...');
+    });
+
+    it('should handle empty entries list', async () => {
+      mockEntry.getMany.mockResolvedValue({ items: [] });
+
+      await deleteAllEntriesForContentType(
+        'test-content-type',
+        mockClient as PlainClientAPI,
+        mockReadlineInterface,
+        process.env.DELETE_CONTENT_TYPE_NAME
+      );
+
+      expect(consoleSpy.log).toHaveBeenCalledWith('✅ No entries found for this content type.');
+      expect(mockEntry.delete).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/bulk-edit/test/scripts/generateEntries.spec.ts
+++ b/apps/bulk-edit/test/scripts/generateEntries.spec.ts
@@ -1,0 +1,465 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createClient, PlainClientAPI } from 'contentful-management';
+import {
+  generateEntries,
+  createContentTypeWithAllFields,
+  createSampleEntry,
+  batchEntries,
+} from '../../src/scripts/generateEntries';
+
+// Mock contentful-management
+vi.mock('contentful-management', () => ({
+  createClient: vi.fn(),
+}));
+
+// Mock console methods
+const consoleSpy = {
+  log: vi.spyOn(console, 'log').mockImplementation(() => {}),
+  error: vi.spyOn(console, 'error').mockImplementation(() => {}),
+};
+
+// Mock process.env
+const originalEnv = process.env;
+
+describe('generateEntries.ts', () => {
+  let mockClient: Partial<PlainClientAPI>;
+  let mockContentType: any;
+  let mockEntry: any;
+
+  beforeEach(() => {
+    // Reset mocks
+    vi.clearAllMocks();
+
+    // Reset environment variables to test values
+    process.env = { ...originalEnv };
+
+    // Setup mock content type
+    mockContentType = {
+      create: vi.fn(),
+      publish: vi.fn(),
+    };
+
+    // Setup mock entry
+    mockEntry = {
+      create: vi.fn(),
+      publish: vi.fn(),
+    };
+
+    // Setup mock client
+    mockClient = {
+      contentType: mockContentType,
+      entry: mockEntry,
+    };
+
+    // Setup mocks for external dependencies only
+    (createClient as any).mockReturnValue(mockClient);
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe('createContentTypeWithAllFields', () => {
+    it('should create a content type with all field types', async () => {
+      const mockContentTypeProps = {
+        sys: { id: 'test-content-type-id' },
+        name: 'All Field Types',
+        displayField: 'shortText',
+        fields: [],
+      };
+
+      mockContentType.create.mockResolvedValue(mockContentTypeProps);
+      mockContentType.publish.mockResolvedValue(mockContentTypeProps);
+
+      const result = await createContentTypeWithAllFields(mockClient as PlainClientAPI);
+
+      expect(mockContentType.create).toHaveBeenCalledWith(
+        {},
+        {
+          name: 'All Field Types',
+          displayField: 'shortText',
+          description:
+            'A comprehensive content type with all possible field types for testing the app integration',
+          fields: expect.arrayContaining([
+            expect.objectContaining({ id: 'shortText', type: 'Symbol' }),
+            expect.objectContaining({ id: 'longText', type: 'Text' }),
+            expect.objectContaining({ id: 'richText', type: 'RichText' }),
+            expect.objectContaining({ id: 'integerNumber', type: 'Integer' }),
+            expect.objectContaining({ id: 'decimalNumber', type: 'Number' }),
+            expect.objectContaining({ id: 'dateTime', type: 'Date' }),
+            expect.objectContaining({ id: 'boolean', type: 'Boolean' }),
+            expect.objectContaining({ id: 'jsonObject', type: 'Object' }),
+            expect.objectContaining({ id: 'location', type: 'Location' }),
+            expect.objectContaining({ id: 'asset', type: 'Link', linkType: 'Asset' }),
+            expect.objectContaining({ id: 'reference', type: 'Link', linkType: 'Entry' }),
+            expect.objectContaining({
+              id: 'symbolArray',
+              type: 'Array',
+              items: { type: 'Symbol' },
+            }),
+            expect.objectContaining({
+              id: 'assetArray',
+              type: 'Array',
+              items: { type: 'Link', linkType: 'Asset' },
+            }),
+            expect.objectContaining({
+              id: 'entryArray',
+              type: 'Array',
+              items: { type: 'Link', linkType: 'Entry' },
+            }),
+          ]),
+        }
+      );
+
+      expect(mockContentType.publish).toHaveBeenCalledWith(
+        { contentTypeId: 'test-content-type-id' },
+        mockContentTypeProps
+      );
+      expect(result).toBe('test-content-type-id');
+    });
+
+    it('should handle content type creation errors gracefully', async () => {
+      const mockError = new Error('Content type creation failed');
+      mockContentType.create.mockRejectedValue(mockError);
+
+      await expect(createContentTypeWithAllFields(mockClient as PlainClientAPI)).rejects.toThrow(
+        'Content type creation failed'
+      );
+
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        expect.stringContaining('❌ Content type creation failed')
+      );
+    });
+
+    it('should log progress messages during content type creation', async () => {
+      const mockContentTypeProps = {
+        sys: { id: 'test-content-type-id' },
+        name: 'All Field Types',
+        displayField: 'shortText',
+        fields: [],
+      };
+
+      mockContentType.create.mockResolvedValue(mockContentTypeProps);
+      mockContentType.publish.mockResolvedValue(mockContentTypeProps);
+
+      await createContentTypeWithAllFields(mockClient as PlainClientAPI);
+
+      expect(consoleSpy.log).toHaveBeenCalledWith('Creating content type: All Field Types');
+      expect(consoleSpy.log).toHaveBeenCalledWith('Created content type: test-content-type-id');
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        '✅ Created and published content type: test-content-type-id'
+      );
+    });
+  });
+
+  describe('createSampleEntry', () => {
+    it('should create an entry with correct field values', async () => {
+      const mockEntryProps = {
+        sys: { id: 'entry-1' },
+        fields: {
+          title: { 'en-US': 'Sample Entry 1' },
+          shortText: { 'en-US': 'Sample Short Text' },
+          longText: { 'en-US': expect.stringContaining('This is a sample long text field') },
+          richText: { 'en-US': expect.objectContaining({ nodeType: 'document' }) },
+          integerNumber: { 'en-US': 42 },
+          decimalNumber: { 'en-US': 3.14159 },
+          dateTime: { 'en-US': '2024-01-15T10:30:00.000Z' },
+          boolean: { 'en-US': true },
+          jsonObject: { 'en-US': { key: 'value', nested: { data: 'example' } } },
+          location: { 'en-US': { lat: 40.7128, lon: -74.006 } },
+          symbolArray: { 'en-US': ['Item 1', 'Item 2', 'Item 3'] },
+        },
+      };
+
+      mockEntry.create.mockResolvedValue(mockEntryProps);
+      mockEntry.publish.mockResolvedValue(mockEntryProps);
+
+      const result = await createSampleEntry(
+        'test-content-type-id',
+        0,
+        mockClient as PlainClientAPI
+      );
+
+      expect(mockEntry.create).toHaveBeenCalledWith(
+        { contentTypeId: 'test-content-type-id' },
+        expect.objectContaining({
+          title: { 'en-US': 'Sample Entry 1' },
+          fields: expect.objectContaining({
+            shortText: { 'en-US': expect.stringContaining('Sample Short Text') },
+            longText: { 'en-US': expect.stringContaining('This is a sample long text field') },
+            richText: { 'en-US': expect.objectContaining({ nodeType: 'document' }) },
+            integerNumber: { 'en-US': 42 },
+            decimalNumber: { 'en-US': 3.14159 },
+            dateTime: { 'en-US': '2024-01-15T10:30:00.000Z' },
+            boolean: { 'en-US': true },
+            jsonObject: { 'en-US': { key: 'value', nested: { data: 'example' } } },
+            location: { 'en-US': { lat: 40.7128, lon: -74.006 } },
+            symbolArray: { 'en-US': ['Item 1', 'Item 2', 'Item 3'] },
+          }),
+        })
+      );
+
+      expect(mockEntry.publish).toHaveBeenCalledWith({ entryId: 'entry-1' }, mockEntryProps);
+      expect(result).toBe('entry-1');
+    });
+
+    it('should handle entry creation errors gracefully', async () => {
+      const mockError = new Error('Entry creation failed');
+      mockEntry.create.mockRejectedValue(mockError);
+
+      await expect(
+        createSampleEntry('test-content-type-id', 0, mockClient as PlainClientAPI)
+      ).rejects.toThrow('Entry creation failed');
+
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        expect.stringContaining('❌ Entry 1 creation failed')
+      );
+    });
+
+    it('should log progress messages during entry creation', async () => {
+      const mockEntryProps = {
+        sys: { id: 'entry-1' },
+        fields: { title: { 'en-US': 'Sample Entry 1' } },
+      };
+
+      mockEntry.create.mockResolvedValue(mockEntryProps);
+      mockEntry.publish.mockResolvedValue(mockEntryProps);
+
+      await createSampleEntry('test-content-type-id', 0, mockClient as PlainClientAPI);
+
+      expect(consoleSpy.log).toHaveBeenCalledWith('Creating sample entry 1...');
+      expect(consoleSpy.log).toHaveBeenCalledWith('✅ Created sample entry: entry-1');
+      expect(consoleSpy.log).toHaveBeenCalledWith('✅ Published sample entry 1');
+    });
+  });
+
+  describe('batchEntries', () => {
+    beforeEach(() => {
+      // Setup successful content type creation for batch tests
+      const mockContentTypeProps = {
+        sys: { id: 'test-content-type-id' },
+        name: 'All Field Types',
+        displayField: 'shortText',
+        fields: [],
+      };
+
+      mockContentType.create.mockResolvedValue(mockContentTypeProps);
+      mockContentType.publish.mockResolvedValue(mockContentTypeProps);
+    });
+
+    it('should create entries in batches', async () => {
+      const mockEntryProps = {
+        sys: { id: 'entry-1' },
+        fields: { title: { 'en-US': 'Sample Entry 1' } },
+      };
+
+      mockEntry.create.mockResolvedValue(mockEntryProps);
+      mockEntry.publish.mockResolvedValue(mockEntryProps);
+
+      await batchEntries(25, 'test-content-type-id', mockClient as PlainClientAPI);
+
+      // Should create 25 entries (3 batches: 10, 10, 5)
+      expect(mockEntry.create).toHaveBeenCalledTimes(25);
+      expect(mockEntry.publish).toHaveBeenCalledTimes(25);
+    });
+
+    it('should handle batch failures gracefully', async () => {
+      const mockError = new Error('Batch creation failed');
+      mockEntry.create.mockRejectedValue(mockError);
+
+      await batchEntries(5, 'test-content-type-id', mockClient as PlainClientAPI);
+
+      // Check that individual entry errors are logged
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        expect.stringContaining('❌ Entry 1 creation failed')
+      );
+      // Check that batch error is also logged (with the actual format)
+      expect(consoleSpy.error).toHaveBeenCalledWith('❌ Batch 1 failed:', expect.any(Error));
+    });
+
+    it('should log batch processing information', async () => {
+      const mockEntryProps = {
+        sys: { id: 'entry-1' },
+        fields: { title: { 'en-US': 'Sample Entry 1' } },
+      };
+
+      mockEntry.create.mockResolvedValue(mockEntryProps);
+      mockEntry.publish.mockResolvedValue(mockEntryProps);
+
+      await batchEntries(15, 'test-content-type-id', mockClient as PlainClientAPI);
+
+      expect(consoleSpy.log).toHaveBeenCalledWith('Creating 15 entries in batches...');
+      expect(consoleSpy.log).toHaveBeenCalledWith('\n📦 Processing batch 1/2');
+      expect(consoleSpy.log).toHaveBeenCalledWith('✅ Completed batch 1');
+      expect(consoleSpy.log).toHaveBeenCalledWith('⏳ Waiting 1 second before next batch...');
+      expect(consoleSpy.log).toHaveBeenCalledWith('\n📦 Processing batch 2/2');
+      expect(consoleSpy.log).toHaveBeenCalledWith('✅ Completed batch 2');
+    });
+
+    it('should log summary information at the end', async () => {
+      const mockEntryProps = {
+        sys: { id: 'entry-1' },
+        fields: { title: { 'en-US': 'Sample Entry 1' } },
+      };
+
+      mockEntry.create.mockResolvedValue(mockEntryProps);
+      mockEntry.publish.mockResolvedValue(mockEntryProps);
+
+      await batchEntries(5, 'test-content-type-id', mockClient as PlainClientAPI);
+
+      expect(consoleSpy.log).toHaveBeenCalledWith('\n📊 Creation Summary:');
+      expect(consoleSpy.log).toHaveBeenCalledWith('   ✅ Successfully created: 5 entries');
+      expect(consoleSpy.log).toHaveBeenCalledWith('   ❌ Failed to create: 0 entries');
+      expect(consoleSpy.log).toHaveBeenCalledWith('   📊 Total processed: 5 entries');
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        '\n🎉 Success! Content type generation complete.'
+      );
+      expect(consoleSpy.log).toHaveBeenCalledWith('\n📋 Summary:');
+      expect(consoleSpy.log).toHaveBeenCalledWith('   • Content Type ID: test-content-type-id');
+      expect(consoleSpy.log).toHaveBeenCalledWith('   • Total Fields: 14');
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        '   • Field Types: Symbol, Text, RichText, Integer, Number, Date, Boolean, Object, Location, Link, Link, Array, Array, Array'
+      );
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        '\n🔗 You can now use this content type to test the app integration.'
+      );
+      expect(consoleSpy.log).toHaveBeenCalledWith(
+        '   Visit your Contentful space to see the new content type and sample entry.'
+      );
+    });
+  });
+
+  describe('generateEntries (main function)', () => {
+    it('should use AMOUNT_OF_ENTRIES environment variable when available', async () => {
+      process.env.AMOUNT_OF_ENTRIES = '10';
+
+      const mockContentTypeProps = {
+        sys: { id: 'test-content-type-id' },
+        name: 'All Field Types',
+        displayField: 'shortText',
+        fields: [],
+      };
+
+      mockContentType.create.mockResolvedValue(mockContentTypeProps);
+      mockContentType.publish.mockResolvedValue(mockContentTypeProps);
+
+      const mockEntryProps = {
+        sys: { id: 'entry-1' },
+        fields: { title: { 'en-US': 'Sample Entry 1' } },
+      };
+
+      mockEntry.create.mockResolvedValue(mockEntryProps);
+      mockEntry.publish.mockResolvedValue(mockEntryProps);
+
+      await generateEntries();
+
+      expect(mockEntry.create).toHaveBeenCalledTimes(10);
+      expect(mockEntry.publish).toHaveBeenCalledTimes(10);
+    });
+
+    it('should handle errors during execution', async () => {
+      const mockError = new Error('Script execution failed');
+      mockContentType.create.mockRejectedValue(mockError);
+
+      await expect(generateEntries()).rejects.toThrow('Script execution failed');
+
+      expect(consoleSpy.error).toHaveBeenCalledWith(
+        expect.stringContaining('❌ Content type creation failed')
+      );
+    });
+  });
+
+  describe('Field Types Configuration', () => {
+    it('should include all required field types', async () => {
+      const mockContentTypeProps = {
+        sys: { id: 'test-content-type-id' },
+        name: 'All Field Types',
+        displayField: 'shortText',
+        fields: [],
+      };
+
+      mockContentType.create.mockResolvedValue(mockContentTypeProps);
+      mockContentType.publish.mockResolvedValue(mockContentTypeProps);
+
+      await createContentTypeWithAllFields(mockClient as PlainClientAPI);
+
+      const callArgs = mockContentType.create.mock.calls[0];
+      const fields = callArgs[1].fields;
+
+      // Check that all field types are included
+      const fieldIds = fields.map((f: any) => f.id);
+      expect(fieldIds).toContain('shortText');
+      expect(fieldIds).toContain('longText');
+      expect(fieldIds).toContain('richText');
+      expect(fieldIds).toContain('integerNumber');
+      expect(fieldIds).toContain('decimalNumber');
+      expect(fieldIds).toContain('dateTime');
+      expect(fieldIds).toContain('boolean');
+      expect(fieldIds).toContain('jsonObject');
+      expect(fieldIds).toContain('location');
+      expect(fieldIds).toContain('asset');
+      expect(fieldIds).toContain('reference');
+      expect(fieldIds).toContain('symbolArray');
+      expect(fieldIds).toContain('assetArray');
+      expect(fieldIds).toContain('entryArray');
+
+      expect(fields).toHaveLength(14);
+    });
+
+    it('should configure field properties correctly', async () => {
+      const mockContentTypeProps = {
+        sys: { id: 'test-content-type-id' },
+        name: 'All Field Types',
+        displayField: 'shortText',
+        fields: [],
+      };
+
+      mockContentType.create.mockResolvedValue(mockContentTypeProps);
+      mockContentType.publish.mockResolvedValue(mockContentTypeProps);
+
+      await createContentTypeWithAllFields(mockClient as PlainClientAPI);
+
+      const callArgs = mockContentType.create.mock.calls[0];
+      const fields = callArgs[1].fields;
+
+      // Check field properties
+      const shortTextField = fields.find((f: any) => f.id === 'shortText');
+      expect(shortTextField).toEqual({
+        id: 'shortText',
+        name: 'Short Text',
+        type: 'Symbol',
+        required: false,
+        localized: false,
+        validations: [],
+        disabled: false,
+        omitted: false,
+      });
+
+      const linkField = fields.find((f: any) => f.id === 'asset');
+      expect(linkField).toEqual({
+        id: 'asset',
+        name: 'Asset',
+        type: 'Link',
+        linkType: 'Asset',
+        required: false,
+        localized: false,
+        validations: [],
+        disabled: false,
+        omitted: false,
+      });
+
+      const arrayField = fields.find((f: any) => f.id === 'symbolArray');
+      expect(arrayField).toEqual({
+        id: 'symbolArray',
+        name: 'Symbol Array',
+        type: 'Array',
+        items: { type: 'Symbol' },
+        required: false,
+        localized: false,
+        validations: [],
+        disabled: false,
+        omitted: false,
+      });
+    });
+  });
+});

--- a/apps/bulk-edit/vite.config.mts
+++ b/apps/bulk-edit/vite.config.mts
@@ -3,11 +3,6 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
-  test: {
-    globals: true, // Enables Jest-like global test functions (test, expect)
-    environment: 'jsdom', // Simulates a browser for component tests
-    setupFiles: './src/setupTests.ts', // Equivalent to Jest's setup file
-  },
   base: '',
   build: {
     outDir: 'build',

--- a/apps/bulk-edit/vitest.config.mts
+++ b/apps/bulk-edit/vitest.config.mts
@@ -1,0 +1,13 @@
+import { loadEnv } from 'vite';
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: ['./src/setupTests.ts'],
+    env: loadEnv('test', process.cwd(), ''),
+  },
+});


### PR DESCRIPTION
## Purpose
 Version 1.1 for bulk edit

## Approach

In this iteration:
- Freeze top headers and status column
- Editing more than 100+ at a time. 
- Viewing more than 100+ at a time
- Skeletons for loading
- Modal adjustments:
    - Loading waiting times.
    - Disable cancel button
- Fix values for fields using truncation

Main tickets:
2847, 2953, 3106 y 3104

## Testing steps

