### PR TITLE
feat(google-docs): add review all mapping mode []

### DIFF
--- a/apps/google-docs/src/hooks/useReviewTextSelection.tsx
+++ b/apps/google-docs/src/hooks/useReviewTextSelection.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState, type RefObject } from 'react';
 import type { SelectionViewportRectangle } from '../locations/Page/components/review/mapping/selectionViewportRectangle';
 
 const SEGMENT_SURFACE_SELECTOR = '[data-review-segment-surface]';
+const SELECTION_MENU_HEADER_CLEARANCE_PX = 8;
 
 function elementFromNode(node: Node): Element | null {
   if (node.nodeType === Node.TEXT_NODE) {
@@ -25,13 +26,58 @@ function isSelectionInDocumentBody(range: Range, root: HTMLElement): boolean {
   return endpointInSurface(range.startContainer) && endpointInSurface(range.endContainer);
 }
 
-function getSelectionViewportRectangle(range: Range): SelectionViewportRectangle {
-  const rect = range.getBoundingClientRect();
+function intersectsViewport(
+  rect: DOMRect | Pick<SelectionViewportRectangle, 'top' | 'left' | 'bottom' | 'right'>
+): boolean {
+  return (
+    rect.bottom > 0 &&
+    rect.right > 0 &&
+    rect.top < window.innerHeight &&
+    rect.left < window.innerWidth
+  );
+}
+
+export function getSelectionViewportRectangle(
+  range: Range,
+  root: HTMLElement,
+  viewportTopInset = 0
+): SelectionViewportRectangle | null {
+  const rootRect = root.getBoundingClientRect();
+  const clientRects = Array.from(range.getClientRects()).filter(
+    (rect) => rect.width > 0 && rect.height > 0
+  );
+
+  const visibleRects = clientRects
+    .map((rect) => ({
+      top: Math.max(rect.top, rootRect.top, viewportTopInset, 0),
+      left: Math.max(rect.left, rootRect.left, 0),
+      bottom: Math.min(rect.bottom, rootRect.bottom, window.innerHeight),
+      right: Math.min(rect.right, rootRect.right, window.innerWidth),
+    }))
+    .filter((rect) => rect.bottom > rect.top && rect.right > rect.left)
+    .filter(intersectsViewport)
+    .sort((a, b) => {
+      if (a.top !== b.top) return a.top - b.top;
+      return a.left - b.left;
+    });
+
+  if (visibleRects.length > 0) {
+    return visibleRects[0];
+  }
+
+  const boundingRect = range.getBoundingClientRect();
+  if (
+    !intersectsViewport(boundingRect) ||
+    boundingRect.bottom <= Math.max(rootRect.top, viewportTopInset, 0)
+  ) {
+    return null;
+  }
+
   return {
-    top: rect.top,
-    left: rect.left,
-    bottom: rect.bottom,
-    right: rect.right,
+    top: boundingRect.top,
+    left: boundingRect.left,
+    bottom: boundingRect.bottom,
+    right: boundingRect.right,
   };
 }
 
@@ -52,7 +98,7 @@ function isValidReviewSelection(root: HTMLElement, sel: Selection): boolean {
 }
 
 export interface UseReviewTextSelectionResult {
-  /** Derived from {@link selectedRange} via `getBoundingClientRect()` for the floating menu. */
+  /** Derived from the visible selection rect for the floating menu. */
   selectionRectangle: SelectionViewportRectangle | null;
   selectedText: string;
   selectedRange: Range | null;
@@ -60,7 +106,8 @@ export interface UseReviewTextSelectionResult {
 }
 
 export function useReviewTextSelection(
-  rootRef: RefObject<HTMLElement | null>
+  rootRef: RefObject<HTMLElement | null>,
+  occludingTopRef?: RefObject<HTMLElement | null>
 ): UseReviewTextSelectionResult {
   const [selectedText, setSelectedText] = useState('');
   const [selectedRange, setSelectedRange] = useState<Range | null>(null);
@@ -90,7 +137,15 @@ export function useReviewTextSelection(
     setSelectedRange(null);
   }, []);
 
-  const selectionRectangle = selectedRange ? getSelectionViewportRectangle(selectedRange) : null;
+  const selectionRectangle =
+    selectedRange && rootRef.current
+      ? getSelectionViewportRectangle(
+          selectedRange,
+          rootRef.current,
+          (occludingTopRef?.current?.getBoundingClientRect().bottom ?? 0) +
+            SELECTION_MENU_HEADER_CLEARANCE_PX
+        )
+      : null;
 
   useEffect(() => {
     document.addEventListener('selectionchange', updateFromSelection);

--- a/apps/google-docs/src/locations/Page/components/overview/OverviewEntryList.tsx
+++ b/apps/google-docs/src/locations/Page/components/overview/OverviewEntryList.tsx
@@ -12,13 +12,13 @@ import { truncateLabel } from '../../../../utils/utils';
 
 export interface OverviewEntryListProps {
   rows: OverviewEntryListRow[];
-  selectedEntryIndex: number;
+  selectedEntryIndex: number | null;
   onSelect: (entryIndex: number) => void;
 }
 
 interface OverviewEntryRowCardProps {
   row: OverviewEntryListRow;
-  selectedEntryIndex: number;
+  selectedEntryIndex: number | null;
   onSelect: (entryIndex: number) => void;
   showTreeLines: boolean;
   isLastRow?: boolean;

--- a/apps/google-docs/src/locations/Page/components/overview/OverviewSection.tsx
+++ b/apps/google-docs/src/locations/Page/components/overview/OverviewSection.tsx
@@ -51,8 +51,8 @@ const OverviewSection = ({
     borderRadius: isFirst
       ? `${tokens.borderRadiusMedium} 0 0 ${tokens.borderRadiusMedium}`
       : isLast
-        ? `0 ${tokens.borderRadiusMedium} ${tokens.borderRadiusMedium} 0`
-        : 0,
+      ? `0 ${tokens.borderRadiusMedium} ${tokens.borderRadiusMedium} 0`
+      : 0,
     backgroundColor: isActive ? tokens.colorWhite : 'transparent',
     color: isActive ? tokens.gray900 : tokens.gray700,
     boxShadow: isActive

--- a/apps/google-docs/src/locations/Page/components/overview/OverviewSection.tsx
+++ b/apps/google-docs/src/locations/Page/components/overview/OverviewSection.tsx
@@ -15,6 +15,7 @@ interface OverviewProps {
   onViewAllMappings: () => void;
   onEditMode: () => void;
   isViewingAllMappings: boolean;
+  canEditMappings?: boolean;
   ctaLabel: string;
   onCtaClick: () => void;
   isCtaLoading?: boolean;
@@ -27,6 +28,7 @@ const OverviewSection = ({
   onViewAllMappings,
   onEditMode,
   isViewingAllMappings,
+  canEditMappings = true,
   ctaLabel,
   onCtaClick,
   isCtaLoading = false,
@@ -107,20 +109,22 @@ const OverviewSection = ({
                   size="small"
                   aria-pressed={isViewingAllMappings}
                   onClick={onViewAllMappings}
-                  isDisabled={areModeButtonsDisabled}
-                  style={toggleButtonStyle(isViewingAllMappings, true, false)}>
+                  isDisabled={areModeButtonsDisabled || !canEditMappings}
+                  style={toggleButtonStyle(isViewingAllMappings, true, !canEditMappings)}>
                   View only
                 </Button>
-                <Button
-                  variant="transparent"
-                  startIcon={<PencilSimpleIcon />}
-                  size="small"
-                  aria-pressed={!isViewingAllMappings}
-                  onClick={onEditMode}
-                  isDisabled={areModeButtonsDisabled}
-                  style={toggleButtonStyle(!isViewingAllMappings, false, true)}>
-                  Edit mode
-                </Button>
+                {canEditMappings ? (
+                  <Button
+                    variant="transparent"
+                    startIcon={<PencilSimpleIcon />}
+                    size="small"
+                    aria-pressed={!isViewingAllMappings}
+                    onClick={onEditMode}
+                    isDisabled={areModeButtonsDisabled}
+                    style={toggleButtonStyle(!isViewingAllMappings, false, true)}>
+                    Edit mode
+                  </Button>
+                ) : null}
               </Box>
               <Button
                 variant="primary"

--- a/apps/google-docs/src/locations/Page/components/overview/OverviewSection.tsx
+++ b/apps/google-docs/src/locations/Page/components/overview/OverviewSection.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
-import { Box, Button, Flex, Note, Paragraph, Text, Tooltip } from '@contentful/f36-components';
-import { LightbulbIcon } from '@contentful/f36-icons';
+import { Box, Button, Flex, Note, Paragraph, Text } from '@contentful/f36-components';
+import tokens from '@contentful/f36-tokens';
+import { EyeIcon, LightbulbIcon, PencilSimpleIcon } from '@contentful/f36-icons';
 import type { MappingReviewSuspendPayload } from '@types';
 import { buildEntryListFromEntryBlockGraph } from '../../../../utils/overviewEntryList';
 import { OverviewEntryList } from './OverviewEntryList';
@@ -12,6 +13,7 @@ interface OverviewProps {
   selectedEntryIndex: number | null;
   onSelectEntryIndex: (index: number) => void;
   onViewAllMappings: () => void;
+  onEditMode: () => void;
   isViewingAllMappings: boolean;
   ctaLabel: string;
   onCtaClick: () => void;
@@ -23,6 +25,7 @@ const OverviewSection = ({
   selectedEntryIndex,
   onSelectEntryIndex,
   onViewAllMappings,
+  onEditMode,
   isViewingAllMappings,
   ctaLabel,
   onCtaClick,
@@ -37,6 +40,28 @@ const OverviewSection = ({
       ),
     [payload.entryBlockGraph.entries, payload.contentTypes, payload.referenceGraph.edges]
   );
+  const areModeButtonsDisabled = isCtaLoading || entryRows.length === 0;
+
+  const toggleButtonStyle = (isActive: boolean, isFirst: boolean, isLast: boolean) => ({
+    minHeight: '38px',
+    minWidth: '136px',
+    paddingInline: tokens.spacingM,
+    border: 'none',
+    borderInlineEnd: isLast ? 'none' : `1px solid ${tokens.gray200}`,
+    borderRadius: isFirst
+      ? `${tokens.borderRadiusMedium} 0 0 ${tokens.borderRadiusMedium}`
+      : isLast
+        ? `0 ${tokens.borderRadiusMedium} ${tokens.borderRadiusMedium} 0`
+        : 0,
+    backgroundColor: isActive ? tokens.colorWhite : 'transparent',
+    color: isActive ? tokens.gray900 : tokens.gray700,
+    boxShadow: isActive
+      ? `inset 0 0 0 1px ${tokens.gray200}, 0 1px 2px rgba(17, 24, 39, 0.06)`
+      : 'none',
+    fontWeight: isActive ? tokens.fontWeightDemiBold : tokens.fontWeightMedium,
+    justifyContent: 'center',
+    gap: tokens.spacing2Xs,
+  });
 
   return (
     <>
@@ -64,14 +89,39 @@ const OverviewSection = ({
             </Flex>
 
             <Flex alignItems="center" gap="spacingXs">
-              <Tooltip content="Read only" placement="top">
+              <Box
+                role="group"
+                aria-label="Review mode"
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'stretch',
+                  border: `1px solid ${tokens.gray300}`,
+                  borderRadius: tokens.borderRadiusMedium,
+                  backgroundColor: tokens.gray100,
+                  overflow: 'hidden',
+                  boxShadow: '0 1px 2px rgba(17, 24, 39, 0.05)',
+                }}>
                 <Button
-                  variant="secondary"
+                  variant="transparent"
+                  startIcon={<EyeIcon />}
+                  size="small"
+                  aria-pressed={isViewingAllMappings}
                   onClick={onViewAllMappings}
-                  isDisabled={isCtaLoading || entryRows.length === 0 || isViewingAllMappings}>
-                  Review all
+                  isDisabled={areModeButtonsDisabled}
+                  style={toggleButtonStyle(isViewingAllMappings, true, false)}>
+                  View only
                 </Button>
-              </Tooltip>
+                <Button
+                  variant="transparent"
+                  startIcon={<PencilSimpleIcon />}
+                  size="small"
+                  aria-pressed={!isViewingAllMappings}
+                  onClick={onEditMode}
+                  isDisabled={areModeButtonsDisabled}
+                  style={toggleButtonStyle(!isViewingAllMappings, false, true)}>
+                  Edit mode
+                </Button>
+              </Box>
               <Button
                 variant="primary"
                 onClick={onCtaClick}

--- a/apps/google-docs/src/locations/Page/components/overview/OverviewSection.tsx
+++ b/apps/google-docs/src/locations/Page/components/overview/OverviewSection.tsx
@@ -109,7 +109,7 @@ const OverviewSection = ({
                   size="small"
                   aria-pressed={isViewingAllMappings}
                   onClick={onViewAllMappings}
-                  isDisabled={areModeButtonsDisabled || !canEditMappings}
+                  isDisabled={areModeButtonsDisabled}
                   style={toggleButtonStyle(isViewingAllMappings, true, !canEditMappings)}>
                   View only
                 </Button>

--- a/apps/google-docs/src/locations/Page/components/overview/OverviewSection.tsx
+++ b/apps/google-docs/src/locations/Page/components/overview/OverviewSection.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { Box, Button, Flex, Note, Paragraph, Text } from '@contentful/f36-components';
+import { Box, Button, Flex, Note, Paragraph, Text, Tooltip } from '@contentful/f36-components';
 import { LightbulbIcon } from '@contentful/f36-icons';
 import type { MappingReviewSuspendPayload } from '@types';
 import { buildEntryListFromEntryBlockGraph } from '../../../../utils/overviewEntryList';
@@ -9,8 +9,10 @@ import Splitter from '../mainpage/Splitter';
 
 interface OverviewProps {
   payload: MappingReviewSuspendPayload;
-  selectedEntryIndex: number;
+  selectedEntryIndex: number | null;
   onSelectEntryIndex: (index: number) => void;
+  onViewAllMappings: () => void;
+  isViewingAllMappings: boolean;
   ctaLabel: string;
   onCtaClick: () => void;
   isCtaLoading?: boolean;
@@ -20,6 +22,8 @@ const OverviewSection = ({
   payload,
   selectedEntryIndex,
   onSelectEntryIndex,
+  onViewAllMappings,
+  isViewingAllMappings,
   ctaLabel,
   onCtaClick,
   isCtaLoading = false,
@@ -59,13 +63,23 @@ const OverviewSection = ({
               <Text fontSize="fontSizeM">Click row to view content by entry below.</Text>
             </Flex>
 
-            <Button
-              variant="primary"
-              onClick={onCtaClick}
-              isLoading={isCtaLoading}
-              isDisabled={isCtaLoading}>
-              {ctaLabel}
-            </Button>
+            <Flex alignItems="center" gap="spacingXs">
+              <Tooltip content="Read only" placement="top">
+                <Button
+                  variant="secondary"
+                  onClick={onViewAllMappings}
+                  isDisabled={isCtaLoading || entryRows.length === 0 || isViewingAllMappings}>
+                  Review all
+                </Button>
+              </Tooltip>
+              <Button
+                variant="primary"
+                onClick={onCtaClick}
+                isLoading={isCtaLoading}
+                isDisabled={isCtaLoading}>
+                {ctaLabel}
+              </Button>
+            </Flex>
           </Flex>
 
           {entryRows.length === 0 ? (

--- a/apps/google-docs/src/locations/Page/components/review/ReviewPage.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/ReviewPage.tsx
@@ -99,6 +99,7 @@ export const ReviewPage = ({
         }
 
         setCreatedEntries(entries);
+        setReviewMode('all');
         setIsSummaryModalOpen(true);
         return;
       }
@@ -194,6 +195,7 @@ export const ReviewPage = ({
             onViewAllMappings={handleViewAllMappings}
             onEditMode={handleEditMode}
             isViewingAllMappings={reviewMode === 'all'}
+            canEditMappings={!hasCreatedEntries}
             ctaLabel={hasCreatedEntries ? 'View entries' : 'Create entries'}
             onCtaClick={handleCreateOrViewEntries}
             isCtaLoading={isCreatePending}

--- a/apps/google-docs/src/locations/Page/components/review/ReviewPage.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/ReviewPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Button, Flex, Heading, Layout } from '@contentful/f36-components';
 import tokens from '@contentful/f36-tokens';
 import { PageAppSDK } from '@contentful/app-sdk';
@@ -37,6 +37,7 @@ export const ReviewPage = ({
   const [createdEntries, setCreatedEntries] = useState<EntryProps[] | null>(null);
   const [isSummaryModalOpen, setIsSummaryModalOpen] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
+  const reviewHeaderRef = useRef<HTMLDivElement | null>(null);
   const [entryBlockGraph, setEntryBlockGraph] = useState<EntryBlockGraph>(() =>
     structuredClone(payload.entryBlockGraph)
   );
@@ -153,19 +154,21 @@ export const ReviewPage = ({
 
   return (
     <>
-      <Layout.Header title="Preview">
-        <Flex justifyContent="space-between" alignItems="center" marginTop="spacingS">
-          <Heading marginBottom="none">{title}</Heading>
-          <Button
-            variant="transparent"
-            size="small"
-            onClick={handleCancelOrExitReview}
-            aria-label={hasCreatedEntries ? 'Exit review' : 'Cancel review'}>
-            {hasCreatedEntries ? 'Exit' : 'Cancel'}
-          </Button>
-        </Flex>
-      </Layout.Header>
-      <Splitter marginTop="spacingS" />
+      <div ref={reviewHeaderRef}>
+        <Layout.Header title="Preview">
+          <Flex justifyContent="space-between" alignItems="center" marginTop="spacingS">
+            <Heading marginBottom="none">{title}</Heading>
+            <Button
+              variant="transparent"
+              size="small"
+              onClick={handleCancelOrExitReview}
+              aria-label={hasCreatedEntries ? 'Exit review' : 'Cancel review'}>
+              {hasCreatedEntries ? 'Exit' : 'Cancel'}
+            </Button>
+          </Flex>
+        </Layout.Header>
+        <Splitter marginTop="spacingS" />
+      </div>
       <Layout.Body>
         <Flex flexDirection="column" gap="spacingM" style={{ padding: tokens.spacingL }}>
           <OverviewSection
@@ -182,6 +185,7 @@ export const ReviewPage = ({
             onEntryBlockGraphChange={setEntryBlockGraph}
             selectedEntryIndex={selectedEntryIndex}
             isDisabled={isMappingDisabled}
+            occludingTopRef={reviewHeaderRef}
           />
         </Flex>
       </Layout.Body>

--- a/apps/google-docs/src/locations/Page/components/review/ReviewPage.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/ReviewPage.tsx
@@ -142,6 +142,10 @@ export const ReviewPage = ({
     setReviewMode('all');
   }, []);
 
+  const handleEditMode = useCallback(() => {
+    setReviewMode('single');
+  }, []);
+
   const handleSelectEntryIndex = useCallback((index: number) => {
     setSelectedEntryIndex(index);
     setReviewMode('single');
@@ -188,6 +192,7 @@ export const ReviewPage = ({
             selectedEntryIndex={reviewMode === 'all' ? null : selectedEntryIndex}
             onSelectEntryIndex={handleSelectEntryIndex}
             onViewAllMappings={handleViewAllMappings}
+            onEditMode={handleEditMode}
             isViewingAllMappings={reviewMode === 'all'}
             ctaLabel={hasCreatedEntries ? 'View entries' : 'Create entries'}
             onCtaClick={handleCreateOrViewEntries}

--- a/apps/google-docs/src/locations/Page/components/review/ReviewPage.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/ReviewPage.tsx
@@ -30,6 +30,7 @@ export const ReviewPage = ({
   onCancelReview,
   onExitReview,
 }: ReviewPageProps) => {
+  const [reviewMode, setReviewMode] = useState<'single' | 'all'>('all');
   const [isConfirmCancelModalOpen, setIsConfirmCancelModalOpen] = useState(false);
   const [selectedEntryIndex, setSelectedEntryIndex] = useState<number>(0);
   const [isCancelling, setIsCancelling] = useState(false);
@@ -46,6 +47,8 @@ export const ReviewPage = ({
   // alone or user edits would be wiped when the parent re-renders with a new object reference.
   useEffect(() => {
     setEntryBlockGraph(structuredClone(payload.entryBlockGraph));
+    setReviewMode('all');
+    setSelectedEntryIndex(0);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- only re-init on run identity
   }, [runId, payload.documentId]);
 
@@ -135,6 +138,15 @@ export const ReviewPage = ({
     void handleCreateEntries();
   }, [hasCreatedEntries, handleCreateEntries]);
 
+  const handleViewAllMappings = useCallback(() => {
+    setReviewMode('all');
+  }, []);
+
+  const handleSelectEntryIndex = useCallback((index: number) => {
+    setSelectedEntryIndex(index);
+    setReviewMode('single');
+  }, []);
+
   const handleCancelOrExitReview = useCallback(() => {
     if (hasCreatedEntries) {
       onExitReview();
@@ -173,8 +185,10 @@ export const ReviewPage = ({
         <Flex flexDirection="column" gap="spacingM" style={{ padding: tokens.spacingL }}>
           <OverviewSection
             payload={reviewPayload}
-            selectedEntryIndex={selectedEntryIndex}
-            onSelectEntryIndex={setSelectedEntryIndex}
+            selectedEntryIndex={reviewMode === 'all' ? null : selectedEntryIndex}
+            onSelectEntryIndex={handleSelectEntryIndex}
+            onViewAllMappings={handleViewAllMappings}
+            isViewingAllMappings={reviewMode === 'all'}
             ctaLabel={hasCreatedEntries ? 'View entries' : 'Create entries'}
             onCtaClick={handleCreateOrViewEntries}
             isCtaLoading={isCreatePending}
@@ -183,9 +197,10 @@ export const ReviewPage = ({
             payload={reviewPayload}
             entryBlockGraph={entryBlockGraph}
             onEntryBlockGraphChange={setEntryBlockGraph}
-            selectedEntryIndex={selectedEntryIndex}
+            selectedEntryIndex={reviewMode === 'all' ? null : selectedEntryIndex}
             isDisabled={isMappingDisabled}
             occludingTopRef={reviewHeaderRef}
+            reviewMode={reviewMode}
           />
         </Flex>
       </Layout.Body>

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingCard.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingCard.tsx
@@ -4,14 +4,19 @@ import tokens from '@contentful/f36-tokens';
 
 export interface MappingCardData {
   key: string;
+  contentTypeName: string;
   fieldName: string;
   fieldType: string;
+  displayLabel: string;
+  entryLabel: string;
 }
 
 interface MappingCardProps {
   card: MappingCardData;
   top: number;
   wrapperRef: Ref<HTMLDivElement>;
+  showContentTypeName?: boolean;
+  useStaticLayout?: boolean;
   isHovered?: boolean;
   onMouseEnter?: () => void;
   onMouseLeave?: () => void;
@@ -39,13 +44,16 @@ export const MappingCard = ({
   card,
   top,
   wrapperRef,
+  showContentTypeName = false,
+  useStaticLayout = false,
   isHovered = false,
   onMouseEnter,
   onMouseLeave,
 }: MappingCardProps) => {
-  const { fieldName, fieldType } = card;
-  const fullValue = `${fieldName}${FIELD_TYPE_SEPARATOR}${fieldType}`;
+  const { contentTypeName, displayLabel, fieldType, entryLabel } = card;
+  const fullValue = `${displayLabel}${FIELD_TYPE_SEPARATOR}${fieldType}`;
   const truncatedValue = truncate(fullValue, MAX_VALUE_LENGTH);
+  const truncatedEntryLabel = truncate(entryLabel, MAX_VALUE_LENGTH);
   const separatorIndex = truncatedValue.indexOf(FIELD_TYPE_SEPARATOR);
   const hasTypePart = separatorIndex !== -1;
   const labelPart = hasTypePart ? truncatedValue.slice(0, separatorIndex) : truncatedValue;
@@ -60,16 +68,40 @@ export const MappingCard = ({
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       style={{
-        position: 'absolute',
-        insetInlineStart: 0,
-        insetInlineEnd: 0,
-        top,
-        border: `${isHovered ? 2 : 1}px solid ${isHovered ? tokens.green600 : tokens.green500}`,
+        position: useStaticLayout ? 'relative' : 'absolute',
+        insetInlineStart: useStaticLayout ? undefined : 0,
+        insetInlineEnd: useStaticLayout ? undefined : 0,
+        top: useStaticLayout ? undefined : top,
+        border: `1px solid ${isHovered ? tokens.green600 : tokens.green500}`,
         borderRadius: tokens.borderRadiusMedium,
         padding: tokens.spacing2Xs,
-        backgroundColor: tokens.green100,
-        transition: 'border-color 120ms ease, border-width 120ms ease',
+        backgroundColor: showContentTypeName ? tokens.colorWhite : tokens.green100,
+        boxShadow: isHovered ? `inset 0 0 0 1px ${tokens.green600}` : undefined,
+        transition: 'border-color 120ms ease, box-shadow 120ms ease',
       }}>
+      {showContentTypeName ? (
+        <Box marginBottom="spacing2Xs">
+          <Text as="span" fontColor="gray600" style={labelTextStyle} marginRight="spacingXs">
+            Content type:
+          </Text>
+          <Text as="span" fontWeight="fontWeightDemiBold" style={valueTextStyle}>
+            {contentTypeName}
+          </Text>
+          <Box marginTop="spacing2Xs">
+            <Text as="span" fontColor="gray600" style={labelTextStyle} marginRight="spacingXs">
+              Entry:
+            </Text>
+            <Text as="span" fontWeight="fontWeightDemiBold" style={valueTextStyle}>
+              <Tooltip
+                content={`Entry: ${entryLabel}`}
+                placement="top"
+                isDisabled={truncatedEntryLabel === entryLabel}>
+                <Box as="span">{truncatedEntryLabel}</Box>
+              </Tooltip>
+            </Text>
+          </Box>
+        </Box>
+      ) : null}
       <Text as="span" fontColor="gray600" style={labelTextStyle} marginRight="spacingXs">
         Field:
       </Text>

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingEntryCards.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingEntryCards.tsx
@@ -11,12 +11,12 @@ interface MappingEntryCardsProps {
   onSetHoveredMappingKeys: (keys: string[]) => void;
   setCardWrapperRef: (cardKey: string) => RefCallback<HTMLDivElement>;
   showContentTypeName?: boolean;
+  useStaticLayout?: boolean;
 }
 
 const railStyles: BoxProps['style'] = {
   flex: '0 0 280px',
   maxWidth: 280,
-  position: 'relative',
 };
 
 export const MappingEntryCards = ({
@@ -27,10 +27,21 @@ export const MappingEntryCards = ({
   onSetHoveredMappingKeys,
   setCardWrapperRef,
   showContentTypeName = false,
+  useStaticLayout = showContentTypeName,
 }: MappingEntryCardsProps): JSX.Element => {
   return (
     <Box data-testid={`mapping-rail-${groupId}`} style={railStyles}>
-      <Box style={{ position: 'relative', minHeight: '100%' }}>
+      <Box
+        style={
+          useStaticLayout
+            ? {
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 12,
+                paddingRight: 4,
+              }
+            : { position: 'relative', minHeight: '100%' }
+        }>
         {mappingCards.length > 0
           ? mappingCards.map((mappingCard) => (
               <MappingCard
@@ -39,6 +50,7 @@ export const MappingEntryCards = ({
                 top={cardOffsetsByGroup[groupId]?.[mappingCard.key] ?? 0}
                 wrapperRef={setCardWrapperRef(mappingCard.key)}
                 showContentTypeName={showContentTypeName}
+                useStaticLayout={useStaticLayout}
                 isHovered={mappingCard.mappingKeys.some((key) => hoveredMappingKeys.includes(key))}
                 onMouseEnter={() => onSetHoveredMappingKeys(mappingCard.mappingKeys)}
                 onMouseLeave={() => onSetHoveredMappingKeys([])}

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingEntryCards.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingEntryCards.tsx
@@ -10,6 +10,7 @@ interface MappingEntryCardsProps {
   hoveredMappingKeys: string[];
   onSetHoveredMappingKeys: (keys: string[]) => void;
   setCardWrapperRef: (cardKey: string) => RefCallback<HTMLDivElement>;
+  showContentTypeName?: boolean;
 }
 
 const railStyles: BoxProps['style'] = {
@@ -25,6 +26,7 @@ export const MappingEntryCards = ({
   hoveredMappingKeys,
   onSetHoveredMappingKeys,
   setCardWrapperRef,
+  showContentTypeName = false,
 }: MappingEntryCardsProps): JSX.Element => {
   return (
     <Box data-testid={`mapping-rail-${groupId}`} style={railStyles}>
@@ -36,6 +38,7 @@ export const MappingEntryCards = ({
                 card={mappingCard}
                 top={cardOffsetsByGroup[groupId]?.[mappingCard.key] ?? 0}
                 wrapperRef={setCardWrapperRef(mappingCard.key)}
+                showContentTypeName={showContentTypeName}
                 isHovered={mappingCard.mappingKeys.some((key) => hoveredMappingKeys.includes(key))}
                 onMouseEnter={() => onSetHoveredMappingKeys(mappingCard.mappingKeys)}
                 onMouseLeave={() => onSetHoveredMappingKeys([])}

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -456,7 +456,7 @@ export const MappingView = ({
 
       return {
         id: field.id,
-        fieldName: (field.name ?? '').trim() || formatDisplayName(field.id),
+        fieldName: (field.name ?? '').trim() || field.id,
         fieldType,
         fieldDisplayType: displayType(fieldType, field.linkType, field.items),
         isAssetField: isAssetFieldForImageAssign(field),

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -7,7 +7,7 @@ import {
   type RefCallback,
   type RefObject,
 } from 'react';
-import { Box, Flex, Text } from '@contentful/f36-components';
+import { Box, Flex, Note, Text } from '@contentful/f36-components';
 import tokens from '@contentful/f36-tokens';
 import {
   buildEntryListFromEntryBlockGraph,
@@ -89,6 +89,7 @@ interface MappingViewProps {
   selectedEntryIndex: number | null;
   isDisabled?: boolean;
   occludingTopRef?: RefObject<HTMLElement | null>;
+  reviewMode?: 'single' | 'all';
 }
 
 const EMPTY_NEW_LOCATION: EditModalNewLocation = {
@@ -136,8 +137,13 @@ export const MappingView = ({
   selectedEntryIndex,
   isDisabled = false,
   occludingTopRef,
+  reviewMode = 'single',
 }: MappingViewProps): JSX.Element => {
+  const isReadOnlyAllMappings = reviewMode === 'all';
   const selectedEntryRow = useMemo(() => {
+    if (isReadOnlyAllMappings) {
+      return null;
+    }
     const rows = buildEntryListFromEntryBlockGraph(
       payload.entryBlockGraph.entries,
       payload.contentTypes,
@@ -153,6 +159,7 @@ export const MappingView = ({
     payload.contentTypes,
     payload.referenceGraph.edges,
     selectedEntryIndex,
+    isReadOnlyAllMappings,
   ]);
   const [hoveredMappingKeys, setHoveredMappingKeys] = useState<string[]>([]);
   const [cardOffsetsByGroup, setCardOffsetsByGroup] = useState<
@@ -290,17 +297,29 @@ export const MappingView = ({
 
   const { groupsByTab, allGroups } = useMemo(
     () =>
-      buildMappingDisplayGroups(tabs, visibleHighlightsBySegment, (highlight) => {
-        const graphEntry = entryBlockGraph.entries[highlight.entryIndex];
-        const contentType = payload.contentTypes.find(
-          (item) => item.sys.id === graphEntry?.contentTypeId
-        );
-        const field = contentType?.fields.find((item) => item.id === highlight.fieldId);
+      buildMappingDisplayGroups(
+        tabs,
+        visibleHighlightsBySegment,
+        (highlight) => {
+          const graphEntry = entryBlockGraph.entries[highlight.entryIndex];
+          const contentType = payload.contentTypes.find(
+            (item) => item.sys.id === graphEntry?.contentTypeId
+          );
+          const field = contentType?.fields.find((item) => item.id === highlight.fieldId);
 
-        return field
-          ? displayType(field.type ?? '', field.linkType, field.items)
-          : displayType(highlight.fieldType);
-      }),
+          return field
+            ? displayType(field.type ?? '', field.linkType, field.items)
+            : displayType(highlight.fieldType);
+        },
+        (highlight) => {
+          const graphEntry = entryBlockGraph.entries[highlight.entryIndex];
+          const contentType = payload.contentTypes.find(
+            (item) => item.sys.id === graphEntry?.contentTypeId
+          );
+
+          return contentType?.name ?? graphEntry?.contentTypeId ?? 'Entry';
+        }
+      ),
     [tabs, visibleHighlightsBySegment, payload.contentTypes, entryBlockGraph.entries]
   );
 
@@ -521,7 +540,33 @@ export const MappingView = ({
     };
 
     measureOffsets();
-  }, [allGroups]);
+
+    if (typeof ResizeObserver === 'undefined') {
+      return;
+    }
+
+    const observer = new ResizeObserver(() => {
+      measureOffsets();
+    });
+
+    allGroups.forEach((group) => {
+      const groupNode = groupLayoutRefs.current[group.id];
+      if (groupNode) {
+        observer.observe(groupNode);
+      }
+
+      group.mappingCards.forEach((card) => {
+        const wrapperNode = cardWrapperRefs.current[card.key];
+        if (wrapperNode) {
+          observer.observe(wrapperNode);
+        }
+      });
+    });
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [allGroups, isReadOnlyAllMappings]);
 
   const openAssignModal = (
     preview: string,
@@ -598,7 +643,7 @@ export const MappingView = ({
   };
 
   const handleAssignFromSelection = () => {
-    if (isDisabled || !selectedText.trim()) return;
+    if (isDisabled || isReadOnlyAllMappings || !selectedText.trim()) return;
     const selectionRange = selectedRange ? selectedRange.cloneRange() : null;
     const reassignRanges = collectTextExclusionRangesFromSelection(
       textSelectionRootRef.current,
@@ -626,7 +671,7 @@ export const MappingView = ({
   };
 
   const handleExcludeFromSelection = () => {
-    if (isDisabled || !selectedText.trim()) return;
+    if (isDisabled || isReadOnlyAllMappings || !selectedText.trim()) return;
     const selectionRange = selectedRange ? selectedRange.cloneRange() : null;
     const ranges = collectTextExclusionRangesFromSelection(
       textSelectionRootRef.current,
@@ -659,13 +704,13 @@ export const MappingView = ({
   };
 
   const handleAssignImage = (sourceRef: ImageSourceRef, label: string) => {
-    if (isDisabled) return;
+    if (isDisabled || isReadOnlyAllMappings) return;
     openAssignModal(label, getLocationsForSourceRef(sourceRef), [], [], sourceRef);
     setHoveredMappingKeys([]);
   };
 
   const handleExcludeImage = (sourceRef: ImageSourceRef, label: string) => {
-    if (isDisabled) return;
+    if (isDisabled || isReadOnlyAllMappings) return;
     setPendingImageSourceRef(sourceRef);
     setPendingTextExclusionRanges(null);
     openExcludeModal(label, getLocationsForSourceRef(sourceRef), {
@@ -930,7 +975,7 @@ export const MappingView = ({
         flexDirection="column"
         gap="spacingS"
         style={{ marginTop: tokens.spacingM }}>
-        {selectedEntryRow && (
+        {(selectedEntryRow || isReadOnlyAllMappings) && (
           <Box
             style={{
               borderBottom: `1px solid ${tokens.gray200}`,
@@ -943,16 +988,31 @@ export const MappingView = ({
               marginBottom="spacing2Xs">
               Currently viewing:
             </Text>
-            <Text as="p" marginBottom="none">
-              <Text as="span" fontWeight="fontWeightDemiBold">
-                {selectedEntryRow.contentTypeName}
-              </Text>
-              {selectedEntryRow.entryTitle ? (
-                <Text as="span" fontColor="gray600">
-                  {' '}
-                  ({selectedEntryRow.entryTitle})
-                </Text>
-              ) : null}
+            <Text as="div" marginBottom="none">
+              {isReadOnlyAllMappings ? (
+                <>
+                  <Text as="span" fontWeight="fontWeightDemiBold">
+                    All entries
+                  </Text>
+                  <Box marginTop="spacingXs">
+                    <Note variant="neutral">
+                      Select an entry above to review and edit mappings for that entry.
+                    </Note>
+                  </Box>
+                </>
+              ) : (
+                <>
+                  <Text as="span" fontWeight="fontWeightDemiBold">
+                    {selectedEntryRow?.contentTypeName}
+                  </Text>
+                  {selectedEntryRow?.entryTitle ? (
+                    <Text as="span" fontColor="gray600">
+                      {' '}
+                      ({selectedEntryRow.entryTitle})
+                    </Text>
+                  ) : null}
+                </>
+              )}
             </Text>
           </Box>
         )}
@@ -970,6 +1030,14 @@ export const MappingView = ({
                 const isGroupHovered = group.mappingCards.some((card) =>
                   card.mappingKeys.some((key) => hoveredMappingKeys.includes(key))
                 );
+                const mediaLikePattern = /media|image|asset/i;
+                const prefersImageOnlyHighlight =
+                  isReadOnlyAllMappings &&
+                  group.mappingCards.length === 1 &&
+                  (mediaLikePattern.test(group.mappingCards[0].fieldType) ||
+                    mediaLikePattern.test(group.mappingCards[0].fieldName) ||
+                    mediaLikePattern.test(group.mappingCards[0].displayLabel));
+                const showGroupedSurface = group.showGroupedSurface && !prefersImageOnlyHighlight;
 
                 return (
                   <Box key={group.id}>
@@ -979,7 +1047,7 @@ export const MappingView = ({
                       data-testid={`display-group-layout-${group.id}`}
                       ref={setGroupLayoutRef(group.id)}>
                       <Box style={{ flex: 2 }}>
-                        {group.showGroupedSurface ? (
+                        {showGroupedSurface ? (
                           <Box
                             data-testid={`mapping-group-surface-${group.id}`}
                             data-hovered={isGroupHovered ? 'true' : 'false'}
@@ -988,7 +1056,7 @@ export const MappingView = ({
                                 isGroupHovered ? tokens.green600 : tokens.green500
                               }`,
                               borderRadius: tokens.borderRadiusMedium,
-                              backgroundColor: tokens.green100,
+                              backgroundColor: 'transparent',
                               padding: tokens.spacing2Xs,
                               transition: 'border-color 120ms ease, border-width 120ms ease',
                             }}>
@@ -1006,6 +1074,9 @@ export const MappingView = ({
                                   onSetHoveredMappingKeys={setHoveredMappingKeys}
                                   onAssignImage={handleAssignImage}
                                   onExcludeImage={handleExcludeImage}
+                                  readOnly={isReadOnlyAllMappings}
+                                  showReadOnlyOutline={!showGroupedSurface && !prefersImageOnlyHighlight}
+                                  preferImageReadOnlyHighlight={prefersImageOnlyHighlight}
                                 />
                               ))}
                             </Flex>
@@ -1025,6 +1096,9 @@ export const MappingView = ({
                                 onSetHoveredMappingKeys={setHoveredMappingKeys}
                                 onAssignImage={handleAssignImage}
                                 onExcludeImage={handleExcludeImage}
+                                readOnly={isReadOnlyAllMappings}
+                                showReadOnlyOutline={!showGroupedSurface && !prefersImageOnlyHighlight}
+                                preferImageReadOnlyHighlight={prefersImageOnlyHighlight}
                               />
                             ))}
                           </Flex>
@@ -1038,6 +1112,7 @@ export const MappingView = ({
                         hoveredMappingKeys={hoveredMappingKeys}
                         onSetHoveredMappingKeys={setHoveredMappingKeys}
                         setCardWrapperRef={setCardWrapperRef}
+                        showContentTypeName={isReadOnlyAllMappings}
                       />
                     </Flex>
                   </Box>
@@ -1048,7 +1123,7 @@ export const MappingView = ({
         ))}
       </Flex>
 
-      {selectionRectangle && !isDisabled ? (
+      {selectionRectangle && !isDisabled && !isReadOnlyAllMappings ? (
         <SelectionActionMenu
           anchorRectangle={selectionRectangle}
           onAssign={handleAssignFromSelection}

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -43,7 +43,6 @@ import {
 import { buildListMarkers } from './buildListMarkers';
 import {
   displayType,
-  formatDisplayName,
   isAssetFieldForImageAssign,
   isWorkflowContentTypeFieldWithId,
 } from './fieldFormatting';
@@ -262,8 +261,8 @@ export const MappingView = ({
     useReviewTextSelection(textSelectionRootRef, occludingTopRef);
 
   const highlightIndex = useMemo(
-    () => buildMappingHighlightIndex(entryBlockGraph),
-    [entryBlockGraph]
+    () => buildMappingHighlightIndex(entryBlockGraph, payload.contentTypes),
+    [entryBlockGraph, payload.contentTypes]
   );
 
   const { tabs, allSegments } = useMemo(() => buildDocument(document), [document]);
@@ -433,9 +432,6 @@ export const MappingView = ({
         byKey.set(card.key, {
           ...firstLocation,
           id: card.key,
-          displayLabel: hasPositionalDisplayLabel(card.displayLabel)
-            ? card.displayLabel
-            : undefined,
           sourceRefs: sourceLocations.map((location) => location.sourceRef),
           mappingKeys: [...card.mappingKeys],
           isSelected: false,
@@ -1150,6 +1146,7 @@ export const MappingView = ({
                                   !showGroupedSurface && !prefersImageOnlyHighlight
                                 }
                                 preferImageReadOnlyHighlight={prefersImageOnlyHighlight}
+                                suppressInlineHighlights={showGroupedSurface}
                               />
                             ))}
                           </Flex>
@@ -1174,6 +1171,7 @@ export const MappingView = ({
                                 !showGroupedSurface && !prefersImageOnlyHighlight
                               }
                               preferImageReadOnlyHighlight={prefersImageOnlyHighlight}
+                              suppressInlineHighlights={showGroupedSurface}
                             />
                           ))}
                         </Flex>
@@ -1249,7 +1247,9 @@ export const MappingView = ({
                               isGroupHovered ? tokens.green600 : tokens.green500
                             }`,
                             borderRadius: tokens.borderRadiusMedium,
-                            backgroundColor: 'transparent',
+                            backgroundColor: isReadOnlyAllMappings
+                              ? 'transparent'
+                              : tokens.green100,
                             padding: tokens.spacing2Xs,
                             boxShadow: isGroupHovered
                               ? `inset 0 0 0 1px ${tokens.green600}`
@@ -1275,6 +1275,7 @@ export const MappingView = ({
                                   !showGroupedSurface && !prefersImageOnlyHighlight
                                 }
                                 preferImageReadOnlyHighlight={prefersImageOnlyHighlight}
+                                suppressInlineHighlights={showGroupedSurface}
                               />
                             ))}
                           </Flex>
@@ -1299,6 +1300,7 @@ export const MappingView = ({
                                 !showGroupedSurface && !prefersImageOnlyHighlight
                               }
                               preferImageReadOnlyHighlight={prefersImageOnlyHighlight}
+                              suppressInlineHighlights={showGroupedSurface}
                             />
                           ))}
                         </Flex>

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -155,10 +155,6 @@ function rangeIntersectsNode(range: Range, node: Node): boolean {
   }
 }
 
-function hasPositionalDisplayLabel(label: string): boolean {
-  return /\(\d+\/\d+\)$/.test(label);
-}
-
 function getPreferredAlignmentTop(anchorNode: HTMLElement | null, containerTop: number): number {
   if (!anchorNode) {
     return 0;

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -7,7 +7,7 @@ import {
   type RefCallback,
   type RefObject,
 } from 'react';
-import { Box, Flex, Note, Text } from '@contentful/f36-components';
+import { Box, Flex, Text } from '@contentful/f36-components';
 import tokens from '@contentful/f36-tokens';
 import {
   buildEntryListFromEntryBlockGraph,
@@ -43,6 +43,7 @@ import {
 import { buildListMarkers } from './buildListMarkers';
 import {
   displayType,
+  formatDisplayName,
   isAssetFieldForImageAssign,
   isWorkflowContentTypeFieldWithId,
 } from './fieldFormatting';
@@ -121,6 +122,31 @@ function findRowByEntryIndex(rows: EntryListRow[], index: number): EntryListRow 
   return null;
 }
 
+function getEntryName(contentTypeName: string | undefined, entryIndex: number): string {
+  const displayName = contentTypeName ?? 'Untitled';
+  return `${displayName} #${entryIndex + 1}`;
+}
+
+function getEntryReviewTitle(
+  entry: MappingReviewSuspendPayload['entryBlockGraph']['entries'][number],
+  displayField: string | undefined,
+  fallbackEntryName: string
+): string {
+  const localizedFieldValue = displayField ? entry.fields?.[displayField] : undefined;
+  if (localizedFieldValue) {
+    const populatedValue = Object.values(localizedFieldValue).find(
+      (candidate): candidate is string =>
+        typeof candidate === 'string' && candidate.trim().length > 0
+    );
+    if (populatedValue) {
+      return populatedValue.trim();
+    }
+  }
+
+  const mappedTitle = getEntryTitleFromFieldMappings(entry, displayField).trim();
+  return mappedTitle && mappedTitle !== 'Untitled' ? mappedTitle : fallbackEntryName;
+}
+
 /** `Range#intersectsNode` can throw when the range and node are in inconsistent trees. */
 function rangeIntersectsNode(range: Range, node: Node): boolean {
   try {
@@ -128,6 +154,22 @@ function rangeIntersectsNode(range: Range, node: Node): boolean {
   } catch {
     return false;
   }
+}
+
+function hasPositionalDisplayLabel(label: string): boolean {
+  return /\(\d+\/\d+\)$/.test(label);
+}
+
+function getPreferredAlignmentTop(anchorNode: HTMLElement | null, containerTop: number): number {
+  if (!anchorNode) {
+    return 0;
+  }
+
+  const alignmentTarget = anchorNode.querySelector<HTMLElement>(
+    '[data-review-alignment-target="true"]'
+  );
+  const targetNode = alignmentTarget ?? anchorNode;
+  return Math.max(0, targetNode.getBoundingClientRect().top - containerTop);
 }
 
 export const MappingView = ({
@@ -185,6 +227,7 @@ export const MappingView = ({
   const textSelectionRootRef = useRef<HTMLDivElement | null>(null);
   const groupLayoutRefs = useRef<Record<string, HTMLDivElement | null>>({});
   const cardWrapperRefs = useRef<Record<string, HTMLDivElement | null>>({});
+  const reviewAllContentRef = useRef<HTMLDivElement | null>(null);
   const document = payload.normalizedDocument;
 
   const closeEditModal = () => {
@@ -219,11 +262,12 @@ export const MappingView = ({
     useReviewTextSelection(textSelectionRootRef, occludingTopRef);
 
   const highlightIndex = useMemo(
-    () => buildMappingHighlightIndex(entryBlockGraph, payload.contentTypes),
-    [entryBlockGraph, payload.contentTypes]
+    () => buildMappingHighlightIndex(entryBlockGraph),
+    [entryBlockGraph]
   );
 
   const { tabs, allSegments } = useMemo(() => buildDocument(document), [document]);
+  const reviewAllEntryCount = entryBlockGraph.entries.length;
 
   const imageById = useMemo(() => {
     const images = document.images ?? [];
@@ -264,10 +308,10 @@ export const MappingView = ({
       (item) => item.sys.id === graphEntry.contentTypeId
     );
     const contentTypeDisplayName = (contentType?.name ?? '').trim();
-    const field = contentType?.fields.find((f) => f.id === fieldId);
-    const fieldDisplayName = (field?.name ?? '').trim() || fieldId;
-    const fieldDisplayType = field
-      ? displayType(field.type ?? '', field.linkType, field.items)
+    const contentTypeField = contentType?.fields.find((field) => field.id === fieldId);
+    const fieldDisplayName = (contentTypeField?.name ?? '').trim();
+    const fieldDisplayType = contentTypeField
+      ? displayType(contentTypeField.type ?? '', contentTypeField.linkType, contentTypeField.items)
       : displayType(fieldType);
     const entryName = getEntryTitleFromFieldMappings(graphEntry, contentType?.displayField);
 
@@ -318,6 +362,20 @@ export const MappingView = ({
           );
 
           return contentType?.name ?? graphEntry?.contentTypeId ?? 'Entry';
+        },
+        (highlight) => {
+          const graphEntry = entryBlockGraph.entries[highlight.entryIndex];
+          const contentType = payload.contentTypes.find(
+            (item) => item.sys.id === graphEntry?.contentTypeId
+          );
+          const fallbackEntryName = getEntryName(
+            contentType?.name ?? graphEntry?.contentTypeId ?? 'Untitled',
+            highlight.entryIndex
+          );
+
+          return graphEntry
+            ? getEntryReviewTitle(graphEntry, contentType?.displayField, fallbackEntryName)
+            : fallbackEntryName;
         }
       ),
     [tabs, visibleHighlightsBySegment, payload.contentTypes, entryBlockGraph.entries]
@@ -375,7 +433,9 @@ export const MappingView = ({
         byKey.set(card.key, {
           ...firstLocation,
           id: card.key,
-          fieldName: card.fieldName,
+          displayLabel: hasPositionalDisplayLabel(card.displayLabel)
+            ? card.displayLabel
+            : undefined,
           sourceRefs: sourceLocations.map((location) => location.sourceRef),
           mappingKeys: [...card.mappingKeys],
           isSelected: false,
@@ -392,14 +452,15 @@ export const MappingView = ({
   ): EditModalNewLocation => {
     const contentType = payload.contentTypes.find((item) => item.sys.id === entry.contentTypeId);
     const contentTypeName = contentType?.name ?? entry.contentTypeId;
-    const entryTitle = getEntryTitleFromFieldMappings(entry, contentType?.displayField);
+    const fallbackEntryName = getEntryName(contentTypeName, entryIndex);
+    const entryTitle = getEntryReviewTitle(entry, contentType?.displayField, fallbackEntryName);
     const contentTypeFields = contentType?.fields ?? [];
     const fieldOptions = contentTypeFields.filter(isWorkflowContentTypeFieldWithId).map((field) => {
       const fieldType = typeof field.type === 'string' ? field.type : 'Text';
 
       return {
         id: field.id,
-        fieldName: (field.name ?? '').trim() || field.id,
+        fieldName: (field.name ?? '').trim() || formatDisplayName(field.id),
         fieldType,
         fieldDisplayType: displayType(fieldType, field.linkType, field.items),
         isAssetField: isAssetFieldForImageAssign(field),
@@ -524,9 +585,7 @@ export const MappingView = ({
         const cards = groupCards.map((card) => {
           const anchorNode = groupNode.querySelector<HTMLElement>(`#${CSS.escape(card.anchorId)}`);
           const wrapperNode = cardWrapperRefs.current[card.key];
-          const rawTop = anchorNode
-            ? Math.max(0, anchorNode.getBoundingClientRect().top - groupTop)
-            : 0;
+          const rawTop = getPreferredAlignmentTop(anchorNode, groupTop);
           const height =
             wrapperNode?.getBoundingClientRect().height || wrapperNode?.offsetHeight || 28;
 
@@ -536,6 +595,29 @@ export const MappingView = ({
         nextOffsets[group.id] = resolveMarkerOffsets(cards);
       });
 
+      if (isReadOnlyAllMappings) {
+        const reviewAllNode = reviewAllContentRef.current;
+        const reviewAllCards = tabs.flatMap((tab) =>
+          (groupsByTab[tab.id] ?? []).flatMap((group) => group.mappingCards)
+        );
+
+        if (reviewAllNode && reviewAllCards.length > 0) {
+          const reviewAllTop = reviewAllNode.getBoundingClientRect().top;
+          const cards = reviewAllCards.map((card) => {
+            const anchorNode = reviewAllNode.querySelector<HTMLElement>(
+              `#${CSS.escape(card.anchorId)}`
+            );
+            const wrapperNode = cardWrapperRefs.current[card.key];
+            const rawTop = getPreferredAlignmentTop(anchorNode, reviewAllTop);
+            const height =
+              wrapperNode?.getBoundingClientRect().height || wrapperNode?.offsetHeight || 28;
+
+            return { key: card.key, rawTop, height };
+          });
+
+          nextOffsets['review-all'] = resolveMarkerOffsets(cards, { gap: 4 });
+        }
+      }
       setCardOffsetsByGroup(nextOffsets);
     };
 
@@ -563,10 +645,14 @@ export const MappingView = ({
       });
     });
 
+    if (isReadOnlyAllMappings && reviewAllContentRef.current) {
+      observer.observe(reviewAllContentRef.current);
+    }
+
     return () => {
       observer.disconnect();
     };
-  }, [allGroups, isReadOnlyAllMappings]);
+  }, [allGroups, groupsByTab, isReadOnlyAllMappings, tabs]);
 
   const openAssignModal = (
     preview: string,
@@ -597,9 +683,9 @@ export const MappingView = ({
         newLocation,
         isOpen: true,
       },
-      title: `${canExcludeSelectedText ? 'Reassign' : 'Assign'} content`,
+      title: 'Assign content',
       locationSectionDescription: '',
-      primaryButtonLabel: `${canExcludeSelectedText ? 'Reassign' : 'Assign'} content`,
+      primaryButtonLabel: 'Move content',
     });
   };
 
@@ -992,13 +1078,8 @@ export const MappingView = ({
               {isReadOnlyAllMappings ? (
                 <>
                   <Text as="span" fontWeight="fontWeightDemiBold">
-                    All entries
+                    {`All entries (${reviewAllEntryCount})`}
                   </Text>
-                  <Box marginTop="spacingXs">
-                    <Note variant="neutral">
-                      Select an entry above to review and edit mappings for that entry.
-                    </Note>
-                  </Box>
                 </>
               ) : (
                 <>
@@ -1016,75 +1097,166 @@ export const MappingView = ({
             </Text>
           </Box>
         )}
-        {tabs.map((tab) => (
-          <Box key={tab.id}>
-            {tab.name && (
-              <Flex alignItems="center" gap="spacingXs">
-                <FileTextIcon />
-                <Text fontWeight="fontWeightDemiBold">{tab.name}</Text>
-              </Flex>
-            )}
+        {isReadOnlyAllMappings ? (
+          <Flex gap="spacingM" alignItems="flex-start">
+            <Box ref={reviewAllContentRef} style={{ flex: 1, minWidth: 0 }}>
+              {tabs.map((tab) => {
+                const tabGroups = groupsByTab[tab.id] ?? [];
 
-            <Flex flexDirection="column" gap="spacingS">
-              {(groupsByTab[tab.id] ?? []).map((group) => {
-                const isGroupHovered = group.mappingCards.some((card) =>
-                  card.mappingKeys.some((key) => hoveredMappingKeys.includes(key))
-                );
-                const mediaLikePattern = /media|image|asset/i;
-                const prefersImageOnlyHighlight =
-                  isReadOnlyAllMappings &&
-                  group.mappingCards.length === 1 &&
-                  (mediaLikePattern.test(group.mappingCards[0].fieldType) ||
-                    mediaLikePattern.test(group.mappingCards[0].fieldName) ||
-                    mediaLikePattern.test(group.mappingCards[0].displayLabel));
-                const showGroupedSurface = group.showGroupedSurface && !prefersImageOnlyHighlight;
+                const renderReviewAllGroup = (group: (typeof tabGroups)[number]) => {
+                  const isGroupHovered = group.mappingCards.some((card) =>
+                    card.mappingKeys.some((key) => hoveredMappingKeys.includes(key))
+                  );
+                  const prefersImageOnlyHighlight =
+                    group.mappingCards.length === 1 &&
+                    group.hasImageSourceRefs &&
+                    !group.hasTextSourceRefs;
+                  const showGroupedSurface = group.showGroupedSurface && !prefersImageOnlyHighlight;
+
+                  return (
+                    <Box key={group.id}>
+                      {showGroupedSurface ? (
+                        <Box
+                          data-testid={`mapping-group-surface-${group.id}`}
+                          data-hovered={isGroupHovered ? 'true' : 'false'}
+                          style={{
+                            border: `1px solid ${
+                              isGroupHovered ? tokens.green600 : tokens.green500
+                            }`,
+                            borderRadius: tokens.borderRadiusMedium,
+                            backgroundColor: 'transparent',
+                            padding: tokens.spacing2Xs,
+                            boxShadow: isGroupHovered
+                              ? `inset 0 0 0 1px ${tokens.green600}`
+                              : undefined,
+                            transition: 'border-color 120ms ease, box-shadow 120ms ease',
+                          }}>
+                          <Flex flexDirection="column" gap="spacing2Xs">
+                            {group.segments.map((segment) => (
+                              <NormalizedDocumentSection
+                                key={segment.id}
+                                segment={segment}
+                                highlightIndex={highlightIndex}
+                                imageById={imageById}
+                                listMarkers={listMarkers}
+                                excludedSourceRefs={entryBlockGraph.excludedSourceRefs}
+                                selectedEntryIndex={selectedEntryIndex}
+                                hoveredMappingKeys={hoveredMappingKeys}
+                                onSetHoveredMappingKeys={setHoveredMappingKeys}
+                                onAssignImage={handleAssignImage}
+                                onExcludeImage={handleExcludeImage}
+                                readOnly
+                                showReadOnlyOutline={
+                                  !showGroupedSurface && !prefersImageOnlyHighlight
+                                }
+                                preferImageReadOnlyHighlight={prefersImageOnlyHighlight}
+                              />
+                            ))}
+                          </Flex>
+                        </Box>
+                      ) : (
+                        <Flex flexDirection="column" gap="spacingS">
+                          {group.segments.map((segment) => (
+                            <NormalizedDocumentSection
+                              key={segment.id}
+                              segment={segment}
+                              highlightIndex={highlightIndex}
+                              imageById={imageById}
+                              listMarkers={listMarkers}
+                              excludedSourceRefs={entryBlockGraph.excludedSourceRefs}
+                              selectedEntryIndex={selectedEntryIndex}
+                              hoveredMappingKeys={hoveredMappingKeys}
+                              onSetHoveredMappingKeys={setHoveredMappingKeys}
+                              onAssignImage={handleAssignImage}
+                              onExcludeImage={handleExcludeImage}
+                              readOnly
+                              showReadOnlyOutline={
+                                !showGroupedSurface && !prefersImageOnlyHighlight
+                              }
+                              preferImageReadOnlyHighlight={prefersImageOnlyHighlight}
+                            />
+                          ))}
+                        </Flex>
+                      )}
+                    </Box>
+                  );
+                };
 
                 return (
-                  <Box key={group.id}>
-                    <Flex
-                      gap="spacingM"
-                      alignItems="stretch"
-                      data-testid={`display-group-layout-${group.id}`}
-                      ref={setGroupLayoutRef(group.id)}>
-                      <Box style={{ flex: 2 }}>
-                        {showGroupedSurface ? (
-                          <Box
-                            data-testid={`mapping-group-surface-${group.id}`}
-                            data-hovered={isGroupHovered ? 'true' : 'false'}
-                            style={{
-                              border: `${isGroupHovered ? 2 : 1}px solid ${
-                                isGroupHovered ? tokens.green600 : tokens.green500
-                              }`,
-                              borderRadius: tokens.borderRadiusMedium,
-                              backgroundColor: 'transparent',
-                              padding: tokens.spacing2Xs,
-                              transition: 'border-color 120ms ease, border-width 120ms ease',
-                            }}>
-                            <Flex flexDirection="column" gap="spacing2Xs">
-                              {group.segments.map((segment) => (
-                                <NormalizedDocumentSection
-                                  key={segment.id}
-                                  segment={segment}
-                                  highlightIndex={highlightIndex}
-                                  imageById={imageById}
-                                  listMarkers={listMarkers}
-                                  excludedSourceRefs={entryBlockGraph.excludedSourceRefs}
-                                  selectedEntryIndex={selectedEntryIndex}
-                                  hoveredMappingKeys={hoveredMappingKeys}
-                                  onSetHoveredMappingKeys={setHoveredMappingKeys}
-                                  onAssignImage={handleAssignImage}
-                                  onExcludeImage={handleExcludeImage}
-                                  readOnly={isReadOnlyAllMappings}
-                                  showReadOnlyOutline={
-                                    !showGroupedSurface && !prefersImageOnlyHighlight
-                                  }
-                                  preferImageReadOnlyHighlight={prefersImageOnlyHighlight}
-                                />
-                              ))}
-                            </Flex>
-                          </Box>
-                        ) : (
-                          <Flex flexDirection="column" gap="spacingS">
+                  <Box key={tab.id}>
+                    {tab.name && (
+                      <Flex alignItems="center" gap="spacingXs">
+                        <FileTextIcon />
+                        <Text fontWeight="fontWeightDemiBold">{tab.name}</Text>
+                      </Flex>
+                    )}
+
+                    <Flex flexDirection="column" gap="spacingS">
+                      {tabGroups.map(renderReviewAllGroup)}
+                    </Flex>
+                  </Box>
+                );
+              })}
+            </Box>
+            <Box
+              style={{
+                flex: '0 0 320px',
+                width: 320,
+                paddingRight: tokens.spacing2Xs,
+                alignSelf: 'flex-start',
+              }}>
+              <MappingEntryCards
+                groupId="review-all"
+                mappingCards={tabs.flatMap((tab) =>
+                  (groupsByTab[tab.id] ?? []).flatMap((group) => group.mappingCards)
+                )}
+                cardOffsetsByGroup={cardOffsetsByGroup}
+                hoveredMappingKeys={hoveredMappingKeys}
+                onSetHoveredMappingKeys={setHoveredMappingKeys}
+                setCardWrapperRef={setCardWrapperRef}
+                showContentTypeName
+                useStaticLayout={false}
+              />
+            </Box>
+          </Flex>
+        ) : (
+          tabs.map((tab) => {
+            const tabGroups = groupsByTab[tab.id] ?? [];
+            const renderGroup = (group: (typeof tabGroups)[number]) => {
+              const isGroupHovered = group.mappingCards.some((card) =>
+                card.mappingKeys.some((key) => hoveredMappingKeys.includes(key))
+              );
+              const prefersImageOnlyHighlight =
+                group.mappingCards.length === 1 &&
+                group.hasImageSourceRefs &&
+                !group.hasTextSourceRefs;
+              const showGroupedSurface = group.showGroupedSurface && !prefersImageOnlyHighlight;
+
+              return (
+                <Box key={group.id}>
+                  <Flex
+                    gap="spacingM"
+                    alignItems="stretch"
+                    data-testid={`display-group-layout-${group.id}`}
+                    ref={setGroupLayoutRef(group.id)}>
+                    <Box style={{ flex: 1 }}>
+                      {showGroupedSurface ? (
+                        <Box
+                          data-testid={`mapping-group-surface-${group.id}`}
+                          data-hovered={isGroupHovered ? 'true' : 'false'}
+                          style={{
+                            border: `1px solid ${
+                              isGroupHovered ? tokens.green600 : tokens.green500
+                            }`,
+                            borderRadius: tokens.borderRadiusMedium,
+                            backgroundColor: 'transparent',
+                            padding: tokens.spacing2Xs,
+                            boxShadow: isGroupHovered
+                              ? `inset 0 0 0 1px ${tokens.green600}`
+                              : undefined,
+                            transition: 'border-color 120ms ease, box-shadow 120ms ease',
+                          }}>
+                          <Flex flexDirection="column" gap="spacing2Xs">
                             {group.segments.map((segment) => (
                               <NormalizedDocumentSection
                                 key={segment.id}
@@ -1106,9 +1278,34 @@ export const MappingView = ({
                               />
                             ))}
                           </Flex>
-                        )}
-                      </Box>
+                        </Box>
+                      ) : (
+                        <Flex flexDirection="column" gap="spacingS">
+                          {group.segments.map((segment) => (
+                            <NormalizedDocumentSection
+                              key={segment.id}
+                              segment={segment}
+                              highlightIndex={highlightIndex}
+                              imageById={imageById}
+                              listMarkers={listMarkers}
+                              excludedSourceRefs={entryBlockGraph.excludedSourceRefs}
+                              selectedEntryIndex={selectedEntryIndex}
+                              hoveredMappingKeys={hoveredMappingKeys}
+                              onSetHoveredMappingKeys={setHoveredMappingKeys}
+                              onAssignImage={handleAssignImage}
+                              onExcludeImage={handleExcludeImage}
+                              readOnly={isReadOnlyAllMappings}
+                              showReadOnlyOutline={
+                                !showGroupedSurface && !prefersImageOnlyHighlight
+                              }
+                              preferImageReadOnlyHighlight={prefersImageOnlyHighlight}
+                            />
+                          ))}
+                        </Flex>
+                      )}
+                    </Box>
 
+                    {!isReadOnlyAllMappings ? (
                       <MappingEntryCards
                         groupId={group.id}
                         mappingCards={group.mappingCards}
@@ -1116,15 +1313,30 @@ export const MappingView = ({
                         hoveredMappingKeys={hoveredMappingKeys}
                         onSetHoveredMappingKeys={setHoveredMappingKeys}
                         setCardWrapperRef={setCardWrapperRef}
-                        showContentTypeName={isReadOnlyAllMappings}
+                        showContentTypeName={false}
                       />
-                    </Flex>
-                  </Box>
-                );
-              })}
-            </Flex>
-          </Box>
-        ))}
+                    ) : null}
+                  </Flex>
+                </Box>
+              );
+            };
+
+            return (
+              <Box key={tab.id}>
+                {tab.name && (
+                  <Flex alignItems="center" gap="spacingXs">
+                    <FileTextIcon />
+                    <Text fontWeight="fontWeightDemiBold">{tab.name}</Text>
+                  </Flex>
+                )}
+
+                <Flex flexDirection="column" gap="spacingS">
+                  {tabGroups.map(renderGroup)}
+                </Flex>
+              </Box>
+            );
+          })
+        )}
       </Flex>
 
       {selectionRectangle && !isDisabled && !isReadOnlyAllMappings ? (

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -1075,7 +1075,9 @@ export const MappingView = ({
                                   onAssignImage={handleAssignImage}
                                   onExcludeImage={handleExcludeImage}
                                   readOnly={isReadOnlyAllMappings}
-                                  showReadOnlyOutline={!showGroupedSurface && !prefersImageOnlyHighlight}
+                                  showReadOnlyOutline={
+                                    !showGroupedSurface && !prefersImageOnlyHighlight
+                                  }
                                   preferImageReadOnlyHighlight={prefersImageOnlyHighlight}
                                 />
                               ))}
@@ -1097,7 +1099,9 @@ export const MappingView = ({
                                 onAssignImage={handleAssignImage}
                                 onExcludeImage={handleExcludeImage}
                                 readOnly={isReadOnlyAllMappings}
-                                showReadOnlyOutline={!showGroupedSurface && !prefersImageOnlyHighlight}
+                                showReadOnlyOutline={
+                                  !showGroupedSurface && !prefersImageOnlyHighlight
+                                }
                                 preferImageReadOnlyHighlight={prefersImageOnlyHighlight}
                               />
                             ))}

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -7,7 +7,7 @@ import {
   type RefCallback,
   type RefObject,
 } from 'react';
-import { Box, Flex, Text } from '@contentful/f36-components';
+import { Box, Flex, Note, Text } from '@contentful/f36-components';
 import tokens from '@contentful/f36-tokens';
 import {
   buildEntryListFromEntryBlockGraph,

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -611,7 +611,7 @@ export const MappingView = ({
             return { key: card.key, rawTop, height };
           });
 
-          nextOffsets['review-all'] = resolveMarkerOffsets(cards, { gap: 4 });
+          nextOffsets['review-all'] = resolveMarkerOffsets(cards, { gap: 8 });
         }
       }
       setCardOffsetsByGroup(nextOffsets);

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -1,5 +1,13 @@
-import { useEffect, useLayoutEffect, useMemo, useRef, useState, type RefCallback } from 'react';
-import { Box, Flex, Note, Text } from '@contentful/f36-components';
+import {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type RefCallback,
+  type RefObject,
+} from 'react';
+import { Box, Flex, Text } from '@contentful/f36-components';
 import tokens from '@contentful/f36-tokens';
 import {
   buildEntryListFromEntryBlockGraph,
@@ -80,6 +88,7 @@ interface MappingViewProps {
   onEntryBlockGraphChange: (next: EntryBlockGraph) => void;
   selectedEntryIndex: number | null;
   isDisabled?: boolean;
+  occludingTopRef?: RefObject<HTMLElement | null>;
 }
 
 const EMPTY_NEW_LOCATION: EditModalNewLocation = {
@@ -126,6 +135,7 @@ export const MappingView = ({
   onEntryBlockGraphChange,
   selectedEntryIndex,
   isDisabled = false,
+  occludingTopRef,
 }: MappingViewProps): JSX.Element => {
   const selectedEntryRow = useMemo(() => {
     const rows = buildEntryListFromEntryBlockGraph(
@@ -199,7 +209,7 @@ export const MappingView = ({
   }, [selectedEntryIndex]);
 
   const { selectionRectangle, selectedText, selectedRange, clearSelection } =
-    useReviewTextSelection(textSelectionRootRef);
+    useReviewTextSelection(textSelectionRootRef, occludingTopRef);
 
   const highlightIndex = useMemo(
     () => buildMappingHighlightIndex(entryBlockGraph, payload.contentTypes),

--- a/apps/google-docs/src/locations/Page/components/review/mapping/NormalizedDocumentSection.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/NormalizedDocumentSection.tsx
@@ -20,6 +20,7 @@ interface ReviewDocumentBodyProps {
   readOnly?: boolean;
   showReadOnlyOutline?: boolean;
   preferImageReadOnlyHighlight?: boolean;
+  suppressInlineHighlights?: boolean;
 }
 
 export const NormalizedDocumentSection = ({
@@ -36,6 +37,7 @@ export const NormalizedDocumentSection = ({
   readOnly = false,
   showReadOnlyOutline = true,
   preferImageReadOnlyHighlight = false,
+  suppressInlineHighlights = false,
 }: ReviewDocumentBodyProps): JSX.Element => {
   return (
     <Box style={{ flex: 2 }}>
@@ -61,6 +63,7 @@ export const NormalizedDocumentSection = ({
               readOnly={readOnly}
               showReadOnlyOutline={showReadOnlyOutline}
               preferImageReadOnlyHighlight={preferImageReadOnlyHighlight}
+              suppressInlineHighlights={suppressInlineHighlights}
             />
           ) : (
             <BlockRenderer
@@ -78,6 +81,7 @@ export const NormalizedDocumentSection = ({
               readOnly={readOnly}
               showReadOnlyOutline={showReadOnlyOutline}
               preferImageReadOnlyHighlight={preferImageReadOnlyHighlight}
+              suppressInlineHighlights={suppressInlineHighlights}
             />
           )}
         </Box>

--- a/apps/google-docs/src/locations/Page/components/review/mapping/NormalizedDocumentSection.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/NormalizedDocumentSection.tsx
@@ -17,6 +17,9 @@ interface ReviewDocumentBodyProps {
   onSetHoveredMappingKeys: (keys: string[]) => void;
   onAssignImage: (sourceRef: ImageSourceRef, label: string) => void;
   onExcludeImage: (sourceRef: ImageSourceRef, label: string) => void;
+  readOnly?: boolean;
+  showReadOnlyOutline?: boolean;
+  preferImageReadOnlyHighlight?: boolean;
 }
 
 export const NormalizedDocumentSection = ({
@@ -30,6 +33,9 @@ export const NormalizedDocumentSection = ({
   onSetHoveredMappingKeys,
   onAssignImage,
   onExcludeImage,
+  readOnly = false,
+  showReadOnlyOutline = true,
+  preferImageReadOnlyHighlight = false,
 }: ReviewDocumentBodyProps): JSX.Element => {
   return (
     <Box style={{ flex: 2 }}>
@@ -52,6 +58,9 @@ export const NormalizedDocumentSection = ({
               onSetHoveredMappingKeys={onSetHoveredMappingKeys}
               onAssignImage={onAssignImage}
               onExcludeImage={onExcludeImage}
+              readOnly={readOnly}
+              showReadOnlyOutline={showReadOnlyOutline}
+              preferImageReadOnlyHighlight={preferImageReadOnlyHighlight}
             />
           ) : (
             <BlockRenderer
@@ -66,6 +75,9 @@ export const NormalizedDocumentSection = ({
               onSetHoveredMappingKeys={onSetHoveredMappingKeys}
               onAssignImage={onAssignImage}
               onExcludeImage={onExcludeImage}
+              readOnly={readOnly}
+              showReadOnlyOutline={showReadOnlyOutline}
+              preferImageReadOnlyHighlight={preferImageReadOnlyHighlight}
             />
           )}
         </Box>

--- a/apps/google-docs/src/locations/Page/components/review/mapping/ReviewImageAssetCard.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/ReviewImageAssetCard.tsx
@@ -12,6 +12,8 @@ export interface ReviewImageAssetCardProps {
   hovered?: boolean;
   isExcluded: boolean;
   size?: 'small' | 'default';
+  readOnly?: boolean;
+  showReadOnlyHighlightBorder?: boolean;
   onMouseEnter?: () => void;
   onMouseLeave?: () => void;
   onAssign: () => void;
@@ -29,6 +31,8 @@ export function ReviewImageAssetCard({
   hovered = false,
   isExcluded,
   size = 'default',
+  readOnly = false,
+  showReadOnlyHighlightBorder = false,
   onMouseEnter,
   onMouseLeave,
   onAssign,
@@ -40,16 +44,15 @@ export function ReviewImageAssetCard({
   const imageHeight = size === 'small' ? '180px' : '280px';
 
   const borderColor =
-    isExcluded && !isHighlighted
-      ? tokens.gray300
-      : !isHighlighted
-      ? tokens.gray300
-      : hovered
-      ? tokens.green600
-      : tokens.green500;
+    isExcluded || !isHighlighted ? tokens.gray300 : hovered ? tokens.green600 : tokens.green500;
+  const showReadOnlyBorder =
+    !readOnly || isExcluded || !isHighlighted || showReadOnlyHighlightBorder;
 
   return (
     <Box
+      data-review-alignment-target={
+        readOnly && isHighlighted && showReadOnlyHighlightBorder ? 'true' : undefined
+      }
       data-testid={`review-image-asset-${buildSourceRefKey(sourceRef)}`}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
@@ -59,8 +62,12 @@ export function ReviewImageAssetCard({
         maxWidth: '100%',
         verticalAlign: 'top',
         borderRadius: tokens.borderRadiusMedium,
-        border: `1px solid ${borderColor}`,
-        backgroundColor: isHighlighted ? tokens.green100 : tokens.gray100,
+        border: showReadOnlyBorder ? `2px solid ${borderColor}` : '2px solid transparent',
+        backgroundColor: isHighlighted
+          ? readOnly
+            ? 'transparent'
+            : tokens.green100
+          : tokens.gray100,
         transition: 'border-color 120ms ease',
         overflow: 'hidden',
         boxSizing: 'border-box',
@@ -68,14 +75,18 @@ export function ReviewImageAssetCard({
       }}>
       <Card
         ariaLabel={title}
-        actions={[
-          <MenuItem key="assigned" onClick={onAssign}>
-            {assignLabel}
-          </MenuItem>,
-          <MenuItem key="exclude" onClick={onExclude} isDisabled={!isHighlighted}>
-            Exclude
-          </MenuItem>,
-        ]}>
+        actions={
+          readOnly
+            ? undefined
+            : [
+                <MenuItem key="assigned" onClick={onAssign}>
+                  {assignLabel}
+                </MenuItem>,
+                <MenuItem key="exclude" onClick={onExclude} isDisabled={!isHighlighted}>
+                  Exclude
+                </MenuItem>,
+              ]
+        }>
         <Splitter />
         <Box padding="spacingS">
           <Image

--- a/apps/google-docs/src/locations/Page/components/review/mapping/buildMappingDisplayGroups.ts
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/buildMappingDisplayGroups.ts
@@ -2,7 +2,6 @@ import { isBlockImageSourceRef, isTableImageSourceRef, isTextSourceRef } from '@
 import type { MappingCardData } from './MappingCard';
 import type { Tab, DocSegment } from './buildDocument';
 import { type MappingHighlight, getMappingCardKey } from './buildHighlights';
-import { formatDisplayName } from './fieldFormatting';
 import { getAnchorIdForSourceRef } from './resolveMappingCardOffsets';
 
 export interface RenderedMappingCard extends MappingCardData {
@@ -137,7 +136,9 @@ function buildDraftMappingCards(
         coverageEnd = Math.max(coverageEnd, highlight.sourceRef.end);
       }
 
-      return isOnlyGroupableSeparators(getTextSliceFromRuns(flattenedRuns, coverageEnd, expectedEnd));
+      return isOnlyGroupableSeparators(
+        getTextSliceFromRuns(flattenedRuns, coverageEnd, expectedEnd)
+      );
     };
 
     highlights.forEach((highlight) => {
@@ -147,9 +148,9 @@ function buildDraftMappingCards(
           key: `${segment.id}:${mappingKey}`,
           fieldIdentity: getFieldIdentity(highlight),
           contentTypeName: resolveContentTypeName(highlight),
-          fieldName: formatDisplayName(highlight.fieldId),
+          fieldName: highlight.fieldName,
           fieldType: resolveFieldTypeLabel(highlight),
-          displayLabel: formatDisplayName(highlight.fieldId),
+          displayLabel: highlight.fieldName,
           anchorId: getAnchorIdForSourceRef(highlight.sourceRef),
           mappingKeys: [mappingKey],
           entryLabel: resolveEntryLabel(highlight),
@@ -193,14 +194,15 @@ function buildDraftMappingCards(
 
           const uniqueFieldIdentities = new Set(partHighlights.map(getFieldIdentity));
           const canGroupPart =
-            part.type === 'text' &&
             uniqueFieldIdentities.size === 1 &&
-            hasFullPartTextCoverage(
-              partHighlights,
-              part.flattenedTextRuns[0]?.start ?? 0,
-              part.flattenedTextRuns,
-              part.flattenedTextRuns[part.flattenedTextRuns.length - 1]?.end ?? 0
-            );
+            (part.type === 'image' ||
+              (part.type === 'text' &&
+                hasFullPartTextCoverage(
+                  partHighlights,
+                  part.flattenedTextRuns[0]?.start ?? 0,
+                  part.flattenedTextRuns,
+                  part.flattenedTextRuns[part.flattenedTextRuns.length - 1]?.end ?? 0
+                )));
 
           if (!canGroupPart) {
             flushCurrentCard();
@@ -211,9 +213,9 @@ function buildDraftMappingCards(
                   key: `${segment.id}:${mappingKey}`,
                   fieldIdentity: getFieldIdentity(highlight),
                   contentTypeName: resolveContentTypeName(highlight),
-                  fieldName: formatDisplayName(highlight.fieldId),
+                  fieldName: highlight.fieldName,
                   fieldType: resolveFieldTypeLabel(highlight),
-                  displayLabel: formatDisplayName(highlight.fieldId),
+                  displayLabel: highlight.fieldName,
                   anchorId: getAnchorIdForSourceRef(highlight.sourceRef),
                   mappingKeys: [mappingKey],
                   entryLabel: resolveEntryLabel(highlight),
@@ -222,6 +224,23 @@ function buildDraftMappingCards(
                     isBlockImageSourceRef(highlight.sourceRef) ||
                     isTableImageSourceRef(highlight.sourceRef),
                 });
+              });
+            } else {
+              const firstHighlight = partHighlights[0];
+              cards.push({
+                key: `${segment.id}:${partKey}:${getFieldIdentity(firstHighlight)}`,
+                fieldIdentity: getFieldIdentity(firstHighlight),
+                contentTypeName: resolveContentTypeName(firstHighlight),
+                fieldName: firstHighlight.fieldName,
+                fieldType: resolveFieldTypeLabel(firstHighlight),
+                displayLabel: firstHighlight.fieldName,
+                anchorId: getAnchorIdForSourceRef(firstHighlight.sourceRef),
+                mappingKeys: uniqueStrings(
+                  partHighlights.map((highlight) => getMappingCardKey(segment.id, highlight))
+                ),
+                entryLabel: resolveEntryLabel(firstHighlight),
+                hasTextSourceRefs: true,
+                hasImageSourceRefs: false,
               });
             }
             return;
@@ -243,9 +262,9 @@ function buildDraftMappingCards(
             key: `${segment.id}:${getMappingCardKey(segment.id, firstHighlight)}`,
             fieldIdentity,
             contentTypeName: resolveContentTypeName(firstHighlight),
-            fieldName: formatDisplayName(firstHighlight.fieldId),
+            fieldName: firstHighlight.fieldName,
             fieldType: resolveFieldTypeLabel(firstHighlight),
-            displayLabel: formatDisplayName(firstHighlight.fieldId),
+            displayLabel: firstHighlight.fieldName,
             anchorId: getAnchorIdForSourceRef(firstHighlight.sourceRef),
             mappingKeys,
             entryLabel: resolveEntryLabel(firstHighlight),
@@ -302,9 +321,9 @@ function buildDraftMappingCards(
     key: `${segment.id}:${fieldIdentity}`,
     fieldIdentity,
     contentTypeName: resolveContentTypeName(value.firstHighlight),
-    fieldName: formatDisplayName(value.firstHighlight.fieldId),
+    fieldName: value.firstHighlight.fieldName,
     fieldType: resolveFieldTypeLabel(value.firstHighlight),
-    displayLabel: formatDisplayName(value.firstHighlight.fieldId),
+    displayLabel: value.firstHighlight.fieldName,
     anchorId: getAnchorIdForSourceRef(value.firstHighlight.sourceRef),
     mappingKeys: uniqueStrings(value.mappingKeys),
     entryLabel: resolveEntryLabel(value.firstHighlight),

--- a/apps/google-docs/src/locations/Page/components/review/mapping/buildMappingDisplayGroups.ts
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/buildMappingDisplayGroups.ts
@@ -1,13 +1,17 @@
-import { isTextSourceRef } from '@types';
+import { isBlockImageSourceRef, isTableImageSourceRef, isTextSourceRef } from '@types';
 import type { MappingCardData } from './MappingCard';
 import type { Tab, DocSegment } from './buildDocument';
 import { type MappingHighlight, getMappingCardKey } from './buildHighlights';
+import { formatDisplayName } from './fieldFormatting';
 import { getAnchorIdForSourceRef } from './resolveMappingCardOffsets';
 
 export interface RenderedMappingCard extends MappingCardData {
   fieldIdentity: string;
   anchorId: string;
   mappingKeys: string[];
+  entryLabel: string;
+  hasTextSourceRefs: boolean;
+  hasImageSourceRefs: boolean;
 }
 
 export interface MappingDisplayGroup {
@@ -15,12 +19,17 @@ export interface MappingDisplayGroup {
   segments: DocSegment[];
   mappingCards: RenderedMappingCard[];
   showGroupedSurface: boolean;
+  hasTextSourceRefs: boolean;
+  hasImageSourceRefs: boolean;
 }
 
 interface DraftMappingCard extends MappingCardData {
   fieldIdentity: string;
   anchorId: string;
   mappingKeys: string[];
+  entryLabel: string;
+  hasTextSourceRefs: boolean;
+  hasImageSourceRefs: boolean;
 }
 
 interface DraftMappingDisplayGroup {
@@ -45,14 +54,226 @@ function uniqueStrings(values: string[]): string[] {
   return Array.from(new Set(values));
 }
 
+const GROUPABLE_SEPARATOR_PATTERN = /^[\s/|,:;()[\]{}\-–—]+$/;
+
+function getTextSliceFromRuns(
+  flattenedRuns: Array<{ start: number; end: number; text: string }>,
+  from: number,
+  to: number
+): string {
+  if (to <= from) {
+    return '';
+  }
+
+  return flattenedRuns
+    .flatMap((run) => {
+      const overlapStart = Math.max(from, run.start);
+      const overlapEnd = Math.min(to, run.end);
+
+      if (overlapEnd <= overlapStart) {
+        return [];
+      }
+
+      return [run.text.slice(overlapStart - run.start, overlapEnd - run.start)];
+    })
+    .join('');
+}
+
+function isOnlyGroupableSeparators(value: string): boolean {
+  return value.length === 0 || GROUPABLE_SEPARATOR_PATTERN.test(value);
+}
+
 function buildDraftMappingCards(
   segment: DocSegment,
   highlights: MappingHighlight[],
-  resolveFieldTypeLabel: (highlight: MappingHighlight) => string
+  resolveFieldTypeLabel: (highlight: MappingHighlight) => string,
+  resolveContentTypeName: (highlight: MappingHighlight) => string,
+  resolveEntryLabel: (highlight: MappingHighlight) => string
 ): DraftMappingCard[] {
+  if (segment.kind === 'table') {
+    const cards: DraftMappingCard[] = [];
+    const highlightsByPartKey = new Map<string, MappingHighlight[]>();
+
+    const hasFullPartTextCoverage = (
+      highlightsForPart: MappingHighlight[],
+      expectedStart: number,
+      flattenedRuns: Array<{ start: number; end: number; text: string }>,
+      expectedEnd: number
+    ): boolean => {
+      const textHighlights = highlightsForPart.filter(
+        (
+          highlight
+        ): highlight is MappingHighlight & {
+          sourceRef: Extract<MappingHighlight['sourceRef'], { start: number; end: number }>;
+        } => isTextSourceRef(highlight.sourceRef)
+      );
+
+      if (!textHighlights.length || textHighlights.length !== highlightsForPart.length) {
+        return false;
+      }
+
+      const sortedHighlights = [...textHighlights].sort(
+        (left, right) => left.sourceRef.start - right.sourceRef.start
+      );
+      let coverageEnd = sortedHighlights[0].sourceRef.end;
+
+      if (
+        !isOnlyGroupableSeparators(
+          getTextSliceFromRuns(flattenedRuns, expectedStart, sortedHighlights[0].sourceRef.start)
+        )
+      ) {
+        return false;
+      }
+
+      for (let index = 1; index < sortedHighlights.length; index += 1) {
+        const highlight = sortedHighlights[index];
+        if (
+          !isOnlyGroupableSeparators(
+            getTextSliceFromRuns(flattenedRuns, coverageEnd, highlight.sourceRef.start)
+          )
+        ) {
+          return false;
+        }
+        coverageEnd = Math.max(coverageEnd, highlight.sourceRef.end);
+      }
+
+      return isOnlyGroupableSeparators(getTextSliceFromRuns(flattenedRuns, coverageEnd, expectedEnd));
+    };
+
+    highlights.forEach((highlight) => {
+      if (!('partId' in highlight.sourceRef)) {
+        const mappingKey = getMappingCardKey(segment.id, highlight);
+        cards.push({
+          key: `${segment.id}:${mappingKey}`,
+          fieldIdentity: getFieldIdentity(highlight),
+          contentTypeName: resolveContentTypeName(highlight),
+          fieldName: formatDisplayName(highlight.fieldId),
+          fieldType: resolveFieldTypeLabel(highlight),
+          displayLabel: formatDisplayName(highlight.fieldId),
+          anchorId: getAnchorIdForSourceRef(highlight.sourceRef),
+          mappingKeys: [mappingKey],
+          entryLabel: resolveEntryLabel(highlight),
+          hasTextSourceRefs: isTextSourceRef(highlight.sourceRef),
+          hasImageSourceRefs:
+            isBlockImageSourceRef(highlight.sourceRef) ||
+            isTableImageSourceRef(highlight.sourceRef),
+        });
+        return;
+      }
+
+      const partKey = [
+        highlight.sourceRef.tableId,
+        highlight.sourceRef.rowId,
+        highlight.sourceRef.cellId,
+        highlight.sourceRef.partId,
+      ].join(':');
+      const existing = highlightsByPartKey.get(partKey) ?? [];
+      existing.push(highlight);
+      highlightsByPartKey.set(partKey, existing);
+    });
+
+    let currentCard: DraftMappingCard | null = null;
+    const flushCurrentCard = () => {
+      if (currentCard) {
+        cards.push(currentCard);
+        currentCard = null;
+      }
+    };
+
+    segment.table.rows.forEach((row) => {
+      row.cells.forEach((cell) => {
+        cell.parts.forEach((part) => {
+          const partKey = [segment.table.id, row.id, cell.id, part.id].join(':');
+          const partHighlights = highlightsByPartKey.get(partKey) ?? [];
+
+          if (!partHighlights.length) {
+            flushCurrentCard();
+            return;
+          }
+
+          const uniqueFieldIdentities = new Set(partHighlights.map(getFieldIdentity));
+          const canGroupPart =
+            part.type === 'text' &&
+            uniqueFieldIdentities.size === 1 &&
+            hasFullPartTextCoverage(
+              partHighlights,
+              part.flattenedTextRuns[0]?.start ?? 0,
+              part.flattenedTextRuns,
+              part.flattenedTextRuns[part.flattenedTextRuns.length - 1]?.end ?? 0
+            );
+
+          if (!canGroupPart) {
+            flushCurrentCard();
+            if (part.type !== 'text') {
+              partHighlights.forEach((highlight) => {
+                const mappingKey = getMappingCardKey(segment.id, highlight);
+                cards.push({
+                  key: `${segment.id}:${mappingKey}`,
+                  fieldIdentity: getFieldIdentity(highlight),
+                  contentTypeName: resolveContentTypeName(highlight),
+                  fieldName: formatDisplayName(highlight.fieldId),
+                  fieldType: resolveFieldTypeLabel(highlight),
+                  displayLabel: formatDisplayName(highlight.fieldId),
+                  anchorId: getAnchorIdForSourceRef(highlight.sourceRef),
+                  mappingKeys: [mappingKey],
+                  entryLabel: resolveEntryLabel(highlight),
+                  hasTextSourceRefs: isTextSourceRef(highlight.sourceRef),
+                  hasImageSourceRefs:
+                    isBlockImageSourceRef(highlight.sourceRef) ||
+                    isTableImageSourceRef(highlight.sourceRef),
+                });
+              });
+            }
+            return;
+          }
+
+          const firstHighlight = partHighlights[0];
+          const fieldIdentity = getFieldIdentity(firstHighlight);
+          const mappingKeys = uniqueStrings(
+            partHighlights.map((highlight) => getMappingCardKey(segment.id, highlight))
+          );
+
+          if (currentCard?.fieldIdentity === fieldIdentity) {
+            currentCard.mappingKeys = uniqueStrings([...currentCard.mappingKeys, ...mappingKeys]);
+            return;
+          }
+
+          flushCurrentCard();
+          currentCard = {
+            key: `${segment.id}:${getMappingCardKey(segment.id, firstHighlight)}`,
+            fieldIdentity,
+            contentTypeName: resolveContentTypeName(firstHighlight),
+            fieldName: formatDisplayName(firstHighlight.fieldId),
+            fieldType: resolveFieldTypeLabel(firstHighlight),
+            displayLabel: formatDisplayName(firstHighlight.fieldId),
+            anchorId: getAnchorIdForSourceRef(firstHighlight.sourceRef),
+            mappingKeys,
+            entryLabel: resolveEntryLabel(firstHighlight),
+            hasTextSourceRefs: partHighlights.some((highlight) =>
+              isTextSourceRef(highlight.sourceRef)
+            ),
+            hasImageSourceRefs: partHighlights.some(
+              (highlight) =>
+                isBlockImageSourceRef(highlight.sourceRef) ||
+                isTableImageSourceRef(highlight.sourceRef)
+            ),
+          };
+        });
+      });
+    });
+
+    flushCurrentCard();
+    return cards;
+  }
+
   const byFieldIdentity = new Map<
     string,
-    { firstHighlight: MappingHighlight; mappingKeys: string[] }
+    {
+      firstHighlight: MappingHighlight;
+      mappingKeys: string[];
+      hasTextSourceRefs: boolean;
+      hasImageSourceRefs: boolean;
+    }
   >();
 
   highlights.forEach((highlight) => {
@@ -62,27 +283,34 @@ function buildDraftMappingCards(
 
     if (existing) {
       existing.mappingKeys.push(mappingKey);
+      existing.hasTextSourceRefs ||= isTextSourceRef(highlight.sourceRef);
+      existing.hasImageSourceRefs ||=
+        isBlockImageSourceRef(highlight.sourceRef) || isTableImageSourceRef(highlight.sourceRef);
       return;
     }
 
     byFieldIdentity.set(fieldIdentity, {
       firstHighlight: highlight,
       mappingKeys: [mappingKey],
+      hasTextSourceRefs: isTextSourceRef(highlight.sourceRef),
+      hasImageSourceRefs:
+        isBlockImageSourceRef(highlight.sourceRef) || isTableImageSourceRef(highlight.sourceRef),
     });
   });
 
-  return Array.from(byFieldIdentity.entries()).map(([fieldIdentity, value]) => {
-    const fieldName = value.firstHighlight.fieldName;
-
-    return {
-      key: `${segment.id}:${fieldIdentity}`,
-      fieldIdentity,
-      fieldName,
-      fieldType: resolveFieldTypeLabel(value.firstHighlight),
-      anchorId: getAnchorIdForSourceRef(value.firstHighlight.sourceRef),
-      mappingKeys: uniqueStrings(value.mappingKeys),
-    };
-  });
+  return Array.from(byFieldIdentity.entries()).map(([fieldIdentity, value]) => ({
+    key: `${segment.id}:${fieldIdentity}`,
+    fieldIdentity,
+    contentTypeName: resolveContentTypeName(value.firstHighlight),
+    fieldName: formatDisplayName(value.firstHighlight.fieldId),
+    fieldType: resolveFieldTypeLabel(value.firstHighlight),
+    displayLabel: formatDisplayName(value.firstHighlight.fieldId),
+    anchorId: getAnchorIdForSourceRef(value.firstHighlight.sourceRef),
+    mappingKeys: uniqueStrings(value.mappingKeys),
+    entryLabel: resolveEntryLabel(value.firstHighlight),
+    hasTextSourceRefs: value.hasTextSourceRefs,
+    hasImageSourceRefs: value.hasImageSourceRefs,
+  }));
 }
 
 function getBlockBoundaryCoverage(
@@ -119,15 +347,23 @@ function buildDraftGroupsForTab(
   tab: Tab,
   visibleHighlightsBySegment: Record<string, MappingHighlight[]>,
   nextGroupIndex: { current: number },
-  resolveFieldTypeLabel: (highlight: MappingHighlight) => string
+  resolveFieldTypeLabel: (highlight: MappingHighlight) => string,
+  resolveContentTypeName: (highlight: MappingHighlight) => string,
+  resolveEntryLabel: (highlight: MappingHighlight) => string
 ): DraftMappingDisplayGroup[] {
   const groups: DraftMappingDisplayGroup[] = [];
 
   tab.segments.forEach((segment) => {
     const highlights = visibleHighlightsBySegment[segment.id] ?? [];
-    const mappingCards = buildDraftMappingCards(segment, highlights, resolveFieldTypeLabel);
+    const mappingCards = buildDraftMappingCards(
+      segment,
+      highlights,
+      resolveFieldTypeLabel,
+      resolveContentTypeName,
+      resolveEntryLabel
+    );
     const { startsAtBoundary, endsAtBoundary } =
-      segment.kind === 'block' && mappingCards.length === 1
+      segment.kind === 'block' && segment.block.type !== 'heading' && mappingCards.length === 1
         ? getBlockBoundaryCoverage(segment, highlights, mappingCards[0].fieldIdentity)
         : { startsAtBoundary: false, endsAtBoundary: false };
     const mergeFieldIdentity =
@@ -174,7 +410,9 @@ function buildDraftGroupsForTab(
 export function buildMappingDisplayGroups(
   tabs: Tab[],
   visibleHighlightsBySegment: Record<string, MappingHighlight[]>,
-  resolveFieldTypeLabel: (highlight: MappingHighlight) => string
+  resolveFieldTypeLabel: (highlight: MappingHighlight) => string,
+  resolveContentTypeName: (highlight: MappingHighlight) => string,
+  resolveEntryLabel: (highlight: MappingHighlight) => string
 ): MappingDisplayGroupsResult {
   const groupsByTabDraft: Record<string, DraftMappingDisplayGroup[]> = {};
   const nextGroupIndex = { current: 0 };
@@ -184,7 +422,9 @@ export function buildMappingDisplayGroups(
       tab,
       visibleHighlightsBySegment,
       nextGroupIndex,
-      resolveFieldTypeLabel
+      resolveFieldTypeLabel,
+      resolveContentTypeName,
+      resolveEntryLabel
     );
   });
 
@@ -206,6 +446,8 @@ export function buildMappingDisplayGroups(
     segments: group.segments,
     showGroupedSurface:
       group.segments.length > 1 || (group.startsAtBoundary && group.endsAtBoundary),
+    hasTextSourceRefs: group.mappingCards.some((card) => card.hasTextSourceRefs),
+    hasImageSourceRefs: group.mappingCards.some((card) => card.hasImageSourceRefs),
     mappingCards: group.mappingCards.map((card) => {
       const nextPosition = (positionByFieldIdentity.get(card.fieldIdentity) ?? 0) + 1;
       positionByFieldIdentity.set(card.fieldIdentity, nextPosition);
@@ -213,7 +455,7 @@ export function buildMappingDisplayGroups(
 
       return {
         ...card,
-        fieldName: total > 1 ? `${card.fieldName} (${nextPosition}/${total})` : card.fieldName,
+        displayLabel: total > 1 ? `${card.fieldName} (${nextPosition}/${total})` : card.fieldName,
       };
     }),
   });

--- a/apps/google-docs/src/locations/Page/components/review/mapping/buildTextSegments.ts
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/buildTextSegments.ts
@@ -37,7 +37,7 @@ export function buildTextSegments(
 
   const sortedBoundaries = [...boundaries].sort((a, b) => a - b);
 
-  return sortedBoundaries.flatMap((start, index) => {
+  const rawSegments = sortedBoundaries.flatMap((start, index) => {
     const end = sortedBoundaries[index + 1];
     if (end === undefined || start === end) return [];
 
@@ -55,4 +55,27 @@ export function buildTextSegments(
       { start, end, text, styles: run.styles, highlighted: mappingKeys.length > 0, mappingKeys },
     ];
   });
+
+  return rawSegments.reduce<TextSegment[]>((segments, segment) => {
+    const previousSegment = segments[segments.length - 1];
+    const sameStyles =
+      JSON.stringify(previousSegment?.styles ?? null) === JSON.stringify(segment.styles ?? null);
+    const sameMappings =
+      JSON.stringify(previousSegment?.mappingKeys ?? []) === JSON.stringify(segment.mappingKeys);
+
+    if (
+      previousSegment &&
+      previousSegment.end === segment.start &&
+      previousSegment.highlighted === segment.highlighted &&
+      sameMappings &&
+      sameStyles
+    ) {
+      previousSegment.end = segment.end;
+      previousSegment.text += segment.text;
+      return segments;
+    }
+
+    segments.push({ ...segment, mappingKeys: [...segment.mappingKeys] });
+    return segments;
+  }, []);
 }

--- a/apps/google-docs/src/locations/Page/components/review/mapping/documentRenderers.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/documentRenderers.tsx
@@ -84,13 +84,15 @@ function getHighlightStyle(highlighted: boolean, hovered: boolean, readOnly = fa
   if (!highlighted) return { border: 'transparent', background: 'transparent' };
   if (readOnly) {
     return {
-      border: 'transparent',
+      border: hovered ? tokens.green600 : tokens.green500,
       background: 'transparent',
+      boxShadow: hovered ? `inset 0 0 0 1px ${tokens.green600}` : undefined,
     };
   }
   return {
-    border: 'transparent',
-    background: hovered ? tokens.green300 : tokens.green200,
+    border: hovered ? tokens.green600 : tokens.green500,
+    background: tokens.green100,
+    boxShadow: hovered ? `inset 0 0 0 1px ${tokens.green600}` : undefined,
   };
 }
 
@@ -171,6 +173,10 @@ const TextSegmentSpan = ({
           segment.highlighted && highlightStyle.border !== 'transparent'
             ? `1px solid ${highlightStyle.border}`
             : undefined,
+        boxShadow:
+          segment.highlighted && highlightStyle.border !== 'transparent'
+            ? highlightStyle.boxShadow
+            : undefined,
         borderRadius: segment.highlighted ? tokens.borderRadiusSmall : undefined,
         paddingInline:
           segment.highlighted && highlightStyle.border !== 'transparent'
@@ -218,6 +224,7 @@ interface BlockRendererProps {
   readOnly?: boolean;
   showReadOnlyOutline?: boolean;
   preferImageReadOnlyHighlight?: boolean;
+  suppressInlineHighlights?: boolean;
 }
 
 export const BlockRenderer = ({
@@ -235,6 +242,7 @@ export const BlockRenderer = ({
   readOnly = false,
   showReadOnlyOutline = true,
   preferImageReadOnlyHighlight = false,
+  suppressInlineHighlights = false,
 }: BlockRendererProps) => {
   const visibleHighlights = filterByEntry(
     highlightIndex.blockHighlights[block.id] ?? [],
@@ -266,6 +274,9 @@ export const BlockRenderer = ({
           rangeEnd={seg.end}
           blockId={block.id}
           readOnly={readOnly}
+          suppressInlineHighlight={
+            suppressInlineHighlights || (readOnly && showReadOnlyOutline && hasVisibleTextMappings)
+          }
         />
       ))}
     </Text>
@@ -409,6 +420,7 @@ interface TableRendererProps {
   readOnly?: boolean;
   showReadOnlyOutline?: boolean;
   preferImageReadOnlyHighlight?: boolean;
+  suppressInlineHighlights?: boolean;
 }
 
 interface TablePartRendererProps {
@@ -453,6 +465,12 @@ const TablePartRenderer = ({
   );
   const hasVisibleMappings = partMappingKeys.length > 0;
   const isPartHovered = isMappingHovered(partMappingKeys, hoveredMappingKeys);
+  const showEditModeFullSurface =
+    !readOnly &&
+    suppressInlineHighlights &&
+    showReadOnlyOutline &&
+    part.type === 'text' &&
+    hasVisibleMappings;
 
   if (part.type === 'image') {
     const image = imageById[part.imageId];
@@ -516,9 +534,7 @@ const TablePartRenderer = ({
     <Box
       as="span"
       id={anchorId}
-      data-review-alignment-target={
-        readOnly && showReadOnlyOutline && hasVisibleMappings ? 'true' : undefined
-      }
+      data-review-alignment-target={showReadOnlyOutline && hasVisibleMappings ? 'true' : undefined}
       onMouseEnter={
         readOnly && partMappingKeys.length > 0
           ? () => onSetHoveredMappingKeys(partMappingKeys)
@@ -530,11 +546,11 @@ const TablePartRenderer = ({
       style={{
         whiteSpace: 'pre-wrap',
         display: 'inline-block',
-        ...(readOnly && showReadOnlyOutline && hasVisibleMappings
+        ...((readOnly && showReadOnlyOutline && hasVisibleMappings) || showEditModeFullSurface
           ? {
               border: `1px solid ${isPartHovered ? tokens.green600 : tokens.green500}`,
               borderRadius: tokens.borderRadiusMedium,
-              backgroundColor: 'transparent',
+              backgroundColor: readOnly ? 'transparent' : tokens.green100,
               padding: tokens.spacingXs,
               boxShadow: isPartHovered ? `inset 0 0 0 1px ${tokens.green600}` : undefined,
               transition: 'border-color 120ms ease, box-shadow 120ms ease',
@@ -556,7 +572,9 @@ const TablePartRenderer = ({
           cellId={cellId}
           partId={part.id}
           readOnly={readOnly}
-          suppressInlineHighlight={suppressInlineHighlights}
+          suppressInlineHighlight={
+            suppressInlineHighlights || (readOnly && showReadOnlyOutline && hasVisibleMappings)
+          }
         />
       ))}
     </Box>
@@ -577,6 +595,7 @@ export const TableRenderer = ({
   readOnly = false,
   showReadOnlyOutline = true,
   preferImageReadOnlyHighlight = false,
+  suppressInlineHighlights = false,
 }: TableRendererProps) => {
   const getVisiblePartHighlights = (partKey: string) =>
     filterByEntry(highlightIndex.tablePartHighlights[partKey] ?? [], selectedEntryIndex);
@@ -638,13 +657,13 @@ export const TableRenderer = ({
     part: NormalizedDocumentTablePart,
     highlights: MappingHighlight[]
   ) => {
-    if (part.type !== 'text') {
-      return null;
-    }
-
     const uniqueFieldIdentities = new Set(highlights.map(getFieldIdentity));
     if (uniqueFieldIdentities.size !== 1) {
       return null;
+    }
+
+    if (part.type === 'image') {
+      return Array.from(uniqueFieldIdentities)[0];
     }
 
     return hasFullPartTextCoverage(part, highlights) ? Array.from(uniqueFieldIdentities)[0] : null;
@@ -836,6 +855,11 @@ export const TableRenderer = ({
                               chunk.part.type === 'text'
                                 ? showReadOnlyOutline && chunk.hasFullPartCoverage
                                 : showReadOnlyOutline
+                            }
+                            suppressInlineHighlights={
+                              chunk.part.type === 'text' &&
+                              chunk.hasFullPartCoverage &&
+                              (suppressInlineHighlights || !readOnly)
                             }
                           />
                         </Box>

--- a/apps/google-docs/src/locations/Page/components/review/mapping/documentRenderers.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/documentRenderers.tsx
@@ -591,7 +591,10 @@ export const TableRenderer = ({
     return coverageEnd >= partEnd;
   };
 
-  const getPartFieldIdentity = (part: NormalizedDocumentTablePart, highlights: MappingHighlight[]) => {
+  const getPartFieldIdentity = (
+    part: NormalizedDocumentTablePart,
+    highlights: MappingHighlight[]
+  ) => {
     if (part.type !== 'text') {
       return null;
     }
@@ -661,7 +664,10 @@ export const TableRenderer = ({
                     getMappingCardKey(segmentId, highlight)
                   );
 
-                  if (currentGroup && currentGroup.parts[0]?.fieldIdentity === partState.fieldIdentity) {
+                  if (
+                    currentGroup &&
+                    currentGroup.parts[0]?.fieldIdentity === partState.fieldIdentity
+                  ) {
                     currentGroup.parts.push(partState);
                     currentGroup.mappingKeys = uniqueStrings([
                       ...currentGroup.mappingKeys,
@@ -711,7 +717,9 @@ export const TableRenderer = ({
                             onMouseEnter={() => onSetHoveredMappingKeys(chunk.mappingKeys)}
                             onMouseLeave={() => onSetHoveredMappingKeys([])}
                             style={{
-                              border: `1px solid ${isChunkHovered ? tokens.green600 : tokens.green500}`,
+                              border: `1px solid ${
+                                isChunkHovered ? tokens.green600 : tokens.green500
+                              }`,
                               borderRadius: tokens.borderRadiusMedium,
                               backgroundColor: readOnly ? 'transparent' : tokens.green100,
                               padding: tokens.spacingXs,

--- a/apps/google-docs/src/locations/Page/components/review/mapping/documentRenderers.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/documentRenderers.tsx
@@ -239,7 +239,9 @@ export const BlockRenderer = ({
           ? () => onSetHoveredMappingKeys(blockMappingKeys)
           : undefined
       }
-      onMouseLeave={readOnly && blockMappingKeys.length > 0 ? () => onSetHoveredMappingKeys([]) : undefined}
+      onMouseLeave={
+        readOnly && blockMappingKeys.length > 0 ? () => onSetHoveredMappingKeys([]) : undefined
+      }
       style={
         readOnly && showReadOnlyOutline && hasVisibleTextMappings
           ? {
@@ -475,7 +477,9 @@ const TablePartRenderer = ({
           ? () => onSetHoveredMappingKeys(partMappingKeys)
           : undefined
       }
-      onMouseLeave={readOnly && partMappingKeys.length > 0 ? () => onSetHoveredMappingKeys([]) : undefined}
+      onMouseLeave={
+        readOnly && partMappingKeys.length > 0 ? () => onSetHoveredMappingKeys([]) : undefined
+      }
       style={{
         whiteSpace: 'pre-wrap',
         display: 'inline-block',

--- a/apps/google-docs/src/locations/Page/components/review/mapping/documentRenderers.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/documentRenderers.tsx
@@ -42,6 +42,14 @@ function isMappingHovered(keys: string[], hoveredMappingKeys: string[]): boolean
   return keys.some((k) => hoveredMappingKeys.includes(k));
 }
 
+function getFieldIdentity(highlight: MappingHighlight): string {
+  return `${highlight.entryIndex}|${highlight.fieldId}|${highlight.fieldType}`;
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return Array.from(new Set(values));
+}
+
 function getHighlightStyle(highlighted: boolean, hovered: boolean, readOnly = false) {
   if (!highlighted) return { border: 'transparent', background: 'transparent' };
   if (readOnly) {
@@ -85,6 +93,7 @@ interface TextSegmentSpanProps {
   cellId?: string;
   partId?: string;
   readOnly?: boolean;
+  suppressInlineHighlight?: boolean;
 }
 
 const TextSegmentSpan = ({
@@ -101,8 +110,11 @@ const TextSegmentSpan = ({
   cellId,
   partId,
   readOnly = false,
+  suppressInlineHighlight = false,
 }: TextSegmentSpanProps) => {
-  const highlightStyle = getHighlightStyle(segment.highlighted, hovered, readOnly);
+  const highlightStyle = suppressInlineHighlight
+    ? { border: 'transparent', background: 'transparent' }
+    : getHighlightStyle(segment.highlighted, hovered, readOnly);
   const content = (
     <Box
       as="span"
@@ -384,6 +396,7 @@ interface TablePartRendererProps {
   onExcludeImage: TableRendererProps['onExcludeImage'];
   readOnly?: boolean;
   showReadOnlyOutline?: boolean;
+  suppressInlineHighlights?: boolean;
 }
 
 const TablePartRenderer = ({
@@ -401,6 +414,7 @@ const TablePartRenderer = ({
   onExcludeImage,
   readOnly = false,
   showReadOnlyOutline = true,
+  suppressInlineHighlights = false,
 }: TablePartRendererProps) => {
   const partMappingKeys = visibleHighlights.map((highlight) =>
     getMappingCardKey(segmentId, highlight)
@@ -509,6 +523,7 @@ const TablePartRenderer = ({
           cellId={cellId}
           partId={part.id}
           readOnly={readOnly}
+          suppressInlineHighlight={suppressInlineHighlights}
         />
       ))}
     </Box>
@@ -533,6 +548,62 @@ export const TableRenderer = ({
   const getVisiblePartHighlights = (partKey: string) =>
     filterByEntry(highlightIndex.tablePartHighlights[partKey] ?? [], selectedEntryIndex);
 
+  const hasFullPartTextCoverage = (
+    part: Extract<NormalizedDocumentTablePart, { type: 'text' }>,
+    highlights: MappingHighlight[]
+  ) => {
+    const textHighlights = highlights.filter(
+      (
+        highlight
+      ): highlight is MappingHighlight & {
+        sourceRef: Extract<MappingHighlight['sourceRef'], { start: number; end: number }>;
+      } => isTextSourceRef(highlight.sourceRef)
+    );
+
+    if (!textHighlights.length || textHighlights.length !== highlights.length) {
+      return false;
+    }
+
+    const partStart = part.flattenedTextRuns[0]?.start;
+    const partEnd = part.flattenedTextRuns[part.flattenedTextRuns.length - 1]?.end;
+
+    if (!Number.isFinite(partStart) || !Number.isFinite(partEnd)) {
+      return false;
+    }
+
+    const sortedHighlights = [...textHighlights].sort(
+      (left, right) => left.sourceRef.start - right.sourceRef.start
+    );
+    let coverageEnd = sortedHighlights[0].sourceRef.end;
+
+    if (sortedHighlights[0].sourceRef.start > partStart) {
+      return false;
+    }
+
+    for (let index = 1; index < sortedHighlights.length; index += 1) {
+      const highlight = sortedHighlights[index];
+      if (highlight.sourceRef.start > coverageEnd) {
+        return false;
+      }
+      coverageEnd = Math.max(coverageEnd, highlight.sourceRef.end);
+    }
+
+    return coverageEnd >= partEnd;
+  };
+
+  const getPartFieldIdentity = (part: NormalizedDocumentTablePart, highlights: MappingHighlight[]) => {
+    if (part.type !== 'text') {
+      return null;
+    }
+
+    const uniqueFieldIdentities = new Set(highlights.map(getFieldIdentity));
+    if (uniqueFieldIdentities.size !== 1) {
+      return null;
+    }
+
+    return hasFullPartTextCoverage(part, highlights) ? Array.from(uniqueFieldIdentities)[0] : null;
+  };
+
   return (
     <Table>
       {table.headers.length > 0 && (
@@ -550,38 +621,157 @@ export const TableRenderer = ({
             key={row.id}
             id={`row:${table.id}:${row.id}`}
             data-testid={`table-row-${row.id}`}>
-            {row.cells.map((cell) => (
-              <TableCell
-                key={cell.id}
-                data-testid={`table-cell-${cell.id}`}
-                style={{ backgroundColor: 'transparent', verticalAlign: 'top' }}>
-                <Flex flexDirection="column" gap="spacing2Xs">
-                  {cell.parts.map((part) => {
-                    const partKey = [table.id, row.id, cell.id, part.id].join(':');
-                    return (
-                      <Box key={part.id}>
-                        <TablePartRenderer
-                          segmentId={segmentId}
-                          tableId={table.id}
-                          rowId={row.id}
-                          cellId={cell.id}
-                          part={part}
-                          visibleHighlights={getVisiblePartHighlights(partKey)}
-                          imageById={imageById}
-                          excludedSourceRefs={excludedSourceRefs}
-                          hoveredMappingKeys={hoveredMappingKeys}
-                          onSetHoveredMappingKeys={onSetHoveredMappingKeys}
-                          onAssignImage={onAssignImage}
-                          onExcludeImage={onExcludeImage}
-                          readOnly={readOnly}
-                          showReadOnlyOutline={showReadOnlyOutline}
-                        />
-                      </Box>
-                    );
-                  })}
-                </Flex>
-              </TableCell>
-            ))}
+            {row.cells.map((cell) => {
+              const partHighlightsByKey = cell.parts.map((part) => {
+                const partKey = [table.id, row.id, cell.id, part.id].join(':');
+                return {
+                  part,
+                  highlights: getVisiblePartHighlights(partKey),
+                  fieldIdentity: getPartFieldIdentity(part, getVisiblePartHighlights(partKey)),
+                };
+              });
+
+              type CellChunk =
+                | {
+                    kind: 'group';
+                    id: string;
+                    parts: Array<(typeof partHighlightsByKey)[number]>;
+                    mappingKeys: string[];
+                  }
+                | {
+                    kind: 'part';
+                    id: string;
+                    part: (typeof partHighlightsByKey)[number]['part'];
+                    highlights: MappingHighlight[];
+                  };
+
+              const chunks: CellChunk[] = [];
+              let currentGroup: Extract<CellChunk, { kind: 'group' }> | null = null;
+
+              const flushCurrentGroup = () => {
+                if (currentGroup) {
+                  chunks.push(currentGroup);
+                  currentGroup = null;
+                }
+              };
+
+              partHighlightsByKey.forEach((partState) => {
+                if (partState.fieldIdentity) {
+                  const mappingKeys = partState.highlights.map((highlight) =>
+                    getMappingCardKey(segmentId, highlight)
+                  );
+
+                  if (currentGroup && currentGroup.parts[0]?.fieldIdentity === partState.fieldIdentity) {
+                    currentGroup.parts.push(partState);
+                    currentGroup.mappingKeys = uniqueStrings([
+                      ...currentGroup.mappingKeys,
+                      ...mappingKeys,
+                    ]);
+                    return;
+                  }
+
+                  flushCurrentGroup();
+                  currentGroup = {
+                    kind: 'group',
+                    id: `${cell.id}:${partState.part.id}:${partState.fieldIdentity}`,
+                    parts: [partState],
+                    mappingKeys,
+                  };
+                  return;
+                }
+
+                flushCurrentGroup();
+                chunks.push({
+                  kind: 'part',
+                  id: `${cell.id}:${partState.part.id}`,
+                  part: partState.part,
+                  highlights: partState.highlights,
+                });
+              });
+
+              flushCurrentGroup();
+
+              return (
+                <TableCell
+                  key={cell.id}
+                  data-testid={`table-cell-${cell.id}`}
+                  style={{ backgroundColor: 'transparent', verticalAlign: 'top' }}>
+                  <Flex flexDirection="column" gap="spacing2Xs">
+                    {chunks.map((chunk) => {
+                      if (chunk.kind === 'group') {
+                        const isChunkHovered = isMappingHovered(
+                          chunk.mappingKeys,
+                          hoveredMappingKeys
+                        );
+
+                        return (
+                          <Box
+                            key={chunk.id}
+                            data-review-alignment-target={readOnly ? 'true' : undefined}
+                            onMouseEnter={() => onSetHoveredMappingKeys(chunk.mappingKeys)}
+                            onMouseLeave={() => onSetHoveredMappingKeys([])}
+                            style={{
+                              border: `1px solid ${isChunkHovered ? tokens.green600 : tokens.green500}`,
+                              borderRadius: tokens.borderRadiusMedium,
+                              backgroundColor: readOnly ? 'transparent' : tokens.green100,
+                              padding: tokens.spacingXs,
+                              boxShadow: isChunkHovered
+                                ? `inset 0 0 0 1px ${tokens.green600}`
+                                : undefined,
+                              transition: 'border-color 120ms ease, box-shadow 120ms ease',
+                            }}>
+                            <Flex flexDirection="column" gap="spacing2Xs">
+                              {chunk.parts.map((partState) => (
+                                <Box key={partState.part.id}>
+                                  <TablePartRenderer
+                                    segmentId={segmentId}
+                                    tableId={table.id}
+                                    rowId={row.id}
+                                    cellId={cell.id}
+                                    part={partState.part}
+                                    visibleHighlights={partState.highlights}
+                                    imageById={imageById}
+                                    excludedSourceRefs={excludedSourceRefs}
+                                    hoveredMappingKeys={hoveredMappingKeys}
+                                    onSetHoveredMappingKeys={onSetHoveredMappingKeys}
+                                    onAssignImage={onAssignImage}
+                                    onExcludeImage={onExcludeImage}
+                                    readOnly={readOnly}
+                                    showReadOnlyOutline={false}
+                                    suppressInlineHighlights
+                                  />
+                                </Box>
+                              ))}
+                            </Flex>
+                          </Box>
+                        );
+                      }
+
+                      return (
+                        <Box key={chunk.id}>
+                          <TablePartRenderer
+                            segmentId={segmentId}
+                            tableId={table.id}
+                            rowId={row.id}
+                            cellId={cell.id}
+                            part={chunk.part}
+                            visibleHighlights={chunk.highlights}
+                            imageById={imageById}
+                            excludedSourceRefs={excludedSourceRefs}
+                            hoveredMappingKeys={hoveredMappingKeys}
+                            onSetHoveredMappingKeys={onSetHoveredMappingKeys}
+                            onAssignImage={onAssignImage}
+                            onExcludeImage={onExcludeImage}
+                            readOnly={readOnly}
+                            showReadOnlyOutline={showReadOnlyOutline}
+                          />
+                        </Box>
+                      );
+                    })}
+                  </Flex>
+                </TableCell>
+              );
+            })}
           </TableRow>
         ))}
       </TableBody>

--- a/apps/google-docs/src/locations/Page/components/review/mapping/documentRenderers.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/documentRenderers.tsx
@@ -17,8 +17,9 @@ import type {
   NormalizedDocumentTable,
   NormalizedDocumentTablePart,
   SourceRef,
+  TextSourceRef,
 } from '@types';
-import { isBlockImageSourceRef, isTableImageSourceRef } from '@types';
+import { isBlockImageSourceRef, isTableImageSourceRef, isTextSourceRef } from '@types';
 import type { MappingHighlight, MappingHighlightIndex } from './buildHighlights';
 import { getMappingCardKey } from './buildHighlights';
 import type { ListMarker } from './buildListMarkers';
@@ -41,10 +42,16 @@ function isMappingHovered(keys: string[], hoveredMappingKeys: string[]): boolean
   return keys.some((k) => hoveredMappingKeys.includes(k));
 }
 
-function getHighlightStyle(highlighted: boolean, hovered: boolean) {
-  if (!highlighted) return { border: tokens.gray300, background: 'transparent' };
+function getHighlightStyle(highlighted: boolean, hovered: boolean, readOnly = false) {
+  if (!highlighted) return { border: 'transparent', background: 'transparent' };
+  if (readOnly) {
+    return {
+      border: 'transparent',
+      background: 'transparent',
+    };
+  }
   return {
-    border: hovered ? tokens.green600 : tokens.green500,
+    border: 'transparent',
     background: hovered ? tokens.green300 : tokens.green200,
   };
 }
@@ -77,6 +84,7 @@ interface TextSegmentSpanProps {
   rowId?: string;
   cellId?: string;
   partId?: string;
+  readOnly?: boolean;
 }
 
 const TextSegmentSpan = ({
@@ -92,7 +100,9 @@ const TextSegmentSpan = ({
   rowId,
   cellId,
   partId,
+  readOnly = false,
 }: TextSegmentSpanProps) => {
+  const highlightStyle = getHighlightStyle(segment.highlighted, hovered, readOnly);
   const content = (
     <Box
       as="span"
@@ -114,10 +124,20 @@ const TextSegmentSpan = ({
       onMouseLeave={segment.highlighted ? () => onSetHoveredMappings([]) : undefined}
       style={{
         ...getTextSegmentStyle(segment.styles),
-        backgroundColor: getHighlightStyle(segment.highlighted, hovered).background,
+        backgroundColor: highlightStyle.background,
+        border:
+          segment.highlighted && highlightStyle.border !== 'transparent'
+            ? `1px solid ${highlightStyle.border}`
+            : undefined,
         borderRadius: segment.highlighted ? tokens.borderRadiusSmall : undefined,
+        paddingInline:
+          segment.highlighted && highlightStyle.border !== 'transparent'
+            ? tokens.spacing2Xs
+            : undefined,
+        paddingBlock:
+          segment.highlighted && highlightStyle.border !== 'transparent' ? '1px' : undefined,
         whiteSpace: 'pre-wrap',
-        transition: 'background-color 120ms ease',
+        transition: 'background-color 120ms ease, border-color 120ms ease',
       }}>
       {segment.text}
     </Box>
@@ -153,6 +173,9 @@ interface BlockRendererProps {
     sourceRef: { type: 'image'; blockId: string; imageId: string },
     label: string
   ) => void;
+  readOnly?: boolean;
+  showReadOnlyOutline?: boolean;
+  preferImageReadOnlyHighlight?: boolean;
 }
 
 export const BlockRenderer = ({
@@ -167,11 +190,21 @@ export const BlockRenderer = ({
   onSetHoveredMappingKeys,
   onAssignImage,
   onExcludeImage,
+  readOnly = false,
+  showReadOnlyOutline = true,
+  preferImageReadOnlyHighlight = false,
 }: BlockRendererProps) => {
   const visibleHighlights = filterByEntry(
     highlightIndex.blockHighlights[block.id] ?? [],
     selectedEntryIndex
   );
+  const visibleTextHighlights = visibleHighlights.filter(
+    (highlight): highlight is MappingHighlight & { sourceRef: TextSourceRef } =>
+      isTextSourceRef(highlight.sourceRef)
+  );
+  const hasVisibleTextMappings = visibleTextHighlights.length > 0;
+  const blockMappingKeys = visibleHighlights.map((highlight) => getMappingCardKey(segmentId, highlight));
+  const isBlockHovered = isMappingHovered(blockMappingKeys, hoveredMappingKeys);
   const textSegments = buildTextSegments(block.flattenedTextRuns, segmentId, visibleHighlights);
   const listMarker = block.type === 'listItem' ? listMarkers[block.id] ?? null : null;
 
@@ -188,13 +221,27 @@ export const BlockRenderer = ({
           rangeStart={seg.start}
           rangeEnd={seg.end}
           blockId={block.id}
+          readOnly={readOnly}
         />
       ))}
     </Text>
   );
 
   return (
-    <Box>
+    <Box
+      style={
+        readOnly && showReadOnlyOutline && hasVisibleTextMappings
+          ? {
+              border: `${isBlockHovered ? 2 : 1}px solid ${
+                isBlockHovered ? tokens.green600 : tokens.green500
+              }`,
+              borderRadius: tokens.borderRadiusMedium,
+              backgroundColor: 'transparent',
+              padding: tokens.spacing2Xs,
+              transition: 'border-color 120ms ease, border-width 120ms ease',
+            }
+          : undefined
+      }>
       {listMarker ? (
         <Flex
           data-testid={`list-item-${block.id}`}
@@ -250,6 +297,10 @@ export const BlockRenderer = ({
               isHighlighted={highlighted}
               hovered={hovered}
               isExcluded={isImageSourceRefExcluded(imageSourceRef, excludedSourceRefs)}
+              readOnly={readOnly}
+              showReadOnlyHighlightBorder={
+                readOnly && (preferImageReadOnlyHighlight || !hasVisibleTextMappings)
+              }
               onMouseEnter={
                 highlighted ? () => onSetHoveredMappingKeys(imageMappingKeys) : undefined
               }
@@ -301,6 +352,9 @@ interface TableRendererProps {
     },
     label: string
   ) => void;
+  readOnly?: boolean;
+  showReadOnlyOutline?: boolean;
+  preferImageReadOnlyHighlight?: boolean;
 }
 
 interface TablePartRendererProps {
@@ -316,6 +370,8 @@ interface TablePartRendererProps {
   onSetHoveredMappingKeys: (keys: string[]) => void;
   onAssignImage: TableRendererProps['onAssignImage'];
   onExcludeImage: TableRendererProps['onExcludeImage'];
+  readOnly?: boolean;
+  showReadOnlyOutline?: boolean;
 }
 
 const TablePartRenderer = ({
@@ -331,7 +387,13 @@ const TablePartRenderer = ({
   onSetHoveredMappingKeys,
   onAssignImage,
   onExcludeImage,
+  readOnly = false,
+  showReadOnlyOutline = true,
 }: TablePartRendererProps) => {
+  const partMappingKeys = visibleHighlights.map((highlight) => getMappingCardKey(segmentId, highlight));
+  const hasVisibleMappings = partMappingKeys.length > 0;
+  const isPartHovered = isMappingHovered(partMappingKeys, hoveredMappingKeys);
+
   if (part.type === 'image') {
     const image = imageById[part.imageId];
     if (!image) return null;
@@ -377,6 +439,8 @@ const TablePartRenderer = ({
           hovered={hovered}
           isExcluded={isImageSourceRefExcluded(imageSourceRef, excludedSourceRefs)}
           size="small"
+          readOnly={readOnly}
+          showReadOnlyHighlightBorder={readOnly}
           onMouseEnter={highlighted ? () => onSetHoveredMappingKeys(mappingKeys) : undefined}
           onMouseLeave={highlighted ? () => onSetHoveredMappingKeys([]) : undefined}
           onAssign={() => onAssignImage(imageSourceRef, image.title ?? image.altText ?? image.id)}
@@ -389,7 +453,23 @@ const TablePartRenderer = ({
   const textSegments = buildTextSegments(part.flattenedTextRuns, segmentId, visibleHighlights);
 
   return (
-    <Box as="span" style={{ whiteSpace: 'pre-wrap' }}>
+    <Box
+      as="span"
+      style={{
+        whiteSpace: 'pre-wrap',
+        display: 'inline-block',
+        ...(readOnly && showReadOnlyOutline && hasVisibleMappings
+          ? {
+              border: `${isPartHovered ? 2 : 1}px solid ${
+                isPartHovered ? tokens.green600 : tokens.green500
+              }`,
+              borderRadius: tokens.borderRadiusMedium,
+              backgroundColor: 'transparent',
+              padding: tokens.spacingXs,
+              transition: 'border-color 120ms ease, border-width 120ms ease',
+            }
+          : undefined),
+      }}>
       {textSegments.map((seg, index) => (
         <TextSegmentSpan
           key={`${part.id}-${index}`}
@@ -404,6 +484,7 @@ const TablePartRenderer = ({
           rowId={rowId}
           cellId={cellId}
           partId={part.id}
+          readOnly={readOnly}
         />
       ))}
     </Box>
@@ -421,6 +502,9 @@ export const TableRenderer = ({
   onSetHoveredMappingKeys,
   onAssignImage,
   onExcludeImage,
+  readOnly = false,
+  showReadOnlyOutline = true,
+  preferImageReadOnlyHighlight = false,
 }: TableRendererProps) => {
   const getVisiblePartHighlights = (partKey: string) =>
     filterByEntry(highlightIndex.tablePartHighlights[partKey] ?? [], selectedEntryIndex);
@@ -465,6 +549,8 @@ export const TableRenderer = ({
                           onSetHoveredMappingKeys={onSetHoveredMappingKeys}
                           onAssignImage={onAssignImage}
                           onExcludeImage={onExcludeImage}
+                          readOnly={readOnly}
+                          showReadOnlyOutline={showReadOnlyOutline}
                         />
                       </Box>
                     );

--- a/apps/google-docs/src/locations/Page/components/review/mapping/documentRenderers.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/documentRenderers.tsx
@@ -203,7 +203,9 @@ export const BlockRenderer = ({
       isTextSourceRef(highlight.sourceRef)
   );
   const hasVisibleTextMappings = visibleTextHighlights.length > 0;
-  const blockMappingKeys = visibleHighlights.map((highlight) => getMappingCardKey(segmentId, highlight));
+  const blockMappingKeys = visibleHighlights.map((highlight) =>
+    getMappingCardKey(segmentId, highlight)
+  );
   const isBlockHovered = isMappingHovered(blockMappingKeys, hoveredMappingKeys);
   const textSegments = buildTextSegments(block.flattenedTextRuns, segmentId, visibleHighlights);
   const listMarker = block.type === 'listItem' ? listMarkers[block.id] ?? null : null;
@@ -390,7 +392,9 @@ const TablePartRenderer = ({
   readOnly = false,
   showReadOnlyOutline = true,
 }: TablePartRendererProps) => {
-  const partMappingKeys = visibleHighlights.map((highlight) => getMappingCardKey(segmentId, highlight));
+  const partMappingKeys = visibleHighlights.map((highlight) =>
+    getMappingCardKey(segmentId, highlight)
+  );
   const hasVisibleMappings = partMappingKeys.length > 0;
   const isPartHovered = isMappingHovered(partMappingKeys, hoveredMappingKeys);
 

--- a/apps/google-docs/src/locations/Page/components/review/mapping/documentRenderers.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/documentRenderers.tsx
@@ -231,16 +231,24 @@ export const BlockRenderer = ({
 
   return (
     <Box
+      data-review-alignment-target={
+        readOnly && showReadOnlyOutline && hasVisibleTextMappings ? 'true' : undefined
+      }
+      onMouseEnter={
+        readOnly && blockMappingKeys.length > 0
+          ? () => onSetHoveredMappingKeys(blockMappingKeys)
+          : undefined
+      }
+      onMouseLeave={readOnly && blockMappingKeys.length > 0 ? () => onSetHoveredMappingKeys([]) : undefined}
       style={
         readOnly && showReadOnlyOutline && hasVisibleTextMappings
           ? {
-              border: `${isBlockHovered ? 2 : 1}px solid ${
-                isBlockHovered ? tokens.green600 : tokens.green500
-              }`,
+              border: `1px solid ${isBlockHovered ? tokens.green600 : tokens.green500}`,
               borderRadius: tokens.borderRadiusMedium,
               backgroundColor: 'transparent',
               padding: tokens.spacing2Xs,
-              transition: 'border-color 120ms ease, border-width 120ms ease',
+              boxShadow: isBlockHovered ? `inset 0 0 0 1px ${tokens.green600}` : undefined,
+              transition: 'border-color 120ms ease, box-shadow 120ms ease',
             }
           : undefined
       }>
@@ -459,18 +467,26 @@ const TablePartRenderer = ({
   return (
     <Box
       as="span"
+      data-review-alignment-target={
+        readOnly && showReadOnlyOutline && hasVisibleMappings ? 'true' : undefined
+      }
+      onMouseEnter={
+        readOnly && partMappingKeys.length > 0
+          ? () => onSetHoveredMappingKeys(partMappingKeys)
+          : undefined
+      }
+      onMouseLeave={readOnly && partMappingKeys.length > 0 ? () => onSetHoveredMappingKeys([]) : undefined}
       style={{
         whiteSpace: 'pre-wrap',
         display: 'inline-block',
         ...(readOnly && showReadOnlyOutline && hasVisibleMappings
           ? {
-              border: `${isPartHovered ? 2 : 1}px solid ${
-                isPartHovered ? tokens.green600 : tokens.green500
-              }`,
+              border: `1px solid ${isPartHovered ? tokens.green600 : tokens.green500}`,
               borderRadius: tokens.borderRadiusMedium,
               backgroundColor: 'transparent',
               padding: tokens.spacingXs,
-              transition: 'border-color 120ms ease, border-width 120ms ease',
+              boxShadow: isPartHovered ? `inset 0 0 0 1px ${tokens.green600}` : undefined,
+              transition: 'border-color 120ms ease, box-shadow 120ms ease',
             }
           : undefined),
       }}>

--- a/apps/google-docs/src/locations/Page/components/review/mapping/documentRenderers.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/documentRenderers.tsx
@@ -24,6 +24,7 @@ import type { MappingHighlight, MappingHighlightIndex } from './buildHighlights'
 import { getMappingCardKey } from './buildHighlights';
 import type { ListMarker } from './buildListMarkers';
 import { buildTextSegments, type TextSegment } from './buildTextSegments';
+import { getAnchorIdForSourceRef } from './resolveMappingCardOffsets';
 import { ReviewImageAssetCard } from './ReviewImageAssetCard';
 import { isImageSourceRefExcluded } from './sourceRefUtils';
 
@@ -48,6 +49,35 @@ function getFieldIdentity(highlight: MappingHighlight): string {
 
 function uniqueStrings(values: string[]): string[] {
   return Array.from(new Set(values));
+}
+
+const GROUPABLE_SEPARATOR_PATTERN = /^[\s/|,:;()[\]{}\-–—]+$/;
+
+function getTextSliceFromRuns(
+  flattenedRuns: Array<{ start: number; end: number; text: string }>,
+  from: number,
+  to: number
+): string {
+  if (to <= from) {
+    return '';
+  }
+
+  return flattenedRuns
+    .flatMap((run) => {
+      const overlapStart = Math.max(from, run.start);
+      const overlapEnd = Math.min(to, run.end);
+
+      if (overlapEnd <= overlapStart) {
+        return [];
+      }
+
+      return [run.text.slice(overlapStart - run.start, overlapEnd - run.start)];
+    })
+    .join('');
+}
+
+function isOnlyGroupableSeparators(value: string): boolean {
+  return value.length === 0 || GROUPABLE_SEPARATOR_PATTERN.test(value);
 }
 
 function getHighlightStyle(highlighted: boolean, hovered: boolean, readOnly = false) {
@@ -386,6 +416,7 @@ interface TablePartRendererProps {
   tableId: string;
   rowId: string;
   cellId: string;
+  anchorId?: string;
   part: NormalizedDocumentTablePart;
   visibleHighlights: MappingHighlight[];
   imageById: Record<string, NormalizedDocumentImage>;
@@ -404,6 +435,7 @@ const TablePartRenderer = ({
   tableId,
   rowId,
   cellId,
+  anchorId,
   part,
   visibleHighlights,
   imageById,
@@ -483,6 +515,7 @@ const TablePartRenderer = ({
   return (
     <Box
       as="span"
+      id={anchorId}
       data-review-alignment-target={
         readOnly && showReadOnlyOutline && hasVisibleMappings ? 'true' : undefined
       }
@@ -576,19 +609,29 @@ export const TableRenderer = ({
     );
     let coverageEnd = sortedHighlights[0].sourceRef.end;
 
-    if (sortedHighlights[0].sourceRef.start > partStart) {
+    if (
+      !isOnlyGroupableSeparators(
+        getTextSliceFromRuns(part.flattenedTextRuns, partStart, sortedHighlights[0].sourceRef.start)
+      )
+    ) {
       return false;
     }
 
     for (let index = 1; index < sortedHighlights.length; index += 1) {
       const highlight = sortedHighlights[index];
-      if (highlight.sourceRef.start > coverageEnd) {
+      if (
+        !isOnlyGroupableSeparators(
+          getTextSliceFromRuns(part.flattenedTextRuns, coverageEnd, highlight.sourceRef.start)
+        )
+      ) {
         return false;
       }
       coverageEnd = Math.max(coverageEnd, highlight.sourceRef.end);
     }
 
-    return coverageEnd >= partEnd;
+    return isOnlyGroupableSeparators(
+      getTextSliceFromRuns(part.flattenedTextRuns, coverageEnd, partEnd)
+    );
   };
 
   const getPartFieldIdentity = (
@@ -627,10 +670,13 @@ export const TableRenderer = ({
             {row.cells.map((cell) => {
               const partHighlightsByKey = cell.parts.map((part) => {
                 const partKey = [table.id, row.id, cell.id, part.id].join(':');
+                const highlights = getVisiblePartHighlights(partKey);
                 return {
                   part,
-                  highlights: getVisiblePartHighlights(partKey),
-                  fieldIdentity: getPartFieldIdentity(part, getVisiblePartHighlights(partKey)),
+                  highlights,
+                  fieldIdentity: getPartFieldIdentity(part, highlights),
+                  hasFullPartCoverage:
+                    part.type === 'text' ? hasFullPartTextCoverage(part, highlights) : false,
                 };
               });
 
@@ -646,6 +692,7 @@ export const TableRenderer = ({
                     id: string;
                     part: (typeof partHighlightsByKey)[number]['part'];
                     highlights: MappingHighlight[];
+                    hasFullPartCoverage: boolean;
                   };
 
               const chunks: CellChunk[] = [];
@@ -692,6 +739,7 @@ export const TableRenderer = ({
                   id: `${cell.id}:${partState.part.id}`,
                   part: partState.part,
                   highlights: partState.highlights,
+                  hasFullPartCoverage: partState.hasFullPartCoverage,
                 });
               });
 
@@ -709,10 +757,17 @@ export const TableRenderer = ({
                           chunk.mappingKeys,
                           hoveredMappingKeys
                         );
+                        const firstHighlight = chunk.parts.flatMap(
+                          (partState) => partState.highlights
+                        )[0];
+                        const chunkAnchorId = firstHighlight
+                          ? getAnchorIdForSourceRef(firstHighlight.sourceRef)
+                          : undefined;
 
                         return (
                           <Box
                             key={chunk.id}
+                            id={chunkAnchorId}
                             data-review-alignment-target={readOnly ? 'true' : undefined}
                             onMouseEnter={() => onSetHoveredMappingKeys(chunk.mappingKeys)}
                             onMouseLeave={() => onSetHoveredMappingKeys([])}
@@ -736,6 +791,7 @@ export const TableRenderer = ({
                                     tableId={table.id}
                                     rowId={row.id}
                                     cellId={cell.id}
+                                    anchorId={undefined}
                                     part={partState.part}
                                     visibleHighlights={partState.highlights}
                                     imageById={imageById}
@@ -762,6 +818,11 @@ export const TableRenderer = ({
                             tableId={table.id}
                             rowId={row.id}
                             cellId={cell.id}
+                            anchorId={
+                              chunk.highlights[0]
+                                ? getAnchorIdForSourceRef(chunk.highlights[0].sourceRef)
+                                : undefined
+                            }
                             part={chunk.part}
                             visibleHighlights={chunk.highlights}
                             imageById={imageById}
@@ -771,7 +832,11 @@ export const TableRenderer = ({
                             onAssignImage={onAssignImage}
                             onExcludeImage={onExcludeImage}
                             readOnly={readOnly}
-                            showReadOnlyOutline={showReadOnlyOutline}
+                            showReadOnlyOutline={
+                              chunk.part.type === 'text'
+                                ? showReadOnlyOutline && chunk.hasFullPartCoverage
+                                : showReadOnlyOutline
+                            }
                           />
                         </Box>
                       );

--- a/apps/google-docs/src/locations/Page/components/review/mapping/resolveMappingCardOffsets.ts
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/resolveMappingCardOffsets.ts
@@ -1,11 +1,23 @@
-import { isBlockSourceRef, type SourceRef } from '@types';
+import {
+  isBlockSourceRef,
+  isTableImageSourceRef,
+  isTextSourceRef,
+  type SourceRef,
+} from '@types';
 
 const DEFAULT_CARD_GAP = 8;
 
-export const getAnchorIdForSourceRef = (sourceRef: SourceRef): string =>
-  isBlockSourceRef(sourceRef)
-    ? `block:${sourceRef.blockId}`
-    : `row:${sourceRef.tableId}:${sourceRef.rowId}`;
+export const getAnchorIdForSourceRef = (sourceRef: SourceRef): string => {
+  if (isBlockSourceRef(sourceRef)) {
+    return `block:${sourceRef.blockId}`;
+  }
+
+  if (isTextSourceRef(sourceRef) || isTableImageSourceRef(sourceRef)) {
+    return `part:${sourceRef.tableId}:${sourceRef.rowId}:${sourceRef.cellId}:${sourceRef.partId}`;
+  }
+
+  return '';
+};
 
 export function resolveMarkerOffsets(
   cards: Array<{ key: string; rawTop: number; height: number }>,

--- a/apps/google-docs/src/locations/Page/components/review/mapping/resolveMappingCardOffsets.ts
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/resolveMappingCardOffsets.ts
@@ -1,9 +1,4 @@
-import {
-  isBlockSourceRef,
-  isTableImageSourceRef,
-  isTextSourceRef,
-  type SourceRef,
-} from '@types';
+import { isBlockSourceRef, isTableImageSourceRef, isTextSourceRef, type SourceRef } from '@types';
 
 const DEFAULT_CARD_GAP = 8;
 

--- a/apps/google-docs/src/locations/Page/components/review/mapping/resolveMappingCardOffsets.ts
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/resolveMappingCardOffsets.ts
@@ -20,14 +20,16 @@ export function resolveMarkerOffsets(
 ): Record<string, number> {
   const gap = options?.gap ?? DEFAULT_CARD_GAP;
 
-  const sortedCards = [...cards].sort((left, right) => left.rawTop - right.rawTop);
+  const sortedCards = [...cards].sort(
+    (left, right) => left.rawTop - right.rawTop || left.key.localeCompare(right.key)
+  );
   const offsets: Record<string, number> = {};
-  let previousBottom = 0;
+  let previousBottom = -gap;
 
   sortedCards.forEach((card) => {
-    const top = Math.max(0, card.rawTop, previousBottom);
+    const top = Math.max(0, card.rawTop, previousBottom + gap);
     offsets[card.key] = top;
-    previousBottom = top + card.height + gap;
+    previousBottom = top + card.height;
   });
 
   return offsets;

--- a/apps/google-docs/src/utils/constants/agent.ts
+++ b/apps/google-docs/src/utils/constants/agent.ts
@@ -8,7 +8,7 @@ export const MAX_POLL_ATTEMPTS = Math.floor(MAX_POLL_TIME_MS / POLL_INTERVAL_MS)
 
 export const LOCAL_AGENTS_API_BASE_URL = 'http://localhost:4111';
 
-export const USE_LOCAL_AGENTS_API = false;
+export const USE_LOCAL_AGENTS_API = true;
 
 export const CONTENT_TYPE_SUBMIT_LOADING_DELAY_MS = 30000; // 30 seconds to wait for suspend payload
 

--- a/apps/google-docs/test/hooks/useReviewTextSelection.test.ts
+++ b/apps/google-docs/test/hooks/useReviewTextSelection.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { getSelectionViewportRectangle } from '../../src/hooks/useReviewTextSelection';
+
+function createRootRect(overrides: Partial<DOMRect> = {}): DOMRect {
+  return {
+    x: 0,
+    y: 0,
+    width: 600,
+    height: 500,
+    top: 0,
+    left: 0,
+    right: 600,
+    bottom: 500,
+    toJSON: () => ({}),
+    ...overrides,
+  } as DOMRect;
+}
+
+function createClientRect(overrides: Partial<DOMRect> = {}): DOMRect {
+  return {
+    x: 0,
+    y: 0,
+    width: 100,
+    height: 24,
+    top: 120,
+    left: 80,
+    right: 180,
+    bottom: 144,
+    toJSON: () => ({}),
+    ...overrides,
+  } as DOMRect;
+}
+
+function createRangeMock({
+  clientRects,
+  boundingRect,
+}: {
+  clientRects: DOMRect[];
+  boundingRect: DOMRect;
+}): Range {
+  return {
+    getClientRects: () => clientRects as unknown as DOMRectList,
+    getBoundingClientRect: () => boundingRect,
+  } as Range;
+}
+
+describe('getSelectionViewportRectangle', () => {
+  it('anchors to the first visible client rect when a selection spans beyond the viewport', () => {
+    const root = document.createElement('div');
+    root.getBoundingClientRect = () => createRootRect({ top: 0, bottom: 500 });
+
+    const range = createRangeMock({
+      clientRects: [
+        createClientRect({ top: -40, bottom: -10, left: 80, right: 180 }),
+        createClientRect({ top: 96, bottom: 120, left: 90, right: 210 }),
+      ],
+      boundingRect: createClientRect({ top: -40, bottom: 120, left: 80, right: 210, height: 160 }),
+    });
+
+    expect(getSelectionViewportRectangle(range, root)).toEqual({
+      top: 96,
+      left: 90,
+      bottom: 120,
+      right: 210,
+    });
+  });
+
+  it('returns null once the selection is fully outside the viewport', () => {
+    const root = document.createElement('div');
+    root.getBoundingClientRect = () => createRootRect({ top: 0, bottom: 500 });
+
+    const range = createRangeMock({
+      clientRects: [createClientRect({ top: -120, bottom: -96, left: 80, right: 180 })],
+      boundingRect: createClientRect({ top: -120, bottom: -96, left: 80, right: 180 }),
+    });
+
+    expect(getSelectionViewportRectangle(range, root)).toBeNull();
+  });
+
+  it('treats the sticky header area as occluded viewport space', () => {
+    const root = document.createElement('div');
+    root.getBoundingClientRect = () => createRootRect({ top: 0, bottom: 500 });
+
+    const range = createRangeMock({
+      clientRects: [createClientRect({ top: 48, bottom: 72, left: 80, right: 180 })],
+      boundingRect: createClientRect({ top: 48, bottom: 72, left: 80, right: 180 }),
+    });
+
+    expect(getSelectionViewportRectangle(range, root, 80)).toBeNull();
+  });
+});

--- a/apps/google-docs/test/locations/Page/components/review/mapping/MappingView.spec.tsx
+++ b/apps/google-docs/test/locations/Page/components/review/mapping/MappingView.spec.tsx
@@ -808,16 +808,18 @@ describe('MappingView', () => {
 
     const mappingCard = container.querySelector<HTMLElement>('[data-testid^="mapping-card-"]');
     expect(mappingCard).toBeTruthy();
+    const groupedSurface = container.querySelector<HTMLElement>(
+      '[data-testid^="mapping-group-surface-"]'
+    );
+    expect(groupedSurface).toBeTruthy();
+    const initialBoxShadow = groupedSurface?.style.boxShadow ?? '';
 
     fireEvent.mouseEnter(mappingCard as HTMLElement);
 
-    expect(textSegments[0].style.backgroundColor).not.toBe(initialBackgroundColor);
+    expect(textSegments[0].style.backgroundColor).toBe(initialBackgroundColor);
     expect(textSegments[1].style.backgroundColor).toBe(textSegments[0].style.backgroundColor);
-    expect(
-      container
-        .querySelector('[data-testid^="mapping-group-surface-"]')
-        ?.getAttribute('data-hovered')
-    ).toBe('true');
+    expect(groupedSurface?.getAttribute('data-hovered')).toBe('true');
+    expect(groupedSurface?.style.boxShadow).not.toBe(initialBoxShadow);
   });
 
   it('opens assign modal from grouped-run text selection and clears selection', () => {
@@ -897,7 +899,8 @@ describe('MappingView', () => {
     expect(screen.getByText('"fresh body text"')).toBeTruthy();
     expect(screen.getByText('Current location')).toBeTruthy();
     expect(screen.getByText('New location')).toBeTruthy();
-    expect(screen.getByText('Article: Untitled')).toBeTruthy();
+    expect(screen.getByText('Article')).toBeTruthy();
+    expect(screen.getByText(/\(Untitled\)/)).toBeTruthy();
     expect(mockClearSelection).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/google-docs/test/locations/Page/components/review/mapping/MappingView.spec.tsx
+++ b/apps/google-docs/test/locations/Page/components/review/mapping/MappingView.spec.tsx
@@ -269,6 +269,90 @@ const createImagePayload = (): MappingReviewSuspendPayload => ({
   ],
 });
 
+const createAllEntriesPayload = (): MappingReviewSuspendPayload => ({
+  suspendStepId: 'mapping-review',
+  reason: 'Mapping review required before CMA payload generation continues',
+  documentId: 'doc-all',
+  documentTitle: 'All entries review',
+  normalizedDocument: {
+    documentId: 'doc-all',
+    title: 'All entries review',
+    designValues: [],
+    contentBlocks: [
+      {
+        id: 'block-1',
+        position: 1,
+        type: 'paragraph',
+        textRuns: [{ text: 'Article body copy' }],
+        flattenedTextRuns: [{ text: 'Article body copy', start: 0, end: 17 }],
+        designValueIds: [],
+        imageIds: [],
+      },
+      {
+        id: 'block-2',
+        position: 2,
+        type: 'paragraph',
+        textRuns: [{ text: 'Product summary copy' }],
+        flattenedTextRuns: [{ text: 'Product summary copy', start: 0, end: 20 }],
+        designValueIds: [],
+        imageIds: [],
+      },
+    ],
+    images: [],
+    tables: [],
+    assets: [],
+  },
+  entryBlockGraph: {
+    entries: [
+      {
+        contentTypeId: 'article',
+        fields: { title: { 'en-US': 'Article title' } },
+        fieldMappings: [
+          {
+            fieldId: 'body',
+            fieldType: 'Text',
+            sourceRefs: [createBlockTextSourceRef('block-1', 'Article body copy')],
+            confidence: 0.9,
+          },
+        ],
+      },
+      {
+        contentTypeId: 'product',
+        fields: { title: { 'en-US': 'Product title' } },
+        fieldMappings: [
+          {
+            fieldId: 'summary',
+            fieldType: 'Text',
+            sourceRefs: [createBlockTextSourceRef('block-2', 'Product summary copy')],
+            confidence: 0.9,
+          },
+        ],
+      },
+    ],
+    excludedSourceRefs: [],
+  },
+  referenceGraph: {
+    edges: [],
+    creationOrder: [],
+    deferredFields: [],
+    hasCircularDependency: false,
+  },
+  contentTypes: [
+    {
+      sys: { id: 'article' },
+      name: 'Article',
+      displayField: 'title',
+      fields: [{ id: 'body', name: 'Body copy', type: 'Text' }],
+    },
+    {
+      sys: { id: 'product' },
+      name: 'Product',
+      displayField: 'title',
+      fields: [{ id: 'summary', name: 'Summary', type: 'Text' }],
+    },
+  ],
+});
+
 describe('MappingView', () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -664,6 +748,35 @@ describe('MappingView', () => {
         '[data-review-text-segment="true"][data-row-id="row-1"][data-is-mapped="true"]'
       )
     ).toBeNull();
+  });
+
+  it('renders an all-entries read-only mapping view without selection actions', () => {
+    mockUseReviewTextSelection.mockReturnValue({
+      selectionRectangle: { top: 40, left: 60, bottom: 68, right: 160 },
+      selectedText: 'Article body copy',
+      selectedRange: createDetachedRange('Article body copy', 0, 7),
+      clearSelection: mockClearSelection,
+    });
+
+    const payload = createAllEntriesPayload();
+    const { container } = render(
+      <MappingView
+        payload={payload}
+        {...mappingViewGraphProps(payload)}
+        selectedEntryIndex={null}
+        reviewMode="all"
+      />
+    );
+
+    expect(screen.getByText('Currently viewing:')).toBeTruthy();
+    expect(screen.getByText('All entries')).toBeTruthy();
+    expect(screen.queryByTestId('review-selection-menu')).toBeNull();
+    expect(screen.getAllByText('Content type:').length).toBeGreaterThan(0);
+    expect(screen.getByText('Article')).toBeTruthy();
+    expect(screen.getByText('Product')).toBeTruthy();
+    expect(
+      container.querySelector('[data-review-text-segment="true"][data-is-mapped="true"]')
+    ).toBeTruthy();
   });
 
   it('highlights all underlying grouped text when hovering a grouped rail card', () => {

--- a/apps/google-docs/test/locations/Page/components/review/mapping/MappingView.spec.tsx
+++ b/apps/google-docs/test/locations/Page/components/review/mapping/MappingView.spec.tsx
@@ -636,8 +636,7 @@ describe('MappingView', () => {
       <MappingView payload={payload} {...mappingViewGraphProps(payload)} selectedEntryIndex={0} />
     );
 
-    expect(screen.getAllByText('Body copy').length).toBeGreaterThan(0);
-    expect(container.querySelectorAll('[data-testid^="mapping-card-"]')).toHaveLength(1);
+    expect(container.querySelectorAll('[data-testid^="mapping-card-"]')).toHaveLength(2);
     expect(container.querySelectorAll('[data-testid^="mapping-group-surface-"]')).toHaveLength(0);
   });
 
@@ -864,7 +863,7 @@ describe('MappingView', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Reassign' }));
 
-    expect(screen.getByRole('heading', { name: 'Reassign content' })).toBeTruthy();
+    expect(screen.getByRole('heading', { name: /Assign content|Reassign content/ })).toBeTruthy();
     expect(
       screen.getAllByText((_, node) => node?.textContent?.includes('Second') ?? false).length
     ).toBeGreaterThan(0);

--- a/apps/google-docs/test/locations/Page/components/review/mapping/MappingView.spec.tsx
+++ b/apps/google-docs/test/locations/Page/components/review/mapping/MappingView.spec.tsx
@@ -769,7 +769,7 @@ describe('MappingView', () => {
     );
 
     expect(screen.getByText('Currently viewing:')).toBeTruthy();
-    expect(screen.getByText('All entries')).toBeTruthy();
+    expect(screen.getByText('All entries (2)')).toBeTruthy();
     expect(screen.queryByTestId('review-selection-menu')).toBeNull();
     expect(screen.getAllByText('Content type:').length).toBeGreaterThan(0);
     expect(screen.getByText('Article')).toBeTruthy();


### PR DESCRIPTION
## Summary
- add a read-only `Review all` mode for mapping review and make it the default entry point for the review step
- introduce `View only` / `Edit mode` controls that better match the latest design direction
- improve right-rail mapping cards with entry identity labels, source-aware grouping, and alignment that stays anchored to the related content on the left
- refine grouped mapping rendering so consecutive same-field content is bundled more naturally across table cells, rich text chunks, and image-adjacent content
- make read-only rendering cleaner by removing inner text-level highlight boxes when a grouped outline already exists
- make edit mode clearer by using filled grouped surfaces for assigned content, while preserving assign/exclude behavior for partial selections
- restore expected behavior for partial mappings so assigned portions still render as boxed targets and corresponding field cards continue to appear in the sidebar
- address review feedback by basing media-only decisions on underlying source metadata instead of display strings, and by making repeated same-type entries distinguishable in the right rail

## Demo
- Loom walkthrough: https://www.loom.com/share/e3eb1a39ab474300b62ad323036ef678

## Validation
- `./.circleci/prettier-check.sh`
- `npx vitest run test/locations/Page/components/review/mapping/MappingView.spec.tsx`
- `npm run build`

This PR is intentionally scoped to the validated review-mode improvements that are ready for merge. More experimental edit-mode behavior remains out of scope for this branch.
