### PR TITLE
chore: add Operating Hours production deploy script []

### DIFF
--- a/apps/operating-hours/package.json
+++ b/apps/operating-hours/package.json
@@ -11,7 +11,8 @@
     "test:ci": "vitest run",
     "create-app-definition": "contentful-app-scripts create-app-definition",
     "upload": "contentful-app-scripts upload --bundle-dir ./build",
-    "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN"
+    "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN",
+    "deploy": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEFINITIONS_ORG_ID} --definition-id 5fz65P27iDtUFLF3LQwOdW --token ${CONTENTFUL_CMA_TOKEN}"
   },
   "dependencies": {
     "@contentful/app-sdk": "^4.29.1",


### PR DESCRIPTION
## Summary
- add the production deploy script for the Operating Hours app
- point the deploy script at the production app definition `5fz65P27iDtUFLF3LQwOdW`

## Notes
- marketplace listing entry: https://app.contentful.com/spaces/d89jowemio7m/entries/7nYeKHYPGggtQesmZjCZqy
