### PR TITLE
feat: add reassign capability [INTEG-3799]

### DIFF
--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -10,6 +10,7 @@ import type {
   EditModalNewLocation,
   SourceRef,
 } from '@types';
+import { isTextSourceRef } from '@types';
 import { FileTextIcon } from '@contentful/f36-icons';
 import { useReviewTextSelection } from '@hooks/useReviewTextSelection';
 import { getEntryTitleFromFieldMappings } from '../../../../../utils/getEntryTitle';
@@ -32,8 +33,10 @@ import { NormalizedDocumentSection } from './NormalizedDocumentSection';
 import {
   applyImageExclusionToEntryBlockGraph,
   applyTextExclusionToEntryBlockGraph,
+  applyTextReassignToEntryBlockGraph,
   collectMappedExclusionPreviewText,
   collectTextExclusionRangesFromSelection,
+  fullSpanTextExclusionRangesForSourceRef,
   type TextExclusionRange,
 } from './entryBlockGraphExclusion';
 
@@ -115,6 +118,9 @@ export const MappingView = ({
     TextExclusionRange[] | null
   >(null);
   const [pendingImageSourceRef, setPendingImageSourceRef] = useState<ImageSourceRef | null>(null);
+  const [pendingTextReassignRanges, setPendingTextReassignRanges] = useState<TextExclusionRange[]>(
+    []
+  );
   const textSelectionRootRef = useRef<HTMLDivElement | null>(null);
   const segmentLayoutRefs = useRef<Record<string, HTMLDivElement | null>>({});
   const cardWrapperRefs = useRef<Record<string, HTMLDivElement | null>>({});
@@ -125,6 +131,7 @@ export const MappingView = ({
     setEditModalState(EMPTY_EDIT_MODAL);
     setPendingTextExclusionRanges(null);
     setPendingImageSourceRef(null);
+    setPendingTextReassignRanges([]);
   };
 
   const previousSelectedEntryIndexRef = useRef<number | null | undefined>(undefined);
@@ -409,9 +416,14 @@ export const MappingView = ({
     measureOffsets();
   }, [mappingCardsBySegment, allSegments]);
 
-  const openAssignModal = (preview: string, currentLocations: EditLocationOption[]) => {
+  const openAssignModal = (
+    preview: string,
+    currentLocations: EditLocationOption[],
+    reassignRanges: TextExclusionRange[]
+  ) => {
     setPendingTextExclusionRanges(null);
     setPendingImageSourceRef(null);
+    setPendingTextReassignRanges(reassignRanges);
     setEditModalState({
       mode: 'assign',
       viewModel: {
@@ -449,7 +461,11 @@ export const MappingView = ({
 
   const handleAssignFromSelection = () => {
     if (!selectedText.trim()) return;
-    openAssignModal(selectedText.trim(), getLocationsForSelectedText());
+    const reassignRanges = collectTextExclusionRangesFromSelection(
+      textSelectionRootRef.current,
+      selectedRange
+    );
+    openAssignModal(selectedText.trim(), getLocationsForSelectedText(), reassignRanges);
     clearSelection();
   };
 
@@ -474,7 +490,7 @@ export const MappingView = ({
   };
 
   const handleAssignImage = (sourceRef: ImageSourceRef, label: string) => {
-    openAssignModal(label, getLocationsForSourceRef(sourceRef));
+    openAssignModal(label, getLocationsForSourceRef(sourceRef), []);
     setHoveredMappingKeys([]);
   };
 
@@ -490,10 +506,60 @@ export const MappingView = ({
 
   const handleEditModalConfirmPrimary = ({
     selectedLocationId,
+    selectedFieldIdsByLocationId = {},
   }: {
     selectedLocationId: string | null;
+    selectedFieldIdsByLocationId?: Record<string, string[]>;
   }) => {
     if (editModalState.mode === 'assign') {
+      const locations = editModalState.viewModel.currentLocations;
+      if (!locations.length) {
+        closeEditModal();
+        return;
+      }
+
+      const from =
+        locations.find((location) => location.id === selectedLocationId) ??
+        locations.find((location) => location.isSelected) ??
+        locations[0];
+
+      if (!from || !isTextSourceRef(from.sourceRef)) {
+        closeEditModal();
+        return;
+      }
+
+      const targets: { entryIndex: number; fieldId: string; fieldType: string }[] = [];
+      for (let entryIndex = 0; entryIndex < entryBlockGraph.entries.length; entryIndex++) {
+        const entry = entryBlockGraph.entries[entryIndex];
+        const newLocId = entry.tempId ?? `${entry.contentTypeId}-${entryIndex}`;
+        const fieldIds = selectedFieldIdsByLocationId[newLocId] ?? [];
+        const contentType = payload.contentTypes.find((c) => c.sys.id === entry.contentTypeId);
+        for (const fieldId of fieldIds) {
+          const field = contentType?.fields?.find((f) => 'id' in f && f.id === fieldId);
+          const fieldType =
+            field && 'type' in field && typeof field.type === 'string' ? field.type : 'Text';
+          targets.push({
+            entryIndex,
+            fieldId,
+            fieldType,
+          });
+        }
+      }
+
+      const resolvedTargets = targets.filter((t) => t.fieldId.length > 0);
+
+      if (!resolvedTargets.length) {
+        closeEditModal();
+        return;
+      }
+
+      const effectiveRanges = pendingTextReassignRanges.length
+        ? pendingTextReassignRanges
+        : fullSpanTextExclusionRangesForSourceRef(from.sourceRef);
+
+      onEntryBlockGraphChange(
+        applyTextReassignToEntryBlockGraph(entryBlockGraph, from, effectiveRanges, resolvedTargets)
+      );
       closeEditModal();
       return;
     }

--- a/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/EditModal.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/EditModal.tsx
@@ -20,7 +20,10 @@ interface EditModalProps {
   locationSectionDescription: string;
   primaryButtonLabel: string;
   additionalContent?: ReactNode;
-  onConfirmPrimary?: (details: { selectedLocationId: string | null }) => void;
+  onConfirmPrimary?: (details: {
+    selectedLocationId: string | null;
+    selectedFieldIdsByLocationId: Record<string, string[]>;
+  }) => void;
 }
 
 export const EditModal = ({
@@ -63,7 +66,12 @@ export const EditModal = ({
     setSelectedLocationId(initialSelectedLocationId);
   }, [initialSelectedLocationId]);
 
+  const newLocationRowIdsKey = (viewModel.newLocations ?? []).map((nl) => nl.id).join('|');
+
+  // Reset field multiselect when the modal opens or when the set of destination rows changes.
+  // Do not depend on `viewModel.newLocations` reference (it can churn without semantic change).
   useEffect(() => {
+    if (!isOpen) return;
     setSelectedFieldIdsByLocationId(
       Object.fromEntries(
         (viewModel.newLocations ?? []).map((newLocation) => [
@@ -72,17 +80,24 @@ export const EditModal = ({
         ])
       )
     );
-  }, [viewModel.newLocations]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- sync from props only on open / row-id set change, not array identity
+  }, [isOpen, newLocationRowIdsKey]);
 
-  const handleSelectedFieldIdsChange = (locationId: string, selectedFieldIds: string[]) => {
+  const handleSelectedFieldIdsChange = (
+    locationId: string,
+    updater: (previous: string[]) => string[]
+  ) => {
     setSelectedFieldIdsByLocationId((previous) => ({
       ...previous,
-      [locationId]: selectedFieldIds,
+      [locationId]: updater(previous[locationId] ?? []),
     }));
   };
 
   const handlePrimaryAction = () => {
-    onConfirmPrimary?.({ selectedLocationId: selectedLocationId });
+    onConfirmPrimary?.({
+      selectedLocationId,
+      selectedFieldIdsByLocationId: { ...selectedFieldIdsByLocationId },
+    });
   };
 
   const previewSectionTitle = viewModel.previewSectionTitle ?? 'Selected content';
@@ -164,7 +179,7 @@ export const EditModal = ({
                   </Text>
                   <Box className={locationList}>
                     {viewModel.newLocations?.map((newLocation) => (
-                      <Box className={sectionCard} key={newLocation.title}>
+                      <Box className={sectionCard} key={newLocation.id}>
                         <Text as="p" fontWeight="fontWeightDemiBold" marginBottom="spacingM">
                           {newLocation.title}
                         </Text>
@@ -180,8 +195,8 @@ export const EditModal = ({
                             newLocation.selectedFieldIds ??
                             []
                           }
-                          onSelectedFieldIdsChange={(selectedFieldIds) =>
-                            handleSelectedFieldIdsChange(newLocation.id, selectedFieldIds)
+                          onSelectedFieldIdsChange={(updater) =>
+                            handleSelectedFieldIdsChange(newLocation.id, updater)
                           }
                         />
                       </Box>

--- a/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/FieldSelectionDropdown.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/FieldSelectionDropdown.tsx
@@ -11,7 +11,8 @@ interface FieldSelectionDropdownProps {
   fieldOptions: EditModalFieldOption[];
   fieldMappings: EditModalFieldMapping[];
   selectedFieldIds: string[];
-  onSelectedFieldIdsChange: (selectedFieldIds: string[]) => void;
+  /** Functional updates avoid stale `selectedFieldIds` when selecting multiple fields quickly. */
+  onSelectedFieldIdsChange: (updater: (previous: string[]) => string[]) => void;
 }
 
 export const FieldSelectionDropdown = ({
@@ -36,8 +37,12 @@ export const FieldSelectionDropdown = ({
   const handleSelectField = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { checked, value } = event.target;
 
-    onSelectedFieldIdsChange(
-      checked ? [...selectedFieldIds, value] : selectedFieldIds.filter((id) => id !== value)
+    onSelectedFieldIdsChange((previous) =>
+      checked
+        ? previous.includes(value)
+          ? previous
+          : [...previous, value]
+        : previous.filter((id) => id !== value)
     );
   };
 

--- a/apps/google-docs/src/locations/Page/components/review/mapping/entryBlockGraphExclusion.ts
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/entryBlockGraphExclusion.ts
@@ -3,9 +3,10 @@ import type {
   EntryBlockGraph,
   ImageSourceRef,
   NormalizedDocumentFlattenedRun,
+  SourceRef,
   TextSourceRef,
 } from '@types';
-import { isTableSourceRef, isTextSourceRef } from '@types';
+import { isTableSourceRef, isTableTextSourceRef, isTextSourceRef } from '@types';
 import { buildSourceRefKey } from './sourceRefUtils';
 
 export type TextExclusionRange =
@@ -368,6 +369,142 @@ export function applyTextExclusionToEntryBlockGraph(
   });
 
   return { ...graph, entries: nextEntries };
+}
+
+function cloneTextSourceRef(ref: TextSourceRef): TextSourceRef {
+  return {
+    ...ref,
+    flattenedRuns: ref.flattenedRuns.map((run) => ({ ...run })),
+  };
+}
+
+function textExclusionRangesForCuts(
+  sourceRef: TextSourceRef,
+  cuts: [number, number][]
+): TextExclusionRange[] {
+  if (isTableTextSourceRef(sourceRef)) {
+    return cuts.map(([start, end]) => ({
+      scope: 'table' as const,
+      tableId: sourceRef.tableId,
+      rowId: sourceRef.rowId,
+      cellId: sourceRef.cellId,
+      partId: sourceRef.partId,
+      start,
+      end,
+    }));
+  }
+  return cuts.map(([start, end]) => ({
+    scope: 'block' as const,
+    blockId: sourceRef.blockId,
+    start,
+    end,
+  }));
+}
+
+function appendTextRefsToFieldMapping(
+  graph: EntryBlockGraph,
+  entryIndex: number,
+  fieldId: string,
+  fieldType: string,
+  refs: TextSourceRef[]
+): EntryBlockGraph {
+  if (!refs.length) return graph;
+
+  return {
+    ...graph,
+    entries: graph.entries.map((entry, idx) => {
+      if (idx !== entryIndex) return entry;
+
+      const fmIdx = entry.fieldMappings.findIndex((fm) => fm.fieldId === fieldId);
+      if (fmIdx === -1) {
+        return {
+          ...entry,
+          fieldMappings: [
+            ...entry.fieldMappings,
+            { fieldId, fieldType, sourceRefs: refs.map(cloneTextSourceRef), confidence: 1 },
+          ],
+        };
+      }
+
+      return {
+        ...entry,
+        fieldMappings: entry.fieldMappings.map((fm, j) =>
+          j === fmIdx
+            ? { ...fm, sourceRefs: [...fm.sourceRefs, ...refs.map(cloneTextSourceRef)] }
+            : fm
+        ),
+      };
+    }),
+  };
+}
+
+/**
+ * Moves selected character ranges from a text `sourceRef` on `from` into one or more target fields.
+ * Reuses exclusion-style splitting on the source field, then appends moved slices to each target.
+ */
+export function applyTextReassignToEntryBlockGraph(
+  graph: EntryBlockGraph,
+  from: EditLocationOption,
+  pendingRanges: TextExclusionRange[],
+  targets: ReadonlyArray<{ entryIndex: number; fieldId: string; fieldType: string }>
+): EntryBlockGraph {
+  if (!isTextSourceRef(from.sourceRef) || !targets.length) return graph;
+
+  const fromKey = buildSourceRefKey(from.sourceRef);
+  const seen = new Set<string>();
+  const dedupedTargets = targets.filter((t) => {
+    if (t.entryIndex === from.entryIndex && t.fieldId === from.fieldId) return false;
+    const k = `${t.entryIndex}|${t.fieldId}`;
+    if (seen.has(k)) return false;
+    seen.add(k);
+    return true;
+  });
+  if (!dedupedTargets.length) return graph;
+
+  const fromEntry = graph.entries[from.entryIndex];
+  const fromFm = fromEntry?.fieldMappings.find((fm) => fm.fieldId === from.fieldId);
+  const fromSr = fromFm?.sourceRefs.find(
+    (sr) => buildSourceRefKey(sr) === fromKey && isTextSourceRef(sr)
+  ) as TextSourceRef | undefined;
+  if (!fromSr) return graph;
+
+  const mergedCuts = mergeIntervals(rangesOverlappingTextSourceRef(fromSr, pendingRanges));
+  if (!mergedCuts.length) return graph;
+
+  const movedRefs = buildTextRefsFromSpans(fromSr, mergedCuts).filter((r) => r.start < r.end);
+  if (!movedRefs.length) return graph;
+
+  const exclusionRanges = textExclusionRangesForCuts(fromSr, mergedCuts);
+  let next = applyTextExclusionToEntryBlockGraph(graph, from, exclusionRanges);
+
+  for (const t of dedupedTargets) {
+    next = appendTextRefsToFieldMapping(next, t.entryIndex, t.fieldId, t.fieldType, movedRefs);
+  }
+
+  return next;
+}
+
+/** When the DOM produced no merged ranges, use the whole mapped text ref span for reassign. */
+export function fullSpanTextExclusionRangesForSourceRef(
+  sourceRef: SourceRef
+): TextExclusionRange[] {
+  if (!isTextSourceRef(sourceRef)) return [];
+  if (isTableTextSourceRef(sourceRef)) {
+    return [
+      {
+        scope: 'table',
+        tableId: sourceRef.tableId,
+        rowId: sourceRef.rowId,
+        cellId: sourceRef.cellId,
+        partId: sourceRef.partId,
+        start: sourceRef.start,
+        end: sourceRef.end,
+      },
+    ];
+  }
+  return [
+    { scope: 'block', blockId: sourceRef.blockId, start: sourceRef.start, end: sourceRef.end },
+  ];
 }
 
 /**

--- a/apps/google-docs/test/locations/Page/components/modals/EditModal.spec.tsx
+++ b/apps/google-docs/test/locations/Page/components/modals/EditModal.spec.tsx
@@ -167,6 +167,42 @@ describe('EditModal', () => {
     });
   });
 
+  it('keys new location rows by id so duplicate titles do not break reconciliation', async () => {
+    const duplicateTitle = 'Article: Untitled';
+    render(
+      <EditModal
+        isOpen={true}
+        onClose={onClose}
+        viewModel={{
+          ...viewModel,
+          newLocations: [
+            {
+              id: 'entry-a',
+              title: duplicateTitle,
+              fieldMappings: [],
+              fieldOptions: [{ id: 'body', fieldName: 'Body', fieldType: 'Text' }],
+            },
+            {
+              id: 'entry-b',
+              title: duplicateTitle,
+              fieldMappings: [],
+              fieldOptions: [{ id: 'summary', fieldName: 'Summary', fieldType: 'Text' }],
+            },
+          ],
+        }}
+        title="Assign content"
+        locationSectionDescription=""
+        primaryButtonLabel="Move content"
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByText(duplicateTitle)).toHaveLength(2);
+      expect(screen.getAllByText('Fields')).toHaveLength(2);
+      expect(screen.getAllByText('Select one or more')).toHaveLength(2);
+    });
+  });
+
   it('keeps the current location heading visible when the section is empty', async () => {
     render(
       <EditModal

--- a/apps/google-docs/test/locations/Page/components/modals/FieldSelectionDropdown.spec.tsx
+++ b/apps/google-docs/test/locations/Page/components/modals/FieldSelectionDropdown.spec.tsx
@@ -5,7 +5,10 @@ import { FieldSelectionDropdown } from '../../../../../src/locations/Page/compon
 
 describe('FieldSelectionDropdown', () => {
   it('enables numeric field types only when the selected text is numeric', async () => {
-    const onSelectedFieldIdsChange = vi.fn();
+    let selectedFieldIds: string[] = [];
+    const onSelectedFieldIdsChange = vi.fn((updater: (prev: string[]) => string[]) => {
+      selectedFieldIds = updater(selectedFieldIds);
+    });
 
     render(
       <FieldSelectionDropdown
@@ -68,9 +71,7 @@ describe('FieldSelectionDropdown', () => {
     fireEvent.click(decimalOption);
 
     await waitFor(() => {
-      expect(onSelectedFieldIdsChange).toHaveBeenCalledWith(['name']);
-      expect(onSelectedFieldIdsChange).toHaveBeenCalledWith(['headingSize']);
-      expect(onSelectedFieldIdsChange).toHaveBeenCalledWith(['price']);
+      expect(selectedFieldIds).toEqual(['name', 'headingSize', 'price']);
     });
   });
 

--- a/apps/google-docs/test/locations/Page/components/review/mapping/entryBlockGraphExclusion.spec.ts
+++ b/apps/google-docs/test/locations/Page/components/review/mapping/entryBlockGraphExclusion.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { EditLocationOption, EntryBlockGraph, SourceRef } from '@types';
 import {
   applyTextExclusionToEntryBlockGraph,
+  applyTextReassignToEntryBlockGraph,
   collectMappedExclusionPreviewText,
   collectTextExclusionRangesFromSelection,
 } from '../../../../../../src/locations/Page/components/review/mapping/entryBlockGraphExclusion';
@@ -149,5 +150,150 @@ describe('entryBlockGraphExclusion', () => {
       { scope: 'block', blockId: 'block-1', start: 5, end: 8 },
     ]);
     expect(collectMappedExclusionPreviewText(root, range)).toBe('567');
+  });
+});
+
+describe('applyTextReassignToEntryBlockGraph', () => {
+  it('moves a short middle slice from body to subtitle and splits the source ref', () => {
+    const graph: EntryBlockGraph = {
+      entries: [
+        {
+          contentTypeId: 'article',
+          fieldMappings: [
+            {
+              fieldId: 'body',
+              fieldType: 'Text',
+              sourceRefs: [blockRef(0, 11, 'Hello world')],
+              confidence: 1,
+            },
+          ],
+        },
+      ],
+      excludedSourceRefs: [],
+    };
+    const from: EditLocationOption = {
+      entryIndex: 0,
+      id: '0-article-body',
+      contentTypeId: 'article',
+      contentTypeName: 'Article',
+      entryName: 'A',
+      fieldId: 'body',
+      fieldName: 'Body',
+      fieldType: 'Text',
+      sourceRef: blockRef(0, 11, 'Hello world'),
+    };
+
+    const next = applyTextReassignToEntryBlockGraph(
+      graph,
+      from,
+      [{ scope: 'block', blockId: 'block-1', start: 6, end: 11 }],
+      [{ entryIndex: 0, fieldId: 'subtitle', fieldType: 'Text' }]
+    );
+
+    const bodyRefs = next.entries[0]!.fieldMappings.find((f) => f.fieldId === 'body')!.sourceRefs;
+    const subtitleFm = next.entries[0]!.fieldMappings.find((f) => f.fieldId === 'subtitle');
+    expect(bodyRefs).toHaveLength(1);
+    expect(bodyRefs[0]).toMatchObject({ start: 0, end: 6, type: 'blockText' });
+    expect(subtitleFm?.sourceRefs).toHaveLength(1);
+    expect(subtitleFm?.sourceRefs[0]).toMatchObject({ start: 6, end: 11, type: 'blockText' });
+    expect(
+      (subtitleFm?.sourceRefs[0] as { flattenedRuns: { text: string }[] }).flattenedRuns[0]?.text
+    ).toBe('world');
+  });
+
+  it('moves a slice from long body text to another field', () => {
+    const longBody = 'a'.repeat(100);
+    const graph: EntryBlockGraph = {
+      entries: [
+        {
+          contentTypeId: 'article',
+          fieldMappings: [
+            {
+              fieldId: 'body',
+              fieldType: 'Text',
+              sourceRefs: [blockRef(0, 100, longBody)],
+              confidence: 1,
+            },
+          ],
+        },
+      ],
+      excludedSourceRefs: [],
+    };
+    const from: EditLocationOption = {
+      entryIndex: 0,
+      id: '0-article-body',
+      contentTypeId: 'article',
+      contentTypeName: 'Article',
+      entryName: 'A',
+      fieldId: 'body',
+      fieldName: 'Body',
+      fieldType: 'Text',
+      sourceRef: blockRef(0, 100, longBody),
+    };
+
+    const next = applyTextReassignToEntryBlockGraph(
+      graph,
+      from,
+      [{ scope: 'block', blockId: 'block-1', start: 40, end: 60 }],
+      [{ entryIndex: 0, fieldId: 'subtitle', fieldType: 'Text' }]
+    );
+
+    const bodyRefs = next.entries[0]!.fieldMappings.find((f) => f.fieldId === 'body')!.sourceRefs;
+    const subRefs = next.entries[0]!.fieldMappings.find(
+      (f) => f.fieldId === 'subtitle'
+    )!.sourceRefs;
+    expect(bodyRefs).toHaveLength(2);
+    expect(subRefs).toHaveLength(1);
+    expect(subRefs[0]).toMatchObject({ start: 40, end: 60 });
+    expect((subRefs[0] as { flattenedRuns: { text: string }[] }).flattenedRuns[0]?.text).toBe(
+      'a'.repeat(20)
+    );
+  });
+
+  it('appends the same moved slice to two target fields', () => {
+    const graph: EntryBlockGraph = {
+      entries: [
+        {
+          contentTypeId: 'article',
+          fieldMappings: [
+            {
+              fieldId: 'body',
+              fieldType: 'Text',
+              sourceRefs: [blockRef(0, 10, '0123456789')],
+              confidence: 1,
+            },
+          ],
+        },
+      ],
+      excludedSourceRefs: [],
+    };
+    const from: EditLocationOption = {
+      entryIndex: 0,
+      id: '0-article-body',
+      contentTypeId: 'article',
+      contentTypeName: 'Article',
+      entryName: 'A',
+      fieldId: 'body',
+      fieldName: 'Body',
+      fieldType: 'Text',
+      sourceRef: blockRef(0, 10, '0123456789'),
+    };
+
+    const next = applyTextReassignToEntryBlockGraph(
+      graph,
+      from,
+      [{ scope: 'block', blockId: 'block-1', start: 3, end: 7 }],
+      [
+        { entryIndex: 0, fieldId: 'a', fieldType: 'Text' },
+        { entryIndex: 0, fieldId: 'b', fieldType: 'Text' },
+      ]
+    );
+
+    const aRefs = next.entries[0]!.fieldMappings.find((f) => f.fieldId === 'a')!.sourceRefs;
+    const bRefs = next.entries[0]!.fieldMappings.find((f) => f.fieldId === 'b')!.sourceRefs;
+    expect(aRefs).toHaveLength(1);
+    expect(bRefs).toHaveLength(1);
+    expect(aRefs[0]).toMatchObject({ start: 3, end: 7 });
+    expect(bRefs[0]).toMatchObject({ start: 3, end: 7 });
   });
 });


### PR DESCRIPTION
## Title

`feat(google-docs): text reassign on entryBlockGraph + stable assign modal`

## Description

### Summary

Improves the mapping **review** flow: **text reassign** updates `entryBlockGraph` (the highlighted range is removed from the chosen “from” field, then appended to each selected destination), and fixes **Assign** UI so choosing **multiple destination fields** and **multiple overview rows** behaves correctly.

### What changed

- **Reassign:** `applyTextReassignToEntryBlockGraph` reuses exclude-style splitting on the source field, then appends moved text `sourceRef`s to each target field (partial selection, full ref fallback, multiple targets).
- **EditModal:** “New location” list items use **`key={newLocation.id}`** instead of `title` so duplicate entry titles do not break React reconciliation. Multiselect state resets only when the modal opens or the **row id set** changes, not on unrelated `newLocations` reference churn. **FieldSelectionDropdown** uses **functional** selection updates so toggling several fields does not hit stale `selectedFieldIds`.
- **MappingView:** Confirming “Move content” calls `onEntryBlockGraphChange`; reassign ranges come from the text selection; modal closes when the focused overview entry changes so confirm is not tied to the wrong entry.

### How to verify

- Reassign a mapped span into **two** short-text targets on one entry — both fields gain the slice; the source field loses that range.
- Two overview entries with the **same title** — each “New location” multiselect keeps independent selections.
- Run Vitest: mapping / `entryBlockGraphExclusion`, `EditModal`, `FieldSelectionDropdown` (plus any MappingView specs your CI runs).
