### PR TITLE
[] Skip serverless-offline during GA4 lambda deploy

### DIFF
--- a/apps/google-analytics-4/lambda/serverless-plugins.cjs
+++ b/apps/google-analytics-4/lambda/serverless-plugins.cjs
@@ -1,0 +1,7 @@
+const shouldLoadOfflinePlugin = process.argv.includes('offline');
+
+module.exports.plugins = [
+  'serverless-domain-manager',
+  ...(shouldLoadOfflinePlugin ? ['serverless-offline'] : []),
+  'serverless-prune-plugin',
+];

--- a/apps/google-analytics-4/lambda/serverless.yml
+++ b/apps/google-analytics-4/lambda/serverless.yml
@@ -2,10 +2,7 @@ service: sls-apps-google-analytics-4
 
 frameworkVersion: '>=3.0.0 <4.0.0'
 
-plugins:
-  - serverless-domain-manager
-  - serverless-offline
-  - serverless-prune-plugin
+plugins: ${file(./serverless-plugins.cjs):plugins}
 
 custom:
   sentryDSN: https://b8f524eae7c446fb8071476431426640@o2239.ingest.sentry.io/4504725335834624


### PR DESCRIPTION
## Summary
This avoids loading serverless-offline during GA4 lambda deploys, which currently fail in CI under Node 22 when Serverless tries to require the plugin.

## Changes
- move the GA4 lambda plugin list behind a small helper file
- load serverless-offline only for offline/local commands
- keep deploy and print paths limited to the plugins needed in CI

Updated in:
- apps/google-analytics-4/lambda

## Notes
- serverless-offline remains available for local development
- verified sls print --stage dev succeeds after the change
