### PR TITLE
fix: bulk edit field menu scrolling [ES-105] 

### DIFF
--- a/apps/bulk-edit/src/locations/Page/components/FieldVisibiltyMenu.tsx
+++ b/apps/bulk-edit/src/locations/Page/components/FieldVisibiltyMenu.tsx
@@ -2,6 +2,7 @@ import { IconButton, Menu } from '@contentful/f36-components';
 import * as icons from '@contentful/f36-icons';
 import { ContentTypeField, FilterOption } from '../types';
 import tokens from '@contentful/f36-tokens';
+import { scrollableMenuListStyle } from './menuStyles';
 
 interface FieldVisibiltyMenuProps {
   selectedColumns: FilterOption[];
@@ -25,7 +26,7 @@ export const FieldVisibiltyMenu = ({
           icon={<icons.GearSixIcon />}
         />
       </Menu.Trigger>
-      <Menu.List>
+      <Menu.List style={scrollableMenuListStyle}>
         <Menu.Item onClick={() => setSelectedColumns(getFieldsMapped(fields))}>
           Select all
         </Menu.Item>

--- a/apps/bulk-edit/src/locations/Page/components/SearchBar.tsx
+++ b/apps/bulk-edit/src/locations/Page/components/SearchBar.tsx
@@ -9,6 +9,7 @@ import { fieldFilterValuesToQuery } from '../utils/contentfulQueryUtils';
 import StatusFilter from './StatusFilter';
 import tokens from '@contentful/f36-tokens';
 import { SortMenu } from './SortMenu';
+import { scrollableMenuListStyle } from './menuStyles';
 
 function toggleFieldInFilter(
   field: ContentTypeField,
@@ -133,7 +134,7 @@ export const SearchBar: React.FC<SearchBarProps> = ({
               Fields
             </Button>
           </Menu.Trigger>
-          <Menu.List>
+          <Menu.List style={scrollableMenuListStyle}>
             <Menu.Item
               onClick={() => {
                 setFieldFilterValues([]);

--- a/apps/bulk-edit/src/locations/Page/components/menuStyles.ts
+++ b/apps/bulk-edit/src/locations/Page/components/menuStyles.ts
@@ -1,0 +1,5 @@
+export const scrollableMenuListStyle = {
+  maxHeight: 'calc(100vh - 8rem)',
+  overflowY: 'auto' as const,
+  overscrollBehavior: 'contain' as const,
+};

--- a/apps/bulk-edit/test/locations/Page/ColumnsVisibility.test.tsx
+++ b/apps/bulk-edit/test/locations/Page/ColumnsVisibility.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/re
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { FieldVisibiltyMenu } from '../../../src/locations/Page/components/FieldVisibiltyMenu';
 import { ContentTypeField, FilterOption } from '../../../src/locations/Page/types';
+import { scrollableMenuListStyle } from '../../../src/locations/Page/components/menuStyles';
 
 // Non-localized fields for basic tests
 const mockFields: ContentTypeField[] = [
@@ -107,6 +108,19 @@ describe('FieldVisibiltyMenu (Column Selection)', () => {
       await waitFor(() => {
         expect(screen.getByText('Select all')).toBeInTheDocument();
         expect(screen.getByText('Clear all')).toBeInTheDocument();
+      });
+    });
+
+    it('caps the menu height so the field list can scroll on short viewports', async () => {
+      render(<FieldVisibiltyMenu {...defaultProps} />);
+
+      const triggerButton = screen.getByRole('button', { name: /field visibility/i });
+      fireEvent.click(triggerButton);
+
+      await waitFor(() => {
+        expect(screen.getByRole('menu')).toHaveStyle(
+          `max-height: ${scrollableMenuListStyle.maxHeight}; overflow-y: ${scrollableMenuListStyle.overflowY};`
+        );
       });
     });
 

--- a/apps/bulk-edit/test/locations/Page/SearchFilter.test.tsx
+++ b/apps/bulk-edit/test/locations/Page/SearchFilter.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SearchBar } from '../../../src/locations/Page/components/SearchBar';
 import { ContentTypeField, FieldFilterValue } from '../../../src/locations/Page/types';
+import { scrollableMenuListStyle } from '../../../src/locations/Page/components/menuStyles';
 
 vi.mock('use-debounce', () => ({
   useDebounce: (value: string, delay: number) => {
@@ -245,6 +246,18 @@ describe('SearchFilter', () => {
         expect(screen.getByText('Title')).toBeInTheDocument();
         expect(screen.getByText('Description')).toBeInTheDocument();
         expect(screen.getByText('Count')).toBeInTheDocument();
+      });
+    });
+
+    it('caps the fields menu height so it remains scrollable on short viewports', async () => {
+      render(<SearchBar {...defaultProps} />);
+
+      fireEvent.click(screen.getByText('Fields'));
+
+      await waitFor(() => {
+        expect(screen.getByRole('menu')).toHaveStyle(
+          `max-height: ${scrollableMenuListStyle.maxHeight}; overflow-y: ${scrollableMenuListStyle.overflowY};`
+        );
       });
     });
 


### PR DESCRIPTION
## Summary
Adjust the Bulk Edit field menus to use the available viewport height before becoming scrollable.

## Changes
- apply a shared viewport-aware max-height to the field filter and field visibility menus
- keep menu scrolling enabled only when the list exceeds the available viewport space
- add coverage for the menu sizing behavior in both menu entry points

Updated in:
- apps/bulk-edit/src/locations/Page/components
- apps/bulk-edit/test/locations/Page
