### PR TITLE
chore: remove ts ignore warning[CNX-271]

### DIFF
--- a/examples/native-external-references-mockshop/functions/mockShop.ts
+++ b/examples/native-external-references-mockshop/functions/mockShop.ts
@@ -93,7 +93,6 @@ const lookupHandler: ResourcesLookupHandler = async (event, context) => {
   const mockShopUrl = getMockShopUrl(context);
 
   const isContentDeliveryApi = ['cda', 'cpa'].includes(
-    // @ts-ignore - context.originalRequest is not in the types yet
     context.originalRequest?.headers['contentful-api']
   );
 

--- a/examples/native-external-references-mockshop/package.json
+++ b/examples/native-external-references-mockshop/package.json
@@ -26,6 +26,6 @@
   },
   "homepage": ".",
   "dependencies": {
-    "@contentful/node-apps-toolkit": "^3.12.0"
+    "@contentful/node-apps-toolkit": "^3.15.0"
   }
 }


### PR DESCRIPTION
## Purpose

We can remove the `ts-ignore` warning now since we updated the types.

## Approach

We are updating the types in node app toolkit here 
- https://github.com/contentful/node-apps-toolkit/pull/780

## Testing steps

Tested by updating the local node modules files in code.

## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

Do not merge until this PR is merged.
https://github.com/contentful/node-apps-toolkit/pull/780

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
