### PR TITLE
merge: resolve master conflicts into fix/reassign with rail spacing fix []

### DIFF
--- a/apps/google-docs/src/locations/Page/components/overview/OverviewEntryList.tsx
+++ b/apps/google-docs/src/locations/Page/components/overview/OverviewEntryList.tsx
@@ -12,13 +12,13 @@ import { truncateLabel } from '../../../../utils/utils';
 
 export interface OverviewEntryListProps {
   rows: OverviewEntryListRow[];
-  selectedEntryIndex: number;
+  selectedEntryIndex: number | null;
   onSelect: (entryIndex: number) => void;
 }
 
 interface OverviewEntryRowCardProps {
   row: OverviewEntryListRow;
-  selectedEntryIndex: number;
+  selectedEntryIndex: number | null;
   onSelect: (entryIndex: number) => void;
   showTreeLines: boolean;
   isLastRow?: boolean;

--- a/apps/google-docs/src/locations/Page/components/overview/OverviewSection.tsx
+++ b/apps/google-docs/src/locations/Page/components/overview/OverviewSection.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { Box, Button, Flex, Note, Paragraph, Text } from '@contentful/f36-components';
-import { LightbulbIcon } from '@contentful/f36-icons';
+import { EyeIcon, LightbulbIcon, PencilSimpleIcon } from '@contentful/f36-icons';
 import type { MappingReviewSuspendPayload } from '@types';
 import { buildEntryListFromEntryBlockGraph } from '../../../../utils/overviewEntryList';
 import { OverviewEntryList } from './OverviewEntryList';
@@ -9,8 +9,10 @@ import Splitter from '../mainpage/Splitter';
 
 interface OverviewProps {
   payload: MappingReviewSuspendPayload;
-  selectedEntryIndex: number;
+  selectedEntryIndex: number | null;
   onSelectEntryIndex: (index: number) => void;
+  reviewMode: 'view' | 'edit';
+  onReviewModeChange: (mode: 'view' | 'edit') => void;
   ctaLabel: string;
   onCtaClick: () => void;
   isCtaLoading?: boolean;
@@ -20,6 +22,8 @@ const OverviewSection = ({
   payload,
   selectedEntryIndex,
   onSelectEntryIndex,
+  reviewMode,
+  onReviewModeChange,
   ctaLabel,
   onCtaClick,
   isCtaLoading = false,
@@ -59,13 +63,33 @@ const OverviewSection = ({
               <Text fontSize="fontSizeM">Click row to view content by entry below.</Text>
             </Flex>
 
-            <Button
-              variant="primary"
-              onClick={onCtaClick}
-              isLoading={isCtaLoading}
-              isDisabled={isCtaLoading}>
-              {ctaLabel}
-            </Button>
+            <Flex alignItems="center" gap="spacingS">
+              <Button
+                size="small"
+                variant="secondary"
+                startIcon={<EyeIcon />}
+                onClick={() => onReviewModeChange('view')}
+                aria-pressed={reviewMode === 'view'}
+                style={reviewMode === 'view' ? { fontWeight: 600 } : undefined}>
+                View
+              </Button>
+              <Button
+                size="small"
+                variant="secondary"
+                startIcon={<PencilSimpleIcon />}
+                onClick={() => onReviewModeChange('edit')}
+                aria-pressed={reviewMode === 'edit'}
+                style={reviewMode === 'edit' ? { fontWeight: 600 } : undefined}>
+                Edit
+              </Button>
+              <Button
+                variant="primary"
+                onClick={onCtaClick}
+                isLoading={isCtaLoading}
+                isDisabled={isCtaLoading}>
+                {ctaLabel}
+              </Button>
+            </Flex>
           </Flex>
 
           {entryRows.length === 0 ? (

--- a/apps/google-docs/src/locations/Page/components/review/ReviewPage.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/ReviewPage.tsx
@@ -31,7 +31,8 @@ export const ReviewPage = ({
   onExitReview,
 }: ReviewPageProps) => {
   const [isConfirmCancelModalOpen, setIsConfirmCancelModalOpen] = useState(false);
-  const [selectedEntryIndex, setSelectedEntryIndex] = useState<number>(0);
+  const [selectedEntryIndex, setSelectedEntryIndex] = useState<number | null>(null);
+  const [reviewMode, setReviewMode] = useState<'view' | 'edit'>('view');
   const [isCancelling, setIsCancelling] = useState(false);
   const [isCreatePending, setIsCreatePending] = useState(false);
   const [createdEntries, setCreatedEntries] = useState<EntryProps[] | null>(null);
@@ -171,7 +172,19 @@ export const ReviewPage = ({
           <OverviewSection
             payload={reviewPayload}
             selectedEntryIndex={selectedEntryIndex}
-            onSelectEntryIndex={setSelectedEntryIndex}
+            onSelectEntryIndex={(index) => {
+              setSelectedEntryIndex(index);
+              setReviewMode('edit');
+            }}
+            reviewMode={reviewMode}
+            onReviewModeChange={(mode) => {
+              setReviewMode(mode);
+              if (mode === 'view') {
+                setSelectedEntryIndex(null);
+              } else if (mode === 'edit' && selectedEntryIndex === null) {
+                setSelectedEntryIndex(entryBlockGraph.entries.length > 0 ? 0 : null);
+              }
+            }}
             ctaLabel={hasCreatedEntries ? 'View entries' : 'Create entries'}
             onCtaClick={handleCreateOrViewEntries}
             isCtaLoading={isCreatePending}
@@ -182,6 +195,7 @@ export const ReviewPage = ({
             onEntryBlockGraphChange={setEntryBlockGraph}
             selectedEntryIndex={selectedEntryIndex}
             isDisabled={isMappingDisabled}
+            mode={reviewMode}
           />
         </Flex>
       </Layout.Body>

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingEntryCards.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingEntryCards.tsx
@@ -7,6 +7,7 @@ interface MappingEntryCardsProps {
   groupId: string;
   mappingCards: RenderedMappingCard[];
   cardOffsetsByGroup: Record<string, Record<string, number>>;
+  cardHeightsByGroup: Record<string, Record<string, number>>;
   hoveredMappingKeys: string[];
   onSetHoveredMappingKeys: (keys: string[]) => void;
   setCardWrapperRef: (cardKey: string) => RefCallback<HTMLDivElement>;
@@ -22,13 +23,21 @@ export const MappingEntryCards = ({
   groupId,
   mappingCards,
   cardOffsetsByGroup,
+  cardHeightsByGroup,
   hoveredMappingKeys,
   onSetHoveredMappingKeys,
   setCardWrapperRef,
 }: MappingEntryCardsProps): JSX.Element => {
+  const offsets = cardOffsetsByGroup[groupId] ?? {};
+  const heights = cardHeightsByGroup[groupId] ?? {};
+  const minHeight = Math.max(
+    0,
+    ...mappingCards.map((card) => (offsets[card.key] ?? 0) + (heights[card.key] ?? 28))
+  );
+
   return (
     <Box data-testid={`mapping-rail-${groupId}`} style={railStyles}>
-      <Box style={{ position: 'relative', minHeight: '100%' }}>
+      <Box style={{ position: 'relative', minHeight: Math.max(minHeight, 0) }}>
         {mappingCards.length > 0
           ? mappingCards.map((mappingCard) => (
               <MappingCard

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -30,6 +30,7 @@ import {
   buildMappingHighlightIndex,
   getMappingCardKey,
   type MappingHighlight,
+  type MappingHighlightIndex,
   uniqueHighlights,
 } from './buildHighlights';
 import { buildListMarkers } from './buildListMarkers';
@@ -46,6 +47,7 @@ import { buildSourceRefKey } from './sourceRefUtils';
 import { MappingEntryCards } from './MappingEntryCards';
 import { NormalizedDocumentSection } from './NormalizedDocumentSection';
 import { buildMappingDisplayGroups } from './buildMappingDisplayGroups';
+import { ViewMappingRail, type ViewMappingCardEntry } from './ViewMappingRail';
 import {
   applyImageExclusionToEntryBlockGraph,
   applyImageReassignToEntryBlockGraph,
@@ -80,6 +82,7 @@ interface MappingViewProps {
   onEntryBlockGraphChange: (next: EntryBlockGraph) => void;
   selectedEntryIndex: number | null;
   isDisabled?: boolean;
+  mode?: 'view' | 'edit';
 }
 
 const EMPTY_NEW_LOCATION: EditModalNewLocation = {
@@ -120,13 +123,21 @@ function rangeIntersectsNode(range: Range, node: Node): boolean {
   }
 }
 
+const EMPTY_HIGHLIGHT_INDEX: MappingHighlightIndex = {
+  blockHighlights: {},
+  tablePartHighlights: {},
+  tableHighlights: {},
+};
+
 export const MappingView = ({
   payload,
   entryBlockGraph,
   onEntryBlockGraphChange,
   selectedEntryIndex,
   isDisabled = false,
+  mode = 'view',
 }: MappingViewProps): JSX.Element => {
+  const isViewMode = mode === 'view';
   const selectedEntryRow = useMemo(() => {
     const rows = buildEntryListFromEntryBlockGraph(
       payload.entryBlockGraph.entries,
@@ -219,7 +230,7 @@ export const MappingView = ({
   const listMarkers = useMemo(() => buildListMarkers(allSegments), [allSegments]);
 
   const getVisibleHighlights = <T extends MappingHighlight>(highlights: T[]): T[] => {
-    if (selectedEntryIndex === null) {
+    if (isViewMode || selectedEntryIndex === null) {
       return highlights;
     }
     return highlights.filter((item) => item.entryIndex === selectedEntryIndex);
@@ -897,6 +908,42 @@ export const MappingView = ({
     closeEditModal();
   };
 
+  const viewCardsByGroup = useMemo((): Record<string, ViewMappingCardEntry[]> => {
+    const result: Record<string, ViewMappingCardEntry[]> = {};
+
+    allGroups.forEach((group) => {
+      const cards: ViewMappingCardEntry[] = [];
+
+      group.mappingCards.forEach((card) => {
+        const location = locationsByCardKey.get(card.key);
+        if (!location) return;
+
+        const graphEntry = entryBlockGraph.entries[location.entryIndex];
+        const contentType = payload.contentTypes.find(
+          (ct) => ct.sys.id === graphEntry?.contentTypeId
+        );
+        const contentTypeName = (contentType?.name ?? graphEntry?.contentTypeId ?? '').trim();
+        const entryName = getEntryTitleFromFieldMappings(graphEntry, contentType?.displayField);
+        const field = contentType?.fields.find((f) => f.id === location.fieldId);
+        const fieldType = field
+          ? displayType(field.type ?? '', field.linkType, field.items)
+          : location.fieldType;
+
+        cards.push({
+          key: card.key,
+          contentTypeName,
+          entryName,
+          fieldName: card.fieldName,
+          fieldType,
+        });
+      });
+
+      result[group.id] = cards;
+    });
+
+    return result;
+  }, [allGroups, locationsByCardKey, entryBlockGraph.entries, payload.contentTypes]);
+
   const canExcludeSelectedText = useMemo(() => {
     const root = textSelectionRootRef.current;
     if (!root || !selectedRange) {
@@ -957,8 +1004,31 @@ export const MappingView = ({
 
             <Flex flexDirection="column" gap="spacingS">
               {(groupsByTab[tab.id] ?? []).map((group) => {
+                const activeHighlightIndex = isViewMode ? EMPTY_HIGHLIGHT_INDEX : highlightIndex;
                 const isGroupHovered = group.mappingCards.some((card) =>
                   card.mappingKeys.some((key) => hoveredMappingKeys.includes(key))
+                );
+                const hasMappedCards = group.mappingCards.length > 0;
+                const showSurface = isViewMode ? hasMappedCards : group.showGroupedSurface;
+
+                const segmentContent = (
+                  <Flex flexDirection="column" gap="spacing2Xs">
+                    {group.segments.map((segment) => (
+                      <NormalizedDocumentSection
+                        key={segment.id}
+                        segment={segment}
+                        highlightIndex={activeHighlightIndex}
+                        imageById={imageById}
+                        listMarkers={listMarkers}
+                        excludedSourceRefs={entryBlockGraph.excludedSourceRefs}
+                        selectedEntryIndex={selectedEntryIndex}
+                        hoveredMappingKeys={hoveredMappingKeys}
+                        onSetHoveredMappingKeys={setHoveredMappingKeys}
+                        onAssignImage={handleAssignImage}
+                        onExcludeImage={handleExcludeImage}
+                      />
+                    ))}
+                  </Flex>
                 );
 
                 return (
@@ -969,7 +1039,7 @@ export const MappingView = ({
                       data-testid={`display-group-layout-${group.id}`}
                       ref={setGroupLayoutRef(group.id)}>
                       <Box style={{ flex: 2 }}>
-                        {group.showGroupedSurface ? (
+                        {showSurface ? (
                           <Box
                             data-testid={`mapping-group-surface-${group.id}`}
                             data-hovered={isGroupHovered ? 'true' : 'false'}
@@ -978,57 +1048,32 @@ export const MappingView = ({
                                 isGroupHovered ? tokens.green600 : tokens.green500
                               }`,
                               borderRadius: tokens.borderRadiusMedium,
-                              backgroundColor: tokens.green100,
+                              backgroundColor: isViewMode ? undefined : tokens.green100,
                               padding: tokens.spacing2Xs,
                               transition: 'border-color 120ms ease, border-width 120ms ease',
                             }}>
-                            <Flex flexDirection="column" gap="spacing2Xs">
-                              {group.segments.map((segment) => (
-                                <NormalizedDocumentSection
-                                  key={segment.id}
-                                  segment={segment}
-                                  highlightIndex={highlightIndex}
-                                  imageById={imageById}
-                                  listMarkers={listMarkers}
-                                  excludedSourceRefs={entryBlockGraph.excludedSourceRefs}
-                                  selectedEntryIndex={selectedEntryIndex}
-                                  hoveredMappingKeys={hoveredMappingKeys}
-                                  onSetHoveredMappingKeys={setHoveredMappingKeys}
-                                  onAssignImage={handleAssignImage}
-                                  onExcludeImage={handleExcludeImage}
-                                />
-                              ))}
-                            </Flex>
+                            {segmentContent}
                           </Box>
                         ) : (
-                          <Flex flexDirection="column" gap="spacingS">
-                            {group.segments.map((segment) => (
-                              <NormalizedDocumentSection
-                                key={segment.id}
-                                segment={segment}
-                                highlightIndex={highlightIndex}
-                                imageById={imageById}
-                                listMarkers={listMarkers}
-                                excludedSourceRefs={entryBlockGraph.excludedSourceRefs}
-                                selectedEntryIndex={selectedEntryIndex}
-                                hoveredMappingKeys={hoveredMappingKeys}
-                                onSetHoveredMappingKeys={setHoveredMappingKeys}
-                                onAssignImage={handleAssignImage}
-                                onExcludeImage={handleExcludeImage}
-                              />
-                            ))}
-                          </Flex>
+                          segmentContent
                         )}
                       </Box>
 
-                      <MappingEntryCards
-                        groupId={group.id}
-                        mappingCards={group.mappingCards}
-                        cardOffsetsByGroup={cardOffsetsByGroup}
-                        hoveredMappingKeys={hoveredMappingKeys}
-                        onSetHoveredMappingKeys={setHoveredMappingKeys}
-                        setCardWrapperRef={setCardWrapperRef}
-                      />
+                      {isViewMode ? (
+                        <ViewMappingRail
+                          segmentId={group.id}
+                          cards={viewCardsByGroup[group.id] ?? []}
+                        />
+                      ) : (
+                        <MappingEntryCards
+                          groupId={group.id}
+                          mappingCards={group.mappingCards}
+                          cardOffsetsByGroup={cardOffsetsByGroup}
+                          hoveredMappingKeys={hoveredMappingKeys}
+                          onSetHoveredMappingKeys={setHoveredMappingKeys}
+                          setCardWrapperRef={setCardWrapperRef}
+                        />
+                      )}
                     </Flex>
                   </Box>
                 );
@@ -1038,7 +1083,7 @@ export const MappingView = ({
         ))}
       </Flex>
 
-      {selectionRectangle && !isDisabled ? (
+      {selectionRectangle && !isDisabled && !isViewMode ? (
         <SelectionActionMenu
           anchorRectangle={selectionRectangle}
           onAssign={handleAssignFromSelection}

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -41,6 +41,7 @@ import { buildSourceRefKey } from './sourceRefUtils';
 import { MappingEntryCards } from './MappingEntryCards';
 import { NormalizedDocumentSection } from './NormalizedDocumentSection';
 import { buildMappingDisplayGroups } from './buildMappingDisplayGroups';
+import { ViewMappingRail, type ViewMappingCardEntry } from './ViewMappingRail';
 import {
   applyImageExclusionToEntryBlockGraph,
   applyRichTextAssignToEntryBlockGraph,
@@ -65,6 +66,7 @@ interface MappingViewProps {
   onEntryBlockGraphChange: (next: EntryBlockGraph) => void;
   selectedEntryIndex: number | null;
   isDisabled?: boolean;
+  mode?: 'view' | 'edit';
 }
 
 const EMPTY_NEW_LOCATION: EditModalNewLocation = {
@@ -111,7 +113,9 @@ export const MappingView = ({
   onEntryBlockGraphChange,
   selectedEntryIndex,
   isDisabled = false,
+  mode = 'view',
 }: MappingViewProps): JSX.Element => {
+  const isViewMode = mode === 'view';
   const selectedEntryRow = useMemo(() => {
     const rows = buildEntryListFromEntryBlockGraph(
       payload.entryBlockGraph.entries,
@@ -131,6 +135,9 @@ export const MappingView = ({
   ]);
   const [hoveredMappingKeys, setHoveredMappingKeys] = useState<string[]>([]);
   const [cardOffsetsByGroup, setCardOffsetsByGroup] = useState<
+    Record<string, Record<string, number>>
+  >({});
+  const [cardHeightsByGroup, setCardHeightsByGroup] = useState<
     Record<string, Record<string, number>>
   >({});
   const [editModalState, setEditModalState] = useState<EditModalState>(EMPTY_EDIT_MODAL);
@@ -195,7 +202,7 @@ export const MappingView = ({
   const listMarkers = useMemo(() => buildListMarkers(allSegments), [allSegments]);
 
   const getVisibleHighlights = <T extends MappingHighlight>(highlights: T[]): T[] => {
-    if (selectedEntryIndex === null) {
+    if (isViewMode || selectedEntryIndex === null) {
       return highlights;
     }
     return highlights.filter((item) => item.entryIndex === selectedEntryIndex);
@@ -458,6 +465,7 @@ export const MappingView = ({
   useLayoutEffect(() => {
     const measureOffsets = () => {
       const nextOffsets: Record<string, Record<string, number>> = {};
+      const nextHeights: Record<string, Record<string, number>> = {};
 
       allGroups.forEach((group) => {
         const groupNode = groupLayoutRefs.current[group.id];
@@ -482,12 +490,21 @@ export const MappingView = ({
         });
 
         nextOffsets[group.id] = resolveMarkerOffsets(cards);
+        nextHeights[group.id] = Object.fromEntries(cards.map((c) => [c.key, c.height]));
       });
 
       setCardOffsetsByGroup(nextOffsets);
+      setCardHeightsByGroup(nextHeights);
     };
 
     measureOffsets();
+
+    const observer = new ResizeObserver(measureOffsets);
+    Object.values(cardWrapperRefs.current).forEach((node) => {
+      if (node) observer.observe(node);
+    });
+
+    return () => observer.disconnect();
   }, [allGroups]);
 
   const handleEditFromSelection = () => {
@@ -655,6 +672,42 @@ export const MappingView = ({
     closeEditModal();
   };
 
+  const viewCardsByGroup = useMemo((): Record<string, ViewMappingCardEntry[]> => {
+    const result: Record<string, ViewMappingCardEntry[]> = {};
+
+    allGroups.forEach((group) => {
+      const cards: ViewMappingCardEntry[] = [];
+
+      group.mappingCards.forEach((card) => {
+        const location = locationsByCardKey.get(card.key);
+        if (!location) return;
+
+        const graphEntry = entryBlockGraph.entries[location.entryIndex];
+        const contentType = payload.contentTypes.find(
+          (ct) => ct.sys.id === graphEntry?.contentTypeId
+        );
+        const contentTypeName = (contentType?.name ?? graphEntry?.contentTypeId ?? '').trim();
+        const entryName = getEntryTitleFromFieldMappings(graphEntry, contentType?.displayField);
+        const field = contentType?.fields.find((f) => f.id === location.fieldId);
+        const fieldType = field
+          ? displayType(field.type ?? '', field.linkType, field.items)
+          : location.fieldType;
+
+        cards.push({
+          key: card.key,
+          contentTypeName,
+          entryName,
+          fieldName: card.fieldName,
+          fieldType,
+        });
+      });
+
+      result[group.id] = cards;
+    });
+
+    return result;
+  }, [allGroups, locationsByCardKey, entryBlockGraph.entries, payload.contentTypes]);
+
   return (
     <>
       <Flex
@@ -702,6 +755,8 @@ export const MappingView = ({
                 const isGroupHovered = group.mappingCards.some((card) =>
                   card.mappingKeys.some((key) => hoveredMappingKeys.includes(key))
                 );
+                const hasMappedCards = group.mappingCards.length > 0;
+                const showSurface = isViewMode ? hasMappedCards : group.showGroupedSurface;
 
                 return (
                   <Box key={group.id}>
@@ -711,7 +766,7 @@ export const MappingView = ({
                       data-testid={`display-group-layout-${group.id}`}
                       ref={setGroupLayoutRef(group.id)}>
                       <Box style={{ flex: 2 }}>
-                        {group.showGroupedSurface ? (
+                        {showSurface ? (
                           <Box
                             data-testid={`mapping-group-surface-${group.id}`}
                             data-hovered={isGroupHovered ? 'true' : 'false'}
@@ -720,7 +775,7 @@ export const MappingView = ({
                                 isGroupHovered ? tokens.green600 : tokens.green500
                               }`,
                               borderRadius: tokens.borderRadiusMedium,
-                              backgroundColor: tokens.green100,
+                              backgroundColor: isViewMode ? undefined : tokens.green100,
                               padding: tokens.spacing2Xs,
                               transition: 'border-color 120ms ease, border-width 120ms ease',
                             }}>
@@ -761,14 +816,22 @@ export const MappingView = ({
                         )}
                       </Box>
 
-                      <MappingEntryCards
-                        groupId={group.id}
-                        mappingCards={group.mappingCards}
-                        cardOffsetsByGroup={cardOffsetsByGroup}
-                        hoveredMappingKeys={hoveredMappingKeys}
-                        onSetHoveredMappingKeys={setHoveredMappingKeys}
-                        setCardWrapperRef={setCardWrapperRef}
-                      />
+                      {isViewMode ? (
+                        <ViewMappingRail
+                          segmentId={group.id}
+                          cards={viewCardsByGroup[group.id] ?? []}
+                        />
+                      ) : (
+                        <MappingEntryCards
+                          groupId={group.id}
+                          mappingCards={group.mappingCards}
+                          cardOffsetsByGroup={cardOffsetsByGroup}
+                          cardHeightsByGroup={cardHeightsByGroup}
+                          hoveredMappingKeys={hoveredMappingKeys}
+                          onSetHoveredMappingKeys={setHoveredMappingKeys}
+                          setCardWrapperRef={setCardWrapperRef}
+                        />
+                      )}
                     </Flex>
                   </Box>
                 );
@@ -778,7 +841,7 @@ export const MappingView = ({
         ))}
       </Flex>
 
-      {selectionRectangle && !isDisabled ? (
+      {selectionRectangle && !isDisabled && !isViewMode ? (
         <EditMappingButton anchorRectangle={selectionRectangle} onEdit={handleEditFromSelection} />
       ) : null}
 

--- a/apps/google-docs/src/locations/Page/components/review/mapping/ViewMappingCard.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/ViewMappingCard.tsx
@@ -1,0 +1,67 @@
+import { Box, Text } from '@contentful/f36-components';
+import tokens from '@contentful/f36-tokens';
+
+export interface ViewMappingCardData {
+  key: string;
+  contentTypeName: string;
+  entryName: string;
+  fieldName: string;
+  fieldType: string;
+}
+
+interface ViewMappingCardProps {
+  card: ViewMappingCardData;
+}
+
+const rowTextStyle = {
+  fontSize: tokens.fontSizeS,
+  lineHeight: tokens.lineHeightS,
+} as const;
+
+const truncatedValueStyle = {
+  fontSize: tokens.fontSizeS,
+  lineHeight: tokens.lineHeightS,
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+} as const;
+
+export const ViewMappingCard = ({ card }: ViewMappingCardProps) => (
+  <Box
+    data-testid={`view-mapping-card-${card.key}`}
+    style={{
+      border: `1px solid ${tokens.green500}`,
+      borderRadius: tokens.borderRadiusMedium,
+      padding: tokens.spacing2Xs,
+      backgroundColor: tokens.green100,
+    }}>
+    <Text as="p" marginBottom="none" style={rowTextStyle}>
+      <Text as="span" fontColor="gray600" marginRight="spacingXs" style={rowTextStyle}>
+        Content Type:
+      </Text>
+      <Text as="span" fontWeight="fontWeightDemiBold" style={truncatedValueStyle}>
+        {card.contentTypeName}
+      </Text>
+    </Text>
+    <Text as="p" marginBottom="none" style={rowTextStyle}>
+      <Text as="span" fontColor="gray600" marginRight="spacingXs" style={rowTextStyle}>
+        Entry:
+      </Text>
+      <Text as="span" fontWeight="fontWeightDemiBold" style={truncatedValueStyle}>
+        {card.entryName}
+      </Text>
+    </Text>
+    <Text as="p" marginBottom="none" style={rowTextStyle}>
+      <Text as="span" fontColor="gray600" marginRight="spacingXs" style={rowTextStyle}>
+        Field:
+      </Text>
+      <Text as="span" fontWeight="fontWeightDemiBold" style={truncatedValueStyle}>
+        {card.fieldName}
+        <Box as="span" style={{ color: tokens.gray600 }}>
+          {' | '}
+          {card.fieldType}
+        </Box>
+      </Text>
+    </Text>
+  </Box>
+);

--- a/apps/google-docs/src/locations/Page/components/review/mapping/ViewMappingRail.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/ViewMappingRail.tsx
@@ -1,0 +1,25 @@
+import { Box, Flex } from '@contentful/f36-components';
+import type { BoxProps } from '@contentful/f36-components';
+import { ViewMappingCard, type ViewMappingCardData } from './ViewMappingCard';
+
+export type ViewMappingCardEntry = ViewMappingCardData;
+
+interface ViewMappingRailProps {
+  segmentId: string;
+  cards: ViewMappingCardEntry[];
+}
+
+const railStyles: BoxProps['style'] = {
+  flex: '0 0 280px',
+  maxWidth: 280,
+};
+
+export const ViewMappingRail = ({ segmentId, cards }: ViewMappingRailProps): JSX.Element => (
+  <Box data-testid={`view-mapping-rail-${segmentId}`} style={railStyles}>
+    <Flex flexDirection="column" gap="spacing2Xs">
+      {cards.map((card) => (
+        <ViewMappingCard key={card.key} card={card} />
+      ))}
+    </Flex>
+  </Box>
+);

--- a/apps/google-docs/src/setupTests.ts
+++ b/apps/google-docs/src/setupTests.ts
@@ -3,6 +3,14 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 
+if (typeof window !== 'undefined' && typeof ResizeObserver === 'undefined') {
+  window.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}
+
 // Only configure if we're in a DOM environment (not Node.js)
 // This file is for frontend tests only - function tests use functions/vitest.config.mts
 if (typeof window !== 'undefined') {

--- a/apps/google-docs/test/locations/Page/components/review/mapping/MappingView.spec.tsx
+++ b/apps/google-docs/test/locations/Page/components/review/mapping/MappingView.spec.tsx
@@ -14,20 +14,15 @@ vi.mock(
   '../../../../../../src/locations/Page/components/review/mapping/ReviewImageAssetCard',
   () => ({
     ReviewImageAssetCard: ({
-      onAssign,
-      onExclude,
+      onEdit,
       isHighlighted,
     }: {
-      onAssign: () => void;
-      onExclude: () => void;
+      onEdit: () => void;
       isHighlighted: boolean;
     }) => (
       <div>
-        <button type="button" onClick={onAssign}>
+        <button type="button" onClick={onEdit}>
           {isHighlighted ? 'Reassign image' : 'Assign image'}
-        </button>
-        <button type="button" onClick={onExclude}>
-          Exclude image
         </button>
       </div>
     ),
@@ -307,7 +302,12 @@ describe('MappingView', () => {
     });
 
     const { container } = render(
-      <MappingView payload={payload} {...mappingViewGraphProps(payload)} selectedEntryIndex={0} />
+      <MappingView
+        payload={payload}
+        {...mappingViewGraphProps(payload)}
+        selectedEntryIndex={0}
+        mode="edit"
+      />
     );
 
     expect(container.querySelectorAll('[data-testid^="mapping-card-"]')).toHaveLength(1);
@@ -335,7 +335,12 @@ describe('MappingView', () => {
     });
 
     const { container } = render(
-      <MappingView payload={payload} {...mappingViewGraphProps(payload)} selectedEntryIndex={0} />
+      <MappingView
+        payload={payload}
+        {...mappingViewGraphProps(payload)}
+        selectedEntryIndex={0}
+        mode="edit"
+      />
     );
 
     expect(container.querySelectorAll('[data-testid^="mapping-card-"]')).toHaveLength(1);
@@ -368,7 +373,12 @@ describe('MappingView', () => {
     });
 
     render(
-      <MappingView payload={payload} {...mappingViewGraphProps(payload)} selectedEntryIndex={0} />
+      <MappingView
+        payload={payload}
+        {...mappingViewGraphProps(payload)}
+        selectedEntryIndex={0}
+        mode="edit"
+      />
     );
 
     expect(screen.getByText('Body copy (1/2)')).toBeTruthy();
@@ -403,7 +413,12 @@ describe('MappingView', () => {
     ];
 
     render(
-      <MappingView payload={payload} {...mappingViewGraphProps(payload)} selectedEntryIndex={0} />
+      <MappingView
+        payload={payload}
+        {...mappingViewGraphProps(payload)}
+        selectedEntryIndex={0}
+        mode="edit"
+      />
     );
 
     expect(screen.getByText('SEO Description')).toBeTruthy();
@@ -433,7 +448,12 @@ describe('MappingView', () => {
     });
 
     const { container } = render(
-      <MappingView payload={payload} {...mappingViewGraphProps(payload)} selectedEntryIndex={0} />
+      <MappingView
+        payload={payload}
+        {...mappingViewGraphProps(payload)}
+        selectedEntryIndex={0}
+        mode="edit"
+      />
     );
 
     expect(screen.getByText('Body copy (1/3)')).toBeTruthy();
@@ -549,7 +569,12 @@ describe('MappingView', () => {
     });
 
     const { container } = render(
-      <MappingView payload={payload} {...mappingViewGraphProps(payload)} selectedEntryIndex={0} />
+      <MappingView
+        payload={payload}
+        {...mappingViewGraphProps(payload)}
+        selectedEntryIndex={0}
+        mode="edit"
+      />
     );
 
     expect(screen.getAllByText('Body copy').length).toBeGreaterThan(0);
@@ -650,7 +675,12 @@ describe('MappingView', () => {
     });
 
     const { container } = render(
-      <MappingView payload={payload} {...mappingViewGraphProps(payload)} selectedEntryIndex={0} />
+      <MappingView
+        payload={payload}
+        {...mappingViewGraphProps(payload)}
+        selectedEntryIndex={0}
+        mode="edit"
+      />
     );
 
     expect(container.querySelectorAll('[data-testid^="mapping-group-surface-"]')).toHaveLength(0);
@@ -683,7 +713,12 @@ describe('MappingView', () => {
     });
 
     const { container } = render(
-      <MappingView payload={payload} {...mappingViewGraphProps(payload)} selectedEntryIndex={0} />
+      <MappingView
+        payload={payload}
+        {...mappingViewGraphProps(payload)}
+        selectedEntryIndex={0}
+        mode="edit"
+      />
     );
 
     const textSegments = Array.from(
@@ -731,7 +766,12 @@ describe('MappingView', () => {
     });
 
     const { container, rerender } = render(
-      <MappingView payload={payload} {...mappingViewGraphProps(payload)} selectedEntryIndex={0} />
+      <MappingView
+        payload={payload}
+        {...mappingViewGraphProps(payload)}
+        selectedEntryIndex={0}
+        mode="edit"
+      />
     );
     const groupedTextSegments = container.querySelectorAll('[data-review-text-segment="true"]');
     const selectedRange = createDomRange(groupedTextSegments[1].firstChild as Text, 0, 6);
@@ -744,23 +784,21 @@ describe('MappingView', () => {
     });
 
     rerender(
-      <MappingView payload={payload} {...mappingViewGraphProps(payload)} selectedEntryIndex={0} />
+      <MappingView
+        payload={payload}
+        {...mappingViewGraphProps(payload)}
+        selectedEntryIndex={0}
+        mode="edit"
+      />
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Reassign' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Edit content mapping' }));
 
-    expect(screen.getByRole('heading', { name: 'Reassign content' })).toBeTruthy();
+    expect(screen.getByRole('heading', { name: 'Edit content mapping' })).toBeTruthy();
     expect(
       screen.getAllByText((_, node) => node?.textContent?.includes('Second') ?? false).length
     ).toBeGreaterThan(0);
-    expect(screen.getAllByText('Article').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('Body copy').length).toBeGreaterThan(0);
-    expect(screen.getByText('Current location')).toBeTruthy();
-    expect(screen.getByText('New location')).toBeTruthy();
-    expect(screen.getAllByText('Untitled').length).toBeGreaterThan(0);
-    expect(
-      screen.getAllByText((_, node) => node?.textContent?.includes('| Long text') ?? false).length
-    ).toBeGreaterThan(0);
+    expect(screen.getByText('Assign to fields')).toBeTruthy();
     expect(mockClearSelection).toHaveBeenCalledTimes(1);
   });
 
@@ -775,20 +813,24 @@ describe('MappingView', () => {
 
     const payload = createPayload();
     render(
-      <MappingView payload={payload} {...mappingViewGraphProps(payload)} selectedEntryIndex={0} />
+      <MappingView
+        payload={payload}
+        {...mappingViewGraphProps(payload)}
+        selectedEntryIndex={0}
+        mode="edit"
+      />
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Assign' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Edit content mapping' }));
 
-    expect(screen.getByRole('heading', { name: 'Assign content' })).toBeTruthy();
+    expect(screen.getByRole('heading', { name: 'Edit content mapping' })).toBeTruthy();
     expect(screen.getByText('"fresh body text"')).toBeTruthy();
-    expect(screen.getByText('Current location')).toBeTruthy();
-    expect(screen.getByText('New location')).toBeTruthy();
+    expect(screen.getByText('Assign to fields')).toBeTruthy();
     expect(screen.getByText('Article: Untitled')).toBeTruthy();
     expect(mockClearSelection).toHaveBeenCalledTimes(1);
   });
 
-  it('disables exclude when selected text has no mapped segments', () => {
+  it('shows edit mapping button when text is selected', () => {
     const selectedRange = createDetachedRange('plain text', 0, 5);
     mockUseReviewTextSelection.mockReturnValue({
       selectionRectangle: { top: 100, left: 100, right: 160, bottom: 120 },
@@ -802,16 +844,15 @@ describe('MappingView', () => {
       <MappingView
         payload={payload}
         {...mappingViewGraphProps(payload)}
-        selectedEntryIndex={null}
+        selectedEntryIndex={0}
+        mode="edit"
       />
     );
 
-    expect(screen.getByRole('button', { name: 'Assign' })).toBeTruthy();
-    const excludeButton = screen.getByRole('button', { name: 'Exclude' }) as HTMLButtonElement;
-    expect(excludeButton.disabled).toBe(true);
+    expect(screen.getByRole('button', { name: 'Edit content mapping' })).toBeTruthy();
   });
 
-  it('opens exclude modal with current locations for mapped text', () => {
+  it('opens edit modal with current field pre-selected for mapped text', () => {
     mockUseReviewTextSelection.mockReturnValueOnce({
       selectionRectangle: null,
       selectedText: '',
@@ -821,7 +862,12 @@ describe('MappingView', () => {
 
     const payload = createPayload();
     const { container, rerender } = render(
-      <MappingView payload={payload} {...mappingViewGraphProps(payload)} selectedEntryIndex={0} />
+      <MappingView
+        payload={payload}
+        {...mappingViewGraphProps(payload)}
+        selectedEntryIndex={0}
+        mode="edit"
+      />
     );
     const selectedRange = createDomRange(
       container.querySelector('[data-review-text-segment="true"]')?.firstChild as Text,
@@ -835,22 +881,23 @@ describe('MappingView', () => {
       clearSelection: mockClearSelection,
     });
     rerender(
-      <MappingView payload={payload} {...mappingViewGraphProps(payload)} selectedEntryIndex={0} />
+      <MappingView
+        payload={payload}
+        {...mappingViewGraphProps(payload)}
+        selectedEntryIndex={0}
+        mode="edit"
+      />
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Exclude' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Edit content mapping' }));
 
-    expect(screen.getByRole('heading', { name: 'Exclude content' })).toBeTruthy();
-    expect(screen.getAllByText('Article').length).toBeGreaterThan(0);
+    expect(screen.getByRole('heading', { name: 'Edit content mapping' })).toBeTruthy();
+    expect(screen.getByText('Assign to fields')).toBeTruthy();
     expect(screen.getAllByText('Body copy').length).toBeGreaterThan(0);
-    expect(screen.queryByText('New location')).toBeNull();
-    expect(
-      screen.getAllByText((_, node) => node?.textContent?.includes('| Long text') ?? false).length
-    ).toBeGreaterThan(0);
     expect(mockClearSelection).toHaveBeenCalledTimes(1);
   });
 
-  it('excludes grouped selections as one visible location and splits the remaining runs', () => {
+  it('opens edit modal with field pre-selected for grouped-run selection', () => {
     const blocks = [
       createBlock('block-1', 1, 'First body paragraph.'),
       createBlock('block-2', 2, 'Second body paragraph.'),
@@ -886,6 +933,7 @@ describe('MappingView', () => {
         entryBlockGraph={currentGraph}
         onEntryBlockGraphChange={onEntryBlockGraphChange}
         selectedEntryIndex={0}
+        mode="edit"
       />
     );
 
@@ -910,42 +958,16 @@ describe('MappingView', () => {
         entryBlockGraph={currentGraph}
         onEntryBlockGraphChange={onEntryBlockGraphChange}
         selectedEntryIndex={0}
+        mode="edit"
       />
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Exclude' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Edit content mapping' }));
 
-    expect(screen.getByRole('heading', { name: 'Exclude content' })).toBeTruthy();
-    expect(document.querySelectorAll('button[aria-pressed]')).toHaveLength(1);
-    expect(
-      screen.queryByText(
-        'This content is used in more than one place in the entry. Select which item to exclude.'
-      )
-    ).toBeNull();
-
-    const locationCard = document.querySelector('button[aria-pressed]') as HTMLElement;
-    expect(locationCard).toBeTruthy();
-    fireEvent.click(locationCard);
-
-    const confirmButton = screen.getAllByRole('button', { name: 'Exclude content' }).at(-1);
-    expect(confirmButton).toBeTruthy();
-    fireEvent.click(confirmButton as HTMLElement);
-
-    expect(onEntryBlockGraphChange).toHaveBeenCalledTimes(1);
-
-    rerender(
-      <MappingView
-        payload={payload}
-        entryBlockGraph={currentGraph}
-        onEntryBlockGraphChange={onEntryBlockGraphChange}
-        selectedEntryIndex={0}
-      />
-    );
-
-    expect(screen.getByText('Body copy (1/2)')).toBeTruthy();
-    expect(screen.getByText('Body copy (2/2)')).toBeTruthy();
-    expect(container.querySelectorAll('[data-testid^="mapping-card-"]')).toHaveLength(2);
-    expect(container.querySelectorAll('[data-testid^="mapping-group-surface-"]')).toHaveLength(0);
+    expect(screen.getByRole('heading', { name: 'Edit content mapping' })).toBeTruthy();
+    expect(screen.getByText('Assign to fields')).toBeTruthy();
+    expect(screen.getAllByText('Body copy').length).toBeGreaterThan(0);
+    expect(mockClearSelection).toHaveBeenCalledTimes(1);
   });
 
   it('scopes image assignment destinations to currently selected entry', () => {
@@ -963,7 +985,7 @@ describe('MappingView', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Assign image' }));
 
-    expect(screen.getByRole('heading', { name: 'Assign content' })).toBeTruthy();
+    expect(screen.getByRole('heading', { name: 'Edit content mapping' })).toBeTruthy();
     expect(screen.getAllByText('Untitled').length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary

- Merges `origin/master` into `fix/reassign`, resolving 3 conflicts in `MappingView.tsx`
- Keeps `fix/reassign`'s `EditMappingButton` unified edit flow while adding master's view/edit mode toggle (`isViewMode` guard)
- Adds `cardHeightsByGroup` fix for absolutely-positioned rail cards overflowing their container
- Updates `MappingView.spec.tsx` to match the new `EditMappingButton` / unified modal API

<img width="1841" height="691" alt="image" src="https://github.com/user-attachments/assets/345d59f5-ab45-4965-ae4e-e3df53afd129" />

<img width="1831" height="700" alt="image" src="https://github.com/user-attachments/assets/69a493cd-abaa-49cb-9e8f-a34ed516c4a5" />

<img width="1831" height="329" alt="image" src="https://github.com/user-attachments/assets/783a77dc-8e3a-4078-89b5-f53b64fc5240" />
