### PR TITLE
fix(google-docs): add copy to overview section [INTEG-3839]

### DIFF
--- a/apps/google-docs/src/locations/Page/components/overview/OverviewSection.tsx
+++ b/apps/google-docs/src/locations/Page/components/overview/OverviewSection.tsx
@@ -98,7 +98,7 @@ const OverviewSection = ({
               <LightbulbIcon size="small" />
               <Text fontWeight="fontWeightDemiBold">How to use this app</Text>
             </Flex>
-            <Paragraph marginBottom="none" fontColor="gray600">
+            <Paragraph marginBottom="none">
               Review your content and associated entries below. Highlight text to make adjustments.
               Create entries when you are complete.
             </Paragraph>

--- a/apps/google-docs/src/locations/Page/components/overview/OverviewSection.tsx
+++ b/apps/google-docs/src/locations/Page/components/overview/OverviewSection.tsx
@@ -92,7 +92,7 @@ const OverviewSection = ({
   return (
     <>
       <Box padding="spacingL" className={overviewSectionBox}>
-        <Flex flexDirection="column" gap="spacingS">
+        <Flex flexDirection="column" gap="spacingM">
           <Flex flexDirection="column" gap="spacingXs">
             <Flex alignItems="center" gap="spacingXs">
               <LightbulbIcon size="small" />
@@ -106,10 +106,14 @@ const OverviewSection = ({
 
           <Splitter />
 
-          <Flex justifyContent="space-between" alignItems="center">
-            <Text fontWeight="fontWeightDemiBold" fontSize="fontSizeL">
-              Entries
-            </Text>
+          <Flex justifyContent="space-between" alignItems="center" paddingBottom="none">
+            <Flex flexDirection="column" gap="spacingXs">
+              <Text fontWeight="fontWeightDemiBold" fontSize="fontSizeL">
+                Entries
+              </Text>
+              <Text fontSize="fontSizeM">Click row to view content by entry below.</Text>
+            </Flex>
+
             <Button
               variant="primary"
               onClick={() => void handleCreateEntries()}

--- a/apps/google-docs/src/utils/constants/agent.ts
+++ b/apps/google-docs/src/utils/constants/agent.ts
@@ -8,4 +8,4 @@ export const MAX_POLL_ATTEMPTS = Math.floor(MAX_POLL_TIME_MS / POLL_INTERVAL_MS)
 
 export const LOCAL_AGENTS_API_BASE_URL = 'http://localhost:4111';
 
-export const CONTENT_TYPE_SUBMIT_LOADING_DELAY_MS = 15000; // 15 seconds to wait for suspend payload
+export const CONTENT_TYPE_SUBMIT_LOADING_DELAY_MS = 30000; // 30 seconds to wait for suspend payload


### PR DESCRIPTION
## Purpose
- increase CONTENT_TYPE_SUBMIT_LOADING_DELAY_MS to 30s
- add `Click row to view content by entry below.` in overview section
<img width="1034" height="457" alt="Screenshot 2026-04-22 at 1 32 39 PM" src="https://github.com/user-attachments/assets/7531f963-9253-489e-8eb0-cb5984cc7c44" />
