### PR TITLE
chore: Add Extensibility as a CODEOWNER []

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
-# team marketplace and 10 pines own all code in this repository by default
+# team marketplace, extensibility, and 10 pines own all code in this repository by default
 
-* @contentful/team-marketplace @contentful/team-10-pines
+* @contentful/team-extensibility @contentful/team-marketplace @contentful/team-10-pines
 
 # team tundra co-owns examples and function examples
 


### PR DESCRIPTION
## Summary
Add Extensibility as a default code owner for the repository.

## Changes
- add `@contentful/team-extensibility` to the default `CODEOWNERS` entry
- keep existing owners in place

## Notes
- no product or runtime behavior changes