### PR TITLE
Disable edit for images []

### DIFF
--- a/apps/google-docs/src/locations/Page/components/review/mapping/ReviewImageAssetCard.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/ReviewImageAssetCard.tsx
@@ -3,6 +3,7 @@ import tokens from '@contentful/f36-tokens';
 import type { ImageSourceRef, NormalizedDocumentImage, SourceRef } from '@types';
 import Splitter from '../../mainpage/Splitter';
 import { buildSourceRefKey, isImageSourceRefExcluded } from './sourceRefUtils';
+import { isDataUIPart } from 'ai';
 
 export interface ReviewImageAssetCardProps {
   image: NormalizedDocumentImage;
@@ -62,10 +63,10 @@ export function ReviewImageAssetCard({
       <Card
         ariaLabel={title}
         actions={[
-          <MenuItem key="assigned" onClick={onAssign}>
+          <MenuItem key="assigned" onClick={onAssign} isDisabled>
             Assign
           </MenuItem>,
-          <MenuItem key="exclude" onClick={onExclude}>
+          <MenuItem key="exclude" onClick={onExclude} isDisabled>
             Exclude
           </MenuItem>,
         ]}>

--- a/apps/google-docs/src/locations/Page/components/review/mapping/ReviewImageAssetCard.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/ReviewImageAssetCard.tsx
@@ -3,7 +3,6 @@ import tokens from '@contentful/f36-tokens';
 import type { ImageSourceRef, NormalizedDocumentImage, SourceRef } from '@types';
 import Splitter from '../../mainpage/Splitter';
 import { buildSourceRefKey, isImageSourceRefExcluded } from './sourceRefUtils';
-import { isDataUIPart } from 'ai';
 
 export interface ReviewImageAssetCardProps {
   image: NormalizedDocumentImage;


### PR DESCRIPTION
## Purpose

Disable edit for images. There is a bug when loading the modal for images, that allows a user to assign an image to a text field. We currently aren't assigning images, so I though of disabling this options until we do.

## Approach

- Disable menu options
## Testing steps

<img width="1615" height="610" alt="Captura de pantalla 2026-04-17 a las 5 13 46 p  m" src="https://github.com/user-attachments/assets/63b36a31-cfaf-4bf8-82cb-39f20cd4456a" />

