### PR TITLE
Refine GA4 advanced matching configuration UX []

### DIFF
--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentType.styles.ts
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentType.styles.ts
@@ -15,6 +15,13 @@ export const styles = {
     flexWrap: 'wrap',
     width: '100%',
   }),
+  advancedMatchingGroup: css({
+    background: '#F7FAFC',
+    border: '1px solid #D5DFE5',
+    borderRadius: '8px',
+    marginBottom: '16px',
+    padding: '12px',
+  }),
   advancedMatchingTopRow: css({
     alignItems: 'flex-start',
     display: 'flex',
@@ -32,10 +39,10 @@ export const styles = {
     flex: 4,
   }),
   advancedMatchingPanel: css({
-    background: '#FCFDFD',
+    background: '#FFFFFF',
     border: '1px solid #E5EBED',
     borderRadius: '6px',
-    marginTop: '4px',
+    marginTop: '8px',
     padding: '10px 12px 12px',
     width: '100%',
   }),
@@ -47,6 +54,17 @@ export const styles = {
     alignItems: 'center',
     display: 'flex',
     gap: '12px',
+    width: '100%',
+  }),
+  baseRowPanel: css({
+    background: '#FFFFFF',
+    border: '1px solid #E5EBED',
+    borderRadius: '6px',
+    padding: '12px',
+    width: '100%',
+  }),
+  rowSpacing: css({
+    marginBottom: '16px',
     width: '100%',
   }),
   removeItem: css({

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeCard.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeCard.spec.tsx
@@ -38,9 +38,11 @@ describe('Assign Content Type Card for Config Screen', () => {
         contentTypeRules={contentTypeRules}
         onContentTypeChange={() => {}}
         onContentTypeFieldChange={() => {}}
+        onContentTypeRuleChange={() => {}}
         onRemoveContentType={() => {}}
         currentEditorInterface={{}}
         originalContentTypeRules={[]}
+        rulesMissingPattern={new Set()}
       />
     );
 
@@ -58,9 +60,11 @@ describe('Assign Content Type Card for Config Screen', () => {
         contentTypeRules={contentTypeRules}
         onContentTypeChange={() => {}}
         onContentTypeFieldChange={() => {}}
+        onContentTypeRuleChange={() => {}}
         onRemoveContentType={() => {}}
         currentEditorInterface={{}}
         originalContentTypeRules={[]}
+        rulesMissingPattern={new Set()}
       />
     );
 

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeCard.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeCard.tsx
@@ -2,7 +2,7 @@ import { Box, Card, Flex, FormControl, Tooltip } from '@contentful/f36-component
 import { HelpCircleIcon } from '@contentful/f36-icons';
 import { styles } from 'components/config-screen/assign-content-type/AssignContentType.styles';
 import { EditorInterface } from '@contentful/app-sdk';
-import { AllContentTypes, AllContentTypeEntries, ContentTypeRules } from 'types';
+import { AllContentTypes, AllContentTypeEntries, ContentTypeRule, ContentTypeRules } from 'types';
 import AssignContentTypeRow from 'components/config-screen/assign-content-type/AssignContentTypeRow';
 
 interface AssignContentTypeCardProps {
@@ -15,9 +15,11 @@ interface AssignContentTypeCardProps {
     field: string,
     value: string | boolean | string[]
   ) => void;
+  onContentTypeRuleChange: (ruleId: string, updates: Partial<ContentTypeRule>) => void;
   onRemoveContentType: (ruleId: string) => void;
   currentEditorInterface: Partial<EditorInterface>;
   originalContentTypeRules: ContentTypeRules;
+  rulesMissingPattern: Set<string>;
 }
 
 interface HeaderLabelProps {
@@ -58,9 +60,11 @@ const AssignContentTypeCard = (props: AssignContentTypeCardProps) => {
     contentTypeRules,
     onContentTypeChange,
     onContentTypeFieldChange,
+    onContentTypeRuleChange,
     onRemoveContentType,
     currentEditorInterface,
     originalContentTypeRules,
+    rulesMissingPattern,
   } = props;
 
   return (
@@ -81,7 +85,7 @@ const AssignContentTypeCard = (props: AssignContentTypeCardProps) => {
         <HeaderLabel
           label="Advanced"
           className={styles.toggleItem}
-          helpText="Use advanced matching for query strings or variable prefixes that do not fit the standard URL prefix plus slug setup."
+          helpText="Use advanced matching when the URL needs more than a fixed prefix plus the selected slug field, like query strings or custom path patterns."
         />
         <Box className={styles.removeItem}></Box>
       </Flex>
@@ -96,9 +100,11 @@ const AssignContentTypeCard = (props: AssignContentTypeCardProps) => {
             contentTypeRules={contentTypeRules}
             onContentTypeChange={onContentTypeChange}
             onContentTypeFieldChange={onContentTypeFieldChange}
+            onContentTypeRuleChange={onContentTypeRuleChange}
             onRemoveContentType={onRemoveContentType}
             currentEditorInterface={currentEditorInterface}
             originalContentTypeRules={originalContentTypeRules}
+            isMissingPattern={rulesMissingPattern.has(contentTypeRule.id)}
             focus={index + 1 === contentTypeRules.length}
           />
         );

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeRow.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeRow.spec.tsx
@@ -158,13 +158,10 @@ describe('Assign Content Type Card for Config Screen', () => {
     await user.click(screen.getByTestId('advancedMatchingToggle'));
 
     expect(screen.getByTestId('advancedMatchingPanel')).toBeVisible();
-    expect(onContentTypeRuleChange).toHaveBeenCalledWith(
-      'rule-course',
-      {
-        enableAdvancedMatching: true,
-        pathPattern: '/about/{slug}',
-      }
-    );
+    expect(onContentTypeRuleChange).toHaveBeenCalledWith('rule-course', {
+      enableAdvancedMatching: true,
+      pathPattern: '/about/{slug}',
+    });
   });
 
   it('shows advanced matching controls when a row is already configured for them', () => {
@@ -205,16 +202,13 @@ describe('Assign Content Type Card for Config Screen', () => {
     await user.click(screen.getByTestId('advancedMatchingToggle'));
 
     expect(screen.queryByTestId('advancedMatchingPanel')).not.toBeInTheDocument();
-    expect(onContentTypeRuleChange).toHaveBeenCalledWith(
-      'rule-course',
-      {
-        enableAdvancedMatching: false,
-        additionalFieldIds: [],
-        pathPattern: '',
-        matchDimension: 'unifiedPagePathScreen',
-        matchType: 'EXACT',
-      }
-    );
+    expect(onContentTypeRuleChange).toHaveBeenCalledWith('rule-course', {
+      enableAdvancedMatching: false,
+      additionalFieldIds: [],
+      pathPattern: '',
+      matchDimension: 'unifiedPagePathScreen',
+      matchType: 'EXACT',
+    });
   });
 
   it('shows a preview with additional page property tokens when configured', () => {
@@ -393,13 +387,10 @@ describe('Assign Content Type Card for Config Screen', () => {
 
     await user.click(screen.getByTestId('additionalFieldOption-sectionSlug'));
 
-    expect(onContentTypeRuleChange).toHaveBeenCalledWith(
-      'rule-category',
-      {
-        additionalFieldIds: ['sectionSlug'],
-        pathPattern: '/search/{slug}?sectionSlug={sectionSlug}',
-      }
-    );
+    expect(onContentTypeRuleChange).toHaveBeenCalledWith('rule-category', {
+      additionalFieldIds: ['sectionSlug'],
+      pathPattern: '/search/{slug}?sectionSlug={sectionSlug}',
+    });
   });
 
   it('updates the generated pattern when selected page-path fields change', async () => {
@@ -422,13 +413,10 @@ describe('Assign Content Type Card for Config Screen', () => {
 
     await user.click(screen.getByTestId('additionalFieldOption-sectionSlug'));
 
-    expect(onContentTypeRuleChange).toHaveBeenCalledWith(
-      'rule-category',
-      {
-        additionalFieldIds: ['sectionSlug'],
-        pathPattern: '/{sectionSlug}/{slug}',
-      }
-    );
+    expect(onContentTypeRuleChange).toHaveBeenCalledWith('rule-category', {
+      additionalFieldIds: ['sectionSlug'],
+      pathPattern: '/{sectionSlug}/{slug}',
+    });
   });
 
   it('does not overwrite a custom pattern when selected query-string fields change', async () => {
@@ -451,11 +439,9 @@ describe('Assign Content Type Card for Config Screen', () => {
 
     await user.click(screen.getByTestId('additionalFieldOption-sectionSlug'));
 
-    expect(onContentTypeFieldChange).toHaveBeenCalledWith(
-      'rule-category',
-      'additionalFieldIds',
-      ['sectionSlug']
-    );
+    expect(onContentTypeFieldChange).toHaveBeenCalledWith('rule-category', 'additionalFieldIds', [
+      'sectionSlug',
+    ]);
   });
 
   it('calls field change handler when matching mode selection is changed', async () => {

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeRow.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeRow.spec.tsx
@@ -46,14 +46,17 @@ const contentTypeRules: ContentTypeRules = [
 const onRemoveContentType = vi.fn();
 const onContentTypeChange = vi.fn();
 const onContentTypeFieldChange = vi.fn();
+const onContentTypeRuleChange = vi.fn();
 
 const props = {
   index: 0,
   allContentTypes,
   allContentTypeEntries,
   contentTypeRules,
+  isMissingPattern: false,
   onContentTypeChange,
   onContentTypeFieldChange,
+  onContentTypeRuleChange,
   onRemoveContentType,
   currentEditorInterface: {},
   originalContentTypeRules: [],
@@ -147,7 +150,7 @@ describe('Assign Content Type Card for Config Screen', () => {
     const user = userEvent.setup();
     render(
       <AssignContentTypeRow
-        contentTypeRule={{ ...contentTypeRules[0], urlPrefix: '' }}
+        contentTypeRule={{ ...contentTypeRules[0], urlPrefix: '/about' }}
         {...props}
       />
     );
@@ -155,10 +158,12 @@ describe('Assign Content Type Card for Config Screen', () => {
     await user.click(screen.getByTestId('advancedMatchingToggle'));
 
     expect(screen.getByTestId('advancedMatchingPanel')).toBeVisible();
-    expect(onContentTypeFieldChange).toHaveBeenCalledWith(
+    expect(onContentTypeRuleChange).toHaveBeenCalledWith(
       'rule-course',
-      'enableAdvancedMatching',
-      true
+      {
+        enableAdvancedMatching: true,
+        pathPattern: '/about/{slug}',
+      }
     );
   });
 
@@ -180,6 +185,38 @@ describe('Assign Content Type Card for Config Screen', () => {
     expect(screen.queryByTestId('urlPrefixInput')).not.toBeInTheDocument();
   });
 
+  it('clears advanced-only fields when advanced matching is turned off', async () => {
+    const user = userEvent.setup();
+    render(
+      <AssignContentTypeRow
+        contentTypeRule={{
+          ...contentTypeRules[0],
+          urlPrefix: '',
+          enableAdvancedMatching: true,
+          additionalFieldIds: ['slug'],
+          pathPattern: '/blog/{slug}',
+          matchDimension: 'pagePathPlusQueryString',
+          matchType: 'PARTIAL_REGEXP',
+        }}
+        {...props}
+      />
+    );
+
+    await user.click(screen.getByTestId('advancedMatchingToggle'));
+
+    expect(screen.queryByTestId('advancedMatchingPanel')).not.toBeInTheDocument();
+    expect(onContentTypeRuleChange).toHaveBeenCalledWith(
+      'rule-course',
+      {
+        enableAdvancedMatching: false,
+        additionalFieldIds: [],
+        pathPattern: '',
+        matchDimension: 'unifiedPagePathScreen',
+        matchType: 'EXACT',
+      }
+    );
+  });
+
   it('shows a preview with additional page property tokens when configured', () => {
     render(
       <AssignContentTypeRow
@@ -196,6 +233,52 @@ describe('Assign Content Type Card for Config Screen', () => {
     );
 
     expect(screen.getByTestId('pathPatternInput')).toHaveValue('/{sectionSlug}/{slug}');
+  });
+
+  it('explains token usage and updated matching terminology in advanced mode', () => {
+    render(
+      <AssignContentTypeRow
+        contentTypeRule={{
+          ...contentTypeRules[1],
+          contentTypeId: 'category',
+          slugField: 'title',
+          enableAdvancedMatching: true,
+          additionalFieldIds: ['sectionSlug'],
+          pathPattern: '/{sectionSlug}/{slug}',
+        }}
+        {...props}
+      />
+    );
+
+    expect(
+      screen.getByText(
+        /A pattern is generated for you automatically\. Edit it if you need a different URL structure/
+      )
+    ).toBeVisible();
+    expect(
+      screen.getByText(/Use the placeholder shown next to each field in the pattern\./)
+    ).toBeVisible();
+    expect(screen.getByText('{sectionSlug}')).toBeVisible();
+    expect(screen.getByRole('option', { name: 'Flexible match' })).toBeInTheDocument();
+  });
+
+  it('shows missing pattern validation inside the advanced panel', () => {
+    render(
+      <AssignContentTypeRow
+        contentTypeRule={{
+          ...contentTypeRules[0],
+          enableAdvancedMatching: true,
+          pathPattern: '',
+        }}
+        {...props}
+        isMissingPattern={true}
+      />
+    );
+
+    expect(screen.getByText('Add a pattern for this advanced rule before saving.')).toBeVisible();
+    expect(screen.getByTestId('advancedMatchingPanel')).toContainElement(
+      screen.getByText('Add a pattern for this advanced rule before saving.')
+    );
   });
 
   it('calls field change handler when path pattern input is changed', async () => {
@@ -235,7 +318,144 @@ describe('Assign Content Type Card for Config Screen', () => {
       'pagePathPlusQueryString',
     ]);
 
-    expect(onContentTypeFieldChange).toHaveBeenCalled();
+    expect(onContentTypeFieldChange).toHaveBeenCalledWith(
+      'rule-course',
+      'matchDimension',
+      'pagePathPlusQueryString'
+    );
+  });
+
+  it('updates the generated pattern when match dimension changes before customization', async () => {
+    const user = userEvent.setup();
+    render(
+      <AssignContentTypeRow
+        contentTypeRule={{
+          ...contentTypeRules[0],
+          urlPrefix: '/article',
+          enableAdvancedMatching: true,
+          pathPattern: '/article/{articleId}/{slug}',
+          additionalFieldIds: ['articleId'],
+        }}
+        allContentTypes={{
+          ...allContentTypes,
+          course: {
+            name: 'Course',
+            fields: [
+              { id: 'slug', name: 'Slug', type: 'Symbol' },
+              { id: 'articleId', name: 'Article ID', type: 'Symbol' },
+            ],
+          },
+        }}
+        allContentTypeEntries={[
+          [
+            'course',
+            {
+              name: 'Course',
+              fields: [
+                { id: 'slug', name: 'Slug', type: 'Symbol' },
+                { id: 'articleId', name: 'Article ID', type: 'Symbol' },
+              ],
+            },
+          ],
+          allContentTypeEntries[1],
+        ]}
+        {...props}
+      />
+    );
+
+    await user.selectOptions(screen.getByTestId('matchDimensionSelect'), [
+      'pagePathPlusQueryString',
+    ]);
+
+    expect(onContentTypeRuleChange).toHaveBeenCalledWith('rule-course', {
+      matchDimension: 'pagePathPlusQueryString',
+      pathPattern: '/article/{slug}?articleId={articleId}',
+    });
+  });
+
+  it('updates the generated pattern when selected query-string fields change', async () => {
+    const user = userEvent.setup();
+    render(
+      <AssignContentTypeRow
+        contentTypeRule={{
+          ...contentTypeRules[1],
+          contentTypeId: 'category',
+          slugField: 'title',
+          urlPrefix: '/search',
+          enableAdvancedMatching: true,
+          pathPattern: '/search/{slug}',
+          matchDimension: 'pagePathPlusQueryString',
+          additionalFieldIds: [],
+        }}
+        {...props}
+      />
+    );
+
+    await user.click(screen.getByTestId('additionalFieldOption-sectionSlug'));
+
+    expect(onContentTypeRuleChange).toHaveBeenCalledWith(
+      'rule-category',
+      {
+        additionalFieldIds: ['sectionSlug'],
+        pathPattern: '/search/{slug}?sectionSlug={sectionSlug}',
+      }
+    );
+  });
+
+  it('updates the generated pattern when selected page-path fields change', async () => {
+    const user = userEvent.setup();
+    render(
+      <AssignContentTypeRow
+        contentTypeRule={{
+          ...contentTypeRules[1],
+          contentTypeId: 'category',
+          slugField: 'title',
+          urlPrefix: '',
+          enableAdvancedMatching: true,
+          pathPattern: '/{slug}',
+          matchDimension: 'unifiedPagePathScreen',
+          additionalFieldIds: [],
+        }}
+        {...props}
+      />
+    );
+
+    await user.click(screen.getByTestId('additionalFieldOption-sectionSlug'));
+
+    expect(onContentTypeRuleChange).toHaveBeenCalledWith(
+      'rule-category',
+      {
+        additionalFieldIds: ['sectionSlug'],
+        pathPattern: '/{sectionSlug}/{slug}',
+      }
+    );
+  });
+
+  it('does not overwrite a custom pattern when selected query-string fields change', async () => {
+    const user = userEvent.setup();
+    render(
+      <AssignContentTypeRow
+        contentTypeRule={{
+          ...contentTypeRules[1],
+          contentTypeId: 'category',
+          slugField: 'title',
+          urlPrefix: '/search',
+          enableAdvancedMatching: true,
+          pathPattern: '/search?category={slug}',
+          matchDimension: 'pagePathPlusQueryString',
+          additionalFieldIds: [],
+        }}
+        {...props}
+      />
+    );
+
+    await user.click(screen.getByTestId('additionalFieldOption-sectionSlug'));
+
+    expect(onContentTypeFieldChange).toHaveBeenCalledWith(
+      'rule-category',
+      'additionalFieldIds',
+      ['sectionSlug']
+    );
   });
 
   it('calls field change handler when matching mode selection is changed', async () => {

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeRow.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeRow.tsx
@@ -279,8 +279,7 @@ const AssignContentTypeRow = (props: Props) => {
             </Note>
           )}
           <Text fontColor="gray600" className={styles.advancedMatchingIntro}>
-            Build a custom URL pattern for query strings, extra path segments, or variable
-            prefixes.
+            Build a custom URL pattern for query strings, extra path segments, or variable prefixes.
           </Text>
           <Box className={styles.advancedMatchingFields}>
             <Flex className={styles.advancedMatchingTopRow}>
@@ -312,7 +311,11 @@ const AssignContentTypeRow = (props: Props) => {
                               return;
                             }
 
-                            onContentTypeFieldChange(ruleId, 'additionalFieldIds', nextSelectedFields);
+                            onContentTypeFieldChange(
+                              ruleId,
+                              'additionalFieldIds',
+                              nextSelectedFields
+                            );
                           }}>
                           <Flex alignItems="center" gap="spacing2Xs">
                             <Text as="span">{field.name}</Text>
@@ -375,26 +378,24 @@ const AssignContentTypeRow = (props: Props) => {
                     name={`matchDimension-${index}`}
                     testId="matchDimensionSelect"
                     isDisabled={!contentTypeId || !isContentTypeInOptions}
-                    onChange={(event: React.ChangeEvent<HTMLSelectElement>) =>
-                      {
-                        const nextMatchDimension = event.target.value;
-                        const currentGeneratedPattern = getGeneratedPattern();
-                        const nextGeneratedPattern = getGeneratedPattern(
-                          additionalFieldIds,
-                          nextMatchDimension as ContentTypeValue['matchDimension']
-                        );
+                    onChange={(event: React.ChangeEvent<HTMLSelectElement>) => {
+                      const nextMatchDimension = event.target.value;
+                      const currentGeneratedPattern = getGeneratedPattern();
+                      const nextGeneratedPattern = getGeneratedPattern(
+                        additionalFieldIds,
+                        nextMatchDimension as ContentTypeValue['matchDimension']
+                      );
 
-                        if (!pathPattern.trim() || pathPattern === currentGeneratedPattern) {
-                          onContentTypeRuleChange(ruleId, {
-                            matchDimension: nextMatchDimension,
-                            pathPattern: nextGeneratedPattern,
-                          });
-                          return;
-                        }
-
-                        onContentTypeFieldChange(ruleId, 'matchDimension', nextMatchDimension);
+                      if (!pathPattern.trim() || pathPattern === currentGeneratedPattern) {
+                        onContentTypeRuleChange(ruleId, {
+                          matchDimension: nextMatchDimension,
+                          pathPattern: nextGeneratedPattern,
+                        });
+                        return;
                       }
-                    }
+
+                      onContentTypeFieldChange(ruleId, 'matchDimension', nextMatchDimension);
+                    }}
                     value={matchDimension}>
                     <Select.Option value="unifiedPagePathScreen">Page path</Select.Option>
                     <Select.Option value="pagePathPlusQueryString">

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeRow.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeRow.tsx
@@ -24,7 +24,6 @@ import {
 } from 'types';
 import ContentTypeWarning from 'components/config-screen/assign-content-type/ContentTypeWarning';
 import { buildDefaultPathPattern } from 'utils/getReportSlug';
-import { hasAdvancedMatchingConfigured } from 'utils/contentTypeMatching';
 
 interface Props {
   contentTypeRule: ContentTypeRule;
@@ -82,9 +81,7 @@ const AssignContentTypeRow = (props: Props) => {
   const [isContentTypeInOptions, setIsContentTypeInOptions] = useState(true);
   const [isSlugFieldInOptions, setIsSlugFieldInOptions] = useState(true);
   const [isInSidebar, setIsInSidebar] = useState(false);
-  const [showAdvancedMatching, setShowAdvancedMatching] = useState(
-    Boolean(enableAdvancedMatching || hasAdvancedMatchingConfigured(contentTypeRule))
-  );
+  const [showAdvancedMatching, setShowAdvancedMatching] = useState(Boolean(enableAdvancedMatching));
 
   useEffect(() => {
     setIsSaved(originalContentTypeRules.some((rule) => rule.id === ruleId));
@@ -111,10 +108,8 @@ const AssignContentTypeRow = (props: Props) => {
   }, [allContentTypeEntries, allContentTypes, contentTypeId, contentTypeRules, isSaved, slugField]);
 
   useEffect(() => {
-    setShowAdvancedMatching(
-      Boolean(enableAdvancedMatching || hasAdvancedMatchingConfigured(contentTypeRule))
-    );
-  }, [contentTypeRule, enableAdvancedMatching]);
+    setShowAdvancedMatching(Boolean(enableAdvancedMatching));
+  }, [enableAdvancedMatching]);
 
   useEffect(() => {
     if (focus) {

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeRow.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeRow.tsx
@@ -4,6 +4,7 @@ import {
   Checkbox,
   Flex,
   FormControl,
+  Note,
   Select,
   Stack,
   Text,
@@ -22,7 +23,7 @@ import {
   ContentTypeValue,
 } from 'types';
 import ContentTypeWarning from 'components/config-screen/assign-content-type/ContentTypeWarning';
-import { pathPatternPreview } from 'utils/getReportSlug';
+import { buildDefaultPathPattern } from 'utils/getReportSlug';
 import { hasAdvancedMatchingConfigured } from 'utils/contentTypeMatching';
 
 interface Props {
@@ -31,12 +32,14 @@ interface Props {
   allContentTypes: AllContentTypes;
   allContentTypeEntries: AllContentTypeEntries;
   contentTypeRules: ContentTypeRules;
+  isMissingPattern: boolean;
   onContentTypeChange: (ruleId: string, newContentTypeId: string) => void;
   onContentTypeFieldChange: (
     ruleId: string,
     field: string,
     value: string | boolean | string[]
   ) => void;
+  onContentTypeRuleChange: (ruleId: string, updates: Partial<ContentTypeRule>) => void;
   onRemoveContentType: (ruleId: string) => void;
   currentEditorInterface: Partial<EditorInterface>;
   originalContentTypeRules: ContentTypeRules;
@@ -50,8 +53,10 @@ const AssignContentTypeRow = (props: Props) => {
     allContentTypes,
     allContentTypeEntries,
     contentTypeRules,
+    isMissingPattern,
     onContentTypeChange,
     onContentTypeFieldChange,
+    onContentTypeRuleChange,
     onRemoveContentType,
     currentEditorInterface,
     originalContentTypeRules,
@@ -138,16 +143,35 @@ const AssignContentTypeRow = (props: Props) => {
     return value;
   };
 
+  const resetAdvancedMatching = () => {
+    onContentTypeRuleChange(ruleId, {
+      enableAdvancedMatching: false,
+      additionalFieldIds: [],
+      pathPattern: '',
+      matchDimension: 'unifiedPagePathScreen',
+      matchType: 'EXACT',
+    });
+  };
+
   const selectableAdditionalFields =
     contentTypeId && allContentTypes[contentTypeId]?.fields
       ? allContentTypes[contentTypeId].fields.filter((field) => field.id !== slugField)
       : [];
 
+  const getGeneratedPattern = (
+    selectedFieldIds = additionalFieldIds,
+    selectedMatchDimension = matchDimension
+  ) => buildDefaultPathPattern(urlPrefix, selectedFieldIds, selectedMatchDimension);
+
   return (
     <Stack
       spacing="spacingS"
-      paddingBottom="spacingS"
       flexDirection="column"
+      className={
+        showAdvancedMatching
+          ? `${styles.advancedMatchingGroup} ${styles.rowSpacing}`
+          : styles.rowSpacing
+      }
       key={contentTypeId}
       testId="contentTypeRow">
       <ContentTypeWarning
@@ -158,89 +182,105 @@ const AssignContentTypeRow = (props: Props) => {
         isContentTypeInOptions={isContentTypeInOptions}
         isSlugFieldInOptions={isSlugFieldInOptions}
       />
-      <Flex className={styles.baseRow}>
-        <Box className={styles.contentTypeItem}>
-          <Select
-            id={`contentType-${index}`}
-            name={`contentType-${index}`}
-            testId="contentTypeSelect"
-            isInvalid={!isContentTypeInOptions && contentTypeId !== ''}
-            onChange={(event: React.ChangeEvent<HTMLSelectElement>) =>
-              onContentTypeChange(ruleId, event.target.value)
-            }
-            value={validateSelectedOption(contentTypeId)}>
-            <Select.Option value="" isDisabled>
-              Select content type
-            </Select.Option>
-            {contentTypeOptions.map(([type, { name: typeName }]) => (
-              <Select.Option value={type} key={`type-${type}`}>
-                {typeName}
+      <Box className={styles.baseRowPanel}>
+        <Flex className={styles.baseRow}>
+          <Box className={styles.contentTypeItem}>
+            <Select
+              id={`contentType-${index}`}
+              name={`contentType-${index}`}
+              testId="contentTypeSelect"
+              isInvalid={!isContentTypeInOptions && contentTypeId !== ''}
+              onChange={(event: React.ChangeEvent<HTMLSelectElement>) =>
+                onContentTypeChange(ruleId, event.target.value)
+              }
+              value={validateSelectedOption(contentTypeId)}>
+              <Select.Option value="" isDisabled>
+                Select content type
               </Select.Option>
-            ))}
-          </Select>
-        </Box>
-        <Box className={styles.contentTypeItem}>
-          <Select
-            id={`slugField-${index}`}
-            name={`slugField-${index}`}
-            testId="slugFieldSelect"
-            isDisabled={!contentTypeId || !isContentTypeInOptions}
-            onChange={(event: React.ChangeEvent<HTMLSelectElement>) =>
-              onContentTypeFieldChange(ruleId, 'slugField', event.target.value)
-            }
-            value={validateSelectedOption(contentTypeId, slugField)}>
-            <Select.Option value="" isDisabled>
-              Select slug field
-            </Select.Option>
-            {contentTypeId &&
-              allContentTypes[contentTypeId]?.fields?.map((field) => (
-                <Select.Option key={`${contentTypeId}.${field.id}`} value={field.id}>
-                  {field.name}
+              {contentTypeOptions.map(([type, { name: typeName }]) => (
+                <Select.Option value={type} key={`type-${type}`}>
+                  {typeName}
                 </Select.Option>
               ))}
-          </Select>
-        </Box>
-        <Box className={styles.urlPrefixItem}>
-          {!showAdvancedMatching ? (
-            <TextInput
-              id={`urlPrefix-${index}`}
-              name={`urlPrefix-${index}`}
-              testId="urlPrefixInput"
+            </Select>
+          </Box>
+          <Box className={styles.contentTypeItem}>
+            <Select
+              id={`slugField-${index}`}
+              name={`slugField-${index}`}
+              testId="slugFieldSelect"
               isDisabled={!contentTypeId || !isContentTypeInOptions}
-              onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
-                onContentTypeFieldChange(ruleId, 'urlPrefix', event.target.value)
+              onChange={(event: React.ChangeEvent<HTMLSelectElement>) =>
+                onContentTypeFieldChange(ruleId, 'slugField', event.target.value)
               }
-              value={urlPrefix}
-            />
-          ) : (
-            <Text fontColor="gray500">Configured below</Text>
-          )}
-        </Box>
-        <Box className={styles.toggleItem}>
-          <Checkbox
-            id={`advancedMatching-${index}`}
-            name={`advancedMatching-${index}`}
-            testId="advancedMatchingToggle"
-            isChecked={showAdvancedMatching}
-            isDisabled={!contentTypeId || !isContentTypeInOptions}
-            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-              const nextIsAdvanced = event.target.checked;
-              setShowAdvancedMatching(nextIsAdvanced);
-              onContentTypeFieldChange(ruleId, 'enableAdvancedMatching', nextIsAdvanced);
-            }}>
-            Advanced
-          </Checkbox>
-        </Box>
-        <Box className={styles.removeItem}>
-          <TextLink as="button" onClick={() => onRemoveContentType(ruleId)}>
-            Remove
-          </TextLink>
-        </Box>
-      </Flex>
+              value={validateSelectedOption(contentTypeId, slugField)}>
+              <Select.Option value="" isDisabled>
+                Select slug field
+              </Select.Option>
+              {contentTypeId &&
+                allContentTypes[contentTypeId]?.fields?.map((field) => (
+                  <Select.Option key={`${contentTypeId}.${field.id}`} value={field.id}>
+                    {field.name}
+                  </Select.Option>
+                ))}
+            </Select>
+          </Box>
+          <Box className={styles.urlPrefixItem}>
+            {!showAdvancedMatching ? (
+              <TextInput
+                id={`urlPrefix-${index}`}
+                name={`urlPrefix-${index}`}
+                testId="urlPrefixInput"
+                isDisabled={!contentTypeId || !isContentTypeInOptions}
+                onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+                  onContentTypeFieldChange(ruleId, 'urlPrefix', event.target.value)
+                }
+                value={urlPrefix}
+              />
+            ) : (
+              <Text fontColor="gray500">Configured below</Text>
+            )}
+          </Box>
+          <Box className={styles.toggleItem}>
+            <Checkbox
+              id={`advancedMatching-${index}`}
+              name={`advancedMatching-${index}`}
+              testId="advancedMatchingToggle"
+              isChecked={showAdvancedMatching}
+              isDisabled={!contentTypeId || !isContentTypeInOptions}
+              onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                const nextIsAdvanced = event.target.checked;
+                setShowAdvancedMatching(nextIsAdvanced);
+                if (nextIsAdvanced) {
+                  onContentTypeRuleChange(ruleId, {
+                    enableAdvancedMatching: true,
+                    pathPattern: pathPattern.trim() ? pathPattern : getGeneratedPattern(),
+                  });
+                  return;
+                }
+
+                resetAdvancedMatching();
+              }}>
+              Advanced
+            </Checkbox>
+          </Box>
+          <Box className={styles.removeItem}>
+            <TextLink as="button" onClick={() => onRemoveContentType(ruleId)}>
+              Remove
+            </TextLink>
+          </Box>
+        </Flex>
+      </Box>
       {showAdvancedMatching && (
         <Box className={styles.advancedMatchingPanel} testId="advancedMatchingPanel">
+          {isMissingPattern && (
+            <Note variant="negative" title="Fix this before saving">
+              Add a pattern for this advanced rule before saving.
+            </Note>
+          )}
           <Text fontColor="gray600" className={styles.advancedMatchingIntro}>
-            Use this for query strings or variable prefixes.
+            Build a custom URL pattern for query strings, extra path segments, or variable
+            prefixes.
           </Text>
           <Box className={styles.advancedMatchingFields}>
             <Flex className={styles.advancedMatchingTopRow}>
@@ -261,14 +301,25 @@ const AssignContentTypeRow = (props: Props) => {
                               : additionalFieldIds.filter(
                                   (selectedFieldId) => selectedFieldId !== field.id
                                 );
+                            const currentGeneratedPattern = getGeneratedPattern();
+                            const nextGeneratedPattern = getGeneratedPattern(nextSelectedFields);
 
-                            onContentTypeFieldChange(
-                              ruleId,
-                              'additionalFieldIds',
-                              nextSelectedFields
-                            );
+                            if (!pathPattern.trim() || pathPattern === currentGeneratedPattern) {
+                              onContentTypeRuleChange(ruleId, {
+                                additionalFieldIds: nextSelectedFields,
+                                pathPattern: nextGeneratedPattern,
+                              });
+                              return;
+                            }
+
+                            onContentTypeFieldChange(ruleId, 'additionalFieldIds', nextSelectedFields);
                           }}>
-                          {field.name}
+                          <Flex alignItems="center" gap="spacing2Xs">
+                            <Text as="span">{field.name}</Text>
+                            <Text as="span" fontColor="gray600">
+                              {`{${field.id}}`}
+                            </Text>
+                          </Flex>
                         </Checkbox>
                       ))
                     ) : (
@@ -278,7 +329,8 @@ const AssignContentTypeRow = (props: Props) => {
                     )}
                   </Stack>
                   <FormControl.HelpText>
-                    Select any extra fields you want to reference in the pattern.
+                    Select extra fields to include in the URL. Use the placeholder shown next to
+                    each field in the pattern.
                   </FormControl.HelpText>
                 </FormControl>
               </Box>
@@ -297,8 +349,8 @@ const AssignContentTypeRow = (props: Props) => {
                     value={pathPattern}
                   />
                   <FormControl.HelpText>
-                    Use {'{slug}'} plus any selected property tokens. Example: /{'{sectionSlug}'}/
-                    {'{slug}'}
+                    A pattern is generated for you automatically. Edit it if you need a different
+                    URL structure or want to use placeholders from the left.
                   </FormControl.HelpText>
                 </FormControl>
               </Box>
@@ -306,14 +358,42 @@ const AssignContentTypeRow = (props: Props) => {
             <Flex className={styles.advancedMatchingBottomRow}>
               <Box className={styles.compactField}>
                 <FormControl>
-                  <FormControl.Label>Match against</FormControl.Label>
+                  <FormControl.Label>
+                    <Flex alignItems="center">
+                      Match against
+                      <Tooltip
+                        placement="top"
+                        content="Choose whether to match just the page path, or the page path plus any query parameters in the URL.">
+                        <Flex marginLeft="spacing2Xs" className={styles.tooltipIcon}>
+                          <HelpCircleIcon />
+                        </Flex>
+                      </Tooltip>
+                    </Flex>
+                  </FormControl.Label>
                   <Select
                     id={`matchDimension-${index}`}
                     name={`matchDimension-${index}`}
                     testId="matchDimensionSelect"
                     isDisabled={!contentTypeId || !isContentTypeInOptions}
                     onChange={(event: React.ChangeEvent<HTMLSelectElement>) =>
-                      onContentTypeFieldChange(ruleId, 'matchDimension', event.target.value)
+                      {
+                        const nextMatchDimension = event.target.value;
+                        const currentGeneratedPattern = getGeneratedPattern();
+                        const nextGeneratedPattern = getGeneratedPattern(
+                          additionalFieldIds,
+                          nextMatchDimension as ContentTypeValue['matchDimension']
+                        );
+
+                        if (!pathPattern.trim() || pathPattern === currentGeneratedPattern) {
+                          onContentTypeRuleChange(ruleId, {
+                            matchDimension: nextMatchDimension,
+                            pathPattern: nextGeneratedPattern,
+                          });
+                          return;
+                        }
+
+                        onContentTypeFieldChange(ruleId, 'matchDimension', nextMatchDimension);
+                      }
                     }
                     value={matchDimension}>
                     <Select.Option value="unifiedPagePathScreen">Page path</Select.Option>
@@ -330,7 +410,7 @@ const AssignContentTypeRow = (props: Props) => {
                       Matching mode
                       <Tooltip
                         placement="top"
-                        content="Use Literal for one exact URL. Use Flexible pattern when parts of the URL can vary, like multiple category prefixes.">
+                        content="Use Literal for one exact URL pattern. Use Flexible match when part of the URL can vary, like different category prefixes.">
                         <Flex marginLeft="spacing2Xs" className={styles.tooltipIcon}>
                           <HelpCircleIcon />
                         </Flex>
@@ -347,7 +427,7 @@ const AssignContentTypeRow = (props: Props) => {
                     }
                     value={matchType}>
                     <Select.Option value="EXACT">Literal</Select.Option>
-                    <Select.Option value="PARTIAL_REGEXP">Flexible pattern</Select.Option>
+                    <Select.Option value="PARTIAL_REGEXP">Flexible match</Select.Option>
                   </Select>
                 </FormControl>
               </Box>

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { mockSdk, mockCma } from '../../../../test/mocks';
 import AssignContentTypeSection from 'components/config-screen/assign-content-type/AssignContentTypeSection';
 import { vi } from 'vitest';
@@ -26,5 +26,76 @@ describe('Assign Content Type Section for Config Screen', () => {
 
     expect(screen.getByText('Content type configuration')).toBeVisible();
     expect(screen.getByText('Use trailing slash for all page paths')).toBeVisible();
+  });
+
+  it('marks advanced rules without a pattern as invalid', async () => {
+    const onIsValidContentTypeAssignment = vi.fn();
+
+    render(
+      <AssignContentTypeSection
+        mergeSdkParameters={() => {}}
+        onIsValidContentTypeAssignment={onIsValidContentTypeAssignment}
+        parameters={{
+          contentTypeRules: [
+            {
+              id: 'rule-1',
+              contentTypeId: 'searchPage',
+              slugField: 'slug',
+              urlPrefix: '',
+              enableAdvancedMatching: true,
+              pathPattern: '',
+              matchDimension: 'pagePathPlusQueryString',
+              matchType: 'EXACT',
+            },
+          ],
+        }}
+        currentEditorInterface={{}}
+        originalContentTypes={{}}
+        originalContentTypeRules={[]}
+      />
+    );
+
+    expect(
+      await screen.findByText('Add a pattern for this advanced rule before saving.')
+    ).toBeVisible();
+
+    await waitFor(() =>
+      expect(onIsValidContentTypeAssignment).toHaveBeenLastCalledWith(false)
+    );
+  });
+
+  it('keeps trailing slash enabled when any rule uses advanced matching', async () => {
+    render(
+      <AssignContentTypeSection
+        mergeSdkParameters={() => {}}
+        onIsValidContentTypeAssignment={() => {}}
+        parameters={{
+          forceTrailingSlash: true,
+          contentTypeRules: [
+            {
+              id: 'rule-1',
+              contentTypeId: 'searchPage',
+              slugField: 'slug',
+              urlPrefix: '',
+              enableAdvancedMatching: true,
+              pathPattern: '/search?category={slug}',
+              matchDimension: 'pagePathPlusQueryString',
+              matchType: 'EXACT',
+            },
+          ],
+        }}
+        currentEditorInterface={{}}
+        originalContentTypes={{}}
+        originalContentTypeRules={[]}
+      />
+    );
+
+    expect(
+      await screen.findByText(
+        'Applies to standard configurations only. Advanced patterns are used exactly as written.'
+      )
+    ).toBeVisible();
+    expect(screen.getByLabelText('Use trailing slash for all page paths')).toBeEnabled();
+    expect(screen.getByLabelText('Use trailing slash for all page paths')).toBeChecked();
   });
 });

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.spec.tsx
@@ -59,9 +59,7 @@ describe('Assign Content Type Section for Config Screen', () => {
       await screen.findByText('Add a pattern for this advanced rule before saving.')
     ).toBeVisible();
 
-    await waitFor(() =>
-      expect(onIsValidContentTypeAssignment).toHaveBeenLastCalledWith(false)
-    );
+    await waitFor(() => expect(onIsValidContentTypeAssignment).toHaveBeenLastCalledWith(false));
   });
 
   it('keeps trailing slash enabled when any rule uses advanced matching', async () => {

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.tsx
@@ -86,7 +86,9 @@ const AssignContentTypeSection = (props: Props) => {
 
   const rulesMissingPattern = new Set(
     contentTypeRules
-      .filter((rule) => rule.enableAdvancedMatching && rule.contentTypeId && !rule.pathPattern?.trim())
+      .filter(
+        (rule) => rule.enableAdvancedMatching && rule.contentTypeId && !rule.pathPattern?.trim()
+      )
       .map((rule) => rule.id)
   );
 

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.tsx
@@ -84,6 +84,18 @@ const AssignContentTypeSection = (props: Props) => {
     setHasIncompleteContentTypes(contentTypeRules.some((rule) => !rule.contentTypeId));
   }, [contentTypeRules]);
 
+  const rulesMissingPattern = new Set(
+    contentTypeRules
+      .filter((rule) => rule.enableAdvancedMatching && rule.contentTypeId && !rule.pathPattern?.trim())
+      .map((rule) => rule.id)
+  );
+
+  const isContentTypeAssignmentValid = rulesMissingPattern.size === 0;
+
+  useEffect(() => {
+    onIsValidContentTypeAssignment(isContentTypeAssignmentValid);
+  }, [isContentTypeAssignmentValid, onIsValidContentTypeAssignment]);
+
   const fetchAllContentTypes = async (sdk: KnownAppSDK): Promise<ContentTypeProps[]> => {
     const cma = createClient({ apiAdapter: sdk.cmaAdapter });
     const space = await cma.getSpace(sdk.ids.space);
@@ -124,15 +136,12 @@ const AssignContentTypeSection = (props: Props) => {
   const trailingSlashHandler = () => {
     setForceTrailingSlash(!forceTrailingSlash);
     mergeSdkParameters({ forceTrailingSlash: !forceTrailingSlash });
-    onIsValidContentTypeAssignment(true);
   };
 
   const contentTypeRulesHandler = (newContentTypeRules: ContentTypeRules) => {
     setContentTypeRules(newContentTypeRules);
     const _parameters = { contentTypeRules: newContentTypeRules };
     mergeSdkParameters(_parameters);
-    // We always want the user to be able to save the configuration, even if there are errors or warnings
-    onIsValidContentTypeAssignment(true);
   };
 
   const handleContentTypeChange = (ruleId: string, newContentTypeId: string) => {
@@ -160,6 +169,19 @@ const AssignContentTypeSection = (props: Props) => {
         ? {
             ...rule,
             [field]: value,
+          }
+        : rule
+    );
+
+    contentTypeRulesHandler(newContentTypeRules);
+  };
+
+  const handleContentTypeRuleChange = (ruleId: string, updates: Partial<ContentTypeRule>) => {
+    const newContentTypeRules = contentTypeRules.map((rule) =>
+      rule.id === ruleId
+        ? {
+            ...rule,
+            ...updates,
           }
         : rule
     );
@@ -203,6 +225,9 @@ const AssignContentTypeSection = (props: Props) => {
           onChange={trailingSlashHandler}>
           Use trailing slash for all page paths
         </Checkbox>
+        <Paragraph marginTop="spacing2Xs" marginBottom="none">
+          Applies to standard configurations only. Advanced patterns are used exactly as written.
+        </Paragraph>
       </Box>
       {!loadingContentTypes && !loadingAllContentTypes ? (
         <>
@@ -213,9 +238,11 @@ const AssignContentTypeSection = (props: Props) => {
               contentTypeRules={contentTypeRules}
               onContentTypeChange={handleContentTypeChange}
               onContentTypeFieldChange={handleContentTypeFieldChange}
+              onContentTypeRuleChange={handleContentTypeRuleChange}
               onRemoveContentType={handleRemoveContentType}
               currentEditorInterface={currentEditorInterface}
               originalContentTypeRules={originalContentTypeRules}
+              rulesMissingPattern={rulesMissingPattern}
             />
           )}
           {contentTypeRules.length < Object.keys(allContentTypes).length * 5 && (

--- a/apps/google-analytics-4/frontend/src/components/main-app/AnalyticsApp/AnalyticsApp.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/AnalyticsApp/AnalyticsApp.spec.tsx
@@ -40,6 +40,7 @@ const stableSidebarRulesState = {
   isContentTypeWarning: false,
   warningRule: undefined,
   haveLoadedFieldValues: true,
+  haveLoadedPublicationState: true,
 };
 
 const renderAnalyticsApp = () =>
@@ -142,6 +143,7 @@ describe('AnalyticsApp when content types are not configured correctly', () => {
       summaryLabel: '',
       isContentTypeWarning: true,
       haveLoadedFieldValues: true,
+      haveLoadedPublicationState: true,
       warningRule,
     }));
     mockApi.mockImplementation(() => runReportResponseHasViews);

--- a/apps/google-analytics-4/frontend/src/components/main-app/AnalyticsApp/AnalyticsApp.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/AnalyticsApp/AnalyticsApp.tsx
@@ -151,7 +151,7 @@ const AnalyticsApp = (props: Props) => {
 
   const pendingData = isEmpty(runReportResponse) && !error && runReportFetchRequirements;
   const showInitialLoadingSkeleton =
-    (loading && pendingData) || !haveLoadedFieldValues || !haveLoadedPublicationState;
+    pendingData || !haveLoadedFieldValues || !haveLoadedPublicationState;
 
   const renderAnalyticContent = () => {
     if (showInitialLoadingSkeleton) {

--- a/apps/google-analytics-4/frontend/src/components/main-app/AnalyticsApp/AnalyticsApp.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/AnalyticsApp/AnalyticsApp.tsx
@@ -62,8 +62,14 @@ const AnalyticsApp = (props: Props) => {
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<Error>();
 
-  const { validRules, summaryLabel, isContentTypeWarning, warningRule, haveLoadedFieldValues } =
-    useSidebarRules(slugFieldRules);
+  const {
+    validRules,
+    summaryLabel,
+    isContentTypeWarning,
+    warningRule,
+    haveLoadedFieldValues,
+    haveLoadedPublicationState,
+  } = useSidebarRules(slugFieldRules);
 
   useAutoResizer();
 
@@ -144,7 +150,8 @@ const AnalyticsApp = (props: Props) => {
   const metricName = runReportResponse.metricHeaders && runReportResponse.metricHeaders[0].name;
 
   const pendingData = isEmpty(runReportResponse) && !error && runReportFetchRequirements;
-  const showInitialLoadingSkeleton = (loading && pendingData) || !haveLoadedFieldValues;
+  const showInitialLoadingSkeleton =
+    (loading && pendingData) || !haveLoadedFieldValues || !haveLoadedPublicationState;
 
   const renderAnalyticContent = () => {
     if (showInitialLoadingSkeleton) {

--- a/apps/google-analytics-4/frontend/src/components/main-app/AnalyticsMetricDisplays/AnalyticsMetricDisplay.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/AnalyticsMetricDisplays/AnalyticsMetricDisplay.tsx
@@ -40,6 +40,7 @@ const AnalyticsMetricDisplay = (props: Props) => {
     selectedMetric,
     isLoading = false,
   } = props;
+  const safePageViews = Number.isFinite(pageViews) ? pageViews : 0;
 
   const propertyIdNumber = propertyId.split('/')[1] || '';
   const viewUrl = canOpenInGoogleAnalytics
@@ -50,7 +51,7 @@ const AnalyticsMetricDisplay = (props: Props) => {
     <>
       <ChartHeader
         metricName={metricName ? metricName : ''}
-        metricValue={Intl.NumberFormat('en', { notation: 'compact' }).format(pageViews)}
+        metricValue={Intl.NumberFormat('en', { notation: 'compact' }).format(safePageViews)}
         handleChange={handleDateRangeChange}
         handleMetricChange={handleMetricChange}
         handleCustomRangeRequest={handleCustomRangeRequest}

--- a/apps/google-analytics-4/frontend/src/helpers/contentTypeRules/contentTypeRules.spec.ts
+++ b/apps/google-analytics-4/frontend/src/helpers/contentTypeRules/contentTypeRules.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeContentTypeRules } from './contentTypeRules';
+
+describe('contentTypeRules normalization', () => {
+  it('marks legacy advanced-looking content type rules as advanced', () => {
+    const [rule] = normalizeContentTypeRules([
+      {
+        id: 'legacy-rule',
+        contentTypeId: 'searchPage',
+        slugField: 'slug',
+        urlPrefix: '',
+        enableAdvancedMatching: false,
+        pathPattern: '/search/{slug}?category={category}',
+        additionalFieldIds: ['category'],
+        matchDimension: 'pagePathPlusQueryString',
+        matchType: 'EXACT',
+      },
+    ]);
+
+    expect(rule.enableAdvancedMatching).toBe(true);
+  });
+
+  it('marks legacy advanced-looking content types as advanced', () => {
+    const [rule] = normalizeContentTypeRules(undefined, {
+      searchPage: {
+        slugField: 'slug',
+        urlPrefix: '',
+        pathPattern: '/search/{slug}?category={category}',
+        additionalFieldIds: ['category'],
+        matchDimension: 'pagePathPlusQueryString',
+        matchType: 'EXACT',
+      },
+    });
+
+    expect(rule.enableAdvancedMatching).toBe(true);
+  });
+});

--- a/apps/google-analytics-4/frontend/src/helpers/contentTypeRules/contentTypeRules.ts
+++ b/apps/google-analytics-4/frontend/src/helpers/contentTypeRules/contentTypeRules.ts
@@ -1,4 +1,5 @@
 import { ContentTypeRule, ContentTypeRules, ContentTypes, ContentTypeValue } from 'types';
+import { hasAdvancedMatchingConfigured } from 'utils/contentTypeMatching';
 
 const createRuleId = () =>
   typeof crypto !== 'undefined' && 'randomUUID' in crypto
@@ -26,7 +27,7 @@ export const createRuleFromContentType = (
   slugField: value.slugField,
   urlPrefix: value.urlPrefix,
   additionalFieldIds: value.additionalFieldIds || [],
-  enableAdvancedMatching: value.enableAdvancedMatching || false,
+  enableAdvancedMatching: hasAdvancedMatchingConfigured(value),
   pathPattern: value.pathPattern || '',
   matchDimension: value.matchDimension || 'unifiedPagePathScreen',
   matchType: value.matchType || 'EXACT',
@@ -46,8 +47,17 @@ export const normalizeContentTypeRules = (
 ): ContentTypeRules => {
   if (contentTypeRules?.length) {
     return contentTypeRules.map((rule) => ({
-      ...createDefaultRule(rule.contentTypeId),
-      ...rule,
+      ...(() => {
+        const normalizedRule = {
+          ...createDefaultRule(rule.contentTypeId),
+          ...rule,
+        };
+
+        return {
+          ...normalizedRule,
+          enableAdvancedMatching: hasAdvancedMatchingConfigured(normalizedRule),
+        };
+      })(),
       id: rule.id || createRuleId(),
     }));
   }

--- a/apps/google-analytics-4/frontend/src/hooks/useSidebarRules/useSidebarRules.tsx
+++ b/apps/google-analytics-4/frontend/src/hooks/useSidebarRules/useSidebarRules.tsx
@@ -21,6 +21,7 @@ export const useSidebarRules = (slugFieldRules: ContentTypeRule[]) => {
   const entryFields = sdk.entry?.fields ?? {};
 
   const [isPublished, setIsPublished] = useState(false);
+  const [haveLoadedPublicationState, setHaveLoadedPublicationState] = useState(false);
   const [fieldValues, setFieldValues] = useState<Record<string, string | object>>({});
   const [debouncedFieldValues, setDebouncedFieldValues] = useState<Record<string, string | object>>(
     {}
@@ -46,9 +47,13 @@ export const useSidebarRules = (slugFieldRules: ContentTypeRule[]) => {
   useEffect(() => {
     const handlePublishedStatus = (sys: ContentEntitySys) => {
       setIsPublished(Boolean(sys.publishedAt));
+      setHaveLoadedPublicationState(true);
     };
 
-    if (!sdk.entry?.onSysChanged) return;
+    if (!sdk.entry?.onSysChanged) {
+      setHaveLoadedPublicationState(true);
+      return;
+    }
     return sdk.entry.onSysChanged((sys) => handlePublishedStatus(sys));
   }, [sdk.entry]);
 
@@ -131,6 +136,7 @@ export const useSidebarRules = (slugFieldRules: ContentTypeRule[]) => {
   return {
     isPublished,
     haveLoadedFieldValues,
+    haveLoadedPublicationState,
     resolvedRules,
     validRules,
     summaryLabel,

--- a/apps/google-analytics-4/frontend/src/locations/Sidebar.tsx
+++ b/apps/google-analytics-4/frontend/src/locations/Sidebar.tsx
@@ -11,7 +11,9 @@ import { normalizeContentTypeRules } from 'helpers/contentTypeRules/contentTypeR
 
 const Sidebar = () => {
   const sdk = useSDK<SidebarExtensionSDK>();
-  const installationParameters = sdk.parameters.installation as AppInstallationParameters | undefined;
+  const installationParameters = sdk.parameters.installation as
+    | AppInstallationParameters
+    | undefined;
 
   const { serviceAccountKeyId, propertyId, contentTypes, contentTypeRules } =
     installationParameters || {};

--- a/apps/google-analytics-4/frontend/src/locations/Sidebar.tsx
+++ b/apps/google-analytics-4/frontend/src/locations/Sidebar.tsx
@@ -1,6 +1,7 @@
 import AnalyticsApp from 'components/main-app/AnalyticsApp/AnalyticsApp';
 import { useSDK } from '@contentful/react-apps-toolkit';
 import { SidebarExtensionSDK } from '@contentful/app-sdk';
+import { Skeleton } from '@contentful/f36-components';
 import { useApi } from 'hooks/useApi';
 import { AppInstallationParameters, CustomRangeDialogResult, StartEndDates } from 'types';
 import Note from 'components/common/Note/Note';
@@ -10,9 +11,10 @@ import { normalizeContentTypeRules } from 'helpers/contentTypeRules/contentTypeR
 
 const Sidebar = () => {
   const sdk = useSDK<SidebarExtensionSDK>();
+  const installationParameters = sdk.parameters.installation as AppInstallationParameters | undefined;
 
-  const { serviceAccountKeyId, propertyId, contentTypes, contentTypeRules } = sdk.parameters
-    .installation as AppInstallationParameters;
+  const { serviceAccountKeyId, propertyId, contentTypes, contentTypeRules } =
+    installationParameters || {};
 
   const currentContentType = sdk.contentType.sys.id;
   const slugFieldRules = normalizeContentTypeRules(contentTypeRules, contentTypes).filter(
@@ -41,6 +43,16 @@ const Sidebar = () => {
 
     return result as CustomRangeDialogResult | undefined;
   };
+
+  if (!installationParameters) {
+    return (
+      <Skeleton.Container svgHeight={300}>
+        <Skeleton.Image height={68} width={325} offsetTop={10} />
+        <Skeleton.Image height={160} width={325} offsetTop={93} />
+        <Skeleton.Image height={25} width={200} offsetTop={268} />
+      </Skeleton.Container>
+    );
+  }
 
   if (!hasInstallationParams) {
     const bodyMsg = getMissingParamsMsg(!serviceAccountKeyId, !propertyId);

--- a/apps/google-analytics-4/frontend/src/locations/Sidebar.tsx
+++ b/apps/google-analytics-4/frontend/src/locations/Sidebar.tsx
@@ -1,16 +1,19 @@
 import AnalyticsApp from 'components/main-app/AnalyticsApp/AnalyticsApp';
-import { useSDK } from '@contentful/react-apps-toolkit';
+import { useCMA, useSDK } from '@contentful/react-apps-toolkit';
 import { SidebarExtensionSDK } from '@contentful/app-sdk';
+import { useMemo } from 'react';
 import { Skeleton } from '@contentful/f36-components';
-import { useApi } from 'hooks/useApi';
 import { AppInstallationParameters, CustomRangeDialogResult, StartEndDates } from 'types';
 import Note from 'components/common/Note/Note';
 import { getMissingParamsMsg } from 'components/main-app/constants/noteMessages';
 import { AppConfigPageHyperLink } from 'components/main-app/ErrorDisplay/CommonErrorDisplays';
 import { normalizeContentTypeRules } from 'helpers/contentTypeRules/contentTypeRules';
+import { Api } from 'apis/api';
+import { contentfulContext } from 'helpers/contentfulContext';
 
 const Sidebar = () => {
   const sdk = useSDK<SidebarExtensionSDK>();
+  const cma = useCMA();
   const installationParameters = sdk.parameters.installation as
     | AppInstallationParameters
     | undefined;
@@ -22,8 +25,10 @@ const Sidebar = () => {
   const slugFieldRules = normalizeContentTypeRules(contentTypeRules, contentTypes).filter(
     (rule) => rule.contentTypeId === currentContentType
   );
-
-  const api = useApi(serviceAccountKeyId);
+  const api = useMemo(
+    () => new Api(contentfulContext(sdk), cma, serviceAccountKeyId),
+    [cma, sdk, serviceAccountKeyId]
+  );
 
   const hasInstallationParams = serviceAccountKeyId && propertyId;
 

--- a/apps/google-analytics-4/frontend/src/utils/getReportSlug.spec.ts
+++ b/apps/google-analytics-4/frontend/src/utils/getReportSlug.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getReportSlug, pathPatternPreview } from './getReportSlug';
+import { buildDefaultPathPattern, getReportSlug, pathPatternPreview } from './getReportSlug';
 
 describe('getReportSlug', () => {
   it('supports advanced patterns with multiple field tokens', () => {
@@ -41,9 +41,42 @@ describe('getReportSlug', () => {
     expect(reportSlug).toBe('/north-america/denver/luxury-homes/');
   });
 
+  it('does not append a trailing slash after query string patterns', () => {
+    const reportSlug = getReportSlug(
+      {
+        slugField: 'slug',
+        urlPrefix: '',
+        enableAdvancedMatching: true,
+        pathPattern: '/search/?category={slug}',
+      },
+      {
+        slug: 'platform',
+      },
+      true
+    );
+
+    expect(reportSlug).toBe('/search/?category=platform');
+  });
+
   it('builds previews for additional field tokens', () => {
     expect(pathPatternPreview('/{sectionSlug}/{slug}', ['sectionSlug'])).toBe(
       '/example-sectionSlug/example-slug'
+    );
+  });
+
+  it('builds a default page-path pattern from the existing url prefix', () => {
+    expect(buildDefaultPathPattern('/blog/')).toBe('/blog/{slug}');
+  });
+
+  it('builds a default page-path pattern with selected path segments', () => {
+    expect(buildDefaultPathPattern('', ['regionSlug', 'citySlug'])).toBe(
+      '/{regionSlug}/{citySlug}/{slug}'
+    );
+  });
+
+  it('builds a default query-string pattern when extra fields are selected', () => {
+    expect(buildDefaultPathPattern('/search', ['category'], 'pagePathPlusQueryString')).toBe(
+      '/search/{slug}?category={category}'
     );
   });
 });

--- a/apps/google-analytics-4/frontend/src/utils/getReportSlug.ts
+++ b/apps/google-analytics-4/frontend/src/utils/getReportSlug.ts
@@ -33,15 +33,17 @@ export const buildDefaultPathPattern = (
   const basePath =
     matchDimension === 'pagePathPlusQueryString'
       ? `/${pathJoin(urlPrefix, SLUG_TOKEN)}`
-      : `/${pathJoin(urlPrefix, ...additionalFieldIds.map((fieldId) => `{${fieldId}}`), SLUG_TOKEN)}`;
+      : `/${pathJoin(
+          urlPrefix,
+          ...additionalFieldIds.map((fieldId) => `{${fieldId}}`),
+          SLUG_TOKEN
+        )}`;
 
   if (matchDimension !== 'pagePathPlusQueryString' || additionalFieldIds.length === 0) {
     return basePath;
   }
 
-  const queryString = additionalFieldIds
-    .map((fieldId) => `${fieldId}={${fieldId}}`)
-    .join('&');
+  const queryString = additionalFieldIds.map((fieldId) => `${fieldId}={${fieldId}}`).join('&');
 
   return `${basePath}?${queryString}`;
 };

--- a/apps/google-analytics-4/frontend/src/utils/getReportSlug.ts
+++ b/apps/google-analytics-4/frontend/src/utils/getReportSlug.ts
@@ -17,6 +17,35 @@ const normalizePattern = (pathPattern: string, fieldValues: FieldValueMap) => {
   return pathPattern.replace(TOKEN_REGEX, (_match, token) => getPatternValue(token, fieldValues));
 };
 
+const applyTrailingSlash = (path: string, forceTrailingSlash: boolean) => {
+  if (!forceTrailingSlash || path.includes('?')) {
+    return path;
+  }
+
+  return path.endsWith('/') ? path : `${path}/`;
+};
+
+export const buildDefaultPathPattern = (
+  urlPrefix = '',
+  additionalFieldIds: string[] = [],
+  matchDimension: ContentTypeValue['matchDimension'] = 'unifiedPagePathScreen'
+) => {
+  const basePath =
+    matchDimension === 'pagePathPlusQueryString'
+      ? `/${pathJoin(urlPrefix, SLUG_TOKEN)}`
+      : `/${pathJoin(urlPrefix, ...additionalFieldIds.map((fieldId) => `{${fieldId}}`), SLUG_TOKEN)}`;
+
+  if (matchDimension !== 'pagePathPlusQueryString' || additionalFieldIds.length === 0) {
+    return basePath;
+  }
+
+  const queryString = additionalFieldIds
+    .map((fieldId) => `${fieldId}={${fieldId}}`)
+    .join('&');
+
+  return `${basePath}?${queryString}`;
+};
+
 export const getReportSlug = (
   contentTypeValue: ContentTypeValue,
   slugFieldValue: string | object,
@@ -32,7 +61,7 @@ export const getReportSlug = (
       ? normalizePattern(pathPattern, fieldValues)
       : pathJoin(urlPrefix || '', fieldValues.slug || '');
 
-  return `/${pathJoin(basePath)}${forceTrailingSlash ? '/' : ''}`;
+  return `/${applyTrailingSlash(pathJoin(basePath), forceTrailingSlash)}`;
 };
 
 export const pathPatternPreview = (pathPattern: string, additionalFieldIds: string[] = []) => {


### PR DESCRIPTION
## Summary
- refine the GA4 advanced matching configuration UX based on staging feedback
- improve grouping, spacing, and contextual validation for advanced configuration rows
- auto-generate advanced patterns from the current setup, update them as page properties are added, and preserve manual edits
- clarify matching terminology and standard-vs-advanced trailing slash behavior

## Validation
- frontend targeted vitest run for AssignContentTypeRow.spec.tsx, AssignContentTypeSection.spec.tsx, and src/utils/getReportSlug.spec.ts passed
- staging branch batched frontend vitest run completed successfully while validating these changes

## Notes
- multiple rules per content type remain allowed intentionally for the customer use case
- advanced rules require a pattern before save, and the validation now renders in context