### PR TITLE
Location entry name fix and padding fixes []

### DIFF
--- a/apps/google-docs/src/locations/Page/components/modals/step_2/ContentTypePickerModal.tsx
+++ b/apps/google-docs/src/locations/Page/components/modals/step_2/ContentTypePickerModal.tsx
@@ -155,7 +155,6 @@ export const ContentTypePickerModal = ({
             }}>
             {filteredContentTypes.map((ct) => (
               <Multiselect.Option
-                className={css({ padding: `0.25rem` })}
                 key={ct.sys.id}
                 value={ct.sys.id}
                 itemId={ct.sys.id}

--- a/apps/google-docs/src/locations/Page/components/modals/step_3/SelectTabsModal.styles.ts
+++ b/apps/google-docs/src/locations/Page/components/modals/step_3/SelectTabsModal.styles.ts
@@ -5,10 +5,6 @@ export const multiselect = css({
   maxWidth: '68%',
 });
 
-export const multiselectOption = css({
-  padding: tokens.spacing2Xs,
-});
-
 export const pillsContainer = css({
   marginRight: tokens.spacingXl,
   maxHeight: '100px',

--- a/apps/google-docs/src/locations/Page/components/modals/step_3/SelectTabsModal.tsx
+++ b/apps/google-docs/src/locations/Page/components/modals/step_3/SelectTabsModal.tsx
@@ -10,12 +10,7 @@ import {
   Multiselect,
   Radio,
 } from '@contentful/f36-components';
-import {
-  modalControls,
-  multiselect,
-  multiselectOption,
-  pillsContainer,
-} from './SelectTabsModal.styles';
+import { modalControls, multiselect, pillsContainer } from './SelectTabsModal.styles';
 import { useMultiselectScrollReflow } from '@hooks/useMultiselectReflow';
 import { DocumentTabProps } from '@types';
 import { truncateLabel } from '../../../../../utils/utils';
@@ -108,7 +103,6 @@ export const SelectTabsModal = ({
                       }}>
                       {availableTabs.map((tab) => (
                         <Multiselect.Option
-                          className={multiselectOption}
                           key={tab.tabId}
                           value={tab.tabId}
                           itemId={tab.tabId}

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -26,7 +26,7 @@ import { SelectionActionMenu } from './SelectionActionMenu';
 import { buildSourceRefKey } from './sourceRefUtils';
 import { MappingEntryCards, type AnchoredMappingCard } from './MappingEntryCards';
 import { NormalizedDocumentSection } from './NormalizedDocumentSection';
-import { getTitleFromFieldMappings } from '../../../../../utils/overviewEntryList';
+import { getEntryTitleFromFieldMappings } from '../../../../../utils/getEntryTitle';
 
 interface EditModalState {
   viewModel: EditModalContent;
@@ -138,7 +138,7 @@ export const MappingView = ({ payload, selectedEntryIndex }: MappingViewProps): 
     const contentTypeField = contentType?.fields.find((field) => field.id === fieldId);
     const fieldDisplayName = (contentTypeField?.name ?? '').trim();
     const fieldDisplayType = getFieldTypeLabel(fieldType);
-    const entryName = getTitleFromFieldMappings(graphEntry, contentType?.displayField);
+    const entryName = getEntryTitleFromFieldMappings(graphEntry, contentType?.displayField);
 
     return {
       id: `${entryIndex}-${graphEntry.contentTypeId}-${fieldId}`,

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -26,6 +26,7 @@ import { SelectionActionMenu } from './SelectionActionMenu';
 import { buildSourceRefKey } from './sourceRefUtils';
 import { MappingEntryCards, type AnchoredMappingCard } from './MappingEntryCards';
 import { NormalizedDocumentSection } from './NormalizedDocumentSection';
+import { getTitleFromFieldMappings } from '../../../../../utils/overviewEntryList';
 
 interface EditModalState {
   viewModel: EditModalContent;
@@ -49,11 +50,6 @@ const EMPTY_EDIT_MODAL: EditModalState = {
   locationSectionDescription: '',
   primaryButtonLabel: '',
 };
-
-function getEntryName(contentTypeName: string | undefined, entryIndex: number): string {
-  const displayName = contentTypeName ?? 'Untitled';
-  return `${displayName} #${entryIndex + 1}`;
-}
 
 /** `Range#intersectsNode` can throw when the range and node are in inconsistent trees. */
 function rangeIntersectsNode(range: Range, node: Node): boolean {
@@ -142,12 +138,13 @@ export const MappingView = ({ payload, selectedEntryIndex }: MappingViewProps): 
     const contentTypeField = contentType?.fields.find((field) => field.id === fieldId);
     const fieldDisplayName = (contentTypeField?.name ?? '').trim();
     const fieldDisplayType = getFieldTypeLabel(fieldType);
+    const entryName = getTitleFromFieldMappings(graphEntry, contentType?.displayField);
 
     return {
       id: `${entryIndex}-${graphEntry.contentTypeId}-${fieldId}`,
       contentTypeId: graphEntry.contentTypeId,
       contentTypeName: contentTypeDisplayName,
-      entryName: getEntryName(contentTypeDisplayName, entryIndex),
+      entryName,
       fieldId,
       fieldName: fieldDisplayName,
       fieldType: fieldDisplayType,

--- a/apps/google-docs/src/utils/overviewEntryList.ts
+++ b/apps/google-docs/src/utils/overviewEntryList.ts
@@ -1,5 +1,6 @@
 import type { EntryToCreate, CompletedWorkflowPayload } from '@types';
 import type { EntryBlockGraphEntry } from '../types/entryBlockGraph';
+import { isTextSourceRef } from '../types/entryBlockGraph';
 import type { WorkflowContentType } from '../types/workflow';
 import { collectReferencedTempIdsFromEntry } from '../services/referenceResolution';
 import { type ContentTypeDisplayInfo } from '../services/contentTypeService';
@@ -36,6 +37,24 @@ function resolveContentTypeLabel(
 ): string {
   const name = contentTypeDisplayInfoMap?.get(contentTypeId)?.name?.trim();
   return name && name.length > 0 ? name : '';
+}
+
+function getTitleFromFieldMappings(
+  entry: EntryBlockGraphEntry,
+  displayField?: string
+): string | undefined {
+  if (!displayField) return undefined;
+  const fieldMapping = entry.fieldMappings.find((m) => m.fieldId === displayField);
+  if (!fieldMapping) return undefined;
+
+  const text = fieldMapping.sourceRefs
+    .filter(isTextSourceRef)
+    .flatMap((ref) => ref.flattenedRuns)
+    .map((run) => run.text)
+    .join('')
+    .trim();
+
+  return text.length > 0 ? text : undefined;
 }
 
 function createRow(

--- a/apps/google-docs/src/utils/overviewEntryList.ts
+++ b/apps/google-docs/src/utils/overviewEntryList.ts
@@ -15,6 +15,8 @@ export interface EntryListRow {
   children: EntryListRow[];
 }
 
+const UNTITLED = 'Untitled';
+
 export type ContentTypeDisplayInfoMap = ReadonlyMap<string, ContentTypeDisplayInfo>;
 
 interface OrderedEntriesContext {

--- a/apps/google-docs/src/utils/overviewEntryList.ts
+++ b/apps/google-docs/src/utils/overviewEntryList.ts
@@ -15,8 +15,6 @@ export interface EntryListRow {
   children: EntryListRow[];
 }
 
-const UNTITLED = 'Untitled';
-
 export type ContentTypeDisplayInfoMap = ReadonlyMap<string, ContentTypeDisplayInfo>;
 
 interface OrderedEntriesContext {

--- a/apps/google-docs/src/utils/overviewEntryList.ts
+++ b/apps/google-docs/src/utils/overviewEntryList.ts
@@ -1,6 +1,5 @@
 import type { EntryToCreate, CompletedWorkflowPayload } from '@types';
 import type { EntryBlockGraphEntry } from '../types/entryBlockGraph';
-import { isTextSourceRef } from '../types/entryBlockGraph';
 import type { WorkflowContentType } from '../types/workflow';
 import { collectReferencedTempIdsFromEntry } from '../services/referenceResolution';
 import { type ContentTypeDisplayInfo } from '../services/contentTypeService';
@@ -37,24 +36,6 @@ function resolveContentTypeLabel(
 ): string {
   const name = contentTypeDisplayInfoMap?.get(contentTypeId)?.name?.trim();
   return name && name.length > 0 ? name : '';
-}
-
-function getTitleFromFieldMappings(
-  entry: EntryBlockGraphEntry,
-  displayField?: string
-): string | undefined {
-  if (!displayField) return undefined;
-  const fieldMapping = entry.fieldMappings.find((m) => m.fieldId === displayField);
-  if (!fieldMapping) return undefined;
-
-  const text = fieldMapping.sourceRefs
-    .filter(isTextSourceRef)
-    .flatMap((ref) => ref.flattenedRuns)
-    .map((run) => run.text)
-    .join('')
-    .trim();
-
-  return text.length > 0 ? text : undefined;
 }
 
 function createRow(

--- a/apps/google-docs/test/locations/Page/components/review/mapping/MappingView.spec.tsx
+++ b/apps/google-docs/test/locations/Page/components/review/mapping/MappingView.spec.tsx
@@ -129,7 +129,7 @@ describe('MappingView', () => {
     expect(screen.getByRole('heading', { name: 'Assign content' })).toBeTruthy();
     expect(screen.getByText('"selected body text"')).toBeTruthy();
     expect(screen.getByText('Article')).toBeTruthy();
-    expect(screen.getByText('Article #1')).toBeTruthy();
+    expect(screen.getByText('Untitled')).toBeTruthy();
     expect(screen.getByText('Body copy')).toBeTruthy();
     expect(
       screen.getAllByText((_, node) => node?.textContent?.includes('| Long text') ?? false).length

--- a/apps/google-docs/test/utils/getEntryTitle.test.ts
+++ b/apps/google-docs/test/utils/getEntryTitle.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { getEntryTitleFromFieldMappings } from '../../src/utils/getEntryTitle';
+
+describe('getEntryTitleFromFieldMappings', () => {
+  const createTextSourceRef = (text: string) => ({
+    type: 'blockText' as const,
+    blockId: 'block-1',
+    start: 0,
+    end: text.length,
+    flattenedRuns: [{ text, start: 0, end: text.length }],
+  });
+
+  it('extracts the entry title from the display field mapping', () => {
+    const title = getEntryTitleFromFieldMappings(
+      {
+        tempId: 'entry-1',
+        contentTypeId: 'article',
+        fieldMappings: [
+          {
+            fieldId: 'title',
+            fieldType: 'Symbol',
+            sourceRefs: [createTextSourceRef('Entry title')],
+            confidence: 0.9,
+          },
+        ],
+      },
+      'title'
+    );
+
+    expect(title).toBe('Entry title');
+  });
+});

--- a/apps/google-docs/test/utils/overviewEntryList.test.ts
+++ b/apps/google-docs/test/utils/overviewEntryList.test.ts
@@ -1,10 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { CompletedWorkflowPayload } from '../../src/types';
 import type { ContentTypeDisplayInfo } from '../../src/services/contentTypeService';
-import {
-  buildEntryList,
-  buildEntryListFromEntryBlockGraph,
-} from '../../src/utils/overviewEntryList';
+import { buildEntryList } from '../../src/utils/overviewEntryList';
 
 describe('buildEntryList', () => {
   it('omits entries without tempId', () => {
@@ -118,48 +115,5 @@ describe('buildEntryList', () => {
     const rows = buildEntryList(payload, contentTypeDisplayInfoById, 'en-US');
     expect(rows[0].contentTypeName).toBe('Page (space name)');
     expect(rows[0].entryTitle).toBe('Event Detail');
-  });
-});
-
-describe('buildEntryListFromEntryBlockGraph', () => {
-  const contentTypes = [
-    {
-      sys: { id: 'article' },
-      name: 'Article',
-      displayField: 'title',
-      fields: [],
-    },
-  ];
-
-  const createTextSourceRef = (text: string) => ({
-    type: 'blockText' as const,
-    blockId: 'block-1',
-    start: 0,
-    end: text.length,
-    flattenedRuns: [{ text, start: 0, end: text.length }],
-  });
-
-  it('extracts the entry title from the display field mapping', () => {
-    const rows = buildEntryListFromEntryBlockGraph(
-      [
-        {
-          tempId: 'entry-1',
-          contentTypeId: 'article',
-          fieldMappings: [
-            {
-              fieldId: 'title',
-              fieldType: 'Symbol',
-              sourceRefs: [createTextSourceRef('Entry title')],
-              confidence: 0.9,
-            },
-          ],
-        },
-      ],
-      contentTypes
-    );
-
-    expect(rows).toHaveLength(1);
-    expect(rows[0].contentTypeName).toBe('Article');
-    expect(rows[0].entryTitle).toBe('Entry title');
   });
 });


### PR DESCRIPTION
## Purpose
Fix location entry name and content type/tabs padding

## Approach

- Use the same logic for getting the entry name
- Fix an issue with content type picker modal for multiselect padding
- Fix same issue for tabs picker

## Testing steps

Location fix

https://github.com/user-attachments/assets/f05e4492-1e3f-410d-9db7-bbc2c4f6d3d0


Content type 
Before
<img width="875" height="632" alt="Captura de pantalla 2026-04-17 a las 12 19 41 p  m" src="https://github.com/user-attachments/assets/e59218ae-5699-4f0a-b376-4c435e6aff01" />

After
<img width="845" height="673" alt="Captura de pantalla 2026-04-17 a las 12 19 58 p  m" src="https://github.com/user-attachments/assets/4fafa606-250b-466f-bbd0-ca65fe954d8f" />

Tabs picker
Before
<img width="524" height="259" alt="Captura de pantalla 2026-04-17 a las 12 29 37 p  m" src="https://github.com/user-attachments/assets/26b4c869-5e28-4477-872a-4098ce8dd066" />

After
<img width="767" height="523" alt="Captura de pantalla 2026-04-17 a las 12 30 30 p  m" src="https://github.com/user-attachments/assets/d430d1c7-66ce-4a69-9a1f-7168d40c435d" />
