### PR TITLE
fix(google-docs): improve highlight styling and consistency across view/edit mode [INTEG-3861]

### DIFF
--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingCard.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingCard.tsx
@@ -41,7 +41,7 @@ export const MappingCard = ({
         insetInlineStart: 0,
         insetInlineEnd: 0,
         top,
-        border: `${isHovered ? 2 : 1}px solid ${isHovered ? tokens.green600 : tokens.green500}`,
+        border: `${isHovered ? 2 : 1}px solid`,
         borderRadius: tokens.borderRadiusMedium,
         padding: tokens.spacing2Xs,
         backgroundColor: tokens.green100,

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -16,7 +16,7 @@ import type {
   TableTextSourceRef,
 } from '@types';
 import { isBlockImageSourceRef, isTableImageSourceRef, isTableTextSourceRef } from '@types';
-import { FileTextIcon } from '@contentful/f36-icons';
+import { FileTextIcon, LightbulbIcon } from '@contentful/f36-icons';
 import { useReviewTextSelection } from '@hooks/useReviewTextSelection';
 import { getEntryTitleFromFieldMappings } from '../../../../../utils/getEntryTitle';
 import { resolveMarkerOffsets } from './resolveMappingCardOffsets';
@@ -758,30 +758,40 @@ export const MappingView = ({
         gap="spacingS"
         style={{ marginTop: tokens.spacingM }}>
         {selectedEntryRow && (
-          <Box
+          <Flex
+            gap="spacingM"
+            alignItems="flex-end"
             style={{
               borderBottom: `1px solid ${tokens.gray200}`,
               paddingBottom: tokens.spacingXs,
             }}>
-            <Text
-              as="p"
-              fontSize="fontSizeS"
-              fontWeight="fontWeightMedium"
-              marginBottom="spacing2Xs">
-              Currently viewing:
-            </Text>
-            <Text as="p" marginBottom="none">
-              <Text as="span" fontWeight="fontWeightDemiBold">
-                {selectedEntryRow.contentTypeName}
+            <Box style={{ flex: 2 }}>
+              <Text
+                as="p"
+                fontSize="fontSizeS"
+                fontWeight="fontWeightMedium"
+                marginBottom="spacing2Xs">
+                Currently viewing:
               </Text>
-              {selectedEntryRow.entryTitle ? (
-                <Text as="span" fontColor="gray600">
-                  {' '}
-                  ({selectedEntryRow.entryTitle})
+              <Text as="p" marginBottom="none">
+                <Text as="span" fontWeight="fontWeightDemiBold">
+                  {selectedEntryRow.contentTypeName}
                 </Text>
-              ) : null}
-            </Text>
-          </Box>
+                {selectedEntryRow.entryTitle ? (
+                  <Text as="span" fontColor="gray600">
+                    {' '}
+                    ({selectedEntryRow.entryTitle})
+                  </Text>
+                ) : null}
+              </Text>
+            </Box>
+            <Flex alignItems="center" gap="spacing2Xs" style={{ flex: '0 0 280px', maxWidth: 280 }}>
+              <LightbulbIcon size="tiny" style={{ color: tokens.gray600, flexShrink: 0 }} />
+              <Text as="span" fontSize="fontSizeS" fontColor="gray600">
+                Tip: hover over a card to highlight its content
+              </Text>
+            </Flex>
+          </Flex>
         )}
         {tabs.map((tab) => (
           <Box key={tab.id}>

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -110,12 +110,6 @@ function rangeIntersectsNode(range: Range, node: Node): boolean {
   }
 }
 
-const EMPTY_HIGHLIGHT_INDEX: MappingHighlightIndex = {
-  blockHighlights: {},
-  tablePartHighlights: {},
-  tableHighlights: {},
-};
-
 export const MappingView = ({
   payload,
   entryBlockGraph,
@@ -746,6 +740,7 @@ export const MappingView = ({
           entryName,
           fieldName: card.fieldName,
           fieldType,
+          mappingKeys: card.mappingKeys,
         });
       });
 
@@ -799,7 +794,7 @@ export const MappingView = ({
 
             <Flex flexDirection="column" gap="spacingS">
               {(groupsByTab[tab.id] ?? []).map((group) => {
-                const activeHighlightIndex = isViewMode ? EMPTY_HIGHLIGHT_INDEX : highlightIndex;
+                const activeHighlightIndex = highlightIndex;
                 const isGroupHovered = group.mappingCards.some((card) =>
                   card.mappingKeys.some((key) => hoveredMappingKeys.includes(key))
                 );
@@ -948,15 +943,25 @@ export const MappingView = ({
                           </Flex>
                         )}
                       </Box>
-                      <MappingEntryCards
-                        groupId={group.id}
-                        mappingCards={group.mappingCards}
-                        cardOffsetsByGroup={cardOffsetsByGroup}
-                        cardHeightsByGroup={cardHeightsByGroup}
-                        hoveredMappingKeys={hoveredMappingKeys}
-                        onSetHoveredMappingKeys={setHoveredMappingKeys}
-                        setCardWrapperRef={setCardWrapperRef}
-                      />
+
+                      {isViewMode ? (
+                        <ViewMappingRail
+                          segmentId={group.id}
+                          cards={viewCardsByGroup[group.id] ?? []}
+                          hoveredMappingKeys={hoveredMappingKeys}
+                          onSetHoveredMappingKeys={setHoveredMappingKeys}
+                        />
+                      ) : (
+                        <MappingEntryCards
+                          groupId={group.id}
+                          mappingCards={group.mappingCards}
+                          cardOffsetsByGroup={cardOffsetsByGroup}
+                          cardHeightsByGroup={cardHeightsByGroup}
+                          hoveredMappingKeys={hoveredMappingKeys}
+                          onSetHoveredMappingKeys={setHoveredMappingKeys}
+                          setCardWrapperRef={setCardWrapperRef}
+                        />
+                      )}
                     </Flex>
                   </Box>
                 );

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -800,92 +800,6 @@ export const MappingView = ({
                 );
                 const showSurface = group.showGroupedSurface;
 
-                if (isViewMode) {
-                  const viewCards = viewCardsByGroup[group.id] ?? [];
-                  const isTableGroup = group.segments.every((s) => s.kind === 'table');
-                  return (
-                    <Box
-                      key={group.id}
-                      data-testid={`display-group-layout-${group.id}`}
-                      ref={setGroupLayoutRef(group.id)}>
-                      <Flex gap="spacingM" alignItems="flex-start">
-                        <Box
-                          style={{ flex: 2, position: 'relative' }}
-                          onMouseEnter={
-                            !isTableGroup && viewCards.length === 1
-                              ? () => setHoveredMappingKeys(viewCards[0]!.mappingKeys)
-                              : undefined
-                          }
-                          onMouseLeave={
-                            !isTableGroup ? () => setHoveredMappingKeys([]) : undefined
-                          }>
-                          <Flex
-                            flexDirection="column"
-                            gap="spacing2Xs"
-                            style={{ padding: tokens.spacing2Xs }}>
-                            {group.segments.map((segment) => (
-                              <NormalizedDocumentSection
-                                key={segment.id}
-                                segment={segment}
-                                highlightIndex={activeHighlightIndex}
-                                fullHighlightIndex={highlightIndex}
-                                imageById={imageById}
-                                listMarkers={listMarkers}
-                                excludedSourceRefs={entryBlockGraph.excludedSourceRefs}
-                                selectedEntryIndex={selectedEntryIndex}
-                                hoveredMappingKeys={hoveredMappingKeys}
-                                onSetHoveredMappingKeys={setHoveredMappingKeys}
-                                isViewMode={true}
-                                onEditImage={handleEditImage}
-                              />
-                            ))}
-                          </Flex>
-                          {!isTableGroup &&
-                            viewCards.map((card) => {
-                              const isCardHovered = card.mappingKeys.some((k) =>
-                                hoveredMappingKeys.includes(k)
-                              );
-                              return (
-                                <Box
-                                  key={card.key}
-                                  style={{
-                                    position: 'absolute',
-                                    inset: 0,
-                                    border: `${isCardHovered ? 2 : 1}px solid ${
-                                      isCardHovered ? tokens.green600 : tokens.green500
-                                    }`,
-                                    borderRadius: tokens.borderRadiusMedium,
-                                    pointerEvents: 'none',
-                                    transition: 'border-color 120ms ease, border-width 120ms ease',
-                                  }}
-                                />
-                              );
-                            })}
-                        </Box>
-                        <Flex
-                          flexDirection="column"
-                          gap="spacing2Xs"
-                          style={{ flex: '0 0 280px', maxWidth: 280 }}>
-                          {viewCards.map((card) => {
-                            const isCardHovered = card.mappingKeys.some((k) =>
-                              hoveredMappingKeys.includes(k)
-                            );
-                            return (
-                              <ViewMappingCard
-                                key={card.key}
-                                card={card}
-                                isHovered={isCardHovered}
-                                onMouseEnter={() => setHoveredMappingKeys(card.mappingKeys)}
-                                onMouseLeave={() => setHoveredMappingKeys([])}
-                              />
-                            );
-                          })}
-                        </Flex>
-                      </Flex>
-                    </Box>
-                  );
-                }
-
                 return (
                   <Box key={group.id}>
                     <Flex
@@ -919,6 +833,7 @@ export const MappingView = ({
                                   selectedEntryIndex={selectedEntryIndex}
                                   hoveredMappingKeys={hoveredMappingKeys}
                                   onSetHoveredMappingKeys={setHoveredMappingKeys}
+                                  showSpanOutline={!showSurface}
                                   onEditImage={isViewMode ? undefined : handleEditImage}
                                 />
                               ))}
@@ -937,6 +852,7 @@ export const MappingView = ({
                                 selectedEntryIndex={selectedEntryIndex}
                                 hoveredMappingKeys={hoveredMappingKeys}
                                 onSetHoveredMappingKeys={setHoveredMappingKeys}
+                                showSpanOutline={!showSurface}
                                 onEditImage={isViewMode ? undefined : handleEditImage}
                               />
                             ))}

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -42,7 +42,7 @@ import { buildSourceRefKey } from './sourceRefUtils';
 import { MappingEntryCards } from './MappingEntryCards';
 import { NormalizedDocumentSection } from './NormalizedDocumentSection';
 import { buildMappingDisplayGroups } from './buildMappingDisplayGroups';
-import { type ViewMappingCardEntry } from './ViewMappingRail';
+import { ViewMappingRail, type ViewMappingCardEntry } from './ViewMappingRail';
 import { ViewMappingCard } from './ViewMappingCard';
 import {
   applyImageExclusionToEntryBlockGraph,
@@ -740,7 +740,6 @@ export const MappingView = ({
           entryName,
           fieldName: card.fieldName,
           fieldType,
-          mappingKeys: card.mappingKeys,
         });
       });
 

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -919,7 +919,7 @@ export const MappingView = ({
                                   selectedEntryIndex={selectedEntryIndex}
                                   hoveredMappingKeys={hoveredMappingKeys}
                                   onSetHoveredMappingKeys={setHoveredMappingKeys}
-                                  onEditImage={handleEditImage}
+                                  onEditImage={isViewMode ? undefined : handleEditImage}
                                 />
                               ))}
                             </Flex>
@@ -937,7 +937,7 @@ export const MappingView = ({
                                 selectedEntryIndex={selectedEntryIndex}
                                 hoveredMappingKeys={hoveredMappingKeys}
                                 onSetHoveredMappingKeys={setHoveredMappingKeys}
-                                onEditImage={handleEditImage}
+                                onEditImage={isViewMode ? undefined : handleEditImage}
                               />
                             ))}
                           </Flex>

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -795,9 +795,6 @@ export const MappingView = ({
             <Flex flexDirection="column" gap="spacingS">
               {(groupsByTab[tab.id] ?? []).map((group) => {
                 const activeHighlightIndex = highlightIndex;
-                const isGroupHovered = group.mappingCards.some((card) =>
-                  card.mappingKeys.some((key) => hoveredMappingKeys.includes(key))
-                );
                 const showSurface = group.showGroupedSurface;
 
                 return (
@@ -811,15 +808,10 @@ export const MappingView = ({
                         {showSurface ? (
                           <Box
                             data-testid={`mapping-group-surface-${group.id}`}
-                            data-hovered={isGroupHovered ? 'true' : 'false'}
                             style={{
-                              border: `${isGroupHovered ? 2 : 1}px solid ${
-                                isGroupHovered ? tokens.green600 : tokens.green500
-                              }`,
                               borderRadius: tokens.borderRadiusMedium,
                               backgroundColor: tokens.green100,
                               padding: tokens.spacing2Xs,
-                              transition: 'border-color 120ms ease, border-width 120ms ease',
                             }}>
                             <Flex flexDirection="column" gap="spacing2Xs">
                               {group.segments.map((segment) => (
@@ -833,7 +825,6 @@ export const MappingView = ({
                                   selectedEntryIndex={selectedEntryIndex}
                                   hoveredMappingKeys={hoveredMappingKeys}
                                   onSetHoveredMappingKeys={setHoveredMappingKeys}
-                                  showSpanOutline={!showSurface}
                                   onEditImage={isViewMode ? undefined : handleEditImage}
                                 />
                               ))}
@@ -852,7 +843,6 @@ export const MappingView = ({
                                 selectedEntryIndex={selectedEntryIndex}
                                 hoveredMappingKeys={hoveredMappingKeys}
                                 onSetHoveredMappingKeys={setHoveredMappingKeys}
-                                showSpanOutline={!showSurface}
                                 onEditImage={isViewMode ? undefined : handleEditImage}
                               />
                             ))}

--- a/apps/google-docs/src/locations/Page/components/review/mapping/NormalizedDocumentSection.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/NormalizedDocumentSection.tsx
@@ -17,8 +17,7 @@ interface ReviewDocumentBodyProps {
   selectedEntryIndex: number | null;
   hoveredMappingKeys: string[];
   onSetHoveredMappingKeys: (keys: string[]) => void;
-  isViewMode?: boolean;
-  onEditImage: (sourceRef: ImageSourceRef, label: string) => void;
+  onEditImage?: (sourceRef: ImageSourceRef, label: string) => void;
 }
 
 export const NormalizedDocumentSection = ({

--- a/apps/google-docs/src/locations/Page/components/review/mapping/NormalizedDocumentSection.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/NormalizedDocumentSection.tsx
@@ -30,7 +30,6 @@ export const NormalizedDocumentSection = ({
   selectedEntryIndex,
   hoveredMappingKeys,
   onSetHoveredMappingKeys,
-  isViewMode = false,
   onEditImage,
 }: ReviewDocumentBodyProps): JSX.Element => {
   return (
@@ -53,7 +52,6 @@ export const NormalizedDocumentSection = ({
               selectedEntryIndex={selectedEntryIndex}
               hoveredMappingKeys={hoveredMappingKeys}
               onSetHoveredMappingKeys={onSetHoveredMappingKeys}
-              isViewMode={isViewMode}
               onEditImage={onEditImage}
             />
           ) : (

--- a/apps/google-docs/src/locations/Page/components/review/mapping/NormalizedDocumentSection.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/NormalizedDocumentSection.tsx
@@ -16,6 +16,7 @@ interface ReviewDocumentBodyProps {
   excludedSourceRefs: SourceRef[];
   selectedEntryIndex: number | null;
   hoveredMappingKeys: string[];
+  showSpanOutline: boolean;
   onSetHoveredMappingKeys: (keys: string[]) => void;
   onEditImage?: (sourceRef: ImageSourceRef, label: string) => void;
 }
@@ -29,6 +30,7 @@ export const NormalizedDocumentSection = ({
   excludedSourceRefs,
   selectedEntryIndex,
   hoveredMappingKeys,
+  showSpanOutline,
   onSetHoveredMappingKeys,
   isViewMode = false,
   onEditImage,
@@ -52,6 +54,7 @@ export const NormalizedDocumentSection = ({
               excludedSourceRefs={excludedSourceRefs}
               selectedEntryIndex={selectedEntryIndex}
               hoveredMappingKeys={hoveredMappingKeys}
+              showSpanOutline={showSpanOutline}
               onSetHoveredMappingKeys={onSetHoveredMappingKeys}
               isViewMode={isViewMode}
               onEditImage={onEditImage}
@@ -66,6 +69,7 @@ export const NormalizedDocumentSection = ({
               excludedSourceRefs={excludedSourceRefs}
               selectedEntryIndex={selectedEntryIndex}
               hoveredMappingKeys={hoveredMappingKeys}
+              showSpanOutline={showSpanOutline}
               onSetHoveredMappingKeys={onSetHoveredMappingKeys}
               onEditImage={onEditImage}
             />

--- a/apps/google-docs/src/locations/Page/components/review/mapping/NormalizedDocumentSection.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/NormalizedDocumentSection.tsx
@@ -16,7 +16,6 @@ interface ReviewDocumentBodyProps {
   excludedSourceRefs: SourceRef[];
   selectedEntryIndex: number | null;
   hoveredMappingKeys: string[];
-  showSpanOutline: boolean;
   onSetHoveredMappingKeys: (keys: string[]) => void;
   onEditImage?: (sourceRef: ImageSourceRef, label: string) => void;
 }
@@ -30,7 +29,6 @@ export const NormalizedDocumentSection = ({
   excludedSourceRefs,
   selectedEntryIndex,
   hoveredMappingKeys,
-  showSpanOutline,
   onSetHoveredMappingKeys,
   isViewMode = false,
   onEditImage,
@@ -54,7 +52,6 @@ export const NormalizedDocumentSection = ({
               excludedSourceRefs={excludedSourceRefs}
               selectedEntryIndex={selectedEntryIndex}
               hoveredMappingKeys={hoveredMappingKeys}
-              showSpanOutline={showSpanOutline}
               onSetHoveredMappingKeys={onSetHoveredMappingKeys}
               isViewMode={isViewMode}
               onEditImage={onEditImage}
@@ -69,7 +66,6 @@ export const NormalizedDocumentSection = ({
               excludedSourceRefs={excludedSourceRefs}
               selectedEntryIndex={selectedEntryIndex}
               hoveredMappingKeys={hoveredMappingKeys}
-              showSpanOutline={showSpanOutline}
               onSetHoveredMappingKeys={onSetHoveredMappingKeys}
               onEditImage={onEditImage}
             />

--- a/apps/google-docs/src/locations/Page/components/review/mapping/ReviewImageAssetCard.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/ReviewImageAssetCard.tsx
@@ -37,14 +37,11 @@ export function ReviewImageAssetCard({
 
   const imageHeight = size === 'small' ? '180px' : '280px';
 
-  const borderColor =
-    isExcluded && !isHighlighted
-      ? tokens.gray300
-      : !isHighlighted
-      ? tokens.gray300
-      : hovered
-      ? tokens.green600
-      : tokens.green500;
+  const backgroundColor = isHighlighted
+    ? hovered
+      ? tokens.green300
+      : tokens.green100
+    : tokens.gray100;
 
   return (
     <Box
@@ -57,9 +54,9 @@ export function ReviewImageAssetCard({
         maxWidth: '100%',
         verticalAlign: 'top',
         borderRadius: tokens.borderRadiusMedium,
-        border: `1px solid ${borderColor}`,
-        backgroundColor: isHighlighted ? tokens.green100 : tokens.gray100,
-        transition: 'border-color 120ms ease',
+        border: `1px solid ${isHighlighted ? 'transparent' : tokens.gray300}`,
+        backgroundColor,
+        transition: 'background-color 120ms ease',
         overflow: 'hidden',
         boxSizing: 'border-box',
         padding: tokens.spacingXs,

--- a/apps/google-docs/src/locations/Page/components/review/mapping/ReviewImageAssetCard.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/ReviewImageAssetCard.tsx
@@ -15,7 +15,7 @@ export interface ReviewImageAssetCardProps {
   size?: 'small' | 'default';
   onMouseEnter?: () => void;
   onMouseLeave?: () => void;
-  onEdit: () => void;
+  onEdit?: () => void;
 }
 
 export function getNormalizedImageDisplayName(image: NormalizedDocumentImage): string {
@@ -66,14 +66,18 @@ export function ReviewImageAssetCard({
       }}>
       <Card
         ariaLabel={title}
-        actions={[
-          <MenuItem key="edit" onClick={onEdit}>
-            <Flex alignItems="center" gap="spacing2Xs">
-              <PencilSimpleIcon size="tiny" />
-              <Text>Edit content mapping</Text>
-            </Flex>
-          </MenuItem>,
-        ]}>
+        actions={
+          onEdit
+            ? [
+                <MenuItem key="edit" onClick={onEdit}>
+                  <Flex alignItems="center" gap="spacing2Xs">
+                    <PencilSimpleIcon size="tiny" />
+                    <Text>Edit content mapping</Text>
+                  </Flex>
+                </MenuItem>,
+              ]
+            : undefined
+        }>
         <Splitter />
         <Box padding="spacingS">
           <Image

--- a/apps/google-docs/src/locations/Page/components/review/mapping/ViewMappingRail.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/ViewMappingRail.tsx
@@ -28,7 +28,7 @@ export const ViewMappingRail = ({
         <ViewMappingCard
           key={card.key}
           card={card}
-          isHovered={card.mappingKeys.some((k) => hoveredMappingKeys.includes(k))}
+          isHovered={card.mappingKeys.some((key) => hoveredMappingKeys.includes(key))}
           onMouseEnter={() => onSetHoveredMappingKeys(card.mappingKeys)}
           onMouseLeave={() => onSetHoveredMappingKeys([])}
         />

--- a/apps/google-docs/src/locations/Page/components/review/mapping/documentRenderers.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/documentRenderers.tsx
@@ -145,7 +145,7 @@ interface BlockRendererProps {
   selectedEntryIndex: number | null;
   hoveredMappingKeys: string[];
   onSetHoveredMappingKeys: (keys: string[]) => void;
-  onEditImage: (
+  onEditImage?: (
     sourceRef: { type: 'image'; blockId: string; imageId: string },
     label: string
   ) => void;
@@ -249,7 +249,11 @@ export const BlockRenderer = ({
                 highlighted ? () => onSetHoveredMappingKeys(imageMappingKeys) : undefined
               }
               onMouseLeave={highlighted ? () => onSetHoveredMappingKeys([]) : undefined}
-              onEdit={() => onEditImage(imageSourceRef, image.title ?? image.altText ?? image.id)}
+              onEdit={
+                onEditImage
+                  ? () => onEditImage(imageSourceRef, image.title ?? image.altText ?? image.id)
+                  : undefined
+              }
             />
           </Box>
         );
@@ -271,8 +275,7 @@ interface TableRendererProps {
   selectedEntryIndex: number | null;
   hoveredMappingKeys: string[];
   onSetHoveredMappingKeys: (keys: string[]) => void;
-  isViewMode?: boolean;
-  onEditImage: (
+  onEditImage?: (
     sourceRef: {
       type: 'tableImage';
       tableId: string;
@@ -296,7 +299,7 @@ interface TablePartRendererProps {
   excludedSourceRefs: SourceRef[];
   hoveredMappingKeys: string[];
   onSetHoveredMappingKeys: (keys: string[]) => void;
-  onEditImage: TableRendererProps['onEditImage'];
+  onEditImage?: TableRendererProps['onEditImage'];
 }
 
 const TablePartRenderer = ({
@@ -359,7 +362,11 @@ const TablePartRenderer = ({
           size="small"
           onMouseEnter={highlighted ? () => onSetHoveredMappingKeys(mappingKeys) : undefined}
           onMouseLeave={highlighted ? () => onSetHoveredMappingKeys([]) : undefined}
-          onEdit={() => onEditImage(imageSourceRef, image.title ?? image.altText ?? image.id)}
+          onEdit={
+            onEditImage
+              ? () => onEditImage(imageSourceRef, image.title ?? image.altText ?? image.id)
+              : undefined
+          }
         />
       </Box>
     );

--- a/apps/google-docs/src/locations/Page/components/review/mapping/documentRenderers.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/documentRenderers.tsx
@@ -45,7 +45,7 @@ function getHighlightStyle(highlighted: boolean, hovered: boolean) {
   if (!highlighted) return { border: tokens.gray300, background: 'transparent' };
   return {
     border: hovered ? tokens.green600 : tokens.green500,
-    background: hovered ? tokens.green300 : tokens.green200,
+    background: hovered ? tokens.green200 : tokens.green100,
   };
 }
 

--- a/apps/google-docs/src/locations/Page/components/review/mapping/documentRenderers.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/documentRenderers.tsx
@@ -45,7 +45,7 @@ function getHighlightStyle(highlighted: boolean, hovered: boolean) {
   if (!highlighted) return { border: tokens.gray300, background: 'transparent' };
   return {
     border: hovered ? tokens.green600 : tokens.green500,
-    background: hovered ? tokens.green200 : tokens.green100,
+    background: hovered ? tokens.green300 : tokens.green100,
   };
 }
 
@@ -68,7 +68,6 @@ interface TextSegmentSpanProps {
   id: string;
   segment: TextSegment;
   hovered: boolean;
-  showSpanOutline: boolean;
   onSetHoveredMappings: (keys: string[]) => void;
   textScope: 'block' | 'table';
   rangeStart: number;
@@ -84,7 +83,6 @@ const TextSegmentSpan = ({
   id,
   segment,
   hovered,
-  showSpanOutline,
   onSetHoveredMappings,
   textScope,
   rangeStart,
@@ -117,14 +115,10 @@ const TextSegmentSpan = ({
       style={{
         ...getTextSegmentStyle(segment.styles),
         backgroundColor: getHighlightStyle(segment.highlighted, hovered).background,
-        borderRadius: segment.highlighted ? tokens.borderRadiusSmall : undefined,
-        padding: segment.highlighted && showSpanOutline ? tokens.spacing2Xs : undefined,
-        outline:
-          segment.highlighted && showSpanOutline
-            ? `${hovered ? 2 : 1}px solid ${getHighlightStyle(segment.highlighted, hovered).border}`
-            : undefined,
+        // borderRadius: segment.highlighted ? tokens.borderRadiusSmall : undefined,
+        padding: segment.highlighted ? `${tokens.spacing2Xs} 0` : undefined,
         whiteSpace: 'pre-wrap',
-        transition: 'background-color 120ms ease, outline 120ms ease',
+        transition: 'background-color 120ms ease',
       }}>
       {segment.text}
     </Box>
@@ -151,7 +145,6 @@ interface BlockRendererProps {
   excludedSourceRefs: SourceRef[];
   selectedEntryIndex: number | null;
   hoveredMappingKeys: string[];
-  showSpanOutline: boolean;
   onSetHoveredMappingKeys: (keys: string[]) => void;
   onEditImage?: (
     sourceRef: { type: 'image'; blockId: string; imageId: string },
@@ -168,7 +161,6 @@ export const BlockRenderer = ({
   excludedSourceRefs,
   selectedEntryIndex,
   hoveredMappingKeys,
-  showSpanOutline,
   onSetHoveredMappingKeys,
   onEditImage,
 }: BlockRendererProps) => {
@@ -187,7 +179,6 @@ export const BlockRenderer = ({
           id={`${block.id}-${index}`}
           segment={seg}
           hovered={isMappingHovered(seg.mappingKeys, hoveredMappingKeys)}
-          showSpanOutline={showSpanOutline}
           onSetHoveredMappings={onSetHoveredMappingKeys}
           textScope="block"
           rangeStart={seg.start}
@@ -284,7 +275,6 @@ interface TableRendererProps {
   excludedSourceRefs: SourceRef[];
   selectedEntryIndex: number | null;
   hoveredMappingKeys: string[];
-  showSpanOutline: boolean;
   onSetHoveredMappingKeys: (keys: string[]) => void;
   onEditImage?: (
     sourceRef: {
@@ -309,7 +299,6 @@ interface TablePartRendererProps {
   imageById: Record<string, NormalizedDocumentImage>;
   excludedSourceRefs: SourceRef[];
   hoveredMappingKeys: string[];
-  showSpanOutline: boolean;
   onSetHoveredMappingKeys: (keys: string[]) => void;
   onEditImage?: TableRendererProps['onEditImage'];
 }
@@ -324,7 +313,6 @@ const TablePartRenderer = ({
   imageById,
   excludedSourceRefs,
   hoveredMappingKeys,
-  showSpanOutline,
   onSetHoveredMappingKeys,
   onEditImage,
 }: TablePartRendererProps) => {
@@ -395,7 +383,6 @@ const TablePartRenderer = ({
           id={`${part.id}-${index}`}
           segment={seg}
           hovered={isMappingHovered(seg.mappingKeys, hoveredMappingKeys)}
-          showSpanOutline={showSpanOutline}
           onSetHoveredMappings={onSetHoveredMappingKeys}
           textScope="table"
           rangeStart={seg.start}
@@ -419,7 +406,6 @@ export const TableRenderer = ({
   excludedSourceRefs,
   selectedEntryIndex,
   hoveredMappingKeys,
-  showSpanOutline,
   onSetHoveredMappingKeys,
   isViewMode = false,
   onEditImage,

--- a/apps/google-docs/src/locations/Page/components/review/mapping/documentRenderers.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/documentRenderers.tsx
@@ -115,7 +115,6 @@ const TextSegmentSpan = ({
       style={{
         ...getTextSegmentStyle(segment.styles),
         backgroundColor: getHighlightStyle(segment.highlighted, hovered).background,
-        // borderRadius: segment.highlighted ? tokens.borderRadiusSmall : undefined,
         padding: segment.highlighted ? `${tokens.spacing2Xs} 0` : undefined,
         whiteSpace: 'pre-wrap',
         transition: 'background-color 120ms ease',
@@ -407,7 +406,6 @@ export const TableRenderer = ({
   selectedEntryIndex,
   hoveredMappingKeys,
   onSetHoveredMappingKeys,
-  isViewMode = false,
   onEditImage,
 }: TableRendererProps) => {
   const borderIndex = fullHighlightIndex ?? highlightIndex;

--- a/apps/google-docs/src/locations/Page/components/review/mapping/documentRenderers.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/documentRenderers.tsx
@@ -68,6 +68,7 @@ interface TextSegmentSpanProps {
   id: string;
   segment: TextSegment;
   hovered: boolean;
+  showSpanOutline: boolean;
   onSetHoveredMappings: (keys: string[]) => void;
   textScope: 'block' | 'table';
   rangeStart: number;
@@ -83,6 +84,7 @@ const TextSegmentSpan = ({
   id,
   segment,
   hovered,
+  showSpanOutline,
   onSetHoveredMappings,
   textScope,
   rangeStart,
@@ -116,8 +118,13 @@ const TextSegmentSpan = ({
         ...getTextSegmentStyle(segment.styles),
         backgroundColor: getHighlightStyle(segment.highlighted, hovered).background,
         borderRadius: segment.highlighted ? tokens.borderRadiusSmall : undefined,
+        padding: segment.highlighted && showSpanOutline ? tokens.spacing2Xs : undefined,
+        outline:
+          segment.highlighted && showSpanOutline
+            ? `${hovered ? 2 : 1}px solid ${getHighlightStyle(segment.highlighted, hovered).border}`
+            : undefined,
         whiteSpace: 'pre-wrap',
-        transition: 'background-color 120ms ease',
+        transition: 'background-color 120ms ease, outline 120ms ease',
       }}>
       {segment.text}
     </Box>
@@ -144,6 +151,7 @@ interface BlockRendererProps {
   excludedSourceRefs: SourceRef[];
   selectedEntryIndex: number | null;
   hoveredMappingKeys: string[];
+  showSpanOutline: boolean;
   onSetHoveredMappingKeys: (keys: string[]) => void;
   onEditImage?: (
     sourceRef: { type: 'image'; blockId: string; imageId: string },
@@ -160,6 +168,7 @@ export const BlockRenderer = ({
   excludedSourceRefs,
   selectedEntryIndex,
   hoveredMappingKeys,
+  showSpanOutline,
   onSetHoveredMappingKeys,
   onEditImage,
 }: BlockRendererProps) => {
@@ -178,6 +187,7 @@ export const BlockRenderer = ({
           id={`${block.id}-${index}`}
           segment={seg}
           hovered={isMappingHovered(seg.mappingKeys, hoveredMappingKeys)}
+          showSpanOutline={showSpanOutline}
           onSetHoveredMappings={onSetHoveredMappingKeys}
           textScope="block"
           rangeStart={seg.start}
@@ -274,6 +284,7 @@ interface TableRendererProps {
   excludedSourceRefs: SourceRef[];
   selectedEntryIndex: number | null;
   hoveredMappingKeys: string[];
+  showSpanOutline: boolean;
   onSetHoveredMappingKeys: (keys: string[]) => void;
   onEditImage?: (
     sourceRef: {
@@ -298,6 +309,7 @@ interface TablePartRendererProps {
   imageById: Record<string, NormalizedDocumentImage>;
   excludedSourceRefs: SourceRef[];
   hoveredMappingKeys: string[];
+  showSpanOutline: boolean;
   onSetHoveredMappingKeys: (keys: string[]) => void;
   onEditImage?: TableRendererProps['onEditImage'];
 }
@@ -312,6 +324,7 @@ const TablePartRenderer = ({
   imageById,
   excludedSourceRefs,
   hoveredMappingKeys,
+  showSpanOutline,
   onSetHoveredMappingKeys,
   onEditImage,
 }: TablePartRendererProps) => {
@@ -382,6 +395,7 @@ const TablePartRenderer = ({
           id={`${part.id}-${index}`}
           segment={seg}
           hovered={isMappingHovered(seg.mappingKeys, hoveredMappingKeys)}
+          showSpanOutline={showSpanOutline}
           onSetHoveredMappings={onSetHoveredMappingKeys}
           textScope="table"
           rangeStart={seg.start}
@@ -405,6 +419,7 @@ export const TableRenderer = ({
   excludedSourceRefs,
   selectedEntryIndex,
   hoveredMappingKeys,
+  showSpanOutline,
   onSetHoveredMappingKeys,
   isViewMode = false,
   onEditImage,
@@ -446,61 +461,35 @@ export const TableRenderer = ({
             key={row.id}
             id={`row:${table.id}:${row.id}`}
             data-testid={`table-row-${row.id}`}>
-            {row.cells.map((cell) => {
-              const cellMappingKeys = isViewMode ? getCellMappingKeys(row.id, cell.id) : [];
-              const isCellMapped = cellMappingKeys.length > 0;
-              const isCellHovered =
-                isCellMapped && cellMappingKeys.some((k) => hoveredMappingKeys.includes(k));
-              return (
-                <TableCell
-                  key={cell.id}
-                  data-testid={`table-cell-${cell.id}`}
-                  onMouseEnter={
-                    isViewMode && isCellMapped
-                      ? () => onSetHoveredMappingKeys(cellMappingKeys)
-                      : undefined
-                  }
-                  onMouseLeave={
-                    isViewMode && isCellMapped ? () => onSetHoveredMappingKeys([]) : undefined
-                  }
-                  style={{
-                    backgroundColor: 'transparent',
-                    verticalAlign: 'top',
-                    ...(isViewMode && isCellMapped
-                      ? {
-                          border: `${isCellHovered ? 2 : 1}px solid ${
-                            isCellHovered ? tokens.green600 : tokens.green500
-                          }`,
-                          borderRadius: tokens.borderRadiusMedium,
-                          transition: 'border-color 120ms ease, border-width 120ms ease',
-                        }
-                      : {}),
-                  }}>
-                  <Flex flexDirection="column" gap="spacing2Xs">
-                    {cell.parts.map((part) => {
-                      const partKey = [table.id, row.id, cell.id, part.id].join(':');
-                      return (
-                        <Box key={part.id}>
-                          <TablePartRenderer
-                            segmentId={segmentId}
-                            tableId={table.id}
-                            rowId={row.id}
-                            cellId={cell.id}
-                            part={part}
-                            visibleHighlights={getVisiblePartHighlights(partKey)}
-                            imageById={imageById}
-                            excludedSourceRefs={excludedSourceRefs}
-                            hoveredMappingKeys={hoveredMappingKeys}
-                            onSetHoveredMappingKeys={onSetHoveredMappingKeys}
-                            onEditImage={onEditImage}
-                          />
-                        </Box>
-                      );
-                    })}
-                  </Flex>
-                </TableCell>
-              );
-            })}
+            {row.cells.map((cell) => (
+              <TableCell
+                key={cell.id}
+                data-testid={`table-cell-${cell.id}`}
+                style={{ backgroundColor: 'transparent', verticalAlign: 'top' }}>
+                <Flex flexDirection="column" gap="spacing2Xs">
+                  {cell.parts.map((part) => {
+                    const partKey = [table.id, row.id, cell.id, part.id].join(':');
+                    return (
+                      <Box key={part.id}>
+                        <TablePartRenderer
+                          segmentId={segmentId}
+                          tableId={table.id}
+                          rowId={row.id}
+                          cellId={cell.id}
+                          part={part}
+                          visibleHighlights={getVisiblePartHighlights(partKey)}
+                          imageById={imageById}
+                          excludedSourceRefs={excludedSourceRefs}
+                          hoveredMappingKeys={hoveredMappingKeys}
+                          onSetHoveredMappingKeys={onSetHoveredMappingKeys}
+                          onEditImage={onEditImage}
+                        />
+                      </Box>
+                    );
+                  })}
+                </Flex>
+              </TableCell>
+            ))}
           </TableRow>
         ))}
       </TableBody>


### PR DESCRIPTION
## Purpose

  Improves highlight styling consistency and adds hover-based highlighting to view mode in
  the Google Docs mapping review UI. Previously, view mode suppressed all highlighting; now
   cards and document segments respond to hover the same way edit mode does.

  ## Summary

  - **View mode highlighting**: Removed `EMPTY_HIGHLIGHT_INDEX` override so view mode
  highlights on hover like edit mode
  - **Hover wiring**: Connected `hoveredMappingKeys` into `ViewMappingRail` →
  `ViewMappingCard`; card border thickens on hover
  - **Optional `onEditImage`**: Made optional throughout — view mode image cards render
  without an actions menu
  - **Image card styling**: Switched highlight from border-color to background-color
  transition (`green100` → `green300`)
  - **Text highlight styling**: Background changed `green200` → `green100`; border-radius
  swapped for vertical padding
  - **Tip hint**: Added "Tip: hover over a card to highlight its content" with
  `LightbulbIcon`


https://github.com/user-attachments/assets/98a11e1b-c7c5-4628-9e5f-9347d067f6c8



  Testing Steps

  1. Open the Google Docs app and navigate to the review mapping view.
  2. In view mode, hover over a mapping card in the rail — verify the corresponding
  document content highlights (background turns green, card border thickens).
  3. Move the mouse away — verify highlights clear.
  4. Switch to edit mode and confirm the same hover behavior works as before.
  5. In view mode, verify image asset cards render without an "Edit content mapping"
  actions menu.
  6. Verify the tip hint ("Tip: hover over a card to highlight its content") appears below
  the "Currently viewing" label.
