### PR TITLE
fix(google-docs): handle missing suspendPayload on PENDING_REVIEW as retry signal [INTEG-3750]

### DIFF
--- a/apps/google-docs/src/hooks/useWorkflowAgent.ts
+++ b/apps/google-docs/src/hooks/useWorkflowAgent.ts
@@ -1,6 +1,11 @@
 import { useState, useCallback } from 'react';
 import { PageAppSDK } from '@contentful/app-sdk';
-import { POLL_INTERVAL_MS, MAX_POLL_ATTEMPTS, WORKFLOW_AGENT_ID } from '../utils/constants/agent';
+import {
+  POLL_INTERVAL_MS,
+  MAX_POLL_ATTEMPTS,
+  WORKFLOW_AGENT_ID,
+  MAX_PENDING_REVIEW_MISSING_PAYLOAD_RETRIES,
+} from '../utils/constants/agent';
 import {
   MappingReviewSuspendPayload,
   ResumePayload,
@@ -112,7 +117,8 @@ const getSuspendPayload = (
 
 const getWorkflowRunResult = (
   runData: AgentRunData,
-  threadId: string
+  threadId: string,
+  pendingReviewMissingPayloadCount: number
 ): WorkflowRunResult | null => {
   const status = getRunStatus(runData);
 
@@ -123,7 +129,10 @@ const getWorkflowRunResult = (
     case RunStatus.PENDING_REVIEW: {
       const suspendPayload = getSuspendPayload(runData);
       if (!suspendPayload) {
-        return null; // suspendPayload not flushed yet; poller will retry
+        if (pendingReviewMissingPayloadCount < MAX_PENDING_REVIEW_MISSING_PAYLOAD_RETRIES) {
+          return null; // suspendPayload not flushed yet; poller will retry
+        }
+        throw new Error('Workflow paused for review, but suspend payload was missing.');
       }
 
       return {
@@ -159,6 +168,7 @@ const pollAgentRun = async (
   runId: string
 ): Promise<WorkflowRunResult> => {
   const startMs = Date.now();
+  let pendingReviewMissingPayloadCount = 0;
   console.log(`⏳ Polling run [${runId}]`);
 
   for (let attempt = 0; attempt < MAX_POLL_ATTEMPTS; attempt++) {
@@ -173,7 +183,13 @@ const pollAgentRun = async (
     const status = getRunStatus(runData);
     console.log(`  #${attempt + 1} — status: ${status} (${elapsedSec(startMs)})`);
 
-    const workflowRun = getWorkflowRunResult(runData, runId);
+    if (status === RunStatus.PENDING_REVIEW && !getSuspendPayload(runData)) {
+      pendingReviewMissingPayloadCount++;
+    } else {
+      pendingReviewMissingPayloadCount = 0;
+    }
+
+    const workflowRun = getWorkflowRunResult(runData, runId, pendingReviewMissingPayloadCount);
     if (workflowRun) {
       console.log(`✓ Run [${runId}] settled: ${status} in ${elapsedSec(startMs)}`);
       return workflowRun;

--- a/apps/google-docs/src/hooks/useWorkflowAgent.ts
+++ b/apps/google-docs/src/hooks/useWorkflowAgent.ts
@@ -123,7 +123,7 @@ const getWorkflowRunResult = (
     case RunStatus.PENDING_REVIEW: {
       const suspendPayload = getSuspendPayload(runData);
       if (!suspendPayload) {
-        throw new Error('Workflow paused for review, but suspend payload was missing.');
+        return null; // suspendPayload not flushed yet; poller will retry
       }
 
       return {

--- a/apps/google-docs/src/utils/constants/agent.ts
+++ b/apps/google-docs/src/utils/constants/agent.ts
@@ -11,3 +11,7 @@ export const LOCAL_AGENTS_API_BASE_URL = 'http://localhost:4111';
 export const USE_LOCAL_AGENTS_API = false;
 
 export const CONTENT_TYPE_SUBMIT_LOADING_DELAY_MS = 30000; // 30 seconds to wait for suspend payload
+
+// Agents-api writes PENDING_REVIEW status before the suspendPayload metadata flushes.
+// Allow this many consecutive PENDING_REVIEW polls with no suspendPayload before giving up.
+export const MAX_PENDING_REVIEW_MISSING_PAYLOAD_RETRIES = 5; // 5 × 10s = 50s max wait

--- a/apps/google-docs/src/utils/constants/messages.ts
+++ b/apps/google-docs/src/utils/constants/messages.ts
@@ -3,7 +3,8 @@ export const ERROR_MESSAGES = {
   NO_DOCUMENT: 'Please select a document',
   NO_CONTENT_TYPE: 'Please select at least one content type',
   CREATE_ENTRIES_ERROR: 'No entries were created, please try again.',
-  GENERIC_ERROR: 'This preview could not be completed. Please start again.',
+  GENERIC_ERROR:
+    'This preview could not be completed. If your Google Drive connection has expired, try reconnecting your account and starting again.',
 } as const;
 
 export const SUCCESS_MESSAGES = {


### PR DESCRIPTION
## Problem

When the Google Docs workflow agent suspends for HIL review, the app occasionally shows:

> **Unable to generate preview** — This preview could not be completed. Please start again.

The AgentRun response at that point has `sys.status: "PENDING_REVIEW"` but `metadata.suspendPayload` is `undefined`. The previous code threw immediately on a missing `suspendPayload`, which propagated to the error modal.

## Root cause: race condition in agents-api

The issue is a write-ordering race in [`ThreadManager.setThreadStatus`](https://github.com/contentful/agents-api/blob/c63bd580c54a6129606b290a149396c3f577f40f/services/api/src/mastra/utils/thread-manager.ts#L224-L238):

```ts
// thread-manager.ts — setThreadStatus
await this.storage.updateThread({ metadata: { ...thread.metadata, status } })  // 1. status written
this.hasInitializedStatus = true
if (this.deferredOperations.length > 0) {
  await this.executeDeferredOperations()  // 2. suspendPayload written (deferred)
}
```

In [`mapping-review-step.ts`](https://github.com/contentful/agents-api/blob/c63bd580c54a6129606b290a149396c3f577f40f/services/api/src/mastra/agents/google-docs-agent/workflow/steps/step9/mapping-review-step.ts#L72-L76), `updateMetadata` (which queues a deferred operation) is called before `transitionToPendingReview` (which triggers `setThreadStatus`):

```ts
// mapping-review-step.ts
await threadManager.updateMetadata({ suspendPayload, workflowId, workflowRunId: runId })  // queued as deferred op
await threadManager.transitionToPendingReview()  // writes status, THEN flushes deferred ops
```

If the app polls between steps 1 and 2, it sees `PENDING_REVIEW` with no `suspendPayload` yet. The root fix belongs in agents-api (flush deferred ops *before* writing status, or ensure `updateMetadata` is atomic with the transition). This PR is the app-side mitigation.

## Fixes

### 1. PENDING_REVIEW retry logic

Instead of throwing immediately when `suspendPayload` is missing on `PENDING_REVIEW`, we treat it as "not ready yet" and keep polling — up to `MAX_PENDING_REVIEW_MISSING_PAYLOAD_RETRIES` (5) consecutive times before giving up. At a 10s polling interval that's a 50s window, which is more than enough to absorb the flush delay while still surfacing genuine failures.

The retry counter resets if the run transitions to any other state or if `suspendPayload` appears, so it only counts consecutive missing-payload polls on `PENDING_REVIEW`.

### 2. Improved error message for expired Google Drive connection

The generic failure message has been updated to hint at reconnecting Google Drive when a workflow fails. Previously the message gave users no actionable guidance; now it points them toward reconnecting their account as a first step.

Refs: INTEG-3853