### PR TITLE
[INTEG-3819] feat: add assign capability to review page for google docs app

### DIFF
--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -32,9 +32,11 @@ import { MappingEntryCards, type AnchoredMappingCard } from './MappingEntryCards
 import { NormalizedDocumentSection } from './NormalizedDocumentSection';
 import {
   applyImageExclusionToEntryBlockGraph,
+  applyTextAssignToEntryBlockGraph,
   applyTextExclusionToEntryBlockGraph,
   applyTextReassignToEntryBlockGraph,
   collectMappedExclusionPreviewText,
+  collectTextAssignRangesFromSelection,
   collectTextExclusionRangesFromSelection,
   fullSpanTextExclusionRangesForSourceRef,
   type TextExclusionRange,
@@ -121,6 +123,7 @@ export const MappingView = ({
   const [pendingTextReassignRanges, setPendingTextReassignRanges] = useState<TextExclusionRange[]>(
     []
   );
+  const [pendingTextAssignRanges, setPendingTextAssignRanges] = useState<TextExclusionRange[]>([]);
   const textSelectionRootRef = useRef<HTMLDivElement | null>(null);
   const segmentLayoutRefs = useRef<Record<string, HTMLDivElement | null>>({});
   const cardWrapperRefs = useRef<Record<string, HTMLDivElement | null>>({});
@@ -132,6 +135,7 @@ export const MappingView = ({
     setPendingTextExclusionRanges(null);
     setPendingImageSourceRef(null);
     setPendingTextReassignRanges([]);
+    setPendingTextAssignRanges([]);
   };
 
   const previousSelectedEntryIndexRef = useRef<number | null | undefined>(undefined);
@@ -419,11 +423,13 @@ export const MappingView = ({
   const openAssignModal = (
     preview: string,
     currentLocations: EditLocationOption[],
-    reassignRanges: TextExclusionRange[]
+    reassignRanges: TextExclusionRange[],
+    assignRanges: TextExclusionRange[]
   ) => {
     setPendingTextExclusionRanges(null);
     setPendingImageSourceRef(null);
     setPendingTextReassignRanges(reassignRanges);
+    setPendingTextAssignRanges(assignRanges);
     setEditModalState({
       mode: 'assign',
       viewModel: {
@@ -465,7 +471,16 @@ export const MappingView = ({
       textSelectionRootRef.current,
       selectedRange
     );
-    openAssignModal(selectedText.trim(), getLocationsForSelectedText(), reassignRanges);
+    const assignRanges = collectTextAssignRangesFromSelection(
+      textSelectionRootRef.current,
+      selectedRange
+    );
+    openAssignModal(
+      selectedText.trim(),
+      getLocationsForSelectedText(),
+      reassignRanges,
+      assignRanges
+    );
     clearSelection();
   };
 
@@ -490,7 +505,7 @@ export const MappingView = ({
   };
 
   const handleAssignImage = (sourceRef: ImageSourceRef, label: string) => {
-    openAssignModal(label, getLocationsForSourceRef(sourceRef), []);
+    openAssignModal(label, getLocationsForSourceRef(sourceRef), [], []);
     setHoveredMappingKeys([]);
   };
 
@@ -513,20 +528,6 @@ export const MappingView = ({
   }) => {
     if (editModalState.mode === 'assign') {
       const locations = editModalState.viewModel.currentLocations;
-      if (!locations.length) {
-        closeEditModal();
-        return;
-      }
-
-      const from =
-        locations.find((location) => location.id === selectedLocationId) ??
-        locations.find((location) => location.isSelected) ??
-        locations[0];
-
-      if (!from || !isTextSourceRef(from.sourceRef)) {
-        closeEditModal();
-        return;
-      }
 
       const targets: { entryIndex: number; fieldId: string; fieldType: string }[] = [];
       for (let entryIndex = 0; entryIndex < entryBlockGraph.entries.length; entryIndex++) {
@@ -553,12 +554,45 @@ export const MappingView = ({
         return;
       }
 
-      const effectiveRanges = pendingTextReassignRanges.length
-        ? pendingTextReassignRanges
-        : fullSpanTextExclusionRangesForSourceRef(from.sourceRef);
+      if (locations.length > 0) {
+        const from =
+          locations.find((location) => location.id === selectedLocationId) ??
+          locations.find((location) => location.isSelected) ??
+          locations[0];
+
+        if (!from || !isTextSourceRef(from.sourceRef)) {
+          closeEditModal();
+          return;
+        }
+
+        const effectiveRanges = pendingTextReassignRanges.length
+          ? pendingTextReassignRanges
+          : fullSpanTextExclusionRangesForSourceRef(from.sourceRef);
+
+        onEntryBlockGraphChange(
+          applyTextReassignToEntryBlockGraph(
+            entryBlockGraph,
+            from,
+            effectiveRanges,
+            resolvedTargets
+          )
+        );
+        closeEditModal();
+        return;
+      }
+
+      if (!pendingTextAssignRanges.length) {
+        closeEditModal();
+        return;
+      }
 
       onEntryBlockGraphChange(
-        applyTextReassignToEntryBlockGraph(entryBlockGraph, from, effectiveRanges, resolvedTargets)
+        applyTextAssignToEntryBlockGraph(
+          entryBlockGraph,
+          document,
+          pendingTextAssignRanges,
+          resolvedTargets
+        )
       );
       closeEditModal();
       return;

--- a/apps/google-docs/src/locations/Page/components/review/mapping/entryBlockGraphExclusion.ts
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/entryBlockGraphExclusion.ts
@@ -6,7 +6,7 @@ import type {
   NormalizedDocumentContentBlock,
   NormalizedDocumentFlattenedRun,
   SourceRef,
-  TextSourceRef,
+  TextRangeSourceRef,
 } from '@types';
 import { isTableSourceRef, isTableTextSourceRef, isTextSourceRef } from '@types';
 import { buildSourceRefKey } from './sourceRefUtils';
@@ -80,9 +80,9 @@ function clipFlattenedRuns(
 }
 
 function buildTextRefsFromSpans(
-  baseRef: TextSourceRef,
+  baseRef: TextRangeSourceRef,
   spans: [number, number][]
-): TextSourceRef[] {
+): TextRangeSourceRef[] {
   return spans.map(([s, e]) => ({
     ...baseRef,
     start: s,
@@ -104,7 +104,7 @@ function intersectSpan(
 }
 
 function rangesOverlappingTextSourceRef(
-  ref: TextSourceRef,
+  ref: TextRangeSourceRef,
   pending: TextExclusionRange[]
 ): [number, number][] {
   const cuts: [number, number][] = [];
@@ -415,27 +415,42 @@ function findTableTextPart(
 }
 
 /**
- * Builds `blockText` / `tableText` refs for assign from merged ranges and the normalized document.
+ * Builds indexed text refs for assign (same discriminant vocabulary as agents-api
+ * `indexedEntryBlockGraph`) so mapping-review resume passes Zod.
  */
 export function buildTextSourceRefsForAssignRanges(
   document: NormalizedDocument,
   ranges: TextExclusionRange[]
-): TextSourceRef[] {
-  const out: TextSourceRef[] = [];
+): TextRangeSourceRef[] {
+  const out: TextRangeSourceRef[] = [];
 
   for (const r of ranges) {
     if (r.scope === 'block') {
       const block = findContentBlockById(document, r.blockId);
-      if (!block?.flattenedTextRuns?.length) continue;
+      if (!block?.flattenedTextRuns?.length || block.type === 'image') continue;
       const flattenedRuns = clipFlattenedRuns(block.flattenedTextRuns, r.start, r.end);
       if (!flattenedRuns.length) continue;
-      out.push({
-        type: 'blockText',
-        blockId: r.blockId,
-        start: r.start,
-        end: r.end,
-        flattenedRuns,
-      });
+
+      const base = { blockId: r.blockId, start: r.start, end: r.end, flattenedRuns };
+
+      if (block.type === 'heading') {
+        out.push({
+          type: 'heading',
+          ...base,
+          ...(block.headingLevel !== undefined && { headingLevel: block.headingLevel }),
+        });
+        continue;
+      }
+      if (block.type === 'listItem') {
+        out.push({
+          type: 'listItem',
+          ...base,
+          ...(block.bullet !== undefined && { bullet: block.bullet }),
+        });
+        continue;
+      }
+
+      out.push({ type: 'paragraph', ...base });
       continue;
     }
 
@@ -529,7 +544,7 @@ export function applyTextExclusionToEntryBlockGraph(
   return { ...graph, entries: nextEntries };
 }
 
-function cloneTextSourceRef(ref: TextSourceRef): TextSourceRef {
+function cloneTextRangeSourceRef(ref: TextRangeSourceRef): TextRangeSourceRef {
   return {
     ...ref,
     flattenedRuns: ref.flattenedRuns.map((run) => ({ ...run })),
@@ -537,7 +552,7 @@ function cloneTextSourceRef(ref: TextSourceRef): TextSourceRef {
 }
 
 function textExclusionRangesForCuts(
-  sourceRef: TextSourceRef,
+  sourceRef: TextRangeSourceRef,
   cuts: [number, number][]
 ): TextExclusionRange[] {
   if (isTableTextSourceRef(sourceRef)) {
@@ -564,7 +579,7 @@ function appendTextRefsToFieldMapping(
   entryIndex: number,
   fieldId: string,
   fieldType: string,
-  refs: TextSourceRef[]
+  refs: TextRangeSourceRef[]
 ): EntryBlockGraph {
   if (!refs.length) return graph;
 
@@ -579,7 +594,7 @@ function appendTextRefsToFieldMapping(
           ...entry,
           fieldMappings: [
             ...entry.fieldMappings,
-            { fieldId, fieldType, sourceRefs: refs.map(cloneTextSourceRef), confidence: 1 },
+            { fieldId, fieldType, sourceRefs: refs.map(cloneTextRangeSourceRef), confidence: 1 },
           ],
         };
       }
@@ -588,7 +603,7 @@ function appendTextRefsToFieldMapping(
         ...entry,
         fieldMappings: entry.fieldMappings.map((fm, j) =>
           j === fmIdx
-            ? { ...fm, sourceRefs: [...fm.sourceRefs, ...refs.map(cloneTextSourceRef)] }
+            ? { ...fm, sourceRefs: [...fm.sourceRefs, ...refs.map(cloneTextRangeSourceRef)] }
             : fm
         ),
       };
@@ -623,7 +638,7 @@ export function applyTextReassignToEntryBlockGraph(
   const fromFm = fromEntry?.fieldMappings.find((fm) => fm.fieldId === from.fieldId);
   const fromSr = fromFm?.sourceRefs.find(
     (sr) => buildSourceRefKey(sr) === fromKey && isTextSourceRef(sr)
-  ) as TextSourceRef | undefined;
+  ) as TextRangeSourceRef | undefined;
   if (!fromSr) return graph;
 
   const mergedCuts = mergeIntervals(rangesOverlappingTextSourceRef(fromSr, pendingRanges));

--- a/apps/google-docs/src/locations/Page/components/review/mapping/entryBlockGraphExclusion.ts
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/entryBlockGraphExclusion.ts
@@ -2,6 +2,8 @@ import type {
   EditLocationOption,
   EntryBlockGraph,
   ImageSourceRef,
+  NormalizedDocument,
+  NormalizedDocumentContentBlock,
   NormalizedDocumentFlattenedRun,
   SourceRef,
   TextSourceRef,
@@ -330,6 +332,162 @@ export function collectTextExclusionRangesFromSelection(
   });
 
   return mergeTextExclusionRanges(raw);
+}
+
+/**
+ * Unmapped review segments touched by the selection → merged absolute ranges (same shape as exclusion).
+ */
+export function collectTextAssignRangesFromSelection(
+  root: HTMLElement | null,
+  selectedRange: Range | null
+): TextExclusionRange[] {
+  if (!root || !selectedRange) return [];
+
+  const unmapped = root.querySelectorAll<HTMLElement>(
+    '[data-review-text-segment="true"][data-is-mapped="false"]'
+  );
+  const raw: TextExclusionRange[] = [];
+
+  unmapped.forEach((el) => {
+    if (!rangeIntersectsNodeSafe(selectedRange, el)) return;
+
+    const scope = el.dataset.textScope;
+    const segStart = Number(el.dataset.rangeStart);
+    const segEnd = Number(el.dataset.rangeEnd);
+    if (!Number.isFinite(segStart) || !Number.isFinite(segEnd) || segStart >= segEnd) return;
+
+    const abs = getAbsoluteIntersectionForMappedSegment(el, selectedRange, segStart, segEnd);
+    if (!abs) return;
+    const [start, end] = abs;
+
+    if (scope === 'block' && el.dataset.blockId) {
+      raw.push({ scope: 'block', blockId: el.dataset.blockId, start, end });
+      return;
+    }
+
+    if (
+      scope === 'table' &&
+      el.dataset.tableId &&
+      el.dataset.rowId &&
+      el.dataset.cellId &&
+      el.dataset.partId
+    ) {
+      raw.push({
+        scope: 'table',
+        tableId: el.dataset.tableId,
+        rowId: el.dataset.rowId,
+        cellId: el.dataset.cellId,
+        partId: el.dataset.partId,
+        start,
+        end,
+      });
+    }
+  });
+
+  return mergeTextExclusionRanges(raw);
+}
+
+function findContentBlockById(
+  document: NormalizedDocument,
+  blockId: string
+): NormalizedDocumentContentBlock | undefined {
+  for (const block of document.contentBlocks) {
+    if (block.type !== 'tab' && block.id === blockId) {
+      return block;
+    }
+  }
+  return undefined;
+}
+
+function findTableTextPart(
+  document: NormalizedDocument,
+  tableId: string,
+  rowId: string,
+  cellId: string,
+  partId: string
+): { flattenedTextRuns: NormalizedDocumentFlattenedRun[] } | undefined {
+  const table = document.tables.find((t) => t.id === tableId);
+  const row = table?.rows.find((r) => r.id === rowId);
+  const cell = row?.cells.find((c) => c.id === cellId);
+  const part = cell?.parts.find((p) => p.id === partId);
+  if (!part || part.type !== 'text') return undefined;
+  return part;
+}
+
+/**
+ * Builds `blockText` / `tableText` refs for assign from merged ranges and the normalized document.
+ */
+export function buildTextSourceRefsForAssignRanges(
+  document: NormalizedDocument,
+  ranges: TextExclusionRange[]
+): TextSourceRef[] {
+  const out: TextSourceRef[] = [];
+
+  for (const r of ranges) {
+    if (r.scope === 'block') {
+      const block = findContentBlockById(document, r.blockId);
+      if (!block?.flattenedTextRuns?.length) continue;
+      const flattenedRuns = clipFlattenedRuns(block.flattenedTextRuns, r.start, r.end);
+      if (!flattenedRuns.length) continue;
+      out.push({
+        type: 'blockText',
+        blockId: r.blockId,
+        start: r.start,
+        end: r.end,
+        flattenedRuns,
+      });
+      continue;
+    }
+
+    const part = findTableTextPart(document, r.tableId, r.rowId, r.cellId, r.partId);
+    if (!part?.flattenedTextRuns?.length) continue;
+    const flattenedRuns = clipFlattenedRuns(part.flattenedTextRuns, r.start, r.end);
+    if (!flattenedRuns.length) continue;
+    out.push({
+      type: 'tableText',
+      tableId: r.tableId,
+      rowId: r.rowId,
+      cellId: r.cellId,
+      partId: r.partId,
+      start: r.start,
+      end: r.end,
+      flattenedRuns,
+    });
+  }
+
+  return out;
+}
+
+export type TextAssignTarget = { entryIndex: number; fieldId: string; fieldType: string };
+
+/**
+ * Appends new text source refs from unmapped document ranges to each target field (no removal from any field).
+ */
+export function applyTextAssignToEntryBlockGraph(
+  graph: EntryBlockGraph,
+  document: NormalizedDocument,
+  ranges: TextExclusionRange[],
+  targets: ReadonlyArray<TextAssignTarget>
+): EntryBlockGraph {
+  if (!ranges.length || !targets.length) return graph;
+
+  const movedRefs = buildTextSourceRefsForAssignRanges(document, mergeTextExclusionRanges(ranges));
+  if (!movedRefs.length) return graph;
+
+  const seen = new Set<string>();
+  const dedupedTargets = targets.filter((t) => {
+    const k = `${t.entryIndex}|${t.fieldId}`;
+    if (seen.has(k)) return false;
+    seen.add(k);
+    return true;
+  });
+  if (!dedupedTargets.length) return graph;
+
+  let next = graph;
+  for (const t of dedupedTargets) {
+    next = appendTextRefsToFieldMapping(next, t.entryIndex, t.fieldId, t.fieldType, movedRefs);
+  }
+  return next;
 }
 
 /**

--- a/apps/google-docs/src/types/entryBlockGraph.ts
+++ b/apps/google-docs/src/types/entryBlockGraph.ts
@@ -22,6 +22,45 @@ export type TableTextSourceRef = {
 
 export type TextSourceRef = BlockTextSourceRef | TableTextSourceRef;
 
+/**
+ * Block-level text refs after `build-entry-block-graph` / HIL resume (agents-api
+ * `indexedEntryBlockGraph`). Assign-from-unmapped must emit these — not `blockText` —
+ * or resume Zod validation fails.
+ */
+export type IndexedParagraphSourceRef = {
+  type: 'paragraph';
+  blockId: string;
+  start: number;
+  end: number;
+  flattenedRuns: NormalizedDocumentFlattenedRun[];
+};
+
+export type IndexedHeadingSourceRef = {
+  type: 'heading';
+  blockId: string;
+  start: number;
+  end: number;
+  flattenedRuns: NormalizedDocumentFlattenedRun[];
+  headingLevel?: number;
+};
+
+export type IndexedListItemSourceRef = {
+  type: 'listItem';
+  blockId: string;
+  start: number;
+  end: number;
+  flattenedRuns: NormalizedDocumentFlattenedRun[];
+  bullet?: { nestingLevel: number; ordered: boolean };
+};
+
+export type IndexedBlockTextSourceRef =
+  | IndexedParagraphSourceRef
+  | IndexedHeadingSourceRef
+  | IndexedListItemSourceRef;
+
+/** Any source ref that carries a character range + flattened runs (preview or indexed). */
+export type TextRangeSourceRef = TextSourceRef | IndexedBlockTextSourceRef;
+
 export type BlockImageSourceRef = {
   blockId: string;
   imageId: string;
@@ -39,16 +78,21 @@ export type TableImageSourceRef = {
 
 export type ImageSourceRef = BlockImageSourceRef | TableImageSourceRef;
 
-export type SourceRef = TextSourceRef | ImageSourceRef;
+export type SourceRef = TextSourceRef | ImageSourceRef | IndexedBlockTextSourceRef;
 
-export const isTextSourceRef = (sourceRef: SourceRef): sourceRef is TextSourceRef => {
-  return 'start' in sourceRef && 'end' in sourceRef && 'flattenedRuns' in sourceRef;
+export const isTextSourceRef = (sourceRef: SourceRef): sourceRef is TextRangeSourceRef => {
+  if (typeof sourceRef !== 'object' || sourceRef === null) return false;
+  if (sourceRef.type === 'blockImage' || sourceRef.type === 'tableImage') return false;
+  if (!('start' in sourceRef) || !('end' in sourceRef) || !('flattenedRuns' in sourceRef)) {
+    return false;
+  }
+  return Array.isArray((sourceRef as { flattenedRuns: unknown }).flattenedRuns);
 };
 
 export const isBlockSourceRef = (
   sourceRef: SourceRef
-): sourceRef is BlockTextSourceRef | BlockImageSourceRef => {
-  return 'blockId' in sourceRef;
+): sourceRef is BlockTextSourceRef | BlockImageSourceRef | IndexedBlockTextSourceRef => {
+  return 'blockId' in sourceRef && !('tableId' in sourceRef);
 };
 
 export const isTableSourceRef = (
@@ -61,12 +105,14 @@ export const isTableSourceRef = (
 
 export const isEntryBlockGraphBlockTextSourceRef = (
   sourceRef: SourceRef
-): sourceRef is BlockTextSourceRef => {
-  return isBlockSourceRef(sourceRef) && isTextSourceRef(sourceRef);
+): sourceRef is BlockTextSourceRef | IndexedBlockTextSourceRef => {
+  return isBlockSourceRef(sourceRef) && isTextSourceRef(sourceRef) && !('imageId' in sourceRef);
 };
 
 export const isTableTextSourceRef = (sourceRef: SourceRef): sourceRef is TableTextSourceRef => {
-  return isTableSourceRef(sourceRef) && isTextSourceRef(sourceRef);
+  return (
+    isTableSourceRef(sourceRef) && isTextSourceRef(sourceRef) && sourceRef.type === 'tableText'
+  );
 };
 
 export const isBlockImageSourceRef = (sourceRef: SourceRef): sourceRef is BlockImageSourceRef => {

--- a/apps/google-docs/test/locations/Page/components/modals/step_4/IncludeImagesModal.spec.tsx
+++ b/apps/google-docs/test/locations/Page/components/modals/step_4/IncludeImagesModal.spec.tsx
@@ -1,6 +1,6 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { useState } from 'react';
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { afterEach, describe, expect, it, vi, beforeEach } from 'vitest';
 import { Modal } from '@contentful/f36-components';
 import { IncludeImagesModal } from '../../../../../../src/locations/Page/components/modals/step_4/IncludeImagesModal';
 import React from 'react';

--- a/apps/google-docs/test/locations/Page/components/review/mapping/entryBlockGraphExclusion.spec.ts
+++ b/apps/google-docs/test/locations/Page/components/review/mapping/entryBlockGraphExclusion.spec.ts
@@ -231,7 +231,7 @@ describe('applyTextAssignToEntryBlockGraph', () => {
 
     const subtitleFm = next.entries[0]!.fieldMappings.find((f) => f.fieldId === 'subtitle');
     expect(subtitleFm?.sourceRefs).toHaveLength(1);
-    expect(subtitleFm?.sourceRefs[0]).toMatchObject({ start: 5, end: 8, type: 'blockText' });
+    expect(subtitleFm?.sourceRefs[0]).toMatchObject({ start: 5, end: 8, type: 'paragraph' });
     expect(
       (subtitleFm?.sourceRefs[0] as { flattenedRuns: { text: string }[] }).flattenedRuns[0]?.text
     ).toBe('fgh');

--- a/apps/google-docs/test/locations/Page/components/review/mapping/entryBlockGraphExclusion.spec.ts
+++ b/apps/google-docs/test/locations/Page/components/review/mapping/entryBlockGraphExclusion.spec.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import type { EditLocationOption, EntryBlockGraph, SourceRef } from '@types';
+import type { EditLocationOption, EntryBlockGraph, NormalizedDocument, SourceRef } from '@types';
 import {
+  applyTextAssignToEntryBlockGraph,
   applyTextExclusionToEntryBlockGraph,
   applyTextReassignToEntryBlockGraph,
   collectMappedExclusionPreviewText,
+  collectTextAssignRangesFromSelection,
   collectTextExclusionRangesFromSelection,
 } from '../../../../../../src/locations/Page/components/review/mapping/entryBlockGraphExclusion';
 
@@ -150,6 +152,133 @@ describe('entryBlockGraphExclusion', () => {
       { scope: 'block', blockId: 'block-1', start: 5, end: 8 },
     ]);
     expect(collectMappedExclusionPreviewText(root, range)).toBe('567');
+  });
+
+  it('collectTextAssignRangesFromSelection reads unmapped segment datasets', () => {
+    const root = document.createElement('div');
+    const span = document.createElement('span');
+    span.setAttribute('data-review-text-segment', 'true');
+    span.setAttribute('data-is-mapped', 'false');
+    span.setAttribute('data-text-scope', 'block');
+    span.setAttribute('data-range-start', '3');
+    span.setAttribute('data-range-end', '7');
+    span.setAttribute('data-block-id', 'b1');
+    span.appendChild(document.createTextNode('abcd'));
+    root.appendChild(span);
+
+    const range = document.createRange();
+    range.selectNodeContents(span);
+
+    expect(collectTextAssignRangesFromSelection(root, range)).toEqual([
+      { scope: 'block', blockId: 'b1', start: 3, end: 7 },
+    ]);
+  });
+
+  it('collectTextAssignRangesFromSelection uses partial highlight within one unmapped segment', () => {
+    const root = document.createElement('div');
+    const span = document.createElement('span');
+    span.setAttribute('data-review-text-segment', 'true');
+    span.setAttribute('data-is-mapped', 'false');
+    span.setAttribute('data-text-scope', 'block');
+    span.setAttribute('data-range-start', '0');
+    span.setAttribute('data-range-end', '20');
+    span.setAttribute('data-block-id', 'block-1');
+    const text = '01234567890123456789';
+    span.appendChild(document.createTextNode(text));
+    root.appendChild(span);
+
+    const tn = span.firstChild as Text;
+    const range = document.createRange();
+    range.setStart(tn, 5);
+    range.setEnd(tn, 8);
+
+    expect(collectTextAssignRangesFromSelection(root, range)).toEqual([
+      { scope: 'block', blockId: 'block-1', start: 5, end: 8 },
+    ]);
+  });
+});
+
+const minimalNormalizedDoc = (text: string, blockId = 'block-1'): NormalizedDocument => ({
+  documentId: 'doc-1',
+  contentBlocks: [
+    {
+      id: blockId,
+      position: 0,
+      type: 'paragraph',
+      textRuns: [{ text }],
+      flattenedTextRuns: [{ text, start: 0, end: text.length, styles: {} }],
+      designValueIds: [],
+      imageIds: [],
+    },
+  ],
+  tables: [],
+});
+
+describe('applyTextAssignToEntryBlockGraph', () => {
+  it('appends refs from unmapped ranges without changing existing field mappings', () => {
+    const graph = baseGraph();
+    const doc = minimalNormalizedDoc('abcdefghijklmnopqrst');
+    const next = applyTextAssignToEntryBlockGraph(
+      graph,
+      doc,
+      [{ scope: 'block', blockId: 'block-1', start: 5, end: 8 }],
+      [{ entryIndex: 0, fieldId: 'subtitle', fieldType: 'Text' }]
+    );
+
+    const bodyRefs = next.entries[0]!.fieldMappings.find((f) => f.fieldId === 'body')!.sourceRefs;
+    expect(bodyRefs).toHaveLength(1);
+    expect(bodyRefs[0]).toMatchObject({ start: 0, end: 20, type: 'blockText' });
+
+    const subtitleFm = next.entries[0]!.fieldMappings.find((f) => f.fieldId === 'subtitle');
+    expect(subtitleFm?.sourceRefs).toHaveLength(1);
+    expect(subtitleFm?.sourceRefs[0]).toMatchObject({ start: 5, end: 8, type: 'blockText' });
+    expect(
+      (subtitleFm?.sourceRefs[0] as { flattenedRuns: { text: string }[] }).flattenedRuns[0]?.text
+    ).toBe('fgh');
+  });
+
+  it('appends the same assign slice to two target fields', () => {
+    const graph = baseGraph();
+    const doc = minimalNormalizedDoc('0123456789');
+    const next = applyTextAssignToEntryBlockGraph(
+      graph,
+      doc,
+      [{ scope: 'block', blockId: 'block-1', start: 3, end: 7 }],
+      [
+        { entryIndex: 0, fieldId: 'a', fieldType: 'Text' },
+        { entryIndex: 0, fieldId: 'b', fieldType: 'Text' },
+      ]
+    );
+
+    const bodyRefs = next.entries[0]!.fieldMappings.find((f) => f.fieldId === 'body')!.sourceRefs;
+    expect(bodyRefs).toHaveLength(1);
+    const aRefs = next.entries[0]!.fieldMappings.find((f) => f.fieldId === 'a')!.sourceRefs;
+    const bRefs = next.entries[0]!.fieldMappings.find((f) => f.fieldId === 'b')!.sourceRefs;
+    expect(aRefs).toHaveLength(1);
+    expect(bRefs).toHaveLength(1);
+    expect(aRefs[0]).toMatchObject({ start: 3, end: 7 });
+    expect(bRefs[0]).toMatchObject({ start: 3, end: 7 });
+  });
+
+  it('returns the same graph when ranges or targets are empty', () => {
+    const graph = baseGraph();
+    const doc = minimalNormalizedDoc('abc');
+    expect(
+      applyTextAssignToEntryBlockGraph(
+        graph,
+        doc,
+        [],
+        [{ entryIndex: 0, fieldId: 'x', fieldType: 'Text' }]
+      )
+    ).toBe(graph);
+    expect(
+      applyTextAssignToEntryBlockGraph(
+        graph,
+        doc,
+        [{ scope: 'block', blockId: 'block-1', start: 0, end: 1 }],
+        []
+      )
+    ).toBe(graph);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes **mapping-review resume / Create entries** when assigning **unmapped** document text, aligns **Google Docs agent** unit tests with **CODEOWNERS**, and updates the **google-docs** app mapping graph + UI so resumed `entryBlockGraph` matches **`indexedEntryBlockGraphSchema`** on the API.
