### PR TITLE
Remove on close for loading modal []

### DIFF
--- a/apps/google-docs/src/locations/Page/components/mainpage/ModalOrchestrator.tsx
+++ b/apps/google-docs/src/locations/Page/components/mainpage/ModalOrchestrator.tsx
@@ -94,6 +94,11 @@ export const ModalOrchestrator = forwardRef<ModalOrchestratorHandle, ModalOrches
       setIsConfirmCancelModalOpen(true);
     };
 
+    const handleFlowModalCloseRequest = () => {
+      if (flowStep === FlowStep.LOADING) return;
+      showDiscardConfirmation();
+    };
+
     const closeModalAndReset = (setOpen: (open: boolean) => void) => () => {
       setOpen(false);
       resetProgress();
@@ -280,7 +285,6 @@ export const ModalOrchestrator = forwardRef<ModalOrchestratorHandle, ModalOrches
             <LoadingModal
               step="reviewingContentTypes"
               title="Preparing your preview"
-              onClose={showDiscardConfirmation}
               contentTypeCount={selectedContentTypes.length}
             />
           );
@@ -299,7 +303,7 @@ export const ModalOrchestrator = forwardRef<ModalOrchestratorHandle, ModalOrches
 
         <Modal
           isShown={flowStep !== null}
-          onClose={showDiscardConfirmation}
+          onClose={handleFlowModalCloseRequest}
           size={'large'}
           shouldCloseOnOverlayClick={false}
           shouldCloseOnEscapePress={flowStep !== FlowStep.LOADING}>

--- a/apps/google-docs/src/locations/Page/components/modals/LoadingModal.tsx
+++ b/apps/google-docs/src/locations/Page/components/modals/LoadingModal.tsx
@@ -58,7 +58,6 @@ interface LoadingModalProps {
   title: string;
   entriesCount?: number;
   contentTypeCount?: number;
-  onClose: () => void;
 }
 
 export const LoadingModal: React.FC<LoadingModalProps> = ({
@@ -66,7 +65,6 @@ export const LoadingModal: React.FC<LoadingModalProps> = ({
   title,
   entriesCount,
   contentTypeCount,
-  onClose,
 }) => {
   const messages = useMemo(() => {
     if (step === 'reviewingContentTypes') {
@@ -93,7 +91,7 @@ export const LoadingModal: React.FC<LoadingModalProps> = ({
 
   return (
     <>
-      <Modal.Header title={title} onClose={onClose} />
+      <Modal.Header title={title} />
       <Modal.Content>
         {step === 'reviewingContentTypes' ? (
           <Flex justifyContent="center">

--- a/apps/google-docs/test/locations/Page/components/modals/LoadingModal.spec.tsx
+++ b/apps/google-docs/test/locations/Page/components/modals/LoadingModal.spec.tsx
@@ -16,7 +16,6 @@ describe('LoadingModal', () => {
           step="reviewingContentTypes"
           title="Preparing your preview"
           contentTypeCount={2}
-          onClose={vi.fn()}
         />
       </Modal>
     );
@@ -29,6 +28,12 @@ describe('LoadingModal', () => {
     expect(screen.getByText('Fetching document')).toBeTruthy();
     expect(screen.queryByText('Fetching document...')).toBeNull();
     expect(firstRow?.querySelector('[data-test-id="cf-ui-spinner"]')).toBeTruthy();
+  });
+
+  it('does not render a close button', () => {
+    renderLoadingModal();
+
+    expect(screen.queryByRole('button', { name: 'Close' })).toBeNull();
   });
 
   it('moves the active indicator to the newest visible step over time', () => {


### PR DESCRIPTION
## Purpose

 We currently don't allow cancelling a running workflow step in mastra, so we can't allow the user to close when the modal is on loading. 

## Approach
- Remove on close for loading modal

## Testing steps

https://github.com/user-attachments/assets/d326e5c4-0c90-4555-be23-3607f05e5041
