### PR TITLE
fix: run package builds during publish []

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ commands:
             echo "//npm.pkg.github.com/:_authToken=${GITHUB_PACKAGES_WRITE_TOKEN}" >> ~/.npmrc
       - run:
           name: Publish packages
-          command: npm run publish-packages
+          command: NPM_CONFIG_IGNORE_SCRIPTS=false npm run publish-packages
 
   set_since:
     steps:
@@ -31,7 +31,7 @@ commands:
             source $BASH_ENV
 
   run_allow_scripts:
-    description: "Run LavaMoat allow-scripts for packages that use it"
+    description: 'Run LavaMoat allow-scripts for packages that use it'
     steps:
       - run:
           name: Run allow-scripts (lifecycle scripts for whitelisted packages)

--- a/packages/dam-app-base/package.json
+++ b/packages/dam-app-base/package.json
@@ -48,7 +48,7 @@
   "scripts": {
     "build": "rimraf lib && tsc",
     "build:docs": "rimraf docs && typedoc",
-    "prepublishOnly": "npm run build && npm run build:docs",
+    "prepack": "npm run build && npm run build:docs",
     "test": "jest --watch",
     "test:ci": "jest"
   }

--- a/packages/ecommerce-app-base/package.json
+++ b/packages/ecommerce-app-base/package.json
@@ -74,7 +74,7 @@
   "scripts": {
     "build": "rimraf lib && tsc",
     "build:docs": "rimraf docs && typedoc",
-    "prepublishOnly": "npm run build",
+    "prepack": "npm run build",
     "test": "vitest",
     "test:ci": "CI=true vitest",
     "storybook": "storybook dev -p 6006",

--- a/packages/eslint-plugin-contentful-apps/package.json
+++ b/packages/eslint-plugin-contentful-apps/package.json
@@ -25,7 +25,7 @@
   "description": "Eslint plugin for Contentful App Framework Apps",
   "scripts": {
     "build": "rm -rf ./dist && tsup",
-    "prepublishOnly": "npm run build"
+    "prepack": "npm run build"
   },
   "tsup": {
     "entry": [


### PR DESCRIPTION
## Summary
Prevents malformed package releases by ensuring publish-time build scripts run when Lerna publishes tagged packages from CI.

## Changes
- override `ignore-scripts` during the CircleCI package publish step so package lifecycle build scripts can run
- switch publishable packages to `prepack` so packaging itself produces `lib`/`dist` before publish
- cover the packages currently relying on generated publish artifacts: `@contentful/ecommerce-app-base`, `@contentful/dam-app-base`, and `@contentful/eslint-plugin-contentful-apps`

## Notes
- This follows the `@contentful/ecommerce-app-base@4.1.0` release, which produced a package without `lib/` even though the GitHub release/tag existed.
- Verified locally by running `NPM_CONFIG_IGNORE_SCRIPTS=false npm pack --dry-run --json` in `packages/ecommerce-app-base` from a clean directory and confirming the tarball contains `lib/index.js`.

Updated in:
- `.circleci/config.yml`
- `packages/ecommerce-app-base`
- `packages/dam-app-base`
- `packages/eslint-plugin-contentful-apps`
