### PR TITLE
Bulk-Edit-App: Fix sorting error and edit button with no padding [INTEG-3103]

### DIFF
--- a/apps/bulk-edit/src/locations/Page/index.tsx
+++ b/apps/bulk-edit/src/locations/Page/index.tsx
@@ -98,6 +98,12 @@ const Page = () => {
     };
   };
 
+  const clearState = () => {
+    setEntries([]);
+    setFields([]);
+    setTotalEntries(0);
+  };
+
   useEffect(() => {
     const fetchContentTypes = async (): Promise<void> => {
       try {
@@ -122,15 +128,13 @@ const Page = () => {
   }, [sdk]);
 
   useEffect(() => {
-    setActivePage(0);
+    clearState();
   }, [selectedContentTypeId, sortOption]);
 
   useEffect(() => {
     const fetchFieldsAndEntries = async (): Promise<void> => {
       if (!selectedContentTypeId) {
-        setEntries([]);
-        setFields([]);
-        setTotalEntries(0);
+        clearState();
         return;
       }
       setEntriesLoading(true);
@@ -171,15 +175,13 @@ const Page = () => {
         setEntries(entries);
         setTotalEntries(total);
       } catch (e) {
-        setEntries([]);
-        setFields([]);
-        setTotalEntries(0);
+        clearState();
       } finally {
         setEntriesLoading(false);
       }
     };
     void fetchFieldsAndEntries();
-  }, [sdk, selectedContentTypeId, activePage, itemsPerPage, sortOption]);
+  }, [sdk, selectedContentTypeId, sortOption, activePage, itemsPerPage]);
 
   const selectedContentType = contentTypes.find((ct) => ct.sys.id === selectedContentTypeId);
   const selectedEntries = entries.filter((entry) => selectedEntryIds.includes(entry.sys.id));
@@ -401,7 +403,10 @@ const Page = () => {
             <ContentTypeSidebar
               contentTypes={contentTypes}
               selectedContentTypeId={selectedContentTypeId}
-              onContentTypeSelect={setSelectedContentTypeId}
+              onContentTypeSelect={(newCT) => {
+                setSelectedContentTypeId(newCT);
+                setActivePage(0);
+              }}
             />
             <div style={styles.stickySpacer} />
             <Box>
@@ -413,7 +418,13 @@ const Page = () => {
                   <Box style={styles.noEntriesText}>No entries found.</Box>
                 ) : (
                   <>
-                    <SortMenu sortOption={sortOption} onSortChange={setSortOption} />
+                    <SortMenu
+                      sortOption={sortOption}
+                      onSortChange={(newSort) => {
+                        setSortOption(newSort);
+                        setActivePage(0);
+                      }}
+                    />
                     {selectedField && selectedEntryIds.length > 0 && !entriesLoading && (
                       <Flex alignItems="center" gap="spacingS" style={styles.editButton}>
                         <Button variant="primary" onClick={() => setIsModalOpen(true)}>


### PR DESCRIPTION
## Purpose

This tickets includes two main corrections:
- fix bug sorting when active page != 0 (the app crashes)
- bulk edit button hasn’t any padding when entries are selected and it’s loading

https://github.com/user-attachments/assets/46d5adfc-d7db-4a99-84c2-aa2ca359df1f

## Approach

Fixed a race condition between the entries fetch and the checkboxes creation when changing the `activePage` and `sortOption` states.

## Testing steps

https://github.com/user-attachments/assets/f2539550-052a-482c-b617-967f65986d36

## Breaking Changes

N/A

## Dependencies and/or References

Link to [INTEG-3103](https://contentful.atlassian.net/jira/software/c/projects/INTEG/boards/3109?selectedIssue=INTEG-3103)

## Deployment

N/A

[INTEG-3103]: https://contentful.atlassian.net/browse/INTEG-3103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ