### PR TITLE
refactor(google-docs): Enhance tab display logic in document builder + tests fix [INTEG-3233]

### DIFF
--- a/apps/google-docs/src/locations/Page/components/review/mapping/buildDocument.ts
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/buildDocument.ts
@@ -4,6 +4,7 @@ import {
   NormalizedDocumentTabBlock,
 } from '@types';
 import { NormalizedDocumentTable } from '@types';
+import { getTabDisplayName } from '../../../../../utils/utils';
 
 export type DocSegment =
   | { kind: 'block'; id: string; position: number; block: NormalizedDocumentContentBlock }
@@ -24,6 +25,9 @@ interface Document {
 
 export const buildDocument = (normalizedDocument: NormalizedDocument): Document => {
   const allItems: SortableItem[] = [];
+  const tabBlocks = normalizedDocument.contentBlocks.filter(
+    (block): block is NormalizedDocumentTabBlock => block.type === 'tab'
+  );
 
   normalizedDocument.contentBlocks.forEach((block) => {
     if (block.type === 'tab') {
@@ -44,7 +48,11 @@ export const buildDocument = (normalizedDocument: NormalizedDocument): Document 
 
   allItems.forEach((item) => {
     if (item.kind === 'tab') {
-      currentTab = { id: item.tab.id, name: item.tab.name, segments: [] };
+      currentTab = {
+        id: item.tab.id,
+        name: getTabDisplayName(item.tab, tabBlocks.length),
+        segments: [],
+      };
       tabs.push(currentTab);
       return;
     }

--- a/apps/google-docs/src/utils/utils.ts
+++ b/apps/google-docs/src/utils/utils.ts
@@ -1,8 +1,6 @@
 import type { NormalizedDocumentTabBlock } from '@types';
 import type { MappingReviewSuspendPayload, CompletedWorkflowPayload } from '../types/workflow';
 
-const DEFAULT_UNTABBED_DOCUMENT_TAB_NAME = 'tab 1';
-
 export const truncateLabel = (label: string, maxLength: number = 10): string => {
   if (label.length <= maxLength) return label;
 
@@ -20,9 +18,7 @@ export const isPreviewPayload = (
 };
 
 export const getTabDisplayName = (tab: NormalizedDocumentTabBlock, tabCount: number): string => {
-  const tabName = tab.name.trim();
-
-  if (tabCount === 1 && tabName.toLowerCase() === DEFAULT_UNTABBED_DOCUMENT_TAB_NAME) {
+  if (tabCount === 1) {
     return '';
   }
 

--- a/apps/google-docs/src/utils/utils.ts
+++ b/apps/google-docs/src/utils/utils.ts
@@ -1,4 +1,7 @@
+import type { NormalizedDocumentTabBlock } from '@types';
 import type { MappingReviewSuspendPayload, CompletedWorkflowPayload } from '../types/workflow';
+
+const DEFAULT_UNTABBED_DOCUMENT_TAB_NAME = 'tab 1';
 
 export const truncateLabel = (label: string, maxLength: number = 10): string => {
   if (label.length <= maxLength) return label;
@@ -14,4 +17,14 @@ export const isPreviewPayload = (
   payload: CompletedWorkflowPayload | MappingReviewSuspendPayload
 ): payload is CompletedWorkflowPayload => {
   return 'entries' in payload && 'referenceGraph' in payload;
+};
+
+export const getTabDisplayName = (tab: NormalizedDocumentTabBlock, tabCount: number): string => {
+  const tabName = tab.name.trim();
+
+  if (tabCount === 1 && tabName.toLowerCase() === DEFAULT_UNTABBED_DOCUMENT_TAB_NAME) {
+    return '';
+  }
+
+  return tab.name;
 };

--- a/apps/google-docs/test/locations/Page/components/review/mapping/MappingView.spec.tsx
+++ b/apps/google-docs/test/locations/Page/components/review/mapping/MappingView.spec.tsx
@@ -321,6 +321,52 @@ describe('MappingView', () => {
     ).toContain('Second body paragraph.');
   });
 
+  it('does not show the default single-tab label for documents without tabs', () => {
+    const payload = createPayload();
+    payload.normalizedDocument.contentBlocks = [
+      { id: 'tab-1', position: 0, type: 'tab', name: 'Tab 1' },
+      ...payload.normalizedDocument.contentBlocks,
+    ];
+
+    render(
+      <MappingView
+        payload={payload}
+        {...mappingViewGraphProps(payload)}
+        selectedEntryIndex={0}
+        mode="edit"
+      />
+    );
+
+    expect(screen.queryByText('Tab 1')).toBeNull();
+    expect(screen.getByText('Hello world')).toBeTruthy();
+  });
+
+  it('shows tab headings when the document contains multiple tabs', () => {
+    const blocks = [
+      createBlock('block-1', 1, 'First tab content'),
+      createBlock('block-2', 3, 'Second tab content'),
+    ];
+    const payload = createPayload({ blocks });
+    payload.normalizedDocument.contentBlocks = [
+      { id: 'tab-1', position: 0, type: 'tab', name: 'Tab 1' },
+      payload.normalizedDocument.contentBlocks[0],
+      { id: 'tab-2', position: 2, type: 'tab', name: 'Appendix' },
+      payload.normalizedDocument.contentBlocks[1],
+    ];
+
+    render(
+      <MappingView
+        payload={payload}
+        {...mappingViewGraphProps(payload)}
+        selectedEntryIndex={0}
+        mode="edit"
+      />
+    );
+
+    expect(screen.getByText('Tab 1')).toBeTruthy();
+    expect(screen.getByText('Appendix')).toBeTruthy();
+  });
+
   it('does not wrap a partially mapped single block in a grouped surface', () => {
     const block = createBlock('block-1', 1, 'Partially mapped paragraph.');
     const payload = createPayload({
@@ -735,11 +781,7 @@ describe('MappingView', () => {
 
     expect(textSegments[0].style.backgroundColor).not.toBe(initialBackgroundColor);
     expect(textSegments[1].style.backgroundColor).toBe(textSegments[0].style.backgroundColor);
-    expect(
-      container
-        .querySelector('[data-testid^="mapping-group-surface-"]')
-        ?.getAttribute('data-hovered')
-    ).toBe('true');
+    expect(mappingCard?.getAttribute('data-hovered')).toBe('true');
   });
 
   it('opens assign modal from grouped-run text selection and clears selection', () => {
@@ -972,6 +1014,19 @@ describe('MappingView', () => {
 
   it('scopes image assignment destinations to currently selected entry', () => {
     const payload = createImagePayload();
+    payload.entryBlockGraph.entries[1].contentTypeId = 'selectedArticle';
+    payload.contentTypes.push({
+      sys: { id: 'selectedArticle' },
+      name: 'Selected Article',
+      displayField: 'title',
+      fields: [
+        {
+          id: 'body',
+          name: 'Body copy',
+          type: 'Text',
+        },
+      ],
+    });
     const onEntryBlockGraphChange = vi.fn();
 
     render(
@@ -980,12 +1035,13 @@ describe('MappingView', () => {
         entryBlockGraph={payload.entryBlockGraph}
         onEntryBlockGraphChange={onEntryBlockGraphChange}
         selectedEntryIndex={1}
+        mode="edit"
       />
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Assign image' }));
 
     expect(screen.getByRole('heading', { name: 'Edit content mapping' })).toBeTruthy();
-    expect(screen.getAllByText('Untitled').length).toBeGreaterThan(0);
+    expect(screen.getByText('Selected Article: Untitled')).toBeTruthy();
   });
 });

--- a/apps/google-docs/test/locations/Page/components/review/mapping/MappingView.spec.tsx
+++ b/apps/google-docs/test/locations/Page/components/review/mapping/MappingView.spec.tsx
@@ -321,10 +321,10 @@ describe('MappingView', () => {
     ).toContain('Second body paragraph.');
   });
 
-  it('does not show the default single-tab label for documents without tabs', () => {
+  it('does not show the tab heading when the document only contains one tab', () => {
     const payload = createPayload();
     payload.normalizedDocument.contentBlocks = [
-      { id: 'tab-1', position: 0, type: 'tab', name: 'Tab 1' },
+      { id: 'tab-1', position: 0, type: 'tab', name: 'Draft' },
       ...payload.normalizedDocument.contentBlocks,
     ];
 
@@ -337,7 +337,7 @@ describe('MappingView', () => {
       />
     );
 
-    expect(screen.queryByText('Tab 1')).toBeNull();
+    expect(screen.queryByText('Draft')).toBeNull();
     expect(screen.getByText('Hello world')).toBeTruthy();
   });
 


### PR DESCRIPTION
## Purpose

Fix the Google Docs preview so documents with only one tab do not show a tab heading.

Context: 
- Google Docs creates a tab by default. We only want to show tab headings in the preview UI when the document contains multiple tabs. 
- This follows the backend contract, it doesn't show you the tabs modal if there aren't more than 1. So this new update is consistent with that decision.

## Approach

Hide the tab name whenever the normalized document contains a single tab, while preserving tab headings for multi-tab documents.

## Testing steps

Automated test added. And some failing test were found so this update also fix them.

Before ❌: (if the document had one tab)

> <img width="1503" height="443" alt="Captura de pantalla 2026-04-30 a la(s) 4 24 26 p  m" src="https://github.com/user-attachments/assets/70ac2f20-2398-408f-bc00-1a8cc6bba95f" />

Now 🟢: (if the document has just one tab we don't display the tab name)

> <img width="1480" height="565" alt="Captura de pantalla 2026-04-30 a la(s) 4 27 04 p  m" src="https://github.com/user-attachments/assets/6df58833-b671-417f-8b85-20d11e1c40c6" />


Disclaimer: different content types were chosen for each photo, so don't look at the mapping.


## Breaking Changes

No

## Dependencies and/or References

No

## Deployment

No