### PR TITLE
feat(google-docs): adding integer and decimal edit [INTEG-3814]

### DIFF
--- a/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/EditModal.styles.ts
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/EditModal.styles.ts
@@ -46,10 +46,3 @@ export const locationContent = css({
   minWidth: 0,
   textAlign: 'left',
 });
-
-export const fieldPlaceholder = css({
-  border: `1px solid ${tokens.gray300}`,
-  borderRadius: tokens.borderRadiusMedium,
-  color: tokens.gray500,
-  padding: `${tokens.spacingS} ${tokens.spacingM}`,
-});

--- a/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/EditModal.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/EditModal.tsx
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import { Box, Button, Modal, Paragraph, Text } from '@contentful/f36-components';
 import type { EditModalContent } from '@types';
 import {
-  fieldPlaceholder,
   locationButton,
   locationButtonSelected,
   locationButtonUnselected,
@@ -168,6 +167,7 @@ export const EditModal = ({
                           Fields
                         </Text>
                         <FieldSelectionDropdown
+                          selectedText={viewModel.selectedText}
                           fieldOptions={newLocation.fieldOptions}
                           fieldMappings={newLocation.fieldMappings}
                           selectedFieldIds={

--- a/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/FieldSelectionDropdown.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/FieldSelectionDropdown.tsx
@@ -3,6 +3,7 @@ import { Flex, Stack, Text } from '@contentful/f36-components';
 import { Multiselect } from '@contentful/f36-multiselect';
 import type { EditModalFieldMapping, EditModalFieldOption } from '@types';
 import { useMultiselectScrollReflow } from '@hooks/useMultiselectReflow';
+import { getFieldTypeLabel } from '../fieldFormatting';
 import { isSelectableFieldType } from './utils';
 
 interface FieldSelectionDropdownProps {
@@ -56,7 +57,8 @@ export const FieldSelectionDropdown = ({
         }}>
         {fieldOptions.map((option) =>
           (() => {
-            const isDisabled = !isSelectableFieldType(option.fieldType, selectedText);
+            const fieldTypeDisplay = getFieldTypeLabel(option.fieldType);
+            const isDisabled = !isSelectableFieldType(fieldTypeDisplay, selectedText);
             const isFilled = filledFieldIds.has(option.id);
             return (
               <Multiselect.Option
@@ -72,7 +74,7 @@ export const FieldSelectionDropdown = ({
                       {option.fieldName}
                     </Text>
                     <Text as="div" fontColor="gray700" fontWeight="fontWeightNormal">
-                      ({option.fieldType})
+                      ({fieldTypeDisplay})
                     </Text>
                   </Flex>
                   <Text as="div" fontColor="gray700" fontWeight="fontWeightNormal">

--- a/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/FieldSelectionDropdown.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/FieldSelectionDropdown.tsx
@@ -3,8 +3,10 @@ import { Flex, Stack, Text } from '@contentful/f36-components';
 import { Multiselect } from '@contentful/f36-multiselect';
 import type { EditModalFieldMapping, EditModalFieldOption } from '@types';
 import { useMultiselectScrollReflow } from '@hooks/useMultiselectReflow';
+import { isSelectableFieldType } from './utils';
 
 interface FieldSelectionDropdownProps {
+  selectedText: string;
   fieldOptions: EditModalFieldOption[];
   fieldMappings: EditModalFieldMapping[];
   selectedFieldIds: string[];
@@ -12,6 +14,7 @@ interface FieldSelectionDropdownProps {
 }
 
 export const FieldSelectionDropdown = ({
+  selectedText,
   fieldOptions,
   fieldMappings,
   selectedFieldIds,
@@ -41,11 +44,6 @@ export const FieldSelectionDropdown = ({
   const placeholder =
     selectedOptions.length === 0 ? 'Select one or more' : `${selectedOptions.length} selected`;
 
-  const isSelectableFieldType = (fieldType: string) => {
-    const normalizedFieldType = fieldType.trim().toLowerCase();
-    return normalizedFieldType === 'short text' || normalizedFieldType === 'long text';
-  };
-
   return (
     <Stack flexDirection="column" alignItems="start">
       <Multiselect
@@ -58,7 +56,7 @@ export const FieldSelectionDropdown = ({
         }}>
         {fieldOptions.map((option) =>
           (() => {
-            const isDisabled = !isSelectableFieldType(option.fieldType);
+            const isDisabled = !isSelectableFieldType(option.fieldType, selectedText);
             const isFilled = filledFieldIds.has(option.id);
             return (
               <Multiselect.Option

--- a/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/utils.ts
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/utils.ts
@@ -1,0 +1,41 @@
+const enum AllowedContentTypes {
+  INTEGER = 'integer',
+  DECIMAL = 'decimal',
+  TEXT = 'text',
+  SHORT_TEXT = 'short text',
+  LONG_TEXT = 'long text',
+}
+
+export const getSelectedContentMatch = (value: string) => {
+  const trimmedValue = value?.trim() ?? '';
+
+  if (/^[+-]?\d+$/.test(trimmedValue)) {
+    return AllowedContentTypes.INTEGER;
+  }
+
+  if (/^[+-]?(?:\d+\.\d+|\d+\.|\.\d+)$/.test(trimmedValue)) {
+    return AllowedContentTypes.DECIMAL;
+  }
+
+  return AllowedContentTypes.TEXT;
+};
+
+export const isSelectableFieldType = (fieldType: string, selectedText: string) => {
+  const highlightedTextMatch = getSelectedContentMatch(selectedText);
+  const normalizedFieldType = fieldType.trim().toLowerCase();
+
+  switch (normalizedFieldType) {
+    case AllowedContentTypes.SHORT_TEXT:
+    case AllowedContentTypes.LONG_TEXT:
+      return true;
+    case AllowedContentTypes.INTEGER:
+      return highlightedTextMatch === AllowedContentTypes.INTEGER;
+    case AllowedContentTypes.DECIMAL:
+      return (
+        highlightedTextMatch === AllowedContentTypes.INTEGER ||
+        highlightedTextMatch === AllowedContentTypes.DECIMAL
+      );
+    default:
+      return false;
+  }
+};

--- a/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/utils.ts
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/utils.ts
@@ -1,39 +1,33 @@
-const enum AllowedContentTypes {
-  INTEGER = 'integer',
-  DECIMAL = 'decimal',
-  TEXT = 'text',
-  SHORT_TEXT = 'short text',
-  LONG_TEXT = 'long text',
-}
+import { FIELD_TYPE_DISPLAY, getFieldTypeLabel } from '../fieldFormatting';
 
 export const getSelectedContentMatch = (value: string) => {
   const trimmedValue = value?.trim() ?? '';
 
   if (/^[+-]?\d+$/.test(trimmedValue)) {
-    return AllowedContentTypes.INTEGER;
+    return FIELD_TYPE_DISPLAY.INTEGER;
   }
 
   if (/^[+-]?(?:\d+\.\d+|\d+\.|\.\d+)$/.test(trimmedValue)) {
-    return AllowedContentTypes.DECIMAL;
+    return FIELD_TYPE_DISPLAY.DECIMAL;
   }
 
-  return AllowedContentTypes.TEXT;
+  return;
 };
 
 export const isSelectableFieldType = (fieldType: string, selectedText: string) => {
   const highlightedTextMatch = getSelectedContentMatch(selectedText);
-  const normalizedFieldType = fieldType.trim().toLowerCase();
+  const normalizedFieldType = getFieldTypeLabel(fieldType).trim();
 
   switch (normalizedFieldType) {
-    case AllowedContentTypes.SHORT_TEXT:
-    case AllowedContentTypes.LONG_TEXT:
+    case FIELD_TYPE_DISPLAY.SHORT_TEXT:
+    case FIELD_TYPE_DISPLAY.LONG_TEXT:
       return true;
-    case AllowedContentTypes.INTEGER:
-      return highlightedTextMatch === AllowedContentTypes.INTEGER;
-    case AllowedContentTypes.DECIMAL:
+    case FIELD_TYPE_DISPLAY.INTEGER:
+      return highlightedTextMatch === FIELD_TYPE_DISPLAY.INTEGER;
+    case FIELD_TYPE_DISPLAY.DECIMAL:
       return (
-        highlightedTextMatch === AllowedContentTypes.INTEGER ||
-        highlightedTextMatch === AllowedContentTypes.DECIMAL
+        highlightedTextMatch === FIELD_TYPE_DISPLAY.INTEGER ||
+        highlightedTextMatch === FIELD_TYPE_DISPLAY.DECIMAL
       );
     default:
       return false;

--- a/apps/google-docs/src/locations/Page/components/review/mapping/fieldFormatting.ts
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/fieldFormatting.ts
@@ -27,5 +27,12 @@ const FIELD_TYPE_LABELS: Record<string, string> = {
   ResourceLink: 'Resource link',
 };
 
+export const FIELD_TYPE_DISPLAY = {
+  SHORT_TEXT: FIELD_TYPE_LABELS.Symbol,
+  LONG_TEXT: FIELD_TYPE_LABELS.Text,
+  INTEGER: FIELD_TYPE_LABELS.Integer,
+  DECIMAL: FIELD_TYPE_LABELS.Number,
+} as const;
+
 export const getFieldTypeLabel = (fieldType: string): string =>
   FIELD_TYPE_LABELS[fieldType] ?? fieldType;

--- a/apps/google-docs/test/locations/Page/components/modals/FieldSelectionDropdown.spec.tsx
+++ b/apps/google-docs/test/locations/Page/components/modals/FieldSelectionDropdown.spec.tsx
@@ -9,18 +9,18 @@ describe('FieldSelectionDropdown', () => {
 
     render(
       <FieldSelectionDropdown
-        selectedText="5 "
+        selectedText="+5 "
         fieldMappings={[{ fieldId: 'name' }]}
         fieldOptions={[
           {
             id: 'name',
             fieldName: 'Name (Internal)',
-            fieldType: 'Short text',
+            fieldType: 'Symbol',
           },
           {
             id: 'marketo',
             fieldName: 'Marketo',
-            fieldType: 'Reference',
+            fieldType: 'Link',
           },
           {
             id: 'headingSize',
@@ -30,7 +30,7 @@ describe('FieldSelectionDropdown', () => {
           {
             id: 'price',
             fieldName: 'Price',
-            fieldType: 'Decimal',
+            fieldType: 'Number',
           },
         ]}
         selectedFieldIds={[]}
@@ -45,12 +45,12 @@ describe('FieldSelectionDropdown', () => {
       expect(screen.getByText('(Short text)')).toBeTruthy();
       expect(screen.getByText('Filled')).toBeTruthy();
       expect(screen.getByText('Marketo')).toBeTruthy();
-      expect(screen.getByText('(Reference)')).toBeTruthy();
+      expect(screen.getByText('(Media)')).toBeTruthy();
       expect(screen.getAllByText('Empty').length).toBeGreaterThan(0);
       expect(screen.getByText('Heading size')).toBeTruthy();
       expect(screen.getByText('(Integer)')).toBeTruthy();
       expect(screen.getByText('Price')).toBeTruthy();
-      expect(screen.getByText('(Decimal)')).toBeTruthy();
+      expect(screen.getByText('(Number)')).toBeTruthy();
     });
 
     const enabledOption = screen.getByDisplayValue('name');
@@ -83,7 +83,7 @@ describe('FieldSelectionDropdown', () => {
           {
             id: 'title',
             fieldName: 'Title',
-            fieldType: 'Short text',
+            fieldType: 'Symbol',
           },
           {
             id: 'headingSize',
@@ -93,7 +93,7 @@ describe('FieldSelectionDropdown', () => {
           {
             id: 'price',
             fieldName: 'Price',
-            fieldType: 'Decimal',
+            fieldType: 'Number',
           },
         ]}
         selectedFieldIds={[]}

--- a/apps/google-docs/test/locations/Page/components/modals/FieldSelectionDropdown.spec.tsx
+++ b/apps/google-docs/test/locations/Page/components/modals/FieldSelectionDropdown.spec.tsx
@@ -4,11 +4,12 @@ import React from 'react';
 import { FieldSelectionDropdown } from '../../../../../src/locations/Page/components/review/mapping/edit-modals/FieldSelectionDropdown';
 
 describe('FieldSelectionDropdown', () => {
-  it('renders field status from field mappings and disables non-text options', async () => {
+  it('enables numeric field types only when the selected text is numeric', async () => {
     const onSelectedFieldIdsChange = vi.fn();
 
     render(
       <FieldSelectionDropdown
+        selectedText="5 "
         fieldMappings={[{ fieldId: 'name' }]}
         fieldOptions={[
           {
@@ -20,6 +21,16 @@ describe('FieldSelectionDropdown', () => {
             id: 'marketo',
             fieldName: 'Marketo',
             fieldType: 'Reference',
+          },
+          {
+            id: 'headingSize',
+            fieldName: 'Heading size',
+            fieldType: 'Integer',
+          },
+          {
+            id: 'price',
+            fieldName: 'Price',
+            fieldType: 'Decimal',
           },
         ]}
         selectedFieldIds={[]}
@@ -35,19 +46,71 @@ describe('FieldSelectionDropdown', () => {
       expect(screen.getByText('Filled')).toBeTruthy();
       expect(screen.getByText('Marketo')).toBeTruthy();
       expect(screen.getByText('(Reference)')).toBeTruthy();
-      expect(screen.getByText('Empty')).toBeTruthy();
+      expect(screen.getAllByText('Empty').length).toBeGreaterThan(0);
+      expect(screen.getByText('Heading size')).toBeTruthy();
+      expect(screen.getByText('(Integer)')).toBeTruthy();
+      expect(screen.getByText('Price')).toBeTruthy();
+      expect(screen.getByText('(Decimal)')).toBeTruthy();
     });
 
     const enabledOption = screen.getByDisplayValue('name');
     const disabledOption = screen.getByDisplayValue('marketo');
+    const integerOption = screen.getByDisplayValue('headingSize');
+    const decimalOption = screen.getByDisplayValue('price');
 
     expect(enabledOption).not.toBeDisabled();
     expect(disabledOption).toBeDisabled();
+    expect(integerOption).not.toBeDisabled();
+    expect(decimalOption).not.toBeDisabled();
 
     fireEvent.click(enabledOption);
+    fireEvent.click(integerOption);
+    fireEvent.click(decimalOption);
 
     await waitFor(() => {
       expect(onSelectedFieldIdsChange).toHaveBeenCalledWith(['name']);
+      expect(onSelectedFieldIdsChange).toHaveBeenCalledWith(['headingSize']);
+      expect(onSelectedFieldIdsChange).toHaveBeenCalledWith(['price']);
     });
+  });
+
+  it('disables integer and decimal options when the selected text is not numeric', async () => {
+    render(
+      <FieldSelectionDropdown
+        selectedText="Sample selected content"
+        fieldMappings={[]}
+        fieldOptions={[
+          {
+            id: 'title',
+            fieldName: 'Title',
+            fieldType: 'Short text',
+          },
+          {
+            id: 'headingSize',
+            fieldName: 'Heading size',
+            fieldType: 'Integer',
+          },
+          {
+            id: 'price',
+            fieldName: 'Price',
+            fieldType: 'Decimal',
+          },
+        ]}
+        selectedFieldIds={[]}
+        onSelectedFieldIdsChange={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle Multiselect' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Title')).toBeTruthy();
+      expect(screen.getByText('Heading size')).toBeTruthy();
+      expect(screen.getByText('Price')).toBeTruthy();
+    });
+
+    expect(screen.getByDisplayValue('title')).not.toBeDisabled();
+    expect(screen.getByDisplayValue('headingSize')).toBeDisabled();
+    expect(screen.getByDisplayValue('price')).toBeDisabled();
   });
 });


### PR DESCRIPTION
## Purpose

This extends the dropdown field selection logic to allow integer and decimal handling.

## Approach

- Now we check the field type and for the case of integer and decimal we also check if the selected text could be consider as a number.
- The short text and long text are always available, but the integer and decimal are only available if that field type match the selected value.

## Testing steps

Automated tests added.

Manual check:

  - so if we have "5.5 hours" as the selected/highlighted text, that will make short and long text available but no integer and decimal.


> https://github.com/user-attachments/assets/846832ae-d69c-4d0d-abbc-a1d4765ea092


  - if we have just "5.5 ", that will make short text, long text, integer, and decimal available.


> https://github.com/user-attachments/assets/13e482d1-7e82-4e50-98f9-fceee73f84fb


  - if we have just "5", that will make short text, long text and integer available.


> https://github.com/user-attachments/assets/e78f4f91-237e-4bab-b72b-f87bfc814ff9
  

  - if we have just "Hot coffee, haute content, on us.", that will make short text and long text available.


> https://github.com/user-attachments/assets/9fc8e176-7536-41b0-98ae-7f6d0a45d2bc


## Breaking Changes

No

## Dependencies and/or References

[INTEG-3814](https://contentful.atlassian.net/jira/software/c/projects/INTEG/boards/454?issueParent=466416&selectedIssue=INTEG-3814)

## Deployment

No

[INTEG-3814]: https://contentful.atlassian.net/browse/INTEG-3814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ