### PR TITLE
feat(google-docs): Scope assign/reassign to current entry + fixing tests [INTEG-3821]

### DIFF
--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -10,7 +10,11 @@ import type {
   EditModalNewLocation,
   SourceRef,
 } from '@types';
-import { isTextSourceRef } from '@types';
+import {
+  EditModalDestinationStateKind,
+  createEditModalDestinationState,
+  isTextSourceRef,
+} from '@types';
 import { FileTextIcon } from '@contentful/f36-icons';
 import { useReviewTextSelection } from '@hooks/useReviewTextSelection';
 import { getEntryTitleFromFieldMappings } from '../../../../../utils/getEntryTitle';
@@ -59,11 +63,19 @@ interface MappingViewProps {
   selectedEntryIndex: number | null;
 }
 
+const EMPTY_NEW_LOCATION: EditModalNewLocation = {
+  id: '',
+  title: '',
+  fieldOptions: [],
+  fieldMappings: [],
+};
+
 const EMPTY_EDIT_MODAL: EditModalState = {
   mode: null,
   viewModel: {
     selectedText: '',
     currentLocations: [],
+    newLocation: EMPTY_NEW_LOCATION,
     isOpen: false,
   },
   title: '',
@@ -262,41 +274,54 @@ export const MappingView = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [allSegments, entryBlockGraph, payload.contentTypes, selectedEntryIndex]);
 
-  const newLocations = useMemo<EditModalNewLocation[]>(() => {
-    return entryBlockGraph.entries.map((entry, entryIndex) => {
-      const contentType = payload.contentTypes.find((item) => item.sys.id === entry.contentTypeId);
-      const contentTypeName =
-        (contentType?.name ?? entry.contentTypeId).trim() || entry.contentTypeId;
-      const fallbackEntryName = getEntryName(contentTypeName, entryIndex);
-      const entryTitle = getEntryReviewTitle(entry, contentType?.displayField, fallbackEntryName);
-      const contentTypeFields = contentType?.fields ?? [];
-      const fieldOptions =
-        contentTypeFields.length > 0
-          ? contentTypeFields
-              .filter((field): field is (typeof contentTypeFields)[number] & { id: string } =>
-                Boolean(field.id)
-              )
-              .map((field) => ({
-                id: field.id,
-                fieldName: (field.name ?? '').trim() || formatDisplayName(field.id),
-                fieldType: getFieldTypeLabel(field.type ?? ''),
-              }))
-          : entry.fieldMappings.map((fieldMapping) => ({
-              id: fieldMapping.fieldId,
-              fieldName: formatDisplayName(fieldMapping.fieldId),
-              fieldType: getFieldTypeLabel(fieldMapping.fieldType),
-            }));
+  const getNewLocationForEntry = (
+    entry: EntryBlockGraph['entries'][number],
+    entryIndex: number
+  ): EditModalNewLocation => {
+    const contentType = payload.contentTypes.find((item) => item.sys.id === entry.contentTypeId);
+    const contentTypeName = contentType?.name ?? entry.contentTypeId;
+    const fallbackEntryName = getEntryName(contentTypeName, entryIndex);
+    const entryTitle = getEntryReviewTitle(entry, contentType?.displayField, fallbackEntryName);
+    const contentTypeFields = contentType?.fields ?? [];
+    const fieldOptions =
+      contentTypeFields.length > 0
+        ? contentTypeFields
+            .filter((field): field is (typeof contentTypeFields)[number] & { id: string } =>
+              Boolean(field.id)
+            )
+            .map((field) => ({
+              id: field.id,
+              fieldName: (field.name ?? '').trim() || formatDisplayName(field.id),
+              fieldType: getFieldTypeLabel(field.type ?? ''),
+            }))
+        : entry.fieldMappings.map((fieldMapping) => ({
+            id: fieldMapping.fieldId,
+            fieldName: formatDisplayName(fieldMapping.fieldId),
+            fieldType: getFieldTypeLabel(fieldMapping.fieldType),
+          }));
 
-      return {
-        id: entry.tempId ?? `${entry.contentTypeId}-${entryIndex}`,
-        title: `${contentTypeName}: ${entryTitle}`,
-        fieldOptions,
-        fieldMappings: entry.fieldMappings.map((fieldMapping) => ({
-          fieldId: fieldMapping.fieldId,
-        })),
-      };
-    });
-  }, [entryBlockGraph.entries, payload.contentTypes]);
+    return {
+      id: entry.tempId ?? `${entry.contentTypeId}-${entryIndex}`,
+      title: `${contentTypeName}: ${entryTitle}`,
+      fieldOptions,
+      fieldMappings: entry.fieldMappings.map((fieldMapping) => ({
+        fieldId: fieldMapping.fieldId,
+      })),
+    };
+  };
+
+  const newLocation = useMemo<EditModalNewLocation>(() => {
+    if (selectedEntryIndex === null) {
+      return EMPTY_NEW_LOCATION;
+    }
+
+    const selectedEntry = entryBlockGraph.entries[selectedEntryIndex];
+    if (!selectedEntry) {
+      return EMPTY_NEW_LOCATION;
+    }
+
+    return getNewLocationForEntry(selectedEntry, selectedEntryIndex);
+  }, [entryBlockGraph.entries, payload.contentTypes, selectedEntryIndex]);
 
   const getLocationsForSourceRef = (sourceRef: SourceRef): EditLocationOption[] => {
     const targetKey = buildSourceRefKey(sourceRef);
@@ -435,7 +460,7 @@ export const MappingView = ({
       viewModel: {
         selectedText: preview,
         currentLocations,
-        newLocations,
+        newLocation,
         isOpen: true,
       },
       title: 'Assign content',
@@ -456,6 +481,7 @@ export const MappingView = ({
         contentPreview: preview?.contentPreview,
         previewSectionTitle: preview?.previewSectionTitle,
         currentLocations,
+        newLocation: EMPTY_NEW_LOCATION,
         isOpen: true,
       },
       title: 'Exclude content',
@@ -521,36 +547,41 @@ export const MappingView = ({
 
   const handleEditModalConfirmPrimary = ({
     selectedLocationId,
-    selectedFieldIdsByLocationId = {},
+    selectedFieldIds = {},
   }: {
     selectedLocationId: string | null;
-    selectedFieldIdsByLocationId?: Record<string, string[]>;
+    selectedFieldIds?: Record<string, string[]>;
   }) => {
     if (editModalState.mode === 'assign') {
       const locations = editModalState.viewModel.currentLocations;
 
-      const targets: { entryIndex: number; fieldId: string; fieldType: string }[] = [];
-      for (let entryIndex = 0; entryIndex < entryBlockGraph.entries.length; entryIndex++) {
-        const entry = entryBlockGraph.entries[entryIndex];
-        const newLocId = entry.tempId ?? `${entry.contentTypeId}-${entryIndex}`;
-        const fieldIds = selectedFieldIdsByLocationId[newLocId] ?? [];
-        const contentType = payload.contentTypes.find((c) => c.sys.id === entry.contentTypeId);
+      const newLocation = editModalState.viewModel.newLocation;
+      const resolvedTargets: { entryIndex: number; fieldId: string; fieldType: string }[] = [];
+
+      if (newLocation && selectedEntryIndex !== null) {
+        const entry = entryBlockGraph.entries[selectedEntryIndex];
+        const fieldIds = selectedFieldIds[newLocation.id] ?? [];
+        const contentType = entry
+          ? payload.contentTypes.find((c) => c.sys.id === entry.contentTypeId)
+          : undefined;
+
         for (const fieldId of fieldIds) {
           const field = contentType?.fields?.find((f) => 'id' in f && f.id === fieldId);
           const fieldType =
             field && 'type' in field && typeof field.type === 'string' ? field.type : 'Text';
-          targets.push({
-            entryIndex,
+          if (!fieldId.length) {
+            continue;
+          }
+
+          resolvedTargets.push({
+            entryIndex: selectedEntryIndex,
             fieldId,
             fieldType,
           });
         }
       }
 
-      const resolvedTargets = targets.filter((t) => t.fieldId.length > 0);
-
       if (!resolvedTargets.length) {
-        closeEditModal();
         return;
       }
 
@@ -712,6 +743,7 @@ export const MappingView = ({
       <EditModal
         isOpen={editModalState.viewModel.isOpen}
         onClose={closeEditModal}
+        mode={editModalState.mode}
         viewModel={editModalState.viewModel}
         title={editModalState.title}
         locationSectionDescription={editModalState.locationSectionDescription}

--- a/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/EditModal.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/EditModal.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useMemo, useState, type ReactNode } from 'react';
-import { Box, Button, Modal, Paragraph, Text } from '@contentful/f36-components';
-import type { EditModalContent } from '@types';
+import { Box, Button, Modal, Note, Paragraph, Text } from '@contentful/f36-components';
+import {
+  EditModalDestinationStateKind,
+  createEditModalDestinationState,
+  type EditModalContent,
+} from '@types';
 import {
   locationButton,
   locationButtonSelected,
@@ -15,6 +19,7 @@ import { FieldSelectionDropdown } from './FieldSelectionDropdown';
 interface EditModalProps {
   isOpen: boolean;
   onClose: () => void;
+  mode: 'assign' | 'exclude' | null;
   viewModel: EditModalContent;
   title: string;
   locationSectionDescription: string;
@@ -22,13 +27,14 @@ interface EditModalProps {
   additionalContent?: ReactNode;
   onConfirmPrimary?: (details: {
     selectedLocationId: string | null;
-    selectedFieldIdsByLocationId: Record<string, string[]>;
+    selectedFieldIds: Record<string, string[]>;
   }) => void;
 }
 
 export const EditModal = ({
   isOpen,
   onClose,
+  mode,
   viewModel,
   title,
   locationSectionDescription,
@@ -38,7 +44,7 @@ export const EditModal = ({
 }: EditModalProps) => {
   const hasLocationSectionDescription = locationSectionDescription.trim().length > 0;
   const hasCurrentLocations = viewModel.currentLocations.length > 0;
-  const hasNewLocations = (viewModel.newLocations?.length ?? 0) > 0;
+  const hasNewLocation = viewModel.newLocation.id !== '';
   const initialSelectedLocationId = useMemo(
     () =>
       viewModel.currentLocations.find((location) => location.isSelected)?.id ??
@@ -51,57 +57,78 @@ export const EditModal = ({
     initialSelectedLocationId
   );
 
-  const [selectedFieldIdsByLocationId, setSelectedFieldIdsByLocationId] = useState<
-    Record<string, string[]>
-  >(() =>
-    Object.fromEntries(
-      (viewModel.newLocations ?? []).map((newLocation) => [
-        newLocation.id,
-        [...(newLocation.selectedFieldIds ?? [])],
-      ])
-    )
+  const [selectedFieldIds, setSelectedFieldIds] = useState(
+    () => viewModel.newLocation.selectedFieldIds ?? []
   );
+
+  const [destinationFieldState, setDestinationFieldState] = useState<{
+    hasFieldOptions: boolean;
+    hasSelectableOptions: boolean;
+  } | null>(null);
 
   useEffect(() => {
     setSelectedLocationId(initialSelectedLocationId);
   }, [initialSelectedLocationId]);
 
-  const newLocationRowIdsKey = (viewModel.newLocations ?? []).map((nl) => nl.id).join('|');
+  const newLocationRowIdsKey = viewModel.newLocation.id;
 
   // Reset field multiselect when the modal opens or when the set of destination rows changes.
-  // Do not depend on `viewModel.newLocations` reference (it can churn without semantic change).
+  // Do not depend on `viewModel.newLocation` reference (it can churn without semantic change).
   useEffect(() => {
     if (!isOpen) return;
-    setSelectedFieldIdsByLocationId(
-      Object.fromEntries(
-        (viewModel.newLocations ?? []).map((newLocation) => [
-          newLocation.id,
-          [...(newLocation.selectedFieldIds ?? [])],
-        ])
-      )
-    );
+    setSelectedFieldIds(viewModel.newLocation.selectedFieldIds ?? []);
+    setDestinationFieldState(null);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- sync from props only on open / row-id set change, not array identity
   }, [isOpen, newLocationRowIdsKey]);
 
-  const handleSelectedFieldIdsChange = (
-    locationId: string,
-    updater: (previous: string[]) => string[]
-  ) => {
-    setSelectedFieldIdsByLocationId((previous) => ({
-      ...previous,
-      [locationId]: updater(previous[locationId] ?? []),
-    }));
+  const handleSelectedFieldIdsChange = (updater: (previous: string[]) => string[]) => {
+    setSelectedFieldIds((previous) => updater(previous));
   };
 
   const handlePrimaryAction = () => {
     onConfirmPrimary?.({
       selectedLocationId,
-      selectedFieldIdsByLocationId: { ...selectedFieldIdsByLocationId },
+      selectedFieldIds: {
+        [viewModel.newLocation.id]: [...selectedFieldIds],
+      },
     });
   };
 
   const previewSectionTitle = viewModel.previewSectionTitle ?? 'Selected content';
   const previewQuotedText = (viewModel.contentPreview ?? viewModel.selectedText).trim();
+  const selectedDestinationCount = selectedFieldIds.length;
+  const isAssignMode = mode === 'assign';
+  const destinationState = useMemo(() => {
+    if (!isAssignMode) {
+      return createEditModalDestinationState(EditModalDestinationStateKind.Ready);
+    }
+
+    if (!hasNewLocation) {
+      return createEditModalDestinationState(EditModalDestinationStateKind.MissingEntry);
+    }
+
+    if (viewModel.newLocation.fieldOptions.length === 0) {
+      return createEditModalDestinationState(EditModalDestinationStateKind.NoFields);
+    }
+
+    if (destinationFieldState?.hasSelectableOptions === false) {
+      return createEditModalDestinationState(EditModalDestinationStateKind.NoCompatibleFields);
+    }
+
+    if (selectedDestinationCount === 0) {
+      return createEditModalDestinationState(EditModalDestinationStateKind.RequiresSelection);
+    }
+
+    return createEditModalDestinationState(EditModalDestinationStateKind.Ready);
+  }, [
+    isAssignMode,
+    destinationFieldState?.hasSelectableOptions,
+    hasNewLocation,
+    selectedDestinationCount,
+    viewModel.newLocation.fieldOptions.length,
+  ]);
+  const isPrimaryDisabled =
+    isAssignMode && destinationState.kind !== EditModalDestinationStateKind.Ready;
 
   return (
     <Modal isShown={isOpen} onClose={onClose} size="large" shouldCloseOnOverlayClick={false}>
@@ -172,37 +199,41 @@ export const EditModal = ({
                 )}
               </Box>
 
-              {hasNewLocations ? (
+              {hasNewLocation ? (
                 <Box>
                   <Text as="p" fontWeight="fontWeightDemiBold" marginBottom="spacingM">
                     New location
                   </Text>
                   <Box className={locationList}>
-                    {viewModel.newLocations?.map((newLocation) => (
-                      <Box className={sectionCard} key={newLocation.id}>
-                        <Text as="p" fontWeight="fontWeightDemiBold" marginBottom="spacingM">
-                          {newLocation.title}
-                        </Text>
-                        <Text as="p" marginBottom="spacingXs">
-                          Fields
-                        </Text>
-                        <FieldSelectionDropdown
-                          selectedText={viewModel.selectedText}
-                          fieldOptions={newLocation.fieldOptions}
-                          fieldMappings={newLocation.fieldMappings}
-                          selectedFieldIds={
-                            selectedFieldIdsByLocationId[newLocation.id] ??
-                            newLocation.selectedFieldIds ??
-                            []
-                          }
-                          onSelectedFieldIdsChange={(updater) =>
-                            handleSelectedFieldIdsChange(newLocation.id, updater)
-                          }
-                        />
-                      </Box>
-                    ))}
+                    <Box className={sectionCard} key={viewModel.newLocation.id}>
+                      <Text as="p" fontWeight="fontWeightDemiBold" marginBottom="spacingM">
+                        {viewModel.newLocation.title}
+                      </Text>
+                      <Text as="p" marginBottom="spacingXs">
+                        Fields
+                      </Text>
+                      <FieldSelectionDropdown
+                        selectedText={viewModel.selectedText}
+                        fieldOptions={viewModel.newLocation.fieldOptions}
+                        fieldMappings={viewModel.newLocation.fieldMappings}
+                        selectedFieldIds={selectedFieldIds}
+                        onSelectedFieldIdsChange={handleSelectedFieldIdsChange}
+                        onSelectableStateChange={setDestinationFieldState}
+                      />
+                    </Box>
                   </Box>
                 </Box>
+              ) : null}
+
+              {isAssignMode && destinationState.kind !== EditModalDestinationStateKind.Ready ? (
+                <Note
+                  variant={
+                    destinationState.kind === EditModalDestinationStateKind.RequiresSelection
+                      ? 'warning'
+                      : 'neutral'
+                  }>
+                  {destinationState.message}
+                </Note>
               ) : null}
 
               {additionalContent}
@@ -212,7 +243,11 @@ export const EditModal = ({
             <Button onClick={onClose} size="small" variant="secondary">
               Cancel
             </Button>
-            <Button onClick={handlePrimaryAction} size="small" variant="primary">
+            <Button
+              onClick={handlePrimaryAction}
+              size="small"
+              variant="primary"
+              isDisabled={isPrimaryDisabled}>
               {primaryButtonLabel}
             </Button>
           </Modal.Controls>

--- a/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/FieldSelectionDropdown.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/FieldSelectionDropdown.tsx
@@ -1,4 +1,4 @@
-import { useId, useMemo } from 'react';
+import { useEffect, useId, useMemo } from 'react';
 import { Flex, Stack, Text } from '@contentful/f36-components';
 import { Multiselect } from '@contentful/f36-multiselect';
 import type { EditModalFieldMapping, EditModalFieldOption } from '@types';
@@ -13,6 +13,10 @@ interface FieldSelectionDropdownProps {
   selectedFieldIds: string[];
   /** Functional updates avoid stale `selectedFieldIds` when selecting multiple fields quickly. */
   onSelectedFieldIdsChange: (updater: (previous: string[]) => string[]) => void;
+  onSelectableStateChange?: (state: {
+    hasFieldOptions: boolean;
+    hasSelectableOptions: boolean;
+  }) => void;
 }
 
 export const FieldSelectionDropdown = ({
@@ -21,6 +25,7 @@ export const FieldSelectionDropdown = ({
   fieldMappings,
   selectedFieldIds,
   onSelectedFieldIdsChange,
+  onSelectableStateChange,
 }: FieldSelectionDropdownProps) => {
   const key = useId();
   const selectedOptions = useMemo(
@@ -33,6 +38,20 @@ export const FieldSelectionDropdown = ({
     () => new Set(fieldMappings.map((fieldMapping) => fieldMapping.fieldId)),
     [fieldMappings]
   );
+  const selectableOptions = useMemo(
+    () =>
+      fieldOptions.filter((option) =>
+        isSelectableFieldType(getFieldTypeLabel(option.fieldType), selectedText)
+      ),
+    [fieldOptions, selectedText]
+  );
+
+  useEffect(() => {
+    onSelectableStateChange?.({
+      hasFieldOptions: fieldOptions.length > 0,
+      hasSelectableOptions: selectableOptions.length > 0,
+    });
+  }, [fieldOptions.length, onSelectableStateChange, selectableOptions.length]);
 
   const handleSelectField = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { checked, value } = event.target;

--- a/apps/google-docs/src/types/editModal.ts
+++ b/apps/google-docs/src/types/editModal.ts
@@ -31,6 +31,39 @@ export interface EditModalNewLocation {
   selectedFieldIds?: string[];
 }
 
+export enum EditModalDestinationStateKind {
+  Ready = 'ready',
+  MissingEntry = 'missing-entry',
+  NoFields = 'no-fields',
+  NoCompatibleFields = 'no-compatible-fields',
+  RequiresSelection = 'requires-selection',
+}
+
+export interface EditModalDestinationState {
+  kind: EditModalDestinationStateKind;
+  message?: string;
+}
+
+const DEFAULT_DESTINATION_STATE_MESSAGES: Record<EditModalDestinationStateKind, string> = {
+  [EditModalDestinationStateKind.Ready]: '',
+  [EditModalDestinationStateKind.MissingEntry]:
+    'No destination entry is available for the entry currently in view.',
+  [EditModalDestinationStateKind.NoFields]:
+    'The current entry does not have any destination fields available.',
+  [EditModalDestinationStateKind.NoCompatibleFields]:
+    'The current entry does not have any compatible destination fields for this content.',
+  [EditModalDestinationStateKind.RequiresSelection]:
+    'Select at least one destination field in the current entry to continue.',
+};
+
+export const createEditModalDestinationState = (
+  kind: EditModalDestinationStateKind,
+  message?: string
+): EditModalDestinationState => ({
+  kind,
+  message: message ?? DEFAULT_DESTINATION_STATE_MESSAGES[kind] ?? undefined,
+});
+
 export interface EditModalContent {
   selectedText: string;
   /** Mapped-only preview for exclude flow; falls back to selectedText in the modal when absent. */
@@ -39,5 +72,5 @@ export interface EditModalContent {
   previewSectionTitle?: string;
   isOpen: boolean;
   currentLocations: EditLocationOption[];
-  newLocations?: EditModalNewLocation[];
+  newLocation: EditModalNewLocation;
 }

--- a/apps/google-docs/test/locations/Page/components/modals/EditModal.spec.tsx
+++ b/apps/google-docs/test/locations/Page/components/modals/EditModal.spec.tsx
@@ -59,6 +59,12 @@ const viewModel = {
       },
     },
   ],
+  newLocation: {
+    id: '',
+    title: '',
+    fieldMappings: [],
+    fieldOptions: [],
+  },
 };
 
 describe('EditModal', () => {
@@ -71,6 +77,7 @@ describe('EditModal', () => {
       <EditModal
         isOpen={true}
         onClose={onClose}
+        mode="exclude"
         viewModel={viewModel}
         title="Exclude content"
         locationSectionDescription="Choose which location to use."
@@ -93,6 +100,7 @@ describe('EditModal', () => {
       <EditModal
         isOpen={true}
         onClose={onClose}
+        mode="exclude"
         viewModel={viewModel}
         title="Exclude content"
         locationSectionDescription="Choose which location to use."
@@ -121,34 +129,21 @@ describe('EditModal', () => {
       <EditModal
         isOpen={true}
         onClose={onClose}
+        mode="assign"
         viewModel={{
           ...viewModel,
-          newLocations: [
-            {
-              id: 'page-event-detail',
-              title: "Page: Event detail (Don't enter NRF uncaffeinated.)",
-              fieldMappings: [],
-              fieldOptions: [
-                {
-                  id: 'title',
-                  fieldName: 'Title',
-                  fieldType: 'Short text',
-                },
-              ],
-            },
-            {
-              id: 'component-resource-detail-hero',
-              title: "Component: Resource detail hero (Don't enter NRF uncaffeinated.)",
-              fieldMappings: [{ fieldId: 'headline' }],
-              fieldOptions: [
-                {
-                  id: 'headline',
-                  fieldName: 'Headline',
-                  fieldType: 'Short text',
-                },
-              ],
-            },
-          ],
+          newLocation: {
+            id: 'page-event-detail',
+            title: "Page: Event detail (Don't enter NRF uncaffeinated.)",
+            fieldMappings: [],
+            fieldOptions: [
+              {
+                id: 'title',
+                fieldName: 'Title',
+                fieldType: 'Short text',
+              },
+            ],
+          },
         }}
         title="Assign content"
         locationSectionDescription=""
@@ -159,47 +154,29 @@ describe('EditModal', () => {
     await waitFor(() => {
       expect(screen.getByText('New location')).toBeTruthy();
       expect(screen.getByText("Page: Event detail (Don't enter NRF uncaffeinated.)")).toBeTruthy();
-      expect(
-        screen.getByText("Component: Resource detail hero (Don't enter NRF uncaffeinated.)")
-      ).toBeTruthy();
-      expect(screen.getAllByText('Fields')).toHaveLength(2);
-      expect(screen.getAllByText('Select one or more')).toHaveLength(2);
+      expect(screen.getAllByText('Fields')).toHaveLength(1);
+      expect(screen.getAllByText('Select one or more')).toHaveLength(1);
     });
   });
 
-  it('keys new location rows by id so duplicate titles do not break reconciliation', async () => {
-    const duplicateTitle = 'Article: Untitled';
+  it('does not show destination validation or disable submit in exclude mode', async () => {
     render(
       <EditModal
         isOpen={true}
         onClose={onClose}
-        viewModel={{
-          ...viewModel,
-          newLocations: [
-            {
-              id: 'entry-a',
-              title: duplicateTitle,
-              fieldMappings: [],
-              fieldOptions: [{ id: 'body', fieldName: 'Body', fieldType: 'Text' }],
-            },
-            {
-              id: 'entry-b',
-              title: duplicateTitle,
-              fieldMappings: [],
-              fieldOptions: [{ id: 'summary', fieldName: 'Summary', fieldType: 'Text' }],
-            },
-          ],
-        }}
-        title="Assign content"
-        locationSectionDescription=""
-        primaryButtonLabel="Move content"
+        mode="exclude"
+        viewModel={viewModel}
+        title="Exclude content"
+        locationSectionDescription="Choose which location to use."
+        primaryButtonLabel="Exclude content"
       />
     );
 
     await waitFor(() => {
-      expect(screen.getAllByText(duplicateTitle)).toHaveLength(2);
-      expect(screen.getAllByText('Fields')).toHaveLength(2);
-      expect(screen.getAllByText('Select one or more')).toHaveLength(2);
+      expect(
+        screen.queryByText('No destination entry is available for the entry currently in view.')
+      ).toBeNull();
+      expect(screen.getByRole('button', { name: 'Exclude content' })).not.toBeDisabled();
     });
   });
 
@@ -208,6 +185,7 @@ describe('EditModal', () => {
       <EditModal
         isOpen={true}
         onClose={onClose}
+        mode="assign"
         viewModel={{ ...viewModel, currentLocations: [] }}
         title="Assign content"
         locationSectionDescription=""

--- a/apps/google-docs/test/locations/Page/components/review/mapping/MappingView.spec.tsx
+++ b/apps/google-docs/test/locations/Page/components/review/mapping/MappingView.spec.tsx
@@ -23,6 +23,18 @@ const mappingViewGraphProps = (payload: MappingReviewSuspendPayload) => ({
   onEntryBlockGraphChange: vi.fn(),
 });
 
+const createDomRange = (textNode: Text, start: number, end: number) => {
+  const range = document.createRange();
+  range.setStart(textNode, start);
+  range.setEnd(textNode, end);
+  return range;
+};
+
+const createDetachedRange = (text: string, start: number, end: number) => {
+  const textNode = document.createTextNode(text);
+  return createDomRange(textNode, start, end);
+};
+
 const createPayload = (excludedSourceRefs: SourceRef[] = []): MappingReviewSuspendPayload => ({
   suspendStepId: 'mapping-review',
   reason: 'Mapping review required before CMA payload generation continues',
@@ -107,37 +119,30 @@ describe('MappingView', () => {
   });
 
   it('opens assign modal from text selection menu and clears selection', () => {
-    const selectedRange = {
-      intersectsNode: (node: Node) =>
-        node instanceof HTMLElement && node.dataset.isMapped === 'true',
-    } as unknown as Range;
     mockUseReviewTextSelection.mockReturnValueOnce({
       selectionRectangle: null,
       selectedText: '',
       selectedRange: null,
       clearSelection: mockClearSelection,
     });
+
+    const payload = createPayload();
+    const { container, rerender } = render(
+      <MappingView payload={payload} {...mappingViewGraphProps(payload)} selectedEntryIndex={0} />
+    );
+    const selectedRange = createDomRange(
+      container.querySelector('[data-review-text-segment="true"]')?.firstChild as Text,
+      0,
+      5
+    );
     mockUseReviewTextSelection.mockReturnValue({
       selectionRectangle: { top: 100, left: 100, right: 160, bottom: 120 },
       selectedText: '  selected body text  ',
       selectedRange,
       clearSelection: mockClearSelection,
     });
-
-    const payload = createPayload();
-    const { rerender } = render(
-      <MappingView
-        payload={payload}
-        {...mappingViewGraphProps(payload)}
-        selectedEntryIndex={null}
-      />
-    );
     rerender(
-      <MappingView
-        payload={payload}
-        {...mappingViewGraphProps(payload)}
-        selectedEntryIndex={null}
-      />
+      <MappingView payload={payload} {...mappingViewGraphProps(payload)} selectedEntryIndex={0} />
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Reassign' }));
@@ -156,7 +161,7 @@ describe('MappingView', () => {
   });
 
   it('opens assign modal with new locations for unmapped text', () => {
-    const selectedRange = { intersectsNode: () => false } as unknown as Range;
+    const selectedRange = createDetachedRange('fresh body text', 0, 5);
     mockUseReviewTextSelection.mockReturnValue({
       selectionRectangle: { top: 100, left: 100, right: 160, bottom: 120 },
       selectedText: 'fresh body text',
@@ -166,11 +171,7 @@ describe('MappingView', () => {
 
     const payload = createPayload();
     render(
-      <MappingView
-        payload={payload}
-        {...mappingViewGraphProps(payload)}
-        selectedEntryIndex={null}
-      />
+      <MappingView payload={payload} {...mappingViewGraphProps(payload)} selectedEntryIndex={0} />
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Assign' }));
@@ -184,7 +185,7 @@ describe('MappingView', () => {
   });
 
   it('disables exclude when selected text has no mapped segments', () => {
-    const selectedRange = { intersectsNode: () => false } as unknown as Range;
+    const selectedRange = createDetachedRange('plain text', 0, 5);
     mockUseReviewTextSelection.mockReturnValue({
       selectionRectangle: { top: 100, left: 100, right: 160, bottom: 120 },
       selectedText: 'plain text',
@@ -207,37 +208,30 @@ describe('MappingView', () => {
   });
 
   it('opens exclude modal with current locations for mapped text', () => {
-    const selectedRange = {
-      intersectsNode: (node: Node) =>
-        node instanceof HTMLElement && node.dataset.isMapped === 'true',
-    } as unknown as Range;
     mockUseReviewTextSelection.mockReturnValueOnce({
       selectionRectangle: null,
       selectedText: '',
       selectedRange: null,
       clearSelection: mockClearSelection,
     });
+
+    const payload = createPayload();
+    const { container, rerender } = render(
+      <MappingView payload={payload} {...mappingViewGraphProps(payload)} selectedEntryIndex={0} />
+    );
+    const selectedRange = createDomRange(
+      container.querySelector('[data-review-text-segment="true"]')?.firstChild as Text,
+      0,
+      5
+    );
     mockUseReviewTextSelection.mockReturnValue({
       selectionRectangle: { top: 100, left: 100, right: 160, bottom: 120 },
       selectedText: 'selected body text',
       selectedRange,
       clearSelection: mockClearSelection,
     });
-
-    const payload = createPayload();
-    const { rerender } = render(
-      <MappingView
-        payload={payload}
-        {...mappingViewGraphProps(payload)}
-        selectedEntryIndex={null}
-      />
-    );
     rerender(
-      <MappingView
-        payload={payload}
-        {...mappingViewGraphProps(payload)}
-        selectedEntryIndex={null}
-      />
+      <MappingView payload={payload} {...mappingViewGraphProps(payload)} selectedEntryIndex={0} />
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Exclude' }));


### PR DESCRIPTION
## Purpose

Scope mapping review assign/reassign destinations to the entry currently selected in the overview section, so destination fields from other entries are no longer exposed. This also aligns the shared edit modal behavior and fixes some tests that were failing.

## Approach

Updated the Google Docs mapping review flow so MappingView passes only the active entry’s destination data into the shared edit modal. The modal now derives assign-only validation locally, while exclude mode skips destination validation entirely. I also refreshed the modal and mapping-view specs to match the current-entry-only behavior and switched the mapping-view selection tests to use real DOM Range objects instead of brittle mocks.

## Testing steps

Added an automated tests and fixed some tests that were failing.

https://github.com/user-attachments/assets/f509df39-078a-48d7-bab0-266711c8b9e3


## Breaking Changes

No.

## Dependencies and/or References

Ticket: [INTEG-3821](https://contentful.atlassian.net/jira/software/c/projects/INTEG/boards/454?issueParent=466416&selectedIssue=INTEG-3821)

## Deployment

No.

[INTEG-3821]: https://contentful.atlassian.net/browse/INTEG-3821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ