### PR TITLE
fix: reset Link Checker function allowNetworks []

### DIFF
--- a/apps/link-checker/contentful-app-manifest.json
+++ b/apps/link-checker/contentful-app-manifest.json
@@ -9,18 +9,7 @@
       "accepts": [
         "appaction.call"
       ],
-      "allowNetworks": [
-        "*.ai",
-        "*.app",
-        "*.co",
-        "*.com",
-        "*.dev",
-        "*.edu",
-        "*.gov",
-        "*.io",
-        "*.net",
-        "*.org"
-      ]
+      "allowNetworks": []
     },
     {
       "id": "checkEntryLinks",
@@ -31,18 +20,7 @@
       "accepts": [
         "appaction.call"
       ],
-      "allowNetworks": [
-        "*.ai",
-        "*.app",
-        "*.co",
-        "*.com",
-        "*.dev",
-        "*.edu",
-        "*.gov",
-        "*.io",
-        "*.net",
-        "*.org"
-      ]
+      "allowNetworks": []
     },
     {
       "id": "checkAllEntryLinks",
@@ -53,18 +31,7 @@
       "accepts": [
         "appaction.call"
       ],
-      "allowNetworks": [
-        "*.ai",
-        "*.app",
-        "*.co",
-        "*.com",
-        "*.dev",
-        "*.edu",
-        "*.gov",
-        "*.io",
-        "*.net",
-        "*.org"
-      ]
+      "allowNetworks": []
     }
   ],
   "actions": [


### PR DESCRIPTION
## Summary
- revert Link Checker function allowNetworks entries back to empty arrays
- remove the wildcard TLD network patterns from Check Link, Check Entry Field Links, and Check All Entry Links
- restore the original manifest behavior so the app is not restricted to a curated set of network suffixes

## Testing
- manifest diff review only
