### PR TITLE
Bulk edit: Insert columns in initial order after filtering [MAPS-41]

### DIFF
--- a/apps/bulk-edit/src/locations/Page/index.tsx
+++ b/apps/bulk-edit/src/locations/Page/index.tsx
@@ -622,7 +622,12 @@ const Page = () => {
                     options={getFieldsMapped(fields)}
                     selectedItems={selectedColumns}
                     setSelectedItems={(selectedColumns) => {
-                      setSelectedColumns(selectedColumns);
+                      const sortedSelectedColumns = selectedColumns.toSorted((a, b) => {
+                        const aIndex = fields.findIndex((f) => f.uniqueId === a.value);
+                        const bIndex = fields.findIndex((f) => f.uniqueId === b.value);
+                        return aIndex - bIndex;
+                      });
+                      setSelectedColumns(sortedSelectedColumns);
                       setActivePage(0);
                     }}
                     disabled={shouldDisableFilters()}


### PR DESCRIPTION
## Purpose

Right now if you deselect a column and add it again, it will be added at the end of the table instead of its original position

## Approach

Every time we insert a column into the selectedColumns state, we reorder it

## Testing steps

Remove and add a column from the columns filter

https://github.com/user-attachments/assets/00601089-e345-4e06-9b5a-6791e9c3e627
