### PR TITLE
feat(google-docs): handle OAuth expiry mid-workflow with reauth modal []

### DIFF
--- a/apps/google-docs/src/hooks/useWorkflowAgent.ts
+++ b/apps/google-docs/src/hooks/useWorkflowAgent.ts
@@ -8,6 +8,7 @@ import {
 } from '../utils/constants/agent';
 import {
   MappingReviewSuspendPayload,
+  NeedsReauthSuspendPayload,
   ResumePayload,
   TabsImagesSuspendPayload,
   CompletedWorkflowPayload,
@@ -111,7 +112,11 @@ const getRunErrorMessage = (runData: AgentRunData): string => {
 
 const getSuspendPayload = (
   runData: AgentRunData
-): TabsImagesSuspendPayload | MappingReviewSuspendPayload | undefined => {
+):
+  | TabsImagesSuspendPayload
+  | MappingReviewSuspendPayload
+  | NeedsReauthSuspendPayload
+  | undefined => {
   return runData.metadata?.suspendPayload;
 };
 

--- a/apps/google-docs/src/locations/Page/Page.tsx
+++ b/apps/google-docs/src/locations/Page/Page.tsx
@@ -134,6 +134,8 @@ const Page = () => {
         ref={modalOrchestratorRef}
         sdk={sdk}
         oauthToken={oauthToken}
+        onOAuthConnectedChange={handleOAuthConnectedChange}
+        onOauthTokenChange={handleOauthTokenChange}
         onMappingReviewReady={handleMappingReviewReady}
         onResetToMain={handleReturnToMainPage}
       />

--- a/apps/google-docs/src/locations/Page/components/mainpage/ModalOrchestrator.tsx
+++ b/apps/google-docs/src/locations/Page/components/mainpage/ModalOrchestrator.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, useImperativeHandle, useState } from 'react';
 import { PageAppSDK } from '@contentful/app-sdk';
-import { Modal } from '@contentful/f36-components';
+import { Button, Modal, Paragraph } from '@contentful/f36-components';
 import { ContentTypeProps } from 'contentful-management';
 import { ConfirmCancelModal } from '../modals/ConfirmCancelModal';
 import { ErrorModal } from '../modals/ErrorModal';
@@ -12,6 +12,7 @@ import { SelectTabsModal } from '../modals/step_3/SelectTabsModal';
 import {
   DocumentTabProps,
   MappingReviewSuspendPayload,
+  NeedsReauthSuspendPayload,
   CompletedWorkflowPayload,
   ResumePayload,
   TabsImagesSuspendPayload,
@@ -21,6 +22,7 @@ import {
 import { ContentTypePickerModal } from '../modals/step_2/ContentTypePickerModal';
 import { IncludeImagesModal } from '../modals/step_4/IncludeImagesModal';
 import { useWorkflowAgent } from '@hooks/useWorkflowAgent';
+import { OAuthConnector } from './OAuthConnector';
 
 export interface ModalOrchestratorHandle {
   startFlow: () => void;
@@ -32,17 +34,30 @@ enum FlowStep {
   SELECT_TABS = 'selectTabs',
   INCLUDE_IMAGES = 'includeImages',
   LOADING = 'loading',
+  REAUTH = 'reauth',
 }
 
 interface ModalOrchestratorProps {
   sdk: PageAppSDK;
   oauthToken: string;
+  onOAuthConnectedChange: (isConnected: boolean) => void;
+  onOauthTokenChange: (token: string) => void;
   onMappingReviewReady: (payload: MappingReviewSuspendPayload, runId: string) => void;
   onResetToMain: () => void;
 }
 
 export const ModalOrchestrator = forwardRef<ModalOrchestratorHandle, ModalOrchestratorProps>(
-  ({ sdk, oauthToken, onMappingReviewReady, onResetToMain }, ref) => {
+  (
+    {
+      sdk,
+      oauthToken,
+      onOAuthConnectedChange,
+      onOauthTokenChange,
+      onMappingReviewReady,
+      onResetToMain,
+    },
+    ref
+  ) => {
     const [isUploadModalOpen, setIsUploadModalOpen] = useState(false);
     const [isConfirmCancelModalOpen, setIsConfirmCancelModalOpen] = useState(false);
     const [isErrorPreviewModalOpen, setIsErrorPreviewModalOpen] = useState(false);
@@ -55,6 +70,7 @@ export const ModalOrchestrator = forwardRef<ModalOrchestratorHandle, ModalOrches
     const [includeImages, setIncludeImages] = useState<boolean | null>(null);
     const [requiresImageSelection, setRequiresImageSelection] = useState(false);
     const [activeRunId, setActiveRunId] = useState<string | null>(null);
+    const [pendingReauthRunId, setPendingReauthRunId] = useState<string | null>(null);
     const { startWorkflow, resumeWorkflow } = useWorkflowAgent({
       sdk,
       documentId,
@@ -85,6 +101,7 @@ export const ModalOrchestrator = forwardRef<ModalOrchestratorHandle, ModalOrches
       setSelectedContentTypes([]);
       resetDocumentScopeReview();
       setActiveRunId(null);
+      setPendingReauthRunId(null);
       setFlowStep(null);
       setIsUploadModalOpen(false);
     };
@@ -103,9 +120,10 @@ export const ModalOrchestrator = forwardRef<ModalOrchestratorHandle, ModalOrches
     const handleConfirmCancel = async () => {
       setIsConfirmCancelModalOpen(false);
 
-      if (activeRunId) {
+      const runIdToCancel = activeRunId ?? pendingReauthRunId;
+      if (runIdToCancel) {
         try {
-          await resumeWorkflow(activeRunId, { cancelled: true });
+          await resumeWorkflow(runIdToCancel, { cancelled: true });
         } catch (error) {
           console.error(error);
         }
@@ -117,6 +135,7 @@ export const ModalOrchestrator = forwardRef<ModalOrchestratorHandle, ModalOrches
 
     const showWorkflowError = () => {
       setFlowStep(null);
+      setPendingReauthRunId(null);
       setIsErrorPreviewModalOpen(true);
     };
 
@@ -157,17 +176,34 @@ export const ModalOrchestrator = forwardRef<ModalOrchestratorHandle, ModalOrches
       setFlowStep(null);
     };
 
+    const showReauthPrompt = (suspendPayload: NeedsReauthSuspendPayload, runId: string) => {
+      setPendingReauthRunId(runId);
+      setActiveRunId(null);
+      setFlowStep(FlowStep.REAUTH);
+    };
+
     const handleWorkflowResult = (workflowRun: WorkflowRunResult) => {
       setActiveRunId(workflowRun.runId);
 
       if (workflowRun.status === RunStatus.PENDING_REVIEW) {
         if (workflowRun.suspendPayload.suspendStepId === 'mapping-review') {
           setFlowStep(null);
-          onMappingReviewReady(workflowRun.suspendPayload, workflowRun.runId);
+          onMappingReviewReady(
+            workflowRun.suspendPayload as MappingReviewSuspendPayload,
+            workflowRun.runId
+          );
           return;
         }
 
-        showDocumentScopeReview(workflowRun.suspendPayload);
+        if (workflowRun.suspendPayload.suspendStepId === 'needs-google-reauth') {
+          showReauthPrompt(
+            workflowRun.suspendPayload as NeedsReauthSuspendPayload,
+            workflowRun.runId
+          );
+          return;
+        }
+
+        showDocumentScopeReview(workflowRun.suspendPayload as TabsImagesSuspendPayload);
         return;
       }
 
@@ -191,6 +227,24 @@ export const ModalOrchestrator = forwardRef<ModalOrchestratorHandle, ModalOrches
 
       const workflowRun = await resumeWorkflow(activeRunId, resumePayload);
       handleWorkflowResult(workflowRun);
+    };
+
+    // Called when the user successfully reconnects OAuth during a suspended run
+    const handleReauthTokenChange = async (newToken: string) => {
+      onOauthTokenChange(newToken);
+
+      if (!pendingReauthRunId || !newToken) return;
+
+      const runId = pendingReauthRunId;
+      setPendingReauthRunId(null);
+      setFlowStep(FlowStep.LOADING);
+
+      try {
+        const workflowRun = await resumeWorkflow(runId, { oauthToken: newToken });
+        handleWorkflowResult(workflowRun);
+      } catch {
+        showWorkflowError();
+      }
     };
 
     const startWorkflowWithDelayedLoading = async (contentTypeIds: string[]) => {
@@ -284,6 +338,24 @@ export const ModalOrchestrator = forwardRef<ModalOrchestratorHandle, ModalOrches
               contentTypeCount={selectedContentTypes.length}
             />
           );
+        case FlowStep.REAUTH:
+          return (
+            <>
+              <Modal.Header title="Reconnect Google Drive" onClose={showDiscardConfirmation} />
+              <Modal.Content>
+                <Paragraph marginBottom="spacingM">
+                  Your Google Drive connection expired. Please reconnect to continue generating your
+                  preview — your progress has been saved.
+                </Paragraph>
+                <OAuthConnector
+                  oauthToken={oauthToken}
+                  isOAuthConnected={false}
+                  onOAuthConnectedChange={onOAuthConnectedChange}
+                  onOauthTokenChange={handleReauthTokenChange}
+                />
+              </Modal.Content>
+            </>
+          );
         default:
           return null;
       }
@@ -302,7 +374,7 @@ export const ModalOrchestrator = forwardRef<ModalOrchestratorHandle, ModalOrches
           onClose={showDiscardConfirmation}
           size={'large'}
           shouldCloseOnOverlayClick={false}
-          shouldCloseOnEscapePress={flowStep !== FlowStep.LOADING}>
+          shouldCloseOnEscapePress={flowStep !== FlowStep.LOADING && flowStep !== FlowStep.REAUTH}>
           {renderFlowStep}
         </Modal>
 

--- a/apps/google-docs/src/types/workflow.ts
+++ b/apps/google-docs/src/types/workflow.ts
@@ -109,12 +109,21 @@ export interface MappingReviewSuspendPayload {
   contentTypes: WorkflowContentType[];
 }
 
+export interface NeedsReauthSuspendPayload {
+  reason?: string;
+  suspendStepId: 'needs-google-reauth';
+  documentId: string;
+}
+
 export type WorkflowRunResult =
   | {
       status: RunStatus.PENDING_REVIEW;
       runId: string;
       messages: AgentRunMessage[];
-      suspendPayload: TabsImagesSuspendPayload | MappingReviewSuspendPayload;
+      suspendPayload:
+        | TabsImagesSuspendPayload
+        | MappingReviewSuspendPayload
+        | NeedsReauthSuspendPayload;
     }
   | {
       status: RunStatus.COMPLETED;
@@ -129,4 +138,5 @@ export interface ResumePayload {
   editedNormalizedDocument?: NormalizedDocument;
   entryBlockGraph?: EntryBlockGraph;
   cancelled?: true;
+  oauthToken?: string;
 }

--- a/apps/google-docs/test/locations/Page/components/mainpage/ModalOrchestrator.spec.tsx
+++ b/apps/google-docs/test/locations/Page/components/mainpage/ModalOrchestrator.spec.tsx
@@ -61,6 +61,8 @@ vi.mock('@contentful/react-apps-toolkit', () => ({
 const defaultProps = {
   sdk: mockSdk,
   oauthToken: 'mock-oauth-token',
+  onOAuthConnectedChange: vi.fn(),
+  onOauthTokenChange: vi.fn(),
   onMappingReviewReady: vi.fn(),
   onResetToMain: vi.fn(),
 };


### PR DESCRIPTION
## Summary

- Adds `NeedsReauthSuspendPayload` type (`suspendStepId: 'needs-google-reauth'`) to the workflow type union
- When the workflow suspends with that payload, `ModalOrchestrator` now shows a **reconnect modal** instead of an error modal — preserving all workflow progress
- On successful reconnect, the fresh token is passed directly to `resumeWorkflowRun` so the workflow continues from where it left off rather than requiring a full restart
- Adds `oauthToken` to `ResumePayload` type
- Fixes the existing test suite to pass the two new required `ModalOrchestrator` props

## Problem

OAuth tokens expire after ~1 hour. The previous UX was: workflow fails → generic error modal → user must reconnect → user must restart the entire workflow from scratch. All progress (document selection, content type selection, tab/image selection) was lost.

## Solution

The agents-api step now suspends with `needs-google-reauth` instead of failing (see pairing PR). On the frontend:

1. `ModalOrchestrator.handleWorkflowResult` detects `suspendStepId === 'needs-google-reauth'` and calls `showReauthPrompt`, which sets a new `FlowStep.REAUTH` state and saves the `runId` in `pendingReauthRunId`
2. The `REAUTH` flow step renders the existing `OAuthConnector` inside the modal with an explanatory message
3. `handleReauthTokenChange` is wired as the `onOauthTokenChange` callback — when the reconnect completes it immediately calls `resumeWorkflow(pendingReauthRunId, { oauthToken: newToken })` and resumes polling
4. If the resume itself fails, it falls through to `showWorkflowError` as a last resort

## Pairing PR

This PR pairs with [contentful/agents-api#447](https://github.com/contentful/agents-api/pull/447) which adds the suspend-on-401 logic to the workflow step.

## Files changed

| File | Change |
|------|--------|
| `src/types/workflow.ts` | Add `NeedsReauthSuspendPayload`, add `oauthToken` to `ResumePayload`, update `WorkflowRunResult` union |
| `src/hooks/useWorkflowAgent.ts` | Include `NeedsReauthSuspendPayload` in `getSuspendPayload` return type |
| `src/locations/Page/components/mainpage/ModalOrchestrator.tsx` | Add `FlowStep.REAUTH`, `pendingReauthRunId` state, `showReauthPrompt`, `handleReauthTokenChange`, reauth modal render, new required props |
| `src/locations/Page/Page.tsx` | Pass `onOAuthConnectedChange` and `onOauthTokenChange` to `ModalOrchestrator` |
| `test/.../ModalOrchestrator.spec.tsx` | Add missing required props to `defaultProps` |

## Test plan

- [ ] Trigger a `needs-google-reauth` suspend (mock it in `useWorkflowAgent` or deploy pairing agents-api PR) and confirm the reconnect modal appears mid-workflow
- [ ] Complete the reconnect flow and confirm the workflow resumes and completes normally without restarting
- [ ] Confirm the cancel/discard flow works correctly from the reauth modal
- [ ] Confirm the token update from reconnect propagates to the main page `OAuthConnector` so the connected state stays in sync
- [ ] Run existing test suite: `npm run test` in `apps/google-docs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)