### PR TITLE
feat(google-docs): Add support for local Agents API during development [INTEG-3850]

### DIFF
--- a/apps/google-docs/.env.example
+++ b/apps/google-docs/.env.example
@@ -11,4 +11,4 @@ VITE_ENABLE_MOCK_REVIEW_PAYLOAD=
 VITE_ENABLE_MOCK_EDIT_MODAL=
 
 # Frontend (Vite): opt in to a local Agents API during development.
-VITE_LOCAL_AGENTS_API_BASE_URL=http://localhost:4111
+VITE_LOCAL_AGENTS_API_BASE_URL=

--- a/apps/google-docs/.env.example
+++ b/apps/google-docs/.env.example
@@ -9,3 +9,6 @@ VITE_ENABLE_MOCK_REVIEW_PAYLOAD=
 
 # Frontend (Vite): dev-only UI to preview the exclude/edit modal inside the mapping view.
 VITE_ENABLE_MOCK_EDIT_MODAL=
+
+# Frontend (Vite): opt in to a local Agents API during development.
+VITE_LOCAL_AGENTS_API_BASE_URL=http://localhost:4111

--- a/apps/google-docs/README.md
+++ b/apps/google-docs/README.md
@@ -1,36 +1,53 @@
 # Google Docs App for Contentful
 
-A Contentful App that enables importing content from Google Docs into Contentful entries. 
-
+A Contentful App that enables importing content from Google Docs into Contentful entries.
 
 ## Frontend Setup
 
 1. Clone the repository
 2. Navigate to the app directory:
+
 ```bash
 cd apps/google-docs
 ```
 
 3. Install dependencies:
+
 ```bash
 npm install
 ```
 
 4. Copy the example environment file and configure it:
+
 ```bash
 cp .env.example .env
 ```
 
-5. Edit `.env` and add your API keys and tokens 
+5. Edit `.env` and add your API keys and tokens
 
 6. To run locally
 
- ```bash
- npm run dev
- ```
+```bash
+npm run dev
+```
 
 Note: To run the backend locally follow the read me in the agents-api repo
 
+### Local Agents API Development
+
+By default, the app uses the production Agents API through the Contentful CMA SDK. To point the frontend at a locally running `agents-api`, set the local API base URL in `.env`:
+
+```bash
+VITE_LOCAL_AGENTS_API_BASE_URL=http://localhost:4111
+```
+
+When `VITE_LOCAL_AGENTS_API_BASE_URL` is set, agent run, generate, and resume requests are sent to that local endpoint. Leave it empty or unset to use the production CMA path.
+
+Start the local `agents-api` service first, then run the frontend:
+
+```bash
+npm run dev
+```
 
 ### Deployment
 
@@ -49,6 +66,7 @@ npm run deploy:prod     # Deploy to production
 ```
 
 **Note**: Deployment scripts require additional environment variables:
+
 - `STATIC_S3_BASE` - S3 bucket base path for dev/staging
 - `PROD_STATIC_S3_BASE` - S3 bucket base path for production
 - `GOOGLE_DOCS_TEST_CLOUDFRONT_DIST_ID` - CloudFront distribution for dev/staging

--- a/apps/google-docs/src/services/agents-api.ts
+++ b/apps/google-docs/src/services/agents-api.ts
@@ -1,9 +1,5 @@
 import { PageAppSDK } from '@contentful/app-sdk';
-import {
-  LOCAL_AGENTS_API_BASE_URL,
-  WORKFLOW_AGENT_ID,
-  USE_LOCAL_AGENTS_API,
-} from '../utils/constants/agent';
+import { WORKFLOW_AGENT_ID } from '../utils/constants/agent';
 import {
   AgentRunMessage,
   MappingReviewSuspendPayload,
@@ -65,9 +61,10 @@ export async function getWorkflowRun(
   environmentId: string,
   runId: string
 ): Promise<AgentRunData | null> {
-  if (USE_LOCAL_AGENTS_API) {
+  const localAgentsApiBaseUrl = import.meta.env.VITE_LOCAL_AGENTS_API_BASE_URL?.trim();
+  if (localAgentsApiBaseUrl) {
     const response = await fetch(
-      `${LOCAL_AGENTS_API_BASE_URL}/spaces/${spaceId}/environments/${environmentId}/ai_agents/runs/${runId}`,
+      `${localAgentsApiBaseUrl}/spaces/${spaceId}/environments/${environmentId}/ai_agents/runs/${runId}`,
       {
         headers: AGENTS_API_HEADERS,
       }
@@ -107,10 +104,11 @@ export async function startAgentRun(
   payload: AgentGeneratePayload
 ): Promise<string> {
   let runData: AgentRunData;
+  const localAgentsApiBaseUrl = import.meta.env.VITE_LOCAL_AGENTS_API_BASE_URL?.trim();
 
-  if (USE_LOCAL_AGENTS_API) {
+  if (localAgentsApiBaseUrl) {
     const response = await fetch(
-      `${LOCAL_AGENTS_API_BASE_URL}/spaces/${spaceId}/environments/${environmentId}/ai_agents/agents/${WORKFLOW_AGENT_ID}/generate`,
+      `${localAgentsApiBaseUrl}/spaces/${spaceId}/environments/${environmentId}/ai_agents/agents/${WORKFLOW_AGENT_ID}/generate`,
       {
         method: 'POST',
         headers: getJsonHeaders(),
@@ -156,9 +154,10 @@ export async function resumeWorkflowRun(
   runId: string,
   resumePayload: ResumePayload
 ): Promise<void> {
-  if (USE_LOCAL_AGENTS_API) {
+  const localAgentsApiBaseUrl = import.meta.env.VITE_LOCAL_AGENTS_API_BASE_URL?.trim();
+  if (localAgentsApiBaseUrl) {
     const response = await fetch(
-      `${LOCAL_AGENTS_API_BASE_URL}/spaces/${spaceId}/environments/${environmentId}/ai_agents/runs/${runId}/resume`,
+      `${localAgentsApiBaseUrl}/spaces/${spaceId}/environments/${environmentId}/ai_agents/runs/${runId}/resume`,
       {
         method: 'POST',
         headers: getJsonHeaders(),

--- a/apps/google-docs/src/utils/constants/agent.ts
+++ b/apps/google-docs/src/utils/constants/agent.ts
@@ -6,10 +6,6 @@ const MAX_POLL_TIME_MS = 5 * 60 * 1000 * 10; // 50 minutes
 
 export const MAX_POLL_ATTEMPTS = Math.floor(MAX_POLL_TIME_MS / POLL_INTERVAL_MS);
 
-export const LOCAL_AGENTS_API_BASE_URL = 'http://localhost:4111';
-
-export const USE_LOCAL_AGENTS_API = false;
-
 export const CONTENT_TYPE_SUBMIT_LOADING_DELAY_MS = 30000; // 30 seconds to wait for suspend payload
 
 // Agents-api writes PENDING_REVIEW status before the suspendPayload metadata flushes.

--- a/apps/google-docs/src/vite-env.d.ts
+++ b/apps/google-docs/src/vite-env.d.ts
@@ -3,6 +3,7 @@
 interface ImportMetaEnv {
   readonly VITE_ENABLE_MOCK_EDIT_MODAL?: string;
   readonly VITE_ENABLE_MOCK_REVIEW_PAYLOAD?: string;
+  readonly VITE_LOCAL_AGENTS_API_BASE_URL?: string;
 }
 
 declare module '*.png' {


### PR DESCRIPTION
## Purpose

Move hardcoded `LOCAL_AGENTS_API_BASE_URL` and `USE_LOCAL_AGENTS_API` constants out of `agent.ts` and into a `.env` variable so developers can toggle local API mode without touching source code, and so the flag can never accidentally ship as `true` in production.

## Approach

- Removed `LOCAL_AGENTS_API_BASE_URL` and `USE_LOCAL_AGENTS_API` from `src/utils/constants/agent.ts`
- Each of the three agent service functions (`getWorkflowRun`, `startAgentRun`, `resumeWorkflowRun`) now reads `import.meta.env.VITE_LOCAL_AGENTS_API_BASE_URL` at call time — when set and non-empty, requests go to that local endpoint; otherwise the production CMA SDK path is used
- Added `VITE_LOCAL_AGENTS_API_BASE_URL` type declaration to `vite-env.d.ts`
- Added an empty-default entry to `.env.example` (empty so `cp .env.example .env` doesn't silently route to localhost)
- Added a "Local Agents API Development" section to the README

## Testing steps

1. `cp .env.example .env` — confirm app starts and uses production CMA path by default
2. Set `VITE_LOCAL_AGENTS_API_BASE_URL=http://localhost:4111` in `.env`, start `agents-api` locally, and confirm requests route to the local service
3. Unset or leave the variable blank — confirm requests fall back to the CMA SDK path

## Breaking Changes

None — unset `VITE_LOCAL_AGENTS_API_BASE_URL` behaves identically to the previous `USE_LOCAL_AGENTS_API = false` default.

## Dependencies and/or References

- INTEG-3850