### PR TITLE
Closest Preview: Adding backlinks logic [MAPS-60]

### DIFF
--- a/apps/closest-preview/src/locations/Sidebar.tsx
+++ b/apps/closest-preview/src/locations/Sidebar.tsx
@@ -1,23 +1,118 @@
-import { Box, RelativeDateTime, TextLink, List, Paragraph } from '@contentful/f36-components';
+import {
+  Box,
+  List,
+  Paragraph,
+  RelativeDateTime,
+  Skeleton,
+  TextLink,
+} from '@contentful/f36-components';
 import { ArrowSquareOutIcon } from '@contentful/f36-icons';
 import { SidebarAppSDK } from '@contentful/app-sdk';
-import { useSDK, useAutoResizer } from '@contentful/react-apps-toolkit';
-import { EntryProps } from 'contentful-management';
-import { useState, useEffect } from 'react';
+import { useAutoResizer, useSDK } from '@contentful/react-apps-toolkit';
+import { EntryProps, QueryOptions } from 'contentful-management';
+import { useCallback, useEffect, useState } from 'react';
+
+const MAX_DEPTH = 5;
 
 const Sidebar = () => {
   const sdk = useSDK<SidebarAppSDK>();
   useAutoResizer();
   const [entries, setEntries] = useState<EntryProps[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const defaultLocale = sdk.locales.default;
 
-  // TODO: use entries with Live Preview. Using any entries for now.
+  const getRelatedEntries = useCallback(
+    async (id: string): Promise<EntryProps[]> => {
+      try {
+        const response = await sdk.cma.entry.getMany({
+          query: {
+            links_to_entry: id,
+            order: '-sys.updatedAt',
+            limit: 5,
+          },
+          spaceId: sdk.ids.space,
+          environmentId: sdk.ids.environment,
+        });
+
+        return response.items;
+      } catch (error) {
+        console.error(error);
+        return [];
+      }
+    },
+    [sdk.ids.space, sdk.ids.environment]
+  );
+
+  const getUpstreamEntries = useCallback(
+    async (id: string): Promise<EntryProps[]> => {
+      const rootEntryData: EntryProps[] = [];
+      let childEntries: EntryProps[] = [];
+      const checkedEntries: Set<string> = new Set([id]);
+      let depth = 0;
+      const maxDepth = MAX_DEPTH;
+
+      try {
+        const initialEntry = await sdk.cma.entry.get({
+          entryId: id,
+          spaceId: sdk.ids.space,
+          environmentId: sdk.ids.environment,
+        });
+        childEntries = [initialEntry];
+      } catch (error) {
+        console.error('Failed to fetch initial entry:', error);
+        return [];
+      }
+
+      while (childEntries.length > 0 && depth < maxDepth) {
+        const relatedEntries = await Promise.all(
+          childEntries.map((entry) => getRelatedEntries(entry.sys.id))
+        );
+
+        childEntries = relatedEntries.flatMap((rEntry) =>
+          rEntry.filter((item: EntryProps) => {
+            if (item && item.sys.id && !checkedEntries.has(item.sys.id)) {
+              checkedEntries.add(item.sys.id);
+              const slug = item.fields.slug?.[defaultLocale];
+              if (slug) {
+                rootEntryData.push(item);
+                return false;
+              }
+              return true;
+            }
+            return false;
+          })
+        );
+
+        depth++;
+      }
+
+      if (depth >= maxDepth && rootEntryData.length === 0) {
+        console.log(`Max depth of ${maxDepth} reached for entry ID: ${id}`);
+      }
+
+      return rootEntryData;
+    },
+    [getRelatedEntries, sdk.ids.space, sdk.ids.environment, defaultLocale]
+  );
+
   useEffect(() => {
-    const fetchEntries = async () => {
-      const response = await sdk.cma.entry.getMany({});
-      setEntries(response.items.slice(0, 5));
+    const fetchData = async () => {
+      setIsLoading(true);
+      const rootEntries = await getUpstreamEntries(sdk.ids.entry);
+
+      setEntries(rootEntries);
+      setIsLoading(false);
     };
-    fetchEntries();
-  }, []);
+    fetchData();
+  }, [getUpstreamEntries, sdk.ids.entry]);
+
+  if (isLoading) {
+    return (
+      <Skeleton.Container>
+        <Skeleton.BodyText numberOfLines={3} />
+      </Skeleton.Container>
+    );
+  }
 
   return (
     <List>
@@ -32,8 +127,7 @@ const Sidebar = () => {
                 rel="noopener noreferrer"
                 icon={<ArrowSquareOutIcon />}
                 alignIcon="end">
-                {/* TODO: get the title of the entry */}
-                {entry.sys.id.slice(0, 8)}
+                {entry.fields.title?.[defaultLocale] || entry.sys.id.slice(0, 8)}
               </TextLink>
               <br />
               <Paragraph fontSize="fontSizeM" fontColor="gray500" fontWeight="fontWeightMedium">

--- a/apps/closest-preview/src/types.ts
+++ b/apps/closest-preview/src/types.ts
@@ -2,8 +2,3 @@ export interface ContentType {
   id: string;
   name: string;
 }
-export interface EntryData {
-  id: string;
-  title?: string;
-  slug?: string;
-}

--- a/apps/closest-preview/src/types.ts
+++ b/apps/closest-preview/src/types.ts
@@ -2,3 +2,8 @@ export interface ContentType {
   id: string;
   name: string;
 }
+export interface EntryData {
+  id: string;
+  title?: string;
+  slug?: string;
+}

--- a/apps/closest-preview/test/locations/Sidebar.spec.tsx
+++ b/apps/closest-preview/test/locations/Sidebar.spec.tsx
@@ -1,5 +1,5 @@
 import Sidebar from '../../src/locations/Sidebar';
-import { render, waitFor } from '@testing-library/react';
+import { render, waitFor, screen } from '@testing-library/react';
 import { mockSdk } from '../mocks';
 import { vi } from 'vitest';
 
@@ -9,15 +9,50 @@ vi.mock('@contentful/react-apps-toolkit', () => ({
 }));
 
 describe('Sidebar component', () => {
-  it('Renders entry list with ids and relative dates', async () => {
+  it('Renders 5 entries with links and relative dates', async () => {
     const { getAllByText } = render(<Sidebar />);
 
     await waitFor(() => {
-      const entryIds = getAllByText('Entry id', { exact: false });
-      expect(entryIds).toHaveLength(5);
+      const links = screen.getAllByRole('link');
+      expect(links).toHaveLength(5);
     });
 
     const updatedTexts = getAllByText(/Updated/);
     expect(updatedTexts).toHaveLength(5);
+  });
+
+  it('Shows loading state initially then renders list', async () => {
+    render(<Sidebar />);
+    // Initially, the list should not be present
+    expect(screen.queryByRole('list')).not.toBeInTheDocument();
+
+    expect(await screen.findByRole('list')).toBeInTheDocument();
+  });
+
+  it('Shows proper titles and fallbacks for different entry types', async () => {
+    render(<Sidebar />);
+
+    await waitFor(() => {
+      // Entry with proper title should show the title
+      expect(screen.getByRole('link', { name: 'Entry Title 1' })).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: 'Entry Title 4' })).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: 'Entry Title 5' })).toBeInTheDocument();
+    });
+
+    // Entries without titles should show ID prefix (first 8 chars)
+    const links = await screen.findAllByRole('link');
+    const fallbackLinks = links.filter((link) => link.textContent === 'Entry id');
+    expect(fallbackLinks).toHaveLength(2); // Entry id 2 and Entry id 3
+  });
+
+  it('Builds correct web app entry link', async () => {
+    render(<Sidebar />);
+
+    const link = await screen.findByRole('link', { name: /Entry Title 1/ });
+
+    expect(link).toHaveAttribute(
+      'href',
+      `https://${mockSdk.hostnames.webapp}/spaces/${mockSdk.ids.space}/environments/${mockSdk.ids.environment}/entries/Entry id 1`
+    );
   });
 });

--- a/apps/closest-preview/test/mocks/mockCma.ts
+++ b/apps/closest-preview/test/mocks/mockCma.ts
@@ -8,6 +8,10 @@ const mockCma: any = {
     getMany: vi.fn().mockResolvedValue({ items: [] }),
   },
   entry: {
+    get: vi.fn().mockResolvedValue({
+      sys: { id: 'root-entry', updatedAt: '2021-01-01' },
+      fields: { title: { 'en-US': 'Root Entry' }, slug: { 'en-US': undefined } },
+    }),
     getMany: vi.fn().mockResolvedValue({
       items: [
         {
@@ -15,36 +19,42 @@ const mockCma: any = {
             id: 'Entry id 1',
             updatedAt: '2021-01-01',
           },
+          fields: { title: { 'en-US': 'Entry Title 1' }, slug: { 'en-US': 'entry-1' } },
         },
         {
           sys: {
             id: 'Entry id 2',
             updatedAt: '2021-01-01',
           },
+          fields: { title: { 'en-US': '' }, slug: { 'en-US': 'entry-2' } },
         },
         {
           sys: {
             id: 'Entry id 3',
             updatedAt: '2021-01-01',
           },
+          fields: { title: { 'en-US': undefined }, slug: { 'en-US': 'entry-3' } },
         },
         {
           sys: {
             id: 'Entry id 4',
             updatedAt: '2021-01-01',
           },
+          fields: { title: { 'en-US': 'Entry Title 4' }, slug: { 'en-US': 'entry-4' } },
         },
         {
           sys: {
             id: 'Entry id 5',
             updatedAt: '2021-01-01',
           },
+          fields: { title: { 'en-US': 'Entry Title 5' }, slug: { 'en-US': 'entry-5' } },
         },
         {
           sys: {
             id: 'Entry id 6',
             updatedAt: '2021-01-01',
           },
+          fields: { title: { 'en-US': 'Non-root (no slug)' }, slug: { 'en-US': undefined } },
         },
       ],
     }),

--- a/apps/closest-preview/test/mocks/mockSdk.ts
+++ b/apps/closest-preview/test/mocks/mockSdk.ts
@@ -12,7 +12,9 @@ const mockSdk: any = {
     app: 'test-app',
     space: 'test-space',
     environment: 'master',
+    entry: 'root-entry',
   },
+  locales: { default: 'en-US' },
   cma: mockCma,
   hostnames: {
     webapp: 'app.contentful.com',


### PR DESCRIPTION
## Purpose

This update includes the backlinks logic to get the links to the last five updated entries with Live Preview configured.

## Approach

Some logic was reused from the original app but replacing the cma client for the sdk.

## Testing steps

Automated tests added.

Updating an entry with live preview so it appears in the sidebar:

https://github.com/user-attachments/assets/cec06f0d-2c2c-4152-9645-d2dffc19b1fa

Depth message and check when in higher than 10:

https://github.com/user-attachments/assets/30b67773-1492-408b-9893-491204484763


## Breaking Changes

N/A

## Dependencies and/or References

Link to [MAPS-60](https://contentful.atlassian.net/jira/software/c/projects/MAPS/boards/4363)

## Deployment

N/A