### PR TITLE
feat(google-docs): default google doc picker to list view [INTEG-3834]

### DIFF
--- a/apps/google-docs/src/hooks/useGoogleDocPicker.tsx
+++ b/apps/google-docs/src/hooks/useGoogleDocPicker.tsx
@@ -52,6 +52,7 @@ export function useGoogleDocsPicker(
       // Create the document view - only show documents
       const docsView = new google.picker.DocsView(google.picker.ViewId.DOCS);
       docsView.setMimeTypes('application/vnd.google-apps.document');
+      docsView.setMode(google.picker.DocsViewMode.LIST);
       const pickerBuilder = new google.picker.PickerBuilder()
         .setOAuthToken(accessToken)
         .setDeveloperKey(GOOGLE_PICKER_API_KEY)


### PR DESCRIPTION
## Purpose
Just remove grid view for now as well since that's bugged with oauth scopes

<img width="917" height="552" alt="Screenshot 2026-04-22 at 11 09 19 AM" src="https://github.com/user-attachments/assets/a809b6e1-fdbf-41ce-b0dd-ccf449457071" />
