### PR TITLE
[INTEG-3858] fix(google-docs): show all entries label in view mode, entry name in edit mode 

### DIFF
--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -756,7 +756,7 @@ export const MappingView = ({
         flexDirection="column"
         gap="spacingS"
         style={{ marginTop: tokens.spacingM }}>
-        {selectedEntryRow && (
+        {(isViewMode || selectedEntryRow) && (
           <Flex
             gap="spacingM"
             alignItems="flex-end"
@@ -773,15 +773,23 @@ export const MappingView = ({
                 Currently viewing:
               </Text>
               <Text as="p" marginBottom="none">
-                <Text as="span" fontWeight="fontWeightDemiBold">
-                  {selectedEntryRow.contentTypeName}
-                </Text>
-                {selectedEntryRow.entryTitle ? (
-                  <Text as="span" fontColor="gray600">
-                    {' '}
-                    ({selectedEntryRow.entryTitle})
+                {isViewMode ? (
+                  <Text as="span" fontWeight="fontWeightDemiBold">
+                    All entries
                   </Text>
-                ) : null}
+                ) : (
+                  <>
+                    <Text as="span" fontWeight="fontWeightDemiBold">
+                      {selectedEntryRow!.contentTypeName}
+                    </Text>
+                    {selectedEntryRow!.entryTitle ? (
+                      <Text as="span" fontColor="gray600">
+                        {' '}
+                        ({selectedEntryRow!.entryTitle})
+                      </Text>
+                    ) : null}
+                  </>
+                )}
               </Text>
             </Box>
             <Flex alignItems="center" gap="spacing2Xs" style={{ flex: '0 0 280px', maxWidth: 280 }}>


### PR DESCRIPTION
View mode shows "All entries" under "Currently viewing:" since it renders all mappings regardless of selection. Edit mode continues to show the selected entry's content type name and title as before.
