### PR TITLE
fix: show all current locations in reassign modal [INTEG-3848]

### DIFF
--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -293,33 +293,6 @@ export const MappingView = ({
     };
   };
 
-  const locationsByMappingKey = useMemo(() => {
-    const byKey = new Map<string, EditLocationOption>();
-
-    allSegments.forEach((segment) => {
-      const highlights = getVisibleHighlights(getHighlightsForSegment(segment));
-      highlights.forEach((highlight) => {
-        const mappingKey = getMappingCardKey(segment.id, highlight);
-        if (byKey.has(mappingKey)) {
-          return;
-        }
-        const nextLocation = buildLocationOption(
-          highlight.entryIndex,
-          highlight.fieldId,
-          highlight.fieldType,
-          highlight.sourceRef,
-          byKey.size === 0
-        );
-        if (nextLocation) {
-          byKey.set(mappingKey, nextLocation);
-        }
-      });
-    });
-
-    return byKey;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [allSegments, entryBlockGraph, payload.contentTypes, selectedEntryIndex]);
-
   const getNewLocationForEntry = (
     entry: EntryBlockGraph['entries'][number],
     entryIndex: number
@@ -390,35 +363,63 @@ export const MappingView = ({
     return matches;
   };
 
-  const getLocationsForSelectedText = (): EditLocationOption[] => {
-    const root = textSelectionRootRef.current;
-    if (!root || !selectedRange) {
+  const getLocationsForTextRanges = (ranges: TextExclusionRange[]): EditLocationOption[] => {
+    if (!ranges.length) {
       return [];
     }
 
-    const selectedMappedSegments = root.querySelectorAll<HTMLElement>(
-      '[data-review-text-segment="true"][data-is-mapped="true"]'
-    );
-    const mappingKeys = new Set<string>();
+    const locations = new Map<string, EditLocationOption>();
 
-    for (const segment of selectedMappedSegments) {
-      if (!rangeIntersectsNode(selectedRange, segment)) {
-        continue;
+    const textRangeOverlapsSelection = (sourceRef: SourceRef): sourceRef is SourceRef => {
+      if (!isTextSourceRef(sourceRef)) {
+        return false;
       }
 
-      const serializedMappingKeys = segment.dataset.mappingKeys ?? '';
-      serializedMappingKeys
-        .split('|')
-        .map((key) => key.trim())
-        .filter(Boolean)
-        .forEach((key) => mappingKeys.add(key));
-    }
+      return ranges.some((range) => {
+        if (range.scope === 'block' && sourceRef.type === 'blockText') {
+          return (
+            range.blockId === sourceRef.blockId &&
+            range.start < sourceRef.end &&
+            range.end > sourceRef.start
+          );
+        }
 
-    const locations = Array.from(mappingKeys)
-      .map((key) => locationsByMappingKey.get(key))
-      .filter((location): location is EditLocationOption => Boolean(location));
+        if (
+          range.scope === 'table' &&
+          sourceRef.type === 'tableText' &&
+          range.tableId === sourceRef.tableId &&
+          range.rowId === sourceRef.rowId &&
+          range.cellId === sourceRef.cellId &&
+          range.partId === sourceRef.partId
+        ) {
+          return range.start < sourceRef.end && range.end > sourceRef.start;
+        }
 
-    return locations.map((location, index) => ({
+        return false;
+      });
+    };
+
+    entryBlockGraph.entries.forEach((entry, entryIndex) => {
+      entry.fieldMappings.forEach((fieldMapping) => {
+        const matchingSourceRef = fieldMapping.sourceRefs.find(textRangeOverlapsSelection);
+        if (!matchingSourceRef) {
+          return;
+        }
+
+        const nextLocation = buildLocationOption(
+          entryIndex,
+          fieldMapping.fieldId,
+          fieldMapping.fieldType,
+          matchingSourceRef,
+          locations.size === 0
+        );
+        if (nextLocation) {
+          locations.set(nextLocation.id, nextLocation);
+        }
+      });
+    });
+
+    return Array.from(locations.values()).map((location, index) => ({
       ...location,
       isSelected: index === 0,
     }));
@@ -543,7 +544,7 @@ export const MappingView = ({
     );
     openAssignModal(
       selectedText.trim(),
-      getLocationsForSelectedText(),
+      getLocationsForTextRanges(reassignRanges),
       reassignRanges,
       assignRanges
     );
@@ -563,7 +564,7 @@ export const MappingView = ({
       textSelectionRootRef.current,
       selectedRange
     ).trim();
-    openExcludeModal(trimmed, getLocationsForSelectedText(), {
+    openExcludeModal(trimmed, getLocationsForTextRanges(ranges), {
       contentPreview: mappedPreview || trimmed,
       previewSectionTitle: 'Text to exclude',
     });

--- a/apps/google-docs/test/locations/Page/components/review/mapping/MappingView.spec.tsx
+++ b/apps/google-docs/test/locations/Page/components/review/mapping/MappingView.spec.tsx
@@ -127,6 +127,102 @@ const createPayload = (excludedSourceRefs: SourceRef[] = []): MappingReviewSuspe
   ],
 });
 
+const createMultiLocationPayload = (): MappingReviewSuspendPayload => ({
+  suspendStepId: 'mapping-review',
+  reason: 'Mapping review required before CMA payload generation continues',
+  documentId: 'doc-multi-location',
+  documentTitle: 'Mapping review',
+  normalizedDocument: {
+    documentId: 'doc-multi-location',
+    title: 'Mapping review',
+    designValues: [],
+    contentBlocks: [
+      {
+        id: 'block-1',
+        position: 1,
+        type: 'paragraph',
+        textRuns: [{ text: 'Hello world' }],
+        flattenedTextRuns: [{ text: 'Hello world', start: 0, end: 11 }],
+        designValueIds: [],
+        imageIds: [],
+      },
+    ],
+    images: [],
+    tables: [],
+    assets: [],
+  },
+  entryBlockGraph: {
+    entries: [
+      {
+        contentTypeId: 'article',
+        fields: { title: { 'en-US': 'Draft title from display field' } },
+        fieldMappings: [
+          {
+            fieldId: 'body',
+            fieldType: 'Text',
+            sourceRefs: [blockTextSourceRef],
+            confidence: 0.9,
+          },
+          {
+            fieldId: 'excerpt',
+            fieldType: 'Symbol',
+            sourceRefs: [blockTextSourceRef],
+            confidence: 0.9,
+          },
+        ],
+      },
+      {
+        contentTypeId: 'article',
+        fields: { title: { 'en-US': 'Child entry title' } },
+        fieldMappings: [
+          {
+            fieldId: 'summary',
+            fieldType: 'Text',
+            sourceRefs: [blockTextSourceRef],
+            confidence: 0.9,
+          },
+        ],
+      },
+    ],
+    excludedSourceRefs: [],
+  },
+  referenceGraph: {
+    edges: [{ from: '0', to: '1', fieldId: 'children' }],
+    creationOrder: ['0', '1'],
+    deferredFields: [],
+    hasCircularDependency: false,
+  },
+  contentTypes: [
+    {
+      sys: { id: 'article' },
+      name: 'Article',
+      displayField: 'title',
+      fields: [
+        {
+          id: 'title',
+          name: 'Title',
+          type: 'Symbol',
+        },
+        {
+          id: 'body',
+          name: 'Body copy',
+          type: 'Text',
+        },
+        {
+          id: 'excerpt',
+          name: 'Excerpt',
+          type: 'Symbol',
+        },
+        {
+          id: 'summary',
+          name: 'Summary',
+          type: 'Text',
+        },
+      ],
+    },
+  ],
+});
+
 const createImagePayload = (): MappingReviewSuspendPayload => ({
   suspendStepId: 'mapping-review',
   reason: 'Mapping review required before CMA payload generation continues',
@@ -345,6 +441,52 @@ describe('MappingView', () => {
       screen.getAllByText((_, node) => node?.textContent?.includes('| Long text') ?? false).length
     ).toBeGreaterThan(0);
     expect(mockClearSelection).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows all current locations when reassigning text mapped in multiple entry locations', () => {
+    mockUseReviewTextSelection.mockReturnValueOnce({
+      selectionRectangle: null,
+      selectedText: '',
+      selectedRange: null,
+      clearSelection: mockClearSelection,
+    });
+
+    const payload = createMultiLocationPayload();
+    const { container, rerender } = render(
+      <MappingView payload={payload} {...mappingViewGraphProps(payload)} selectedEntryIndex={0} />
+    );
+    const selectedRange = createDomRange(
+      container.querySelector('[data-review-text-segment="true"]')?.firstChild as Text,
+      0,
+      5
+    );
+    mockUseReviewTextSelection.mockReturnValue({
+      selectionRectangle: { top: 100, left: 100, right: 160, bottom: 120 },
+      selectedText: 'selected body text',
+      selectedRange,
+      clearSelection: mockClearSelection,
+    });
+    rerender(
+      <MappingView payload={payload} {...mappingViewGraphProps(payload)} selectedEntryIndex={0} />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reassign' }));
+
+    expect(screen.getByRole('heading', { name: 'Assign content' })).toBeTruthy();
+    expect(screen.getAllByText('Body copy').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Excerpt').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Summary').length).toBeGreaterThan(0);
+    expect(
+      screen
+        .getAllByRole('button')
+        .filter((element) => element.getAttribute('aria-pressed') !== null)
+    ).toHaveLength(3);
+    expect(
+      screen.getAllByText((_, node) => node?.textContent?.includes('| Long text') ?? false).length
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText((_, node) => node?.textContent?.includes('| Short text') ?? false).length
+    ).toBeGreaterThan(0);
   });
 
   it('scopes image assignment destinations to currently selected entry', () => {


### PR DESCRIPTION
## Summary
This fixes the Google Docs mapping review reassignment modal so it shows every current location for a selected generated text item before the user changes destinations.

## Changes
- Resolve current text locations for assign and exclude flows from the underlying `entryBlockGraph` using the selected text ranges, instead of only the currently visible review highlights
- Preserve all overlapping mappings so multi-location assignments remain visible in the modal even when the review UI is scoped to one focused entry
- Add a regression test covering reassignment of text mapped in multiple entry locations

Updated in:
- `apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx`
- `apps/google-docs/test/locations/Page/components/review/mapping/MappingView.spec.tsx`

## Notes
Validation used:
- `npx vitest run test/locations/Page/components/review/mapping/MappingView.spec.tsx`
- `npm run build`
