### PR TITLE
feat: add review-all mapping mode []

### DIFF
--- a/apps/google-docs/src/hooks/useReviewTextSelection.tsx
+++ b/apps/google-docs/src/hooks/useReviewTextSelection.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState, type RefObject } from 'react';
 import type { SelectionViewportRectangle } from '../locations/Page/components/review/mapping/selectionViewportRectangle';
 
 const SEGMENT_SURFACE_SELECTOR = '[data-review-segment-surface]';
+const SELECTION_MENU_HEADER_CLEARANCE_PX = 8;
 
 function elementFromNode(node: Node): Element | null {
   if (node.nodeType === Node.TEXT_NODE) {
@@ -25,13 +26,58 @@ function isSelectionInDocumentBody(range: Range, root: HTMLElement): boolean {
   return endpointInSurface(range.startContainer) && endpointInSurface(range.endContainer);
 }
 
-function getSelectionViewportRectangle(range: Range): SelectionViewportRectangle {
-  const rect = range.getBoundingClientRect();
+function intersectsViewport(
+  rect: DOMRect | Pick<SelectionViewportRectangle, 'top' | 'left' | 'bottom' | 'right'>
+): boolean {
+  return (
+    rect.bottom > 0 &&
+    rect.right > 0 &&
+    rect.top < window.innerHeight &&
+    rect.left < window.innerWidth
+  );
+}
+
+export function getSelectionViewportRectangle(
+  range: Range,
+  root: HTMLElement,
+  viewportTopInset = 0
+): SelectionViewportRectangle | null {
+  const rootRect = root.getBoundingClientRect();
+  const clientRects = Array.from(range.getClientRects()).filter(
+    (rect) => rect.width > 0 && rect.height > 0
+  );
+
+  const visibleRects = clientRects
+    .map((rect) => ({
+      top: Math.max(rect.top, rootRect.top, viewportTopInset, 0),
+      left: Math.max(rect.left, rootRect.left, 0),
+      bottom: Math.min(rect.bottom, rootRect.bottom, window.innerHeight),
+      right: Math.min(rect.right, rootRect.right, window.innerWidth),
+    }))
+    .filter((rect) => rect.bottom > rect.top && rect.right > rect.left)
+    .filter(intersectsViewport)
+    .sort((a, b) => {
+      if (a.top !== b.top) return a.top - b.top;
+      return a.left - b.left;
+    });
+
+  if (visibleRects.length > 0) {
+    return visibleRects[0];
+  }
+
+  const boundingRect = range.getBoundingClientRect();
+  if (
+    !intersectsViewport(boundingRect) ||
+    boundingRect.bottom <= Math.max(rootRect.top, viewportTopInset, 0)
+  ) {
+    return null;
+  }
+
   return {
-    top: rect.top,
-    left: rect.left,
-    bottom: rect.bottom,
-    right: rect.right,
+    top: boundingRect.top,
+    left: boundingRect.left,
+    bottom: boundingRect.bottom,
+    right: boundingRect.right,
   };
 }
 
@@ -52,7 +98,7 @@ function isValidReviewSelection(root: HTMLElement, sel: Selection): boolean {
 }
 
 export interface UseReviewTextSelectionResult {
-  /** Derived from {@link selectedRange} via `getBoundingClientRect()` for the floating menu. */
+  /** Derived from the visible selection rect for the floating menu. */
   selectionRectangle: SelectionViewportRectangle | null;
   selectedText: string;
   selectedRange: Range | null;
@@ -60,7 +106,8 @@ export interface UseReviewTextSelectionResult {
 }
 
 export function useReviewTextSelection(
-  rootRef: RefObject<HTMLElement | null>
+  rootRef: RefObject<HTMLElement | null>,
+  occludingTopRef?: RefObject<HTMLElement | null>
 ): UseReviewTextSelectionResult {
   const [selectedText, setSelectedText] = useState('');
   const [selectedRange, setSelectedRange] = useState<Range | null>(null);
@@ -90,7 +137,15 @@ export function useReviewTextSelection(
     setSelectedRange(null);
   }, []);
 
-  const selectionRectangle = selectedRange ? getSelectionViewportRectangle(selectedRange) : null;
+  const selectionRectangle =
+    selectedRange && rootRef.current
+      ? getSelectionViewportRectangle(
+          selectedRange,
+          rootRef.current,
+          (occludingTopRef?.current?.getBoundingClientRect().bottom ?? 0) +
+            SELECTION_MENU_HEADER_CLEARANCE_PX
+        )
+      : null;
 
   useEffect(() => {
     document.addEventListener('selectionchange', updateFromSelection);

--- a/apps/google-docs/src/locations/Page/components/overview/OverviewEntryList.tsx
+++ b/apps/google-docs/src/locations/Page/components/overview/OverviewEntryList.tsx
@@ -12,13 +12,13 @@ import { truncateLabel } from '../../../../utils/utils';
 
 export interface OverviewEntryListProps {
   rows: OverviewEntryListRow[];
-  selectedEntryIndex: number;
+  selectedEntryIndex: number | null;
   onSelect: (entryIndex: number) => void;
 }
 
 interface OverviewEntryRowCardProps {
   row: OverviewEntryListRow;
-  selectedEntryIndex: number;
+  selectedEntryIndex: number | null;
   onSelect: (entryIndex: number) => void;
   showTreeLines: boolean;
   isLastRow?: boolean;

--- a/apps/google-docs/src/locations/Page/components/overview/OverviewSection.tsx
+++ b/apps/google-docs/src/locations/Page/components/overview/OverviewSection.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { Box, Button, Flex, Note, Paragraph, Text } from '@contentful/f36-components';
+import { Box, Button, Flex, Note, Paragraph, Text, Tooltip } from '@contentful/f36-components';
 import { LightbulbIcon } from '@contentful/f36-icons';
 import type { MappingReviewSuspendPayload } from '@types';
 import { buildEntryListFromEntryBlockGraph } from '../../../../utils/overviewEntryList';
@@ -9,8 +9,10 @@ import Splitter from '../mainpage/Splitter';
 
 interface OverviewProps {
   payload: MappingReviewSuspendPayload;
-  selectedEntryIndex: number;
+  selectedEntryIndex: number | null;
   onSelectEntryIndex: (index: number) => void;
+  onViewAllMappings: () => void;
+  isViewingAllMappings: boolean;
   ctaLabel: string;
   onCtaClick: () => void;
   isCtaLoading?: boolean;
@@ -20,6 +22,8 @@ const OverviewSection = ({
   payload,
   selectedEntryIndex,
   onSelectEntryIndex,
+  onViewAllMappings,
+  isViewingAllMappings,
   ctaLabel,
   onCtaClick,
   isCtaLoading = false,
@@ -59,13 +63,23 @@ const OverviewSection = ({
               <Text fontSize="fontSizeM">Click row to view content by entry below.</Text>
             </Flex>
 
-            <Button
-              variant="primary"
-              onClick={onCtaClick}
-              isLoading={isCtaLoading}
-              isDisabled={isCtaLoading}>
-              {ctaLabel}
-            </Button>
+            <Flex alignItems="center" gap="spacingXs">
+              <Tooltip content="Read only" placement="top">
+                <Button
+                  variant="secondary"
+                  onClick={onViewAllMappings}
+                  isDisabled={isCtaLoading || entryRows.length === 0 || isViewingAllMappings}>
+                  Review all
+                </Button>
+              </Tooltip>
+              <Button
+                variant="primary"
+                onClick={onCtaClick}
+                isLoading={isCtaLoading}
+                isDisabled={isCtaLoading}>
+                {ctaLabel}
+              </Button>
+            </Flex>
           </Flex>
 
           {entryRows.length === 0 ? (

--- a/apps/google-docs/src/locations/Page/components/review/ReviewPage.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/ReviewPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Button, Flex, Heading, Layout } from '@contentful/f36-components';
 import tokens from '@contentful/f36-tokens';
 import { PageAppSDK } from '@contentful/app-sdk';
@@ -37,6 +37,7 @@ export const ReviewPage = ({
   const [createdEntries, setCreatedEntries] = useState<EntryProps[] | null>(null);
   const [isSummaryModalOpen, setIsSummaryModalOpen] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
+  const reviewHeaderRef = useRef<HTMLDivElement | null>(null);
   const [entryBlockGraph, setEntryBlockGraph] = useState<EntryBlockGraph>(() =>
     structuredClone(payload.entryBlockGraph)
   );
@@ -153,19 +154,21 @@ export const ReviewPage = ({
 
   return (
     <>
-      <Layout.Header title="Preview">
-        <Flex justifyContent="space-between" alignItems="center" marginTop="spacingS">
-          <Heading marginBottom="none">{title}</Heading>
-          <Button
-            variant="transparent"
-            size="small"
-            onClick={handleCancelOrExitReview}
-            aria-label={hasCreatedEntries ? 'Exit review' : 'Cancel review'}>
-            {hasCreatedEntries ? 'Exit' : 'Cancel'}
-          </Button>
-        </Flex>
-      </Layout.Header>
-      <Splitter marginTop="spacingS" />
+      <div ref={reviewHeaderRef}>
+        <Layout.Header title="Preview">
+          <Flex justifyContent="space-between" alignItems="center" marginTop="spacingS">
+            <Heading marginBottom="none">{title}</Heading>
+            <Button
+              variant="transparent"
+              size="small"
+              onClick={handleCancelOrExitReview}
+              aria-label={hasCreatedEntries ? 'Exit review' : 'Cancel review'}>
+              {hasCreatedEntries ? 'Exit' : 'Cancel'}
+            </Button>
+          </Flex>
+        </Layout.Header>
+        <Splitter marginTop="spacingS" />
+      </div>
       <Layout.Body>
         <Flex flexDirection="column" gap="spacingM" style={{ padding: tokens.spacingL }}>
           <OverviewSection
@@ -182,6 +185,7 @@ export const ReviewPage = ({
             onEntryBlockGraphChange={setEntryBlockGraph}
             selectedEntryIndex={selectedEntryIndex}
             isDisabled={isMappingDisabled}
+            occludingTopRef={reviewHeaderRef}
           />
         </Flex>
       </Layout.Body>

--- a/apps/google-docs/src/locations/Page/components/review/ReviewPage.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/ReviewPage.tsx
@@ -30,6 +30,7 @@ export const ReviewPage = ({
   onCancelReview,
   onExitReview,
 }: ReviewPageProps) => {
+  const [reviewMode, setReviewMode] = useState<'single' | 'all'>('all');
   const [isConfirmCancelModalOpen, setIsConfirmCancelModalOpen] = useState(false);
   const [selectedEntryIndex, setSelectedEntryIndex] = useState<number>(0);
   const [isCancelling, setIsCancelling] = useState(false);
@@ -46,6 +47,8 @@ export const ReviewPage = ({
   // alone or user edits would be wiped when the parent re-renders with a new object reference.
   useEffect(() => {
     setEntryBlockGraph(structuredClone(payload.entryBlockGraph));
+    setReviewMode('all');
+    setSelectedEntryIndex(0);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- only re-init on run identity
   }, [runId, payload.documentId]);
 
@@ -135,6 +138,15 @@ export const ReviewPage = ({
     void handleCreateEntries();
   }, [hasCreatedEntries, handleCreateEntries]);
 
+  const handleViewAllMappings = useCallback(() => {
+    setReviewMode('all');
+  }, []);
+
+  const handleSelectEntryIndex = useCallback((index: number) => {
+    setSelectedEntryIndex(index);
+    setReviewMode('single');
+  }, []);
+
   const handleCancelOrExitReview = useCallback(() => {
     if (hasCreatedEntries) {
       onExitReview();
@@ -173,8 +185,10 @@ export const ReviewPage = ({
         <Flex flexDirection="column" gap="spacingM" style={{ padding: tokens.spacingL }}>
           <OverviewSection
             payload={reviewPayload}
-            selectedEntryIndex={selectedEntryIndex}
-            onSelectEntryIndex={setSelectedEntryIndex}
+            selectedEntryIndex={reviewMode === 'all' ? null : selectedEntryIndex}
+            onSelectEntryIndex={handleSelectEntryIndex}
+            onViewAllMappings={handleViewAllMappings}
+            isViewingAllMappings={reviewMode === 'all'}
             ctaLabel={hasCreatedEntries ? 'View entries' : 'Create entries'}
             onCtaClick={handleCreateOrViewEntries}
             isCtaLoading={isCreatePending}
@@ -183,9 +197,10 @@ export const ReviewPage = ({
             payload={reviewPayload}
             entryBlockGraph={entryBlockGraph}
             onEntryBlockGraphChange={setEntryBlockGraph}
-            selectedEntryIndex={selectedEntryIndex}
+            selectedEntryIndex={reviewMode === 'all' ? null : selectedEntryIndex}
             isDisabled={isMappingDisabled}
             occludingTopRef={reviewHeaderRef}
+            reviewMode={reviewMode}
           />
         </Flex>
       </Layout.Body>

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingCard.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingCard.tsx
@@ -4,6 +4,7 @@ import tokens from '@contentful/f36-tokens';
 
 export interface MappingCardData {
   key: string;
+  contentTypeName: string;
   fieldName: string;
   fieldType: string;
   displayLabel: string;
@@ -13,6 +14,7 @@ interface MappingCardProps {
   card: MappingCardData;
   top: number;
   wrapperRef: Ref<HTMLDivElement>;
+  showContentTypeName?: boolean;
   isHovered?: boolean;
   onMouseEnter?: () => void;
   onMouseLeave?: () => void;
@@ -40,11 +42,12 @@ export const MappingCard = ({
   card,
   top,
   wrapperRef,
+  showContentTypeName = false,
   isHovered = false,
   onMouseEnter,
   onMouseLeave,
 }: MappingCardProps) => {
-  const { displayLabel, fieldType } = card;
+  const { contentTypeName, displayLabel, fieldType } = card;
   const fullValue = `${displayLabel}${FIELD_TYPE_SEPARATOR}${fieldType}`;
   const truncatedValue = truncate(fullValue, MAX_VALUE_LENGTH);
   const separatorIndex = truncatedValue.indexOf(FIELD_TYPE_SEPARATOR);
@@ -71,6 +74,16 @@ export const MappingCard = ({
         backgroundColor: tokens.green100,
         transition: 'border-color 120ms ease, border-width 120ms ease',
       }}>
+      {showContentTypeName ? (
+        <Box marginBottom="spacing2Xs">
+          <Text as="span" fontColor="gray600" style={labelTextStyle} marginRight="spacingXs">
+            Content type:
+          </Text>
+          <Text as="span" fontWeight="fontWeightDemiBold" style={valueTextStyle}>
+            {contentTypeName}
+          </Text>
+        </Box>
+      ) : null}
       <Text as="span" fontColor="gray600" style={labelTextStyle} marginRight="spacingXs">
         Field:
       </Text>

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingEntryCards.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingEntryCards.tsx
@@ -10,6 +10,7 @@ interface MappingEntryCardsProps {
   hoveredMappingKeys: string[];
   onSetHoveredMappingKeys: (keys: string[]) => void;
   setCardWrapperRef: (cardKey: string) => RefCallback<HTMLDivElement>;
+  showContentTypeName?: boolean;
 }
 
 const railStyles: BoxProps['style'] = {
@@ -25,6 +26,7 @@ export const MappingEntryCards = ({
   hoveredMappingKeys,
   onSetHoveredMappingKeys,
   setCardWrapperRef,
+  showContentTypeName = false,
 }: MappingEntryCardsProps): JSX.Element => {
   return (
     <Box data-testid={`mapping-rail-${groupId}`} style={railStyles}>
@@ -36,6 +38,7 @@ export const MappingEntryCards = ({
                 card={mappingCard}
                 top={cardOffsetsByGroup[groupId]?.[mappingCard.key] ?? 0}
                 wrapperRef={setCardWrapperRef(mappingCard.key)}
+                showContentTypeName={showContentTypeName}
                 isHovered={mappingCard.mappingKeys.some((key) => hoveredMappingKeys.includes(key))}
                 onMouseEnter={() => onSetHoveredMappingKeys(mappingCard.mappingKeys)}
                 onMouseLeave={() => onSetHoveredMappingKeys([])}

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -7,7 +7,7 @@ import {
   type RefCallback,
   type RefObject,
 } from 'react';
-import { Box, Flex, Text } from '@contentful/f36-components';
+import { Box, Flex, Note, Text } from '@contentful/f36-components';
 import tokens from '@contentful/f36-tokens';
 import {
   buildEntryListFromEntryBlockGraph,
@@ -79,6 +79,7 @@ interface MappingViewProps {
   selectedEntryIndex: number | null;
   isDisabled?: boolean;
   occludingTopRef?: RefObject<HTMLElement | null>;
+  reviewMode?: 'single' | 'all';
 }
 
 const EMPTY_NEW_LOCATION: EditModalNewLocation = {
@@ -155,8 +156,13 @@ export const MappingView = ({
   selectedEntryIndex,
   isDisabled = false,
   occludingTopRef,
+  reviewMode = 'single',
 }: MappingViewProps): JSX.Element => {
+  const isReadOnlyAllMappings = reviewMode === 'all';
   const selectedEntryRow = useMemo(() => {
+    if (isReadOnlyAllMappings) {
+      return null;
+    }
     const rows = buildEntryListFromEntryBlockGraph(
       payload.entryBlockGraph.entries,
       payload.contentTypes,
@@ -172,6 +178,7 @@ export const MappingView = ({
     payload.contentTypes,
     payload.referenceGraph.edges,
     selectedEntryIndex,
+    isReadOnlyAllMappings,
   ]);
   const [hoveredMappingKeys, setHoveredMappingKeys] = useState<string[]>([]);
   const [cardOffsetsByGroup, setCardOffsetsByGroup] = useState<
@@ -306,17 +313,29 @@ export const MappingView = ({
 
   const { groupsByTab, allGroups } = useMemo(
     () =>
-      buildMappingDisplayGroups(tabs, visibleHighlightsBySegment, (highlight) => {
-        const graphEntry = entryBlockGraph.entries[highlight.entryIndex];
-        const contentType = payload.contentTypes.find(
-          (item) => item.sys.id === graphEntry?.contentTypeId
-        );
-        const field = contentType?.fields.find((item) => item.id === highlight.fieldId);
+      buildMappingDisplayGroups(
+        tabs,
+        visibleHighlightsBySegment,
+        (highlight) => {
+          const graphEntry = entryBlockGraph.entries[highlight.entryIndex];
+          const contentType = payload.contentTypes.find(
+            (item) => item.sys.id === graphEntry?.contentTypeId
+          );
+          const field = contentType?.fields.find((item) => item.id === highlight.fieldId);
 
-        return field
-          ? displayType(field.type ?? '', field.linkType, field.items)
-          : displayType(highlight.fieldType);
-      }),
+          return field
+            ? displayType(field.type ?? '', field.linkType, field.items)
+            : displayType(highlight.fieldType);
+        },
+        (highlight) => {
+          const graphEntry = entryBlockGraph.entries[highlight.entryIndex];
+          const contentType = payload.contentTypes.find(
+            (item) => item.sys.id === graphEntry?.contentTypeId
+          );
+
+          return contentType?.name ?? graphEntry?.contentTypeId ?? 'Entry';
+        }
+      ),
     [tabs, visibleHighlightsBySegment, payload.contentTypes, entryBlockGraph.entries]
   );
 
@@ -535,7 +554,33 @@ export const MappingView = ({
     };
 
     measureOffsets();
-  }, [allGroups]);
+
+    if (typeof ResizeObserver === 'undefined') {
+      return;
+    }
+
+    const observer = new ResizeObserver(() => {
+      measureOffsets();
+    });
+
+    allGroups.forEach((group) => {
+      const groupNode = groupLayoutRefs.current[group.id];
+      if (groupNode) {
+        observer.observe(groupNode);
+      }
+
+      group.mappingCards.forEach((card) => {
+        const wrapperNode = cardWrapperRefs.current[card.key];
+        if (wrapperNode) {
+          observer.observe(wrapperNode);
+        }
+      });
+    });
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [allGroups, isReadOnlyAllMappings]);
 
   const openAssignModal = (
     preview: string,
@@ -588,7 +633,7 @@ export const MappingView = ({
   };
 
   const handleAssignFromSelection = () => {
-    if (isDisabled || !selectedText.trim()) return;
+    if (isDisabled || isReadOnlyAllMappings || !selectedText.trim()) return;
     const reassignRanges = collectTextExclusionRangesFromSelection(
       textSelectionRootRef.current,
       selectedRange
@@ -607,7 +652,7 @@ export const MappingView = ({
   };
 
   const handleExcludeFromSelection = () => {
-    if (isDisabled || !selectedText.trim()) return;
+    if (isDisabled || isReadOnlyAllMappings || !selectedText.trim()) return;
     const ranges = collectTextExclusionRangesFromSelection(
       textSelectionRootRef.current,
       selectedRange
@@ -627,13 +672,13 @@ export const MappingView = ({
   };
 
   const handleAssignImage = (sourceRef: ImageSourceRef, label: string) => {
-    if (isDisabled) return;
+    if (isDisabled || isReadOnlyAllMappings) return;
     openAssignModal(label, getLocationsForSourceRef(sourceRef), [], [], sourceRef);
     setHoveredMappingKeys([]);
   };
 
   const handleExcludeImage = (sourceRef: ImageSourceRef, label: string) => {
-    if (isDisabled) return;
+    if (isDisabled || isReadOnlyAllMappings) return;
     setPendingImageSourceRef(sourceRef);
     setPendingTextExclusionRanges(null);
     openExcludeModal(label, getLocationsForSourceRef(sourceRef), {
@@ -810,7 +855,7 @@ export const MappingView = ({
         flexDirection="column"
         gap="spacingS"
         style={{ marginTop: tokens.spacingM }}>
-        {selectedEntryRow && (
+        {(selectedEntryRow || isReadOnlyAllMappings) && (
           <Box
             style={{
               borderBottom: `1px solid ${tokens.gray200}`,
@@ -823,16 +868,31 @@ export const MappingView = ({
               marginBottom="spacing2Xs">
               Currently viewing:
             </Text>
-            <Text as="p" marginBottom="none">
-              <Text as="span" fontWeight="fontWeightDemiBold">
-                {selectedEntryRow.contentTypeName}
-              </Text>
-              {selectedEntryRow.entryTitle ? (
-                <Text as="span" fontColor="gray600">
-                  {' '}
-                  ({selectedEntryRow.entryTitle})
-                </Text>
-              ) : null}
+            <Text as="div" marginBottom="none">
+              {isReadOnlyAllMappings ? (
+                <>
+                  <Text as="span" fontWeight="fontWeightDemiBold">
+                    All entries
+                  </Text>
+                  <Box marginTop="spacingXs">
+                    <Note variant="neutral">
+                      Select an entry above to review and edit mappings for that entry.
+                    </Note>
+                  </Box>
+                </>
+              ) : (
+                <>
+                  <Text as="span" fontWeight="fontWeightDemiBold">
+                    {selectedEntryRow?.contentTypeName}
+                  </Text>
+                  {selectedEntryRow?.entryTitle ? (
+                    <Text as="span" fontColor="gray600">
+                      {' '}
+                      ({selectedEntryRow.entryTitle})
+                    </Text>
+                  ) : null}
+                </>
+              )}
             </Text>
           </Box>
         )}
@@ -850,6 +910,14 @@ export const MappingView = ({
                 const isGroupHovered = group.mappingCards.some((card) =>
                   card.mappingKeys.some((key) => hoveredMappingKeys.includes(key))
                 );
+                const mediaLikePattern = /media|image|asset/i;
+                const prefersImageOnlyHighlight =
+                  isReadOnlyAllMappings &&
+                  group.mappingCards.length === 1 &&
+                  (mediaLikePattern.test(group.mappingCards[0].fieldType) ||
+                    mediaLikePattern.test(group.mappingCards[0].fieldName) ||
+                    mediaLikePattern.test(group.mappingCards[0].displayLabel));
+                const showGroupedSurface = group.showGroupedSurface && !prefersImageOnlyHighlight;
 
                 return (
                   <Box key={group.id}>
@@ -859,7 +927,7 @@ export const MappingView = ({
                       data-testid={`display-group-layout-${group.id}`}
                       ref={setGroupLayoutRef(group.id)}>
                       <Box style={{ flex: 2 }}>
-                        {group.showGroupedSurface ? (
+                        {showGroupedSurface ? (
                           <Box
                             data-testid={`mapping-group-surface-${group.id}`}
                             data-hovered={isGroupHovered ? 'true' : 'false'}
@@ -868,7 +936,7 @@ export const MappingView = ({
                                 isGroupHovered ? tokens.green600 : tokens.green500
                               }`,
                               borderRadius: tokens.borderRadiusMedium,
-                              backgroundColor: tokens.green100,
+                              backgroundColor: 'transparent',
                               padding: tokens.spacing2Xs,
                               transition: 'border-color 120ms ease, border-width 120ms ease',
                             }}>
@@ -886,6 +954,9 @@ export const MappingView = ({
                                   onSetHoveredMappingKeys={setHoveredMappingKeys}
                                   onAssignImage={handleAssignImage}
                                   onExcludeImage={handleExcludeImage}
+                                  readOnly={isReadOnlyAllMappings}
+                                  showReadOnlyOutline={!showGroupedSurface && !prefersImageOnlyHighlight}
+                                  preferImageReadOnlyHighlight={prefersImageOnlyHighlight}
                                 />
                               ))}
                             </Flex>
@@ -905,6 +976,9 @@ export const MappingView = ({
                                 onSetHoveredMappingKeys={setHoveredMappingKeys}
                                 onAssignImage={handleAssignImage}
                                 onExcludeImage={handleExcludeImage}
+                                readOnly={isReadOnlyAllMappings}
+                                showReadOnlyOutline={!showGroupedSurface && !prefersImageOnlyHighlight}
+                                preferImageReadOnlyHighlight={prefersImageOnlyHighlight}
                               />
                             ))}
                           </Flex>
@@ -918,6 +992,7 @@ export const MappingView = ({
                         hoveredMappingKeys={hoveredMappingKeys}
                         onSetHoveredMappingKeys={setHoveredMappingKeys}
                         setCardWrapperRef={setCardWrapperRef}
+                        showContentTypeName={isReadOnlyAllMappings}
                       />
                     </Flex>
                   </Box>
@@ -928,7 +1003,7 @@ export const MappingView = ({
         ))}
       </Flex>
 
-      {selectionRectangle && !isDisabled ? (
+      {selectionRectangle && !isDisabled && !isReadOnlyAllMappings ? (
         <SelectionActionMenu
           anchorRectangle={selectionRectangle}
           onAssign={handleAssignFromSelection}

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -1,4 +1,12 @@
-import { useEffect, useLayoutEffect, useMemo, useRef, useState, type RefCallback } from 'react';
+import {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type RefCallback,
+  type RefObject,
+} from 'react';
 import { Box, Flex, Text } from '@contentful/f36-components';
 import tokens from '@contentful/f36-tokens';
 import {
@@ -70,6 +78,7 @@ interface MappingViewProps {
   onEntryBlockGraphChange: (next: EntryBlockGraph) => void;
   selectedEntryIndex: number | null;
   isDisabled?: boolean;
+  occludingTopRef?: RefObject<HTMLElement | null>;
 }
 
 const EMPTY_NEW_LOCATION: EditModalNewLocation = {
@@ -145,6 +154,7 @@ export const MappingView = ({
   onEntryBlockGraphChange,
   selectedEntryIndex,
   isDisabled = false,
+  occludingTopRef,
 }: MappingViewProps): JSX.Element => {
   const selectedEntryRow = useMemo(() => {
     const rows = buildEntryListFromEntryBlockGraph(
@@ -209,7 +219,7 @@ export const MappingView = ({
   }, [selectedEntryIndex]);
 
   const { selectionRectangle, selectedText, selectedRange, clearSelection } =
-    useReviewTextSelection(textSelectionRootRef);
+    useReviewTextSelection(textSelectionRootRef, occludingTopRef);
 
   const highlightIndex = useMemo(
     () => buildMappingHighlightIndex(entryBlockGraph),

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -955,7 +955,9 @@ export const MappingView = ({
                                   onAssignImage={handleAssignImage}
                                   onExcludeImage={handleExcludeImage}
                                   readOnly={isReadOnlyAllMappings}
-                                  showReadOnlyOutline={!showGroupedSurface && !prefersImageOnlyHighlight}
+                                  showReadOnlyOutline={
+                                    !showGroupedSurface && !prefersImageOnlyHighlight
+                                  }
                                   preferImageReadOnlyHighlight={prefersImageOnlyHighlight}
                                 />
                               ))}
@@ -977,7 +979,9 @@ export const MappingView = ({
                                 onAssignImage={handleAssignImage}
                                 onExcludeImage={handleExcludeImage}
                                 readOnly={isReadOnlyAllMappings}
-                                showReadOnlyOutline={!showGroupedSurface && !prefersImageOnlyHighlight}
+                                showReadOnlyOutline={
+                                  !showGroupedSurface && !prefersImageOnlyHighlight
+                                }
                                 preferImageReadOnlyHighlight={prefersImageOnlyHighlight}
                               />
                             ))}

--- a/apps/google-docs/src/locations/Page/components/review/mapping/NormalizedDocumentSection.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/NormalizedDocumentSection.tsx
@@ -17,6 +17,9 @@ interface ReviewDocumentBodyProps {
   onSetHoveredMappingKeys: (keys: string[]) => void;
   onAssignImage: (sourceRef: ImageSourceRef, label: string) => void;
   onExcludeImage: (sourceRef: ImageSourceRef, label: string) => void;
+  readOnly?: boolean;
+  showReadOnlyOutline?: boolean;
+  preferImageReadOnlyHighlight?: boolean;
 }
 
 export const NormalizedDocumentSection = ({
@@ -30,6 +33,9 @@ export const NormalizedDocumentSection = ({
   onSetHoveredMappingKeys,
   onAssignImage,
   onExcludeImage,
+  readOnly = false,
+  showReadOnlyOutline = true,
+  preferImageReadOnlyHighlight = false,
 }: ReviewDocumentBodyProps): JSX.Element => {
   return (
     <Box style={{ flex: 2 }}>
@@ -52,6 +58,9 @@ export const NormalizedDocumentSection = ({
               onSetHoveredMappingKeys={onSetHoveredMappingKeys}
               onAssignImage={onAssignImage}
               onExcludeImage={onExcludeImage}
+              readOnly={readOnly}
+              showReadOnlyOutline={showReadOnlyOutline}
+              preferImageReadOnlyHighlight={preferImageReadOnlyHighlight}
             />
           ) : (
             <BlockRenderer
@@ -66,6 +75,9 @@ export const NormalizedDocumentSection = ({
               onSetHoveredMappingKeys={onSetHoveredMappingKeys}
               onAssignImage={onAssignImage}
               onExcludeImage={onExcludeImage}
+              readOnly={readOnly}
+              showReadOnlyOutline={showReadOnlyOutline}
+              preferImageReadOnlyHighlight={preferImageReadOnlyHighlight}
             />
           )}
         </Box>

--- a/apps/google-docs/src/locations/Page/components/review/mapping/ReviewImageAssetCard.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/ReviewImageAssetCard.tsx
@@ -12,6 +12,8 @@ export interface ReviewImageAssetCardProps {
   hovered?: boolean;
   isExcluded: boolean;
   size?: 'small' | 'default';
+  readOnly?: boolean;
+  showReadOnlyHighlightBorder?: boolean;
   onMouseEnter?: () => void;
   onMouseLeave?: () => void;
   onAssign: () => void;
@@ -29,6 +31,8 @@ export function ReviewImageAssetCard({
   hovered = false,
   isExcluded,
   size = 'default',
+  readOnly = false,
+  showReadOnlyHighlightBorder = false,
   onMouseEnter,
   onMouseLeave,
   onAssign,
@@ -41,6 +45,8 @@ export function ReviewImageAssetCard({
 
   const borderColor =
     isExcluded || !isHighlighted ? tokens.gray300 : hovered ? tokens.green600 : tokens.green500;
+  const showReadOnlyBorder =
+    !readOnly || isExcluded || !isHighlighted || showReadOnlyHighlightBorder;
 
   return (
     <Box
@@ -53,8 +59,12 @@ export function ReviewImageAssetCard({
         maxWidth: '100%',
         verticalAlign: 'top',
         borderRadius: tokens.borderRadiusMedium,
-        border: `2px solid ${borderColor}`,
-        backgroundColor: isHighlighted ? tokens.green100 : tokens.gray100,
+        border: showReadOnlyBorder ? `2px solid ${borderColor}` : '2px solid transparent',
+        backgroundColor: isHighlighted
+          ? readOnly
+            ? 'transparent'
+            : tokens.green100
+          : tokens.gray100,
         transition: 'border-color 120ms ease',
         overflow: 'hidden',
         boxSizing: 'border-box',
@@ -62,14 +72,18 @@ export function ReviewImageAssetCard({
       }}>
       <Card
         ariaLabel={title}
-        actions={[
-          <MenuItem key="assigned" onClick={onAssign}>
-            {assignLabel}
-          </MenuItem>,
-          <MenuItem key="exclude" onClick={onExclude} isDisabled={!isHighlighted}>
-            Exclude
-          </MenuItem>,
-        ]}>
+        actions={
+          readOnly
+            ? undefined
+            : [
+                <MenuItem key="assigned" onClick={onAssign}>
+                  {assignLabel}
+                </MenuItem>,
+                <MenuItem key="exclude" onClick={onExclude} isDisabled={!isHighlighted}>
+                  Exclude
+                </MenuItem>,
+              ]
+        }>
         <Splitter />
         <Box padding="spacingS">
           <Image

--- a/apps/google-docs/src/locations/Page/components/review/mapping/buildMappingDisplayGroups.ts
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/buildMappingDisplayGroups.ts
@@ -49,7 +49,8 @@ function uniqueStrings(values: string[]): string[] {
 function buildDraftMappingCards(
   segment: DocSegment,
   highlights: MappingHighlight[],
-  resolveFieldTypeLabel: (highlight: MappingHighlight) => string
+  resolveFieldTypeLabel: (highlight: MappingHighlight) => string,
+  resolveContentTypeName: (highlight: MappingHighlight) => string
 ): DraftMappingCard[] {
   if (segment.kind === 'table') {
     return highlights.map((highlight) => {
@@ -58,6 +59,7 @@ function buildDraftMappingCards(
       return {
         key: `${segment.id}:${mappingKey}`,
         fieldIdentity: getFieldIdentity(highlight),
+        contentTypeName: resolveContentTypeName(highlight),
         fieldName: formatDisplayName(highlight.fieldId),
         fieldType: resolveFieldTypeLabel(highlight),
         displayLabel: formatDisplayName(highlight.fieldId),
@@ -91,6 +93,7 @@ function buildDraftMappingCards(
   return Array.from(byFieldIdentity.entries()).map(([fieldIdentity, value]) => ({
     key: `${segment.id}:${fieldIdentity}`,
     fieldIdentity,
+    contentTypeName: resolveContentTypeName(value.firstHighlight),
     fieldName: formatDisplayName(value.firstHighlight.fieldId),
     fieldType: resolveFieldTypeLabel(value.firstHighlight),
     displayLabel: formatDisplayName(value.firstHighlight.fieldId),
@@ -133,13 +136,19 @@ function buildDraftGroupsForTab(
   tab: Tab,
   visibleHighlightsBySegment: Record<string, MappingHighlight[]>,
   nextGroupIndex: { current: number },
-  resolveFieldTypeLabel: (highlight: MappingHighlight) => string
+  resolveFieldTypeLabel: (highlight: MappingHighlight) => string,
+  resolveContentTypeName: (highlight: MappingHighlight) => string
 ): DraftMappingDisplayGroup[] {
   const groups: DraftMappingDisplayGroup[] = [];
 
   tab.segments.forEach((segment) => {
     const highlights = visibleHighlightsBySegment[segment.id] ?? [];
-    const mappingCards = buildDraftMappingCards(segment, highlights, resolveFieldTypeLabel);
+    const mappingCards = buildDraftMappingCards(
+      segment,
+      highlights,
+      resolveFieldTypeLabel,
+      resolveContentTypeName
+    );
     const { startsAtBoundary, endsAtBoundary } =
       segment.kind === 'block' && mappingCards.length === 1
         ? getBlockBoundaryCoverage(segment, highlights, mappingCards[0].fieldIdentity)
@@ -188,7 +197,8 @@ function buildDraftGroupsForTab(
 export function buildMappingDisplayGroups(
   tabs: Tab[],
   visibleHighlightsBySegment: Record<string, MappingHighlight[]>,
-  resolveFieldTypeLabel: (highlight: MappingHighlight) => string
+  resolveFieldTypeLabel: (highlight: MappingHighlight) => string,
+  resolveContentTypeName: (highlight: MappingHighlight) => string
 ): MappingDisplayGroupsResult {
   const groupsByTabDraft: Record<string, DraftMappingDisplayGroup[]> = {};
   const nextGroupIndex = { current: 0 };
@@ -198,7 +208,8 @@ export function buildMappingDisplayGroups(
       tab,
       visibleHighlightsBySegment,
       nextGroupIndex,
-      resolveFieldTypeLabel
+      resolveFieldTypeLabel,
+      resolveContentTypeName
     );
   });
 

--- a/apps/google-docs/src/locations/Page/components/review/mapping/documentRenderers.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/documentRenderers.tsx
@@ -203,7 +203,9 @@ export const BlockRenderer = ({
       isTextSourceRef(highlight.sourceRef)
   );
   const hasVisibleTextMappings = visibleTextHighlights.length > 0;
-  const blockMappingKeys = visibleHighlights.map((highlight) => getMappingCardKey(segmentId, highlight));
+  const blockMappingKeys = visibleHighlights.map((highlight) =>
+    getMappingCardKey(segmentId, highlight)
+  );
   const isBlockHovered = isMappingHovered(blockMappingKeys, hoveredMappingKeys);
   const textSegments = buildTextSegments(block.flattenedTextRuns, segmentId, visibleHighlights);
   const listMarker = block.type === 'listItem' ? listMarkers[block.id] ?? null : null;
@@ -382,7 +384,9 @@ const TablePartRenderer = ({
   readOnly = false,
   showReadOnlyOutline = true,
 }: TablePartRendererProps) => {
-  const partMappingKeys = visibleHighlights.map((highlight) => getMappingCardKey(segmentId, highlight));
+  const partMappingKeys = visibleHighlights.map((highlight) =>
+    getMappingCardKey(segmentId, highlight)
+  );
   const hasVisibleMappings = partMappingKeys.length > 0;
   const isPartHovered = isMappingHovered(partMappingKeys, hoveredMappingKeys);
 

--- a/apps/google-docs/src/locations/Page/components/review/mapping/documentRenderers.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/documentRenderers.tsx
@@ -17,8 +17,9 @@ import type {
   NormalizedDocumentTable,
   NormalizedDocumentTablePart,
   SourceRef,
+  TextSourceRef,
 } from '@types';
-import { isBlockImageSourceRef, isTableImageSourceRef } from '@types';
+import { isBlockImageSourceRef, isTableImageSourceRef, isTextSourceRef } from '@types';
 import type { MappingHighlight, MappingHighlightIndex } from './buildHighlights';
 import { getMappingCardKey } from './buildHighlights';
 import type { ListMarker } from './buildListMarkers';
@@ -41,10 +42,16 @@ function isMappingHovered(keys: string[], hoveredMappingKeys: string[]): boolean
   return keys.some((k) => hoveredMappingKeys.includes(k));
 }
 
-function getHighlightStyle(highlighted: boolean, hovered: boolean) {
-  if (!highlighted) return { border: tokens.gray300, background: 'transparent' };
+function getHighlightStyle(highlighted: boolean, hovered: boolean, readOnly = false) {
+  if (!highlighted) return { border: 'transparent', background: 'transparent' };
+  if (readOnly) {
+    return {
+      border: 'transparent',
+      background: 'transparent',
+    };
+  }
   return {
-    border: hovered ? tokens.green600 : tokens.green500,
+    border: 'transparent',
     background: hovered ? tokens.green300 : tokens.green200,
   };
 }
@@ -77,6 +84,7 @@ interface TextSegmentSpanProps {
   rowId?: string;
   cellId?: string;
   partId?: string;
+  readOnly?: boolean;
 }
 
 const TextSegmentSpan = ({
@@ -92,7 +100,9 @@ const TextSegmentSpan = ({
   rowId,
   cellId,
   partId,
+  readOnly = false,
 }: TextSegmentSpanProps) => {
+  const highlightStyle = getHighlightStyle(segment.highlighted, hovered, readOnly);
   const content = (
     <Box
       as="span"
@@ -114,10 +124,20 @@ const TextSegmentSpan = ({
       onMouseLeave={segment.highlighted ? () => onSetHoveredMappings([]) : undefined}
       style={{
         ...getTextSegmentStyle(segment.styles),
-        backgroundColor: getHighlightStyle(segment.highlighted, hovered).background,
+        backgroundColor: highlightStyle.background,
+        border:
+          segment.highlighted && highlightStyle.border !== 'transparent'
+            ? `1px solid ${highlightStyle.border}`
+            : undefined,
         borderRadius: segment.highlighted ? tokens.borderRadiusSmall : undefined,
+        paddingInline:
+          segment.highlighted && highlightStyle.border !== 'transparent'
+            ? tokens.spacing2Xs
+            : undefined,
+        paddingBlock:
+          segment.highlighted && highlightStyle.border !== 'transparent' ? '1px' : undefined,
         whiteSpace: 'pre-wrap',
-        transition: 'background-color 120ms ease',
+        transition: 'background-color 120ms ease, border-color 120ms ease',
       }}>
       {segment.text}
     </Box>
@@ -153,6 +173,9 @@ interface BlockRendererProps {
     sourceRef: { type: 'image'; blockId: string; imageId: string },
     label: string
   ) => void;
+  readOnly?: boolean;
+  showReadOnlyOutline?: boolean;
+  preferImageReadOnlyHighlight?: boolean;
 }
 
 export const BlockRenderer = ({
@@ -167,11 +190,21 @@ export const BlockRenderer = ({
   onSetHoveredMappingKeys,
   onAssignImage,
   onExcludeImage,
+  readOnly = false,
+  showReadOnlyOutline = true,
+  preferImageReadOnlyHighlight = false,
 }: BlockRendererProps) => {
   const visibleHighlights = filterByEntry(
     highlightIndex.blockHighlights[block.id] ?? [],
     selectedEntryIndex
   );
+  const visibleTextHighlights = visibleHighlights.filter(
+    (highlight): highlight is MappingHighlight & { sourceRef: TextSourceRef } =>
+      isTextSourceRef(highlight.sourceRef)
+  );
+  const hasVisibleTextMappings = visibleTextHighlights.length > 0;
+  const blockMappingKeys = visibleHighlights.map((highlight) => getMappingCardKey(segmentId, highlight));
+  const isBlockHovered = isMappingHovered(blockMappingKeys, hoveredMappingKeys);
   const textSegments = buildTextSegments(block.flattenedTextRuns, segmentId, visibleHighlights);
   const listMarker = block.type === 'listItem' ? listMarkers[block.id] ?? null : null;
 
@@ -188,13 +221,27 @@ export const BlockRenderer = ({
           rangeStart={seg.start}
           rangeEnd={seg.end}
           blockId={block.id}
+          readOnly={readOnly}
         />
       ))}
     </Text>
   );
 
   return (
-    <Box>
+    <Box
+      style={
+        readOnly && showReadOnlyOutline && hasVisibleTextMappings
+          ? {
+              border: `${isBlockHovered ? 2 : 1}px solid ${
+                isBlockHovered ? tokens.green600 : tokens.green500
+              }`,
+              borderRadius: tokens.borderRadiusMedium,
+              backgroundColor: 'transparent',
+              padding: tokens.spacing2Xs,
+              transition: 'border-color 120ms ease, border-width 120ms ease',
+            }
+          : undefined
+      }>
       {listMarker ? (
         <Flex
           data-testid={`list-item-${block.id}`}
@@ -242,6 +289,10 @@ export const BlockRenderer = ({
               isHighlighted={highlighted}
               hovered={hovered}
               isExcluded={isImageSourceRefExcluded(imageSourceRef, excludedSourceRefs)}
+              readOnly={readOnly}
+              showReadOnlyHighlightBorder={
+                readOnly && (preferImageReadOnlyHighlight || !hasVisibleTextMappings)
+              }
               onMouseEnter={
                 highlighted ? () => onSetHoveredMappingKeys(imageMappingKeys) : undefined
               }
@@ -293,6 +344,9 @@ interface TableRendererProps {
     },
     label: string
   ) => void;
+  readOnly?: boolean;
+  showReadOnlyOutline?: boolean;
+  preferImageReadOnlyHighlight?: boolean;
 }
 
 interface TablePartRendererProps {
@@ -308,6 +362,8 @@ interface TablePartRendererProps {
   onSetHoveredMappingKeys: (keys: string[]) => void;
   onAssignImage: TableRendererProps['onAssignImage'];
   onExcludeImage: TableRendererProps['onExcludeImage'];
+  readOnly?: boolean;
+  showReadOnlyOutline?: boolean;
 }
 
 const TablePartRenderer = ({
@@ -323,7 +379,13 @@ const TablePartRenderer = ({
   onSetHoveredMappingKeys,
   onAssignImage,
   onExcludeImage,
+  readOnly = false,
+  showReadOnlyOutline = true,
 }: TablePartRendererProps) => {
+  const partMappingKeys = visibleHighlights.map((highlight) => getMappingCardKey(segmentId, highlight));
+  const hasVisibleMappings = partMappingKeys.length > 0;
+  const isPartHovered = isMappingHovered(partMappingKeys, hoveredMappingKeys);
+
   if (part.type === 'image') {
     const image = imageById[part.imageId];
     if (!image) return null;
@@ -359,6 +421,8 @@ const TablePartRenderer = ({
           hovered={hovered}
           isExcluded={isImageSourceRefExcluded(imageSourceRef, excludedSourceRefs)}
           size="small"
+          readOnly={readOnly}
+          showReadOnlyHighlightBorder={readOnly}
           onMouseEnter={highlighted ? () => onSetHoveredMappingKeys(mappingKeys) : undefined}
           onMouseLeave={highlighted ? () => onSetHoveredMappingKeys([]) : undefined}
           onAssign={() => onAssignImage(imageSourceRef, image.title ?? image.altText ?? image.id)}
@@ -371,7 +435,23 @@ const TablePartRenderer = ({
   const textSegments = buildTextSegments(part.flattenedTextRuns, segmentId, visibleHighlights);
 
   return (
-    <Box as="span" style={{ whiteSpace: 'pre-wrap' }}>
+    <Box
+      as="span"
+      style={{
+        whiteSpace: 'pre-wrap',
+        display: 'inline-block',
+        ...(readOnly && showReadOnlyOutline && hasVisibleMappings
+          ? {
+              border: `${isPartHovered ? 2 : 1}px solid ${
+                isPartHovered ? tokens.green600 : tokens.green500
+              }`,
+              borderRadius: tokens.borderRadiusMedium,
+              backgroundColor: 'transparent',
+              padding: tokens.spacingXs,
+              transition: 'border-color 120ms ease, border-width 120ms ease',
+            }
+          : undefined),
+      }}>
       {textSegments.map((seg, index) => (
         <TextSegmentSpan
           key={`${part.id}-${index}`}
@@ -386,6 +466,7 @@ const TablePartRenderer = ({
           rowId={rowId}
           cellId={cellId}
           partId={part.id}
+          readOnly={readOnly}
         />
       ))}
     </Box>
@@ -403,6 +484,9 @@ export const TableRenderer = ({
   onSetHoveredMappingKeys,
   onAssignImage,
   onExcludeImage,
+  readOnly = false,
+  showReadOnlyOutline = true,
+  preferImageReadOnlyHighlight = false,
 }: TableRendererProps) => {
   const getVisiblePartHighlights = (partKey: string) =>
     filterByEntry(highlightIndex.tablePartHighlights[partKey] ?? [], selectedEntryIndex);
@@ -447,6 +531,8 @@ export const TableRenderer = ({
                           onSetHoveredMappingKeys={onSetHoveredMappingKeys}
                           onAssignImage={onAssignImage}
                           onExcludeImage={onExcludeImage}
+                          readOnly={readOnly}
+                          showReadOnlyOutline={showReadOnlyOutline}
                         />
                       </Box>
                     );

--- a/apps/google-docs/test/hooks/useReviewTextSelection.test.ts
+++ b/apps/google-docs/test/hooks/useReviewTextSelection.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { getSelectionViewportRectangle } from '../../src/hooks/useReviewTextSelection';
+
+function createRootRect(overrides: Partial<DOMRect> = {}): DOMRect {
+  return {
+    x: 0,
+    y: 0,
+    width: 600,
+    height: 500,
+    top: 0,
+    left: 0,
+    right: 600,
+    bottom: 500,
+    toJSON: () => ({}),
+    ...overrides,
+  } as DOMRect;
+}
+
+function createClientRect(overrides: Partial<DOMRect> = {}): DOMRect {
+  return {
+    x: 0,
+    y: 0,
+    width: 100,
+    height: 24,
+    top: 120,
+    left: 80,
+    right: 180,
+    bottom: 144,
+    toJSON: () => ({}),
+    ...overrides,
+  } as DOMRect;
+}
+
+function createRangeMock({
+  clientRects,
+  boundingRect,
+}: {
+  clientRects: DOMRect[];
+  boundingRect: DOMRect;
+}): Range {
+  return {
+    getClientRects: () => clientRects as unknown as DOMRectList,
+    getBoundingClientRect: () => boundingRect,
+  } as Range;
+}
+
+describe('getSelectionViewportRectangle', () => {
+  it('anchors to the first visible client rect when a selection spans beyond the viewport', () => {
+    const root = document.createElement('div');
+    root.getBoundingClientRect = () => createRootRect({ top: 0, bottom: 500 });
+
+    const range = createRangeMock({
+      clientRects: [
+        createClientRect({ top: -40, bottom: -10, left: 80, right: 180 }),
+        createClientRect({ top: 96, bottom: 120, left: 90, right: 210 }),
+      ],
+      boundingRect: createClientRect({ top: -40, bottom: 120, left: 80, right: 210, height: 160 }),
+    });
+
+    expect(getSelectionViewportRectangle(range, root)).toEqual({
+      top: 96,
+      left: 90,
+      bottom: 120,
+      right: 210,
+    });
+  });
+
+  it('returns null once the selection is fully outside the viewport', () => {
+    const root = document.createElement('div');
+    root.getBoundingClientRect = () => createRootRect({ top: 0, bottom: 500 });
+
+    const range = createRangeMock({
+      clientRects: [createClientRect({ top: -120, bottom: -96, left: 80, right: 180 })],
+      boundingRect: createClientRect({ top: -120, bottom: -96, left: 80, right: 180 }),
+    });
+
+    expect(getSelectionViewportRectangle(range, root)).toBeNull();
+  });
+
+  it('treats the sticky header area as occluded viewport space', () => {
+    const root = document.createElement('div');
+    root.getBoundingClientRect = () => createRootRect({ top: 0, bottom: 500 });
+
+    const range = createRangeMock({
+      clientRects: [createClientRect({ top: 48, bottom: 72, left: 80, right: 180 })],
+      boundingRect: createClientRect({ top: 48, bottom: 72, left: 80, right: 180 }),
+    });
+
+    expect(getSelectionViewportRectangle(range, root, 80)).toBeNull();
+  });
+});

--- a/apps/google-docs/test/locations/Page/components/review/mapping/MappingView.spec.tsx
+++ b/apps/google-docs/test/locations/Page/components/review/mapping/MappingView.spec.tsx
@@ -269,6 +269,90 @@ const createImagePayload = (): MappingReviewSuspendPayload => ({
   ],
 });
 
+const createAllEntriesPayload = (): MappingReviewSuspendPayload => ({
+  suspendStepId: 'mapping-review',
+  reason: 'Mapping review required before CMA payload generation continues',
+  documentId: 'doc-all',
+  documentTitle: 'All entries review',
+  normalizedDocument: {
+    documentId: 'doc-all',
+    title: 'All entries review',
+    designValues: [],
+    contentBlocks: [
+      {
+        id: 'block-1',
+        position: 1,
+        type: 'paragraph',
+        textRuns: [{ text: 'Article body copy' }],
+        flattenedTextRuns: [{ text: 'Article body copy', start: 0, end: 17 }],
+        designValueIds: [],
+        imageIds: [],
+      },
+      {
+        id: 'block-2',
+        position: 2,
+        type: 'paragraph',
+        textRuns: [{ text: 'Product summary copy' }],
+        flattenedTextRuns: [{ text: 'Product summary copy', start: 0, end: 20 }],
+        designValueIds: [],
+        imageIds: [],
+      },
+    ],
+    images: [],
+    tables: [],
+    assets: [],
+  },
+  entryBlockGraph: {
+    entries: [
+      {
+        contentTypeId: 'article',
+        fields: { title: { 'en-US': 'Article title' } },
+        fieldMappings: [
+          {
+            fieldId: 'body',
+            fieldType: 'Text',
+            sourceRefs: [createBlockTextSourceRef('block-1', 'Article body copy')],
+            confidence: 0.9,
+          },
+        ],
+      },
+      {
+        contentTypeId: 'product',
+        fields: { title: { 'en-US': 'Product title' } },
+        fieldMappings: [
+          {
+            fieldId: 'summary',
+            fieldType: 'Text',
+            sourceRefs: [createBlockTextSourceRef('block-2', 'Product summary copy')],
+            confidence: 0.9,
+          },
+        ],
+      },
+    ],
+    excludedSourceRefs: [],
+  },
+  referenceGraph: {
+    edges: [],
+    creationOrder: [],
+    deferredFields: [],
+    hasCircularDependency: false,
+  },
+  contentTypes: [
+    {
+      sys: { id: 'article' },
+      name: 'Article',
+      displayField: 'title',
+      fields: [{ id: 'body', name: 'Body copy', type: 'Text' }],
+    },
+    {
+      sys: { id: 'product' },
+      name: 'Product',
+      displayField: 'title',
+      fields: [{ id: 'summary', name: 'Summary', type: 'Text' }],
+    },
+  ],
+});
+
 describe('MappingView', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -624,6 +708,35 @@ describe('MappingView', () => {
         '[data-review-text-segment="true"][data-row-id="row-1"][data-is-mapped="true"]'
       )
     ).toBeNull();
+  });
+
+  it('renders an all-entries read-only mapping view without selection actions', () => {
+    mockUseReviewTextSelection.mockReturnValue({
+      selectionRectangle: { top: 40, left: 60, bottom: 68, right: 160 },
+      selectedText: 'Article body copy',
+      selectedRange: createDetachedRange('Article body copy', 0, 7),
+      clearSelection: mockClearSelection,
+    });
+
+    const payload = createAllEntriesPayload();
+    const { container } = render(
+      <MappingView
+        payload={payload}
+        {...mappingViewGraphProps(payload)}
+        selectedEntryIndex={null}
+        reviewMode="all"
+      />
+    );
+
+    expect(screen.getByText('Currently viewing:')).toBeTruthy();
+    expect(screen.getByText('All entries')).toBeTruthy();
+    expect(screen.queryByTestId('review-selection-menu')).toBeNull();
+    expect(screen.getAllByText('Content type:').length).toBeGreaterThan(0);
+    expect(screen.getByText('Article')).toBeTruthy();
+    expect(screen.getByText('Product')).toBeTruthy();
+    expect(
+      container.querySelector('[data-review-text-segment="true"][data-is-mapped="true"]')
+    ).toBeTruthy();
   });
 
   it('highlights all underlying grouped text when hovering a grouped rail card', () => {


### PR DESCRIPTION
## Summary
- add a read-only `Review all` mode for mapping review with a dedicated action in the overview area
- default the review stage into `Review all`, add clearer instructional messaging, and let users jump into per-entry edits from the overview list
- refine read-only mapping highlights so field boxes, table values, image/media mappings, and hover states match the intended review UX without nested or overlapping boxes

## Context
While testing the Drive Integration review experience, the team wanted a faster way to validate all generated entry mappings at a glance before editing. This update adds an all-entries review state that makes the mapping coverage easier to scan, while still keeping the existing per-entry editing flow available from the overview list.

## Validation
- npx vitest run test/locations/Page/components/review/mapping/MappingView.spec.tsx
- npm run build
