### PR TITLE
Fix: Use Untitled for new locations in Asign Content modal [INTEG-3847]

### DIFF
--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -101,31 +101,6 @@ function findRowByEntryIndex(rows: EntryListRow[], index: number): EntryListRow 
   return null;
 }
 
-function getEntryName(contentTypeName: string | undefined, entryIndex: number): string {
-  const displayName = contentTypeName ?? 'Untitled';
-  return `${displayName} #${entryIndex + 1}`;
-}
-
-function getEntryReviewTitle(
-  entry: MappingReviewSuspendPayload['entryBlockGraph']['entries'][number],
-  displayField: string | undefined,
-  fallbackEntryName: string
-): string {
-  const localizedFieldValue = displayField ? entry.fields?.[displayField] : undefined;
-  if (localizedFieldValue) {
-    const populatedValue = Object.values(localizedFieldValue).find(
-      (candidate): candidate is string =>
-        typeof candidate === 'string' && candidate.trim().length > 0
-    );
-    if (populatedValue) {
-      return populatedValue.trim();
-    }
-  }
-
-  const mappedTitle = getEntryTitleFromFieldMappings(entry, displayField).trim();
-  return mappedTitle && mappedTitle !== 'Untitled' ? mappedTitle : fallbackEntryName;
-}
-
 /** `Range#intersectsNode` can throw when the range and node are in inconsistent trees. */
 function rangeIntersectsNode(range: Range, node: Node): boolean {
   try {
@@ -380,8 +355,7 @@ export const MappingView = ({
   ): EditModalNewLocation => {
     const contentType = payload.contentTypes.find((item) => item.sys.id === entry.contentTypeId);
     const contentTypeName = contentType?.name ?? entry.contentTypeId;
-    const fallbackEntryName = getEntryName(contentTypeName, entryIndex);
-    const entryTitle = getEntryReviewTitle(entry, contentType?.displayField, fallbackEntryName);
+    const entryTitle = getEntryTitleFromFieldMappings(entry, contentType?.displayField);
     const contentTypeFields = contentType?.fields ?? [];
     const fieldOptions = contentTypeFields
       .filter(isWorkflowContentTypeFieldWithId)

--- a/apps/google-docs/test/locations/Page/components/review/mapping/MappingView.spec.tsx
+++ b/apps/google-docs/test/locations/Page/components/review/mapping/MappingView.spec.tsx
@@ -714,6 +714,10 @@ describe('MappingView', () => {
     expect(screen.getAllByText('Article').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Untitled').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Body copy').length).toBeGreaterThan(0);
+    expect(screen.getByText('New location')).toBeTruthy();
+    expect(
+      screen.getAllByText((_, node) => node?.textContent?.includes('| Long text') ?? false).length
+    ).toBeGreaterThan(0);
     expect(mockClearSelection).toHaveBeenCalledTimes(1);
   });
 
@@ -737,7 +741,7 @@ describe('MappingView', () => {
     expect(screen.getByText('"fresh body text"')).toBeTruthy();
     expect(screen.getByText('Current location')).toBeTruthy();
     expect(screen.getByText('New location')).toBeTruthy();
-    expect(screen.getByText('Article: Draft title from display field')).toBeTruthy();
+    expect(screen.getByText('Article: Untitled')).toBeTruthy();
     expect(mockClearSelection).toHaveBeenCalledTimes(1);
   });
 
@@ -913,7 +917,6 @@ describe('MappingView', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Assign image' }));
 
     expect(screen.getByRole('heading', { name: 'Assign content' })).toBeTruthy();
-    expect(screen.getByText('Article: Second entry')).toBeTruthy();
-    expect(screen.getAllByText(/Article: .* entry/)).not.toHaveLength(0);
+    expect(screen.getAllByText('Untitled').length).toBeGreaterThan(0);
   });
 });

--- a/apps/google-docs/test/locations/Page/components/review/mapping/MappingView.spec.tsx
+++ b/apps/google-docs/test/locations/Page/components/review/mapping/MappingView.spec.tsx
@@ -712,9 +712,9 @@ describe('MappingView', () => {
     expect(screen.getByRole('heading', { name: 'Assign content' })).toBeTruthy();
     expect(screen.getByText('"Second"')).toBeTruthy();
     expect(screen.getAllByText('Article').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('Untitled').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Body copy').length).toBeGreaterThan(0);
     expect(screen.getByText('New location')).toBeTruthy();
+    expect(screen.getAllByText('Untitled').length).toBeGreaterThan(0);
     expect(
       screen.getAllByText((_, node) => node?.textContent?.includes('| Long text') ?? false).length
     ).toBeGreaterThan(0);


### PR DESCRIPTION
## Purpose

Fix: Use Untitled for new locations in Asign Content modal

## Approach
Fix: Use Untitled for new locations in Asign Content modal
Remove old logic 
## Testing steps

https://github.com/user-attachments/assets/d08e5f22-75ab-499e-83d2-7a589ba3920e


## Breaking Changes

<!-- Are there any changes to be aware of that would break current production build? -->

## Dependencies and/or References

<!-- Where can we get more insights about this change? (Tickets, wiki pages or links to other places/docs -- no private/internal links please) -->

## Deployment

<!-- (Optional) Are there any deployment-related tasks, concerns or risks we should be mindful of? -->
