### PR TITLE
feat: add configurable default for reference include depth to JSON Viewer app []

### DIFF
--- a/apps/json-viewer/src/locations/ConfigScreen.spec.tsx
+++ b/apps/json-viewer/src/locations/ConfigScreen.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ConfigScreen from './ConfigScreen';
-import { render } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import { mockCma, mockSdk } from '../../test/mocks';
 import { vi } from 'vitest';
 
@@ -17,5 +17,31 @@ describe('Config Screen component', () => {
     await mockSdk.app.onConfigure.mock.calls[0][0]();
     const element = getByText('When set to true, all nodes will be collapsed by default');
     expect(element.hasAttribute('class')).toBe(true);
+  });
+
+  it('persists the configured default include depth', async () => {
+    mockSdk.app.getParameters.mockResolvedValueOnce({
+      configOptions: {
+        displayDataTypes: 'false',
+        iconStyle: 'triangle',
+        collapsed: 'false',
+        theme: 'rjv-default',
+        defaultIncludeDepth: '0',
+      },
+    });
+
+    const { container } = render(<ConfigScreen />);
+
+    await waitFor(() => {
+      expect(mockSdk.app.setReady).toHaveBeenCalled();
+    });
+
+    fireEvent.change(container.querySelector('select[name="defaultIncludeDepth"]')!, {
+      target: { value: '3' },
+    });
+
+    const configuredState = await mockSdk.app.onConfigure.mock.calls.at(-1)[0]();
+
+    expect(configuredState.parameters.configOptions.defaultIncludeDepth).toBe('3');
   });
 });

--- a/apps/json-viewer/src/locations/ConfigScreen.tsx
+++ b/apps/json-viewer/src/locations/ConfigScreen.tsx
@@ -186,7 +186,7 @@ const ConfigScreen = () => {
               {Array(11)
                 .fill(0)
                 .map((_, i) => (
-                  <Select.Option key={i} value={i}>
+                  <Select.Option key={i} value={String(i)}>
                     Include: {i}
                   </Select.Option>
                 ))}

--- a/apps/json-viewer/src/locations/ConfigScreen.tsx
+++ b/apps/json-viewer/src/locations/ConfigScreen.tsx
@@ -92,7 +92,10 @@ const ConfigScreen = () => {
   }, [sdk]);
 
   useEffect(() => {
-    setParameters((currentParameters) => ({ ...currentParameters, configOptions: reactJsonConfig }));
+    setParameters((currentParameters) => ({
+      ...currentParameters,
+      configOptions: reactJsonConfig,
+    }));
   }, [reactJsonConfig]);
 
   return (

--- a/apps/json-viewer/src/locations/ConfigScreen.tsx
+++ b/apps/json-viewer/src/locations/ConfigScreen.tsx
@@ -13,17 +13,30 @@ import { css } from 'emotion';
 import { useSDK } from '@contentful/react-apps-toolkit';
 
 // Stores config options
-export interface AppInstallationParameters {}
+interface ReactJsonConfig {
+  displayDataTypes: string;
+  iconStyle: string;
+  collapsed: string;
+  theme: string;
+  defaultIncludeDepth: string;
+}
+
+export interface AppInstallationParameters {
+  configOptions?: ReactJsonConfig;
+}
+
+const defaultReactJsonConfig: ReactJsonConfig = {
+  displayDataTypes: 'false',
+  iconStyle: 'triangle',
+  collapsed: 'false',
+  theme: 'rjv-default',
+  defaultIncludeDepth: '0',
+};
 
 const ConfigScreen = () => {
   const [parameters, setParameters] = useState<AppInstallationParameters>({});
   const sdk = useSDK<AppExtensionSDK>();
-  const [reactJsonConfig, setReactJsonConfig] = useState({
-    displayDataTypes: 'false',
-    iconStyle: 'triangle',
-    collapsed: 'false',
-    theme: 'rjv-default',
-  });
+  const [reactJsonConfig, setReactJsonConfig] = useState<ReactJsonConfig>(defaultReactJsonConfig);
 
   const onChangeHandler = (event: any) => {
     // Handles changes to the configuration form fields.
@@ -66,7 +79,10 @@ const ConfigScreen = () => {
       const currentParameters = await sdk.app.getParameters();
       if (currentParameters) {
         setParameters(currentParameters);
-        setReactJsonConfig(currentParameters.configOptions);
+        setReactJsonConfig({
+          ...defaultReactJsonConfig,
+          ...currentParameters.configOptions,
+        });
       }
 
       // Once preparation has finished, call `setReady` to hide
@@ -76,8 +92,7 @@ const ConfigScreen = () => {
   }, [sdk]);
 
   useEffect(() => {
-    setParameters({ ...parameters, configOptions: reactJsonConfig });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    setParameters((currentParameters) => ({ ...currentParameters, configOptions: reactJsonConfig }));
   }, [reactJsonConfig]);
 
   return (
@@ -155,6 +170,26 @@ const ConfigScreen = () => {
             </Select>
             <FormControl.HelpText>
               When set to true, all nodes will be collapsed by default
+            </FormControl.HelpText>
+          </Box>
+
+          <Box marginTop="spacingM">
+            <FormControl.Label>Default reference include depth:</FormControl.Label>
+            <Select
+              id="defaultIncludeDepth"
+              name="defaultIncludeDepth"
+              value={reactJsonConfig.defaultIncludeDepth}
+              onChange={onChangeHandler}>
+              {Array(11)
+                .fill(0)
+                .map((_, i) => (
+                  <Select.Option key={i} value={i}>
+                    Include: {i}
+                  </Select.Option>
+                ))}
+            </Select>
+            <FormControl.HelpText>
+              Sets the default include depth shown when opening the JSON Viewer tab
             </FormControl.HelpText>
           </Box>
         </Form>

--- a/apps/json-viewer/src/locations/EntryEditor.spec.tsx
+++ b/apps/json-viewer/src/locations/EntryEditor.spec.tsx
@@ -1,19 +1,71 @@
 import React from 'react';
 import EntryEditor from './EntryEditor';
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { mockCma, mockSdk } from '../../test/mocks';
-import { vi } from 'vitest';
+import { beforeEach, vi } from 'vitest';
 
 vi.mock('@contentful/react-apps-toolkit', () => ({
   useSDK: () => mockSdk,
   useCMA: () => mockCma,
 }));
 
-// TODO: Add relevant tests for your EntryEditor component.
-describe.skip('Entry component', () => {
-  it('Component text exists', () => {
-    const { getByText } = render(<EntryEditor />);
+describe('Entry component', () => {
+  beforeEach(() => {
+    mockCma.entry.get.mockClear();
+    mockCma.entry.references.mockClear();
+    mockSdk.parameters.installation.configOptions = {
+      displayDataTypes: 'true',
+      iconStyle: 'triangle',
+      collapsed: 'true',
+      theme: 'rjv-default',
+      defaultIncludeDepth: '0',
+    };
+  });
 
-    expect(getByText('Hello Entry Editor Component (AppId: test-app)')).toBeInTheDocument();
+  it('uses the configured default include depth when loading the entry', async () => {
+    mockSdk.parameters.installation.configOptions = {
+      displayDataTypes: 'true',
+      iconStyle: 'triangle',
+      collapsed: 'true',
+      theme: 'rjv-default',
+      defaultIncludeDepth: '3',
+    };
+
+    render(<EntryEditor />);
+
+    await waitFor(() => {
+      expect(mockCma.entry.references).toHaveBeenCalledWith({
+        entryId: 'test-id',
+        include: 3,
+      });
+    });
+  });
+
+  it('updates the selected include depth when installation parameters arrive after first render', async () => {
+    const { rerender, container } = render(<EntryEditor />);
+
+    await waitFor(() => {
+      expect(mockCma.entry.get).toHaveBeenCalledWith({ entryId: 'test-id' });
+    });
+
+    mockSdk.parameters.installation.configOptions = {
+      displayDataTypes: 'true',
+      iconStyle: 'triangle',
+      collapsed: 'true',
+      theme: 'rjv-default',
+      defaultIncludeDepth: '2',
+    };
+
+    rerender(<EntryEditor />);
+
+    await waitFor(() => {
+      expect((container.querySelector('select[name="includeDepth"]') as HTMLSelectElement).value).toBe(
+        '2'
+      );
+      expect(mockCma.entry.references).toHaveBeenCalledWith({
+        entryId: 'test-id',
+        include: 2,
+      });
+    });
   });
 });

--- a/apps/json-viewer/src/locations/EntryEditor.spec.tsx
+++ b/apps/json-viewer/src/locations/EntryEditor.spec.tsx
@@ -59,9 +59,9 @@ describe('Entry component', () => {
     rerender(<EntryEditor />);
 
     await waitFor(() => {
-      expect((container.querySelector('select[name="includeDepth"]') as HTMLSelectElement).value).toBe(
-        '2'
-      );
+      expect(
+        (container.querySelector('select[name="includeDepth"]') as HTMLSelectElement).value
+      ).toBe('2');
       expect(mockCma.entry.references).toHaveBeenCalledWith({
         entryId: 'test-id',
         include: 2,

--- a/apps/json-viewer/src/locations/EntryEditor.tsx
+++ b/apps/json-viewer/src/locations/EntryEditor.tsx
@@ -70,7 +70,7 @@ const Entry = () => {
                 Array(11)
                   .fill(0)
                   .map((_, i) => (
-                    <Select.Option key={i} value={i}>
+                    <Select.Option key={i} value={String(i)}>
                       Include: {i}
                     </Select.Option>
                   ))

--- a/apps/json-viewer/src/locations/EntryEditor.tsx
+++ b/apps/json-viewer/src/locations/EntryEditor.tsx
@@ -4,15 +4,30 @@ import { useCMA, useSDK } from '@contentful/react-apps-toolkit';
 import { Box, CopyButton, Flex, FormControl, Select, Stack } from '@contentful/f36-components';
 import ReactJson from 'react-json-view';
 
+const defaultConfigOptions = {
+  displayDataTypes: 'false',
+  iconStyle: 'triangle',
+  collapsed: 'false',
+  theme: 'rjv-default',
+  defaultIncludeDepth: '0',
+};
+
 const Entry = () => {
   const sdk = useSDK<EditorExtensionSDK>();
   const cma = useCMA();
   const currentEntry = sdk.entry.getSys();
   const [entry, setEntry] = useState({});
-  const [selectValue, setSelectValue] = useState('0');
-  const handleOnChange = (event: any) => setSelectValue(event.target.value);
   // Get the viewer options set in app config.
-  const { configOptions } = sdk.parameters.installation;
+  const configOptions = {
+    ...defaultConfigOptions,
+    ...(sdk.parameters.installation?.configOptions ?? sdk.parameters.configOptions ?? {}),
+  };
+  const [selectValue, setSelectValue] = useState(configOptions.defaultIncludeDepth);
+  const handleOnChange = (event: any) => setSelectValue(event.target.value);
+
+  useEffect(() => {
+    setSelectValue(configOptions.defaultIncludeDepth);
+  }, [configOptions.defaultIncludeDepth]);
 
   useEffect(() => {
     let entryData = {};

--- a/apps/json-viewer/test/mocks/mockCma.ts
+++ b/apps/json-viewer/test/mocks/mockCma.ts
@@ -1,3 +1,10 @@
-const mockCma: any = {};
+import { vi } from 'vitest';
+
+const mockCma: any = {
+  entry: {
+    get: vi.fn().mockResolvedValue({ sys: { id: 'test-id' } }),
+    references: vi.fn().mockResolvedValue({ items: [] }),
+  },
+};
 
 export { mockCma };

--- a/apps/json-viewer/test/mocks/mockSdk.ts
+++ b/apps/json-viewer/test/mocks/mockSdk.ts
@@ -2,10 +2,13 @@ import { vi } from 'vitest';
 
 const parameters = {
   installation: {
-    displayDataTypes: 'true',
-    iconStyle: {},
-    collapsed: 'true',
-    theme: {},
+    configOptions: {
+      displayDataTypes: 'true',
+      iconStyle: 'triangle',
+      collapsed: 'true',
+      theme: 'rjv-default',
+      defaultIncludeDepth: '0',
+    },
   },
   instance: {},
   configOptions: {},
@@ -14,9 +17,9 @@ const parameters = {
 const mockSdk: any = {
   app: {
     onConfigure: vi.fn(),
-    getParameters: vi.fn().mockReturnValueOnce(parameters),
+    getParameters: vi.fn().mockResolvedValue(parameters),
     setReady: vi.fn(),
-    getCurrentState: vi.fn(),
+    getCurrentState: vi.fn().mockResolvedValue({}),
   },
   ids: {
     app: 'test-app',


### PR DESCRIPTION
## Purpose

Mainly testing/proving Zach's LLM IDE skill, TBH. So I just tried to find a simple improvement I could make to an existing app, that I could use to test it out. 

No customer's have requested this, but I figure it is intuitively a subtle quality of life improvement for users of this app.

## Approach

I added a new optional config field to the apps config screen for the default value of the include reference depth. This will avoid a user having to change the value of the dropdown every time they open the tab, if they are just always setting it to something other than 0. (the default before this PR) 

## Testing steps

Set the 5th optional param in the app install/config screen to a value other than 0. 
Open the JSON Viewer tab in an entry, confirm that the default set in the config screen is used. 

## Breaking Changes

None

## Dependencies and/or References

None

## Deployment

Nothing specific. 
