### PR TITLE
Google Docs: Group mapping cards to the same field [INTEG-3826]

### DIFF
--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingCard.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingCard.tsx
@@ -6,6 +6,7 @@ export interface MappingCardData {
   key: string;
   fieldName: string;
   fieldType: string;
+  displayLabel: string;
 }
 
 interface MappingCardProps {
@@ -61,9 +62,9 @@ export const MappingCard = ({
     <Text
       as="span"
       fontWeight="fontWeightDemiBold"
-      title={`${card.fieldName} (${card.fieldType})`}
+      title={`${card.displayLabel} (${card.fieldType})`}
       style={valueTextStyle}>
-      {card.fieldName}
+      {card.displayLabel}
 
       <Box as="span" style={{ color: tokens.gray600 }}>
         {' | '}

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingCard.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingCard.tsx
@@ -1,5 +1,5 @@
 import { type Ref } from 'react';
-import { Box, Text } from '@contentful/f36-components';
+import { Box, Text, Tooltip } from '@contentful/f36-components';
 import tokens from '@contentful/f36-tokens';
 
 export interface MappingCardData {
@@ -23,13 +23,18 @@ const labelTextStyle = {
   lineHeight: tokens.lineHeightS,
 };
 
+const MAX_VALUE_LENGTH = 35;
+const FIELD_TYPE_SEPARATOR = ' | ';
+
 const valueTextStyle = {
   fontSize: tokens.fontSizeS,
   lineHeight: tokens.lineHeightS,
   whiteSpace: 'nowrap',
   overflow: 'hidden',
-  textOverflow: 'ellipsis',
 } as const;
+
+export const truncate = (str: string, maxLength: number) =>
+  str.length > maxLength ? str.slice(0, maxLength) + ' ...' : str;
 
 export const MappingCard = ({
   card,
@@ -38,38 +43,54 @@ export const MappingCard = ({
   isHovered = false,
   onMouseEnter,
   onMouseLeave,
-}: MappingCardProps) => (
-  <Box
-    ref={wrapperRef}
-    data-testid={`mapping-card-${card.key}`}
-    data-hovered={isHovered ? 'true' : 'false'}
-    onMouseEnter={onMouseEnter}
-    onMouseLeave={onMouseLeave}
-    style={{
-      position: 'absolute',
-      insetInlineStart: 0,
-      insetInlineEnd: 0,
-      top,
-      border: `${isHovered ? 2 : 1}px solid ${isHovered ? tokens.green600 : tokens.green500}`,
-      borderRadius: tokens.borderRadiusMedium,
-      padding: tokens.spacing2Xs,
-      backgroundColor: tokens.green100,
-      transition: 'border-color 120ms ease, border-width 120ms ease',
-    }}>
-    <Text as="span" fontColor="gray600" style={labelTextStyle} marginRight="spacingXs">
-      Field:
-    </Text>
-    <Text
-      as="span"
-      fontWeight="fontWeightDemiBold"
-      title={`${card.displayLabel} (${card.fieldType})`}
-      style={valueTextStyle}>
-      {card.displayLabel}
+}: MappingCardProps) => {
+  const { displayLabel, fieldType } = card;
+  const fullValue = `${displayLabel}${FIELD_TYPE_SEPARATOR}${fieldType}`;
+  const truncatedValue = truncate(fullValue, MAX_VALUE_LENGTH);
+  const separatorIndex = truncatedValue.indexOf(FIELD_TYPE_SEPARATOR);
+  const hasTypePart = separatorIndex !== -1;
+  const labelPart = hasTypePart ? truncatedValue.slice(0, separatorIndex) : truncatedValue;
+  const typePart = hasTypePart
+    ? truncatedValue.slice(separatorIndex + FIELD_TYPE_SEPARATOR.length)
+    : null;
 
-      <Box as="span" style={{ color: tokens.gray600 }}>
-        {' | '}
-        {card.fieldType}
-      </Box>
-    </Text>
-  </Box>
-);
+  return (
+    <Box
+      ref={wrapperRef}
+      data-testid={`mapping-card-${card.key}`}
+      data-hovered={isHovered ? 'true' : 'false'}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      style={{
+        position: 'absolute',
+        insetInlineStart: 0,
+        insetInlineEnd: 0,
+        top,
+        border: `${isHovered ? 2 : 1}px solid ${isHovered ? tokens.green600 : tokens.green500}`,
+        borderRadius: tokens.borderRadiusMedium,
+        padding: tokens.spacing2Xs,
+        backgroundColor: tokens.green100,
+        transition: 'border-color 120ms ease, border-width 120ms ease',
+      }}>
+      <Text as="span" fontColor="gray600" style={labelTextStyle} marginRight="spacingXs">
+        Field:
+      </Text>
+      <Text as="span" fontWeight="fontWeightDemiBold" style={valueTextStyle}>
+        <Tooltip
+          content={`Field: ${fullValue}`}
+          placement="top"
+          isDisabled={truncatedValue === fullValue}>
+          <Box as="span">
+            {labelPart}
+            {typePart ? (
+              <Box as="span" style={{ color: tokens.gray600 }}>
+                {FIELD_TYPE_SEPARATOR}
+                {typePart}
+              </Box>
+            ) : null}
+          </Box>
+        </Tooltip>
+      </Text>
+    </Box>
+  );
+};

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingEntryCards.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingEntryCards.tsx
@@ -1,15 +1,12 @@
 import { Box, type BoxProps } from '@contentful/f36-components';
 import { type RefCallback } from 'react';
-import { MappingCard, type MappingCardData } from './MappingCard';
-
-export type AnchoredMappingCard = MappingCardData & {
-  anchorId: string;
-};
+import { MappingCard } from './MappingCard';
+import type { RenderedMappingCard } from './buildMappingDisplayGroups';
 
 interface MappingEntryCardsProps {
-  segmentId: string;
-  mappingCards: AnchoredMappingCard[];
-  cardOffsetsBySegment: Record<string, Record<string, number>>;
+  groupId: string;
+  mappingCards: RenderedMappingCard[];
+  cardOffsetsByGroup: Record<string, Record<string, number>>;
   hoveredMappingKeys: string[];
   onSetHoveredMappingKeys: (keys: string[]) => void;
   setCardWrapperRef: (cardKey: string) => RefCallback<HTMLDivElement>;
@@ -22,25 +19,25 @@ const railStyles: BoxProps['style'] = {
 };
 
 export const MappingEntryCards = ({
-  segmentId,
+  groupId,
   mappingCards,
-  cardOffsetsBySegment,
+  cardOffsetsByGroup,
   hoveredMappingKeys,
   onSetHoveredMappingKeys,
   setCardWrapperRef,
 }: MappingEntryCardsProps): JSX.Element => {
   return (
-    <Box data-testid={`mapping-rail-${segmentId}`} style={railStyles}>
+    <Box data-testid={`mapping-rail-${groupId}`} style={railStyles}>
       <Box style={{ position: 'relative', minHeight: '100%' }}>
         {mappingCards.length > 0
           ? mappingCards.map((mappingCard) => (
               <MappingCard
                 key={mappingCard.key}
                 card={mappingCard}
-                top={cardOffsetsBySegment[segmentId]?.[mappingCard.key] ?? 0}
+                top={cardOffsetsByGroup[groupId]?.[mappingCard.key] ?? 0}
                 wrapperRef={setCardWrapperRef(mappingCard.key)}
-                isHovered={hoveredMappingKeys.includes(mappingCard.key)}
-                onMouseEnter={() => onSetHoveredMappingKeys([mappingCard.key])}
+                isHovered={mappingCard.mappingKeys.some((key) => hoveredMappingKeys.includes(key))}
+                onMouseEnter={() => onSetHoveredMappingKeys(mappingCard.mappingKeys)}
                 onMouseLeave={() => onSetHoveredMappingKeys([])}
               />
             ))

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -18,7 +18,7 @@ import { isTextSourceRef } from '@types';
 import { FileTextIcon } from '@contentful/f36-icons';
 import { useReviewTextSelection } from '@hooks/useReviewTextSelection';
 import { getEntryTitleFromFieldMappings } from '../../../../../utils/getEntryTitle';
-import { getAnchorIdForSourceRef, resolveMarkerOffsets } from './resolveMappingCardOffsets';
+import { resolveMarkerOffsets } from './resolveMappingCardOffsets';
 import { type DocSegment, buildDocument } from './buildDocument';
 import {
   buildMappingHighlightIndex,
@@ -27,14 +27,19 @@ import {
   uniqueHighlights,
 } from './buildHighlights';
 import { buildListMarkers } from './buildListMarkers';
-import { displayType, formatDisplayName } from './fieldFormatting';
+import {
+  displayType,
+  formatDisplayName,
+  isAssetFieldForImageAssign,
+  isWorkflowContentTypeFieldWithId,
+} from './fieldFormatting';
 import { EditModal } from './edit-modals/EditModal';
-import { isAssetFieldForImageAssign, isWorkflowContentTypeFieldWithId } from './fieldFormatting';
 
 import { SelectionActionMenu } from './SelectionActionMenu';
 import { buildSourceRefKey } from './sourceRefUtils';
-import { MappingEntryCards, type AnchoredMappingCard } from './MappingEntryCards';
+import { MappingEntryCards } from './MappingEntryCards';
 import { NormalizedDocumentSection } from './NormalizedDocumentSection';
+import { buildMappingDisplayGroups } from './buildMappingDisplayGroups';
 import {
   applyImageExclusionToEntryBlockGraph,
   applyImageReassignToEntryBlockGraph,
@@ -155,7 +160,7 @@ export const MappingView = ({
     selectedEntryIndex,
   ]);
   const [hoveredMappingKeys, setHoveredMappingKeys] = useState<string[]>([]);
-  const [cardOffsetsBySegment, setCardOffsetsBySegment] = useState<
+  const [cardOffsetsByGroup, setCardOffsetsByGroup] = useState<
     Record<string, Record<string, number>>
   >({});
   const [editModalState, setEditModalState] = useState<EditModalState>(EMPTY_EDIT_MODAL);
@@ -170,7 +175,7 @@ export const MappingView = ({
   );
   const [pendingTextAssignRanges, setPendingTextAssignRanges] = useState<TextExclusionRange[]>([]);
   const textSelectionRootRef = useRef<HTMLDivElement | null>(null);
-  const segmentLayoutRefs = useRef<Record<string, HTMLDivElement | null>>({});
+  const groupLayoutRefs = useRef<Record<string, HTMLDivElement | null>>({});
   const cardWrapperRefs = useRef<Record<string, HTMLDivElement | null>>({});
 
   const document = payload.normalizedDocument;
@@ -239,24 +244,6 @@ export const MappingView = ({
     return uniqueHighlights(highlightIndex.blockHighlights[segment.id] ?? []);
   };
 
-  const getMappingCardsForSegment = (segment: DocSegment): AnchoredMappingCard[] =>
-    getVisibleHighlights(getHighlightsForSegment(segment)).map((highlight) => {
-      const graphEntry = entryBlockGraph.entries[highlight.entryIndex];
-      const contentType = payload.contentTypes.find(
-        (item) => item.sys.id === graphEntry?.contentTypeId
-      );
-      const field = contentType?.fields.find((item) => item.id === highlight.fieldId);
-
-      return {
-        key: getMappingCardKey(segment.id, highlight),
-        fieldName: formatDisplayName(highlight.fieldId),
-        fieldType: field
-          ? displayType(field.type ?? '', field.linkType, field.items)
-          : displayType(highlight.fieldType),
-        anchorId: getAnchorIdForSourceRef(highlight.sourceRef),
-      };
-    });
-
   const buildLocationOption = (
     entryIndex: number,
     fieldId: string,
@@ -293,11 +280,37 @@ export const MappingView = ({
     };
   };
 
+  const visibleHighlightsBySegment = useMemo(
+    () =>
+      allSegments.reduce<Record<string, MappingHighlight[]>>((acc, segment) => {
+        acc[segment.id] = getVisibleHighlights(getHighlightsForSegment(segment));
+        return acc;
+      }, {}),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [allSegments, entryBlockGraph, selectedEntryIndex]
+  );
+
+  const { groupsByTab, allGroups } = useMemo(
+    () =>
+      buildMappingDisplayGroups(tabs, visibleHighlightsBySegment, (highlight) => {
+        const graphEntry = entryBlockGraph.entries[highlight.entryIndex];
+        const contentType = payload.contentTypes.find(
+          (item) => item.sys.id === graphEntry?.contentTypeId
+        );
+        const field = contentType?.fields.find((item) => item.id === highlight.fieldId);
+
+        return field
+          ? displayType(field.type ?? '', field.linkType, field.items)
+          : displayType(highlight.fieldType);
+      }),
+    [tabs, visibleHighlightsBySegment, payload.contentTypes, entryBlockGraph.entries]
+  );
+
   const locationsByMappingKey = useMemo(() => {
     const byKey = new Map<string, EditLocationOption>();
 
     allSegments.forEach((segment) => {
-      const highlights = getVisibleHighlights(getHighlightsForSegment(segment));
+      const highlights = visibleHighlightsBySegment[segment.id] ?? [];
       highlights.forEach((highlight) => {
         const mappingKey = getMappingCardKey(segment.id, highlight);
         if (byKey.has(mappingKey)) {
@@ -318,7 +331,7 @@ export const MappingView = ({
 
     return byKey;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [allSegments, entryBlockGraph, payload.contentTypes, selectedEntryIndex]);
+  }, [allSegments, entryBlockGraph, payload.contentTypes, visibleHighlightsBySegment]);
 
   const getNewLocationForEntry = (
     entry: EntryBlockGraph['entries'][number],
@@ -424,20 +437,10 @@ export const MappingView = ({
     }));
   };
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const mappingCardsBySegment = useMemo(
-    () =>
-      allSegments.reduce<Record<string, AnchoredMappingCard[]>>((acc, segment) => {
-        acc[segment.id] = getMappingCardsForSegment(segment);
-        return acc;
-      }, {}),
-    [allSegments, selectedEntryIndex, highlightIndex]
-  );
-
-  const setSegmentLayoutRef =
-    (segmentId: string): RefCallback<HTMLDivElement> =>
+  const setGroupLayoutRef =
+    (groupId: string): RefCallback<HTMLDivElement> =>
     (node) => {
-      segmentLayoutRefs.current[segmentId] = node;
+      groupLayoutRefs.current[groupId] = node;
     };
 
   const setCardWrapperRef =
@@ -450,23 +453,21 @@ export const MappingView = ({
     const measureOffsets = () => {
       const nextOffsets: Record<string, Record<string, number>> = {};
 
-      allSegments.forEach((segment) => {
-        const segmentNode = segmentLayoutRefs.current[segment.id];
-        const segmentCards = mappingCardsBySegment[segment.id] ?? [];
+      allGroups.forEach((group) => {
+        const groupNode = groupLayoutRefs.current[group.id];
+        const groupCards = group.mappingCards;
 
-        if (!segmentNode || segmentCards.length === 0) {
+        if (!groupNode || groupCards.length === 0) {
           return;
         }
 
-        const segmentTop = segmentNode.getBoundingClientRect().top;
+        const groupTop = groupNode.getBoundingClientRect().top;
 
-        const cards = segmentCards.map((card) => {
-          const anchorNode = segmentNode.querySelector<HTMLElement>(
-            `#${CSS.escape(card.anchorId)}`
-          );
+        const cards = groupCards.map((card) => {
+          const anchorNode = groupNode.querySelector<HTMLElement>(`#${CSS.escape(card.anchorId)}`);
           const wrapperNode = cardWrapperRefs.current[card.key];
           const rawTop = anchorNode
-            ? Math.max(0, anchorNode.getBoundingClientRect().top - segmentTop)
+            ? Math.max(0, anchorNode.getBoundingClientRect().top - groupTop)
             : 0;
           const height =
             wrapperNode?.getBoundingClientRect().height || wrapperNode?.offsetHeight || 28;
@@ -474,14 +475,14 @@ export const MappingView = ({
           return { key: card.key, rawTop, height };
         });
 
-        nextOffsets[segment.id] = resolveMarkerOffsets(cards);
+        nextOffsets[group.id] = resolveMarkerOffsets(cards);
       });
 
-      setCardOffsetsBySegment(nextOffsets);
+      setCardOffsetsByGroup(nextOffsets);
     };
 
     measureOffsets();
-  }, [mappingCardsBySegment, allSegments]);
+  }, [allGroups]);
 
   const openAssignModal = (
     preview: string,
@@ -790,33 +791,75 @@ export const MappingView = ({
             )}
 
             <Flex flexDirection="column" gap="spacingS">
-              {tab.segments.map((segment) => {
-                const mappingCards = mappingCardsBySegment[segment.id] ?? [];
+              {(groupsByTab[tab.id] ?? []).map((group) => {
+                const isGroupHovered = group.mappingCards.some((card) =>
+                  card.mappingKeys.some((key) => hoveredMappingKeys.includes(key))
+                );
 
                 return (
-                  <Box key={segment.id}>
+                  <Box key={group.id}>
                     <Flex
                       gap="spacingM"
                       alignItems="stretch"
-                      data-testid={`segment-layout-${segment.id}`}
-                      ref={setSegmentLayoutRef(segment.id)}>
-                      <NormalizedDocumentSection
-                        segment={segment}
-                        highlightIndex={highlightIndex}
-                        imageById={imageById}
-                        listMarkers={listMarkers}
-                        excludedSourceRefs={entryBlockGraph.excludedSourceRefs}
-                        selectedEntryIndex={selectedEntryIndex}
-                        hoveredMappingKeys={hoveredMappingKeys}
-                        onSetHoveredMappingKeys={setHoveredMappingKeys}
-                        onAssignImage={handleAssignImage}
-                        onExcludeImage={handleExcludeImage}
-                      />
+                      data-testid={`display-group-layout-${group.id}`}
+                      ref={setGroupLayoutRef(group.id)}>
+                      <Box style={{ flex: 2 }}>
+                        {group.showGroupedSurface ? (
+                          <Box
+                            data-testid={`mapping-group-surface-${group.id}`}
+                            data-hovered={isGroupHovered ? 'true' : 'false'}
+                            style={{
+                              border: `${isGroupHovered ? 2 : 1}px solid ${
+                                isGroupHovered ? tokens.green600 : tokens.green500
+                              }`,
+                              borderRadius: tokens.borderRadiusMedium,
+                              backgroundColor: tokens.green100,
+                              padding: tokens.spacing2Xs,
+                              transition: 'border-color 120ms ease, border-width 120ms ease',
+                            }}>
+                            <Flex flexDirection="column" gap="spacing2Xs">
+                              {group.segments.map((segment) => (
+                                <NormalizedDocumentSection
+                                  key={segment.id}
+                                  segment={segment}
+                                  highlightIndex={highlightIndex}
+                                  imageById={imageById}
+                                  listMarkers={listMarkers}
+                                  excludedSourceRefs={entryBlockGraph.excludedSourceRefs}
+                                  selectedEntryIndex={selectedEntryIndex}
+                                  hoveredMappingKeys={hoveredMappingKeys}
+                                  onSetHoveredMappingKeys={setHoveredMappingKeys}
+                                  onAssignImage={handleAssignImage}
+                                  onExcludeImage={handleExcludeImage}
+                                />
+                              ))}
+                            </Flex>
+                          </Box>
+                        ) : (
+                          <Flex flexDirection="column" gap="spacingS">
+                            {group.segments.map((segment) => (
+                              <NormalizedDocumentSection
+                                key={segment.id}
+                                segment={segment}
+                                highlightIndex={highlightIndex}
+                                imageById={imageById}
+                                listMarkers={listMarkers}
+                                excludedSourceRefs={entryBlockGraph.excludedSourceRefs}
+                                selectedEntryIndex={selectedEntryIndex}
+                                hoveredMappingKeys={hoveredMappingKeys}
+                                onSetHoveredMappingKeys={setHoveredMappingKeys}
+                                onAssignImage={handleAssignImage}
+                                onExcludeImage={handleExcludeImage}
+                              />
+                            ))}
+                          </Flex>
+                        )}
+                      </Box>
 
                       <MappingEntryCards
-                        segmentId={segment.id}
-                        mappingCards={mappingCards}
-                        cardOffsetsBySegment={cardOffsetsBySegment}
+                        groupId={group.id}
+                        mappingCards={group.mappingCards}
+                        cardOffsetsByGroup={cardOffsetsByGroup}
                         hoveredMappingKeys={hoveredMappingKeys}
                         onSetHoveredMappingKeys={setHoveredMappingKeys}
                         setCardWrapperRef={setCardWrapperRef}

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -135,6 +135,10 @@ function rangeIntersectsNode(range: Range, node: Node): boolean {
   }
 }
 
+function hasPositionalDisplayLabel(label: string): boolean {
+  return /\(\d+\/\d+\)$/.test(label);
+}
+
 export const MappingView = ({
   payload,
   entryBlockGraph,
@@ -333,6 +337,43 @@ export const MappingView = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [allSegments, entryBlockGraph, payload.contentTypes, visibleHighlightsBySegment]);
 
+  const locationsByCardKey = useMemo(() => {
+    const byKey = new Map<string, EditLocationOption>();
+
+    allGroups.forEach((group) => {
+      group.mappingCards.forEach((card) => {
+        const sourceLocationByKey = new Map<string, EditLocationOption>();
+
+        card.mappingKeys.forEach((mappingKey) => {
+          const location = locationsByMappingKey.get(mappingKey);
+          if (!location) {
+            return;
+          }
+
+          sourceLocationByKey.set(buildSourceRefKey(location.sourceRef), location);
+        });
+
+        const sourceLocations = Array.from(sourceLocationByKey.values());
+        const firstLocation = sourceLocations[0];
+        if (!firstLocation) {
+          return;
+        }
+
+        byKey.set(card.key, {
+          ...firstLocation,
+          id: card.key,
+          displayLabel: hasPositionalDisplayLabel(card.displayLabel)
+            ? card.displayLabel
+            : undefined,
+          sourceRefs: sourceLocations.map((location) => location.sourceRef),
+          isSelected: false,
+        });
+      });
+    });
+
+    return byKey;
+  }, [allGroups, locationsByMappingKey]);
+
   const getNewLocationForEntry = (
     entry: EntryBlockGraph['entries'][number],
     entryIndex: number
@@ -427,8 +468,10 @@ export const MappingView = ({
         .forEach((key) => mappingKeys.add(key));
     }
 
-    const locations = Array.from(mappingKeys)
-      .map((key) => locationsByMappingKey.get(key))
+    const locations = allGroups
+      .flatMap((group) => group.mappingCards)
+      .filter((card) => card.mappingKeys.some((key) => mappingKeys.has(key)))
+      .map((card) => locationsByCardKey.get(card.key))
       .filter((location): location is EditLocationOption => Boolean(location));
 
     return locations.map((location, index) => ({
@@ -527,7 +570,9 @@ export const MappingView = ({
       },
       title: 'Exclude content',
       locationSectionDescription:
-        'This content is used in more than one place in the entry. Select which item to exclude.',
+        currentLocations.length > 1
+          ? 'This content is used in more than one place in the entry. Select which item to exclude.'
+          : '',
       primaryButtonLabel: 'Exclude content',
     });
   };

--- a/apps/google-docs/src/locations/Page/components/review/mapping/buildMappingDisplayGroups.ts
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/buildMappingDisplayGroups.ts
@@ -1,3 +1,4 @@
+import { isTextSourceRef } from '@types';
 import type { MappingCardData } from './MappingCard';
 import type { Tab, DocSegment } from './buildDocument';
 import { type MappingHighlight, getMappingCardKey } from './buildHighlights';
@@ -28,6 +29,8 @@ interface DraftMappingDisplayGroup {
   segments: DocSegment[];
   mappingCards: DraftMappingCard[];
   mergeFieldIdentity: string | null;
+  startsAtBoundary: boolean;
+  endsAtBoundary: boolean;
 }
 
 export interface MappingDisplayGroupsResult {
@@ -80,6 +83,36 @@ function buildDraftMappingCards(
   }));
 }
 
+function getBlockBoundaryCoverage(
+  segment: Extract<DocSegment, { kind: 'block' }>,
+  highlights: MappingHighlight[],
+  fieldIdentity: string
+): { startsAtBoundary: boolean; endsAtBoundary: boolean } {
+  const blockStart = segment.block.flattenedTextRuns[0]?.start;
+  const blockEnd = segment.block.flattenedTextRuns[segment.block.flattenedTextRuns.length - 1]?.end;
+
+  if (!Number.isFinite(blockStart) || !Number.isFinite(blockEnd)) {
+    return { startsAtBoundary: false, endsAtBoundary: false };
+  }
+
+  const textHighlights = highlights.filter(
+    (
+      highlight
+    ): highlight is MappingHighlight & {
+      sourceRef: Extract<MappingHighlight['sourceRef'], { start: number; end: number }>;
+    } => getFieldIdentity(highlight) === fieldIdentity && isTextSourceRef(highlight.sourceRef)
+  );
+
+  if (!textHighlights.length) {
+    return { startsAtBoundary: false, endsAtBoundary: false };
+  }
+
+  return {
+    startsAtBoundary: textHighlights.some((highlight) => highlight.sourceRef.start <= blockStart),
+    endsAtBoundary: textHighlights.some((highlight) => highlight.sourceRef.end >= blockEnd),
+  };
+}
+
 function buildDraftGroupsForTab(
   tab: Tab,
   visibleHighlightsBySegment: Record<string, MappingHighlight[]>,
@@ -89,16 +122,22 @@ function buildDraftGroupsForTab(
   const groups: DraftMappingDisplayGroup[] = [];
 
   tab.segments.forEach((segment) => {
-    const mappingCards = buildDraftMappingCards(
-      segment,
-      visibleHighlightsBySegment[segment.id] ?? [],
-      resolveFieldTypeLabel
-    );
+    const highlights = visibleHighlightsBySegment[segment.id] ?? [];
+    const mappingCards = buildDraftMappingCards(segment, highlights, resolveFieldTypeLabel);
     const mergeFieldIdentity =
       segment.kind === 'block' && mappingCards.length === 1 ? mappingCards[0].fieldIdentity : null;
+    const { startsAtBoundary, endsAtBoundary } =
+      segment.kind === 'block' && mergeFieldIdentity
+        ? getBlockBoundaryCoverage(segment, highlights, mergeFieldIdentity)
+        : { startsAtBoundary: false, endsAtBoundary: false };
     const previousGroup = groups[groups.length - 1];
 
-    if (mergeFieldIdentity && previousGroup?.mergeFieldIdentity === mergeFieldIdentity) {
+    if (
+      mergeFieldIdentity &&
+      previousGroup?.mergeFieldIdentity === mergeFieldIdentity &&
+      previousGroup.endsAtBoundary &&
+      startsAtBoundary
+    ) {
       previousGroup.segments.push(segment);
       previousGroup.mappingCards[0] = {
         ...previousGroup.mappingCards[0],
@@ -107,6 +146,7 @@ function buildDraftGroupsForTab(
           ...mappingCards[0].mappingKeys,
         ]),
       };
+      previousGroup.endsAtBoundary = endsAtBoundary;
       return;
     }
 
@@ -118,6 +158,8 @@ function buildDraftGroupsForTab(
         key: `mapping-display-group-${nextGroupIndex.current}:${card.fieldIdentity}`,
       })),
       mergeFieldIdentity,
+      startsAtBoundary,
+      endsAtBoundary,
     });
     nextGroupIndex.current += 1;
   });

--- a/apps/google-docs/src/locations/Page/components/review/mapping/buildMappingDisplayGroups.ts
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/buildMappingDisplayGroups.ts
@@ -1,0 +1,183 @@
+import type { MappingCardData } from './MappingCard';
+import type { Tab, DocSegment } from './buildDocument';
+import { type MappingHighlight, getMappingCardKey } from './buildHighlights';
+import { formatDisplayName } from './fieldFormatting';
+import { getAnchorIdForSourceRef } from './resolveMappingCardOffsets';
+
+export interface RenderedMappingCard extends MappingCardData {
+  fieldIdentity: string;
+  anchorId: string;
+  mappingKeys: string[];
+}
+
+export interface MappingDisplayGroup {
+  id: string;
+  segments: DocSegment[];
+  mappingCards: RenderedMappingCard[];
+  showGroupedSurface: boolean;
+}
+
+interface DraftMappingCard extends MappingCardData {
+  fieldIdentity: string;
+  anchorId: string;
+  mappingKeys: string[];
+}
+
+interface DraftMappingDisplayGroup {
+  id: string;
+  segments: DocSegment[];
+  mappingCards: DraftMappingCard[];
+  mergeFieldIdentity: string | null;
+}
+
+export interface MappingDisplayGroupsResult {
+  groupsByTab: Record<string, MappingDisplayGroup[]>;
+  allGroups: MappingDisplayGroup[];
+}
+
+function getFieldIdentity(highlight: MappingHighlight): string {
+  return `${highlight.entryIndex}|${highlight.fieldId}|${highlight.fieldType}`;
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return Array.from(new Set(values));
+}
+
+function buildDraftMappingCards(
+  segment: DocSegment,
+  highlights: MappingHighlight[],
+  resolveFieldTypeLabel: (highlight: MappingHighlight) => string
+): DraftMappingCard[] {
+  const byFieldIdentity = new Map<
+    string,
+    { firstHighlight: MappingHighlight; mappingKeys: string[] }
+  >();
+
+  highlights.forEach((highlight) => {
+    const fieldIdentity = getFieldIdentity(highlight);
+    const mappingKey = getMappingCardKey(segment.id, highlight);
+    const existing = byFieldIdentity.get(fieldIdentity);
+
+    if (existing) {
+      existing.mappingKeys.push(mappingKey);
+      return;
+    }
+
+    byFieldIdentity.set(fieldIdentity, {
+      firstHighlight: highlight,
+      mappingKeys: [mappingKey],
+    });
+  });
+
+  return Array.from(byFieldIdentity.entries()).map(([fieldIdentity, value]) => ({
+    key: `${segment.id}:${fieldIdentity}`,
+    fieldIdentity,
+    fieldName: formatDisplayName(value.firstHighlight.fieldId),
+    fieldType: resolveFieldTypeLabel(value.firstHighlight),
+    displayLabel: formatDisplayName(value.firstHighlight.fieldId),
+    anchorId: getAnchorIdForSourceRef(value.firstHighlight.sourceRef),
+    mappingKeys: uniqueStrings(value.mappingKeys),
+  }));
+}
+
+function buildDraftGroupsForTab(
+  tab: Tab,
+  visibleHighlightsBySegment: Record<string, MappingHighlight[]>,
+  nextGroupIndex: { current: number },
+  resolveFieldTypeLabel: (highlight: MappingHighlight) => string
+): DraftMappingDisplayGroup[] {
+  const groups: DraftMappingDisplayGroup[] = [];
+
+  tab.segments.forEach((segment) => {
+    const mappingCards = buildDraftMappingCards(
+      segment,
+      visibleHighlightsBySegment[segment.id] ?? [],
+      resolveFieldTypeLabel
+    );
+    const mergeFieldIdentity =
+      segment.kind === 'block' && mappingCards.length === 1 ? mappingCards[0].fieldIdentity : null;
+    const previousGroup = groups[groups.length - 1];
+
+    if (mergeFieldIdentity && previousGroup?.mergeFieldIdentity === mergeFieldIdentity) {
+      previousGroup.segments.push(segment);
+      previousGroup.mappingCards[0] = {
+        ...previousGroup.mappingCards[0],
+        mappingKeys: uniqueStrings([
+          ...previousGroup.mappingCards[0].mappingKeys,
+          ...mappingCards[0].mappingKeys,
+        ]),
+      };
+      return;
+    }
+
+    groups.push({
+      id: `mapping-display-group-${nextGroupIndex.current}`,
+      segments: [segment],
+      mappingCards: mappingCards.map((card) => ({
+        ...card,
+        key: `mapping-display-group-${nextGroupIndex.current}:${card.fieldIdentity}`,
+      })),
+      mergeFieldIdentity,
+    });
+    nextGroupIndex.current += 1;
+  });
+
+  return groups;
+}
+
+export function buildMappingDisplayGroups(
+  tabs: Tab[],
+  visibleHighlightsBySegment: Record<string, MappingHighlight[]>,
+  resolveFieldTypeLabel: (highlight: MappingHighlight) => string
+): MappingDisplayGroupsResult {
+  const groupsByTabDraft: Record<string, DraftMappingDisplayGroup[]> = {};
+  const nextGroupIndex = { current: 0 };
+
+  tabs.forEach((tab) => {
+    groupsByTabDraft[tab.id] = buildDraftGroupsForTab(
+      tab,
+      visibleHighlightsBySegment,
+      nextGroupIndex,
+      resolveFieldTypeLabel
+    );
+  });
+
+  const allDraftGroups = tabs.flatMap((tab) => groupsByTabDraft[tab.id] ?? []);
+  const totalByFieldIdentity = new Map<string, number>();
+
+  allDraftGroups.forEach((group) => {
+    group.mappingCards.forEach((card) => {
+      totalByFieldIdentity.set(
+        card.fieldIdentity,
+        (totalByFieldIdentity.get(card.fieldIdentity) ?? 0) + 1
+      );
+    });
+  });
+
+  const positionByFieldIdentity = new Map<string, number>();
+  const finalizeGroup = (group: DraftMappingDisplayGroup): MappingDisplayGroup => ({
+    id: group.id,
+    segments: group.segments,
+    showGroupedSurface: group.mergeFieldIdentity !== null,
+    mappingCards: group.mappingCards.map((card) => {
+      const nextPosition = (positionByFieldIdentity.get(card.fieldIdentity) ?? 0) + 1;
+      positionByFieldIdentity.set(card.fieldIdentity, nextPosition);
+      const total = totalByFieldIdentity.get(card.fieldIdentity) ?? 1;
+
+      return {
+        ...card,
+        displayLabel: total > 1 ? `${card.fieldName} (${nextPosition}/${total})` : card.fieldName,
+      };
+    }),
+  });
+
+  const groupsByTab = tabs.reduce<Record<string, MappingDisplayGroup[]>>((acc, tab) => {
+    acc[tab.id] = (groupsByTabDraft[tab.id] ?? []).map(finalizeGroup);
+    return acc;
+  }, {});
+
+  return {
+    groupsByTab,
+    allGroups: tabs.flatMap((tab) => groupsByTab[tab.id] ?? []),
+  };
+}

--- a/apps/google-docs/src/locations/Page/components/review/mapping/buildMappingDisplayGroups.ts
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/buildMappingDisplayGroups.ts
@@ -51,6 +51,22 @@ function buildDraftMappingCards(
   highlights: MappingHighlight[],
   resolveFieldTypeLabel: (highlight: MappingHighlight) => string
 ): DraftMappingCard[] {
+  if (segment.kind === 'table') {
+    return highlights.map((highlight) => {
+      const mappingKey = getMappingCardKey(segment.id, highlight);
+
+      return {
+        key: `${segment.id}:${mappingKey}`,
+        fieldIdentity: getFieldIdentity(highlight),
+        fieldName: formatDisplayName(highlight.fieldId),
+        fieldType: resolveFieldTypeLabel(highlight),
+        displayLabel: formatDisplayName(highlight.fieldId),
+        anchorId: getAnchorIdForSourceRef(highlight.sourceRef),
+        mappingKeys: [mappingKey],
+      };
+    });
+  }
+
   const byFieldIdentity = new Map<
     string,
     { firstHighlight: MappingHighlight; mappingKeys: string[] }
@@ -124,12 +140,14 @@ function buildDraftGroupsForTab(
   tab.segments.forEach((segment) => {
     const highlights = visibleHighlightsBySegment[segment.id] ?? [];
     const mappingCards = buildDraftMappingCards(segment, highlights, resolveFieldTypeLabel);
-    const mergeFieldIdentity =
-      segment.kind === 'block' && mappingCards.length === 1 ? mappingCards[0].fieldIdentity : null;
     const { startsAtBoundary, endsAtBoundary } =
-      segment.kind === 'block' && mergeFieldIdentity
-        ? getBlockBoundaryCoverage(segment, highlights, mergeFieldIdentity)
+      segment.kind === 'block' && mappingCards.length === 1
+        ? getBlockBoundaryCoverage(segment, highlights, mappingCards[0].fieldIdentity)
         : { startsAtBoundary: false, endsAtBoundary: false };
+    const mergeFieldIdentity =
+      segment.kind === 'block' && mappingCards.length === 1 && (startsAtBoundary || endsAtBoundary)
+        ? mappingCards[0].fieldIdentity
+        : null;
     const previousGroup = groups[groups.length - 1];
 
     if (
@@ -155,7 +173,7 @@ function buildDraftGroupsForTab(
       segments: [segment],
       mappingCards: mappingCards.map((card) => ({
         ...card,
-        key: `mapping-display-group-${nextGroupIndex.current}:${card.fieldIdentity}`,
+        key: `mapping-display-group-${nextGroupIndex.current}:${card.key}`,
       })),
       mergeFieldIdentity,
       startsAtBoundary,
@@ -200,7 +218,8 @@ export function buildMappingDisplayGroups(
   const finalizeGroup = (group: DraftMappingDisplayGroup): MappingDisplayGroup => ({
     id: group.id,
     segments: group.segments,
-    showGroupedSurface: group.mergeFieldIdentity !== null,
+    showGroupedSurface:
+      group.segments.length > 1 || (group.startsAtBoundary && group.endsAtBoundary),
     mappingCards: group.mappingCards.map((card) => {
       const nextPosition = (positionByFieldIdentity.get(card.fieldIdentity) ?? 0) + 1;
       positionByFieldIdentity.set(card.fieldIdentity, nextPosition);

--- a/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/EditModal.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/EditModal.tsx
@@ -211,7 +211,7 @@ export const EditModal = ({
                                   fontSize="fontSizeS"
                                   fontWeight="fontWeightMedium"
                                   fontColor="gray900">
-                                  {location.fieldName}
+                                  {location.displayLabel ?? location.fieldName}
                                 </Text>{' '}
                                 <Text as="span" fontSize="fontSizeS" fontColor="gray700">
                                   | {location.fieldType}

--- a/apps/google-docs/src/locations/Page/components/review/mapping/entryBlockGraphExclusion.ts
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/entryBlockGraphExclusion.ts
@@ -519,6 +519,7 @@ export function applyTextExclusionToEntryBlockGraph(
   pendingRanges: TextExclusionRange[]
 ): EntryBlockGraph {
   if (!pendingRanges.length) return graph;
+  const locationSourceRefKeys = getLocationSourceRefKeys(location);
 
   const nextEntries = graph.entries.map((entry, idx) => {
     if (idx !== location.entryIndex) return entry;
@@ -529,7 +530,7 @@ export function applyTextExclusionToEntryBlockGraph(
         if (fm.fieldId !== location.fieldId) return fm;
 
         const nextRefs = fm.sourceRefs.flatMap((sr) => {
-          if (buildSourceRefKey(sr) !== buildSourceRefKey(location.sourceRef)) return [sr];
+          if (!locationSourceRefKeys.has(buildSourceRefKey(sr))) return [sr];
           if (!isTextSourceRef(sr)) return [sr];
 
           const cuts = rangesOverlappingTextSourceRef(sr, pendingRanges);
@@ -555,27 +556,12 @@ function cloneTextRangeSourceRef(ref: TextRangeSourceRef): TextRangeSourceRef {
   };
 }
 
-function textExclusionRangesForCuts(
-  sourceRef: TextRangeSourceRef,
-  cuts: [number, number][]
-): TextExclusionRange[] {
-  if (isTableTextSourceRef(sourceRef)) {
-    return cuts.map(([start, end]) => ({
-      scope: 'table' as const,
-      tableId: sourceRef.tableId,
-      rowId: sourceRef.rowId,
-      cellId: sourceRef.cellId,
-      partId: sourceRef.partId,
-      start,
-      end,
-    }));
-  }
-  return cuts.map(([start, end]) => ({
-    scope: 'block' as const,
-    blockId: sourceRef.blockId,
-    start,
-    end,
-  }));
+function getLocationSourceRefs(location: EditLocationOption): SourceRef[] {
+  return location.sourceRefs?.length ? location.sourceRefs : [location.sourceRef];
+}
+
+function getLocationSourceRefKeys(location: EditLocationOption): Set<string> {
+  return new Set(getLocationSourceRefs(location).map((sourceRef) => buildSourceRefKey(sourceRef)));
 }
 
 function appendTextRefsToFieldMapping(
@@ -625,9 +611,7 @@ export function applyTextReassignToEntryBlockGraph(
   pendingRanges: TextExclusionRange[],
   targets: ReadonlyArray<{ entryIndex: number; fieldId: string; fieldType: string }>
 ): EntryBlockGraph {
-  if (!isTextSourceRef(from.sourceRef) || !targets.length) return graph;
-
-  const fromKey = buildSourceRefKey(from.sourceRef);
+  if (!targets.length) return graph;
   const seen = new Set<string>();
   const dedupedTargets = targets.filter((t) => {
     if (t.entryIndex === from.entryIndex && t.fieldId === from.fieldId) return false;
@@ -640,19 +624,23 @@ export function applyTextReassignToEntryBlockGraph(
 
   const fromEntry = graph.entries[from.entryIndex];
   const fromFm = fromEntry?.fieldMappings.find((fm) => fm.fieldId === from.fieldId);
-  const fromSr = fromFm?.sourceRefs.find(
-    (sr) => buildSourceRefKey(sr) === fromKey && isTextSourceRef(sr)
-  ) as TextRangeSourceRef | undefined;
-  if (!fromSr) return graph;
+  const sourceRefKeys = getLocationSourceRefKeys(from);
+  const movedRefs =
+    fromFm?.sourceRefs.flatMap((sourceRef) => {
+      if (!sourceRefKeys.has(buildSourceRefKey(sourceRef)) || !isTextSourceRef(sourceRef)) {
+        return [];
+      }
 
-  const mergedCuts = mergeIntervals(rangesOverlappingTextSourceRef(fromSr, pendingRanges));
-  if (!mergedCuts.length) return graph;
+      const mergedCuts = mergeIntervals(rangesOverlappingTextSourceRef(sourceRef, pendingRanges));
+      if (!mergedCuts.length) {
+        return [];
+      }
 
-  const movedRefs = buildTextRefsFromSpans(fromSr, mergedCuts).filter((r) => r.start < r.end);
+      return buildTextRefsFromSpans(sourceRef, mergedCuts).filter((ref) => ref.start < ref.end);
+    }) ?? [];
   if (!movedRefs.length) return graph;
 
-  const exclusionRanges = textExclusionRangesForCuts(fromSr, mergedCuts);
-  let next = applyTextExclusionToEntryBlockGraph(graph, from, exclusionRanges);
+  let next = applyTextExclusionToEntryBlockGraph(graph, from, pendingRanges);
 
   for (const t of dedupedTargets) {
     next = appendTextRefsToFieldMapping(next, t.entryIndex, t.fieldId, t.fieldType, movedRefs);

--- a/apps/google-docs/src/types/editModal.ts
+++ b/apps/google-docs/src/types/editModal.ts
@@ -8,8 +8,10 @@ export interface EditLocationOption {
   entryName: string;
   fieldId: string;
   fieldName: string;
+  displayLabel?: string;
   fieldType: string;
   sourceRef: SourceRef;
+  sourceRefs?: SourceRef[];
   isSelected?: boolean;
 }
 

--- a/apps/google-docs/test/locations/Page/components/review/mapping/MappingView.spec.tsx
+++ b/apps/google-docs/test/locations/Page/components/review/mapping/MappingView.spec.tsx
@@ -314,6 +314,27 @@ describe('MappingView', () => {
     ).toContain('Second body paragraph.');
   });
 
+  it('does not wrap a partially mapped single block in a grouped surface', () => {
+    const block = createBlock('block-1', 1, 'Partially mapped paragraph.');
+    const payload = createPayload({
+      blocks: [block],
+      fieldMappings: [
+        {
+          fieldId: 'body',
+          fieldType: 'Text',
+          sourceRefs: [createBlockTextSourceRef(block.id, block.text, 10, 22)],
+        },
+      ],
+    });
+
+    const { container } = render(
+      <MappingView payload={payload} {...mappingViewGraphProps(payload)} selectedEntryIndex={0} />
+    );
+
+    expect(container.querySelectorAll('[data-testid^="mapping-card-"]')).toHaveLength(1);
+    expect(container.querySelectorAll('[data-testid^="mapping-group-surface-"]')).toHaveLength(0);
+  });
+
   it('labels non-consecutive runs for the same field with positional suffixes', () => {
     const blocks = [
       createBlock('block-1', 1, 'First body paragraph.'),
@@ -380,6 +401,120 @@ describe('MappingView', () => {
     expect(screen.getByText('Summary')).toBeTruthy();
     expect(container.querySelectorAll('[data-testid^="mapping-card-"]')).toHaveLength(4);
     expect(container.querySelectorAll('[data-testid^="mapping-group-surface-"]')).toHaveLength(2);
+  });
+
+  it('keeps separate cards for table rows mapped to the same field', () => {
+    const firstRowText = 'slug-one';
+    const secondRowText = 'slug-two';
+    const payload = createPayload({
+      blocks: [],
+      tables: [
+        {
+          id: 'table-1',
+          position: 1,
+          headers: ['Field', 'Value'],
+          rows: [
+            {
+              id: 'row-1',
+              cells: [
+                {
+                  id: 'cell-1',
+                  parts: [
+                    {
+                      id: 'part-1',
+                      type: 'text',
+                      textRuns: [{ text: 'Slug A' }],
+                      flattenedTextRuns: [{ text: 'Slug A', start: 0, end: 6 }],
+                    },
+                  ],
+                },
+                {
+                  id: 'cell-2',
+                  parts: [
+                    {
+                      id: 'part-2',
+                      type: 'text',
+                      textRuns: [{ text: firstRowText }],
+                      flattenedTextRuns: [
+                        { text: firstRowText, start: 0, end: firstRowText.length },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              id: 'row-2',
+              cells: [
+                {
+                  id: 'cell-3',
+                  parts: [
+                    {
+                      id: 'part-3',
+                      type: 'text',
+                      textRuns: [{ text: 'Slug B' }],
+                      flattenedTextRuns: [{ text: 'Slug B', start: 0, end: 6 }],
+                    },
+                  ],
+                },
+                {
+                  id: 'cell-4',
+                  parts: [
+                    {
+                      id: 'part-4',
+                      type: 'text',
+                      textRuns: [{ text: secondRowText }],
+                      flattenedTextRuns: [
+                        { text: secondRowText, start: 0, end: secondRowText.length },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          designValueIds: [],
+          imageIds: [],
+        },
+      ],
+      fieldMappings: [
+        {
+          fieldId: 'body',
+          fieldType: 'Text',
+          sourceRefs: [
+            {
+              type: 'tableText',
+              tableId: 'table-1',
+              rowId: 'row-1',
+              cellId: 'cell-2',
+              partId: 'part-2',
+              start: 0,
+              end: firstRowText.length,
+              flattenedRuns: [{ text: firstRowText, start: 0, end: firstRowText.length }],
+            },
+            {
+              type: 'tableText',
+              tableId: 'table-1',
+              rowId: 'row-2',
+              cellId: 'cell-4',
+              partId: 'part-4',
+              start: 0,
+              end: secondRowText.length,
+              flattenedRuns: [{ text: secondRowText, start: 0, end: secondRowText.length }],
+            },
+          ],
+        },
+      ],
+    });
+
+    const { container } = render(
+      <MappingView payload={payload} {...mappingViewGraphProps(payload)} selectedEntryIndex={0} />
+    );
+
+    expect(screen.getByText('Body (1/2)')).toBeTruthy();
+    expect(screen.getByText('Body (2/2)')).toBeTruthy();
+    expect(container.querySelectorAll('[data-testid^="mapping-card-"]')).toHaveLength(2);
+    expect(container.querySelectorAll('[data-testid^="mapping-group-surface-"]')).toHaveLength(0);
   });
 
   it('keeps table mappings scoped to the mapped row instead of wrapping the whole table', () => {
@@ -759,7 +894,7 @@ describe('MappingView', () => {
     expect(screen.getByText('Body (1/2)')).toBeTruthy();
     expect(screen.getByText('Body (2/2)')).toBeTruthy();
     expect(container.querySelectorAll('[data-testid^="mapping-card-"]')).toHaveLength(2);
-    expect(container.querySelectorAll('[data-testid^="mapping-group-surface-"]')).toHaveLength(2);
+    expect(container.querySelectorAll('[data-testid^="mapping-group-surface-"]')).toHaveLength(0);
   });
 
   it('scopes image assignment destinations to currently selected entry', () => {

--- a/apps/google-docs/test/locations/Page/components/review/mapping/MappingView.spec.tsx
+++ b/apps/google-docs/test/locations/Page/components/review/mapping/MappingView.spec.tsx
@@ -65,6 +65,18 @@ const createDetachedRange = (text: string, start: number, end: number) => {
   return createDomRange(textNode, start, end);
 };
 
+const createCrossBlockRange = (
+  startNode: Text,
+  startOffset: number,
+  endNode: Text,
+  endOffset: number
+) => {
+  const range = document.createRange();
+  range.setStart(startNode, startOffset);
+  range.setEnd(endNode, endOffset);
+  return range;
+};
+
 const createBlock = (
   id: string,
   position: number,
@@ -654,6 +666,100 @@ describe('MappingView', () => {
       screen.getAllByText((_, node) => node?.textContent?.includes('| Long text') ?? false).length
     ).toBeGreaterThan(0);
     expect(mockClearSelection).toHaveBeenCalledTimes(1);
+  });
+
+  it('excludes grouped selections as one visible location and splits the remaining runs', () => {
+    const blocks = [
+      createBlock('block-1', 1, 'First body paragraph.'),
+      createBlock('block-2', 2, 'Second body paragraph.'),
+    ];
+    const payload = createPayload({
+      blocks,
+      fieldMappings: [
+        {
+          fieldId: 'body',
+          fieldType: 'Text',
+          sourceRefs: blocks.map((block) => createBlockTextSourceRef(block.id, block.text)),
+        },
+      ],
+    });
+
+    let currentGraph = payload.entryBlockGraph;
+    const onEntryBlockGraphChange = vi.fn(
+      (nextGraph: MappingReviewSuspendPayload['entryBlockGraph']) => {
+        currentGraph = nextGraph;
+      }
+    );
+
+    mockUseReviewTextSelection.mockReturnValueOnce({
+      selectionRectangle: null,
+      selectedText: '',
+      selectedRange: null,
+      clearSelection: mockClearSelection,
+    });
+
+    const { container, rerender } = render(
+      <MappingView
+        payload={payload}
+        entryBlockGraph={currentGraph}
+        onEntryBlockGraphChange={onEntryBlockGraphChange}
+        selectedEntryIndex={0}
+      />
+    );
+
+    const groupedTextSegments = container.querySelectorAll('[data-review-text-segment="true"]');
+    const selectedRange = createCrossBlockRange(
+      groupedTextSegments[0].firstChild as Text,
+      6,
+      groupedTextSegments[1].firstChild as Text,
+      6
+    );
+
+    mockUseReviewTextSelection.mockReturnValue({
+      selectionRectangle: { top: 100, left: 100, right: 220, bottom: 130 },
+      selectedText: selectedRange.toString(),
+      selectedRange,
+      clearSelection: mockClearSelection,
+    });
+
+    rerender(
+      <MappingView
+        payload={payload}
+        entryBlockGraph={currentGraph}
+        onEntryBlockGraphChange={onEntryBlockGraphChange}
+        selectedEntryIndex={0}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Exclude' }));
+
+    expect(screen.getByRole('heading', { name: 'Exclude content' })).toBeTruthy();
+    expect(document.querySelectorAll('button[aria-pressed]')).toHaveLength(1);
+    expect(
+      screen.queryByText(
+        'This content is used in more than one place in the entry. Select which item to exclude.'
+      )
+    ).toBeNull();
+
+    const confirmButton = screen.getAllByRole('button', { name: 'Exclude content' }).at(-1);
+    expect(confirmButton).toBeTruthy();
+    fireEvent.click(confirmButton as HTMLElement);
+
+    expect(onEntryBlockGraphChange).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <MappingView
+        payload={payload}
+        entryBlockGraph={currentGraph}
+        onEntryBlockGraphChange={onEntryBlockGraphChange}
+        selectedEntryIndex={0}
+      />
+    );
+
+    expect(screen.getByText('Body (1/2)')).toBeTruthy();
+    expect(screen.getByText('Body (2/2)')).toBeTruthy();
+    expect(container.querySelectorAll('[data-testid^="mapping-card-"]')).toHaveLength(2);
+    expect(container.querySelectorAll('[data-testid^="mapping-group-surface-"]')).toHaveLength(2);
   });
 
   it('scopes image assignment destinations to currently selected entry', () => {

--- a/apps/google-docs/test/locations/Page/components/review/mapping/MappingView.spec.tsx
+++ b/apps/google-docs/test/locations/Page/components/review/mapping/MappingView.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MappingReviewSuspendPayload, SourceRef } from '@types';
 import { MappingView } from '../../../../../../src/locations/Page/components/review/mapping/MappingView';
@@ -34,12 +34,18 @@ vi.mock(
   })
 );
 
-const blockTextSourceRef: SourceRef = {
-  type: 'blockText',
-  blockId: 'block-1',
-  start: 0,
-  end: 11,
-  flattenedRuns: [{ text: 'Hello world', start: 0, end: 11 }],
+type BlockDefinition = {
+  id: string;
+  position: number;
+  text: string;
+  type?: 'paragraph' | 'heading' | 'listItem';
+};
+
+type FieldMappingDefinition = {
+  fieldId: string;
+  fieldType: string;
+  sourceRefs: SourceRef[];
+  confidence?: number;
 };
 
 const mappingViewGraphProps = (payload: MappingReviewSuspendPayload) => ({
@@ -59,73 +65,120 @@ const createDetachedRange = (text: string, start: number, end: number) => {
   return createDomRange(textNode, start, end);
 };
 
-const createPayload = (excludedSourceRefs: SourceRef[] = []): MappingReviewSuspendPayload => ({
-  suspendStepId: 'mapping-review',
-  reason: 'Mapping review required before CMA payload generation continues',
-  documentId: 'doc-1',
-  documentTitle: 'Mapping review',
-  normalizedDocument: {
+const createBlock = (
+  id: string,
+  position: number,
+  text: string,
+  type: BlockDefinition['type'] = 'paragraph'
+): BlockDefinition => ({
+  id,
+  position,
+  text,
+  type,
+});
+
+const createBlockTextSourceRef = (
+  blockId: string,
+  text: string,
+  start = 0,
+  end = text.length
+): SourceRef => ({
+  type: 'blockText',
+  blockId,
+  start,
+  end,
+  flattenedRuns: [{ text: text.slice(start, end), start, end }],
+});
+
+const createPayload = ({
+  blocks = [createBlock('block-1', 1, 'Hello world')],
+  tables = [],
+  fieldMappings,
+  excludedSourceRefs = [],
+}: {
+  blocks?: BlockDefinition[];
+  tables?: MappingReviewSuspendPayload['normalizedDocument']['tables'];
+  fieldMappings?: FieldMappingDefinition[];
+  excludedSourceRefs?: SourceRef[];
+} = {}): MappingReviewSuspendPayload => {
+  const defaultFieldMappings = fieldMappings ?? [
+    {
+      fieldId: 'body',
+      fieldType: 'Text',
+      sourceRefs: [createBlockTextSourceRef(blocks[0].id, blocks[0].text)],
+      confidence: 0.9,
+    },
+  ];
+
+  return {
+    suspendStepId: 'mapping-review',
+    reason: 'Mapping review required before CMA payload generation continues',
     documentId: 'doc-1',
-    title: 'Mapping review',
-    designValues: [],
-    contentBlocks: [
-      {
-        id: 'block-1',
-        position: 1,
-        type: 'paragraph',
-        textRuns: [{ text: 'Hello world' }],
-        flattenedTextRuns: [{ text: 'Hello world', start: 0, end: 11 }],
+    documentTitle: 'Mapping review',
+    normalizedDocument: {
+      documentId: 'doc-1',
+      title: 'Mapping review',
+      designValues: [],
+      contentBlocks: blocks.map((block) => ({
+        id: block.id,
+        position: block.position,
+        type: block.type ?? 'paragraph',
+        textRuns: [{ text: block.text }],
+        flattenedTextRuns: [{ text: block.text, start: 0, end: block.text.length }],
         designValueIds: [],
         imageIds: [],
-      },
-    ],
-    images: [],
-    tables: [],
-    assets: [],
-  },
-  entryBlockGraph: {
-    entries: [
+      })),
+      images: [],
+      tables,
+      assets: [],
+    },
+    entryBlockGraph: {
+      entries: [
+        {
+          contentTypeId: 'article',
+          fields: { title: { 'en-US': 'Draft title from display field' } },
+          fieldMappings: defaultFieldMappings.map((fieldMapping) => ({
+            fieldId: fieldMapping.fieldId,
+            fieldType: fieldMapping.fieldType,
+            sourceRefs: fieldMapping.sourceRefs,
+            confidence: fieldMapping.confidence ?? 0.9,
+          })),
+        },
+      ],
+      excludedSourceRefs,
+    },
+    referenceGraph: {
+      edges: [],
+      creationOrder: [],
+      deferredFields: [],
+      hasCircularDependency: false,
+    },
+    contentTypes: [
       {
-        contentTypeId: 'article',
-        fields: { title: { 'en-US': 'Draft title from display field' } },
-        fieldMappings: [
+        sys: { id: 'article' },
+        name: 'Article',
+        displayField: 'title',
+        fields: [
           {
-            fieldId: 'body',
-            fieldType: 'Text',
-            sourceRefs: [blockTextSourceRef],
-            confidence: 0.9,
+            id: 'title',
+            name: 'Title',
+            type: 'Symbol',
+          },
+          {
+            id: 'body',
+            name: 'Body copy',
+            type: 'Text',
+          },
+          {
+            id: 'summary',
+            name: 'Summary',
+            type: 'Text',
           },
         ],
       },
     ],
-    excludedSourceRefs,
-  },
-  referenceGraph: {
-    edges: [],
-    creationOrder: [],
-    deferredFields: [],
-    hasCircularDependency: false,
-  },
-  contentTypes: [
-    {
-      sys: { id: 'article' },
-      name: 'Article',
-      displayField: 'title',
-      fields: [
-        {
-          id: 'title',
-          name: 'Title',
-          type: 'Symbol',
-        },
-        {
-          id: 'body',
-          name: 'Body copy',
-          type: 'Text',
-        },
-      ],
-    },
-  ],
-});
+  };
+};
 
 const createImagePayload = (): MappingReviewSuspendPayload => ({
   suspendStepId: 'mapping-review',
@@ -208,7 +261,6 @@ describe('MappingView', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.stubGlobal('CSS', {
-      // Keep this aligned with selector usage in MappingView (`#${CSS.escape(id)}`).
       escape: (value: string) => value.replaceAll(':', '\\:'),
     });
     mockUseReviewTextSelection.mockReturnValue({
@@ -219,7 +271,271 @@ describe('MappingView', () => {
     });
   });
 
-  it('opens assign modal from text selection menu and clears selection', () => {
+  it('groups adjacent blocks mapped to the same field into one card and one grouped surface', () => {
+    const blocks = [
+      createBlock('block-1', 1, 'First body paragraph.'),
+      createBlock('block-2', 2, 'Second body paragraph.'),
+    ];
+    const payload = createPayload({
+      blocks,
+      fieldMappings: [
+        {
+          fieldId: 'body',
+          fieldType: 'Text',
+          sourceRefs: blocks.map((block) => createBlockTextSourceRef(block.id, block.text)),
+        },
+      ],
+    });
+
+    const { container } = render(
+      <MappingView payload={payload} {...mappingViewGraphProps(payload)} selectedEntryIndex={0} />
+    );
+
+    expect(container.querySelectorAll('[data-testid^="mapping-card-"]')).toHaveLength(1);
+    expect(container.querySelectorAll('[data-testid^="mapping-group-surface-"]')).toHaveLength(1);
+    expect(screen.getByText('Body')).toBeTruthy();
+    expect(
+      container.querySelector('[data-testid^="mapping-group-surface-"]')?.textContent
+    ).toContain('First body paragraph.');
+    expect(
+      container.querySelector('[data-testid^="mapping-group-surface-"]')?.textContent
+    ).toContain('Second body paragraph.');
+  });
+
+  it('labels non-consecutive runs for the same field with positional suffixes', () => {
+    const blocks = [
+      createBlock('block-1', 1, 'First body paragraph.'),
+      createBlock('block-2', 2, 'Mapped title text'),
+      createBlock('block-3', 3, 'Second body paragraph.'),
+    ];
+    const payload = createPayload({
+      blocks,
+      fieldMappings: [
+        {
+          fieldId: 'body',
+          fieldType: 'Text',
+          sourceRefs: [
+            createBlockTextSourceRef(blocks[0].id, blocks[0].text),
+            createBlockTextSourceRef(blocks[2].id, blocks[2].text),
+          ],
+        },
+        {
+          fieldId: 'title',
+          fieldType: 'Symbol',
+          sourceRefs: [createBlockTextSourceRef(blocks[1].id, blocks[1].text)],
+        },
+      ],
+    });
+
+    render(
+      <MappingView payload={payload} {...mappingViewGraphProps(payload)} selectedEntryIndex={0} />
+    );
+
+    expect(screen.getByText('Body (1/2)')).toBeTruthy();
+    expect(screen.getByText('Body (2/2)')).toBeTruthy();
+    expect(screen.getByText('Title')).toBeTruthy();
+  });
+
+  it('does not merge mixed-mapping blocks with same-field neighbors', () => {
+    const blocks = [
+      createBlock('block-1', 1, 'Intro paragraph.'),
+      createBlock('block-2', 2, 'Mixed paragraph.'),
+      createBlock('block-3', 3, 'Closing paragraph.'),
+    ];
+    const payload = createPayload({
+      blocks,
+      fieldMappings: [
+        {
+          fieldId: 'body',
+          fieldType: 'Text',
+          sourceRefs: blocks.map((block) => createBlockTextSourceRef(block.id, block.text)),
+        },
+        {
+          fieldId: 'summary',
+          fieldType: 'Text',
+          sourceRefs: [createBlockTextSourceRef(blocks[1].id, blocks[1].text)],
+        },
+      ],
+    });
+
+    const { container } = render(
+      <MappingView payload={payload} {...mappingViewGraphProps(payload)} selectedEntryIndex={0} />
+    );
+
+    expect(screen.getByText('Body (1/3)')).toBeTruthy();
+    expect(screen.getByText('Body (2/3)')).toBeTruthy();
+    expect(screen.getByText('Body (3/3)')).toBeTruthy();
+    expect(screen.getByText('Summary')).toBeTruthy();
+    expect(container.querySelectorAll('[data-testid^="mapping-card-"]')).toHaveLength(4);
+    expect(container.querySelectorAll('[data-testid^="mapping-group-surface-"]')).toHaveLength(2);
+  });
+
+  it('keeps table mappings scoped to the mapped row instead of wrapping the whole table', () => {
+    const mappedText = 'Update to - drupal-migration-contentful-static-site';
+    const unmappedText = 'drupal migration (300)';
+    const payload = createPayload({
+      blocks: [],
+      tables: [
+        {
+          id: 'table-1',
+          position: 1,
+          headers: ['Field', 'Value'],
+          rows: [
+            {
+              id: 'row-1',
+              cells: [
+                {
+                  id: 'cell-1',
+                  parts: [
+                    {
+                      id: 'part-1',
+                      type: 'text',
+                      textRuns: [{ text: 'KW' }],
+                      flattenedTextRuns: [{ text: 'KW', start: 0, end: 2 }],
+                    },
+                  ],
+                },
+                {
+                  id: 'cell-2',
+                  parts: [
+                    {
+                      id: 'part-2',
+                      type: 'text',
+                      textRuns: [{ text: unmappedText }],
+                      flattenedTextRuns: [
+                        { text: unmappedText, start: 0, end: unmappedText.length },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              id: 'row-2',
+              cells: [
+                {
+                  id: 'cell-3',
+                  parts: [
+                    {
+                      id: 'part-3',
+                      type: 'text',
+                      textRuns: [{ text: 'Slug' }],
+                      flattenedTextRuns: [{ text: 'Slug', start: 0, end: 4 }],
+                    },
+                  ],
+                },
+                {
+                  id: 'cell-4',
+                  parts: [
+                    {
+                      id: 'part-4',
+                      type: 'text',
+                      textRuns: [{ text: mappedText }],
+                      flattenedTextRuns: [{ text: mappedText, start: 0, end: mappedText.length }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          designValueIds: [],
+          imageIds: [],
+        },
+      ],
+      fieldMappings: [
+        {
+          fieldId: 'body',
+          fieldType: 'Text',
+          sourceRefs: [
+            {
+              type: 'tableText',
+              tableId: 'table-1',
+              rowId: 'row-2',
+              cellId: 'cell-4',
+              partId: 'part-4',
+              start: 0,
+              end: mappedText.length,
+              flattenedRuns: [{ text: mappedText, start: 0, end: mappedText.length }],
+            },
+          ],
+        },
+      ],
+    });
+
+    const { container } = render(
+      <MappingView payload={payload} {...mappingViewGraphProps(payload)} selectedEntryIndex={0} />
+    );
+
+    expect(container.querySelectorAll('[data-testid^="mapping-group-surface-"]')).toHaveLength(0);
+    expect(
+      container.querySelector(
+        '[data-review-text-segment="true"][data-row-id="row-2"][data-is-mapped="true"]'
+      )
+    ).toBeTruthy();
+    expect(
+      container.querySelector(
+        '[data-review-text-segment="true"][data-row-id="row-1"][data-is-mapped="true"]'
+      )
+    ).toBeNull();
+  });
+
+  it('highlights all underlying grouped text when hovering a grouped rail card', () => {
+    const blocks = [
+      createBlock('block-1', 1, 'First body paragraph.'),
+      createBlock('block-2', 2, 'Second body paragraph.'),
+    ];
+    const payload = createPayload({
+      blocks,
+      fieldMappings: [
+        {
+          fieldId: 'body',
+          fieldType: 'Text',
+          sourceRefs: blocks.map((block) => createBlockTextSourceRef(block.id, block.text)),
+        },
+      ],
+    });
+
+    const { container } = render(
+      <MappingView payload={payload} {...mappingViewGraphProps(payload)} selectedEntryIndex={0} />
+    );
+
+    const textSegments = Array.from(
+      container.querySelectorAll<HTMLElement>('[data-review-text-segment="true"]')
+    );
+    expect(textSegments).toHaveLength(2);
+    const initialBackgroundColor = textSegments[0].style.backgroundColor;
+    expect(textSegments[1].style.backgroundColor).toBe(initialBackgroundColor);
+
+    const mappingCard = container.querySelector<HTMLElement>('[data-testid^="mapping-card-"]');
+    expect(mappingCard).toBeTruthy();
+
+    fireEvent.mouseEnter(mappingCard as HTMLElement);
+
+    expect(textSegments[0].style.backgroundColor).not.toBe(initialBackgroundColor);
+    expect(textSegments[1].style.backgroundColor).toBe(textSegments[0].style.backgroundColor);
+    expect(
+      container
+        .querySelector('[data-testid^="mapping-group-surface-"]')
+        ?.getAttribute('data-hovered')
+    ).toBe('true');
+  });
+
+  it('opens assign modal from grouped-run text selection and clears selection', () => {
+    const blocks = [
+      createBlock('block-1', 1, 'First body paragraph.'),
+      createBlock('block-2', 2, 'Second body paragraph.'),
+    ];
+    const payload = createPayload({
+      blocks,
+      fieldMappings: [
+        {
+          fieldId: 'body',
+          fieldType: 'Text',
+          sourceRefs: blocks.map((block) => createBlockTextSourceRef(block.id, block.text)),
+        },
+      ],
+    });
+
     mockUseReviewTextSelection.mockReturnValueOnce({
       selectionRectangle: null,
       selectedText: '',
@@ -227,21 +543,19 @@ describe('MappingView', () => {
       clearSelection: mockClearSelection,
     });
 
-    const payload = createPayload();
     const { container, rerender } = render(
       <MappingView payload={payload} {...mappingViewGraphProps(payload)} selectedEntryIndex={0} />
     );
-    const selectedRange = createDomRange(
-      container.querySelector('[data-review-text-segment="true"]')?.firstChild as Text,
-      0,
-      5
-    );
+    const groupedTextSegments = container.querySelectorAll('[data-review-text-segment="true"]');
+    const selectedRange = createDomRange(groupedTextSegments[1].firstChild as Text, 0, 6);
+
     mockUseReviewTextSelection.mockReturnValue({
       selectionRectangle: { top: 100, left: 100, right: 160, bottom: 120 },
-      selectedText: '  selected body text  ',
+      selectedText: 'Second',
       selectedRange,
       clearSelection: mockClearSelection,
     });
+
     rerender(
       <MappingView payload={payload} {...mappingViewGraphProps(payload)} selectedEntryIndex={0} />
     );
@@ -249,15 +563,10 @@ describe('MappingView', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Reassign' }));
 
     expect(screen.getByRole('heading', { name: 'Assign content' })).toBeTruthy();
-    expect(screen.getByText('"selected body text"')).toBeTruthy();
+    expect(screen.getByText('"Second"')).toBeTruthy();
     expect(screen.getAllByText('Article').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Untitled').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Body copy').length).toBeGreaterThan(0);
-    expect(screen.getByText('New location')).toBeTruthy();
-    expect(screen.getByText('Article: Draft title from display field')).toBeTruthy();
-    expect(
-      screen.getAllByText((_, node) => node?.textContent?.includes('| Long text') ?? false).length
-    ).toBeGreaterThan(0);
     expect(mockClearSelection).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/google-docs/test/locations/Page/components/review/mapping/entryBlockGraphExclusion.spec.ts
+++ b/apps/google-docs/test/locations/Page/components/review/mapping/entryBlockGraphExclusion.spec.ts
@@ -11,9 +11,9 @@ import {
   collectTextExclusionRangesFromSelection,
 } from '../../../../../../src/locations/Page/components/review/mapping/entryBlockGraphExclusion';
 
-const blockRef = (start: number, end: number, text: string): SourceRef => ({
+const blockRef = (start: number, end: number, text: string, blockId = 'block-1'): SourceRef => ({
   type: 'blockText',
-  blockId: 'block-1',
+  blockId,
   start,
   end,
   flattenedRuns: [{ text, start, end, styles: {} }],
@@ -88,6 +88,49 @@ describe('entryBlockGraphExclusion', () => {
       entryBlockGraph: EntryBlockGraph;
     };
     expect(parsed.entryBlockGraph.entries[0]?.fieldMappings[0]?.sourceRefs).toHaveLength(2);
+  });
+
+  it('applyTextExclusionToEntryBlockGraph excludes all source refs in a grouped location', () => {
+    const firstRef = blockRef(0, 20, 'abcdefghijklmnopqrst', 'block-1');
+    const secondRef = blockRef(0, 20, 'uvwxyzabcdefghijkl', 'block-2');
+    const graph: EntryBlockGraph = {
+      entries: [
+        {
+          contentTypeId: 'article',
+          fieldMappings: [
+            {
+              fieldId: 'body',
+              fieldType: 'Text',
+              sourceRefs: [firstRef, secondRef],
+              confidence: 1,
+            },
+          ],
+        },
+      ],
+      excludedSourceRefs: [],
+    };
+    const location: EditLocationOption = {
+      entryIndex: 0,
+      id: 'grouped-body',
+      contentTypeId: 'article',
+      contentTypeName: 'Article',
+      entryName: 'Article #1',
+      fieldId: 'body',
+      fieldName: 'Body',
+      fieldType: 'Text',
+      sourceRef: firstRef,
+      sourceRefs: [firstRef, secondRef],
+    };
+
+    const next = applyTextExclusionToEntryBlockGraph(graph, location, [
+      { scope: 'block', blockId: 'block-1', start: 10, end: 20 },
+      { scope: 'block', blockId: 'block-2', start: 0, end: 6 },
+    ]);
+
+    expect(next.entries[0]?.fieldMappings[0]?.sourceRefs).toEqual([
+      expect.objectContaining({ type: 'blockText', blockId: 'block-1', start: 0, end: 10 }),
+      expect.objectContaining({ type: 'blockText', blockId: 'block-2', start: 6, end: 20 }),
+    ]);
   });
 
   it('collectMappedExclusionPreviewText joins only intersecting mapped segment text', () => {


### PR DESCRIPTION
This PR improves the Google Docs mapping review UI by grouping consecutive document blocks that map to the same Contentful field into a single mapping card, while keeping non-consecutive runs separate and labeled with their position (for example Body (1/2) and Body (2/2)). It also preserves existing HIL actions like reassign, exclude, hover highlighting, image assignment, and partial text selection.

Before

<img width="1423" height="415" alt="Screenshot 2026-04-22 at 16 04 46" src="https://github.com/user-attachments/assets/f94eab7d-7a42-4abe-a396-1f6508bab3f9" />


After

<img width="1430" height="612" alt="Screenshot 2026-04-22 at 16 14 21" src="https://github.com/user-attachments/assets/0bf970bb-d4df-4ea2-b35e-74f3165af821" />

Excluding

https://github.com/user-attachments/assets/3182effe-a1f4-4790-aaab-ea450afeabc3