### PR TITLE
Add production release script for Link Checker actions []

### DIFF
--- a/apps/link-checker/package.json
+++ b/apps/link-checker/package.json
@@ -19,6 +19,7 @@
     "build:all": "npm run build && npm run build:functions",
     "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN",
     "deploy": "npm run build:all && contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEFINITIONS_ORG_ID} --definition-id 55HqLhaYLjQWU5zPfID6mX --token ${CONTENTFUL_CMA_TOKEN}",
+    "deploy:prod-with-actions": "node scripts/release-prod-with-actions.js",
     "deploy:test": "npm run build:all && contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEV_TESTING_ORG_ID} --definition-id 5Sr53r0O6UqTBrp0I9S3OV --token ${TEST_CMA_TOKEN}",
     "upload": "node scripts/upload-with-env.js",
     "upsert-actions": "node scripts/upsert-actions-with-env.js",

--- a/apps/link-checker/scripts/release-prod-with-actions.js
+++ b/apps/link-checker/scripts/release-prod-with-actions.js
@@ -1,0 +1,59 @@
+/**
+ * Builds, uploads, and upserts actions for the production Link Checker app definition.
+ */
+const { spawnSync } = require('child_process');
+const path = require('path');
+
+const cwd = path.join(__dirname, '..');
+const env = {
+  ...process.env,
+  CONTENTFUL_ORG_ID: process.env.DEFINITIONS_ORG_ID,
+  CONTENTFUL_APP_DEF_ID: '55HqLhaYLjQWU5zPfID6mX',
+  CONTENTFUL_ACCESS_TOKEN: process.env.CONTENTFUL_CMA_TOKEN,
+};
+
+function run(command, args) {
+  const result = spawnSync(command, args, {
+    stdio: 'inherit',
+    cwd,
+    env,
+  });
+
+  if ((result.status ?? 1) !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+run('npm', ['run', 'build:all']);
+run('npx', [
+  'contentful-app-scripts',
+  'upload',
+  '--ci',
+  '--bundle-dir',
+  './build',
+  '--organization-id',
+  env.CONTENTFUL_ORG_ID,
+  '--definition-id',
+  env.CONTENTFUL_APP_DEF_ID,
+  '--token',
+  env.CONTENTFUL_ACCESS_TOKEN,
+  '--comment',
+  `Build uploaded at ${new Date().toISOString().replace('T', ' ').slice(0, 19)}`,
+  '--host',
+  'api.contentful.com',
+]);
+run('npx', [
+  'contentful-app-scripts',
+  'upsert-actions',
+  '--ci',
+  '--manifest-file',
+  'contentful-app-manifest.json',
+  '--organization-id',
+  env.CONTENTFUL_ORG_ID,
+  '--definition-id',
+  env.CONTENTFUL_APP_DEF_ID,
+  '--token',
+  env.CONTENTFUL_ACCESS_TOKEN,
+  '--host',
+  'api.contentful.com',
+]);


### PR DESCRIPTION
## Summary
- add a dedicated deploy:prod-with-actions script for the Link Checker app
- build the app, upload the production bundle to app definition 55HqLhaYLjQWU5zPfID6mX, and upsert app actions in one explicit flow
- keep the production release path separate from the existing deploy commands so action updates are harder to miss

## Testing
- npm run lint
