### PR TITLE
feat(google-docs): Adding ability to assign/reassign rich texts V1 [INTEG-3836]

### DIFF
--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -172,7 +172,6 @@ export const MappingView = ({
   const textSelectionRootRef = useRef<HTMLDivElement | null>(null);
   const segmentLayoutRefs = useRef<Record<string, HTMLDivElement | null>>({});
   const cardWrapperRefs = useRef<Record<string, HTMLDivElement | null>>({});
-
   const document = payload.normalizedDocument;
 
   const closeEditModal = () => {
@@ -334,6 +333,7 @@ export const MappingView = ({
       .map((field) => ({
         id: field.id,
         fieldName: (field.name ?? '').trim() || formatDisplayName(field.id),
+        fieldType: field.type,
         fieldDisplayType: displayType(field.type ?? '', field.linkType, field.items),
         isAssetField: isAssetFieldForImageAssign(field),
       }));

--- a/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/utils.ts
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/utils.ts
@@ -4,6 +4,7 @@ import { FIELD_TYPE_LABELS } from '../fieldFormatting';
 const FIELD_TYPE_DISPLAY = {
   SHORT_TEXT: FIELD_TYPE_LABELS.Symbol,
   LONG_TEXT: FIELD_TYPE_LABELS.Text,
+  RICH_TEXT: FIELD_TYPE_LABELS.RichText,
   INTEGER: FIELD_TYPE_LABELS.Integer,
   DECIMAL: FIELD_TYPE_LABELS.Number,
 } as const;
@@ -32,6 +33,7 @@ export const isSelectableFieldType = (
   switch (normalizedFieldType) {
     case FIELD_TYPE_DISPLAY.SHORT_TEXT:
     case FIELD_TYPE_DISPLAY.LONG_TEXT:
+    case FIELD_TYPE_DISPLAY.RICH_TEXT:
       return true;
     case FIELD_TYPE_DISPLAY.INTEGER:
       return highlightedTextMatch === FIELD_TYPE_DISPLAY.INTEGER;

--- a/apps/google-docs/src/types/editModal.ts
+++ b/apps/google-docs/src/types/editModal.ts
@@ -17,6 +17,7 @@ export interface EditModalFieldOption {
   id: string;
   fieldName: string;
   fieldDisplayType: string;
+  fieldType?: string;
   isAssetField?: boolean;
 }
 


### PR DESCRIPTION
## Purpose

Adding ability to assign/reassign rich texts fields.

## Approach

Make the rich text visible and selectable, modifying the entryBlocksGraph.
- when you assign or reassign content, we update that graph’s entries[].fieldMappings
- for Rich Text destinations, the important change is just that the target mapping gets fieldType: "RichText" and the selected sourceRefs with their flattenedRuns and styles preserved
- when you click create/continue, ReviewPage resumes the workflow with that graph in ReviewPage.tsx

## Testing steps


https://github.com/user-attachments/assets/d8c14c64-57df-4727-b5a8-3ba9594b1e7d


https://github.com/user-attachments/assets/8b7ccc59-5a8e-441e-a8f8-32cbe078c8e0


https://github.com/user-attachments/assets/f37cd676-bc56-4d54-8a22-d70b89611c6f


## Breaking Changes

No

## Dependencies and/or References

Link to [INTEG-3836](https://contentful.atlassian.net/browse/INTEG-3836)

## Deployment

No

[INTEG-3836]: https://contentful.atlassian.net/browse/INTEG-3836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ