### PR TITLE
feat: support select options in ecommerce app config []

### DIFF
--- a/packages/ecommerce-app-base/src/AppConfig/AppConfig.spec.tsx
+++ b/packages/ecommerce-app-base/src/AppConfig/AppConfig.spec.tsx
@@ -37,7 +37,7 @@ describe('AppConfig', () => {
       [/Client Secret/, ''],
       [/^API Endpoint/, ''],
       [/Auth API Endpoint/, ''],
-      [/Commercetools data locale/, ''],
+      [/Commercetools data locale/, 'en'],
     ].forEach(([labelRe, expected]) => {
       const configInput = screen.getByLabelText(labelRe) as HTMLInputElement;
       expect(configInput.value).toEqual(expected);
@@ -138,6 +138,26 @@ describe('AppConfig', () => {
         },
       },
     });
+  });
+
+  it('renders select options for parameters with options and saves the selected value', async () => {
+    const sdk = makeSdkMock();
+    renderComponent(sdk);
+
+    const localeSelect = (await screen.findByLabelText(
+      /Commercetools data locale/
+    )) as HTMLSelectElement;
+
+    expect(localeSelect.tagName).toBe('SELECT');
+    expect(screen.getByRole('option', { name: 'en' })).toBeTruthy();
+    expect(screen.getByRole('option', { name: 'de' })).toBeTruthy();
+
+    fireEvent.change(localeSelect, { target: { value: 'de' } });
+
+    const onConfigure = sdk.app.onConfigure.mock.calls[0][0];
+    const configurationResult = onConfigure();
+
+    expect(configurationResult.parameters.locale).toBe('de');
   });
 
   it('does render EAP orchestration note if it is set to true', async () => {

--- a/packages/ecommerce-app-base/src/AppConfig/AppConfig.tsx
+++ b/packages/ecommerce-app-base/src/AppConfig/AppConfig.tsx
@@ -10,6 +10,7 @@ import {
   FormControl,
   Flex,
   TextInput,
+  Select,
 } from '@contentful/f36-components';
 import { OrchestrationEapNote } from './OrchestrationEapNote';
 
@@ -191,7 +192,10 @@ export default class AppConfig extends React.Component<Props, State> {
     );
   }
 
-  onParameterChange = (key: string, e: React.ChangeEvent<HTMLInputElement>) => {
+  onParameterChange = (
+    key: string,
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>
+  ) => {
     const { value } = e.currentTarget;
 
     this.setState((state) => ({
@@ -240,18 +244,32 @@ export default class AppConfig extends React.Component<Props, State> {
                 return (
                   <FormControl key={key} id={key}>
                     <FormControl.Label>{def.name}</FormControl.Label>
-                    <TextInput
-                      name={key}
-                      width={def.type === 'Symbol' ? 'large' : 'medium'}
-                      type={def.type === 'Symbol' ? 'text' : 'number'}
-                      maxLength={255}
-                      isRequired={def.required}
-                      value={parameters[def.id]}
-                      onChange={this.onParameterChange.bind(this, def.id)}
-                    />
+                    {def.options ? (
+                      <Select
+                        name={key}
+                        isRequired={def.required}
+                        value={parameters[def.id] as string}
+                        onChange={this.onParameterChange.bind(this, def.id)}>
+                        {def.options.map((option) => (
+                          <Select.Option key={option} value={option}>
+                            {option}
+                          </Select.Option>
+                        ))}
+                      </Select>
+                    ) : (
+                      <TextInput
+                        name={key}
+                        width={def.type === 'Symbol' ? 'large' : 'medium'}
+                        type={def.type === 'Symbol' ? 'text' : 'number'}
+                        maxLength={255}
+                        isRequired={def.required}
+                        value={parameters[def.id]}
+                        onChange={this.onParameterChange.bind(this, def.id)}
+                      />
+                    )}
                     <Flex justifyContent="space-between">
                       <FormControl.HelpText>{def.description}</FormControl.HelpText>
-                      <FormControl.Counter />
+                      {def.options ? null : <FormControl.Counter />}
                     </Flex>
                   </FormControl>
                 );

--- a/packages/ecommerce-app-base/src/AppConfig/parameters.spec.ts
+++ b/packages/ecommerce-app-base/src/AppConfig/parameters.spec.ts
@@ -43,6 +43,7 @@ export const definitions: ParameterDefinition[] = [
     description: 'The Commercetools data locale to display',
     type: 'Symbol',
     required: true,
+    options: ['en', 'de'],
   },
 ];
 

--- a/packages/ecommerce-app-base/src/types/config.ts
+++ b/packages/ecommerce-app-base/src/types/config.ts
@@ -28,6 +28,12 @@ export type ParameterDefinition = {
   default?: unknown;
 
   /**
+   * Optional select options. When provided, the app config renders a dropdown
+   * instead of a free-text input.
+   */
+  options?: string[];
+
+  /**
    * Parameter type
    * - Symbol: Text
    * - List: List of texts


### PR DESCRIPTION
## Summary
Adds opt-in select support to ecommerce app config parameters so apps can render constrained dropdown values instead of free-text fields.

## Changes
- allow `ParameterDefinition` to declare `options` for dropdown-style config inputs
- render a Forma 36 `Select` in `AppConfig` when options are provided while preserving existing text input behavior by default
- add coverage for select rendering and persisted parameter values

## Notes
- This is intended to unblock the Shopify Storefront API version picker in `marketplace-partner-apps` without requiring a custom config screen there.

Updated in:
- `packages/ecommerce-app-base`
