### PR TITLE
fix(google-docs): Fix connected icon color & assign/reassign modal [INTEG-3838]

### DIFF
--- a/apps/google-docs/src/locations/Page/components/mainpage/OAuthConnector.tsx
+++ b/apps/google-docs/src/locations/Page/components/mainpage/OAuthConnector.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from 'react';
+import { type ComponentProps, useEffect, useState, useRef } from 'react';
 import { Button, Flex, Text, Image } from '@contentful/f36-components';
 import tokens from '@contentful/f36-tokens';
 import { CheckCircleIcon } from '@contentful/f36-icons';
@@ -26,6 +26,10 @@ type CheckStatusResponse = {
   token: string;
   connected: boolean;
 };
+
+const ConnectedStatusIcon = ({ size }: Pick<ComponentProps<typeof CheckCircleIcon>, 'size'>) => (
+  <CheckCircleIcon size={size} color={tokens.colorPositive} />
+);
 
 export const OAuthConnector = ({
   onOAuthConnectedChange,
@@ -252,7 +256,7 @@ export const OAuthConnector = ({
         <Button
           variant={isOAuthConnected && isHoveringConnected ? 'negative' : 'secondary'}
           size="small"
-          endIcon={isOAuthConnected && !isHoveringConnected ? <CheckCircleIcon /> : undefined}
+          endIcon={isOAuthConnected && !isHoveringConnected ? <ConnectedStatusIcon /> : undefined}
           onClick={handleButtonClick}
           isLoading={loadingState !== OAuthLoadingState.IDLE}
           isDisabled={loadingState !== OAuthLoadingState.IDLE}>

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -521,9 +521,9 @@ export const MappingView = ({
         newLocation,
         isOpen: true,
       },
-      title: 'Assign content',
+      title: `${canExcludeSelectedText ? 'Reassign' : 'Assign'} content`,
       locationSectionDescription: '',
-      primaryButtonLabel: 'Move content',
+      primaryButtonLabel: `${canExcludeSelectedText ? 'Reassign' : 'Assign'} content`,
     });
   };
 


### PR DESCRIPTION
## Summary

- Makes the Google OAuth connected icon green.
- Updates assign/reassign modal copy so the title and CTA match the current action.

https://github.com/user-attachments/assets/7d2668ef-9dbd-4e57-813a-9429a57e0fb5