### PR TITLE
refactor(function-appaction-example): use sys for status/result/error [EXT-6783]

### DIFF
--- a/examples/function-appaction/package.json
+++ b/examples/function-appaction/package.json
@@ -11,7 +11,7 @@
     "@rjsf/core": "^5.24.13",
     "@rjsf/validator-ajv8": "^5.24.13",
     "@vitejs/plugin-react": "^4.3.4",
-    "contentful-management": "^11.57.4",
+    "contentful-management": "^11.59.0",
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "vite": "^6.2.0",

--- a/examples/function-appaction/src/components/ActionFailure.tsx
+++ b/examples/function-appaction/src/components/ActionFailure.tsx
@@ -1,25 +1,28 @@
 import { Accordion, Text, Flex, Badge } from '@contentful/f36-components';
-import { ActionResultType } from '../locations/Page';
 import useParseError from '../hooks/useParseError';
 import { styles } from './Action.styles';
 import RawResponseViewer from './RawResponseViewer';
 import { computeDuration } from '../utils/response';
+import type { AppActionCallProps } from 'contentful-management';
 
 interface Props {
-  actionResult: ActionResultType;
+  appActionCall: AppActionCallProps;
   accordionState: any;
   handleExpand: (itemKey: string) => void;
   handleCollapse: (itemKey: string) => void;
 }
 
 const ActionFailure = (props: Props) => {
-  const { actionResult, accordionState, handleCollapse, handleExpand } = props;
-  const { error, timestamp, actionId } = actionResult;
-  const details: string | undefined = actionResult.call?.error?.details as string | undefined;
-  const call = actionResult.call;
-  const createdAt = call?.sys?.createdAt;
-  const updatedAt = call?.sys?.updatedAt;
-  const duration = computeDuration(createdAt, updatedAt);
+  const { appActionCall, accordionState, handleCollapse, handleExpand } = props;
+  const { sys } = appActionCall;
+  if (sys.status !== 'failed') {
+    throw new Error('App action call is not failed');
+  }
+  const { error } = sys;
+  const details = error.details;
+  const duration = computeDuration(sys.createdAt, sys.updatedAt);
+  const timestamp = sys.createdAt;
+  const actionId = sys.action.sys.id;
   const { message, statusCode } = useParseError(error);
 
   return (
@@ -28,7 +31,7 @@ const ActionFailure = (props: Props) => {
         title={
           <Text>
             <Badge variant="negative">Failed</Badge>
-            <Text className={styles.accordionTitleMargin}>[{statusCode}]</Text> - {timestamp}
+            <Text className={styles.accordionTitleMargin}>[{statusCode}]</Text> - {sys.updatedAt}
             {typeof duration === 'number' && (
               <Text className={styles.accordionTitleMargin}>
                 Duration: <strong>{duration}</strong> ms
@@ -45,13 +48,16 @@ const ActionFailure = (props: Props) => {
             <strong>Error Details:</strong>
             <Flex className={styles.bodyContainer}>
               <pre className={styles.body}>
-                <code>{details}</code>
+                <code>{JSON.stringify(details, null, 2)}</code>
               </pre>
             </Flex>
           </Text>
         )}
-        {actionResult.callId && (
-          <RawResponseViewer actionId={actionId} callId={actionResult.callId} />
+        {appActionCall.sys.appActionCallResponse && (
+          <RawResponseViewer
+            actionId={actionId}
+            callId={appActionCall.sys.appActionCallResponse.sys.id}
+          />
         )}
       </Accordion.Item>
     </Accordion>

--- a/examples/function-appaction/src/components/ActionResult.tsx
+++ b/examples/function-appaction/src/components/ActionResult.tsx
@@ -1,20 +1,17 @@
-import { PageAppSDK } from '@contentful/app-sdk';
-import { useSDK } from '@contentful/react-apps-toolkit';
 import { useState } from 'react';
-import { ActionResultType } from '../locations/Page';
 import ActionFailure from './ActionFailure';
 import ActionSuccess from './ActionSuccess';
 import { useClipboard } from '../hooks/useClipboard';
-
+import { AppActionCallProps } from 'contentful-management';
 interface Props {
-  actionResult: ActionResultType;
+  appActionCall: AppActionCallProps;
 }
 
 const ActionResult = (props: Props) => {
   const [accordionState, setAccordionState] = useState<any>({});
 
-  const { actionResult } = props;
-  const { success } = actionResult;
+  const { appActionCall } = props;
+  const success = appActionCall.sys.status === 'succeeded';
   const { copy } = useClipboard();
 
   const handleExpand = (itemKey: string) => () =>
@@ -30,7 +27,7 @@ const ActionResult = (props: Props) => {
       {success ? (
         <ActionSuccess
           accordionState={accordionState}
-          actionResult={actionResult}
+          appActionCall={appActionCall}
           handleCollapse={handleCollapse}
           handleExpand={handleExpand}
           handleCopy={handleCopy}
@@ -38,7 +35,7 @@ const ActionResult = (props: Props) => {
       ) : (
         <ActionFailure
           accordionState={accordionState}
-          actionResult={actionResult}
+          appActionCall={appActionCall}
           handleCollapse={handleCollapse}
           handleExpand={handleExpand}
         />

--- a/examples/function-appaction/src/locations/Page.tsx
+++ b/examples/function-appaction/src/locations/Page.tsx
@@ -17,16 +17,6 @@ import useGetAppActions from '../hooks/useGetAppActions';
 import tokens from '@contentful/f36-tokens';
 import { useSDK } from '@contentful/react-apps-toolkit';
 import { PageAppSDK } from '@contentful/app-sdk';
-import { AppActionCallProps, AppActionCallRawResponseProps } from 'contentful-management';
-export interface ActionResultType {
-  success: boolean;
-  call?: AppActionCallProps;
-  response?: AppActionCallRawResponseProps;
-  error?: unknown;
-  timestamp: string;
-  actionId: string;
-  callId?: string;
-}
 
 const Page = () => {
   const { getAllAppActions, appActions, loading, error } = useGetAppActions();


### PR DESCRIPTION
## Purpose

<!-- Why are we introducing this change now? What problem does it solve? What is the story/background for it? -->

- Refactors function-appaction example app to simplify implementation as a result of a better discriminating union now available in contentful-management.js (see https://github.com/contentful/contentful-management.js/pull/2758)
- Demonstrates that the AppActionCall `status`, `result`, and `error` should be accessed via the `sys` property. 

## Testing steps

<!-- Do you have a happy path a user would run through to test this app or would help the reviewer get started bug testing -->

Validated by building/uploading/executing the app locally. 

