### PR TITLE
refactor(google-docs): Conditional table content placeholder rendering [INTEG-3870]

### DIFF
--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -932,7 +932,7 @@ export const MappingView = ({
             <RichTextSelectionPreview
               document={document}
               sourceRefs={pendingPreviewSourceRefs}
-              showTablePlaceholder={pendingPreviewHasTableContent}
+              selectionIncludesTableContent={pendingPreviewHasTableContent}
             />
           );
         })()}

--- a/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/RichTextSelectionPreview.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/edit-modals/RichTextSelectionPreview.tsx
@@ -1,12 +1,22 @@
 import { Box, Flex, Text } from '@contentful/f36-components';
 import tokens from '@contentful/f36-tokens';
-import type { NormalizedDocument, SourceRef } from '@types';
-import { isBlockImageSourceRef, isTableImageSourceRef, isTextSourceRef } from '@types';
+import type {
+  NormalizedDocument,
+  SourceRef,
+  TableImageSourceRef,
+  TableTextSourceRef,
+} from '@types';
+import {
+  isBlockImageSourceRef,
+  isTableImageSourceRef,
+  isTableTextSourceRef,
+  isTextSourceRef,
+} from '@types';
 
 interface RichTextSelectionPreviewProps {
   document: NormalizedDocument;
   sourceRefs: SourceRef[];
-  showTablePlaceholder?: boolean;
+  selectionIncludesTableContent?: boolean;
 }
 
 function getTextPreview(sourceRef: SourceRef): string {
@@ -25,11 +35,37 @@ function getImageForSourceRef(document: NormalizedDocument, sourceRef: SourceRef
   return document.images?.find((image) => image.id === sourceRef.imageId);
 }
 
+function isTableCellSourceRef(
+  sourceRef: SourceRef
+): sourceRef is TableTextSourceRef | TableImageSourceRef {
+  return isTableTextSourceRef(sourceRef) || isTableImageSourceRef(sourceRef);
+}
+
+function isSingleTableCellSelection(sourceRefs: SourceRef[]): boolean {
+  const tableCellSourceRefs = sourceRefs.filter(isTableCellSourceRef);
+
+  if (!tableCellSourceRefs.length) {
+    return false;
+  }
+
+  const [first] = tableCellSourceRefs;
+
+  return tableCellSourceRefs.every(
+    (sourceRef) =>
+      sourceRef.tableId === first.tableId &&
+      sourceRef.rowId === first.rowId &&
+      sourceRef.cellId === first.cellId
+  );
+}
+
 export const RichTextSelectionPreview = ({
   document,
   sourceRefs,
-  showTablePlaceholder = false,
+  selectionIncludesTableContent = false,
 }: RichTextSelectionPreviewProps): JSX.Element => {
+  const shouldShowTablePlaceholder =
+    selectionIncludesTableContent && !isSingleTableCellSelection(sourceRefs);
+
   return (
     <Flex flexDirection="column" gap="spacingXs">
       {sourceRefs.map((sourceRef, index) => {
@@ -54,6 +90,10 @@ export const RichTextSelectionPreview = ({
           );
         }
 
+        if (shouldShowTablePlaceholder && isTableTextSourceRef(sourceRef)) {
+          return null;
+        }
+
         const text = getTextPreview(sourceRef);
         if (!text.trim().length) {
           return null;
@@ -69,7 +109,7 @@ export const RichTextSelectionPreview = ({
           </Text>
         );
       })}
-      {showTablePlaceholder ? (
+      {shouldShowTablePlaceholder ? (
         <Box
           style={{
             border: `1px dashed ${tokens.gray400}`,

--- a/apps/google-docs/test/locations/Page/components/review/RichTextSelectionPreview.spec.tsx
+++ b/apps/google-docs/test/locations/Page/components/review/RichTextSelectionPreview.spec.tsx
@@ -22,7 +22,7 @@ const previewDocument: NormalizedDocument = {
 };
 
 describe('RichTextSelectionPreview', () => {
-  it('renders text plus compact image and table placeholders without raw table cell text', () => {
+  it('renders text plus compact image and table placeholders without raw multi-cell table text', () => {
     const sourceRefs: SourceRef[] = [
       {
         type: 'paragraph',
@@ -46,13 +46,23 @@ describe('RichTextSelectionPreview', () => {
         end: 6,
         flattenedRuns: [{ text: 'Cell A', start: 0, end: 6, styles: {} }],
       },
+      {
+        type: 'tableText',
+        tableId: 'table-1',
+        rowId: 'row-1',
+        cellId: 'cell-2',
+        partId: 'part-2',
+        start: 0,
+        end: 6,
+        flattenedRuns: [{ text: 'Cell B', start: 0, end: 6, styles: {} }],
+      },
     ];
 
     render(
       <RichTextSelectionPreview
         document={previewDocument}
         sourceRefs={sourceRefs}
-        showTablePlaceholder
+        selectionIncludesTableContent
       />
     );
 
@@ -60,5 +70,66 @@ describe('RichTextSelectionPreview', () => {
     expect(screen.getByText('Duck diagram')).toBeTruthy();
     expect(screen.getByText('Table content')).toBeTruthy();
     expect(screen.queryByText('Cell A')).toBeNull();
+    expect(screen.queryByText('Cell B')).toBeNull();
+  });
+
+  it('renders selected table cell text without the table placeholder', () => {
+    const sourceRefs: SourceRef[] = [
+      {
+        type: 'tableText',
+        tableId: 'table-1',
+        rowId: 'row-1',
+        cellId: 'cell-1',
+        partId: 'part-1',
+        start: 0,
+        end: 6,
+        flattenedRuns: [{ text: 'Cell A', start: 0, end: 6, styles: {} }],
+      },
+    ];
+
+    render(
+      <RichTextSelectionPreview
+        document={previewDocument}
+        sourceRefs={sourceRefs}
+        selectionIncludesTableContent
+      />
+    );
+
+    expect(screen.getByText('Cell A')).toBeTruthy();
+    expect(screen.queryByText('Table content')).toBeNull();
+  });
+
+  it('renders selected content block and table cell text without the table placeholder', () => {
+    const sourceRefs: SourceRef[] = [
+      {
+        type: 'paragraph',
+        blockId: 'paragraph-1',
+        start: 0,
+        end: 15,
+        flattenedRuns: [{ text: 'Intro paragraph', start: 0, end: 15, styles: {} }],
+      },
+      {
+        type: 'tableText',
+        tableId: 'table-1',
+        rowId: 'row-1',
+        cellId: 'cell-1',
+        partId: 'part-1',
+        start: 0,
+        end: 6,
+        flattenedRuns: [{ text: 'Cell A', start: 0, end: 6, styles: {} }],
+      },
+    ];
+
+    render(
+      <RichTextSelectionPreview
+        document={previewDocument}
+        sourceRefs={sourceRefs}
+        selectionIncludesTableContent
+      />
+    );
+
+    expect(screen.getByText('Intro paragraph')).toBeTruthy();
+    expect(screen.getByText('Cell A')).toBeTruthy();
+    expect(screen.queryByText('Table content')).toBeNull();
   });
 });


### PR DESCRIPTION
## Purpose

Fix rich text selection previews for table content. Single-cell selections should show the selected cell value, while broader table selections should show the `Table content` placeholder.

## Approach

Updated the preview logic to inspect only table-related source refs when deciding whether to show the table placeholder. If the table portion of the selection belongs to one cell, the preview renders that cell text. If it spans multiple cells, raw cell text is hidden and the placeholder is shown.

## Testing steps

Automated tests added for the `RichTextSelectionPreview.tsx

Before:

> <img width="1380" height="1434" alt="image" src="https://github.com/user-attachments/assets/045e82d0-2673-4083-b690-3c80f1d3510b" />

Now:

> https://github.com/user-attachments/assets/9af6c35d-2700-4baa-ab87-6397a09f1c21


> https://github.com/user-attachments/assets/edde5e2d-0c1c-4636-a52d-f59eb402a208



## Breaking Changes

No

## Dependencies and/or References

No

## Deployment

No