### PR TITLE
feat(link-checker): add entry field automation action []

### DIFF
--- a/apps/link-checker/__tests__/functions/checkAllEntryLinks.spec.ts
+++ b/apps/link-checker/__tests__/functions/checkAllEntryLinks.spec.ts
@@ -1,0 +1,231 @@
+import { handler } from '../../functions/checkAllEntryLinks';
+import { vi } from 'vitest';
+
+describe('checkAllEntryLinks handler', () => {
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+    global.fetch = mockFetch;
+  });
+
+  it('checks links across supported fields and returns a combined summary', async () => {
+    mockFetch
+      .mockResolvedValueOnce({ status: 200, ok: true })
+      .mockResolvedValueOnce({ status: 404, ok: false })
+      .mockResolvedValueOnce({ status: 404, ok: false });
+
+    const mockCma = {
+      entry: {
+        get: vi.fn().mockResolvedValue({
+          sys: {
+            contentType: {
+              sys: {
+                id: 'post',
+              },
+            },
+          },
+          fields: {
+            ctaUrl: {
+              'en-US': 'https://example.com/healthy',
+            },
+            body: {
+              'en-US': {
+                nodeType: 'document',
+                content: [
+                  {
+                    nodeType: 'paragraph',
+                    content: [
+                      {
+                        nodeType: 'hyperlink',
+                        data: { uri: 'https://example.com/missing' },
+                        content: [{ nodeType: 'text', value: 'missing' }],
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          },
+        }),
+      },
+      contentType: {
+        get: vi.fn().mockResolvedValue({
+          fields: [
+            { id: 'ctaUrl', name: 'CTA URL', type: 'Symbol' },
+            { id: 'body', name: 'Body', type: 'RichText' },
+            { id: 'views', name: 'Views', type: 'Number' },
+          ],
+        }),
+      },
+    };
+
+    const result = await handler(
+      {
+        body: {
+          entryId: 'entry-123',
+          locale: 'en-US',
+        },
+      },
+      {
+        cma: mockCma as any,
+        appInstallationParameters: {},
+      } as any
+    );
+
+    expect(result.checkedFieldIds).toEqual(['ctaUrl', 'body']);
+    expect(result.checkedCount).toBe(2);
+    expect(result.validCount).toBe(1);
+    expect(result.invalidCount).toBe(1);
+    expect(result.summary).toContain('across 2 field(s)');
+    expect(result.summary).toContain('CTA URL (en-US): https://example.com/healthy HTTP 200');
+    expect(result.summary).toContain('Body (en-US): https://example.com/missing HTTP 404');
+  });
+
+  it('supports restricting the scan to specific field ids', async () => {
+    mockFetch.mockResolvedValueOnce({ status: 200, ok: true });
+
+    const mockCma = {
+      entry: {
+        get: vi.fn().mockResolvedValue({
+          sys: {
+            contentType: {
+              sys: {
+                id: 'post',
+              },
+            },
+          },
+          fields: {
+            ctaUrl: {
+              'en-US': 'https://example.com/healthy',
+            },
+            body: {
+              'en-US': 'https://example.com/ignored',
+            },
+          },
+        }),
+      },
+      contentType: {
+        get: vi.fn().mockResolvedValue({
+          fields: [
+            { id: 'ctaUrl', name: 'CTA URL', type: 'Symbol' },
+            { id: 'body', name: 'Body', type: 'Text' },
+          ],
+        }),
+      },
+    };
+
+    const result = await handler(
+      {
+        body: {
+          entryId: 'entry-123',
+          fieldIds: ['ctaUrl'],
+        },
+      },
+      {
+        cma: mockCma as any,
+        appInstallationParameters: {},
+      } as any
+    );
+
+    expect(result.checkedFieldIds).toEqual(['ctaUrl']);
+    expect(result.checkedCount).toBe(1);
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0].fieldId).toBe('ctaUrl');
+  });
+
+  it('skips fields that do not have the requested locale instead of aborting the scan', async () => {
+    mockFetch.mockResolvedValueOnce({ status: 200, ok: true });
+
+    const mockCma = {
+      entry: {
+        get: vi.fn().mockResolvedValue({
+          sys: {
+            contentType: {
+              sys: {
+                id: 'post',
+              },
+            },
+          },
+          fields: {
+            body: {
+              'en-US': 'https://example.com/ignored-for-locale',
+            },
+            ctaUrl: {
+              'de-DE': 'https://example.com/checked',
+            },
+          },
+        }),
+      },
+      contentType: {
+        get: vi.fn().mockResolvedValue({
+          fields: [
+            { id: 'body', name: 'Body', type: 'Text' },
+            { id: 'ctaUrl', name: 'CTA URL', type: 'Symbol' },
+          ],
+        }),
+      },
+    };
+
+    const result = await handler(
+      {
+        body: {
+          entryId: 'entry-123',
+          locale: 'de-DE',
+        },
+      },
+      {
+        cma: mockCma as any,
+        appInstallationParameters: {},
+      } as any
+    );
+
+    expect(result.checkedFieldIds).toEqual(['ctaUrl']);
+    expect(result.checkedCount).toBe(1);
+    expect(result.results[0].fieldId).toBe('ctaUrl');
+  });
+
+  it('uses hostname-aware allow list matching for all-fields scans', async () => {
+    const mockCma = {
+      entry: {
+        get: vi.fn().mockResolvedValue({
+          sys: {
+            contentType: {
+              sys: {
+                id: 'post',
+              },
+            },
+          },
+          fields: {
+            ctaUrl: {
+              'en-US': 'https://notcontentful.com/landing',
+            },
+          },
+        }),
+      },
+      contentType: {
+        get: vi.fn().mockResolvedValue({
+          fields: [{ id: 'ctaUrl', name: 'CTA URL', type: 'Symbol' }],
+        }),
+      },
+    };
+
+    const result = await handler(
+      {
+        body: {
+          entryId: 'entry-123',
+        },
+      },
+      {
+        cma: mockCma as any,
+        appInstallationParameters: {
+          allowedUrlPatterns: 'contentful.com',
+        },
+      } as any
+    );
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(result.invalidCount).toBe(1);
+    expect(result.results[0].error).toBe('Not on allow list');
+  });
+});

--- a/apps/link-checker/__tests__/functions/checkEntryLinks.spec.ts
+++ b/apps/link-checker/__tests__/functions/checkEntryLinks.spec.ts
@@ -1,0 +1,217 @@
+import { handler } from '../../functions/checkEntryLinks';
+import { vi } from 'vitest';
+
+describe('checkEntryLinks handler', () => {
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+    global.fetch = mockFetch;
+  });
+
+  it('checks links from a targeted rich text field and returns a summary', async () => {
+    mockFetch
+      .mockResolvedValueOnce({ status: 200, ok: true })
+      .mockResolvedValueOnce({ status: 404, ok: false })
+      .mockResolvedValueOnce({ status: 404, ok: false });
+
+    const mockCma = {
+      entry: {
+        get: vi.fn().mockResolvedValue({
+          sys: {
+            contentType: {
+              sys: {
+                id: 'post',
+              },
+            },
+          },
+          fields: {
+            body: {
+              'en-US': {
+                nodeType: 'document',
+                content: [
+                  {
+                    nodeType: 'paragraph',
+                    content: [
+                      {
+                        nodeType: 'hyperlink',
+                        data: { uri: 'https://example.com/healthy' },
+                        content: [{ nodeType: 'text', value: 'healthy' }],
+                      },
+                      {
+                        nodeType: 'text',
+                        value: ' and ',
+                      },
+                      {
+                        nodeType: 'hyperlink',
+                        data: { uri: 'https://example.com/missing' },
+                        content: [{ nodeType: 'text', value: 'missing' }],
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          },
+        }),
+      },
+      contentType: {
+        get: vi.fn().mockResolvedValue({
+          fields: [{ id: 'body', name: 'Body', type: 'RichText' }],
+        }),
+      },
+    };
+
+    const result = await handler(
+      {
+        body: {
+          entryId: 'entry-123',
+          fieldId: 'body',
+          locale: 'en-US',
+        },
+      },
+      {
+        cma: mockCma as any,
+        appInstallationParameters: {},
+      } as any
+    );
+
+    expect(result.checkedCount).toBe(2);
+    expect(result.validCount).toBe(1);
+    expect(result.invalidCount).toBe(1);
+    expect(result.skippedCount).toBe(0);
+    expect(result.summary).toContain('Link Checker scanned 2 link(s)');
+    expect(result.summary).toContain('https://example.com/healthy: HTTP 200');
+    expect(result.summary).toContain('https://example.com/missing: HTTP 404');
+  });
+
+  it('resolves relative links with the configured base URL', async () => {
+    mockFetch.mockResolvedValueOnce({ status: 200, ok: true });
+
+    const mockCma = {
+      entry: {
+        get: vi.fn().mockResolvedValue({
+          sys: {
+            contentType: {
+              sys: {
+                id: 'post',
+              },
+            },
+          },
+          fields: {
+            body: {
+              'en-US': 'See /pricing for details.',
+            },
+          },
+        }),
+      },
+      contentType: {
+        get: vi.fn().mockResolvedValue({
+          fields: [{ id: 'body', name: 'Body', type: 'Text' }],
+        }),
+      },
+    };
+
+    const result = await handler(
+      {
+        body: {
+          entryId: 'entry-123',
+          fieldId: 'body',
+        },
+      },
+      {
+        cma: mockCma as any,
+        appInstallationParameters: {
+          baseUrl: 'https://www.contentful.com',
+        },
+      } as any
+    );
+
+    expect(result.checkedCount).toBe(1);
+    expect(result.results[0].resolvedUrl).toBe('https://www.contentful.com/pricing');
+  });
+
+  it('marks links invalid when they violate allow and deny lists', async () => {
+    const mockCma = {
+      entry: {
+        get: vi.fn().mockResolvedValue({
+          sys: {
+            contentType: {
+              sys: {
+                id: 'post',
+              },
+            },
+          },
+          fields: {
+            body: {
+              'en-US': 'Links: https://blocked.example.com and https://private.contentful.com',
+            },
+          },
+        }),
+      },
+      contentType: {
+        get: vi.fn().mockResolvedValue({
+          fields: [{ id: 'body', name: 'Body', type: 'Text' }],
+        }),
+      },
+    };
+
+    const result = await handler(
+      {
+        body: {
+          entryId: 'entry-123',
+          fieldId: 'body',
+        },
+      },
+      {
+        cma: mockCma as any,
+        appInstallationParameters: {
+          allowedUrlPatterns: 'contentful.com',
+          forbiddenUrlPatterns: 'private.contentful.com',
+        },
+      } as any
+    );
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(result.invalidCount).toBe(2);
+    expect(result.results[0].error).toBe('Not on allow list');
+    expect(result.results[1].error).toBe('On deny list');
+  });
+
+  it('throws when the requested field does not exist', async () => {
+    const mockCma = {
+      entry: {
+        get: vi.fn().mockResolvedValue({
+          sys: {
+            contentType: {
+              sys: {
+                id: 'post',
+              },
+            },
+          },
+          fields: {},
+        }),
+      },
+      contentType: {
+        get: vi.fn().mockResolvedValue({
+          fields: [{ id: 'body', name: 'Body', type: 'RichText' }],
+        }),
+      },
+    };
+
+    await expect(
+      handler(
+        {
+          body: {
+            entryId: 'entry-123',
+            fieldId: 'missingField',
+          },
+        },
+        {
+          cma: mockCma as any,
+          appInstallationParameters: {},
+        } as any
+      )
+    ).rejects.toThrow('Field missingField was not found on the content type.');
+  });
+});

--- a/apps/link-checker/contentful-app-manifest.json
+++ b/apps/link-checker/contentful-app-manifest.json
@@ -21,6 +21,50 @@
         "*.net",
         "*.org"
       ]
+    },
+    {
+      "id": "checkEntryLinks",
+      "name": "Check Entry Field Links",
+      "description": "Checks links extracted from a specific entry field and returns a summary for automations.",
+      "path": "functions/checkEntryLinks.js",
+      "entryFile": "functions/checkEntryLinks.ts",
+      "accepts": [
+        "appaction.call"
+      ],
+      "allowNetworks": [
+        "*.ai",
+        "*.app",
+        "*.co",
+        "*.com",
+        "*.dev",
+        "*.edu",
+        "*.gov",
+        "*.io",
+        "*.net",
+        "*.org"
+      ]
+    },
+    {
+      "id": "checkAllEntryLinks",
+      "name": "Check All Entry Links",
+      "description": "Checks links across supported fields on an entry and returns a summary for automations.",
+      "path": "functions/checkAllEntryLinks.js",
+      "entryFile": "functions/checkAllEntryLinks.ts",
+      "accepts": [
+        "appaction.call"
+      ],
+      "allowNetworks": [
+        "*.ai",
+        "*.app",
+        "*.co",
+        "*.com",
+        "*.dev",
+        "*.edu",
+        "*.gov",
+        "*.io",
+        "*.net",
+        "*.org"
+      ]
     }
   ],
   "actions": [
@@ -37,6 +81,56 @@
           "name": "URL",
           "type": "Symbol",
           "required": true
+        }
+      ]
+    },
+    {
+      "id": "checkEntryLinks",
+      "name": "Check Entry Field Links",
+      "description": "Checks links extracted from a specific entry field and returns a summary for automations.",
+      "type": "function-invocation",
+      "functionId": "checkEntryLinks",
+      "category": "Custom",
+      "parameters": [
+        {
+          "id": "entryId",
+          "name": "Entry ID",
+          "type": "Symbol",
+          "required": true
+        },
+        {
+          "id": "fieldId",
+          "name": "Field ID",
+          "type": "Symbol",
+          "required": true
+        },
+        {
+          "id": "locale",
+          "name": "Locale",
+          "type": "Symbol",
+          "required": false
+        }
+      ]
+    },
+    {
+      "id": "checkAllEntryLinks",
+      "name": "Check All Entry Links",
+      "description": "Checks links across supported fields on an entry and returns a summary for automations.",
+      "type": "function-invocation",
+      "functionId": "checkAllEntryLinks",
+      "category": "Custom",
+      "parameters": [
+        {
+          "id": "entryId",
+          "name": "Entry ID",
+          "type": "Symbol",
+          "required": true
+        },
+        {
+          "id": "locale",
+          "name": "Locale",
+          "type": "Symbol",
+          "required": false
         }
       ]
     }

--- a/apps/link-checker/functions/checkAllEntryLinks.ts
+++ b/apps/link-checker/functions/checkAllEntryLinks.ts
@@ -1,0 +1,29 @@
+import { FunctionEventContext } from '@contentful/node-apps-toolkit';
+import { PlainClientAPI } from 'contentful-management';
+import { checkAllEntryLinks, type CheckAllEntryLinksParameters, type CheckAllEntryLinksResponse } from './checkEntryLinks';
+
+interface CheckAllEntryLinksEvent {
+  body?: CheckAllEntryLinksParameters;
+}
+
+export const handler = async (
+  event: CheckAllEntryLinksEvent,
+  context: FunctionEventContext & {
+    cma?: PlainClientAPI;
+    appInstallationParameters?: {
+      allowedUrlPatterns?: string;
+      forbiddenUrlPatterns?: string;
+      baseUrl?: string;
+    };
+  }
+): Promise<CheckAllEntryLinksResponse> => {
+  const entryId = event?.body?.entryId?.trim();
+  const locale = event?.body?.locale?.trim();
+  const fieldIds = event?.body?.fieldIds?.map((fieldId) => fieldId.trim()).filter(Boolean);
+
+  if (!entryId) {
+    throw new Error('entryId is required');
+  }
+
+  return checkAllEntryLinks(entryId, locale, fieldIds, context);
+};

--- a/apps/link-checker/functions/checkEntryLinks.ts
+++ b/apps/link-checker/functions/checkEntryLinks.ts
@@ -1,0 +1,454 @@
+import { FunctionEventContext } from '@contentful/node-apps-toolkit';
+import { createClient, PlainClientAPI } from 'contentful-management';
+import { extractUrlsFromEntry, isRelativeUrl, type ExtractedUrl } from '../utils/extractUrls';
+import { normalizeDomainPattern, urlMatchesAnyDomainPattern } from '../utils/domainPatterns';
+import { checkUrl, type CheckLinkResult } from './checkLink';
+
+interface CheckEntryLinksParameters {
+  entryId?: string;
+  fieldId?: string;
+  locale?: string;
+}
+
+interface CheckEntryLinksEvent {
+  body?: CheckEntryLinksParameters;
+}
+
+interface ContentTypeField {
+  id: string;
+  name?: string;
+  type: string;
+}
+
+interface RichEntryField {
+  [locale: string]: unknown;
+}
+
+interface EntryLikeField {
+  id: string;
+  name: string;
+  type: string;
+  locales: string[];
+  getValue: (locale?: string) => unknown;
+}
+
+interface EntryLike {
+  fields: Record<string, EntryLikeField>;
+}
+
+interface EntryLinkResult extends CheckLinkResult {
+  url: string;
+  resolvedUrl?: string;
+  fieldId: string;
+  fieldName: string;
+  locale: string;
+  isValid: boolean;
+  isBlockedByAllowList: boolean;
+  isOnDenyList: boolean;
+}
+
+interface AppInstallationParameters {
+  allowedUrlPatterns?: string;
+  forbiddenUrlPatterns?: string;
+  baseUrl?: string;
+}
+
+interface CheckEntryLinksResponse {
+  entryId: string;
+  fieldId: string;
+  locale?: string;
+  checkedCount: number;
+  validCount: number;
+  invalidCount: number;
+  skippedCount: number;
+  summary: string;
+  results: EntryLinkResult[];
+}
+
+export interface CheckAllEntryLinksParameters {
+  entryId?: string;
+  locale?: string;
+  fieldIds?: string[];
+}
+
+export interface CheckAllEntryLinksResponse {
+  entryId: string;
+  locale?: string;
+  checkedFieldIds: string[];
+  checkedCount: number;
+  validCount: number;
+  invalidCount: number;
+  skippedCount: number;
+  summary: string;
+  results: EntryLinkResult[];
+}
+
+function isSuccessStatus(status: number): boolean {
+  return status >= 200 && status < 300;
+}
+
+function isUrlOnDenyList(url: string, patterns: string[]): boolean {
+  if (!patterns.length) return false;
+  return urlMatchesAnyDomainPattern(url, patterns);
+}
+
+function isUrlAllowedByAllowList(url: string, patterns: string[]): boolean {
+  if (!patterns.length) return true;
+  return urlMatchesAnyDomainPattern(url, patterns);
+}
+
+function initContentfulManagementClient(context: FunctionEventContext): PlainClientAPI {
+  if (!context.cmaClientOptions) {
+    throw new Error(
+      'Contentful Management API client options are only provided for certain function types.'
+    );
+  }
+
+  return createClient(context.cmaClientOptions, {
+    type: 'plain',
+    defaults: {
+      spaceId: context.spaceId,
+      environmentId: context.environmentId,
+    },
+  });
+}
+
+function getAvailableLocales(
+  fieldValues: RichEntryField,
+  targetLocale?: string,
+  options: { skipMissingRequestedLocale?: boolean } = {}
+): string[] {
+  const availableLocales = Object.keys(fieldValues);
+  const locales = targetLocale
+    ? availableLocales.filter((itemLocale) => itemLocale === targetLocale)
+    : availableLocales;
+
+  if (targetLocale && locales.length === 0) {
+    if (options.skipMissingRequestedLocale) {
+      return [];
+    }
+    throw new Error('Requested locale is not available on the target field.');
+  }
+
+  return locales;
+}
+
+function buildEntryLike(
+  contentTypeFields: ContentTypeField[],
+  entryFields: Record<string, RichEntryField>,
+  targetFieldId: string,
+  targetLocale?: string
+): EntryLike {
+  const contentTypeField = contentTypeFields.find((field) => field.id === targetFieldId);
+  if (!contentTypeField) {
+    throw new Error(`Field ${targetFieldId} was not found on the content type.`);
+  }
+
+  const fieldValues = entryFields[targetFieldId];
+  if (!fieldValues || typeof fieldValues !== 'object') {
+    return { fields: {} };
+  }
+
+  const locales = getAvailableLocales(fieldValues, targetLocale);
+
+  return {
+    fields: {
+      [targetFieldId]: {
+        id: targetFieldId,
+        name: contentTypeField.name || targetFieldId,
+        type: contentTypeField.type,
+        locales,
+        getValue: (locale?: string) => {
+          if (!locale) return undefined;
+          return fieldValues[locale];
+        },
+      },
+    },
+  };
+}
+
+function buildEntryLikeForFields(
+  contentTypeFields: ContentTypeField[],
+  entryFields: Record<string, RichEntryField>,
+  fieldIds?: string[],
+  targetLocale?: string
+): EntryLike {
+  const supportedFieldTypes = new Set(['Symbol', 'Text', 'RichText', 'Array']);
+  const requestedFieldIds = fieldIds?.filter(Boolean);
+  const selectedFields =
+    requestedFieldIds && requestedFieldIds.length > 0
+      ? requestedFieldIds.map((fieldId) => {
+          const field = contentTypeFields.find((item) => item.id === fieldId);
+          if (!field) {
+            throw new Error(`Field ${fieldId} was not found on the content type.`);
+          }
+          return field;
+        })
+      : contentTypeFields.filter((field) => supportedFieldTypes.has(field.type));
+
+  const fields = selectedFields.reduce<Record<string, EntryLikeField>>((acc, field) => {
+    const fieldValues = entryFields[field.id];
+    if (!fieldValues || typeof fieldValues !== 'object') {
+      return acc;
+    }
+
+    const locales = getAvailableLocales(fieldValues, targetLocale, {
+      skipMissingRequestedLocale: true,
+    });
+    if (locales.length === 0) {
+      return acc;
+    }
+    acc[field.id] = {
+      id: field.id,
+      name: field.name || field.id,
+      type: field.type,
+      locales,
+      getValue: (locale?: string) => {
+        if (!locale) return undefined;
+        return fieldValues[locale];
+      },
+    };
+    return acc;
+  }, {});
+
+  return { fields };
+}
+
+function buildSummary(
+  entryId: string,
+  fieldName: string,
+  response: Omit<CheckEntryLinksResponse, 'summary'>
+): string {
+  const localeText = response.locale ? ` (${response.locale})` : '';
+  const headline = `Link Checker scanned ${response.checkedCount} link(s) in ${fieldName}${localeText} on entry ${entryId}.`;
+  const counts = `${response.validCount} valid, ${response.invalidCount} invalid, ${response.skippedCount} skipped.`;
+
+  if (!response.results.length) {
+    return `${headline} No links were found.`;
+  }
+
+  const details = response.results
+    .map((result) => {
+      const target = result.resolvedUrl ?? result.url;
+      if (result.isBlockedByAllowList) {
+        return `- ${target}: blocked by allow list`;
+      }
+      if (result.isOnDenyList) {
+        return `- ${target}: blocked by deny list`;
+      }
+      if (result.error) {
+        return `- ${target}: ${result.error}`;
+      }
+      if (result.status != null) {
+        return `- ${target}: HTTP ${result.status}`;
+      }
+      return `- ${target}: no result`;
+    })
+    .join('\n');
+
+  return `${headline} ${counts}\n${details}`;
+}
+
+async function checkExtractedUrls(
+  extracted: ExtractedUrl[],
+  installationParameters: AppInstallationParameters
+): Promise<Omit<CheckEntryLinksResponse, 'entryId' | 'fieldId' | 'locale' | 'summary'>> {
+  const explicitAllowedPatterns = (installationParameters.allowedUrlPatterns || '')
+    .split(',')
+    .map((pattern) => normalizeDomainPattern(pattern))
+    .filter(Boolean);
+  const forbiddenPatterns = (installationParameters.forbiddenUrlPatterns || '')
+    .split(',')
+    .map((pattern) => normalizeDomainPattern(pattern))
+    .filter(Boolean);
+  const baseUrl = (installationParameters.baseUrl || '').trim().replace(/\/$/, '') || null;
+
+  const results: EntryLinkResult[] = [];
+  let skippedCount = 0;
+
+  for (const item of extracted) {
+    let resolvedUrl = item.url;
+
+    if (isRelativeUrl(item.url)) {
+      if (!baseUrl) {
+        skippedCount += 1;
+        continue;
+      }
+
+      try {
+        resolvedUrl = new URL(
+          item.url,
+          baseUrl.startsWith('http') ? baseUrl : `https://${baseUrl}`
+        ).href;
+      } catch {
+        skippedCount += 1;
+        continue;
+      }
+    }
+
+    const isBlockedByAllowList = !isUrlAllowedByAllowList(resolvedUrl, explicitAllowedPatterns);
+    const isOnDenyList = isUrlOnDenyList(resolvedUrl, forbiddenPatterns);
+
+    if (isBlockedByAllowList || isOnDenyList) {
+      results.push({
+        ...item,
+        resolvedUrl,
+        isBlockedByAllowList,
+        isOnDenyList,
+        isValid: false,
+        error: isBlockedByAllowList ? 'Not on allow list' : 'On deny list',
+      });
+      continue;
+    }
+
+    const checkResult = await checkUrl(resolvedUrl);
+    const isValid = checkResult.status != null ? isSuccessStatus(checkResult.status) : false;
+
+    results.push({
+      ...item,
+      ...checkResult,
+      resolvedUrl,
+      isBlockedByAllowList: false,
+      isOnDenyList: false,
+      isValid,
+    });
+  }
+
+  const validCount = results.filter((result) => result.isValid).length;
+
+  return {
+    checkedCount: results.length,
+    validCount,
+    invalidCount: results.length - validCount,
+    skippedCount,
+    results,
+  };
+}
+
+function buildAllFieldsSummary(response: CheckAllEntryLinksResponse): string {
+  const localeText = response.locale ? ` (${response.locale})` : '';
+  const fieldList =
+    response.checkedFieldIds.length > 0 ? response.checkedFieldIds.join(', ') : 'no fields';
+  const headline = `Link Checker scanned ${response.checkedCount} link(s) across ${response.checkedFieldIds.length} field(s)${localeText} on entry ${response.entryId}.`;
+  const counts = `${response.validCount} valid, ${response.invalidCount} invalid, ${response.skippedCount} skipped.`;
+
+  if (!response.results.length) {
+    return `${headline} Checked fields: ${fieldList}. No links were found.`;
+  }
+
+  const details = response.results
+    .map((result) => {
+      const target = result.resolvedUrl ?? result.url;
+      if (result.isBlockedByAllowList) {
+        return `- ${result.fieldName} (${result.locale}): ${target} blocked by allow list`;
+      }
+      if (result.isOnDenyList) {
+        return `- ${result.fieldName} (${result.locale}): ${target} blocked by deny list`;
+      }
+      if (result.error) {
+        return `- ${result.fieldName} (${result.locale}): ${target} ${result.error}`;
+      }
+      if (result.status != null) {
+        return `- ${result.fieldName} (${result.locale}): ${target} HTTP ${result.status}`;
+      }
+      return `- ${result.fieldName} (${result.locale}): ${target} no result`;
+    })
+    .join('\n');
+
+  return `${headline} Checked fields: ${fieldList}. ${counts}\n${details}`;
+}
+
+export async function checkEntryFieldLinks(
+  entryId: string,
+  fieldId: string,
+  locale: string | undefined,
+  context: FunctionEventContext & {
+    cma?: PlainClientAPI;
+    appInstallationParameters?: AppInstallationParameters;
+  }
+): Promise<CheckEntryLinksResponse> {
+  const cma = context.cma ?? initContentfulManagementClient(context);
+  const entry = await cma.entry.get({ entryId });
+  const contentTypeId = entry.sys.contentType.sys.id;
+  const contentType = await cma.contentType.get({ contentTypeId });
+
+  const entryLike = buildEntryLike(
+    (contentType.fields || []) as ContentTypeField[],
+    (entry.fields || {}) as Record<string, RichEntryField>,
+    fieldId,
+    locale
+  );
+  const extracted = extractUrlsFromEntry(entryLike);
+
+  const counts = await checkExtractedUrls(extracted, context.appInstallationParameters || {});
+  const fieldName = entryLike.fields[fieldId]?.name || fieldId;
+
+  return {
+    entryId,
+    fieldId,
+    locale,
+    ...counts,
+    summary: buildSummary(entryId, fieldName, {
+      entryId,
+      fieldId,
+      locale,
+      ...counts,
+    }),
+  };
+}
+
+export async function checkAllEntryLinks(
+  entryId: string,
+  locale: string | undefined,
+  fieldIds: string[] | undefined,
+  context: FunctionEventContext & {
+    cma?: PlainClientAPI;
+    appInstallationParameters?: AppInstallationParameters;
+  }
+): Promise<CheckAllEntryLinksResponse> {
+  const cma = context.cma ?? initContentfulManagementClient(context);
+  const entry = await cma.entry.get({ entryId });
+  const contentTypeId = entry.sys.contentType.sys.id;
+  const contentType = await cma.contentType.get({ contentTypeId });
+
+  const entryLike = buildEntryLikeForFields(
+    (contentType.fields || []) as ContentTypeField[],
+    (entry.fields || {}) as Record<string, RichEntryField>,
+    fieldIds,
+    locale
+  );
+  const extracted = extractUrlsFromEntry(entryLike);
+  const counts = await checkExtractedUrls(extracted, context.appInstallationParameters || {});
+  const checkedFieldIds = Object.keys(entryLike.fields);
+
+  const response: CheckAllEntryLinksResponse = {
+    entryId,
+    locale,
+    checkedFieldIds,
+    ...counts,
+    summary: '',
+  };
+  response.summary = buildAllFieldsSummary(response);
+  return response;
+}
+
+export const handler = async (
+  event: CheckEntryLinksEvent,
+  context: FunctionEventContext & {
+    cma?: PlainClientAPI;
+    appInstallationParameters?: AppInstallationParameters;
+  }
+): Promise<CheckEntryLinksResponse> => {
+  const entryId = event?.body?.entryId?.trim();
+  const fieldId = event?.body?.fieldId?.trim();
+  const locale = event?.body?.locale?.trim();
+
+  if (!entryId) {
+    throw new Error('entryId is required');
+  }
+  if (!fieldId) {
+    throw new Error('fieldId is required');
+  }
+
+  return checkEntryFieldLinks(entryId, fieldId, locale, context);
+};

--- a/apps/link-checker/functions/checkLink.ts
+++ b/apps/link-checker/functions/checkLink.ts
@@ -6,22 +6,20 @@
 
 const TIMEOUT_MS = 10000;
 
-interface CheckLinkParameters {
+export interface CheckLinkParameters {
   url?: string;
 }
 
-interface CheckLinkEvent {
+export interface CheckLinkEvent {
   body: CheckLinkParameters;
 }
 
-export const handler = async (
-  event: CheckLinkEvent
-): Promise<{ status?: number; error?: string }> => {
-  const url = event?.body?.url;
-  if (typeof url !== 'string' || !url.trim()) {
-    return { error: 'Missing or invalid url parameter' };
-  }
+export interface CheckLinkResult {
+  status?: number;
+  error?: string;
+}
 
+export async function checkUrl(url: string): Promise<CheckLinkResult> {
   const trimmed = url.trim();
   if (!trimmed.startsWith('http://') && !trimmed.startsWith('https://')) {
     return { error: 'URL must use http or https' };
@@ -57,4 +55,15 @@ export const handler = async (
     const message = err instanceof Error ? err.message : 'Request failed';
     return { error: message };
   }
+}
+
+export const handler = async (
+  event: CheckLinkEvent
+): Promise<CheckLinkResult> => {
+  const url = event?.body?.url;
+  if (typeof url !== 'string' || !url.trim()) {
+    return { error: 'Missing or invalid url parameter' };
+  }
+
+  return checkUrl(url);
 };

--- a/apps/link-checker/package-lock.json
+++ b/apps/link-checker/package-lock.json
@@ -12,6 +12,7 @@
         "@contentful/f36-components": "4.45.0",
         "@contentful/f36-multiselect": "^4.81.1",
         "@contentful/f36-tokens": "4.0.2",
+        "@contentful/node-apps-toolkit": "^3.13.0",
         "@contentful/react-apps-toolkit": "1.2.16",
         "react": "18.2.0",
         "react-dom": "18.2.0"
@@ -1361,6 +1362,30 @@
         "react": ">=16.8",
         "react-dom": ">=16.8"
       }
+    },
+    "node_modules/@contentful/node-apps-toolkit": {
+      "version": "3.16.1",
+      "resolved": "https://registry.npmjs.org/@contentful/node-apps-toolkit/-/node-apps-toolkit-3.16.1.tgz",
+      "integrity": "sha512-lCmmtJ2DoCdH7XSEIFajKmp30cDTctkNiJ7r6o8jR6/DxKVfyVZUD4BZKi96wvqner57+55vzDg+P1TJqxHa/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.1.5",
+        "contentful-management": "^11.6.1",
+        "debug": "^4.2.0",
+        "got": "^11.7.0",
+        "jsonwebtoken": "^9.0.0",
+        "lru-cache": "^10.4.3",
+        "runtypes": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@contentful/node-apps-toolkit/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
     },
     "node_modules/@contentful/react-apps-toolkit": {
       "version": "1.2.16",
@@ -3040,6 +3065,30 @@
         "node": ">=20"
       }
     },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "license": "MIT",
+      "dependencies": {
+        "defer-to-connect": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "9.3.4",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.4.tgz",
@@ -3168,6 +3217,18 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/cacheable-request": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "^3.1.4",
+        "@types/node": "*",
+        "@types/responselike": "^1.0.0"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -3177,6 +3238,15 @@
       "dependencies": {
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
       }
     },
     "node_modules/@types/deep-eql": {
@@ -3193,13 +3263,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/keyv": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.19.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
       "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3245,6 +3334,15 @@
       "license": "MIT",
       "dependencies": {
         "@types/react": "*"
+      }
+    },
+    "node_modules/@types/responselike": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/scheduler": {
@@ -3818,12 +3916,45 @@
         "ieee754": "^1.2.1"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
       "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.6.0"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "license": "MIT",
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      },
       "engines": {
         "node": ">=8"
       }
@@ -4011,6 +4142,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/clone-response": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/color-convert": {
@@ -4246,6 +4389,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -4307,6 +4477,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/define-data-property": {
@@ -4443,6 +4622,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.302",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
@@ -4458,6 +4646,15 @@
       "dependencies": {
         "babel-plugin-emotion": "^10.0.27",
         "create-emotion": "^10.0.27"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/enquirer": {
@@ -5144,6 +5341,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/glob": {
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
@@ -5215,6 +5427,31 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/got": {
+      "version": "11.8.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.2",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
       }
     },
     "node_modules/graceful-fs": {
@@ -5319,6 +5556,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -5341,6 +5584,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "license": "MIT",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -6021,7 +6277,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-parse-even-better-errors": {
@@ -6070,11 +6325,53 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
@@ -6122,11 +6419,53 @@
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/log-symbols": {
@@ -6164,6 +6503,15 @@
       "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -6246,6 +6594,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/min-indent": {
@@ -6396,6 +6753,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/nwsapi": {
       "version": "2.2.23",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
@@ -6476,7 +6845,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -6556,6 +6924,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/p-limit": {
@@ -6781,6 +7158,16 @@
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
     },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -6826,6 +7213,18 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/react": {
       "version": "18.2.0",
@@ -7045,6 +7444,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "license": "MIT"
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -7052,6 +7457,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/responselike": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "license": "MIT",
+      "dependencies": {
+        "lowercase-keys": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/restore-cursor": {
@@ -7215,6 +7632,12 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/runtypes": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/runtypes/-/runtypes-5.1.0.tgz",
+      "integrity": "sha512-OMHkz6dxysXj4E8Fj/HCGjtdJUhapQUN7puvqzuzvjaX28pd52PZmEMqQlkIzCfKdhXdM0ghx8PpvELprEnOLQ==",
+      "license": "MIT"
+    },
     "node_modules/rxjs": {
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
@@ -7229,7 +7652,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7291,6 +7713,18 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/set-function-length": {
@@ -7891,7 +8325,6 @@
       "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7904,7 +8337,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/universalify": {
@@ -8850,7 +9282,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ws": {

--- a/apps/link-checker/package.json
+++ b/apps/link-checker/package.json
@@ -29,6 +29,7 @@
     "@contentful/f36-components": "4.45.0",
     "@contentful/f36-multiselect": "^4.81.1",
     "@contentful/f36-tokens": "4.0.2",
+    "@contentful/node-apps-toolkit": "^3.13.0",
     "@contentful/react-apps-toolkit": "1.2.16",
     "react": "18.2.0",
     "react-dom": "18.2.0"


### PR DESCRIPTION
## Summary
- add a new `Check Entry Field Links` app action for automations
- add a new `Check All Entry Links` app action to scan supported fields across an entry
- scan a target entry field like `body` or scan all supported fields and return a Slack-friendly summary of link results
- reuse the existing single-URL checker and add tests for both automation actions

## Testing
- npm run lint
- npm run build
- npm run test:ci -- __tests__/functions/checkLink.spec.ts __tests__/functions/checkEntryLinks.spec.ts __tests__/functions/checkAllEntryLinks.spec.ts __tests__/utils/extractUrls.spec.ts
- npm run build:functions