### PR TITLE
feat: first working version of exclusion for the google docs agent [INTEG-3800]

### DIFF
--- a/apps/google-docs/src/locations/Page/components/review/ReviewPage.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/ReviewPage.tsx
@@ -1,8 +1,12 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Button, Flex, Heading, Layout } from '@contentful/f36-components';
 import tokens from '@contentful/f36-tokens';
 import { PageAppSDK } from '@contentful/app-sdk';
-import type { MappingReviewSuspendPayload, CompletedWorkflowPayload } from '@types';
+import type {
+  EntryBlockGraph,
+  MappingReviewSuspendPayload,
+  CompletedWorkflowPayload,
+} from '@types';
 import { RunStatus } from '@types';
 import { useWorkflowAgent } from '@hooks/useWorkflowAgent';
 import Splitter from '../mainpage/Splitter';
@@ -28,6 +32,21 @@ export const ReviewPage = ({
   const [isConfirmCancelModalOpen, setIsConfirmCancelModalOpen] = useState(false);
   const [selectedEntryIndex, setSelectedEntryIndex] = useState<number>(0);
   const [isCancelling, setIsCancelling] = useState(false);
+  const [entryBlockGraph, setEntryBlockGraph] = useState<EntryBlockGraph>(() =>
+    structuredClone(payload.entryBlockGraph)
+  );
+
+  // Reset local graph when starting a different run; do not depend on payload.entryBlockGraph
+  // alone or user edits would be wiped when the parent re-renders with a new object reference.
+  useEffect(() => {
+    setEntryBlockGraph(structuredClone(payload.entryBlockGraph));
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only re-init on run identity
+  }, [runId, payload.documentId]);
+
+  const reviewPayload = useMemo(
+    (): MappingReviewSuspendPayload => ({ ...payload, entryBlockGraph }),
+    [payload, entryBlockGraph]
+  );
 
   const { resumeWorkflow } = useWorkflowAgent({ sdk, documentId: '', oauthToken: '' });
 
@@ -39,7 +58,7 @@ export const ReviewPage = ({
 
     try {
       const result = await resumeWorkflow(runId, {
-        entryBlockGraph: payload.entryBlockGraph,
+        entryBlockGraph,
       });
 
       if (result.status === RunStatus.COMPLETED && 'googleDocPayload' in result) {
@@ -53,7 +72,7 @@ export const ReviewPage = ({
       onReturnToMainPage();
       return null;
     }
-  }, [runId, resumeWorkflow, payload.entryBlockGraph, onReturnToMainPage]);
+  }, [runId, resumeWorkflow, entryBlockGraph, onReturnToMainPage]);
 
   const handleConfirmCancel = useCallback(async () => {
     setIsCancelling(true);
@@ -89,13 +108,18 @@ export const ReviewPage = ({
         <Flex flexDirection="column" gap="spacingM" style={{ padding: tokens.spacingL }}>
           <OverviewSection
             sdk={sdk}
-            payload={payload}
+            payload={reviewPayload}
             selectedEntryIndex={selectedEntryIndex}
             onSelectEntryIndex={setSelectedEntryIndex}
             onCreateEntries={handleCreateEntries}
             onReturnToMainPage={onReturnToMainPage}
           />
-          <MappingView payload={payload} selectedEntryIndex={selectedEntryIndex} />
+          <MappingView
+            payload={reviewPayload}
+            entryBlockGraph={entryBlockGraph}
+            onEntryBlockGraphChange={setEntryBlockGraph}
+            selectedEntryIndex={selectedEntryIndex}
+          />
         </Flex>
       </Layout.Body>
       <ConfirmCancelModal

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -1,7 +1,8 @@
-import { useLayoutEffect, useMemo, useRef, useState, type RefCallback } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState, type RefCallback } from 'react';
 import { Box, Button, Flex, Text } from '@contentful/f36-components';
 import tokens from '@contentful/f36-tokens';
 import type {
+  EntryBlockGraph,
   ImageSourceRef,
   MappingReviewSuspendPayload,
   EditModalContent,
@@ -28,8 +29,18 @@ import { SelectionActionMenu } from './SelectionActionMenu';
 import { buildSourceRefKey } from './sourceRefUtils';
 import { MappingEntryCards, type AnchoredMappingCard } from './MappingEntryCards';
 import { NormalizedDocumentSection } from './NormalizedDocumentSection';
+import {
+  applyImageExclusionToEntryBlockGraph,
+  applyTextExclusionToEntryBlockGraph,
+  collectMappedExclusionPreviewText,
+  collectTextExclusionRangesFromSelection,
+  type TextExclusionRange,
+} from './entryBlockGraphExclusion';
+
+type EditModalMode = 'exclude' | 'assign' | null;
 
 interface EditModalState {
+  mode: EditModalMode;
   viewModel: EditModalContent;
   title: string;
   locationSectionDescription: string;
@@ -38,10 +49,13 @@ interface EditModalState {
 
 interface MappingViewProps {
   payload: MappingReviewSuspendPayload;
+  entryBlockGraph: EntryBlockGraph;
+  onEntryBlockGraphChange: (next: EntryBlockGraph) => void;
   selectedEntryIndex: number | null;
 }
 
 const EMPTY_EDIT_MODAL: EditModalState = {
+  mode: null,
   viewModel: {
     selectedText: '',
     currentLocations: [],
@@ -86,18 +100,48 @@ function rangeIntersectsNode(range: Range, node: Node): boolean {
   }
 }
 
-export const MappingView = ({ payload, selectedEntryIndex }: MappingViewProps): JSX.Element => {
+export const MappingView = ({
+  payload,
+  entryBlockGraph,
+  onEntryBlockGraphChange,
+  selectedEntryIndex,
+}: MappingViewProps): JSX.Element => {
   const [hoveredMappingKeys, setHoveredMappingKeys] = useState<string[]>([]);
   const [cardOffsetsBySegment, setCardOffsetsBySegment] = useState<
     Record<string, Record<string, number>>
   >({});
   const [editModalState, setEditModalState] = useState<EditModalState>(EMPTY_EDIT_MODAL);
+  const [pendingTextExclusionRanges, setPendingTextExclusionRanges] = useState<
+    TextExclusionRange[] | null
+  >(null);
+  const [pendingImageSourceRef, setPendingImageSourceRef] = useState<ImageSourceRef | null>(null);
   const textSelectionRootRef = useRef<HTMLDivElement | null>(null);
   const segmentLayoutRefs = useRef<Record<string, HTMLDivElement | null>>({});
   const cardWrapperRefs = useRef<Record<string, HTMLDivElement | null>>({});
 
   const document = payload.normalizedDocument;
-  const entryBlockGraph = payload.entryBlockGraph;
+
+  const closeEditModal = () => {
+    setEditModalState(EMPTY_EDIT_MODAL);
+    setPendingTextExclusionRanges(null);
+    setPendingImageSourceRef(null);
+  };
+
+  const previousSelectedEntryIndexRef = useRef<number | null | undefined>(undefined);
+
+  // Avoid confirming an exclude/assign that was opened under a different overview entry.
+  useEffect(() => {
+    if (previousSelectedEntryIndexRef.current === undefined) {
+      previousSelectedEntryIndexRef.current = selectedEntryIndex;
+      return;
+    }
+    if (previousSelectedEntryIndexRef.current !== selectedEntryIndex) {
+      previousSelectedEntryIndexRef.current = selectedEntryIndex;
+      closeEditModal();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only react to entry focus changes
+  }, [selectedEntryIndex]);
+
   const { selectionRectangle, selectedText, selectedRange, clearSelection } =
     useReviewTextSelection(textSelectionRootRef);
 
@@ -167,6 +211,7 @@ export const MappingView = ({ payload, selectedEntryIndex }: MappingViewProps): 
     const entryName = getEntryTitleFromFieldMappings(graphEntry, contentType?.displayField);
 
     return {
+      entryIndex,
       id: `${entryIndex}-${graphEntry.contentTypeId}-${fieldId}`,
       contentTypeId: graphEntry.contentTypeId,
       contentTypeName: contentTypeDisplayName,
@@ -365,7 +410,10 @@ export const MappingView = ({ payload, selectedEntryIndex }: MappingViewProps): 
   }, [mappingCardsBySegment, allSegments]);
 
   const openAssignModal = (preview: string, currentLocations: EditLocationOption[]) => {
+    setPendingTextExclusionRanges(null);
+    setPendingImageSourceRef(null);
     setEditModalState({
+      mode: 'assign',
       viewModel: {
         selectedText: preview,
         currentLocations,
@@ -378,10 +426,17 @@ export const MappingView = ({ payload, selectedEntryIndex }: MappingViewProps): 
     });
   };
 
-  const openExcludeModal = (preview: string, currentLocations: EditLocationOption[]) => {
+  const openExcludeModal = (
+    selectedText: string,
+    currentLocations: EditLocationOption[],
+    preview?: { contentPreview: string; previewSectionTitle: string }
+  ) => {
     setEditModalState({
+      mode: 'exclude',
       viewModel: {
-        selectedText: preview,
+        selectedText,
+        contentPreview: preview?.contentPreview,
+        previewSectionTitle: preview?.previewSectionTitle,
         currentLocations,
         isOpen: true,
       },
@@ -400,7 +455,21 @@ export const MappingView = ({ payload, selectedEntryIndex }: MappingViewProps): 
 
   const handleExcludeFromSelection = () => {
     if (!selectedText.trim()) return;
-    openExcludeModal(selectedText.trim(), getLocationsForSelectedText());
+    const ranges = collectTextExclusionRangesFromSelection(
+      textSelectionRootRef.current,
+      selectedRange
+    );
+    setPendingTextExclusionRanges(ranges.length ? ranges : null);
+    setPendingImageSourceRef(null);
+    const trimmed = selectedText.trim();
+    const mappedPreview = collectMappedExclusionPreviewText(
+      textSelectionRootRef.current,
+      selectedRange
+    ).trim();
+    openExcludeModal(trimmed, getLocationsForSelectedText(), {
+      contentPreview: mappedPreview || trimmed,
+      previewSectionTitle: 'Text to exclude',
+    });
     clearSelection();
   };
 
@@ -410,8 +479,52 @@ export const MappingView = ({ payload, selectedEntryIndex }: MappingViewProps): 
   };
 
   const handleExcludeImage = (sourceRef: ImageSourceRef, label: string) => {
-    openExcludeModal(label, getLocationsForSourceRef(sourceRef));
+    setPendingImageSourceRef(sourceRef);
+    setPendingTextExclusionRanges(null);
+    openExcludeModal(label, getLocationsForSourceRef(sourceRef), {
+      contentPreview: label,
+      previewSectionTitle: 'Image to exclude',
+    });
     setHoveredMappingKeys([]);
+  };
+
+  const handleEditModalConfirmPrimary = ({
+    selectedLocationId,
+  }: {
+    selectedLocationId: string | null;
+  }) => {
+    if (editModalState.mode === 'assign') {
+      closeEditModal();
+      return;
+    }
+
+    if (editModalState.mode !== 'exclude') {
+      closeEditModal();
+      return;
+    }
+
+    const locations = editModalState.viewModel.currentLocations;
+    const selected =
+      locations.find((location) => location.id === selectedLocationId) ??
+      locations.find((location) => location.isSelected) ??
+      locations[0];
+
+    if (!selected) {
+      closeEditModal();
+      return;
+    }
+
+    if (pendingImageSourceRef) {
+      onEntryBlockGraphChange(
+        applyImageExclusionToEntryBlockGraph(entryBlockGraph, selected, pendingImageSourceRef)
+      );
+    } else if (pendingTextExclusionRanges?.length) {
+      onEntryBlockGraphChange(
+        applyTextExclusionToEntryBlockGraph(entryBlockGraph, selected, pendingTextExclusionRanges)
+      );
+    }
+
+    closeEditModal();
   };
 
   const canExcludeSelectedText = useMemo(() => {
@@ -498,11 +611,12 @@ export const MappingView = ({ payload, selectedEntryIndex }: MappingViewProps): 
 
       <EditModal
         isOpen={editModalState.viewModel.isOpen}
-        onClose={() => setEditModalState(EMPTY_EDIT_MODAL)}
+        onClose={closeEditModal}
         viewModel={editModalState.viewModel}
         title={editModalState.title}
         locationSectionDescription={editModalState.locationSectionDescription}
         primaryButtonLabel={editModalState.primaryButtonLabel}
+        onConfirmPrimary={handleEditModalConfirmPrimary}
       />
     </>
   );

--- a/apps/google-docs/src/locations/Page/components/review/mapping/buildHighlights.ts
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/buildHighlights.ts
@@ -1,5 +1,6 @@
 import type { EntryBlockGraph, SourceRef } from '@types';
 import { isBlockSourceRef, isTableSourceRef } from '@types';
+import { buildSourceRefKey } from './sourceRefUtils';
 
 export interface MappingHighlight {
   entryIndex: number;
@@ -63,19 +64,30 @@ export function buildMappingHighlightIndex(
   return { blockHighlights, tablePartHighlights, tableHighlights };
 }
 
-export const getMappingCardKey = (segmentId: string, highlight: MappingHighlight): string =>
-  `${segmentId}-${highlight.entryIndex}-${highlight.fieldId}`;
+/**
+ * Stable id for a mapping card / DOM segment. Includes the source ref so the same
+ * field can map multiple disjoint ranges (e.g. after text exclusions split a ref).
+ */
+export const getMappingCardKey = (segmentId: string, highlight: MappingHighlight): string => {
+  const refKey = buildSourceRefKey(highlight.sourceRef);
+  return refKey
+    ? `${segmentId}-${highlight.entryIndex}-${highlight.fieldId}:${refKey}`
+    : `${segmentId}-${highlight.entryIndex}-${highlight.fieldId}`;
+};
 
 export function uniqueHighlights<T extends MappingHighlight>(highlights: T[]): T[] {
   const seen = new Set<string>();
 
   return highlights.filter((item) => {
-    const key = `${item.entryIndex}-${item.fieldId}-${item.fieldType}`;
-    if (seen.has(key)) {
+    const refKey = buildSourceRefKey(item.sourceRef);
+    // Scope by entry + field: different fields can legally share the same block/range
+    // (e.g. page.pageName vs blogPost.internalLabel on block-4). Dedupe only true duplicates.
+    const dedupeKey = `${item.entryIndex}|${item.fieldId}|${refKey || item.fieldType}`;
+    if (seen.has(dedupeKey)) {
       return false;
     }
 
-    seen.add(key);
+    seen.add(dedupeKey);
     return true;
   });
 }

--- a/apps/google-docs/src/locations/Page/components/review/mapping/documentRenderers.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/documentRenderers.tsx
@@ -69,15 +69,44 @@ interface TextSegmentSpanProps {
   segment: TextSegment;
   hovered: boolean;
   onSetHoveredMappings: (keys: string[]) => void;
+  textScope: 'block' | 'table';
+  rangeStart: number;
+  rangeEnd: number;
+  blockId?: string;
+  tableId?: string;
+  rowId?: string;
+  cellId?: string;
+  partId?: string;
 }
 
-const TextSegmentSpan = ({ id, segment, hovered, onSetHoveredMappings }: TextSegmentSpanProps) => {
+const TextSegmentSpan = ({
+  id,
+  segment,
+  hovered,
+  onSetHoveredMappings,
+  textScope,
+  rangeStart,
+  rangeEnd,
+  blockId,
+  tableId,
+  rowId,
+  cellId,
+  partId,
+}: TextSegmentSpanProps) => {
   const content = (
     <Box
       as="span"
       key={id}
       data-review-text-segment="true"
       data-is-mapped={segment.highlighted ? 'true' : 'false'}
+      data-text-scope={textScope}
+      data-range-start={String(rangeStart)}
+      data-range-end={String(rangeEnd)}
+      data-block-id={blockId ?? undefined}
+      data-table-id={tableId ?? undefined}
+      data-row-id={rowId ?? undefined}
+      data-cell-id={cellId ?? undefined}
+      data-part-id={partId ?? undefined}
       data-mapping-keys={segment.mappingKeys.join('|')}
       onMouseEnter={
         segment.highlighted ? () => onSetHoveredMappings(segment.mappingKeys) : undefined
@@ -155,6 +184,10 @@ export const BlockRenderer = ({
           segment={seg}
           hovered={isMappingHovered(seg.mappingKeys, hoveredMappingKeys)}
           onSetHoveredMappings={onSetHoveredMappingKeys}
+          textScope="block"
+          rangeStart={seg.start}
+          rangeEnd={seg.end}
+          blockId={block.id}
         />
       ))}
     </Text>
@@ -346,6 +379,13 @@ const TablePartRenderer = ({
           segment={seg}
           hovered={isMappingHovered(seg.mappingKeys, hoveredMappingKeys)}
           onSetHoveredMappings={onSetHoveredMappingKeys}
+          textScope="table"
+          rangeStart={seg.start}
+          rangeEnd={seg.end}
+          tableId={tableId}
+          rowId={rowId}
+          cellId={cellId}
+          partId={part.id}
         />
       ))}
     </Box>

--- a/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/EditModal.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/EditModal.tsx
@@ -20,6 +20,7 @@ interface EditModalProps {
   locationSectionDescription: string;
   primaryButtonLabel: string;
   additionalContent?: ReactNode;
+  onConfirmPrimary?: (details: { selectedLocationId: string | null }) => void;
 }
 
 export const EditModal = ({
@@ -30,6 +31,7 @@ export const EditModal = ({
   locationSectionDescription,
   primaryButtonLabel,
   additionalContent,
+  onConfirmPrimary,
 }: EditModalProps) => {
   const hasLocationSectionDescription = locationSectionDescription.trim().length > 0;
   const hasCurrentLocations = viewModel.currentLocations.length > 0;
@@ -80,8 +82,11 @@ export const EditModal = ({
   };
 
   const handlePrimaryAction = () => {
-    // TODO: Wire the primary edit-modal action to use the selected fields per new location.
+    onConfirmPrimary?.({ selectedLocationId: selectedLocationId });
   };
+
+  const previewSectionTitle = viewModel.previewSectionTitle ?? 'Selected content';
+  const previewQuotedText = (viewModel.contentPreview ?? viewModel.selectedText).trim();
 
   return (
     <Modal isShown={isOpen} onClose={onClose} size="large" shouldCloseOnOverlayClick={false}>
@@ -92,10 +97,10 @@ export const EditModal = ({
             <Box className={modalContent}>
               <Box className={sectionCard}>
                 <Text as="p" fontWeight="fontWeightDemiBold" marginBottom="spacingM">
-                  Selected content
+                  {previewSectionTitle}
                 </Text>
                 <Text as="p" fontSize="fontSizeL">
-                  "{viewModel.selectedText}"
+                  "{previewQuotedText}"
                 </Text>
               </Box>
 

--- a/apps/google-docs/src/locations/Page/components/review/mapping/entryBlockGraphExclusion.ts
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/entryBlockGraphExclusion.ts
@@ -1,0 +1,406 @@
+import type {
+  EditLocationOption,
+  EntryBlockGraph,
+  ImageSourceRef,
+  NormalizedDocumentFlattenedRun,
+  TextSourceRef,
+} from '@types';
+import { isTableSourceRef, isTextSourceRef } from '@types';
+import { buildSourceRefKey } from './sourceRefUtils';
+
+export type TextExclusionRange =
+  | { scope: 'block'; blockId: string; start: number; end: number }
+  | {
+      scope: 'table';
+      tableId: string;
+      rowId: string;
+      cellId: string;
+      partId: string;
+      start: number;
+      end: number;
+    };
+
+function mergeIntervals(intervals: [number, number][]): [number, number][] {
+  if (!intervals.length) return [];
+  const sorted = [...intervals].sort((a, b) => a[0] - b[0]);
+  const merged: [number, number][] = [];
+  for (const [s, e] of sorted) {
+    if (e <= s) continue;
+    const last = merged[merged.length - 1];
+    if (!last || s > last[1]) merged.push([s, e]);
+    else last[1] = Math.max(last[1], e);
+  }
+  return merged;
+}
+
+function subtractIntervalsFromSpan(
+  spanStart: number,
+  spanEnd: number,
+  remove: [number, number][]
+): [number, number][] {
+  const cuts = mergeIntervals(
+    remove
+      .map(([s, e]) => [Math.max(s, spanStart), Math.min(e, spanEnd)] as [number, number])
+      .filter(([s, e]) => s < e)
+  );
+  if (!cuts.length) return [[spanStart, spanEnd]];
+  const out: [number, number][] = [];
+  let cur = spanStart;
+  for (const [cs, ce] of cuts) {
+    if (cur < cs) out.push([cur, cs]);
+    cur = Math.max(cur, ce);
+  }
+  if (cur < spanEnd) out.push([cur, spanEnd]);
+  return out;
+}
+
+function clipFlattenedRuns(
+  runs: NormalizedDocumentFlattenedRun[],
+  segStart: number,
+  segEnd: number
+): NormalizedDocumentFlattenedRun[] {
+  const out: NormalizedDocumentFlattenedRun[] = [];
+  for (const run of runs) {
+    const innerStart = Math.max(run.start, segStart);
+    const innerEnd = Math.min(run.end, segEnd);
+    if (innerStart >= innerEnd) continue;
+    const textSliceStart = innerStart - run.start;
+    const textSliceEnd = innerEnd - run.start;
+    out.push({
+      ...run,
+      start: innerStart,
+      end: innerEnd,
+      text: run.text.slice(textSliceStart, textSliceEnd),
+    });
+  }
+  return out;
+}
+
+function buildTextRefsFromSpans(
+  baseRef: TextSourceRef,
+  spans: [number, number][]
+): TextSourceRef[] {
+  return spans.map(([s, e]) => ({
+    ...baseRef,
+    start: s,
+    end: e,
+    flattenedRuns: clipFlattenedRuns(baseRef.flattenedRuns, s, e),
+  }));
+}
+
+function intersectSpan(
+  refStart: number,
+  refEnd: number,
+  rStart: number,
+  rEnd: number
+): [number, number] | null {
+  const start = Math.max(refStart, rStart);
+  const end = Math.min(refEnd, rEnd);
+  if (start >= end) return null;
+  return [start, end];
+}
+
+function rangesOverlappingTextSourceRef(
+  ref: TextSourceRef,
+  pending: TextExclusionRange[]
+): [number, number][] {
+  const cuts: [number, number][] = [];
+  for (const r of pending) {
+    if (r.scope === 'block' && 'blockId' in ref && !isTableSourceRef(ref)) {
+      if (r.blockId === ref.blockId) {
+        const hit = intersectSpan(ref.start, ref.end, r.start, r.end);
+        if (hit) cuts.push(hit);
+      }
+    }
+    if (r.scope === 'table' && isTableSourceRef(ref) && isTextSourceRef(ref)) {
+      if (
+        ref.tableId === r.tableId &&
+        ref.rowId === r.rowId &&
+        ref.cellId === r.cellId &&
+        ref.partId === r.partId
+      ) {
+        const hit = intersectSpan(ref.start, ref.end, r.start, r.end);
+        if (hit) cuts.push(hit);
+      }
+    }
+  }
+  return cuts;
+}
+
+function rangeIntersectsNodeSafe(range: Range, node: Node): boolean {
+  try {
+    return range.intersectsNode(node);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Character offsets `[localStart, localEnd)` within `el.textContent` for the
+ * intersection of `selection` with the text inside `el`.
+ */
+function getIntersectionCharOffsetsWithinElement(
+  el: HTMLElement,
+  selection: Range
+): [number, number] | null {
+  if (!rangeIntersectsNodeSafe(selection, el)) return null;
+
+  const innerStart = document.createRange();
+  innerStart.selectNodeContents(el);
+  innerStart.collapse(true);
+
+  const selStart = selection.cloneRange();
+  selStart.collapse(true);
+
+  let localStart: number;
+  if (innerStart.compareBoundaryPoints(Range.START_TO_START, selStart) > 0) {
+    localStart = 0;
+  } else {
+    const pre = document.createRange();
+    pre.selectNodeContents(el);
+    try {
+      pre.setEnd(selection.startContainer, selection.startOffset);
+    } catch {
+      return null;
+    }
+    localStart = pre.toString().length;
+  }
+
+  const innerEnd = document.createRange();
+  innerEnd.selectNodeContents(el);
+  innerEnd.collapse(false);
+
+  const selEnd = selection.cloneRange();
+  selEnd.collapse(false);
+
+  const textLen = (el.textContent ?? '').length;
+  let localEnd: number;
+  if (innerEnd.compareBoundaryPoints(Range.END_TO_END, selEnd) > 0) {
+    const pre = document.createRange();
+    pre.selectNodeContents(el);
+    try {
+      pre.setEnd(selection.endContainer, selection.endOffset);
+    } catch {
+      return null;
+    }
+    localEnd = pre.toString().length;
+  } else {
+    localEnd = textLen;
+  }
+
+  localStart = Math.max(0, Math.min(textLen, localStart));
+  localEnd = Math.max(0, Math.min(textLen, localEnd));
+
+  if (localEnd <= localStart) return null;
+  return [localStart, localEnd];
+}
+
+/**
+ * Maps DOM-local intersection to absolute normalized-document indices for this segment.
+ */
+function getAbsoluteIntersectionForMappedSegment(
+  el: HTMLElement,
+  selection: Range,
+  segStart: number,
+  segEnd: number
+): [number, number] | null {
+  const local = getIntersectionCharOffsetsWithinElement(el, selection);
+  if (!local) return null;
+
+  const [localStart, localEnd] = local;
+  const absStart = segStart + localStart;
+  const absEnd = segStart + localEnd;
+  const clampedStart = Math.max(segStart, Math.min(segEnd, absStart));
+  const clampedEnd = Math.max(segStart, Math.min(segEnd, absEnd));
+  if (clampedEnd <= clampedStart) return null;
+  return [clampedStart, clampedEnd];
+}
+
+function mergeTextExclusionRanges(ranges: TextExclusionRange[]): TextExclusionRange[] {
+  const blockBuckets = new Map<string, [number, number][]>();
+  const tableBuckets = new Map<string, [number, number][]>();
+
+  for (const r of ranges) {
+    if (r.scope === 'block') {
+      const arr = blockBuckets.get(r.blockId) ?? [];
+      arr.push([r.start, r.end]);
+      blockBuckets.set(r.blockId, arr);
+    } else {
+      const key = JSON.stringify([r.tableId, r.rowId, r.cellId, r.partId]);
+      const arr = tableBuckets.get(key) ?? [];
+      arr.push([r.start, r.end]);
+      tableBuckets.set(key, arr);
+    }
+  }
+
+  const out: TextExclusionRange[] = [];
+  for (const [blockId, intervals] of blockBuckets) {
+    for (const [start, end] of mergeIntervals(intervals)) {
+      out.push({ scope: 'block', blockId, start, end });
+    }
+  }
+  for (const [key, intervals] of tableBuckets) {
+    const [tableId, rowId, cellId, partId] = JSON.parse(key) as [string, string, string, string];
+    for (const [start, end] of mergeIntervals(intervals)) {
+      out.push({ scope: 'table', tableId, rowId, cellId, partId, start, end });
+    }
+  }
+  return out;
+}
+
+/**
+ * Text from mapped review segments that intersect the selection (DOM order).
+ * Omits unmapped text so the exclude modal shows only what maps to fields.
+ */
+export function collectMappedExclusionPreviewText(
+  root: HTMLElement | null,
+  selectedRange: Range | null
+): string {
+  if (!root || !selectedRange) return '';
+
+  const mapped = root.querySelectorAll<HTMLElement>(
+    '[data-review-text-segment="true"][data-is-mapped="true"]'
+  );
+  const pieces: string[] = [];
+  mapped.forEach((el) => {
+    if (!rangeIntersectsNodeSafe(selectedRange, el)) return;
+
+    const segStart = Number(el.dataset.rangeStart);
+    const segEnd = Number(el.dataset.rangeEnd);
+    if (!Number.isFinite(segStart) || !Number.isFinite(segEnd) || segStart >= segEnd) return;
+
+    const local = getIntersectionCharOffsetsWithinElement(el, selectedRange);
+    if (!local) return;
+    const [ls, le] = local;
+    pieces.push((el.textContent ?? '').slice(ls, le));
+  });
+  return pieces.join('');
+}
+
+/**
+ * Reads mapped review text segments touched by the selection and returns merged
+ * character ranges in normalized-document coordinates (per block or table text part).
+ */
+export function collectTextExclusionRangesFromSelection(
+  root: HTMLElement | null,
+  selectedRange: Range | null
+): TextExclusionRange[] {
+  if (!root || !selectedRange) return [];
+
+  const mapped = root.querySelectorAll<HTMLElement>(
+    '[data-review-text-segment="true"][data-is-mapped="true"]'
+  );
+  const raw: TextExclusionRange[] = [];
+
+  mapped.forEach((el) => {
+    if (!rangeIntersectsNodeSafe(selectedRange, el)) return;
+
+    const scope = el.dataset.textScope;
+    const segStart = Number(el.dataset.rangeStart);
+    const segEnd = Number(el.dataset.rangeEnd);
+    if (!Number.isFinite(segStart) || !Number.isFinite(segEnd) || segStart >= segEnd) return;
+
+    const abs = getAbsoluteIntersectionForMappedSegment(el, selectedRange, segStart, segEnd);
+    if (!abs) return;
+    const [start, end] = abs;
+
+    if (scope === 'block' && el.dataset.blockId) {
+      raw.push({ scope: 'block', blockId: el.dataset.blockId, start, end });
+      return;
+    }
+
+    if (
+      scope === 'table' &&
+      el.dataset.tableId &&
+      el.dataset.rowId &&
+      el.dataset.cellId &&
+      el.dataset.partId
+    ) {
+      raw.push({
+        scope: 'table',
+        tableId: el.dataset.tableId,
+        rowId: el.dataset.rowId,
+        cellId: el.dataset.cellId,
+        partId: el.dataset.partId,
+        start,
+        end,
+      });
+    }
+  });
+
+  return mergeTextExclusionRanges(raw);
+}
+
+/**
+ * Returns a new graph where the chosen field's matching text source ref(s) are split/shrunk
+ * so excluded character ranges are no longer part of any source ref (for CMA resume).
+ */
+export function applyTextExclusionToEntryBlockGraph(
+  graph: EntryBlockGraph,
+  location: EditLocationOption,
+  pendingRanges: TextExclusionRange[]
+): EntryBlockGraph {
+  if (!pendingRanges.length) return graph;
+
+  const nextEntries = graph.entries.map((entry, idx) => {
+    if (idx !== location.entryIndex) return entry;
+
+    return {
+      ...entry,
+      fieldMappings: entry.fieldMappings.map((fm) => {
+        if (fm.fieldId !== location.fieldId) return fm;
+
+        const nextRefs = fm.sourceRefs.flatMap((sr) => {
+          if (buildSourceRefKey(sr) !== buildSourceRefKey(location.sourceRef)) return [sr];
+          if (!isTextSourceRef(sr)) return [sr];
+
+          const cuts = rangesOverlappingTextSourceRef(sr, pendingRanges);
+          if (!cuts.length) return [sr];
+
+          const remaining = subtractIntervalsFromSpan(sr.start, sr.end, cuts);
+          const pieces = buildTextRefsFromSpans(sr, remaining).filter((r) => r.start < r.end);
+          return pieces.length ? pieces : [];
+        });
+
+        return { ...fm, sourceRefs: nextRefs };
+      }),
+    };
+  });
+
+  return { ...graph, entries: nextEntries };
+}
+
+/**
+ * Removes the image ref from the chosen field mapping and records it in excludedSourceRefs for UI.
+ */
+export function applyImageExclusionToEntryBlockGraph(
+  graph: EntryBlockGraph,
+  location: EditLocationOption,
+  imageRef: ImageSourceRef
+): EntryBlockGraph {
+  const key = buildSourceRefKey(imageRef);
+
+  const nextEntries = graph.entries.map((entry, idx) => {
+    if (idx !== location.entryIndex) return entry;
+
+    return {
+      ...entry,
+      fieldMappings: entry.fieldMappings.map((fm) => {
+        if (fm.fieldId !== location.fieldId) return fm;
+        return {
+          ...fm,
+          sourceRefs: fm.sourceRefs.filter((sr) => buildSourceRefKey(sr) !== key),
+        };
+      }),
+    };
+  });
+
+  const already = graph.excludedSourceRefs.some((r) => buildSourceRefKey(r) === key);
+  return {
+    ...graph,
+    entries: nextEntries,
+    excludedSourceRefs: already
+      ? graph.excludedSourceRefs
+      : [...graph.excludedSourceRefs, imageRef],
+  };
+}

--- a/apps/google-docs/src/services/agents-api.ts
+++ b/apps/google-docs/src/services/agents-api.ts
@@ -137,6 +137,12 @@ export async function startAgentRun(
   return runData.sys.id;
 }
 
+/**
+ * Resumes a suspended agent run. For the Google Docs mapping-review step, the
+ * edited `entryBlockGraph` must live in `resumePayload` (see Network tab). After resume,
+ * mapping-review repopulates `metadata.suspendPayload` with the reviewed graph (the resume
+ * handler clears it first).
+ */
 export async function resumeWorkflowRun(
   sdk: PageAppSDK,
   spaceId: string,

--- a/apps/google-docs/src/types/editModal.ts
+++ b/apps/google-docs/src/types/editModal.ts
@@ -1,6 +1,7 @@
 import type { SourceRef } from './entryBlockGraph';
 
 export interface EditLocationOption {
+  entryIndex: number;
   id: string;
   contentTypeId: string;
   contentTypeName: string;
@@ -32,6 +33,10 @@ export interface EditModalNewLocation {
 
 export interface EditModalContent {
   selectedText: string;
+  /** Mapped-only preview for exclude flow; falls back to selectedText in the modal when absent. */
+  contentPreview?: string;
+  /** Replaces the default "Selected content" heading for the preview card. */
+  previewSectionTitle?: string;
   isOpen: boolean;
   currentLocations: EditLocationOption[];
   newLocations?: EditModalNewLocation[];

--- a/apps/google-docs/src/utils/getEntryTitle.ts
+++ b/apps/google-docs/src/utils/getEntryTitle.ts
@@ -2,6 +2,7 @@ import { ContentType, PageAppSDK } from '@contentful/app-sdk';
 import type { EntryToCreate } from '@types';
 import type { EntryBlockGraphEntry } from '../types/entryBlockGraph';
 import { isTextSourceRef } from '../types/entryBlockGraph';
+import { truncateLabel } from './utils';
 
 /**
  * Gets the title of an entry by fetching its content type's display field
@@ -13,6 +14,9 @@ export interface GetEntryTitleProps {
 }
 
 const UNTITLED_ENTRY_LABEL = 'Untitled';
+
+/** Max length for overview row titles derived from display-field source refs (before card-level truncate). */
+const DISPLAY_FIELD_TITLE_EXCERPT_MAX = 80;
 
 export const getEntryTitle = async ({
   sdk,
@@ -60,12 +64,15 @@ export function getEntryTitleFromFieldMappings(
   const fieldMapping = entry.fieldMappings.find((mapping) => mapping.fieldId === displayField);
   if (!fieldMapping) return UNTITLED_ENTRY_LABEL;
 
-  const text = fieldMapping.sourceRefs
-    .filter(isTextSourceRef)
-    .flatMap((ref) => ref.flattenedRuns)
+  const firstTextRef = fieldMapping.sourceRefs.find(isTextSourceRef);
+  if (!firstTextRef) return UNTITLED_ENTRY_LABEL;
+
+  const text = firstTextRef.flattenedRuns
     .map((run) => run.text)
     .join('')
     .trim();
 
-  return text.length > 0 ? text : UNTITLED_ENTRY_LABEL;
+  if (!text.length) return UNTITLED_ENTRY_LABEL;
+
+  return truncateLabel(text, DISPLAY_FIELD_TITLE_EXCERPT_MAX);
 }

--- a/apps/google-docs/test/locations/Page/components/modals/EditModal.spec.tsx
+++ b/apps/google-docs/test/locations/Page/components/modals/EditModal.spec.tsx
@@ -10,6 +10,7 @@ const viewModel = {
   isOpen: true,
   currentLocations: [
     {
+      entryIndex: 0,
       id: 'summary',
       contentTypeId: 'sampleContentType',
       contentTypeName: 'Sample content type',
@@ -34,6 +35,7 @@ const viewModel = {
       isSelected: true,
     },
     {
+      entryIndex: 0,
       id: 'description',
       contentTypeId: 'sampleContentType',
       contentTypeName: 'Sample content type',

--- a/apps/google-docs/test/locations/Page/components/review/mapping/MappingView.spec.tsx
+++ b/apps/google-docs/test/locations/Page/components/review/mapping/MappingView.spec.tsx
@@ -18,6 +18,11 @@ const blockTextSourceRef: SourceRef = {
   flattenedRuns: [{ text: 'Hello world', start: 0, end: 11 }],
 };
 
+const mappingViewGraphProps = (payload: MappingReviewSuspendPayload) => ({
+  entryBlockGraph: payload.entryBlockGraph,
+  onEntryBlockGraphChange: vi.fn(),
+});
+
 const createPayload = (excludedSourceRefs: SourceRef[] = []): MappingReviewSuspendPayload => ({
   suspendStepId: 'mapping-review',
   reason: 'Mapping review required before CMA payload generation continues',
@@ -119,10 +124,21 @@ describe('MappingView', () => {
       clearSelection: mockClearSelection,
     });
 
+    const payload = createPayload();
     const { rerender } = render(
-      <MappingView payload={createPayload()} selectedEntryIndex={null} />
+      <MappingView
+        payload={payload}
+        {...mappingViewGraphProps(payload)}
+        selectedEntryIndex={null}
+      />
     );
-    rerender(<MappingView payload={createPayload()} selectedEntryIndex={null} />);
+    rerender(
+      <MappingView
+        payload={payload}
+        {...mappingViewGraphProps(payload)}
+        selectedEntryIndex={null}
+      />
+    );
 
     fireEvent.click(screen.getByRole('button', { name: 'Reassign' }));
 
@@ -148,7 +164,14 @@ describe('MappingView', () => {
       clearSelection: mockClearSelection,
     });
 
-    render(<MappingView payload={createPayload()} selectedEntryIndex={null} />);
+    const payload = createPayload();
+    render(
+      <MappingView
+        payload={payload}
+        {...mappingViewGraphProps(payload)}
+        selectedEntryIndex={null}
+      />
+    );
 
     fireEvent.click(screen.getByRole('button', { name: 'Assign' }));
 
@@ -169,7 +192,14 @@ describe('MappingView', () => {
       clearSelection: mockClearSelection,
     });
 
-    render(<MappingView payload={createPayload()} selectedEntryIndex={null} />);
+    const payload = createPayload();
+    render(
+      <MappingView
+        payload={payload}
+        {...mappingViewGraphProps(payload)}
+        selectedEntryIndex={null}
+      />
+    );
 
     expect(screen.getByRole('button', { name: 'Assign' })).toBeTruthy();
     const excludeButton = screen.getByRole('button', { name: 'Exclude' }) as HTMLButtonElement;
@@ -194,10 +224,21 @@ describe('MappingView', () => {
       clearSelection: mockClearSelection,
     });
 
+    const payload = createPayload();
     const { rerender } = render(
-      <MappingView payload={createPayload()} selectedEntryIndex={null} />
+      <MappingView
+        payload={payload}
+        {...mappingViewGraphProps(payload)}
+        selectedEntryIndex={null}
+      />
     );
-    rerender(<MappingView payload={createPayload()} selectedEntryIndex={null} />);
+    rerender(
+      <MappingView
+        payload={payload}
+        {...mappingViewGraphProps(payload)}
+        selectedEntryIndex={null}
+      />
+    );
 
     fireEvent.click(screen.getByRole('button', { name: 'Exclude' }));
 

--- a/apps/google-docs/test/locations/Page/components/review/mapping/buildHighlights.spec.ts
+++ b/apps/google-docs/test/locations/Page/components/review/mapping/buildHighlights.spec.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import type { EntryBlockGraph, SourceRef } from '@types';
+import {
+  buildMappingHighlightIndex,
+  getMappingCardKey,
+  uniqueHighlights,
+  type MappingHighlight,
+} from '../../../../../../src/locations/Page/components/review/mapping/buildHighlights';
+
+const blockTextRef = (start: number, end: number, text: string): SourceRef => ({
+  type: 'blockText',
+  blockId: 'block-4',
+  start,
+  end,
+  flattenedRuns: [{ text, start, end, styles: {} }],
+});
+
+describe('buildHighlights', () => {
+  it('uniqueHighlights keeps two disjoint sourceRefs for the same field', () => {
+    const h1: MappingHighlight = {
+      entryIndex: 0,
+      fieldId: 'heading',
+      fieldType: 'Symbol',
+      sourceRef: blockTextRef(0, 10, 'Show up fr'),
+    };
+    const h2: MappingHighlight = {
+      entryIndex: 0,
+      fieldId: 'heading',
+      fieldType: 'Symbol',
+      sourceRef: blockTextRef(33, 58, 'terest…'),
+    };
+
+    const out = uniqueHighlights([h1, h2]);
+    expect(out).toHaveLength(2);
+  });
+
+  it('getMappingCardKey differs per sourceRef so locations and segments stay aligned after splits', () => {
+    const h1: MappingHighlight = {
+      entryIndex: 0,
+      fieldId: 'heading',
+      fieldType: 'Symbol',
+      sourceRef: blockTextRef(0, 10, 'a'),
+    };
+    const h2: MappingHighlight = {
+      entryIndex: 0,
+      fieldId: 'heading',
+      fieldType: 'Symbol',
+      sourceRef: blockTextRef(33, 58, 'b'),
+    };
+
+    const seg = 'block:block-4';
+    expect(getMappingCardKey(seg, h1)).toContain('block-4:0:10');
+    expect(getMappingCardKey(seg, h2)).toContain('block-4:33:58');
+    expect(getMappingCardKey(seg, h1)).not.toBe(getMappingCardKey(seg, h2));
+  });
+
+  it('uniqueHighlights keeps two fields that share the same block range (different fieldId)', () => {
+    const shared = blockTextRef(0, 58, 'same');
+    const hPage: MappingHighlight = {
+      entryIndex: 0,
+      fieldId: 'pageName',
+      fieldType: 'Symbol',
+      sourceRef: shared,
+    };
+    const hBlog: MappingHighlight = {
+      entryIndex: 1,
+      fieldId: 'internalLabel',
+      fieldType: 'Symbol',
+      sourceRef: shared,
+    };
+
+    expect(uniqueHighlights([hPage, hBlog])).toHaveLength(2);
+  });
+
+  it('buildMappingHighlightIndex lists both split refs on the same block', () => {
+    const graph: EntryBlockGraph = {
+      entries: [
+        {
+          contentTypeId: 'blogPost',
+          fieldMappings: [
+            {
+              fieldId: 'heading',
+              fieldType: 'Symbol',
+              sourceRefs: [blockTextRef(0, 10, 'a'), blockTextRef(33, 58, 'b')],
+              confidence: 1,
+            },
+          ],
+        },
+      ],
+      excludedSourceRefs: [],
+    };
+
+    const idx = buildMappingHighlightIndex(graph);
+    const list = uniqueHighlights(idx.blockHighlights['block-4'] ?? []);
+    expect(list).toHaveLength(2);
+  });
+});

--- a/apps/google-docs/test/locations/Page/components/review/mapping/entryBlockGraphExclusion.spec.ts
+++ b/apps/google-docs/test/locations/Page/components/review/mapping/entryBlockGraphExclusion.spec.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest';
+import type { EditLocationOption, EntryBlockGraph, SourceRef } from '@types';
+import {
+  applyTextExclusionToEntryBlockGraph,
+  collectMappedExclusionPreviewText,
+  collectTextExclusionRangesFromSelection,
+} from '../../../../../../src/locations/Page/components/review/mapping/entryBlockGraphExclusion';
+
+const blockRef = (start: number, end: number, text: string): SourceRef => ({
+  type: 'blockText',
+  blockId: 'block-1',
+  start,
+  end,
+  flattenedRuns: [{ text, start, end, styles: {} }],
+});
+
+const baseGraph = (): EntryBlockGraph => ({
+  entries: [
+    {
+      contentTypeId: 'article',
+      fieldMappings: [
+        {
+          fieldId: 'body',
+          fieldType: 'Text',
+          sourceRefs: [blockRef(0, 20, 'abcdefghijklmnopqrst')],
+          confidence: 1,
+        },
+      ],
+    },
+  ],
+  excludedSourceRefs: [],
+});
+
+describe('entryBlockGraphExclusion', () => {
+  it('applyTextExclusionToEntryBlockGraph splits a block text ref around the excluded range', () => {
+    const graph = baseGraph();
+    const location: EditLocationOption = {
+      entryIndex: 0,
+      id: '0-article-body',
+      contentTypeId: 'article',
+      contentTypeName: 'Article',
+      entryName: 'Article #1',
+      fieldId: 'body',
+      fieldName: 'Body',
+      fieldType: 'Text',
+      sourceRef: blockRef(0, 20, 'abcdefghijklmnopqrst'),
+    };
+
+    const next = applyTextExclusionToEntryBlockGraph(graph, location, [
+      { scope: 'block', blockId: 'block-1', start: 8, end: 12 },
+    ]);
+
+    const refs = next.entries[0]?.fieldMappings[0]?.sourceRefs ?? [];
+    expect(refs).toHaveLength(2);
+    expect(refs[0]).toMatchObject({ start: 0, end: 8, type: 'blockText', blockId: 'block-1' });
+    expect(refs[1]).toMatchObject({ start: 12, end: 20, type: 'blockText', blockId: 'block-1' });
+    expect((refs[0] as { flattenedRuns: { text: string }[] }).flattenedRuns[0]?.text).toBe(
+      'abcdefgh'
+    );
+    expect((refs[1] as { flattenedRuns: { text: string }[] }).flattenedRuns[0]?.text).toBe(
+      'mnopqrst'
+    );
+  });
+
+  it('post-exclusion entryBlockGraph serializes for resumePayload.entryBlockGraph', () => {
+    const graph = baseGraph();
+    const location: EditLocationOption = {
+      entryIndex: 0,
+      id: '0-article-body',
+      contentTypeId: 'article',
+      contentTypeName: 'Article',
+      entryName: 'Article #1',
+      fieldId: 'body',
+      fieldName: 'Body',
+      fieldType: 'Text',
+      sourceRef: blockRef(0, 20, 'abcdefghijklmnopqrst'),
+    };
+    const next = applyTextExclusionToEntryBlockGraph(graph, location, [
+      { scope: 'block', blockId: 'block-1', start: 8, end: 12 },
+    ]);
+    expect(() => JSON.stringify({ resumePayload: { entryBlockGraph: next } })).not.toThrow();
+    const parsed = JSON.parse(JSON.stringify({ entryBlockGraph: next })) as {
+      entryBlockGraph: EntryBlockGraph;
+    };
+    expect(parsed.entryBlockGraph.entries[0]?.fieldMappings[0]?.sourceRefs).toHaveLength(2);
+  });
+
+  it('collectMappedExclusionPreviewText joins only intersecting mapped segment text', () => {
+    const root = document.createElement('div');
+    const mapped = document.createElement('span');
+    mapped.setAttribute('data-review-text-segment', 'true');
+    mapped.setAttribute('data-is-mapped', 'true');
+    mapped.setAttribute('data-text-scope', 'block');
+    mapped.setAttribute('data-range-start', '0');
+    mapped.setAttribute('data-range-end', '3');
+    mapped.setAttribute('data-block-id', 'b0');
+    mapped.appendChild(document.createTextNode('abc'));
+    const plain = document.createElement('span');
+    plain.setAttribute('data-review-text-segment', 'true');
+    plain.setAttribute('data-is-mapped', 'false');
+    plain.appendChild(document.createTextNode('IGNORE'));
+    root.appendChild(mapped);
+    root.appendChild(plain);
+
+    const range = document.createRange();
+    range.selectNodeContents(root);
+
+    expect(collectMappedExclusionPreviewText(root, range)).toBe('abc');
+  });
+
+  it('collectTextExclusionRangesFromSelection reads mapped segment datasets', () => {
+    const root = document.createElement('div');
+    const span = document.createElement('span');
+    span.setAttribute('data-review-text-segment', 'true');
+    span.setAttribute('data-is-mapped', 'true');
+    span.setAttribute('data-text-scope', 'block');
+    span.setAttribute('data-range-start', '3');
+    span.setAttribute('data-range-end', '7');
+    span.setAttribute('data-block-id', 'b1');
+    span.appendChild(document.createTextNode('abcd'));
+    root.appendChild(span);
+
+    const range = document.createRange();
+    range.selectNodeContents(span);
+
+    const ranges = collectTextExclusionRangesFromSelection(root, range);
+    expect(ranges).toEqual([{ scope: 'block', blockId: 'b1', start: 3, end: 7 }]);
+  });
+
+  it('collectTextExclusionRangesFromSelection uses partial highlight within one mapped segment', () => {
+    const root = document.createElement('div');
+    const span = document.createElement('span');
+    span.setAttribute('data-review-text-segment', 'true');
+    span.setAttribute('data-is-mapped', 'true');
+    span.setAttribute('data-text-scope', 'block');
+    span.setAttribute('data-range-start', '0');
+    span.setAttribute('data-range-end', '20');
+    span.setAttribute('data-block-id', 'block-1');
+    const text = '01234567890123456789';
+    span.appendChild(document.createTextNode(text));
+    root.appendChild(span);
+
+    const tn = span.firstChild as Text;
+    const range = document.createRange();
+    range.setStart(tn, 5);
+    range.setEnd(tn, 8);
+
+    expect(collectTextExclusionRangesFromSelection(root, range)).toEqual([
+      { scope: 'block', blockId: 'block-1', start: 5, end: 8 },
+    ]);
+    expect(collectMappedExclusionPreviewText(root, range)).toBe('567');
+  });
+});

--- a/apps/google-docs/test/utils/overviewEntryList.test.ts
+++ b/apps/google-docs/test/utils/overviewEntryList.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import type { CompletedWorkflowPayload } from '../../src/types';
 import type { ContentTypeDisplayInfo } from '../../src/services/contentTypeService';
-import { buildEntryList } from '../../src/utils/overviewEntryList';
+import {
+  buildEntryList,
+  buildEntryListFromEntryBlockGraph,
+} from '../../src/utils/overviewEntryList';
+import { truncateLabel } from '../../src/utils/utils';
 
 describe('buildEntryList', () => {
   it('omits entries without tempId', () => {
@@ -115,5 +119,80 @@ describe('buildEntryList', () => {
     const rows = buildEntryList(payload, contentTypeDisplayInfoById, 'en-US');
     expect(rows[0].contentTypeName).toBe('Page (space name)');
     expect(rows[0].entryTitle).toBe('Event Detail');
+  });
+});
+
+describe('buildEntryListFromEntryBlockGraph', () => {
+  const contentTypes = [
+    {
+      sys: { id: 'article' },
+      name: 'Article',
+      displayField: 'title',
+      fields: [],
+    },
+  ];
+
+  const createTextSourceRef = (text: string) => ({
+    type: 'blockText' as const,
+    blockId: 'block-1',
+    start: 0,
+    end: text.length,
+    flattenedRuns: [{ text, start: 0, end: text.length }],
+  });
+
+  it('extracts the entry title from the display field mapping', () => {
+    const rows = buildEntryListFromEntryBlockGraph(
+      [
+        {
+          tempId: 'entry-1',
+          contentTypeId: 'article',
+          fieldMappings: [
+            {
+              fieldId: 'title',
+              fieldType: 'Symbol',
+              sourceRefs: [createTextSourceRef('Entry title')],
+              confidence: 0.9,
+            },
+          ],
+        },
+      ],
+      contentTypes
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].contentTypeName).toBe('Article');
+    expect(rows[0].entryTitle).toBe('Entry title');
+  });
+
+  it('truncates long display-field text using the first text source ref only', () => {
+    const long = 'a'.repeat(100);
+    const rows = buildEntryListFromEntryBlockGraph(
+      [
+        {
+          tempId: 'entry-1',
+          contentTypeId: 'article',
+          fieldMappings: [
+            {
+              fieldId: 'title',
+              fieldType: 'Symbol',
+              sourceRefs: [
+                createTextSourceRef(long),
+                {
+                  type: 'blockText' as const,
+                  blockId: 'block-2',
+                  start: 0,
+                  end: 5,
+                  flattenedRuns: [{ text: 'SKIP', start: 0, end: 5 }],
+                },
+              ],
+              confidence: 0.9,
+            },
+          ],
+        },
+      ],
+      contentTypes
+    );
+
+    expect(rows[0].entryTitle).toBe(truncateLabel(long, 80));
   });
 });


### PR DESCRIPTION
https://github.com/user-attachments/assets/5aea71a3-768e-4710-a761-68739acf00c3

## Description

This change makes Rich Text field values respect **`sourceRefs` ranges** on the `entryBlockGraph` when building CMA payloads, instead of treating the normalized document snapshot as the only source of truth for omitted spans.

### What changed

- **Rich Text construction** slices text (including table cells) using each ref’s `start` / `end` so partial exclusions and post-split refs map to the correct document intervals.
- **Field value path** routes Rich Text through the updated builder so published entries match the graph the user edited in review.
- **Review step** prompt guidance clarifies that excluded spans must not be “restored” from snapshot text.
- **Deterministic follow-up** after LLM review reapplies the same Rich Text rebuild from `entryBlockGraph` (plus heading-corrected blocks) so graph-backed omissions are not overwritten by review output.

### Why

Users can exclude spans in the mapping UI; those edits live on `entryBlockGraph`. Previously, Rich Text could still reflect full snapshot content or review-side replacements, so exclusions did not reliably land in Contentful.

### How to verify

- Run targeted unit tests for the Rich Text builder (e.g. `rich-text-builder.spec.ts`).
- Smoke an import with partial Rich Text exclusions, run through review, and confirm created entries match excluded ranges.