### PR TITLE
[INTEG-3856] fix: rename to Google Drive Integration

### DIFF
--- a/apps/google-docs/src/locations/ConfigScreen/ConfigScreen.spec.tsx
+++ b/apps/google-docs/src/locations/ConfigScreen/ConfigScreen.spec.tsx
@@ -16,14 +16,14 @@ describe('Config Screen component', () => {
   describe('UI Content', () => {
     it('renders the heading', () => {
       const { getByText } = render(<ConfigScreen />);
-      expect(getByText('Drive Integration')).toBeTruthy();
+      expect(getByText('Google Drive Integration')).toBeTruthy();
     });
 
     it('renders the description paragraph', () => {
       const { getByText } = render(<ConfigScreen />);
       expect(
         getByText(
-          'Connect Drive Integration to Contentful to seamlessly sync content, eliminate copy-paste, reduce errors, and speed up your publishing workflow.'
+          'Connect Google Drive Integration to Contentful to seamlessly sync content, eliminate copy-paste, reduce errors, and speed up your publishing workflow.'
         )
       ).toBeTruthy();
     });

--- a/apps/google-docs/src/locations/ConfigScreen/ConfigScreen.tsx
+++ b/apps/google-docs/src/locations/ConfigScreen/ConfigScreen.tsx
@@ -56,10 +56,10 @@ const ConfigScreen = () => {
         className={styles.body}>
         <Box>
           <Heading className={styles.heading} marginBottom="spacingS">
-            Drive Integration
+            Google Drive Integration
           </Heading>
           <Paragraph>
-            Connect Drive Integration to Contentful to seamlessly sync content, eliminate
+            Connect Google Drive Integration to Contentful to seamlessly sync content, eliminate
             copy-paste, reduce errors, and speed up your publishing workflow.
           </Paragraph>
         </Box>

--- a/apps/google-docs/src/locations/Page/components/mainpage/MainPageView.tsx
+++ b/apps/google-docs/src/locations/Page/components/mainpage/MainPageView.tsx
@@ -31,7 +31,7 @@ export const MainPageView = ({
         flexDirection="column"
         gap="spacingXl"
         style={{ maxWidth: '900px', margin: `${tokens.spacingL} auto` }}>
-        <Heading marginBottom="none">Drive Integration</Heading>
+        <Heading marginBottom="none">Google Drive Integration</Heading>
         <OAuthConnector
           oauthToken={oauthToken}
           onOAuthConnectedChange={onOAuthConnectedChange}

--- a/apps/google-docs/src/locations/Page/components/mainpage/OAuthConnector.tsx
+++ b/apps/google-docs/src/locations/Page/components/mainpage/OAuthConnector.tsx
@@ -155,7 +155,7 @@ export const OAuthConnector = ({
     } catch (error) {
       cleanup();
       setLoadingState(OAuthLoadingState.IDLE);
-      sdk.notifier.error('Unable to connect to Drive Integration. Please try again.');
+      sdk.notifier.error('Unable to connect to Google Drive Integration. Please try again.');
     }
   };
 
@@ -169,7 +169,7 @@ export const OAuthConnector = ({
 
       setIsHoveringConnected(false);
     } catch (error) {
-      sdk.notifier.error('Unable to disconnect from Drive Integration. Please try again.');
+      sdk.notifier.error('Unable to disconnect from Google Drive Integration. Please try again.');
     } finally {
       setLoadingState(OAuthLoadingState.IDLE);
     }
@@ -227,10 +227,10 @@ export const OAuthConnector = ({
             borderRadius: tokens.borderRadiusMedium,
             backgroundColor: tokens.gray100,
           }}>
-          <Image src={googleDriveLogo} alt="Drive Integration" height="28px" width="32px" />
+          <Image src={googleDriveLogo} alt="Google Drive Integration" height="28px" width="32px" />
         </Flex>
         <Text fontSize="fontSizeL" fontWeight="fontWeightMedium" lineHeight="lineHeightL">
-          Drive Integration
+          Google Drive Integration
         </Text>
       </Flex>
       <Flex

--- a/apps/google-docs/test/locations/Page/Page.spec.tsx
+++ b/apps/google-docs/test/locations/Page/Page.spec.tsx
@@ -128,7 +128,7 @@ describe('Page component', () => {
     render(<Page />);
 
     await waitFor(() => {
-      expect(screen.getByRole('heading', { name: 'Drive Integration' })).toBeTruthy();
+      expect(screen.getByRole('heading', { name: 'Google Drive Integration' })).toBeTruthy();
       expect(screen.queryByText(/Create from document "Selected document"/)).toBeNull();
     });
   });
@@ -137,7 +137,7 @@ describe('Page component', () => {
     render(<Page />);
 
     await waitFor(() => {
-      expect(screen.getByRole('heading', { name: 'Drive Integration' })).toBeTruthy();
+      expect(screen.getByRole('heading', { name: 'Google Drive Integration' })).toBeTruthy();
     });
 
     fireEvent.click(screen.getByRole('button', { name: 'Trigger Mapping Review Ready' }));
@@ -148,7 +148,7 @@ describe('Page component', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Trigger Reset To Main' }));
 
     await waitFor(() => {
-      expect(screen.getByRole('heading', { name: 'Drive Integration' })).toBeTruthy();
+      expect(screen.getByRole('heading', { name: 'Google Drive Integration' })).toBeTruthy();
       expect(screen.queryByText(/Create from document "Selected document"/)).toBeNull();
     });
   });
@@ -160,7 +160,7 @@ describe('Page component', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Mock review page for Document mapping review')).toBeTruthy();
-      expect(screen.queryByRole('heading', { name: 'Drive Integration' })).toBeNull();
+      expect(screen.queryByRole('heading', { name: 'Google Drive Integration' })).toBeNull();
     });
   });
 
@@ -176,7 +176,7 @@ describe('Page component', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Trigger review exit' }));
 
     await waitFor(() => {
-      expect(screen.getByRole('heading', { name: 'Drive Integration' })).toBeTruthy();
+      expect(screen.getByRole('heading', { name: 'Google Drive Integration' })).toBeTruthy();
     });
 
     expect(mockResumeWorkflow).not.toHaveBeenCalled();
@@ -196,7 +196,7 @@ describe('Page component', () => {
 
     await waitFor(() => {
       expect(mockResumeWorkflow).toHaveBeenCalledWith('run-123', { cancelled: true });
-      expect(screen.getByRole('heading', { name: 'Drive Integration' })).toBeTruthy();
+      expect(screen.getByRole('heading', { name: 'Google Drive Integration' })).toBeTruthy();
     });
 
     expect(mockResetFlow).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary
<img width="1659" height="745" alt="Screenshot 2026-04-27 at 11 55 35 AM" src="https://github.com/user-attachments/assets/ea2baa28-4d4e-44d3-af79-faa6bb7e93d4" />

Updates in-app copy to **Google Drive Integration** while keeping **Drive Integration** in `contentful-app-manifest.json` (app name, description, and App Function descriptions) unchanged for catalog or backend consistency.

## Changes

- **Page:** main heading; OAuth card title, logo `alt`, connect/disconnect error messages (`MainPageView`, `OAuthConnector`).
- **Config screen:** heading and intro paragraph (`ConfigScreen`).
- **Tests:** expectations in `Page.spec.tsx` and `ConfigScreen.spec.tsx`.

## Out of scope

- `contentful-app-manifest.json` — reverted / not part of this rename; still **Drive Integration** there.

## Notes

- No dependency or runtime behavior changes beyond strings.
