### PR TITLE
fix(google-docs): sync field status in edit modal target location dropdown [INTEG-3820]

### DIFF
--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -634,7 +634,7 @@ export const MappingView = ({
       getLocationsForSelectedText(),
       {
         contentPreview: mappedPreview || trimmed,
-        previewSectionTitle: 'Text to exclude',
+        previewSectionTitle: 'Selected content',
       },
       selectionRange,
       previewSourceRefs

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState, type RefCallback } from 'react';
-import { Box, Flex, Text } from '@contentful/f36-components';
+import { Box, Flex, Note, Text } from '@contentful/f36-components';
 import tokens from '@contentful/f36-tokens';
 import {
   buildEntryListFromEntryBlockGraph,
@@ -13,8 +13,14 @@ import type {
   EditLocationOption,
   EditModalNewLocation,
   SourceRef,
+  TableTextSourceRef,
 } from '@types';
-import { isBlockImageSourceRef, isTableImageSourceRef, isTextSourceRef } from '@types';
+import {
+  isBlockImageSourceRef,
+  isTableImageSourceRef,
+  isTableTextSourceRef,
+  isTextSourceRef,
+} from '@types';
 import { FileTextIcon } from '@contentful/f36-icons';
 import { useReviewTextSelection } from '@hooks/useReviewTextSelection';
 import { getEntryTitleFromFieldMappings } from '../../../../../utils/getEntryTitle';
@@ -1046,19 +1052,48 @@ export const MappingView = ({
         onClose={closeEditModal}
         mode={editModalState.mode}
         viewModel={editModalState.viewModel}
-        isImageContent={Boolean(pendingImageReassignSourceRef)}
+        isImageContent={Boolean(pendingImageReassignSourceRef) || Boolean(pendingImageSourceRef)}
         title={editModalState.title}
         locationSectionDescription={editModalState.locationSectionDescription}
         primaryButtonLabel={editModalState.primaryButtonLabel}
-        additionalContent={
-          pendingPreviewSourceRefs.length || pendingPreviewHasTableContent ? (
+        additionalContent={(() => {
+          if (!pendingPreviewSourceRefs.length && !pendingPreviewHasTableContent) return undefined;
+          const allTableText = pendingPreviewSourceRefs.every(isTableTextSourceRef);
+          if (allTableText) {
+            const first = pendingPreviewSourceRefs[0] as TableTextSourceRef;
+            const singleCell = pendingPreviewSourceRefs.every(
+              (ref) =>
+                isTableTextSourceRef(ref) &&
+                ref.tableId === first.tableId &&
+                ref.rowId === first.rowId &&
+                ref.cellId === first.cellId
+            );
+            if (singleCell) return undefined;
+            const table = document.tables.find((t) => t.id === first.tableId);
+            const totalParts =
+              table?.rows.flatMap((r) => r.cells.flatMap((c) => c.parts)).length ?? 0;
+            const coveredParts = new Set(
+              pendingPreviewSourceRefs
+                .filter(isTableTextSourceRef)
+                .map((ref) => `${ref.rowId}:${ref.cellId}:${ref.partId}`)
+            ).size;
+            if (totalParts > 0 && coveredParts < totalParts) {
+              return (
+                <Note variant="warning">
+                  Partial table selections are not supported for rich text fields. Select the entire
+                  table or just from a single cell instead.
+                </Note>
+              );
+            }
+          }
+          return (
             <RichTextSelectionPreview
               document={document}
               sourceRefs={pendingPreviewSourceRefs}
               showTablePlaceholder={pendingPreviewHasTableContent}
             />
-          ) : undefined
-        }
+          );
+        })()}
         onConfirmPrimary={handleEditModalConfirmPrimary}
       />
     </>

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -377,6 +377,7 @@ export const MappingView = ({
       fieldOptions,
       fieldMappings: entry.fieldMappings.map((fieldMapping) => ({
         fieldId: fieldMapping.fieldId,
+        sourceRefs: fieldMapping.sourceRefs,
       })),
     };
   };

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -660,10 +660,10 @@ export const MappingView = ({
   };
 
   const handleEditModalConfirmPrimary = ({
-    selectedLocationId,
+    selectedLocationIds = [],
     selectedFieldIds = {},
   }: {
-    selectedLocationId: string | null;
+    selectedLocationIds?: string[];
     selectedFieldIds?: Record<string, string[]>;
   }) => {
     if (editModalState.mode === 'assign') {
@@ -714,7 +714,7 @@ export const MappingView = ({
         }
 
         const from =
-          locations.find((location) => location.id === selectedLocationId) ??
+          locations.find((location) => location.id === selectedLocationIds[0]) ??
           locations.find((location) => location.isSelected) ??
           locations[0];
 
@@ -737,7 +737,7 @@ export const MappingView = ({
 
       if (locations.length > 0) {
         const from =
-          locations.find((location) => location.id === selectedLocationId) ??
+          locations.find((location) => location.id === selectedLocationIds[0]) ??
           locations.find((location) => location.isSelected) ??
           locations[0];
 
@@ -850,50 +850,42 @@ export const MappingView = ({
     }
 
     const locations = editModalState.viewModel.currentLocations;
-    const selected =
-      locations.find((location) => location.id === selectedLocationId) ??
-      locations.find((location) => location.isSelected) ??
-      locations[0];
+    const selected = locations.filter((location) => selectedLocationIds.includes(location.id));
 
-    if (!selected) {
+    if (!selected.length) {
       closeEditModal();
       return;
     }
 
-    if (pendingImageSourceRef) {
-      onEntryBlockGraphChange(
-        applyImageExclusionToEntryBlockGraph(entryBlockGraph, selected, pendingImageSourceRef)
-      );
-    } else {
-      const selectedSourceRefKeys = new Set(
-        (selected.sourceRefs?.length ? selected.sourceRefs : [selected.sourceRef]).map(
-          (sourceRef) => buildSourceRefKey(sourceRef)
-        )
-      );
-      const matchingImageSourceRefs = pendingExcludeImageSourceRefs.filter((sourceRef) =>
-        selectedSourceRefKeys.has(buildSourceRefKey(sourceRef))
-      );
-
-      let nextGraph = entryBlockGraph;
-
-      if (pendingTextExclusionRanges?.length) {
-        nextGraph = applyTextExclusionToEntryBlockGraph(
-          nextGraph,
-          selected,
-          pendingTextExclusionRanges
+    let next = entryBlockGraph;
+    for (const location of selected) {
+      if (pendingImageSourceRef) {
+        next = applyImageExclusionToEntryBlockGraph(next, location, pendingImageSourceRef);
+      } else {
+        const selectedSourceRefKeys = new Set(
+          (location.sourceRefs?.length ? location.sourceRefs : [location.sourceRef]).map(
+            (sourceRef) => buildSourceRefKey(sourceRef)
+          )
         );
-      }
-
-      if (matchingImageSourceRefs.length) {
-        nextGraph = matchingImageSourceRefs.reduce(
-          (graph, sourceRef) => applyImageExclusionToEntryBlockGraph(graph, selected, sourceRef),
-          nextGraph
+        const matchingImageSourceRefs = pendingExcludeImageSourceRefs.filter((sourceRef) =>
+          selectedSourceRefKeys.has(buildSourceRefKey(sourceRef))
         );
-      }
 
-      if (nextGraph !== entryBlockGraph) {
-        onEntryBlockGraphChange(nextGraph);
+        if (pendingTextExclusionRanges?.length) {
+          next = applyTextExclusionToEntryBlockGraph(next, location, pendingTextExclusionRanges);
+        }
+
+        if (matchingImageSourceRefs.length) {
+          next = matchingImageSourceRefs.reduce(
+            (graph, sourceRef) => applyImageExclusionToEntryBlockGraph(graph, location, sourceRef),
+            next
+          );
+        }
       }
+    }
+
+    if (next !== entryBlockGraph) {
+      onEntryBlockGraphChange(next);
     }
 
     closeEditModal();

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -454,9 +454,9 @@ export const MappingView = ({
       .map((card) => locationsByCardKey.get(card.key))
       .filter((location): location is EditLocationOption => Boolean(location));
 
-    return locations.map((location, index) => ({
+    return locations.map((location) => ({
       ...location,
-      isSelected: index === 0,
+      isSelected: false,
     }));
   };
 

--- a/apps/google-docs/src/locations/Page/components/review/mapping/ReviewImageAssetCard.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/ReviewImageAssetCard.tsx
@@ -59,7 +59,7 @@ export function ReviewImageAssetCard({
         maxWidth: '100%',
         verticalAlign: 'top',
         borderRadius: tokens.borderRadiusMedium,
-        border: `2px solid ${borderColor}`,
+        border: `1px solid ${borderColor}`,
         backgroundColor: isHighlighted ? tokens.green100 : tokens.gray100,
         transition: 'border-color 120ms ease',
         overflow: 'hidden',

--- a/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/EditModal.styles.ts
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/EditModal.styles.ts
@@ -8,7 +8,7 @@ export const modalContent = css({
 });
 
 export const modalContentWithDropdown = css({
-  minHeight: '600px',
+  minHeight: '500px',
 });
 
 export const sectionCard = css({

--- a/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/EditModal.styles.ts
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/EditModal.styles.ts
@@ -5,6 +5,7 @@ export const modalContent = css({
   display: 'flex',
   flexDirection: 'column',
   gap: tokens.spacingL,
+  minHeight: '600px',
 });
 
 export const sectionCard = css({

--- a/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/EditModal.styles.ts
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/EditModal.styles.ts
@@ -5,6 +5,9 @@ export const modalContent = css({
   display: 'flex',
   flexDirection: 'column',
   gap: tokens.spacingL,
+});
+
+export const modalContentWithDropdown = css({
   minHeight: '600px',
 });
 

--- a/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/EditModal.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/EditModal.tsx
@@ -1,10 +1,6 @@
 import { useEffect, useMemo, useState, type ReactNode } from 'react';
-import { Box, Button, Modal, Note, Flex, Text } from '@contentful/f36-components';
-import {
-  EditModalDestinationStateKind,
-  createEditModalDestinationState,
-  type EditModalContent,
-} from '@types';
+import { Box, Button, Modal, Flex, Text } from '@contentful/f36-components';
+import { type EditModalContent } from '@types';
 
 import {
   locationButton,
@@ -101,37 +97,21 @@ export const EditModal = ({
   const previewQuotedText = (viewModel.contentPreview ?? viewModel.selectedText).trim();
   const selectedDestinationCount = selectedFieldIds.length;
   const isAssignMode = mode === 'assign';
-  const destinationState = useMemo(() => {
-    if (!isAssignMode) {
-      return createEditModalDestinationState(EditModalDestinationStateKind.Ready);
-    }
-
-    if (!hasNewLocation) {
-      return createEditModalDestinationState(EditModalDestinationStateKind.MissingEntry);
-    }
-
-    if (viewModel.newLocation.fieldOptions.length === 0) {
-      return createEditModalDestinationState(EditModalDestinationStateKind.NoFields);
-    }
-
-    if (destinationFieldState?.hasSelectableOptions === false) {
-      return createEditModalDestinationState(EditModalDestinationStateKind.NoCompatibleFields);
-    }
-
-    if (selectedDestinationCount === 0) {
-      return createEditModalDestinationState(EditModalDestinationStateKind.RequiresSelection);
-    }
-
-    return createEditModalDestinationState(EditModalDestinationStateKind.Ready);
-  }, [
-    isAssignMode,
-    destinationFieldState?.hasSelectableOptions,
-    hasNewLocation,
-    selectedDestinationCount,
-    viewModel.newLocation.fieldOptions.length,
-  ]);
-  const isPrimaryDisabled =
-    isAssignMode && destinationState.kind !== EditModalDestinationStateKind.Ready;
+  const isPrimaryDisabled = useMemo(
+    () =>
+      isAssignMode &&
+      (!hasNewLocation || // no destination entry available
+        viewModel.newLocation.fieldOptions.length === 0 || // destination entry has no fields
+        destinationFieldState?.hasSelectableOptions === false || // no fields compatible with this content type
+        selectedDestinationCount === 0), // user hasn't selected a destination field yet
+    [
+      isAssignMode,
+      hasNewLocation,
+      viewModel.newLocation.fieldOptions.length,
+      destinationFieldState?.hasSelectableOptions,
+      selectedDestinationCount,
+    ]
+  );
 
   return (
     <Modal isShown={isOpen} onClose={onClose} size="large" shouldCloseOnOverlayClick={false}>
@@ -253,16 +233,7 @@ export const EditModal = ({
                 </Box>
               )}
 
-              {isAssignMode && destinationState.kind !== EditModalDestinationStateKind.Ready ? (
-                <Note
-                  variant={
-                    destinationState.kind === EditModalDestinationStateKind.RequiresSelection
-                      ? 'warning'
-                      : 'neutral'
-                  }>
-                  {destinationState.message}
-                </Note>
-              ) : null}
+              {additionalContent}
             </Box>
           </Modal.Content>
           <Modal.Controls>

--- a/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/EditModal.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/EditModal.tsx
@@ -26,7 +26,7 @@ interface EditModalProps {
   primaryButtonLabel: string;
   additionalContent?: ReactNode;
   onConfirmPrimary?: (details: {
-    selectedLocationId: string | null;
+    selectedLocationIds: string[];
     selectedFieldIds: Record<string, string[]>;
   }) => void;
 }
@@ -46,17 +46,8 @@ export const EditModal = ({
   const hasLocationSectionDescription = locationSectionDescription.trim().length > 0;
   const hasCurrentLocations = viewModel.currentLocations.length > 0;
   const hasNewLocation = viewModel.newLocation.id !== '';
-  const initialSelectedLocationId = useMemo(
-    () =>
-      viewModel.currentLocations.find((location) => location.isSelected)?.id ??
-      viewModel.currentLocations[0]?.id ??
-      null,
-    [viewModel.currentLocations]
-  );
 
-  const [selectedLocationId, setSelectedLocationId] = useState<string | null>(
-    initialSelectedLocationId
-  );
+  const [selectedLocationIds, setSelectedLocationIds] = useState<string[]>([]);
 
   const [selectedFieldIds, setSelectedFieldIds] = useState(
     () => viewModel.newLocation.selectedFieldIds ?? []
@@ -66,10 +57,6 @@ export const EditModal = ({
     hasFieldOptions: boolean;
     hasSelectableOptions: boolean;
   } | null>(null);
-
-  useEffect(() => {
-    setSelectedLocationId(initialSelectedLocationId);
-  }, [initialSelectedLocationId]);
 
   const newLocationRowIdsKey = viewModel.newLocation.id;
 
@@ -88,7 +75,7 @@ export const EditModal = ({
 
   const handlePrimaryAction = () => {
     onConfirmPrimary?.({
-      selectedLocationId,
+      selectedLocationIds,
       selectedFieldIds: {
         [viewModel.newLocation.id]: [...selectedFieldIds],
       },
@@ -101,12 +88,15 @@ export const EditModal = ({
   const isAssignMode = mode === 'assign';
   const isPrimaryDisabled = useMemo(
     () =>
-      isAssignMode &&
-      (!hasNewLocation || // no destination entry available
-        viewModel.newLocation.fieldOptions.length === 0 || // destination entry has no fields
-        destinationFieldState?.hasSelectableOptions === false || // no fields compatible with this content type
-        selectedDestinationCount === 0), // user hasn't selected a destination field yet
+      (hasCurrentLocations && selectedLocationIds.length === 0) || // no current location selected yet
+      (isAssignMode &&
+        (!hasNewLocation || // no destination entry available
+          viewModel.newLocation.fieldOptions.length === 0 || // destination entry has no fields
+          destinationFieldState?.hasSelectableOptions === false || // no fields compatible with this content type
+          selectedDestinationCount === 0)), // user hasn't selected a destination field yet
     [
+      hasCurrentLocations,
+      selectedLocationIds,
       isAssignMode,
       hasNewLocation,
       viewModel.newLocation.fieldOptions.length,
@@ -142,13 +132,19 @@ export const EditModal = ({
                   {hasCurrentLocations && (
                     <Box className={locationList}>
                       {viewModel.currentLocations.map((location) => {
-                        const isSelected = location.id === selectedLocationId;
+                        const isSelected = selectedLocationIds.includes(location.id);
                         return (
                           <Box
                             as="button"
                             type="button"
                             key={location.id}
-                            onClick={() => setSelectedLocationId(location.id)}
+                            onClick={() =>
+                              setSelectedLocationIds((prev) =>
+                                prev.includes(location.id)
+                                  ? prev.filter((id) => id !== location.id)
+                                  : [...prev, location.id]
+                              )
+                            }
                             aria-pressed={isSelected}
                             className={`${locationButton} ${
                               isSelected ? locationButtonSelected : locationButtonUnselected

--- a/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/EditModal.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/EditModal.tsx
@@ -119,7 +119,15 @@ export const EditModal = ({
                   <Text as="p" fontWeight="fontWeightDemiBold">
                     {previewSectionTitle}
                   </Text>
-                  {additionalContent ?? <Text as="p">"{previewQuotedText}"</Text>}
+                  {additionalContent ??
+                    (isImageContent ? (
+                      <Text as="p">
+                        <Text as="span">IMAGE: </Text>
+                        {previewQuotedText}
+                      </Text>
+                    ) : (
+                      <Text as="p">"{previewQuotedText}"</Text>
+                    ))}
                 </Flex>
               </Box>
 
@@ -232,8 +240,6 @@ export const EditModal = ({
                   </Box>
                 </Box>
               )}
-
-              {additionalContent}
             </Box>
           </Modal.Content>
           <Modal.Controls>

--- a/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/EditModal.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/EditModal.tsx
@@ -60,10 +60,11 @@ export const EditModal = ({
 
   const newLocationRowIdsKey = viewModel.newLocation.id;
 
-  // Reset field multiselect when the modal opens or when the set of destination rows changes.
+  // Reset both location and field selections when the modal opens or when the available locations/destination change.
   // Do not depend on `viewModel.newLocation` reference (it can churn without semantic change).
   useEffect(() => {
     if (!isOpen) return;
+    setSelectedLocationIds([]);
     setSelectedFieldIds(viewModel.newLocation.selectedFieldIds ?? []);
     setDestinationFieldState(null);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- sync from props only on open / row-id set change, not array identity
@@ -86,6 +87,7 @@ export const EditModal = ({
   const previewQuotedText = (viewModel.contentPreview ?? viewModel.selectedText).trim();
   const selectedDestinationCount = selectedFieldIds.length;
   const isAssignMode = mode === 'assign';
+
   const isPrimaryDisabled = useMemo(
     () =>
       (hasCurrentLocations && selectedLocationIds.length === 0) || // no current location selected yet

--- a/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/EditModal.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/EditModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import { Box, Button, Modal, Flex, Text } from '@contentful/f36-components';
+import { cx } from '@emotion/css';
 import { type EditModalContent } from '@types';
 
 import {
@@ -9,6 +10,7 @@ import {
   locationContent,
   locationList,
   modalContent,
+  modalContentWithDropdown,
   sectionCard,
 } from './EditModal.styles';
 import { FieldSelectionDropdown } from './FieldSelectionDropdown';
@@ -119,7 +121,7 @@ export const EditModal = ({
         <>
           <Modal.Header title={title} onClose={onClose} />
           <Modal.Content>
-            <Box className={modalContent}>
+            <Box className={cx(modalContent, isAssignMode && modalContentWithDropdown)}>
               <Box className={sectionCard}>
                 <Flex flexDirection="column" gap="spacingXs">
                   <Text as="p" fontWeight="fontWeightDemiBold">

--- a/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/FieldSelectionDropdown.styles.ts
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/FieldSelectionDropdown.styles.ts
@@ -1,0 +1,9 @@
+import { css } from '@emotion/css';
+
+// Forces the Text wrapper inside MultiselectOption to stretch full width
+// so marginLeft:auto on the Badge pushes it to the trailing edge.
+export const optionRow = css({
+  '& [data-test-id^="cf-multiselect-list-item"]': {
+    width: '100%',
+  },
+});

--- a/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/FieldSelectionDropdown.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/FieldSelectionDropdown.tsx
@@ -36,7 +36,12 @@ export const FieldSelectionDropdown = ({
   const multiselectListRef = useMultiselectScrollReflow(selectedFieldIds);
 
   const filledFieldIds = useMemo(
-    () => new Set(fieldMappings.map((fieldMapping) => fieldMapping.fieldId)),
+    () =>
+      new Set(
+        fieldMappings
+          .filter((fieldMapping) => fieldMapping.sourceRefs.length > 0)
+          .map((fieldMapping) => fieldMapping.fieldId)
+      ),
     [fieldMappings]
   );
   const selectableOptions = useMemo(() => {

--- a/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/FieldSelectionDropdown.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/FieldSelectionDropdown.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useId, useMemo } from 'react';
-import { Badge, Flex, Stack, Text } from '@contentful/f36-components';
+import { Badge, Flex, FormControl, Text } from '@contentful/f36-components';
 import { Multiselect } from '@contentful/f36-multiselect';
 import type { EditModalFieldMapping, EditModalFieldOption } from '@types';
 import { useMultiselectScrollReflow } from '@hooks/useMultiselectReflow';
@@ -52,6 +52,16 @@ export const FieldSelectionDropdown = ({
     return fieldOptions.filter((option) => isSelectableFieldType(option, selectedText));
   }, [fieldOptions, isImageContent, selectedText]);
 
+  const hasUnsupportedFields = useMemo(
+    () =>
+      fieldOptions.some((option) =>
+        isImageContent
+          ? !option.isAssetField
+          : !isSelectableFieldType(option, selectedText) && !option.isAssetField
+      ),
+    [fieldOptions, isImageContent, selectedText]
+  );
+
   useEffect(() => {
     onSelectableStateChange?.({
       hasFieldOptions: fieldOptions.length > 0,
@@ -76,7 +86,7 @@ export const FieldSelectionDropdown = ({
     selectedOptions.length === 0 ? 'Select one or more' : `${selectedOptions.length} selected`;
 
   return (
-    <Stack flexDirection="column" alignItems="start">
+    <FormControl as="div">
       <Multiselect
         key={key}
         currentSelection={currentSelection}
@@ -120,6 +130,12 @@ export const FieldSelectionDropdown = ({
           );
         })}
       </Multiselect>
-    </Stack>
+      {hasUnsupportedFields && (
+        <FormControl.HelpText style={{ fontSize: '0.7rem' }}>
+          This app doesn&apos;t support edits for Reference, Boolean, Date &amp; time, Location or
+          JSON fields. Use the entry editor instead.
+        </FormControl.HelpText>
+      )}
+    </FormControl>
   );
 };

--- a/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/FieldSelectionDropdown.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/FieldSelectionDropdown.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useId, useMemo } from 'react';
-import { Flex, Stack, Text } from '@contentful/f36-components';
+import { Badge, Flex, Stack, Text } from '@contentful/f36-components';
 import { Multiselect } from '@contentful/f36-multiselect';
 import type { EditModalFieldMapping, EditModalFieldOption } from '@types';
 import { useMultiselectScrollReflow } from '@hooks/useMultiselectReflow';
 import { isSelectableFieldType } from './utils';
+import { optionRow } from './FieldSelectionDropdown.styles';
 
 interface FieldSelectionDropdownProps {
   selectedText: string;
@@ -81,8 +82,10 @@ export const FieldSelectionDropdown = ({
         currentSelection={currentSelection}
         placeholder={placeholder}
         popoverProps={{
-          listMaxHeight: 360,
+          listMaxHeight: 280,
           listRef: multiselectListRef,
+          placement: 'bottom',
+          isAutoalignmentEnabled: false,
         }}>
         {fieldOptions.map((option) => {
           const fieldTypeDisplay = option.fieldDisplayType;
@@ -97,20 +100,22 @@ export const FieldSelectionDropdown = ({
               itemId={option.id}
               isChecked={selectedFieldIds.includes(option.id)}
               isDisabled={isDisabled}
-              onSelectItem={handleSelectField}>
-              <Flex gap="spacingS">
-                <Flex gap="spacing2Xs">
-                  <Text as="div" fontColor="gray700" fontWeight="fontWeightDemiBold">
-                    {option.fieldName}
-                  </Text>
-                  <Text as="div" fontColor="gray700" fontWeight="fontWeightNormal">
-                    ({fieldTypeDisplay})
-                  </Text>
-                </Flex>
+              onSelectItem={handleSelectField}
+              className={optionRow}>
+              <Flex gap="spacing2Xs">
+                <Text as="div" fontColor="gray700" fontWeight="fontWeightDemiBold">
+                  {option.fieldName}
+                </Text>
                 <Text as="div" fontColor="gray700" fontWeight="fontWeightNormal">
-                  {isFilled ? 'Filled' : 'Empty'}
+                  ({fieldTypeDisplay})
                 </Text>
               </Flex>
+              <Badge
+                variant={isFilled ? 'positive' : 'secondary'}
+                size="small"
+                style={{ marginLeft: 'auto' }}>
+                {isFilled ? 'Filled' : 'Empty'}
+              </Badge>
             </Multiselect.Option>
           );
         })}

--- a/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/RichTextSelectionPreview.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/RichTextSelectionPreview.tsx
@@ -52,6 +52,7 @@ export const RichTextSelectionPreview = ({
                 padding: tokens.spacingS,
               }}>
               <Text as="p" fontSize="fontSizeS" fontColor="gray700" marginBottom="none">
+                <Text as="span">Image: </Text>
                 {title}
               </Text>
             </Box>

--- a/apps/google-docs/src/locations/Page/components/review/mapping/entryBlockGraphExclusion.ts
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/entryBlockGraphExclusion.ts
@@ -815,23 +815,25 @@ export function applyTextExclusionToEntryBlockGraph(
 
     return {
       ...entry,
-      fieldMappings: entry.fieldMappings.map((fm) => {
-        if (fm.fieldId !== location.fieldId) return fm;
+      fieldMappings: entry.fieldMappings
+        .map((fm) => {
+          if (fm.fieldId !== location.fieldId) return fm;
 
         const nextRefs = fm.sourceRefs.flatMap((sr) => {
           if (!locationSourceRefKeys.has(buildSourceRefKey(sr))) return [sr];
           if (!isTextSourceRef(sr)) return [sr];
 
-          const cuts = rangesOverlappingTextSourceRef(sr, pendingRanges);
-          if (!cuts.length) return [sr];
+            const cuts = rangesOverlappingTextSourceRef(sr, pendingRanges);
+            if (!cuts.length) return [sr];
 
-          const remaining = subtractIntervalsFromSpan(sr.start, sr.end, cuts);
-          const pieces = buildTextRefsFromSpans(sr, remaining).filter((r) => r.start < r.end);
-          return pieces.length ? pieces : [];
-        });
+            const remaining = subtractIntervalsFromSpan(sr.start, sr.end, cuts);
+            const pieces = buildTextRefsFromSpans(sr, remaining).filter((r) => r.start < r.end);
+            return pieces.length ? pieces : [];
+          });
 
-        return { ...fm, sourceRefs: nextRefs };
-      }),
+          return nextRefs.length ? { ...fm, sourceRefs: nextRefs } : null;
+        })
+        .filter((fm): fm is NonNullable<typeof fm> => fm !== null),
     };
   });
 
@@ -1144,12 +1146,19 @@ export function applyImageExclusionToEntryBlockGraph(
   imageRef: ImageSourceRef
 ): EntryBlockGraph {
   const key = buildSourceRefKey(imageRef);
-  const nextEntries = removeImageRefFromFieldMapping(
-    graph.entries,
-    location.entryIndex,
-    location.fieldId,
-    key
-  );
+
+  const nextEntries = graph.entries.map((entry, idx) => {
+    if (idx !== location.entryIndex) return entry;
+
+    return {
+      ...entry,
+      fieldMappings: entry.fieldMappings.flatMap((fm) => {
+        if (fm.fieldId !== location.fieldId) return [fm];
+        const nextRefs = fm.sourceRefs.filter((sr) => buildSourceRefKey(sr) !== key);
+        return nextRefs.length ? [{ ...fm, sourceRefs: nextRefs }] : [];
+      }),
+    };
+  });
 
   const already = graph.excludedSourceRefs.some((r) => buildSourceRefKey(r) === key);
   return {

--- a/apps/google-docs/src/locations/Page/components/review/mapping/entryBlockGraphExclusion.ts
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/entryBlockGraphExclusion.ts
@@ -819,9 +819,9 @@ export function applyTextExclusionToEntryBlockGraph(
         .map((fm) => {
           if (fm.fieldId !== location.fieldId) return fm;
 
-        const nextRefs = fm.sourceRefs.flatMap((sr) => {
-          if (!locationSourceRefKeys.has(buildSourceRefKey(sr))) return [sr];
-          if (!isTextSourceRef(sr)) return [sr];
+          const nextRefs = fm.sourceRefs.flatMap((sr) => {
+            if (!locationSourceRefKeys.has(buildSourceRefKey(sr))) return [sr];
+            if (!isTextSourceRef(sr)) return [sr];
 
             const cuts = rangesOverlappingTextSourceRef(sr, pendingRanges);
             if (!cuts.length) return [sr];

--- a/apps/google-docs/src/types/editModal.ts
+++ b/apps/google-docs/src/types/editModal.ts
@@ -36,39 +36,6 @@ export interface EditModalNewLocation {
   selectedFieldIds?: string[];
 }
 
-export enum EditModalDestinationStateKind {
-  Ready = 'ready',
-  MissingEntry = 'missing-entry',
-  NoFields = 'no-fields',
-  NoCompatibleFields = 'no-compatible-fields',
-  RequiresSelection = 'requires-selection',
-}
-
-export interface EditModalDestinationState {
-  kind: EditModalDestinationStateKind;
-  message?: string;
-}
-
-const DEFAULT_DESTINATION_STATE_MESSAGES: Record<EditModalDestinationStateKind, string> = {
-  [EditModalDestinationStateKind.Ready]: '',
-  [EditModalDestinationStateKind.MissingEntry]:
-    'No destination entry is available for the entry currently in view.',
-  [EditModalDestinationStateKind.NoFields]:
-    'The current entry does not have any destination fields available.',
-  [EditModalDestinationStateKind.NoCompatibleFields]:
-    'The current entry does not have any compatible destination fields for this content.',
-  [EditModalDestinationStateKind.RequiresSelection]:
-    'Select at least one destination field in the current entry to continue.',
-};
-
-export const createEditModalDestinationState = (
-  kind: EditModalDestinationStateKind,
-  message?: string
-): EditModalDestinationState => ({
-  kind,
-  message: message ?? DEFAULT_DESTINATION_STATE_MESSAGES[kind] ?? undefined,
-});
-
 export interface EditModalContent {
   selectedText: string;
   /** Mapped-only preview for exclude flow; falls back to selectedText in the modal when absent. */

--- a/apps/google-docs/src/types/editModal.ts
+++ b/apps/google-docs/src/types/editModal.ts
@@ -25,6 +25,7 @@ export interface EditModalFieldOption {
 
 export interface EditModalFieldMapping {
   fieldId: string;
+  sourceRefs: SourceRef[];
 }
 
 export interface EditModalNewLocation {

--- a/apps/google-docs/test/locations/Page/components/modals/EditModal.spec.tsx
+++ b/apps/google-docs/test/locations/Page/components/modals/EditModal.spec.tsx
@@ -95,7 +95,7 @@ describe('EditModal', () => {
     });
   });
 
-  it('allows switching the selected location card', async () => {
+  it('allows selecting and toggling location cards', async () => {
     render(
       <EditModal
         isOpen={true}
@@ -113,10 +113,24 @@ describe('EditModal', () => {
       .filter((element) => element.getAttribute('aria-pressed') !== null);
     const [summaryCard, descriptionCard] = locationCards;
 
-    expect(summaryCard).toHaveAttribute('aria-pressed', 'true');
+    expect(summaryCard).toHaveAttribute('aria-pressed', 'false');
     expect(descriptionCard).toHaveAttribute('aria-pressed', 'false');
 
+    fireEvent.click(summaryCard);
+
+    await waitFor(() => {
+      expect(summaryCard).toHaveAttribute('aria-pressed', 'true');
+      expect(descriptionCard).toHaveAttribute('aria-pressed', 'false');
+    });
+
     fireEvent.click(descriptionCard);
+
+    await waitFor(() => {
+      expect(summaryCard).toHaveAttribute('aria-pressed', 'true');
+      expect(descriptionCard).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    fireEvent.click(summaryCard);
 
     await waitFor(() => {
       expect(summaryCard).toHaveAttribute('aria-pressed', 'false');
@@ -160,7 +174,7 @@ describe('EditModal', () => {
     });
   });
 
-  it('does not show destination validation or disable submit in exclude mode', async () => {
+  it('does not show destination validation in exclude mode and enables submit once a location is selected', async () => {
     render(
       <EditModal
         isOpen={true}
@@ -173,10 +187,17 @@ describe('EditModal', () => {
       />
     );
 
+    expect(
+      screen.queryByText('No destination entry is available for the entry currently in view.')
+    ).toBeNull();
+    expect(screen.getByRole('button', { name: 'Exclude content' })).toBeDisabled();
+
+    const locationCards = screen
+      .getAllByRole('button')
+      .filter((el) => el.getAttribute('aria-pressed') !== null);
+    fireEvent.click(locationCards[0]);
+
     await waitFor(() => {
-      expect(
-        screen.queryByText('No destination entry is available for the entry currently in view.')
-      ).toBeNull();
       expect(screen.getByRole('button', { name: 'Exclude content' })).not.toBeDisabled();
     });
   });

--- a/apps/google-docs/test/locations/Page/components/modals/FieldSelectionDropdown.spec.tsx
+++ b/apps/google-docs/test/locations/Page/components/modals/FieldSelectionDropdown.spec.tsx
@@ -13,7 +13,12 @@ describe('FieldSelectionDropdown', () => {
     render(
       <FieldSelectionDropdown
         selectedText="+5 "
-        fieldMappings={[{ fieldId: 'name' }]}
+        fieldMappings={[
+          {
+            fieldId: 'name',
+            sourceRefs: [{ type: 'block' as const, blockId: 'block-1', start: 0, end: 5 }],
+          },
+        ]}
         fieldOptions={[
           {
             id: 'name',

--- a/apps/google-docs/test/locations/Page/components/modals/FieldSelectionDropdown.spec.tsx
+++ b/apps/google-docs/test/locations/Page/components/modals/FieldSelectionDropdown.spec.tsx
@@ -16,7 +16,15 @@ describe('FieldSelectionDropdown', () => {
         fieldMappings={[
           {
             fieldId: 'name',
-            sourceRefs: [{ type: 'block' as const, blockId: 'block-1', start: 0, end: 5 }],
+            sourceRefs: [
+              {
+                type: 'blockText' as const,
+                blockId: 'block-1',
+                start: 0,
+                end: 5,
+                flattenedRuns: [],
+              },
+            ],
           },
         ]}
         fieldOptions={[

--- a/apps/google-docs/test/locations/Page/components/review/mapping/MappingView.spec.tsx
+++ b/apps/google-docs/test/locations/Page/components/review/mapping/MappingView.spec.tsx
@@ -923,6 +923,10 @@ describe('MappingView', () => {
       )
     ).toBeNull();
 
+    const locationCard = document.querySelector('button[aria-pressed]') as HTMLElement;
+    expect(locationCard).toBeTruthy();
+    fireEvent.click(locationCard);
+
     const confirmButton = screen.getAllByRole('button', { name: 'Exclude content' }).at(-1);
     expect(confirmButton).toBeTruthy();
     fireEvent.click(confirmButton as HTMLElement);


### PR DESCRIPTION
## Purpose

The filled/empty field status wasn't synced with edits made in the review page. This PR fixes the field status signal and improves how unsupported field types are communicated to the user.

## Before
In this example, the content in the `slug` field is excluded . So the field status should be `Empty` after the exclusion but after you reassign, the field status still says `Filled`

https://github.com/user-attachments/assets/f7a96d31-d800-482a-bf46-17402efd25f1


## After
Removed preselected current locations (blue border)

https://github.com/user-attachments/assets/8662395b-411e-481d-8dc1-1bd6bf5fdf07

Edit modal with new badge styles for filled status
<img width="1710" height="883" alt="Screenshot 2026-04-24 at 1 53 39 PM" src="https://github.com/user-attachments/assets/f791485d-0ea9-4d82-8694-476734f58e71" />

Help text to communicate unsupported fields
<img width="1710" height="883" alt="Screenshot 2026-04-24 at 1 53 44 PM" src="https://github.com/user-attachments/assets/5a50d9b0-0f41-4de8-b66d-2132ac493a61" />

Filled / Empty status updated with edits

https://github.com/user-attachments/assets/31614a5f-286e-4d97-b649-a5643fba6d93






Allow multi-exclusion

https://github.com/user-attachments/assets/a1556fab-bef8-4f9f-9a4a-f78081b504bc


## Approach

  **Fix field status detection**
  - Added `sourceRefs` to `EditModalFieldMapping` so the dropdown has the data
    it needs to determine fill state
  - Updated `filledFieldIds` in `FieldSelectionDropdown` to filter on
    `sourceRefs.length > 0` instead of mapping presence alone

  **Improve visual communication in the dropdown**
  - Replaced plain "Filled" / "Empty" text with f36 `Badge` components
    (`positive` / `secondary`) pushed to the trailing edge of each option row
  - Added a conditional `FormControl.HelpText` note below the dropdown when
    unsupported field types are present:
    > "Edits aren't supported for: Reference, Boolean, Date & time, Location or
    > JSON fields. Use the entry editor instead."

  **Multi-select current locations for exclusion**
  - Current location cards now support multi-selection — clicking a card toggles
    it; multiple can be selected at once
  - Nothing is pre-selected when the modal opens
  - The CTA stays disabled until at least one location is selected (both assign
    and exclude modes)
  - On confirm, exclusion is applied to each selected location in sequence
  - Removed `isSelected: index === 0` hardcoding in `MappingView` that was
    forcing the first location to always be pre-selected

  **Clean up edit modal**
  - Removed the orange `Note` validation banner — the disabled CTA already
    communicates the blocked state
  - Removed `EditModalDestinationStateKind`, `EditModalDestinationState`,
    `createEditModalDestinationState`, and `DEFAULT_DESTINATION_STATE_MESSAGES`
    — no longer needed
  - Inlined destination state logic directly into `isPrimaryDisabled` with
    inline comments per condition
  - `minHeight` on the modal content is now only applied in assign mode (the
    exclude modal doesn't have the dropdown and doesn't need the extra height)

  **Fix exclusion behaviour**
  - `applyTextExclusionToEntryBlockGraph` now prunes field mappings when all
    source refs are excluded, rather than leaving an empty mapping behind
  - `applyImageExclusionToEntryBlockGraph` inlined with the same pruning
    behaviour for consistency
  ## Testing steps

  - [ ] Open the edit modal on an entry with a mix of text, reference, boolean,
        and media fields
  - [ ] Verify "Filled" (green) / "Empty" (grey) badges reflect actual mapping
        state
  - [ ] Verify the help text note appears below the dropdown
  - [ ] Verify the "Move content" CTA stays disabled until a compatible field is
        selected, with no orange banner
  - [ ] Exclude all text from a mapped field — verify the field mapping is
        removed rather than left empty

  ## Breaking Changes

  None.

  ## Dependencies and/or References

  None.
