### PR TITLE
fix: avoid docs generation during package publish []

### DIFF
--- a/packages/dam-app-base/package.json
+++ b/packages/dam-app-base/package.json
@@ -48,7 +48,7 @@
   "scripts": {
     "build": "rimraf lib && tsc",
     "build:docs": "rimraf docs && typedoc",
-    "prepack": "npm run build && npm run build:docs",
+    "prepack": "npm run build",
     "test": "jest --watch",
     "test:ci": "jest"
   }


### PR DESCRIPTION
## Summary
Prevents `@contentful/dam-app-base` package publishing from failing on Typedoc by limiting publish-time work to the build artifacts that are actually shipped.

## Changes
- change `@contentful/dam-app-base` `prepack` to run only `npm run build`
- keep docs generation available as `build:docs`, but remove it from the package publish path

## Notes
- `@contentful/dam-app-base` publishes only `lib`, not `docs`
- this follows the failed publish of `@contentful/ecommerce-app-base@4.1.1`, where `dam-app-base` blocked the shared package publish step during `prepack`
- verified with `npm pack --dry-run --json` from a clean `packages/dam-app-base` directory; the tarball now contains `lib/index.js` without invoking Typedoc

Updated in:
- `packages/dam-app-base`
