### PR TITLE
fix(google-docs): add currently viewing section  + polish edit modal styles[INTEG-3822]

### DIFF
--- a/apps/google-docs/src/locations/Page/components/overview/OverviewSection.tsx
+++ b/apps/google-docs/src/locations/Page/components/overview/OverviewSection.tsx
@@ -21,7 +21,7 @@ interface OverviewProps {
   selectedEntryIndex: number;
   onSelectEntryIndex: (index: number) => void;
   onCreateEntries: () => Promise<CompletedWorkflowPayload | null>;
-  onReturnToMainPage: () => void;
+  onIsCreatingChange: (isCreating: boolean) => void;
 }
 
 const OverviewSection = ({
@@ -30,7 +30,7 @@ const OverviewSection = ({
   selectedEntryIndex,
   onSelectEntryIndex,
   onCreateEntries,
-  onReturnToMainPage,
+  onIsCreatingChange,
 }: OverviewProps) => {
   const [isCreating, setIsCreating] = useState(false);
   const [summaryEntries, setSummaryEntries] = useState<EntryProps[] | null>(null);
@@ -60,6 +60,8 @@ const OverviewSection = ({
   const handleCreateEntries = async () => {
     console.log('[create-entries] creating entries, calling onCreateEntries');
     setIsCreating(true);
+    onIsCreatingChange(true);
+    let succeeded = false;
 
     try {
       const previewPayload = await onCreateEntries();
@@ -70,6 +72,7 @@ const OverviewSection = ({
       const result = await createEntriesFromPreviewPayload(sdk, previewPayload);
 
       setSummaryEntries(result.createdEntries);
+      succeeded = true;
     } catch (error) {
       setCreateError(
         error instanceof Error
@@ -78,12 +81,12 @@ const OverviewSection = ({
       );
     } finally {
       setIsCreating(false);
+      if (!succeeded) onIsCreatingChange(false);
     }
   };
 
   const handleSummaryDone = () => {
     setSummaryEntries(null);
-    onReturnToMainPage();
   };
 
   return (

--- a/apps/google-docs/src/locations/Page/components/review/ReviewPage.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/ReviewPage.tsx
@@ -32,6 +32,7 @@ export const ReviewPage = ({
   const [isConfirmCancelModalOpen, setIsConfirmCancelModalOpen] = useState(false);
   const [selectedEntryIndex, setSelectedEntryIndex] = useState<number>(0);
   const [isCancelling, setIsCancelling] = useState(false);
+  const [isCreating, setIsCreating] = useState(false);
   const [entryBlockGraph, setEntryBlockGraph] = useState<EntryBlockGraph>(() =>
     structuredClone(payload.entryBlockGraph)
   );
@@ -98,7 +99,7 @@ export const ReviewPage = ({
             variant="transparent"
             size="small"
             onClick={() => setIsConfirmCancelModalOpen(true)}
-            aria-label="Cancel preview">
+            aria-label="Cancel review">
             Cancel
           </Button>
         </Flex>
@@ -112,13 +113,14 @@ export const ReviewPage = ({
             selectedEntryIndex={selectedEntryIndex}
             onSelectEntryIndex={setSelectedEntryIndex}
             onCreateEntries={handleCreateEntries}
-            onReturnToMainPage={onReturnToMainPage}
+            onIsCreatingChange={setIsCreating}
           />
           <MappingView
             payload={reviewPayload}
             entryBlockGraph={entryBlockGraph}
             onEntryBlockGraphChange={setEntryBlockGraph}
             selectedEntryIndex={selectedEntryIndex}
+            isDisabled={isCreating}
           />
         </Flex>
       </Layout.Body>

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState, type RefCallback } from 'react';
 import { Box, Button, Flex, Text } from '@contentful/f36-components';
 import tokens from '@contentful/f36-tokens';
+import {
+  buildEntryListFromEntryBlockGraph,
+  type EntryListRow,
+} from '../../../../../utils/overviewEntryList';
 import type {
   EntryBlockGraph,
   ImageSourceRef,
@@ -61,6 +65,7 @@ interface MappingViewProps {
   entryBlockGraph: EntryBlockGraph;
   onEntryBlockGraphChange: (next: EntryBlockGraph) => void;
   selectedEntryIndex: number | null;
+  isDisabled?: boolean;
 }
 
 const EMPTY_NEW_LOCATION: EditModalNewLocation = {
@@ -82,6 +87,15 @@ const EMPTY_EDIT_MODAL: EditModalState = {
   locationSectionDescription: '',
   primaryButtonLabel: '',
 };
+
+function findRowByEntryIndex(rows: EntryListRow[], index: number): EntryListRow | null {
+  for (const row of rows) {
+    if (row.entryIndex === index) return row;
+    const found = findRowByEntryIndex(row.children, index);
+    if (found) return found;
+  }
+  return null;
+}
 
 function getEntryName(contentTypeName: string | undefined, entryIndex: number): string {
   const displayName = contentTypeName ?? 'Untitled';
@@ -122,7 +136,25 @@ export const MappingView = ({
   entryBlockGraph,
   onEntryBlockGraphChange,
   selectedEntryIndex,
+  isDisabled = false,
 }: MappingViewProps): JSX.Element => {
+  const selectedEntryRow = useMemo(() => {
+    const rows = buildEntryListFromEntryBlockGraph(
+      payload.entryBlockGraph.entries,
+      payload.contentTypes,
+      payload.referenceGraph.edges
+    );
+    return (
+      (selectedEntryIndex !== null ? findRowByEntryIndex(rows, selectedEntryIndex) : null) ??
+      rows[0] ??
+      null
+    );
+  }, [
+    payload.entryBlockGraph.entries,
+    payload.contentTypes,
+    payload.referenceGraph.edges,
+    selectedEntryIndex,
+  ]);
   const [hoveredMappingKeys, setHoveredMappingKeys] = useState<string[]>([]);
   const [cardOffsetsBySegment, setCardOffsetsBySegment] = useState<
     Record<string, Record<string, number>>
@@ -492,7 +524,7 @@ export const MappingView = ({
   };
 
   const handleAssignFromSelection = () => {
-    if (!selectedText.trim()) return;
+    if (isDisabled || !selectedText.trim()) return;
     const reassignRanges = collectTextExclusionRangesFromSelection(
       textSelectionRootRef.current,
       selectedRange
@@ -511,7 +543,7 @@ export const MappingView = ({
   };
 
   const handleExcludeFromSelection = () => {
-    if (!selectedText.trim()) return;
+    if (isDisabled || !selectedText.trim()) return;
     const ranges = collectTextExclusionRangesFromSelection(
       textSelectionRootRef.current,
       selectedRange
@@ -531,11 +563,13 @@ export const MappingView = ({
   };
 
   const handleAssignImage = (sourceRef: ImageSourceRef, label: string) => {
+    if (isDisabled) return;
     openAssignModal(label, getLocationsForSourceRef(sourceRef), [], []);
     setHoveredMappingKeys([]);
   };
 
   const handleExcludeImage = (sourceRef: ImageSourceRef, label: string) => {
+    if (isDisabled) return;
     setPendingImageSourceRef(sourceRef);
     setPendingTextExclusionRanges(null);
     openExcludeModal(label, getLocationsForSourceRef(sourceRef), {
@@ -680,7 +714,33 @@ export const MappingView = ({
         ref={textSelectionRootRef}
         flexDirection="column"
         gap="spacingS"
-        style={{ padding: tokens.spacingM, marginTop: tokens.spacingM }}>
+        style={{ marginTop: tokens.spacingM }}>
+        {selectedEntryRow && (
+          <Box
+            style={{
+              borderBottom: `1px solid ${tokens.gray200}`,
+              paddingBottom: tokens.spacingXs,
+            }}>
+            <Text
+              as="p"
+              fontSize="fontSizeS"
+              fontWeight="fontWeightMedium"
+              marginBottom="spacing2Xs">
+              Currently viewing:
+            </Text>
+            <Text as="p" marginBottom="none">
+              <Text as="span" fontWeight="fontWeightDemiBold">
+                {selectedEntryRow.contentTypeName}
+              </Text>
+              {selectedEntryRow.entryTitle ? (
+                <Text as="span" fontColor="gray600">
+                  {' '}
+                  ({selectedEntryRow.entryTitle})
+                </Text>
+              ) : null}
+            </Text>
+          </Box>
+        )}
         {tabs.map((tab) => (
           <Box key={tab.id}>
             {tab.name && (
@@ -731,7 +791,7 @@ export const MappingView = ({
         ))}
       </Flex>
 
-      {selectionRectangle ? (
+      {selectionRectangle && !isDisabled ? (
         <SelectionActionMenu
           anchorRectangle={selectionRectangle}
           onAssign={handleAssignFromSelection}

--- a/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/EditModal.styles.ts
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/EditModal.styles.ts
@@ -8,8 +8,8 @@ export const modalContent = css({
 });
 
 export const sectionCard = css({
-  border: `1px solid ${tokens.gray300}`,
-  borderRadius: tokens.borderRadiusMedium,
+  border: `1px solid ${tokens.gray200}`,
+  borderRadius: tokens.borderRadiusSmall,
   padding: tokens.spacingS,
 });
 
@@ -22,9 +22,9 @@ export const locationList = css({
 export const locationButton = css({
   appearance: 'none',
   width: '100%',
-  borderRadius: tokens.borderRadiusMedium,
-  padding: tokens.spacingM,
-  backgroundColor: tokens.colorWhite,
+  borderRadius: tokens.borderRadiusSmall,
+  padding: tokens.spacingXs,
+  backgroundColor: tokens.gray100,
   textAlign: 'left',
   cursor: 'pointer',
   transition: 'border-color 120ms ease, background-color 120ms ease',
@@ -39,10 +39,9 @@ export const locationButtonSelected = css({
 });
 
 export const locationButtonUnselected = css({
-  border: `2px solid ${tokens.gray300}`,
+  border: `1px solid ${tokens.gray200}`,
 });
 
 export const locationContent = css({
   minWidth: 0,
-  textAlign: 'left',
 });

--- a/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/EditModal.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/EditModal.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useMemo, useState, type ReactNode } from 'react';
-import { Box, Button, Modal, Note, Paragraph, Text } from '@contentful/f36-components';
+import { Box, Button, Modal, Note, Flex, Text } from '@contentful/f36-components';
 import {
   EditModalDestinationStateKind,
   createEditModalDestinationState,
   type EditModalContent,
 } from '@types';
+
 import {
   locationButton,
   locationButtonSelected,
@@ -138,68 +139,92 @@ export const EditModal = ({
           <Modal.Content>
             <Box className={modalContent}>
               <Box className={sectionCard}>
-                <Text as="p" fontWeight="fontWeightDemiBold" marginBottom="spacingM">
-                  {previewSectionTitle}
-                </Text>
-                <Text as="p" fontSize="fontSizeL">
-                  "{previewQuotedText}"
-                </Text>
+                <Flex flexDirection="column" gap="spacingXs">
+                  <Text as="p" fontWeight="fontWeightDemiBold">
+                    {previewSectionTitle}
+                  </Text>
+                  <Text as="p">"{previewQuotedText}"</Text>
+                </Flex>
               </Box>
 
               <Box className={sectionCard}>
-                <Text fontWeight="fontWeightDemiBold" marginBottom="spacing2Xs">
-                  Current location
-                </Text>
-                {hasLocationSectionDescription && (
-                  <Paragraph marginBottom={hasCurrentLocations ? 'spacingM' : 'none'}>
-                    {locationSectionDescription}
-                  </Paragraph>
-                )}
-
-                {hasCurrentLocations && (
-                  <Box className={locationList}>
-                    {viewModel.currentLocations.map((location) => {
-                      const isSelected = location.id === selectedLocationId;
-
-                      return (
-                        <Box
-                          as="button"
-                          type="button"
-                          key={location.id}
-                          onClick={() => setSelectedLocationId(location.id)}
-                          aria-pressed={isSelected}
-                          className={`${locationButton} ${
-                            isSelected ? locationButtonSelected : locationButtonUnselected
-                          }`}>
-                          <Box className={locationContent}>
-                            <Text as="p" fontColor="gray600" marginBottom="spacing2Xs">
-                              Content type{' '}
-                              <Text as="span" fontWeight="fontWeightDemiBold" fontColor="gray900">
-                                {location.contentTypeName}
+                <Flex flexDirection="column" gap="spacingXs">
+                  <Text fontWeight="fontWeightDemiBold">Current location</Text>
+                  {hasLocationSectionDescription && (
+                    <Text as="p" marginBottom="none">
+                      {locationSectionDescription}
+                    </Text>
+                  )}
+                  {hasCurrentLocations && (
+                    <Box className={locationList}>
+                      {viewModel.currentLocations.map((location) => {
+                        const isSelected = location.id === selectedLocationId;
+                        return (
+                          <Box
+                            as="button"
+                            type="button"
+                            key={location.id}
+                            onClick={() => setSelectedLocationId(location.id)}
+                            aria-pressed={isSelected}
+                            className={`${locationButton} ${
+                              isSelected ? locationButtonSelected : locationButtonUnselected
+                            }`}>
+                            <Box className={locationContent}>
+                              <Text
+                                as="p"
+                                fontSize="fontSizeS"
+                                fontColor="gray600"
+                                marginBottom="none">
+                                Content type{' '}
+                                <Text
+                                  as="span"
+                                  fontSize="fontSizeS"
+                                  fontWeight="fontWeightMedium"
+                                  fontColor="gray900">
+                                  {location.contentTypeName}
+                                </Text>
                               </Text>
-                            </Text>
-                            <Text as="p" fontColor="gray600" marginBottom="spacing2Xs">
-                              Entry name{' '}
-                              <Text as="span" fontWeight="fontWeightDemiBold" fontColor="gray900">
-                                {location.entryName}
+                              <Text
+                                as="p"
+                                fontSize="fontSizeS"
+                                fontColor="gray600"
+                                marginBottom="none">
+                                Entry name{' '}
+                                <Text
+                                  as="span"
+                                  fontSize="fontSizeS"
+                                  fontWeight="fontWeightMedium"
+                                  fontColor="gray900">
+                                  {location.entryName}
+                                </Text>
                               </Text>
-                            </Text>
-                            <Text as="p" fontColor="gray600">
-                              Field{' '}
-                              <Text as="span" fontWeight="fontWeightDemiBold" fontColor="gray900">
-                                {location.fieldName}
-                              </Text>{' '}
-                              | {location.fieldType}
-                            </Text>
+                              <Text
+                                as="p"
+                                fontSize="fontSizeS"
+                                fontColor="gray600"
+                                marginBottom="none">
+                                Field{' '}
+                                <Text
+                                  as="span"
+                                  fontSize="fontSizeS"
+                                  fontWeight="fontWeightMedium"
+                                  fontColor="gray900">
+                                  {location.fieldName}
+                                </Text>{' '}
+                                <Text as="span" fontSize="fontSizeS" fontColor="gray700">
+                                  | {location.fieldType}
+                                </Text>
+                              </Text>
+                            </Box>
                           </Box>
-                        </Box>
-                      );
-                    })}
-                  </Box>
-                )}
+                        );
+                      })}
+                    </Box>
+                  )}
+                </Flex>
               </Box>
 
-              {hasNewLocation ? (
+              {hasNewLocation && (
                 <Box>
                   <Text as="p" fontWeight="fontWeightDemiBold" marginBottom="spacingM">
                     New location
@@ -223,7 +248,7 @@ export const EditModal = ({
                     </Box>
                   </Box>
                 </Box>
-              ) : null}
+              )}
 
               {isAssignMode && destinationState.kind !== EditModalDestinationStateKind.Ready ? (
                 <Note


### PR DESCRIPTION


  ### What changed

  **Currently viewing indicator**
  Adds a "Currently viewing:" banner above the document outline in the mapping review, showing the selected entry in the
  format **Content type** (entry title). Updates reactively as the user clicks different entries in the overview list,
  including nested children.

<img width="1350" height="862" alt="Screenshot 2026-04-20 at 4 15 56 PM" src="https://github.com/user-attachments/assets/4fe0dde8-085f-4c12-a23e-64dab4b0c587" />

https://github.com/user-attachments/assets/8496dc15-3bf4-452f-9094-776eefba5e36


  **Exit flow**
  - Closing the summary modal after creating entries now returns to the mapping review instead of resetting to the home
  page — state is preserved


https://github.com/user-attachments/assets/49434bb4-7b86-474f-8106-2374d9b02775

  **Disable Editing while creating entries**


https://github.com/user-attachments/assets/e831896a-29d4-43c3-a40e-ccc0bc43870f



  **Edit modal styling**
<img width="1350" height="862" alt="Screenshot 2026-04-20 at 4 16 22 PM" src="https://github.com/user-attachments/assets/250fab51-ca3d-429c-8efb-61939db97774" />


  ### Testing
  - [ ] Select different entries in the overview list — banner updates correctly including nested entries
  - [ ] Create entries → close summary modal → verify mapping review is still visible with state intact
  - [ ] Open assign and exclude modals — verify spacing, colors, and text sizes match design