### PR TITLE
chore: update Phosphor Icon production app definition id []

### DIFF
--- a/apps/phosphor-icon/package.json
+++ b/apps/phosphor-icon/package.json
@@ -28,7 +28,7 @@
     "add-locations": "contentful-app-scripts add-locations",
     "upload": "contentful-app-scripts upload --bundle-dir ./build",
     "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN",
-    "deploy": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEFINITIONS_ORG_ID} --definition-id 21NU7HfPZfpcDRF1WeJJte --token ${CONTENTFUL_CMA_TOKEN}",
+    "deploy": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEFINITIONS_ORG_ID} --definition-id mTgsS49vytEQZvNWn2hXO --token ${CONTENTFUL_CMA_TOKEN}",
     "deploy:test": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEV_TESTING_ORG_ID} --definition-id ${STAGING_APP_ID} --token ${TEST_CMA_TOKEN}"
   },
   "eslintConfig": {


### PR DESCRIPTION
## Summary
- update the Phosphor Icon production deploy script to use the new production app definition ID

## Testing
- not run (package.json configuration update only)