### PR TITLE
Connect newLocations to the EditModal []

### DIFF
--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -6,10 +6,12 @@ import type {
   MappingReviewSuspendPayload,
   EditModalContent,
   EditLocationOption,
+  EditModalNewLocation,
   SourceRef,
 } from '@types';
 import { FileTextIcon } from '@contentful/f36-icons';
 import { useReviewTextSelection } from '@hooks/useReviewTextSelection';
+import { getEntryTitleFromFieldMappings } from '../../../../../utils/getEntryTitle';
 import { getAnchorIdForSourceRef, resolveMarkerOffsets } from './resolveMappingCardOffsets';
 import { type DocSegment, buildDocument } from './buildDocument';
 import {
@@ -53,6 +55,26 @@ const EMPTY_EDIT_MODAL: EditModalState = {
 function getEntryName(contentTypeName: string | undefined, entryIndex: number): string {
   const displayName = contentTypeName ?? 'Untitled';
   return `${displayName} #${entryIndex + 1}`;
+}
+
+function getEntryReviewTitle(
+  entry: MappingReviewSuspendPayload['entryBlockGraph']['entries'][number],
+  displayField: string | undefined,
+  fallbackEntryName: string
+): string {
+  const localizedFieldValue = displayField ? entry.fields?.[displayField] : undefined;
+  if (localizedFieldValue) {
+    const populatedValue = Object.values(localizedFieldValue).find(
+      (candidate): candidate is string =>
+        typeof candidate === 'string' && candidate.trim().length > 0
+    );
+    if (populatedValue) {
+      return populatedValue.trim();
+    }
+  }
+
+  const mappedTitle = getEntryTitleFromFieldMappings(entry, displayField).trim();
+  return mappedTitle && mappedTitle !== 'Untitled' ? mappedTitle : fallbackEntryName;
 }
 
 /** `Range#intersectsNode` can throw when the range and node are in inconsistent trees. */
@@ -183,6 +205,42 @@ export const MappingView = ({ payload, selectedEntryIndex }: MappingViewProps): 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [allSegments, entryBlockGraph, payload.contentTypes, selectedEntryIndex]);
 
+  const newLocations = useMemo<EditModalNewLocation[]>(() => {
+    return entryBlockGraph.entries.map((entry, entryIndex) => {
+      const contentType = payload.contentTypes.find((item) => item.sys.id === entry.contentTypeId);
+      const contentTypeName =
+        (contentType?.name ?? entry.contentTypeId).trim() || entry.contentTypeId;
+      const fallbackEntryName = getEntryName(contentTypeName, entryIndex);
+      const entryTitle = getEntryReviewTitle(entry, contentType?.displayField, fallbackEntryName);
+      const contentTypeFields = contentType?.fields ?? [];
+      const fieldOptions =
+        contentTypeFields.length > 0
+          ? contentTypeFields
+              .filter((field): field is (typeof contentTypeFields)[number] & { id: string } =>
+                Boolean(field.id)
+              )
+              .map((field) => ({
+                id: field.id,
+                fieldName: (field.name ?? '').trim() || formatDisplayName(field.id),
+                fieldType: getFieldTypeLabel(field.type ?? ''),
+              }))
+          : entry.fieldMappings.map((fieldMapping) => ({
+              id: fieldMapping.fieldId,
+              fieldName: formatDisplayName(fieldMapping.fieldId),
+              fieldType: getFieldTypeLabel(fieldMapping.fieldType),
+            }));
+
+      return {
+        id: entry.tempId ?? `${entry.contentTypeId}-${entryIndex}`,
+        title: `${contentTypeName}: ${entryTitle}`,
+        fieldOptions,
+        fieldMappings: entry.fieldMappings.map((fieldMapping) => ({
+          fieldId: fieldMapping.fieldId,
+        })),
+      };
+    });
+  }, [entryBlockGraph.entries, payload.contentTypes]);
+
   const getLocationsForSourceRef = (sourceRef: SourceRef): EditLocationOption[] => {
     const targetKey = buildSourceRefKey(sourceRef);
     const matches: EditLocationOption[] = [];
@@ -310,6 +368,7 @@ export const MappingView = ({ payload, selectedEntryIndex }: MappingViewProps): 
       viewModel: {
         selectedText: preview,
         currentLocations,
+        newLocations,
         isOpen: true,
       },
       title: 'Assign content',

--- a/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/EditModal.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/EditModal.tsx
@@ -164,7 +164,9 @@ export const EditModal = ({
                         <Text as="p" fontWeight="fontWeightDemiBold" marginBottom="spacingM">
                           {newLocation.title}
                         </Text>
-                        <Text marginBottom="spacing2Xs">Fields</Text>
+                        <Text as="p" marginBottom="spacingXs">
+                          Fields
+                        </Text>
                         <FieldSelectionDropdown
                           fieldOptions={newLocation.fieldOptions}
                           fieldMappings={newLocation.fieldMappings}

--- a/apps/google-docs/test/locations/Page/components/review/mapping/MappingView.spec.tsx
+++ b/apps/google-docs/test/locations/Page/components/review/mapping/MappingView.spec.tsx
@@ -130,10 +130,33 @@ describe('MappingView', () => {
     expect(screen.getByText('"selected body text"')).toBeTruthy();
     expect(screen.getByText('Article')).toBeTruthy();
     expect(screen.getByText('Article #1')).toBeTruthy();
-    expect(screen.getByText('Body copy')).toBeTruthy();
+    expect(screen.getAllByText('Body copy').length).toBeGreaterThan(0);
+    expect(screen.getByText('New location')).toBeTruthy();
+    expect(screen.getByText('Article: Draft title from display field')).toBeTruthy();
     expect(
       screen.getAllByText((_, node) => node?.textContent?.includes('| Long text') ?? false).length
     ).toBeGreaterThan(0);
+    expect(mockClearSelection).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens assign modal with new locations for unmapped text', () => {
+    const selectedRange = { intersectsNode: () => false } as unknown as Range;
+    mockUseReviewTextSelection.mockReturnValue({
+      selectionRectangle: { top: 100, left: 100, right: 160, bottom: 120 },
+      selectedText: 'fresh body text',
+      selectedRange,
+      clearSelection: mockClearSelection,
+    });
+
+    render(<MappingView payload={createPayload()} selectedEntryIndex={null} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Assign' }));
+
+    expect(screen.getByRole('heading', { name: 'Assign content' })).toBeTruthy();
+    expect(screen.getByText('"fresh body text"')).toBeTruthy();
+    expect(screen.getByText('Current location')).toBeTruthy();
+    expect(screen.getByText('New location')).toBeTruthy();
+    expect(screen.getByText('Article: Draft title from display field')).toBeTruthy();
     expect(mockClearSelection).toHaveBeenCalledTimes(1);
   });
 
@@ -180,7 +203,8 @@ describe('MappingView', () => {
 
     expect(screen.getByRole('heading', { name: 'Exclude content' })).toBeTruthy();
     expect(screen.getByText('Article')).toBeTruthy();
-    expect(screen.getByText('Body copy')).toBeTruthy();
+    expect(screen.getAllByText('Body copy').length).toBeGreaterThan(0);
+    expect(screen.queryByText('New location')).toBeNull();
     expect(
       screen.getAllByText((_, node) => node?.textContent?.includes('| Long text') ?? false).length
     ).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
- pass `newLocations` from `MappingView` into `EditModal` for assign flows in the `google-docs` app
- show the `New location` section for both `Assign` and `Reassign`, while keeping `Exclude` unchanged
- build the modal's new-location view model from the review payload and add focused tests for assign/reassign/exclude behavior

https://github.com/user-attachments/assets/10adf9fd-4eca-4c7c-b3a9-2d363440386b

