### PR TITLE
fix: republish ecommerce app base []

### DIFF
--- a/packages/ecommerce-app-base/src/types/config.ts
+++ b/packages/ecommerce-app-base/src/types/config.ts
@@ -29,7 +29,7 @@ export type ParameterDefinition = {
 
   /**
    * Optional select options. When provided, the app config renders a dropdown
-   * instead of a free-text input.
+   * instead of a free-text input and persists the selected string value.
    */
   options?: string[];
 


### PR DESCRIPTION
## Summary
Triggers a fresh `@contentful/ecommerce-app-base` release after the stranded `4.1.1` tag so consumers can pick up the shared config dropdown support through a clean published package.

## Changes
- make a minimal source-level documentation update in `@contentful/ecommerce-app-base`

## Notes
- this is intentionally non-behavioral
- the purpose is to cut a new package version after `@contentful/ecommerce-app-base@4.1.1` ended up tagged/released without becoming installable from the registry
- verified `@contentful/ecommerce-app-base` tests and build locally before opening this PR

Updated in:
- `packages/ecommerce-app-base`
