### PR TITLE
Truncate fields for card mappings [INTEG-3837]

### DIFF
--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingCard.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingCard.tsx
@@ -23,6 +23,9 @@ const labelTextStyle = {
   lineHeight: tokens.lineHeightS,
 };
 
+const BASE_FIELD_NAME_MAX_LENGTH = 35;
+const MIN_FIELD_NAME_MAX_LENGTH = 10;
+
 const valueTextStyle = {
   fontSize: tokens.fontSizeS,
   lineHeight: tokens.lineHeightS,
@@ -38,7 +41,11 @@ export const MappingCard = ({
   onMouseEnter,
   onMouseLeave,
 }: MappingCardProps) => {
-  const fieldName = truncateLabel(card.fieldName, 30);
+  const maxLength = Math.max(
+    MIN_FIELD_NAME_MAX_LENGTH,
+    BASE_FIELD_NAME_MAX_LENGTH - card.fieldType.length
+  );
+  const fieldName = truncateLabel(card.fieldName, maxLength);
 
   return (
     <Box

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingCard.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingCard.tsx
@@ -48,7 +48,7 @@ export const MappingCard = ({
   const fullValue = `${fieldName}${FIELD_TYPE_SEPARATOR}${fieldType}`;
   const truncatedValue = truncate(fullValue, MAX_VALUE_LENGTH);
   const separatorIndex = truncatedValue.indexOf(FIELD_TYPE_SEPARATOR);
-  const hasTypePart = separatorIndex >= 0;
+  const hasTypePart = separatorIndex !== -1;
   const namePart = hasTypePart ? fieldName : truncatedValue;
   const typePart = hasTypePart
     ? truncatedValue.slice(separatorIndex + FIELD_TYPE_SEPARATOR.length)

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingCard.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingCard.tsx
@@ -1,7 +1,6 @@
 import { type Ref } from 'react';
-import { Box, Text } from '@contentful/f36-components';
+import { Box, Text, Tooltip } from '@contentful/f36-components';
 import tokens from '@contentful/f36-tokens';
-import { truncateLabel } from '../../../../../utils/utils';
 
 export interface MappingCardData {
   key: string;
@@ -23,8 +22,8 @@ const labelTextStyle = {
   lineHeight: tokens.lineHeightS,
 };
 
-const BASE_FIELD_NAME_MAX_LENGTH = 35;
-const MIN_FIELD_NAME_MAX_LENGTH = 10;
+const MAX_VALUE_LENGTH = 35;
+const FIELD_TYPE_SEPARATOR = ' | ';
 
 const valueTextStyle = {
   fontSize: tokens.fontSizeS,
@@ -32,6 +31,9 @@ const valueTextStyle = {
   whiteSpace: 'nowrap',
   overflow: 'hidden',
 } as const;
+
+export const truncate = (str: string, maxLength: number) =>
+  str.length > maxLength ? str.slice(0, maxLength) + ' ...' : str;
 
 export const MappingCard = ({
   card,
@@ -41,11 +43,16 @@ export const MappingCard = ({
   onMouseEnter,
   onMouseLeave,
 }: MappingCardProps) => {
-  const maxLength = Math.max(
-    MIN_FIELD_NAME_MAX_LENGTH,
-    BASE_FIELD_NAME_MAX_LENGTH - card.fieldType.length
-  );
-  const fieldName = truncateLabel(card.fieldName, maxLength);
+  const { fieldName, fieldType } = card;
+
+  const fullValue = `${fieldName}${FIELD_TYPE_SEPARATOR}${fieldType}`;
+  const truncatedValue = truncate(fullValue, MAX_VALUE_LENGTH);
+  const separatorIndex = truncatedValue.indexOf(FIELD_TYPE_SEPARATOR);
+  const hasTypePart = separatorIndex >= 0;
+  const namePart = hasTypePart ? fieldName : truncatedValue;
+  const typePart = hasTypePart
+    ? truncatedValue.slice(separatorIndex + FIELD_TYPE_SEPARATOR.length)
+    : null;
 
   return (
     <Box
@@ -68,17 +75,21 @@ export const MappingCard = ({
       <Text as="span" fontColor="gray600" style={labelTextStyle} marginRight="spacingXs">
         Field:
       </Text>
-      <Text
-        as="span"
-        fontWeight="fontWeightDemiBold"
-        title={`${card.fieldName} (${card.fieldType})`}
-        style={valueTextStyle}>
-        {fieldName}
-
-        <Box as="span" style={{ color: tokens.gray600 }}>
-          {' | '}
-          {card.fieldType}
-        </Box>
+      <Text as="span" fontWeight="fontWeightDemiBold" style={valueTextStyle}>
+        <Tooltip
+          content={`Field: ${fullValue}`}
+          placement="top"
+          isDisabled={truncatedValue === fullValue}>
+          <Box as="span">
+            {namePart}
+            {typePart ? (
+              <Box as="span" style={{ color: tokens.gray600 }}>
+                {FIELD_TYPE_SEPARATOR}
+                {typePart}
+              </Box>
+            ) : null}
+          </Box>
+        </Tooltip>
       </Text>
     </Box>
   );

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingCard.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingCard.tsx
@@ -1,6 +1,7 @@
 import { type Ref } from 'react';
 import { Box, Text } from '@contentful/f36-components';
 import tokens from '@contentful/f36-tokens';
+import { truncateLabel } from '../../../../../utils/utils';
 
 export interface MappingCardData {
   key: string;
@@ -27,7 +28,6 @@ const valueTextStyle = {
   lineHeight: tokens.lineHeightS,
   whiteSpace: 'nowrap',
   overflow: 'hidden',
-  textOverflow: 'ellipsis',
 } as const;
 
 export const MappingCard = ({
@@ -37,38 +37,42 @@ export const MappingCard = ({
   isHovered = false,
   onMouseEnter,
   onMouseLeave,
-}: MappingCardProps) => (
-  <Box
-    ref={wrapperRef}
-    data-testid={`mapping-card-${card.key}`}
-    data-hovered={isHovered ? 'true' : 'false'}
-    onMouseEnter={onMouseEnter}
-    onMouseLeave={onMouseLeave}
-    style={{
-      position: 'absolute',
-      insetInlineStart: 0,
-      insetInlineEnd: 0,
-      top,
-      border: `${isHovered ? 2 : 1}px solid ${isHovered ? tokens.green600 : tokens.green500}`,
-      borderRadius: tokens.borderRadiusMedium,
-      padding: tokens.spacing2Xs,
-      backgroundColor: tokens.green100,
-      transition: 'border-color 120ms ease, border-width 120ms ease',
-    }}>
-    <Text as="span" fontColor="gray600" style={labelTextStyle} marginRight="spacingXs">
-      Field:
-    </Text>
-    <Text
-      as="span"
-      fontWeight="fontWeightDemiBold"
-      title={`${card.fieldName} (${card.fieldType})`}
-      style={valueTextStyle}>
-      {card.fieldName}
+}: MappingCardProps) => {
+  const fieldName = truncateLabel(card.fieldName, 30);
 
-      <Box as="span" style={{ color: tokens.gray600 }}>
-        {' | '}
-        {card.fieldType}
-      </Box>
-    </Text>
-  </Box>
-);
+  return (
+    <Box
+      ref={wrapperRef}
+      data-testid={`mapping-card-${card.key}`}
+      data-hovered={isHovered ? 'true' : 'false'}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      style={{
+        position: 'absolute',
+        insetInlineStart: 0,
+        insetInlineEnd: 0,
+        top,
+        border: `${isHovered ? 2 : 1}px solid ${isHovered ? tokens.green600 : tokens.green500}`,
+        borderRadius: tokens.borderRadiusMedium,
+        padding: tokens.spacing2Xs,
+        backgroundColor: tokens.green100,
+        transition: 'border-color 120ms ease, border-width 120ms ease',
+      }}>
+      <Text as="span" fontColor="gray600" style={labelTextStyle} marginRight="spacingXs">
+        Field:
+      </Text>
+      <Text
+        as="span"
+        fontWeight="fontWeightDemiBold"
+        title={`${card.fieldName} (${card.fieldType})`}
+        style={valueTextStyle}>
+        {fieldName}
+
+        <Box as="span" style={{ color: tokens.gray600 }}>
+          {' | '}
+          {card.fieldType}
+        </Box>
+      </Text>
+    </Box>
+  );
+};

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -249,7 +249,7 @@ export const MappingView = ({
 
       return {
         key: getMappingCardKey(segment.id, highlight),
-        fieldName: formatDisplayName(highlight.fieldId),
+        fieldName: (field?.name ?? '').trim() || formatDisplayName(highlight.fieldId),
         fieldType: field
           ? displayType(field.type ?? '', field.linkType, field.items)
           : displayType(highlight.fieldType),


### PR DESCRIPTION
## Purpose

Truncate field display name for card mappings
## Approach

- Truncate name with elipsis
- Fix label for hightlightning. Now it uses the actual field name. Fallback to id

## Testing steps

UPDATED ⚠️ 

https://github.com/user-attachments/assets/002e9819-3f0e-43b3-9c46-30fc6dae9cbc

https://github.com/user-attachments/assets/a0ff450b-82d4-4dcc-9480-6bb980d0f2ed

<img width="326" height="139" alt="Captura de pantalla 2026-04-22 a las 5 41 41 p  m" src="https://github.com/user-attachments/assets/aed54e30-b16b-4045-95e7-178425312737" />


## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
