### PR TITLE
Google Docs: Connect frontend to mapping-review suspend step [INTEG-3753]

### DIFF
--- a/apps/google-docs/src/hooks/useWorkflowAgent.ts
+++ b/apps/google-docs/src/hooks/useWorkflowAgent.ts
@@ -2,8 +2,9 @@ import { useState, useCallback } from 'react';
 import { PageAppSDK } from '@contentful/app-sdk';
 import { POLL_INTERVAL_MS, MAX_POLL_ATTEMPTS, WORKFLOW_AGENT_ID } from '../utils/constants/agent';
 import {
+  MappingReviewSuspendPayload,
   ResumePayload,
-  SuspendPayload,
+  TabsImagesSuspendPayload,
   PreviewPayload,
   WorkflowRunResult,
   RunStatus,
@@ -79,8 +80,11 @@ const getRunErrorMessage = (runData: AgentRunData): string => {
   return 'Workflow failed';
 };
 
-const getSuspendPayload = (runData: AgentRunData): SuspendPayload | undefined =>
-  runData.metadata?.suspendPayload as SuspendPayload | undefined;
+const getSuspendPayload = (
+  runData: AgentRunData
+): TabsImagesSuspendPayload | MappingReviewSuspendPayload | undefined => {
+  return runData.metadata?.suspendPayload;
+};
 
 const getWorkflowRunResult = (
   runData: AgentRunData,

--- a/apps/google-docs/src/locations/Page/Page.tsx
+++ b/apps/google-docs/src/locations/Page/Page.tsx
@@ -8,7 +8,8 @@ import {
 } from './components/mainpage/ModalOrchestrator';
 import { MainPageView } from './components/mainpage/MainPageView';
 import { PreviewPageView } from './components/mainpage/PreviewPageView';
-import { PreviewPayload } from '@types';
+import { MappingReviewSuspendPayload, PreviewPayload } from '@types';
+import { isMappingReviewSuspendPayload } from '../../utils/utils';
 
 const Page = () => {
   const sdk = useSDK<PageAppSDK>();
@@ -16,7 +17,9 @@ const Page = () => {
   const [oauthToken, setOauthToken] = useState<string>('');
   const [isOAuthConnected, setIsOAuthConnected] = useState(false);
   const [isOAuthLoading, setIsOAuthLoading] = useState(true);
-  const [previewPayload, setPreviewPayload] = useState<PreviewPayload | null>(null);
+  const [previewPayload, setPreviewPayload] = useState<
+    PreviewPayload | MappingReviewSuspendPayload | null
+  >(null);
 
   const handleOauthTokenChange = (token: string) => {
     setOauthToken(token);
@@ -38,10 +41,29 @@ const Page = () => {
     setPreviewPayload(payload);
   };
 
+  const handleMappingReviewReady = (payload: MappingReviewSuspendPayload) => {
+    setPreviewPayload(payload);
+  };
+
   const handleReturnToMainPage = () => {
     modalOrchestratorRef.current?.resetFlowState();
     setPreviewPayload(null);
   };
+
+  const handleResumeMappingReview = async () => {
+    if (!previewPayload || !isMappingReviewSuspendPayload(previewPayload)) {
+      return;
+    }
+
+    try {
+      await modalOrchestratorRef.current?.resumeMappingReview(previewPayload);
+    } catch (error) {
+      console.error('Failed to resume mapping review:', error);
+      sdk.notifier.error('Unable to resume preview. Please try again.');
+    }
+  };
+
+  console.log('previewPayload', previewPayload);
 
   return (
     <>
@@ -51,6 +73,7 @@ const Page = () => {
             payload={previewPayload}
             oauthToken={oauthToken}
             onLeavePreview={handleReturnToMainPage}
+            onResumeMappingReview={handleResumeMappingReview}
           />
         ) : (
           <MainPageView
@@ -71,6 +94,7 @@ const Page = () => {
         sdk={sdk}
         oauthToken={oauthToken}
         onPreviewReady={handlePreviewReady}
+        onMappingReviewReady={handleMappingReviewReady}
         onResetToMain={handleReturnToMainPage}
       />
     </>

--- a/apps/google-docs/src/locations/Page/components/mainpage/ModalOrchestrator.tsx
+++ b/apps/google-docs/src/locations/Page/components/mainpage/ModalOrchestrator.tsx
@@ -11,8 +11,9 @@ import { CONTENT_TYPE_SUBMIT_LOADING_DELAY_MS } from '@constants/agent';
 import { SelectTabsModal } from '../modals/step_3/SelectTabsModal';
 import {
   DocumentTabProps,
+  MappingReviewSuspendPayload,
   ResumePayload,
-  SuspendPayload,
+  TabsImagesSuspendPayload,
   PreviewPayload,
   RunStatus,
   WorkflowRunResult,
@@ -25,6 +26,7 @@ export interface ModalOrchestratorHandle {
   startFlow: () => void;
   /** Clears in-progress flow state without calling `onResetToMain` (parent clears preview separately). */
   resetFlowState: () => void;
+  resumeMappingReview: (payload: MappingReviewSuspendPayload) => Promise<void>;
 }
 
 enum FlowStep {
@@ -39,10 +41,11 @@ interface ModalOrchestratorProps {
   oauthToken: string;
   onPreviewReady: (payload: PreviewPayload) => void;
   onResetToMain: () => void;
+  onMappingReviewReady: (payload: MappingReviewSuspendPayload) => void;
 }
 
 export const ModalOrchestrator = forwardRef<ModalOrchestratorHandle, ModalOrchestratorProps>(
-  ({ sdk, oauthToken, onPreviewReady, onResetToMain }, ref) => {
+  ({ sdk, oauthToken, onPreviewReady, onMappingReviewReady, onResetToMain }, ref) => {
     const [isUploadModalOpen, setIsUploadModalOpen] = useState(false);
     const [isConfirmCancelModalOpen, setIsConfirmCancelModalOpen] = useState(false);
     const [isErrorPreviewModalOpen, setIsErrorPreviewModalOpen] = useState(false);
@@ -69,6 +72,19 @@ export const ModalOrchestrator = forwardRef<ModalOrchestratorHandle, ModalOrches
         resetProgress();
         setIsConfirmCancelModalOpen(false);
         setIsErrorPreviewModalOpen(false);
+      },
+      resumeMappingReview: async (payload: MappingReviewSuspendPayload) => {
+        if (!activeRunId) {
+          throw new Error('Workflow run id is missing for resume.');
+        }
+
+        // TODO : modify the normalized document and entry block graph with the edited values
+        const workflowRun = await resumeWorkflow(activeRunId, {
+          editedNormalizedDocument: payload.normalizedDocument,
+          entryBlockGraph: payload.entryBlockGraph,
+        });
+
+        handleWorkflowResult(workflowRun);
       },
     }));
 
@@ -117,7 +133,7 @@ export const ModalOrchestrator = forwardRef<ModalOrchestratorHandle, ModalOrches
       showDiscardConfirmation();
     };
 
-    const showDocumentScopeReview = (suspendPayload?: SuspendPayload) => {
+    const showDocumentScopeReview = (suspendPayload?: TabsImagesSuspendPayload) => {
       setAvailableTabs(
         (suspendPayload?.tabs ?? []).map((tab) => ({
           tabId: tab.id ?? '',
@@ -146,6 +162,12 @@ export const ModalOrchestrator = forwardRef<ModalOrchestratorHandle, ModalOrches
       setActiveRunId(workflowRun.runId);
 
       if (workflowRun.status === RunStatus.PENDING_REVIEW) {
+        if (workflowRun.suspendPayload.suspendStepId === 'mapping-review') {
+          setFlowStep(null);
+          onMappingReviewReady(workflowRun.suspendPayload);
+          return;
+        }
+
         showDocumentScopeReview(workflowRun.suspendPayload);
         return;
       }

--- a/apps/google-docs/src/locations/Page/components/mainpage/PreviewPageView.tsx
+++ b/apps/google-docs/src/locations/Page/components/mainpage/PreviewPageView.tsx
@@ -23,6 +23,7 @@ export const PreviewPageView = ({
 }: PreviewPageViewProps) => {
   const sdk = useSDK<PageAppSDK>();
   const [isConfirmCancelModalOpen, setIsConfirmCancelModalOpen] = useState(false);
+  const mappingReviewPayload = isMappingReviewSuspendPayload(payload) ? payload : null;
   const rawTitle = payload.normalizedDocument?.title;
   const docTitle = typeof rawTitle === 'string' ? rawTitle : undefined;
   const title = docTitle && docTitle.trim().length > 0 ? docTitle : 'Selected document';
@@ -49,7 +50,7 @@ export const PreviewPageView = ({
             payload={payload}
             oauthToken={oauthToken}
             onReturnToMainPage={onLeavePreview}
-            onCreateSelected={onResumeMappingReview}
+            onCreateSelected={mappingReviewPayload ? onResumeMappingReview : undefined}
           />
           <Heading as="h2" marginBottom="none">
             Document outline

--- a/apps/google-docs/src/locations/Page/components/mainpage/PreviewPageView.tsx
+++ b/apps/google-docs/src/locations/Page/components/mainpage/PreviewPageView.tsx
@@ -1,19 +1,26 @@
 import { useState } from 'react';
 import { Button, Flex, Heading, Layout } from '@contentful/f36-components';
 import Splitter from './Splitter';
-import { PreviewPayload } from '@types';
+import { MappingReviewSuspendPayload, PreviewPayload } from '@types';
 import { ConfirmCancelModal } from '../modals/ConfirmCancelModal';
 import OverviewSection from '../overview/OverviewSection';
 import { useSDK } from '@contentful/react-apps-toolkit';
 import { PageAppSDK } from '@contentful/app-sdk';
+import { isMappingReviewSuspendPayload } from '../../../../utils/utils';
 
 interface PreviewPageViewProps {
-  payload: PreviewPayload;
+  payload: PreviewPayload | MappingReviewSuspendPayload;
   oauthToken: string;
   onLeavePreview: () => void;
+  onResumeMappingReview?: () => Promise<void>;
 }
 
-export const PreviewPageView = ({ payload, oauthToken, onLeavePreview }: PreviewPageViewProps) => {
+export const PreviewPageView = ({
+  payload,
+  oauthToken,
+  onLeavePreview,
+  onResumeMappingReview,
+}: PreviewPageViewProps) => {
   const sdk = useSDK<PageAppSDK>();
   const [isConfirmCancelModalOpen, setIsConfirmCancelModalOpen] = useState(false);
   const rawTitle = payload.normalizedDocument?.title;
@@ -42,6 +49,7 @@ export const PreviewPageView = ({ payload, oauthToken, onLeavePreview }: Preview
             payload={payload}
             oauthToken={oauthToken}
             onReturnToMainPage={onLeavePreview}
+            onCreateSelected={onResumeMappingReview}
           />
           <Heading as="h2" marginBottom="none">
             Document outline

--- a/apps/google-docs/src/locations/Page/components/overview/OverviewSection.tsx
+++ b/apps/google-docs/src/locations/Page/components/overview/OverviewSection.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { cx } from '@emotion/css';
 import { Box, Button, Flex, Heading, Note, Paragraph } from '@contentful/f36-components';
-import type { PreviewPayload } from '@types';
+import type { MappingReviewSuspendPayload, PreviewPayload } from '@types';
 import {
   buildCheckboxEntryList,
   collectCheckboxEntryListRowIds,
@@ -10,16 +10,17 @@ import {
 import { fetchContentTypesInfoByIds } from '../../../../services/contentTypeService';
 import { CheckboxEntryList } from './CheckboxEntryList';
 import { overviewSectionBox, overviewSectionBoxScrollable } from './OverviewSection.styles';
-import { createEntriesFromPreviewPayload } from '../../../../services/entryService';
 import { PageAppSDK } from '@contentful/app-sdk';
 import type { EntryProps } from 'contentful-management';
 import { SummaryModal } from '../modals/SummaryModal';
+import { isPreviewPayload } from '../../../../utils/utils';
 
 interface OverviewSectionProps {
   sdk: PageAppSDK;
-  payload: PreviewPayload;
+  payload: PreviewPayload | MappingReviewSuspendPayload;
   oauthToken: string;
   onReturnToMainPage: () => void;
+  onCreateSelected?: () => Promise<void>;
 }
 
 const OverviewSection = ({
@@ -27,6 +28,7 @@ const OverviewSection = ({
   payload,
   oauthToken,
   onReturnToMainPage,
+  onCreateSelected,
 }: OverviewSectionProps) => {
   const [contentTypeDisplayInfoMap, setContentTypeDisplayInfoMap] = useState<
     ContentTypeDisplayInfoMap | undefined
@@ -35,9 +37,38 @@ const OverviewSection = ({
   const [isCreating, setIsCreating] = useState(false);
   const [summaryEntries, setSummaryEntries] = useState<EntryProps[] | null>(null);
 
+  const overviewPayload = useMemo<PreviewPayload>(() => {
+    if (isPreviewPayload(payload)) {
+      return payload;
+    }
+
+    return {
+      // TODO: remove this temporary mock once the backend provides preview entries
+      entries: [
+        {
+          fields: {
+            url: {
+              'en-US': '/blog/show-up-first-with-pinterest-top-of-search-ads',
+            },
+            internalLabel: {
+              'en-US': '/blog/show-up-first-with-pinterest-top-of-search-ads',
+            },
+          },
+          tempId: 'url_1',
+          contentTypeId: 'url',
+        },
+      ],
+      assets: [],
+      referenceGraph: payload.referenceGraph,
+      normalizedDocument: payload.normalizedDocument,
+    };
+  }, [payload]);
+
   useEffect(() => {
     const fetchContentTypesInfo = async () => {
-      const contentTypeIds = [...new Set(payload.entries.map((entry) => entry.contentTypeId))]
+      const contentTypeIds = [
+        ...new Set(overviewPayload.entries.map((entry) => entry.contentTypeId)),
+      ]
         .filter((id): id is string => Boolean(id))
         .sort();
       if (contentTypeIds.length === 0) {
@@ -54,11 +85,11 @@ const OverviewSection = ({
     };
 
     fetchContentTypesInfo();
-  }, [sdk, payload.entries]);
+  }, [sdk, overviewPayload.entries]);
 
   const checkboxEntryRows = useMemo(
-    () => buildCheckboxEntryList(payload, contentTypeDisplayInfoMap, sdk.locales.default),
-    [payload, contentTypeDisplayInfoMap, sdk.locales.default]
+    () => buildCheckboxEntryList(overviewPayload, contentTypeDisplayInfoMap, sdk.locales.default),
+    [overviewPayload, contentTypeDisplayInfoMap, sdk.locales.default]
   );
 
   useEffect(() => {
@@ -78,24 +109,14 @@ const OverviewSection = ({
   };
 
   const handleCreateSelected = async () => {
-    if (selectedEntryTempIds.size === 0) {
+    if (selectedEntryTempIds.size === 0 || !onCreateSelected) {
       return;
     }
+
     setIsCreating(true);
+
     try {
-      const result = await createEntriesFromPreviewPayload(
-        sdk,
-        payload,
-        selectedEntryTempIds,
-        oauthToken
-      );
-      if (result.errors.length > 0) {
-        sdk.notifier.error('Failed to create entries');
-      } else {
-        setSummaryEntries(result.createdEntries);
-      }
-    } catch {
-      sdk.notifier.error('Failed to create entries');
+      await onCreateSelected();
     } finally {
       setIsCreating(false);
     }
@@ -128,7 +149,7 @@ const OverviewSection = ({
             variant="primary"
             onClick={handleCreateSelected}
             isLoading={isCreating}
-            isDisabled={selectedEntryTempIds.size === 0}>
+            isDisabled={selectedEntryTempIds.size === 0 || !onCreateSelected}>
             Create selected entries
           </Button>
         </Flex>

--- a/apps/google-docs/src/locations/Page/components/overview/OverviewSection.tsx
+++ b/apps/google-docs/src/locations/Page/components/overview/OverviewSection.tsx
@@ -48,10 +48,10 @@ const OverviewSection = ({
         {
           fields: {
             url: {
-              'en-US': '/blog/show-up-first-with-pinterest-top-of-search-ads',
+              'en-US': '/blog/an-url',
             },
             internalLabel: {
-              'en-US': '/blog/show-up-first-with-pinterest-top-of-search-ads',
+              'en-US': '/blog/another-url',
             },
           },
           tempId: 'url_1',

--- a/apps/google-docs/src/services/agents-api.ts
+++ b/apps/google-docs/src/services/agents-api.ts
@@ -1,6 +1,12 @@
 import { PageAppSDK } from '@contentful/app-sdk';
 import { LOCAL_AGENTS_API_BASE_URL, WORKFLOW_AGENT_ID } from '../utils/constants/agent';
-import { AgentRunMessage, ResumePayload, RunStatus } from '@types';
+import {
+  AgentRunMessage,
+  MappingReviewSuspendPayload,
+  ResumePayload,
+  RunStatus,
+  TabsImagesSuspendPayload,
+} from '@types';
 
 const AGENTS_API_HEADERS = {
   'x-contentful-enable-alpha-feature': 'agents-api',
@@ -32,7 +38,7 @@ export interface AgentRunData {
     status?: RunStatus;
     workflowId?: string;
     workflowRunId?: string;
-    suspendPayload?: Record<string, unknown>;
+    suspendPayload?: TabsImagesSuspendPayload | MappingReviewSuspendPayload;
     googleDocPayload?: Record<string, unknown>;
   };
   payload?: string;

--- a/apps/google-docs/src/types/workflow.ts
+++ b/apps/google-docs/src/types/workflow.ts
@@ -130,8 +130,17 @@ export interface PreviewPayload {
   normalizedDocument: NormalizedDocument;
 }
 
-export interface SuspendPayload {
+export interface MappingReviewEntryBlock {
+  [key: string]: unknown;
+}
+
+export interface MappingReviewContentType {
+  [key: string]: unknown;
+}
+
+export interface TabsImagesSuspendPayload {
   reason?: string;
+  suspendStepId: 'select-tabs-images-step';
   documentId?: string;
   title?: string;
   requiresImageSelection?: boolean;
@@ -143,12 +152,23 @@ export interface SuspendPayload {
   tabs?: DocTabOption[];
 }
 
+export interface MappingReviewSuspendPayload {
+  reason?: string;
+  suspendStepId: 'mapping-review';
+  documentId: string;
+  documentTitle?: string;
+  normalizedDocument: NormalizedDocument;
+  entryBlockGraph: MappingReviewEntryBlock[];
+  referenceGraph: ReviewedReferenceGraph;
+  contentTypes: MappingReviewContentType[];
+}
+
 export type WorkflowRunResult =
   | {
       status: RunStatus.PENDING_REVIEW;
       runId: string;
       messages: AgentRunMessage[];
-      suspendPayload: SuspendPayload;
+      suspendPayload: TabsImagesSuspendPayload | MappingReviewSuspendPayload;
     }
   | {
       status: RunStatus.COMPLETED;
@@ -160,4 +180,6 @@ export type WorkflowRunResult =
 export interface ResumePayload {
   includeImages?: boolean;
   selectedTabIds?: string[];
+  editedNormalizedDocument?: NormalizedDocument;
+  entryBlockGraph?: MappingReviewEntryBlock[];
 }

--- a/apps/google-docs/src/utils/checkboxEntryList.ts
+++ b/apps/google-docs/src/utils/checkboxEntryList.ts
@@ -3,6 +3,7 @@ import { collectReferencedTempIdsFromEntry } from '../services/referenceResoluti
 import { type ContentTypeDisplayInfo } from '../services/contentTypeService';
 import { orderEntriesByCreationOrder } from './previewPayload';
 import { getEntryDisplayTitle } from './getEntryDisplayTitle';
+import { isPreviewPayload } from './utils';
 
 export interface CheckboxEntryListRow {
   id: string;
@@ -163,6 +164,7 @@ export function buildCheckboxEntryList(
   defaultLocale?: string
 ): CheckboxEntryListRow[] {
   const { entries, referenceGraph } = payload;
+
   if (entries.length === 0) {
     return [];
   }

--- a/apps/google-docs/src/utils/utils.ts
+++ b/apps/google-docs/src/utils/utils.ts
@@ -1,3 +1,5 @@
+import type { MappingReviewSuspendPayload, PreviewPayload } from '../types/workflow';
+
 export const truncateLabel = (label: string, maxLength: number = 10): string => {
   if (label.length <= maxLength) return label;
 
@@ -6,4 +8,16 @@ export const truncateLabel = (label: string, maxLength: number = 10): string => 
   const secondHalf = label.slice(label.length - halfLength).trim();
 
   return `${firstHalf}...${secondHalf}`;
+};
+
+export const isMappingReviewSuspendPayload = (
+  payload: PreviewPayload | MappingReviewSuspendPayload
+): payload is MappingReviewSuspendPayload => {
+  return 'suspendStepId' in payload && payload.suspendStepId === 'mapping-review';
+};
+
+export const isPreviewPayload = (
+  payload: PreviewPayload | MappingReviewSuspendPayload
+): payload is PreviewPayload => {
+  return 'entries' in payload && 'referenceGraph' in payload;
 };

--- a/apps/google-docs/test/locations/Page/components/mainpage/ModalOrchestrator.spec.tsx
+++ b/apps/google-docs/test/locations/Page/components/mainpage/ModalOrchestrator.spec.tsx
@@ -66,6 +66,7 @@ const defaultProps = {
   sdk: mockSdk,
   oauthToken: 'mock-oauth-token',
   onPreviewReady: vi.fn(),
+  onMappingReviewReady: vi.fn(),
   onResetToMain: vi.fn(),
 };
 
@@ -73,12 +74,14 @@ describe('ModalOrchestrator', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     defaultProps.onPreviewReady.mockReset();
+    defaultProps.onMappingReviewReady.mockReset();
     defaultProps.onResetToMain.mockReset();
     mockStartWorkflow.mockResolvedValue({
       status: RunStatus.PENDING_REVIEW,
       runId: 'run-123',
       messages: [],
       suspendPayload: {
+        suspendStepId: 'select-tabs-images-step',
         reason: 'Needs document scope review',
         documentId: 'mock-doc-id-123',
         requiresImageSelection: true,
@@ -266,6 +269,7 @@ describe('ModalOrchestrator', () => {
       runId: 'run-123',
       messages: [],
       suspendPayload: {
+        suspendStepId: 'select-tabs-images-step',
         reason: 'Needs document scope review',
         documentId: 'mock-doc-id-123',
         requiresImageSelection: true,

--- a/apps/google-docs/test/locations/Page/components/mainpage/PreviewPageView.spec.tsx
+++ b/apps/google-docs/test/locations/Page/components/mainpage/PreviewPageView.spec.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { PageAppSDK } from '@contentful/app-sdk';
+import { Layout } from '@contentful/f36-components';
+import type { MappingReviewSuspendPayload } from '../../../../../src/types';
+import { PreviewPageView } from '../../../../../src/locations/Page/components/mainpage/PreviewPageView';
+import { createMockSDK } from '../../../../mocks';
+
+const { mockUseSDK } = vi.hoisted(() => ({
+  mockUseSDK: vi.fn(),
+}));
+
+vi.mock('@contentful/react-apps-toolkit', () => ({
+  useSDK: () => mockUseSDK(),
+}));
+
+describe('PreviewPageView', () => {
+  let mockSdk: PageAppSDK;
+
+  const mappingReviewPayload: MappingReviewSuspendPayload = {
+    suspendStepId: 'mapping-review',
+    documentId: 'doc-1',
+    documentTitle: 'Mapping review document',
+    normalizedDocument: {
+      documentId: 'doc-1',
+      title: 'Mapping review document',
+      contentBlocks: [],
+      tables: [],
+    },
+    entryBlockGraph: [],
+    referenceGraph: {},
+    contentTypes: [],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSdk = createMockSDK() as PageAppSDK;
+    mockUseSDK.mockReturnValue(mockSdk);
+  });
+
+  it('delegates create selected to the mapping review resume callback', async () => {
+    const onResumeMappingReview = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <Layout>
+        <PreviewPageView
+          payload={mappingReviewPayload}
+          oauthToken="oauth-token"
+          onLeavePreview={vi.fn()}
+          onResumeMappingReview={onResumeMappingReview}
+        />
+      </Layout>
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { name: 'Create from document "Mapping review document"' })
+      ).toBeTruthy();
+      expect(
+        screen.getByRole('button', { name: 'Create selected entries' }).hasAttribute('disabled')
+      ).toBe(false);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create selected entries' }));
+
+    await waitFor(() => {
+      expect(onResumeMappingReview).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
## Purpose

Add support for the new Google Docs workflow `mapping-review` suspended state while keeping the existing document-scope suspend flow working.

## Approach

- Extended the `workflow/runtime` types to support multiple suspend payload shapes and routed polling results by `metadata.suspendPayload.suspendStepId`. The existing document-scope flow remains in the modal orchestrator, while mapping-review now resumes from the preview page.
- The overview section delegates the `Create selected entries` action to the workflow resume callback. 
- A temporary localized mock remains in the overview rendering path so the preview can still show selectable rows before the backend provides the final payload.
  - This mock will be removed in future PRs.

## Testing steps

1. Start the Google Docs workflow with a document that suspends at `select-tabs-images-step` and confirm the modal flow still works.
2. Start the workflow with a document, get to the preview page and confirm that the `mapping-review` step is suspended.
3. In mapping-review preview, click `Create selected entries` and confirm the resume request is triggered.
4. Verify the app still builds and the added preview tests pass.

## Breaking Changes

No

## Dependencies and/or References

- [INTEG-3753](https://contentful.atlassian.net/browse/INTEG-3753)

## Deployment

No

[INTEG-3753]: https://contentful.atlassian.net/browse/INTEG-3753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ