### PR TITLE
feat(google-docs): add view/edit mode toggle to review page [INTEG-3858]

### DIFF
--- a/apps/google-docs/src/locations/Page/components/overview/OverviewEntryList.tsx
+++ b/apps/google-docs/src/locations/Page/components/overview/OverviewEntryList.tsx
@@ -12,13 +12,13 @@ import { truncateLabel } from '../../../../utils/utils';
 
 export interface OverviewEntryListProps {
   rows: OverviewEntryListRow[];
-  selectedEntryIndex: number;
+  selectedEntryIndex: number | null;
   onSelect: (entryIndex: number) => void;
 }
 
 interface OverviewEntryRowCardProps {
   row: OverviewEntryListRow;
-  selectedEntryIndex: number;
+  selectedEntryIndex: number | null;
   onSelect: (entryIndex: number) => void;
   showTreeLines: boolean;
   isLastRow?: boolean;

--- a/apps/google-docs/src/locations/Page/components/overview/OverviewSection.tsx
+++ b/apps/google-docs/src/locations/Page/components/overview/OverviewSection.tsx
@@ -9,7 +9,7 @@ import Splitter from '../mainpage/Splitter';
 
 interface OverviewProps {
   payload: MappingReviewSuspendPayload;
-  selectedEntryIndex: number;
+  selectedEntryIndex: number | null;
   onSelectEntryIndex: (index: number) => void;
   reviewMode: 'view' | 'edit';
   onReviewModeChange: (mode: 'view' | 'edit') => void;

--- a/apps/google-docs/src/locations/Page/components/overview/OverviewSection.tsx
+++ b/apps/google-docs/src/locations/Page/components/overview/OverviewSection.tsx
@@ -67,16 +67,18 @@ const OverviewSection = ({
               <ButtonGroup variant="spaced">
                 <Button
                   size="small"
-                  variant={reviewMode === 'view' ? 'primary' : 'secondary'}
+                  variant="secondary"
                   onClick={() => onReviewModeChange('view')}
-                  aria-pressed={reviewMode === 'view'}>
+                  aria-pressed={reviewMode === 'view'}
+                  style={reviewMode === 'view' ? { fontWeight: 600 } : undefined}>
                   View
                 </Button>
                 <Button
                   size="small"
-                  variant={reviewMode === 'edit' ? 'primary' : 'secondary'}
+                  variant="secondary"
                   onClick={() => onReviewModeChange('edit')}
-                  aria-pressed={reviewMode === 'edit'}>
+                  aria-pressed={reviewMode === 'edit'}
+                  style={reviewMode === 'edit' ? { fontWeight: 600 } : undefined}>
                   Edit
                 </Button>
               </ButtonGroup>

--- a/apps/google-docs/src/locations/Page/components/overview/OverviewSection.tsx
+++ b/apps/google-docs/src/locations/Page/components/overview/OverviewSection.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { Box, Button, Flex, Note, Paragraph, Text } from '@contentful/f36-components';
+import { Box, Button, ButtonGroup, Flex, Note, Paragraph, Text } from '@contentful/f36-components';
 import { LightbulbIcon } from '@contentful/f36-icons';
 import type { MappingReviewSuspendPayload } from '@types';
 import { buildEntryListFromEntryBlockGraph } from '../../../../utils/overviewEntryList';
@@ -11,6 +11,8 @@ interface OverviewProps {
   payload: MappingReviewSuspendPayload;
   selectedEntryIndex: number;
   onSelectEntryIndex: (index: number) => void;
+  reviewMode: 'view' | 'edit';
+  onReviewModeChange: (mode: 'view' | 'edit') => void;
   ctaLabel: string;
   onCtaClick: () => void;
   isCtaLoading?: boolean;
@@ -20,6 +22,8 @@ const OverviewSection = ({
   payload,
   selectedEntryIndex,
   onSelectEntryIndex,
+  reviewMode,
+  onReviewModeChange,
   ctaLabel,
   onCtaClick,
   isCtaLoading = false,
@@ -59,13 +63,31 @@ const OverviewSection = ({
               <Text fontSize="fontSizeM">Click row to view content by entry below.</Text>
             </Flex>
 
-            <Button
-              variant="primary"
-              onClick={onCtaClick}
-              isLoading={isCtaLoading}
-              isDisabled={isCtaLoading}>
-              {ctaLabel}
-            </Button>
+            <Flex alignItems="center" gap="spacingS">
+              <ButtonGroup variant="spaced">
+                <Button
+                  size="small"
+                  variant={reviewMode === 'view' ? 'primary' : 'secondary'}
+                  onClick={() => onReviewModeChange('view')}
+                  aria-pressed={reviewMode === 'view'}>
+                  View
+                </Button>
+                <Button
+                  size="small"
+                  variant={reviewMode === 'edit' ? 'primary' : 'secondary'}
+                  onClick={() => onReviewModeChange('edit')}
+                  aria-pressed={reviewMode === 'edit'}>
+                  Edit
+                </Button>
+              </ButtonGroup>
+              <Button
+                variant="primary"
+                onClick={onCtaClick}
+                isLoading={isCtaLoading}
+                isDisabled={isCtaLoading}>
+                {ctaLabel}
+              </Button>
+            </Flex>
           </Flex>
 
           {entryRows.length === 0 ? (

--- a/apps/google-docs/src/locations/Page/components/overview/OverviewSection.tsx
+++ b/apps/google-docs/src/locations/Page/components/overview/OverviewSection.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { Box, Button, ButtonGroup, Flex, Note, Paragraph, Text } from '@contentful/f36-components';
-import { LightbulbIcon } from '@contentful/f36-icons';
+import { EyeIcon, LightbulbIcon, PencilSimpleIcon } from '@contentful/f36-icons';
 import type { MappingReviewSuspendPayload } from '@types';
 import { buildEntryListFromEntryBlockGraph } from '../../../../utils/overviewEntryList';
 import { OverviewEntryList } from './OverviewEntryList';
@@ -68,6 +68,7 @@ const OverviewSection = ({
                 <Button
                   size="small"
                   variant="secondary"
+                  startIcon={<EyeIcon />}
                   onClick={() => onReviewModeChange('view')}
                   aria-pressed={reviewMode === 'view'}
                   style={reviewMode === 'view' ? { fontWeight: 600 } : undefined}>
@@ -76,6 +77,7 @@ const OverviewSection = ({
                 <Button
                   size="small"
                   variant="secondary"
+                  startIcon={<PencilSimpleIcon />}
                   onClick={() => onReviewModeChange('edit')}
                   aria-pressed={reviewMode === 'edit'}
                   style={reviewMode === 'edit' ? { fontWeight: 600 } : undefined}>

--- a/apps/google-docs/src/locations/Page/components/overview/OverviewSection.tsx
+++ b/apps/google-docs/src/locations/Page/components/overview/OverviewSection.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { Box, Button, ButtonGroup, Flex, Note, Paragraph, Text } from '@contentful/f36-components';
+import { Box, Button, Flex, Note, Paragraph, Text } from '@contentful/f36-components';
 import { EyeIcon, LightbulbIcon, PencilSimpleIcon } from '@contentful/f36-icons';
 import type { MappingReviewSuspendPayload } from '@types';
 import { buildEntryListFromEntryBlockGraph } from '../../../../utils/overviewEntryList';
@@ -64,26 +64,24 @@ const OverviewSection = ({
             </Flex>
 
             <Flex alignItems="center" gap="spacingS">
-              <ButtonGroup variant="spaced">
-                <Button
-                  size="small"
-                  variant="secondary"
-                  startIcon={<EyeIcon />}
-                  onClick={() => onReviewModeChange('view')}
-                  aria-pressed={reviewMode === 'view'}
-                  style={reviewMode === 'view' ? { fontWeight: 600 } : undefined}>
-                  View
-                </Button>
-                <Button
-                  size="small"
-                  variant="secondary"
-                  startIcon={<PencilSimpleIcon />}
-                  onClick={() => onReviewModeChange('edit')}
-                  aria-pressed={reviewMode === 'edit'}
-                  style={reviewMode === 'edit' ? { fontWeight: 600 } : undefined}>
-                  Edit
-                </Button>
-              </ButtonGroup>
+              <Button
+                size="small"
+                variant="secondary"
+                startIcon={<EyeIcon />}
+                onClick={() => onReviewModeChange('view')}
+                aria-pressed={reviewMode === 'view'}
+                style={reviewMode === 'view' ? { fontWeight: 600 } : undefined}>
+                View
+              </Button>
+              <Button
+                size="small"
+                variant="secondary"
+                startIcon={<PencilSimpleIcon />}
+                onClick={() => onReviewModeChange('edit')}
+                aria-pressed={reviewMode === 'edit'}
+                style={reviewMode === 'edit' ? { fontWeight: 600 } : undefined}>
+                Edit
+              </Button>
               <Button
                 variant="primary"
                 onClick={onCtaClick}

--- a/apps/google-docs/src/locations/Page/components/review/ReviewPage.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/ReviewPage.tsx
@@ -32,6 +32,7 @@ export const ReviewPage = ({
 }: ReviewPageProps) => {
   const [isConfirmCancelModalOpen, setIsConfirmCancelModalOpen] = useState(false);
   const [selectedEntryIndex, setSelectedEntryIndex] = useState<number>(0);
+  const [reviewMode, setReviewMode] = useState<'view' | 'edit'>('view');
   const [isCancelling, setIsCancelling] = useState(false);
   const [isCreatePending, setIsCreatePending] = useState(false);
   const [createdEntries, setCreatedEntries] = useState<EntryProps[] | null>(null);
@@ -171,7 +172,12 @@ export const ReviewPage = ({
           <OverviewSection
             payload={reviewPayload}
             selectedEntryIndex={selectedEntryIndex}
-            onSelectEntryIndex={setSelectedEntryIndex}
+            onSelectEntryIndex={(index) => {
+              setSelectedEntryIndex(index);
+              setReviewMode('edit');
+            }}
+            reviewMode={reviewMode}
+            onReviewModeChange={setReviewMode}
             ctaLabel={hasCreatedEntries ? 'View entries' : 'Create entries'}
             onCtaClick={handleCreateOrViewEntries}
             isCtaLoading={isCreatePending}
@@ -182,6 +188,7 @@ export const ReviewPage = ({
             onEntryBlockGraphChange={setEntryBlockGraph}
             selectedEntryIndex={selectedEntryIndex}
             isDisabled={isMappingDisabled}
+            mode={reviewMode}
           />
         </Flex>
       </Layout.Body>

--- a/apps/google-docs/src/locations/Page/components/review/ReviewPage.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/ReviewPage.tsx
@@ -31,7 +31,7 @@ export const ReviewPage = ({
   onExitReview,
 }: ReviewPageProps) => {
   const [isConfirmCancelModalOpen, setIsConfirmCancelModalOpen] = useState(false);
-  const [selectedEntryIndex, setSelectedEntryIndex] = useState<number>(0);
+  const [selectedEntryIndex, setSelectedEntryIndex] = useState<number | null>(null);
   const [reviewMode, setReviewMode] = useState<'view' | 'edit'>('view');
   const [isCancelling, setIsCancelling] = useState(false);
   const [isCreatePending, setIsCreatePending] = useState(false);
@@ -177,7 +177,10 @@ export const ReviewPage = ({
               setReviewMode('edit');
             }}
             reviewMode={reviewMode}
-            onReviewModeChange={setReviewMode}
+            onReviewModeChange={(mode) => {
+              setReviewMode(mode);
+              if (mode === 'view') setSelectedEntryIndex(null);
+            }}
             ctaLabel={hasCreatedEntries ? 'View entries' : 'Create entries'}
             onCtaClick={handleCreateOrViewEntries}
             isCtaLoading={isCreatePending}

--- a/apps/google-docs/src/locations/Page/components/review/ReviewPage.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/ReviewPage.tsx
@@ -179,7 +179,11 @@ export const ReviewPage = ({
             reviewMode={reviewMode}
             onReviewModeChange={(mode) => {
               setReviewMode(mode);
-              if (mode === 'view') setSelectedEntryIndex(null);
+              if (mode === 'view') {
+                setSelectedEntryIndex(null);
+              } else if (mode === 'edit' && selectedEntryIndex === null) {
+                setSelectedEntryIndex(entryBlockGraph.entries.length > 0 ? 0 : null);
+              }
             }}
             ctaLabel={hasCreatedEntries ? 'View entries' : 'Create entries'}
             onCtaClick={handleCreateOrViewEntries}

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -230,7 +230,7 @@ export const MappingView = ({
   const listMarkers = useMemo(() => buildListMarkers(allSegments), [allSegments]);
 
   const getVisibleHighlights = <T extends MappingHighlight>(highlights: T[]): T[] => {
-    if (selectedEntryIndex === null) {
+    if (isViewMode || selectedEntryIndex === null) {
       return highlights;
     }
     return highlights.filter((item) => item.entryIndex === selectedEntryIndex);

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -1008,7 +1008,28 @@ export const MappingView = ({
                 const isGroupHovered = group.mappingCards.some((card) =>
                   card.mappingKeys.some((key) => hoveredMappingKeys.includes(key))
                 );
-                const showSurface = group.showGroupedSurface;
+                const hasMappedCards = group.mappingCards.length > 0;
+                const showSurface = isViewMode ? hasMappedCards : group.showGroupedSurface;
+
+                const segmentContent = (
+                  <Flex flexDirection="column" gap="spacing2Xs">
+                    {group.segments.map((segment) => (
+                      <NormalizedDocumentSection
+                        key={segment.id}
+                        segment={segment}
+                        highlightIndex={activeHighlightIndex}
+                        imageById={imageById}
+                        listMarkers={listMarkers}
+                        excludedSourceRefs={entryBlockGraph.excludedSourceRefs}
+                        selectedEntryIndex={selectedEntryIndex}
+                        hoveredMappingKeys={hoveredMappingKeys}
+                        onSetHoveredMappingKeys={setHoveredMappingKeys}
+                        onAssignImage={handleAssignImage}
+                        onExcludeImage={handleExcludeImage}
+                      />
+                    ))}
+                  </Flex>
+                );
 
                 return (
                   <Box key={group.id}>
@@ -1027,46 +1048,14 @@ export const MappingView = ({
                                 isGroupHovered ? tokens.green600 : tokens.green500
                               }`,
                               borderRadius: tokens.borderRadiusMedium,
-                              backgroundColor: tokens.green100,
+                              backgroundColor: isViewMode ? undefined : tokens.green100,
                               padding: tokens.spacing2Xs,
                               transition: 'border-color 120ms ease, border-width 120ms ease',
                             }}>
-                            <Flex flexDirection="column" gap="spacing2Xs">
-                              {group.segments.map((segment) => (
-                                <NormalizedDocumentSection
-                                  key={segment.id}
-                                  segment={segment}
-                                  highlightIndex={activeHighlightIndex}
-                                  imageById={imageById}
-                                  listMarkers={listMarkers}
-                                  excludedSourceRefs={entryBlockGraph.excludedSourceRefs}
-                                  selectedEntryIndex={selectedEntryIndex}
-                                  hoveredMappingKeys={hoveredMappingKeys}
-                                  onSetHoveredMappingKeys={setHoveredMappingKeys}
-                                  onAssignImage={handleAssignImage}
-                                  onExcludeImage={handleExcludeImage}
-                                />
-                              ))}
-                            </Flex>
+                            {segmentContent}
                           </Box>
                         ) : (
-                          <Flex flexDirection="column" gap="spacingS">
-                            {group.segments.map((segment) => (
-                              <NormalizedDocumentSection
-                                key={segment.id}
-                                segment={segment}
-                                highlightIndex={activeHighlightIndex}
-                                imageById={imageById}
-                                listMarkers={listMarkers}
-                                excludedSourceRefs={entryBlockGraph.excludedSourceRefs}
-                                selectedEntryIndex={selectedEntryIndex}
-                                hoveredMappingKeys={hoveredMappingKeys}
-                                onSetHoveredMappingKeys={setHoveredMappingKeys}
-                                onAssignImage={handleAssignImage}
-                                onExcludeImage={handleExcludeImage}
-                              />
-                            ))}
-                          </Flex>
+                          segmentContent
                         )}
                       </Box>
 

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -1005,12 +1005,10 @@ export const MappingView = ({
             <Flex flexDirection="column" gap="spacingS">
               {(groupsByTab[tab.id] ?? []).map((group) => {
                 const activeHighlightIndex = isViewMode ? EMPTY_HIGHLIGHT_INDEX : highlightIndex;
-                const isGroupHovered =
-                  !isViewMode &&
-                  group.mappingCards.some((card) =>
-                    card.mappingKeys.some((key) => hoveredMappingKeys.includes(key))
-                  );
-                const showSurface = !isViewMode && group.showGroupedSurface;
+                const isGroupHovered = group.mappingCards.some((card) =>
+                  card.mappingKeys.some((key) => hoveredMappingKeys.includes(key))
+                );
+                const showSurface = group.showGroupedSurface;
 
                 return (
                   <Box key={group.id}>
@@ -1034,32 +1032,6 @@ export const MappingView = ({
                               transition: 'border-color 120ms ease, border-width 120ms ease',
                             }}>
                             <Flex flexDirection="column" gap="spacing2Xs">
-                              {group.segments.map((segment) => (
-                                <NormalizedDocumentSection
-                                  key={segment.id}
-                                  segment={segment}
-                                  highlightIndex={activeHighlightIndex}
-                                  imageById={imageById}
-                                  listMarkers={listMarkers}
-                                  excludedSourceRefs={entryBlockGraph.excludedSourceRefs}
-                                  selectedEntryIndex={selectedEntryIndex}
-                                  hoveredMappingKeys={hoveredMappingKeys}
-                                  onSetHoveredMappingKeys={setHoveredMappingKeys}
-                                  onAssignImage={handleAssignImage}
-                                  onExcludeImage={handleExcludeImage}
-                                />
-                              ))}
-                            </Flex>
-                          </Box>
-                        ) : isViewMode && (viewCardsByGroup[group.id]?.length ?? 0) > 0 ? (
-                          <Box
-                            data-testid={`view-group-surface-${group.id}`}
-                            style={{
-                              border: `1px solid ${tokens.gray300}`,
-                              borderRadius: tokens.borderRadiusMedium,
-                              padding: tokens.spacing2Xs,
-                            }}>
-                            <Flex flexDirection="column" gap="spacingS">
                               {group.segments.map((segment) => (
                                 <NormalizedDocumentSection
                                   key={segment.id}

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -1051,6 +1051,32 @@ export const MappingView = ({
                               ))}
                             </Flex>
                           </Box>
+                        ) : isViewMode && (viewCardsByGroup[group.id]?.length ?? 0) > 0 ? (
+                          <Box
+                            data-testid={`view-group-surface-${group.id}`}
+                            style={{
+                              border: `1px solid ${tokens.gray300}`,
+                              borderRadius: tokens.borderRadiusMedium,
+                              padding: tokens.spacing2Xs,
+                            }}>
+                            <Flex flexDirection="column" gap="spacingS">
+                              {group.segments.map((segment) => (
+                                <NormalizedDocumentSection
+                                  key={segment.id}
+                                  segment={segment}
+                                  highlightIndex={activeHighlightIndex}
+                                  imageById={imageById}
+                                  listMarkers={listMarkers}
+                                  excludedSourceRefs={entryBlockGraph.excludedSourceRefs}
+                                  selectedEntryIndex={selectedEntryIndex}
+                                  hoveredMappingKeys={hoveredMappingKeys}
+                                  onSetHoveredMappingKeys={setHoveredMappingKeys}
+                                  onAssignImage={handleAssignImage}
+                                  onExcludeImage={handleExcludeImage}
+                                />
+                              ))}
+                            </Flex>
+                          </Box>
                         ) : (
                           <Flex flexDirection="column" gap="spacingS">
                             {group.segments.map((segment) => (

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -30,6 +30,7 @@ import {
   buildMappingHighlightIndex,
   getMappingCardKey,
   type MappingHighlight,
+  type MappingHighlightIndex,
   uniqueHighlights,
 } from './buildHighlights';
 import { buildListMarkers } from './buildListMarkers';
@@ -46,6 +47,7 @@ import { buildSourceRefKey } from './sourceRefUtils';
 import { MappingEntryCards } from './MappingEntryCards';
 import { NormalizedDocumentSection } from './NormalizedDocumentSection';
 import { buildMappingDisplayGroups } from './buildMappingDisplayGroups';
+import { ViewMappingRail, type ViewMappingCardEntry } from './ViewMappingRail';
 import {
   applyImageExclusionToEntryBlockGraph,
   applyImageReassignToEntryBlockGraph,
@@ -80,6 +82,7 @@ interface MappingViewProps {
   onEntryBlockGraphChange: (next: EntryBlockGraph) => void;
   selectedEntryIndex: number | null;
   isDisabled?: boolean;
+  mode?: 'view' | 'edit';
 }
 
 const EMPTY_NEW_LOCATION: EditModalNewLocation = {
@@ -120,13 +123,21 @@ function rangeIntersectsNode(range: Range, node: Node): boolean {
   }
 }
 
+const EMPTY_HIGHLIGHT_INDEX: MappingHighlightIndex = {
+  blockHighlights: {},
+  tablePartHighlights: {},
+  tableHighlights: {},
+};
+
 export const MappingView = ({
   payload,
   entryBlockGraph,
   onEntryBlockGraphChange,
   selectedEntryIndex,
   isDisabled = false,
+  mode = 'view',
 }: MappingViewProps): JSX.Element => {
+  const isViewMode = mode === 'view';
   const selectedEntryRow = useMemo(() => {
     const rows = buildEntryListFromEntryBlockGraph(
       payload.entryBlockGraph.entries,
@@ -897,6 +908,42 @@ export const MappingView = ({
     closeEditModal();
   };
 
+  const viewCardsByGroup = useMemo((): Record<string, ViewMappingCardEntry[]> => {
+    const result: Record<string, ViewMappingCardEntry[]> = {};
+
+    allGroups.forEach((group) => {
+      const cards: ViewMappingCardEntry[] = [];
+
+      group.mappingCards.forEach((card) => {
+        const location = locationsByCardKey.get(card.key);
+        if (!location) return;
+
+        const graphEntry = entryBlockGraph.entries[location.entryIndex];
+        const contentType = payload.contentTypes.find(
+          (ct) => ct.sys.id === graphEntry?.contentTypeId
+        );
+        const contentTypeName = (contentType?.name ?? graphEntry?.contentTypeId ?? '').trim();
+        const entryName = getEntryTitleFromFieldMappings(graphEntry, contentType?.displayField);
+        const field = contentType?.fields.find((f) => f.id === location.fieldId);
+        const fieldType = field
+          ? displayType(field.type ?? '', field.linkType, field.items)
+          : location.fieldType;
+
+        cards.push({
+          key: card.key,
+          contentTypeName,
+          entryName,
+          fieldName: card.fieldName,
+          fieldType,
+        });
+      });
+
+      result[group.id] = cards;
+    });
+
+    return result;
+  }, [allGroups, locationsByCardKey, entryBlockGraph.entries, payload.contentTypes]);
+
   const canExcludeSelectedText = useMemo(() => {
     const root = textSelectionRootRef.current;
     if (!root || !selectedRange) {
@@ -957,9 +1004,13 @@ export const MappingView = ({
 
             <Flex flexDirection="column" gap="spacingS">
               {(groupsByTab[tab.id] ?? []).map((group) => {
-                const isGroupHovered = group.mappingCards.some((card) =>
-                  card.mappingKeys.some((key) => hoveredMappingKeys.includes(key))
-                );
+                const activeHighlightIndex = isViewMode ? EMPTY_HIGHLIGHT_INDEX : highlightIndex;
+                const isGroupHovered =
+                  !isViewMode &&
+                  group.mappingCards.some((card) =>
+                    card.mappingKeys.some((key) => hoveredMappingKeys.includes(key))
+                  );
+                const showSurface = !isViewMode && group.showGroupedSurface;
 
                 return (
                   <Box key={group.id}>
@@ -969,7 +1020,7 @@ export const MappingView = ({
                       data-testid={`display-group-layout-${group.id}`}
                       ref={setGroupLayoutRef(group.id)}>
                       <Box style={{ flex: 2 }}>
-                        {group.showGroupedSurface ? (
+                        {showSurface ? (
                           <Box
                             data-testid={`mapping-group-surface-${group.id}`}
                             data-hovered={isGroupHovered ? 'true' : 'false'}
@@ -987,7 +1038,7 @@ export const MappingView = ({
                                 <NormalizedDocumentSection
                                   key={segment.id}
                                   segment={segment}
-                                  highlightIndex={highlightIndex}
+                                  highlightIndex={activeHighlightIndex}
                                   imageById={imageById}
                                   listMarkers={listMarkers}
                                   excludedSourceRefs={entryBlockGraph.excludedSourceRefs}
@@ -1006,7 +1057,7 @@ export const MappingView = ({
                               <NormalizedDocumentSection
                                 key={segment.id}
                                 segment={segment}
-                                highlightIndex={highlightIndex}
+                                highlightIndex={activeHighlightIndex}
                                 imageById={imageById}
                                 listMarkers={listMarkers}
                                 excludedSourceRefs={entryBlockGraph.excludedSourceRefs}
@@ -1021,14 +1072,21 @@ export const MappingView = ({
                         )}
                       </Box>
 
-                      <MappingEntryCards
-                        groupId={group.id}
-                        mappingCards={group.mappingCards}
-                        cardOffsetsByGroup={cardOffsetsByGroup}
-                        hoveredMappingKeys={hoveredMappingKeys}
-                        onSetHoveredMappingKeys={setHoveredMappingKeys}
-                        setCardWrapperRef={setCardWrapperRef}
-                      />
+                      {isViewMode ? (
+                        <ViewMappingRail
+                          segmentId={group.id}
+                          cards={viewCardsByGroup[group.id] ?? []}
+                        />
+                      ) : (
+                        <MappingEntryCards
+                          groupId={group.id}
+                          mappingCards={group.mappingCards}
+                          cardOffsetsByGroup={cardOffsetsByGroup}
+                          hoveredMappingKeys={hoveredMappingKeys}
+                          onSetHoveredMappingKeys={setHoveredMappingKeys}
+                          setCardWrapperRef={setCardWrapperRef}
+                        />
+                      )}
                     </Flex>
                   </Box>
                 );
@@ -1038,7 +1096,7 @@ export const MappingView = ({
         ))}
       </Flex>
 
-      {selectionRectangle && !isDisabled ? (
+      {selectionRectangle && !isDisabled && !isViewMode ? (
         <SelectionActionMenu
           anchorRectangle={selectionRectangle}
           onAssign={handleAssignFromSelection}

--- a/apps/google-docs/src/locations/Page/components/review/mapping/ViewMappingCard.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/ViewMappingCard.tsx
@@ -30,10 +30,10 @@ export const ViewMappingCard = ({ card }: ViewMappingCardProps) => (
   <Box
     data-testid={`view-mapping-card-${card.key}`}
     style={{
-      border: `1px solid ${tokens.gray300}`,
+      border: `1px solid ${tokens.green500}`,
       borderRadius: tokens.borderRadiusMedium,
       padding: tokens.spacing2Xs,
-      backgroundColor: tokens.colorWhite,
+      backgroundColor: tokens.green100,
     }}>
     <Text as="p" marginBottom="none" style={rowTextStyle}>
       <Text as="span" fontColor="gray600" marginRight="spacingXs" style={rowTextStyle}>

--- a/apps/google-docs/src/locations/Page/components/review/mapping/ViewMappingCard.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/ViewMappingCard.tsx
@@ -1,0 +1,67 @@
+import { Box, Text } from '@contentful/f36-components';
+import tokens from '@contentful/f36-tokens';
+
+export interface ViewMappingCardData {
+  key: string;
+  contentTypeName: string;
+  entryName: string;
+  fieldName: string;
+  fieldType: string;
+}
+
+interface ViewMappingCardProps {
+  card: ViewMappingCardData;
+}
+
+const rowTextStyle = {
+  fontSize: tokens.fontSizeS,
+  lineHeight: tokens.lineHeightS,
+} as const;
+
+const truncatedValueStyle = {
+  fontSize: tokens.fontSizeS,
+  lineHeight: tokens.lineHeightS,
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+} as const;
+
+export const ViewMappingCard = ({ card }: ViewMappingCardProps) => (
+  <Box
+    data-testid={`view-mapping-card-${card.key}`}
+    style={{
+      border: `1px solid ${tokens.gray300}`,
+      borderRadius: tokens.borderRadiusMedium,
+      padding: tokens.spacing2Xs,
+      backgroundColor: tokens.colorWhite,
+    }}>
+    <Text as="p" marginBottom="none" style={rowTextStyle}>
+      <Text as="span" fontColor="gray600" marginRight="spacingXs" style={rowTextStyle}>
+        Content Type:
+      </Text>
+      <Text as="span" fontWeight="fontWeightDemiBold" style={truncatedValueStyle}>
+        {card.contentTypeName}
+      </Text>
+    </Text>
+    <Text as="p" marginBottom="none" style={rowTextStyle}>
+      <Text as="span" fontColor="gray600" marginRight="spacingXs" style={rowTextStyle}>
+        Entry:
+      </Text>
+      <Text as="span" fontWeight="fontWeightDemiBold" style={truncatedValueStyle}>
+        {card.entryName}
+      </Text>
+    </Text>
+    <Text as="p" marginBottom="none" style={rowTextStyle}>
+      <Text as="span" fontColor="gray600" marginRight="spacingXs" style={rowTextStyle}>
+        Field:
+      </Text>
+      <Text as="span" fontWeight="fontWeightDemiBold" style={truncatedValueStyle}>
+        {card.fieldName}
+        <Box as="span" style={{ color: tokens.gray600 }}>
+          {' | '}
+          {card.fieldType}
+        </Box>
+      </Text>
+    </Text>
+  </Box>
+);

--- a/apps/google-docs/src/locations/Page/components/review/mapping/ViewMappingRail.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/ViewMappingRail.tsx
@@ -1,0 +1,25 @@
+import { Box, Flex } from '@contentful/f36-components';
+import type { BoxProps } from '@contentful/f36-components';
+import { ViewMappingCard, type ViewMappingCardData } from './ViewMappingCard';
+
+export type ViewMappingCardEntry = ViewMappingCardData;
+
+interface ViewMappingRailProps {
+  segmentId: string;
+  cards: ViewMappingCardEntry[];
+}
+
+const railStyles: BoxProps['style'] = {
+  flex: '0 0 280px',
+  maxWidth: 280,
+};
+
+export const ViewMappingRail = ({ segmentId, cards }: ViewMappingRailProps): JSX.Element => (
+  <Box data-testid={`view-mapping-rail-${segmentId}`} style={railStyles}>
+    <Flex flexDirection="column" gap="spacing2Xs">
+      {cards.map((card) => (
+        <ViewMappingCard key={card.key} card={card} />
+      ))}
+    </Flex>
+  </Box>
+);


### PR DESCRIPTION
[INTEG-3858](https://contentful.atlassian.net/browse/INTEG-3858)

Uploading Screen Recording 2026-04-28 at 3.35.40 PM.mov…

## Summary
- Adds **View** and **Edit** mode toggle buttons to the review page, placed alongside the "Create entries" button in the Overview section
- **View mode** (default): document renders without green highlights or interactive text selection; right rail shows richer entry cards with Content Type, Entry name, and Field name | Field type
- **Edit mode**: unchanged from existing behavior — green highlights, hover states, text selection, exclude/assign actions all work as before
- Clicking an entry row in the entry tree automatically switches to Edit mode for that entry; user must manually toggle back to View
- View mode cards react to assign/reassign/exclude changes (same reactive chain as edit mode — both derive from `entryBlockGraph`)

## Test plan
- [ ] Page loads in View mode by default — no green highlights visible, right rail shows Content Type / Entry / Field cards
- [ ] Toggling to Edit mode restores green highlights, hover states, and text selection menu
- [ ] Clicking an entry in the entry tree while in View mode auto-switches to Edit mode
- [ ] Manually toggling back to View from Edit works
- [ ] After excluding content in Edit mode, switching to View reflects the updated mapping (excluded items no longer appear)
- [ ] After reassigning content in Edit mode, switching to View shows updated cards
- [ ] Multi-span fields (e.g. "Field (1/2)" / "Field (2/2)") show a card per group in View mode, matching Edit mode

Generated with [Claude Code](https://claude.com/claude-code)

[INTEG-3858]: https://contentful.atlassian.net/browse/INTEG-3858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ