### PR TITLE
Refine GA4 advanced matching follow-up UX []

### DIFF
--- a/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage/GoogleAnalyticsConfigPage.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/GoogleAnalyticsConfigPage/GoogleAnalyticsConfigPage.tsx
@@ -37,6 +37,7 @@ export default function GoogleAnalyticsConfigPage() {
   const [hasServiceCheckErrors, setHasServiceCheckErrors] = useState<boolean>(true);
   const [validKeyFile, setValidKeyFile] = useState<ServiceAccountKey | undefined>();
   const [isSavingConfiguration, setIsSavingConfiguration] = useState<boolean>(false);
+  const [showContentTypeValidation, setShowContentTypeValidation] = useState<boolean>(false);
   const [isApiAccessLoading, setIsApiAccessLoading] = useState(true);
 
   const sdk = useSDK<AppExtensionSDK>();
@@ -106,6 +107,7 @@ export default function GoogleAnalyticsConfigPage() {
 
   const handleConfigure = useCallback(async () => {
     setIsSavingConfiguration(true);
+    setShowContentTypeValidation(true);
 
     // if no serviceAccountKeyId (most likely when user is saving on first install without providing a key)
     if (isEmpty(parameters.serviceAccountKeyId)) {
@@ -293,6 +295,7 @@ export default function GoogleAnalyticsConfigPage() {
                 originalParameters.contentTypeRules,
                 originalParameters.contentTypes
               )}
+              showPatternValidation={showContentTypeValidation}
             />
           </>
         )}

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentType.styles.ts
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentType.styles.ts
@@ -63,6 +63,11 @@ export const styles = {
     padding: '12px',
     width: '100%',
   }),
+  hiddenColumnSpacer: css({
+    minHeight: '40px',
+    visibility: 'hidden',
+    width: '100%',
+  }),
   rowSpacing: css({
     marginBottom: '16px',
     width: '100%',

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeCard.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeCard.spec.tsx
@@ -43,6 +43,9 @@ describe('Assign Content Type Card for Config Screen', () => {
         currentEditorInterface={{}}
         originalContentTypeRules={[]}
         rulesMissingPattern={new Set()}
+        rulesWithUnknownPatternTokens={new Map()}
+        duplicateRuleIds={new Set()}
+        showPatternValidation={false}
       />
     );
 
@@ -65,9 +68,34 @@ describe('Assign Content Type Card for Config Screen', () => {
         currentEditorInterface={{}}
         originalContentTypeRules={[]}
         rulesMissingPattern={new Set()}
+        rulesWithUnknownPatternTokens={new Map()}
+        duplicateRuleIds={new Set()}
+        showPatternValidation={false}
       />
     );
 
     expect(screen.getAllByTestId('contentTypeRow').length).toBe(1);
+  });
+
+  it('explains that the selected slug field provides the value for {slug}', async () => {
+    render(
+      <AssignContentTypeCard
+        allContentTypes={allContentTypes}
+        allContentTypeEntries={allContentTypeEntries}
+        contentTypeRules={contentTypeRules}
+        onContentTypeChange={() => {}}
+        onContentTypeFieldChange={() => {}}
+        onContentTypeRuleChange={() => {}}
+        onRemoveContentType={() => {}}
+        currentEditorInterface={{}}
+        originalContentTypeRules={[]}
+        rulesMissingPattern={new Set()}
+        rulesWithUnknownPatternTokens={new Map()}
+        duplicateRuleIds={new Set()}
+        showPatternValidation={false}
+      />
+    );
+
+    expect(screen.getByText('Slug field')).toBeVisible();
   });
 });

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeCard.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeCard.spec.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { AllContentTypes, AllContentTypeEntries, ContentTypeRules } from '../../../types';
 import AssignContentTypeCard from 'components/config-screen/assign-content-type/AssignContentTypeCard';
 
@@ -44,6 +45,7 @@ describe('Assign Content Type Card for Config Screen', () => {
         originalContentTypeRules={[]}
         rulesMissingPattern={new Set()}
         rulesWithUnknownPatternTokens={new Map()}
+        rulesWithMissingSelectedPatternTokens={new Map()}
         duplicateRuleIds={new Set()}
         showPatternValidation={false}
       />
@@ -52,6 +54,7 @@ describe('Assign Content Type Card for Config Screen', () => {
     expect(screen.getByText('Content type')).toBeVisible();
     expect(screen.getByText('Slug field')).toBeVisible();
     expect(screen.getByText('URL prefix')).toBeVisible();
+    expect(screen.getAllByText('Advanced')[0]).toBeVisible();
     expect(screen.queryByText('Path pattern')).not.toBeInTheDocument();
   });
 
@@ -69,6 +72,7 @@ describe('Assign Content Type Card for Config Screen', () => {
         originalContentTypeRules={[]}
         rulesMissingPattern={new Set()}
         rulesWithUnknownPatternTokens={new Map()}
+        rulesWithMissingSelectedPatternTokens={new Map()}
         duplicateRuleIds={new Set()}
         showPatternValidation={false}
       />
@@ -77,7 +81,8 @@ describe('Assign Content Type Card for Config Screen', () => {
     expect(screen.getAllByTestId('contentTypeRow').length).toBe(1);
   });
 
-  it('explains that the selected slug field provides the value for {slug}', async () => {
+  it('uses updated tooltip copy for slug field and advanced matching', async () => {
+    const user = userEvent.setup();
     render(
       <AssignContentTypeCard
         allContentTypes={allContentTypes}
@@ -91,11 +96,32 @@ describe('Assign Content Type Card for Config Screen', () => {
         originalContentTypeRules={[]}
         rulesMissingPattern={new Set()}
         rulesWithUnknownPatternTokens={new Map()}
+        rulesWithMissingSelectedPatternTokens={new Map()}
         duplicateRuleIds={new Set()}
         showPatternValidation={false}
       />
     );
 
-    expect(screen.getByText('Slug field')).toBeVisible();
+    const slugTooltipTrigger = screen
+      .getByText('Slug field')
+      .closest('label')
+      ?.querySelector('[aria-describedby]') as HTMLElement;
+    await user.hover(slugTooltipTrigger);
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(
+      'For standard paths, choose the short text field where the entry stores its page path. Use advanced matching to build a custom page path.'
+    );
+
+    await user.unhover(slugTooltipTrigger);
+
+    const advancedTooltipTrigger = screen
+      .getAllByText('Advanced')[0]
+      .closest('label')
+      ?.querySelector('[aria-describedby]') as HTMLElement;
+    await user.hover(advancedTooltipTrigger);
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(
+      'Enable advanced matching to build a custom path pattern from entry fields, locale, and/or wildcards.'
+    );
   });
 });

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeCard.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeCard.tsx
@@ -21,6 +21,7 @@ interface AssignContentTypeCardProps {
   originalContentTypeRules: ContentTypeRules;
   rulesMissingPattern: Set<string>;
   rulesWithUnknownPatternTokens: Map<string, string[]>;
+  rulesWithMissingSelectedPatternTokens: Map<string, string[]>;
   duplicateRuleIds: Set<string>;
   showPatternValidation: boolean;
 }
@@ -69,6 +70,7 @@ const AssignContentTypeCard = (props: AssignContentTypeCardProps) => {
     originalContentTypeRules,
     rulesMissingPattern,
     rulesWithUnknownPatternTokens,
+    rulesWithMissingSelectedPatternTokens,
     duplicateRuleIds,
     showPatternValidation,
   } = props;
@@ -82,7 +84,7 @@ const AssignContentTypeCard = (props: AssignContentTypeCardProps) => {
         />
         <HeaderLabel
           label="Slug field"
-          helpText='This field provides the value used by {slug} in advanced patterns. For example, if you choose Title here, {slug} will use the Title field value. If you select a short text list field, the elements in the array will be joined by a forward slash.'
+          helpText='For standard paths, choose the short text field where the entry stores its page path. Use advanced matching to build a custom page path.'
         />
         <HeaderLabel
           label="URL prefix"
@@ -91,7 +93,7 @@ const AssignContentTypeCard = (props: AssignContentTypeCardProps) => {
         <HeaderLabel
           label="Advanced"
           className={styles.toggleItem}
-          helpText="Use advanced matching when you want to build the URL pattern from entry fields, query strings, or custom path structures."
+          helpText="Enable advanced matching to build a custom path pattern from entry fields, locale, and/or wildcards."
         />
         <Box className={styles.removeItem}></Box>
       </Flex>
@@ -116,6 +118,11 @@ const AssignContentTypeCard = (props: AssignContentTypeCardProps) => {
             unknownPatternTokens={
               showPatternValidation
                 ? (rulesWithUnknownPatternTokens.get(contentTypeRule.id) ?? [])
+                : []
+            }
+            missingSelectedPatternTokens={
+              showPatternValidation
+                ? (rulesWithMissingSelectedPatternTokens.get(contentTypeRule.id) ?? [])
                 : []
             }
             isDuplicateConfiguration={

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeCard.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeCard.tsx
@@ -91,7 +91,7 @@ const AssignContentTypeCard = (props: AssignContentTypeCardProps) => {
         <HeaderLabel
           label="Advanced"
           className={styles.toggleItem}
-          helpText="Use advanced matching when the URL needs more than a fixed prefix plus the selected slug field, like query strings or custom path patterns."
+          helpText="Use advanced matching when you want to build the URL pattern from entry fields, query strings, or custom path structures."
         />
         <Box className={styles.removeItem}></Box>
       </Flex>

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeCard.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeCard.tsx
@@ -20,6 +20,9 @@ interface AssignContentTypeCardProps {
   currentEditorInterface: Partial<EditorInterface>;
   originalContentTypeRules: ContentTypeRules;
   rulesMissingPattern: Set<string>;
+  rulesWithUnknownPatternTokens: Map<string, string[]>;
+  duplicateRuleIds: Set<string>;
+  showPatternValidation: boolean;
 }
 
 interface HeaderLabelProps {
@@ -65,6 +68,9 @@ const AssignContentTypeCard = (props: AssignContentTypeCardProps) => {
     currentEditorInterface,
     originalContentTypeRules,
     rulesMissingPattern,
+    rulesWithUnknownPatternTokens,
+    duplicateRuleIds,
+    showPatternValidation,
   } = props;
 
   return (
@@ -76,7 +82,7 @@ const AssignContentTypeCard = (props: AssignContentTypeCardProps) => {
         />
         <HeaderLabel
           label="Slug field"
-          helpText='The field on your content type where the page path is stored. If you select a short text list field, the elements in the array will be joined by a forward slash. Example: This field would typically have short slug text like "a-blog-post-i-wrote" that appears in the URL for the page.'
+          helpText='This field provides the value used by {slug} in advanced patterns. For example, if you choose Title here, {slug} will use the Title field value. If you select a short text list field, the elements in the array will be joined by a forward slash.'
         />
         <HeaderLabel
           label="URL prefix"
@@ -104,7 +110,17 @@ const AssignContentTypeCard = (props: AssignContentTypeCardProps) => {
             onRemoveContentType={onRemoveContentType}
             currentEditorInterface={currentEditorInterface}
             originalContentTypeRules={originalContentTypeRules}
-            isMissingPattern={rulesMissingPattern.has(contentTypeRule.id)}
+            isMissingPattern={
+              showPatternValidation && rulesMissingPattern.has(contentTypeRule.id)
+            }
+            unknownPatternTokens={
+              showPatternValidation
+                ? (rulesWithUnknownPatternTokens.get(contentTypeRule.id) ?? [])
+                : []
+            }
+            isDuplicateConfiguration={
+              showPatternValidation && duplicateRuleIds.has(contentTypeRule.id)
+            }
             focus={index + 1 === contentTypeRules.length}
           />
         );

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeRow.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeRow.spec.tsx
@@ -242,7 +242,7 @@ describe('Assign Content Type Card for Config Screen', () => {
       />
     );
 
-    expect(screen.getByText('Add an entry fields used to build URL pattern')).toBeVisible();
+    expect(screen.getByText('Add an entry fields used to build the URL pattern')).toBeVisible();
     expect(
       screen.getByText(/Select the entry fields you want to use in the pattern\./)
     ).toBeVisible();

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeRow.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeRow.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { AllContentTypes, AllContentTypeEntries, ContentTypeRule, ContentTypeRules } from 'types';
 import AssignContentTypeRow from 'components/config-screen/assign-content-type/AssignContentTypeRow';
@@ -181,6 +181,7 @@ describe('Assign Content Type Card for Config Screen', () => {
     expect(screen.getByTestId('advancedMatchingPanel')).toBeVisible();
     expect(screen.getByTestId('pathPatternInput')).toHaveValue('/blog/{slug}');
     expect(screen.queryByTestId('urlPrefixInput')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('slugFieldSelect')).not.toBeInTheDocument();
   });
 
   it('preserves advanced-only fields when advanced matching is turned off', async () => {
@@ -241,14 +242,34 @@ describe('Assign Content Type Card for Config Screen', () => {
       />
     );
 
+    expect(screen.getByText('Entry fields used to build URL pattern')).toBeVisible();
     expect(
-      screen.getByText(/Use the variable shown next to each field in the pattern\./)
+      screen.getByText(/Select the entry fields you want to use in the pattern\./)
     ).toBeVisible();
-    expect(screen.getByText('{sectionSlug}')).toBeVisible();
-    expect(screen.getByRole('option', { name: 'Regex match' })).toBeInTheDocument();
+    expect(screen.getByText(/sectionSlug/)).toBeVisible();
+    expect(screen.getByText(/shop\/products/)).toBeVisible();
   });
 
-  it('shows a suggested pattern as placeholder instead of a saved value', () => {
+  it('lists all content type fields as advanced pattern variables', () => {
+    render(
+      <AssignContentTypeRow
+        contentTypeRule={{
+          ...contentTypeRules[1],
+          contentTypeId: 'category',
+          slugField: 'title',
+          enableAdvancedMatching: true,
+          additionalFieldIds: [],
+          pathPattern: '/{slug}',
+        }}
+        {...props}
+      />
+    );
+
+    expect(screen.getByText(/title/)).toBeVisible();
+    expect(screen.getByText(/sectionSlug/)).toBeVisible();
+  });
+
+  it('does not show configured below headers in advanced mode', () => {
     render(
       <AssignContentTypeRow
         contentTypeRule={{
@@ -261,8 +282,7 @@ describe('Assign Content Type Card for Config Screen', () => {
       />
     );
 
-    expect(screen.getByTestId('pathPatternInput')).toHaveValue('');
-    expect(screen.getByTestId('pathPatternInput')).toHaveAttribute('placeholder', '/about/{slug}');
+    expect(screen.queryByText('Configured below')).not.toBeInTheDocument();
   });
 
   it('shows a duplicate configuration error when the same rule is repeated', () => {
@@ -319,13 +339,12 @@ describe('Assign Content Type Card for Config Screen', () => {
     expect(screen.getByTestId('pathPatternInput')).toHaveAttribute('aria-invalid', 'true');
     expect(
       screen.getByText(
-        'Pattern contains an unknown variable: {sectoinSlug}. Use {slug} and the variables shown in Additional page properties.'
+        'Pattern contains an unknown variable: {sectoinSlug}. Use the variables shown in Entry fields used to build URL pattern.'
       )
     ).toBeVisible();
   });
 
   it('calls field change handler when path pattern input is changed', async () => {
-    const user = userEvent.setup();
     render(
       <AssignContentTypeRow
         contentTypeRule={{
@@ -338,9 +357,14 @@ describe('Assign Content Type Card for Config Screen', () => {
       />
     );
 
-    await user.type(screen.getByTestId('pathPatternInput'), '/blog/{slug}');
+    fireEvent.change(screen.getByTestId('pathPatternInput'), {
+      target: { value: '/blog/{slug}' },
+    });
 
-    expect(onContentTypeFieldChange).toHaveBeenCalled();
+    expect(onContentTypeRuleChange).toHaveBeenLastCalledWith('rule-course', {
+      pathPattern: '/blog/{slug}',
+      matchType: 'EXACT',
+    });
   });
 
   it('calls field change handler when match dimension selection is changed', async () => {
@@ -361,14 +385,14 @@ describe('Assign Content Type Card for Config Screen', () => {
       'pagePathPlusQueryString',
     ]);
 
-    expect(onContentTypeFieldChange).toHaveBeenCalledWith(
-      'rule-course',
-      'matchDimension',
-      'pagePathPlusQueryString'
-    );
+    expect(onContentTypeRuleChange).toHaveBeenCalledWith('rule-course', {
+      matchDimension: 'pagePathPlusQueryString',
+      pathPattern: '/article?articleId={slug}',
+      matchType: 'EXACT',
+    });
   });
 
-  it('updates the match dimension without overwriting the pattern', async () => {
+  it('updates the match dimension without overwriting a custom pattern', async () => {
     const user = userEvent.setup();
     render(
       <AssignContentTypeRow
@@ -410,14 +434,14 @@ describe('Assign Content Type Card for Config Screen', () => {
       'pagePathPlusQueryString',
     ]);
 
-    expect(onContentTypeFieldChange).toHaveBeenCalledWith(
-      'rule-course',
-      'matchDimension',
-      'pagePathPlusQueryString'
-    );
+    expect(onContentTypeRuleChange).toHaveBeenCalledWith('rule-course', {
+      matchDimension: 'pagePathPlusQueryString',
+      pathPattern: '/article/{articleId}/{slug}',
+      matchType: 'EXACT',
+    });
   });
 
-  it('updates selected query-string fields without overwriting the pattern', async () => {
+  it('updates selected query-string fields and regenerates the pattern when it is still automatic', async () => {
     const user = userEvent.setup();
     render(
       <AssignContentTypeRow
@@ -427,7 +451,7 @@ describe('Assign Content Type Card for Config Screen', () => {
           slugField: 'title',
           urlPrefix: '/search',
           enableAdvancedMatching: true,
-          pathPattern: '/search/{slug}',
+          pathPattern: '/',
           matchDimension: 'pagePathPlusQueryString',
           additionalFieldIds: [],
         }}
@@ -437,12 +461,14 @@ describe('Assign Content Type Card for Config Screen', () => {
 
     await user.click(screen.getByTestId('additionalFieldOption-sectionSlug'));
 
-    expect(onContentTypeFieldChange).toHaveBeenCalledWith('rule-category', 'additionalFieldIds', [
-      'sectionSlug',
-    ]);
+    expect(onContentTypeRuleChange).toHaveBeenCalledWith('rule-category', {
+      additionalFieldIds: ['sectionSlug'],
+      pathPattern: '/?sectionSlug={sectionSlug}',
+      matchType: 'EXACT',
+    });
   });
 
-  it('updates selected page-path fields without overwriting the pattern', async () => {
+  it('updates selected page-path fields and regenerates the pattern when it is still automatic', async () => {
     const user = userEvent.setup();
     render(
       <AssignContentTypeRow
@@ -452,7 +478,7 @@ describe('Assign Content Type Card for Config Screen', () => {
           slugField: 'title',
           urlPrefix: '',
           enableAdvancedMatching: true,
-          pathPattern: '/{slug}',
+          pathPattern: '/',
           matchDimension: 'unifiedPagePathScreen',
           additionalFieldIds: [],
         }}
@@ -462,9 +488,11 @@ describe('Assign Content Type Card for Config Screen', () => {
 
     await user.click(screen.getByTestId('additionalFieldOption-sectionSlug'));
 
-    expect(onContentTypeFieldChange).toHaveBeenCalledWith('rule-category', 'additionalFieldIds', [
-      'sectionSlug',
-    ]);
+    expect(onContentTypeRuleChange).toHaveBeenCalledWith('rule-category', {
+      additionalFieldIds: ['sectionSlug'],
+      pathPattern: '/{sectionSlug}',
+      matchType: 'EXACT',
+    });
   });
 
   it('does not overwrite a custom pattern when selected query-string fields change', async () => {
@@ -487,12 +515,14 @@ describe('Assign Content Type Card for Config Screen', () => {
 
     await user.click(screen.getByTestId('additionalFieldOption-sectionSlug'));
 
-    expect(onContentTypeFieldChange).toHaveBeenCalledWith('rule-category', 'additionalFieldIds', [
-      'sectionSlug',
-    ]);
+    expect(onContentTypeRuleChange).toHaveBeenCalledWith('rule-category', {
+      additionalFieldIds: ['sectionSlug'],
+      pathPattern: '/search?category={slug}',
+      matchType: 'EXACT',
+    });
   });
 
-  it('calls field change handler when matching mode selection is changed', async () => {
+  it('infers regex matching when the pattern includes wildcard syntax', async () => {
     const user = userEvent.setup();
     render(
       <AssignContentTypeRow
@@ -508,8 +538,13 @@ describe('Assign Content Type Card for Config Screen', () => {
       />
     );
 
-    await user.selectOptions(screen.getByTestId('matchTypeSelect'), ['PARTIAL_REGEXP']);
+    fireEvent.change(screen.getByTestId('pathPatternInput'), {
+      target: { value: '/article.*/{slug}' },
+    });
 
-    expect(onContentTypeFieldChange).toHaveBeenCalled();
+    expect(onContentTypeRuleChange).toHaveBeenLastCalledWith('rule-course', {
+      pathPattern: '/article.*/{slug}',
+      matchType: 'PARTIAL_REGEXP',
+    });
   });
 });

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeRow.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeRow.spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { AllContentTypes, AllContentTypeEntries, ContentTypeRule, ContentTypeRules } from 'types';
 import AssignContentTypeRow from 'components/config-screen/assign-content-type/AssignContentTypeRow';
@@ -14,6 +14,7 @@ const allContentTypes: AllContentTypes = {
     fields: [
       { id: 'title', name: 'Title', type: 'Symbol' },
       { id: 'sectionSlug', name: 'Section slug', type: 'Symbol' },
+      { id: 'articleId', name: 'Article ID', type: 'Integer' },
     ],
   },
 };
@@ -55,6 +56,7 @@ const props = {
   contentTypeRules,
   isMissingPattern: false,
   unknownPatternTokens: [],
+  missingSelectedPatternTokens: [],
   isDuplicateConfiguration: false,
   onContentTypeChange,
   onContentTypeFieldChange,
@@ -123,6 +125,25 @@ describe('Assign Content Type Card for Config Screen', () => {
     await user.selectOptions(screen.getByTestId('contentTypeSelect'), ['course']);
 
     expect(onContentTypeChange).toHaveBeenCalled();
+  });
+
+  it('does not show integer fields in the standard slug field dropdown', () => {
+    render(
+      <AssignContentTypeRow
+        contentTypeRule={{
+          ...contentTypeRules[1],
+          contentTypeId: 'category',
+          slugField: 'title',
+          enableAdvancedMatching: false,
+        }}
+        {...props}
+      />
+    );
+
+    const slugFieldSelect = screen.getByTestId('slugFieldSelect');
+
+    expect(within(slugFieldSelect).getByRole('option', { name: 'Title' })).toBeVisible();
+    expect(within(slugFieldSelect).queryByRole('option', { name: 'Article ID' })).toBeNull();
   });
 
   it('calls field change handler when slug field selection is changed', async () => {
@@ -242,12 +263,69 @@ describe('Assign Content Type Card for Config Screen', () => {
       />
     );
 
-    expect(screen.getByText('Add an entry fields used to build the URL pattern')).toBeVisible();
     expect(
-      screen.getByText(/Select the entry fields you want to use in the pattern\./)
+      screen.getByText(
+        'Build a custom path pattern for the analytics shown while editing an entry of the chosen content type. Use short text and integer fields to insert entry values into the path.'
+      )
     ).toBeVisible();
+    expect(screen.getByText('Select entry fields to insert into your path pattern')).toBeVisible();
     expect(screen.getByText(/sectionSlug/)).toBeVisible();
-    expect(screen.getByText(/Use \.\* when part of the URL can vary\./)).toBeVisible();
+    expect(screen.getByText('Locale')).toBeVisible();
+    expect(screen.getByText('Insert locale into Pattern')).toBeVisible();
+    expect(screen.getByText(/Use \* when part of the URL can vary\./)).toBeVisible();
+    expect(screen.getByText(/\/shop\/products\/\{product_id\}/)).toBeVisible();
+  });
+
+
+  it('adds the locale token to a custom pattern', async () => {
+    const user = userEvent.setup();
+    render(
+      <AssignContentTypeRow
+        contentTypeRule={{
+          ...contentTypeRules[1],
+          contentTypeId: 'category',
+          slugField: 'title',
+          enableAdvancedMatching: true,
+          pathPattern: '/products/{slug}',
+        }}
+        {...props}
+      />
+    );
+
+    await user.click(screen.getByTestId('localePatternOption'));
+
+    expect(onContentTypeRuleChange).toHaveBeenCalledWith('rule-category', {
+      pathPattern: '/{locale}/products/{slug}',
+      matchType: 'EXACT',
+    });
+  });
+
+  it('allows integer fields as advanced pattern variables', async () => {
+    const user = userEvent.setup();
+    render(
+      <AssignContentTypeRow
+        contentTypeRule={{
+          ...contentTypeRules[1],
+          contentTypeId: 'category',
+          slugField: 'title',
+          enableAdvancedMatching: true,
+          additionalFieldIds: [],
+          pathPattern: '/article',
+          matchDimension: 'pagePathPlusQueryString',
+        }}
+        {...props}
+      />
+    );
+
+    expect(screen.getByText(/articleId/)).toBeVisible();
+
+    await user.click(screen.getByTestId('additionalFieldOption-articleId'));
+
+    expect(onContentTypeRuleChange).toHaveBeenCalledWith('rule-category', {
+      additionalFieldIds: ['articleId'],
+      pathPattern: '/article?articleId={articleId}',
+      matchType: 'EXACT',
+    });
   });
 
   it('lists all content type fields as advanced pattern variables', () => {
@@ -339,7 +417,30 @@ describe('Assign Content Type Card for Config Screen', () => {
     expect(screen.getByTestId('pathPatternInput')).toHaveAttribute('aria-invalid', 'true');
     expect(
       screen.getByText(
-        'Pattern contains an unknown variable: {sectoinSlug}. Use the variables shown in Entry fields used to build URL pattern.'
+        'Pattern contains an unknown variable: {sectoinSlug}. Use the variables shown on the left.'
+      )
+    ).toBeVisible();
+  });
+
+  it('shows selected field validation inside the advanced panel', () => {
+    render(
+      <AssignContentTypeRow
+        contentTypeRule={{
+          ...contentTypeRules[1],
+          contentTypeId: 'category',
+          enableAdvancedMatching: true,
+          additionalFieldIds: ['sectionSlug'],
+          pathPattern: '/products/{slug}',
+        }}
+        {...props}
+        missingSelectedPatternTokens={['sectionSlug']}
+      />
+    );
+
+    expect(screen.getByTestId('pathPatternInput')).toHaveAttribute('aria-invalid', 'true');
+    expect(
+      screen.getByText(
+        'Pattern is missing a substitution tag for the selected entry field: {sectionSlug}. Add the tag to Pattern or uncheck that field.'
       )
     ).toBeVisible();
   });
@@ -557,7 +658,7 @@ describe('Assign Content Type Card for Config Screen', () => {
           ...contentTypeRules[0],
           urlPrefix: '',
           enableAdvancedMatching: true,
-          pathPattern: '/article.*{slug}',
+          pathPattern: '/article*{slug}',
           matchDimension: 'pagePathPlusQueryString',
           matchType: 'EXACT',
         }}
@@ -566,11 +667,11 @@ describe('Assign Content Type Card for Config Screen', () => {
     );
 
     fireEvent.change(screen.getByTestId('pathPatternInput'), {
-      target: { value: '/article.*/{slug}' },
+      target: { value: '/article*/{slug}' },
     });
 
     expect(onContentTypeRuleChange).toHaveBeenLastCalledWith('rule-course', {
-      pathPattern: '/article.*/{slug}',
+      pathPattern: '/article*/{slug}',
       matchType: 'PARTIAL_REGEXP',
     });
   });

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeRow.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeRow.spec.tsx
@@ -54,6 +54,8 @@ const props = {
   allContentTypeEntries,
   contentTypeRules,
   isMissingPattern: false,
+  unknownPatternTokens: [],
+  isDuplicateConfiguration: false,
   onContentTypeChange,
   onContentTypeFieldChange,
   onContentTypeRuleChange,
@@ -160,7 +162,6 @@ describe('Assign Content Type Card for Config Screen', () => {
     expect(screen.getByTestId('advancedMatchingPanel')).toBeVisible();
     expect(onContentTypeRuleChange).toHaveBeenCalledWith('rule-course', {
       enableAdvancedMatching: true,
-      pathPattern: '/about/{slug}',
     });
   });
 
@@ -182,7 +183,7 @@ describe('Assign Content Type Card for Config Screen', () => {
     expect(screen.queryByTestId('urlPrefixInput')).not.toBeInTheDocument();
   });
 
-  it('clears advanced-only fields when advanced matching is turned off', async () => {
+  it('preserves advanced-only fields when advanced matching is turned off', async () => {
     const user = userEvent.setup();
     render(
       <AssignContentTypeRow
@@ -204,10 +205,6 @@ describe('Assign Content Type Card for Config Screen', () => {
     expect(screen.queryByTestId('advancedMatchingPanel')).not.toBeInTheDocument();
     expect(onContentTypeRuleChange).toHaveBeenCalledWith('rule-course', {
       enableAdvancedMatching: false,
-      additionalFieldIds: [],
-      pathPattern: '',
-      matchDimension: 'unifiedPagePathScreen',
-      matchType: 'EXACT',
     });
   });
 
@@ -245,15 +242,43 @@ describe('Assign Content Type Card for Config Screen', () => {
     );
 
     expect(
-      screen.getByText(
-        /A pattern is generated for you automatically\. Edit it if you need a different URL structure/
-      )
-    ).toBeVisible();
-    expect(
-      screen.getByText(/Use the placeholder shown next to each field in the pattern\./)
+      screen.getByText(/Use the variable shown next to each field in the pattern\./)
     ).toBeVisible();
     expect(screen.getByText('{sectionSlug}')).toBeVisible();
-    expect(screen.getByRole('option', { name: 'Flexible match' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Regex match' })).toBeInTheDocument();
+  });
+
+  it('shows a suggested pattern as placeholder instead of a saved value', () => {
+    render(
+      <AssignContentTypeRow
+        contentTypeRule={{
+          ...contentTypeRules[0],
+          urlPrefix: '/about',
+          enableAdvancedMatching: true,
+          pathPattern: '',
+        }}
+        {...props}
+      />
+    );
+
+    expect(screen.getByTestId('pathPatternInput')).toHaveValue('');
+    expect(screen.getByTestId('pathPatternInput')).toHaveAttribute('placeholder', '/about/{slug}');
+  });
+
+  it('shows a duplicate configuration error when the same rule is repeated', () => {
+    render(
+      <AssignContentTypeRow
+        contentTypeRule={contentTypeRules[0]}
+        {...props}
+        isDuplicateConfiguration={true}
+      />
+    );
+
+    expect(
+      screen.getByText(
+        'This rule duplicates another configuration. Remove one of them or change one of the values before saving.'
+      )
+    ).toBeVisible();
   });
 
   it('shows missing pattern validation inside the advanced panel', () => {
@@ -269,10 +294,34 @@ describe('Assign Content Type Card for Config Screen', () => {
       />
     );
 
-    expect(screen.getByText('Add a pattern for this advanced rule before saving.')).toBeVisible();
-    expect(screen.getByTestId('advancedMatchingPanel')).toContainElement(
-      screen.getByText('Add a pattern for this advanced rule before saving.')
+    expect(screen.getByTestId('pathPatternInput')).toHaveAttribute('aria-invalid', 'true');
+    expect(
+      screen.getByText('Pattern is required. Enter a value for the Pattern field before saving.')
     );
+    expect(screen.getByTestId('advancedMatchingPanel')).toContainElement(
+      screen.getByText('Pattern is required. Enter a value for the Pattern field before saving.')
+    );
+  });
+
+  it('shows unknown variable validation inside the advanced panel', () => {
+    render(
+      <AssignContentTypeRow
+        contentTypeRule={{
+          ...contentTypeRules[0],
+          enableAdvancedMatching: true,
+          pathPattern: '/{sectoinSlug}/{slug}',
+        }}
+        {...props}
+        unknownPatternTokens={['sectoinSlug']}
+      />
+    );
+
+    expect(screen.getByTestId('pathPatternInput')).toHaveAttribute('aria-invalid', 'true');
+    expect(
+      screen.getByText(
+        'Pattern contains an unknown variable: {sectoinSlug}. Use {slug} and the variables shown in Additional page properties.'
+      )
+    ).toBeVisible();
   });
 
   it('calls field change handler when path pattern input is changed', async () => {
@@ -319,7 +368,7 @@ describe('Assign Content Type Card for Config Screen', () => {
     );
   });
 
-  it('updates the generated pattern when match dimension changes before customization', async () => {
+  it('updates the match dimension without overwriting the pattern', async () => {
     const user = userEvent.setup();
     render(
       <AssignContentTypeRow
@@ -361,13 +410,14 @@ describe('Assign Content Type Card for Config Screen', () => {
       'pagePathPlusQueryString',
     ]);
 
-    expect(onContentTypeRuleChange).toHaveBeenCalledWith('rule-course', {
-      matchDimension: 'pagePathPlusQueryString',
-      pathPattern: '/article/{slug}?articleId={articleId}',
-    });
+    expect(onContentTypeFieldChange).toHaveBeenCalledWith(
+      'rule-course',
+      'matchDimension',
+      'pagePathPlusQueryString'
+    );
   });
 
-  it('updates the generated pattern when selected query-string fields change', async () => {
+  it('updates selected query-string fields without overwriting the pattern', async () => {
     const user = userEvent.setup();
     render(
       <AssignContentTypeRow
@@ -387,13 +437,12 @@ describe('Assign Content Type Card for Config Screen', () => {
 
     await user.click(screen.getByTestId('additionalFieldOption-sectionSlug'));
 
-    expect(onContentTypeRuleChange).toHaveBeenCalledWith('rule-category', {
-      additionalFieldIds: ['sectionSlug'],
-      pathPattern: '/search/{slug}?sectionSlug={sectionSlug}',
-    });
+    expect(onContentTypeFieldChange).toHaveBeenCalledWith('rule-category', 'additionalFieldIds', [
+      'sectionSlug',
+    ]);
   });
 
-  it('updates the generated pattern when selected page-path fields change', async () => {
+  it('updates selected page-path fields without overwriting the pattern', async () => {
     const user = userEvent.setup();
     render(
       <AssignContentTypeRow
@@ -413,10 +462,9 @@ describe('Assign Content Type Card for Config Screen', () => {
 
     await user.click(screen.getByTestId('additionalFieldOption-sectionSlug'));
 
-    expect(onContentTypeRuleChange).toHaveBeenCalledWith('rule-category', {
-      additionalFieldIds: ['sectionSlug'],
-      pathPattern: '/{sectionSlug}/{slug}',
-    });
+    expect(onContentTypeFieldChange).toHaveBeenCalledWith('rule-category', 'additionalFieldIds', [
+      'sectionSlug',
+    ]);
   });
 
   it('does not overwrite a custom pattern when selected query-string fields change', async () => {

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeRow.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeRow.spec.tsx
@@ -242,12 +242,12 @@ describe('Assign Content Type Card for Config Screen', () => {
       />
     );
 
-    expect(screen.getByText('Entry fields used to build URL pattern')).toBeVisible();
+    expect(screen.getByText('Add an entry fields used to build URL pattern')).toBeVisible();
     expect(
       screen.getByText(/Select the entry fields you want to use in the pattern\./)
     ).toBeVisible();
     expect(screen.getByText(/sectionSlug/)).toBeVisible();
-    expect(screen.getByText(/shop\/products/)).toBeVisible();
+    expect(screen.getByText(/Use \.\* when part of the URL can vary\./)).toBeVisible();
   });
 
   it('lists all content type fields as advanced pattern variables', () => {
@@ -495,6 +495,33 @@ describe('Assign Content Type Card for Config Screen', () => {
     });
   });
 
+  it('appends a newly selected field variable to the end of the existing pattern', async () => {
+    const user = userEvent.setup();
+    render(
+      <AssignContentTypeRow
+        contentTypeRule={{
+          ...contentTypeRules[1],
+          contentTypeId: 'category',
+          slugField: 'title',
+          urlPrefix: '',
+          enableAdvancedMatching: true,
+          pathPattern: '/news/{title}',
+          matchDimension: 'unifiedPagePathScreen',
+          additionalFieldIds: ['title'],
+        }}
+        {...props}
+      />
+    );
+
+    await user.click(screen.getByTestId('additionalFieldOption-sectionSlug'));
+
+    expect(onContentTypeRuleChange).toHaveBeenCalledWith('rule-category', {
+      additionalFieldIds: ['title', 'sectionSlug'],
+      pathPattern: '/news/{title}/{sectionSlug}',
+      matchType: 'EXACT',
+    });
+  });
+
   it('does not overwrite a custom pattern when selected query-string fields change', async () => {
     const user = userEvent.setup();
     render(
@@ -517,7 +544,7 @@ describe('Assign Content Type Card for Config Screen', () => {
 
     expect(onContentTypeRuleChange).toHaveBeenCalledWith('rule-category', {
       additionalFieldIds: ['sectionSlug'],
-      pathPattern: '/search?category={slug}',
+      pathPattern: '/search?category={slug}&sectionSlug={sectionSlug}',
       matchType: 'EXACT',
     });
   });

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeRow.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeRow.tsx
@@ -336,7 +336,7 @@ const AssignContentTypeRow = (props: Props) => {
               <Box className={styles.stackedField}>
                 <FormControl marginBottom="none">
                   <FormControl.Label>
-                    Add an entry fields used to build URL pattern
+                    Add an entry fields used to build the URL pattern
                   </FormControl.Label>
                   <Stack spacing="spacing2Xs" flexDirection="column" alignItems="flex-start">
                     {contentTypeFields.length ? (

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeRow.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeRow.tsx
@@ -23,6 +23,7 @@ import {
 } from 'types';
 import ContentTypeWarning from 'components/config-screen/assign-content-type/ContentTypeWarning';
 import { buildDefaultPathPattern } from 'utils/getReportSlug';
+import { isSlugFieldType } from 'helpers/contentTypeHelpers/contentTypeHelpers';
 import { getPatternTokens, inferMatchTypeFromPattern } from 'utils/contentTypeMatching';
 
 interface Props {
@@ -33,6 +34,7 @@ interface Props {
   contentTypeRules: ContentTypeRules;
   isMissingPattern: boolean;
   unknownPatternTokens: string[];
+  missingSelectedPatternTokens: string[];
   isDuplicateConfiguration: boolean;
   onContentTypeChange: (ruleId: string, newContentTypeId: string) => void;
   onContentTypeFieldChange: (
@@ -56,6 +58,7 @@ const AssignContentTypeRow = (props: Props) => {
     contentTypeRules,
     isMissingPattern,
     unknownPatternTokens,
+    missingSelectedPatternTokens,
     isDuplicateConfiguration,
     onContentTypeChange,
     onContentTypeFieldChange,
@@ -104,7 +107,9 @@ const AssignContentTypeRow = (props: Props) => {
       );
       if (slugField !== undefined) {
         setIsSlugFieldInOptions(
-          allContentTypes[contentTypeId]?.fields.some((field) => field.id === slugField)
+          allContentTypes[contentTypeId]?.fields
+            .filter(isSlugFieldType)
+            .some((field) => field.id === slugField)
         );
       }
     }
@@ -133,7 +138,9 @@ const AssignContentTypeRow = (props: Props) => {
 
     if (
       fieldId !== undefined &&
-      allContentTypes[entryContentTypeId]?.fields.some((field) => field.id === fieldId)
+      allContentTypes[entryContentTypeId]?.fields
+        .filter(isSlugFieldType)
+        .some((field) => field.id === fieldId)
     ) {
       value = fieldId;
     }
@@ -146,6 +153,8 @@ const AssignContentTypeRow = (props: Props) => {
       ? allContentTypes[contentTypeId].fields
       : [];
   const requiresSlugField = !enableAdvancedMatching;
+  const localePatternToken = '{locale}';
+  const hasLocaleToken = getPatternTokens(pathPattern).includes('locale');
 
   const getGeneratedPattern = (
     selectedFieldIds = additionalFieldIds,
@@ -181,6 +190,38 @@ const AssignContentTypeRow = (props: Props) => {
     return `${currentPattern}${separator}${fieldVariable}`;
   };
 
+  const addLocaleVariableToPattern = (currentPattern: string) => {
+    const trimmedPattern = currentPattern.trim();
+
+    if (!trimmedPattern) {
+      return slugField ? '/{locale}/{slug}' : '/{locale}';
+    }
+
+    if (trimmedPattern.includes(localePatternToken)) {
+      return currentPattern;
+    }
+
+    if (trimmedPattern === '/') {
+      return '/{locale}';
+    }
+
+    if (trimmedPattern.startsWith('/')) {
+      return `/${localePatternToken}${currentPattern}`;
+    }
+
+    return `/${localePatternToken}/${currentPattern}`;
+  };
+
+  const removeLocaleVariableFromPattern = (currentPattern: string) => {
+    const nextPattern = currentPattern
+      .replace(/^\/\{locale\}\/?/, '/')
+      .replace(/^\{locale\}\/?/, '')
+      .replace(/\/\{locale\}/g, '')
+      .replace(/\{locale\}/g, '');
+
+    return nextPattern || '/';
+  };
+
   const getNextAutoPattern = (
     currentPattern: string,
     nextSelectedFieldIds = additionalFieldIds,
@@ -194,15 +235,22 @@ const AssignContentTypeRow = (props: Props) => {
     return shouldUpdatePattern ? nextGeneratedPattern : currentPattern;
   };
 
-  const hasInvalidPattern = isMissingPattern || unknownPatternTokens.length > 0;
+  const hasInvalidPattern =
+    isMissingPattern || unknownPatternTokens.length > 0 || missingSelectedPatternTokens.length > 0;
   const availableVariableHint =
-    'Use the variables shown in Entry fields used to build URL pattern.';
+    'Use the variables shown on the left.';
   const unknownPatternMessage =
     unknownPatternTokens.length === 1
       ? `Pattern contains an unknown variable: {${unknownPatternTokens[0]}}. ${availableVariableHint}`
       : `Pattern contains unknown variables: ${unknownPatternTokens
           .map((token) => `{${token}}`)
           .join(', ')}. ${availableVariableHint}`;
+  const missingSelectedPatternTokensMessage =
+    missingSelectedPatternTokens.length === 1
+      ? `Pattern is missing a substitution tag for the selected entry field: {${missingSelectedPatternTokens[0]}}. Add the tag to Pattern or uncheck that field.`
+      : `Pattern is missing substitution tags for selected entry fields: ${missingSelectedPatternTokens
+          .map((token) => `{${token}}`)
+          .join(', ')}. Add the tags to Pattern or uncheck those fields.`;
 
   return (
     <Stack
@@ -261,7 +309,7 @@ const AssignContentTypeRow = (props: Props) => {
                   Select slug field
                 </Select.Option>
                 {contentTypeId &&
-                  allContentTypes[contentTypeId]?.fields?.map((field) => (
+                  allContentTypes[contentTypeId]?.fields?.filter(isSlugFieldType).map((field) => (
                     <Select.Option key={`${contentTypeId}.${field.id}`} value={field.id}>
                       {field.name}
                     </Select.Option>
@@ -329,56 +377,79 @@ const AssignContentTypeRow = (props: Props) => {
       {showAdvancedMatching && (
         <Box className={styles.advancedMatchingPanel} testId="advancedMatchingPanel">
           <Text fontColor="gray600" className={styles.advancedMatchingIntro}>
-            Build a custom URL pattern for the URL that uses the entry being edited.
+            Build a custom path pattern for the analytics shown while editing an entry of the chosen
+            content type. Use short text and integer fields to insert entry values into the path.
           </Text>
           <Box className={styles.advancedMatchingFields}>
             <Flex className={styles.advancedMatchingTopRow}>
               <Box className={styles.stackedField}>
-                <FormControl marginBottom="none">
-                  <FormControl.Label>
-                    Add an entry fields used to build the URL pattern
-                  </FormControl.Label>
-                  <Stack spacing="spacing2Xs" flexDirection="column" alignItems="flex-start">
-                    {contentTypeFields.length ? (
-                      contentTypeFields.map((field) => (
-                        <Flex key={`${contentTypeId}.${field.id}`} alignItems="center">
-                          <Checkbox
-                            testId={`additionalFieldOption-${field.id}`}
-                            isChecked={additionalFieldIds.includes(field.id)}
-                            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                              const checked = event.target.checked;
-                              const nextSelectedFields = checked
-                                ? [...additionalFieldIds, field.id]
-                                : additionalFieldIds.filter(
-                                    (selectedFieldId) => selectedFieldId !== field.id
-                                  );
-                              const nextPattern = checked
-                                ? appendFieldVariableToPattern(
-                                    pathPattern,
-                                    field.id,
-                                    matchDimension
-                                  )
-                                : getNextAutoPattern(pathPattern, nextSelectedFields);
-                              onContentTypeRuleChange(ruleId, {
-                                additionalFieldIds: nextSelectedFields,
-                                pathPattern: nextPattern,
-                                matchType: inferMatchTypeFromPattern(nextPattern),
-                              });
-                            }}>
-                            {field.name} {`{${field.id}}`}
-                          </Checkbox>
-                        </Flex>
-                      ))
-                    ) : (
-                      <Text fontColor="gray500">
-                        No extra fields available for this content type.
-                      </Text>
-                    )}
-                  </Stack>
-                  <FormControl.HelpText>
-                    Select the entry fields you want to use in the pattern.
-                  </FormControl.HelpText>
-                </FormControl>
+                <Stack spacing="spacingS" flexDirection="column" alignItems="flex-start">
+                  <FormControl marginBottom="none">
+                    <FormControl.Label>
+                      Select entry fields to insert into your path pattern
+                    </FormControl.Label>
+                    <Stack spacing="spacing2Xs" flexDirection="column" alignItems="flex-start">
+                      {contentTypeFields.length ? (
+                        contentTypeFields.map((field) => (
+                          <Flex key={`${contentTypeId}.${field.id}`} alignItems="center">
+                            <Checkbox
+                              testId={`additionalFieldOption-${field.id}`}
+                              isChecked={additionalFieldIds.includes(field.id)}
+                              onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                                const checked = event.target.checked;
+                                const nextSelectedFields = checked
+                                  ? [...additionalFieldIds, field.id]
+                                  : additionalFieldIds.filter(
+                                      (selectedFieldId) => selectedFieldId !== field.id
+                                    );
+                                const nextPattern = checked
+                                  ? appendFieldVariableToPattern(
+                                      pathPattern,
+                                      field.id,
+                                      matchDimension
+                                    )
+                                  : getNextAutoPattern(pathPattern, nextSelectedFields);
+                                onContentTypeRuleChange(ruleId, {
+                                  additionalFieldIds: nextSelectedFields,
+                                  pathPattern: nextPattern,
+                                  matchType: inferMatchTypeFromPattern(nextPattern),
+                                });
+                              }}>
+                              {field.name} {`{${field.id}}`}
+                            </Checkbox>
+                          </Flex>
+                        ))
+                      ) : (
+                        <Text fontColor="gray500">
+                          No extra fields available for this content type.
+                        </Text>
+                      )}
+                    </Stack>
+                  </FormControl>
+                  <FormControl marginBottom="none">
+                    <FormControl.Label>Insert locale into Pattern</FormControl.Label>
+                    <Checkbox
+                      testId="localePatternOption"
+                      isChecked={hasLocaleToken}
+                      isDisabled={!contentTypeId || !isContentTypeInOptions}
+                      onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                        const nextPattern = event.target.checked
+                          ? addLocaleVariableToPattern(pathPattern)
+                          : removeLocaleVariableFromPattern(pathPattern);
+
+                        onContentTypeRuleChange(ruleId, {
+                          pathPattern: nextPattern,
+                          matchType: inferMatchTypeFromPattern(nextPattern),
+                        });
+                      }}>
+                      Locale
+                    </Checkbox>
+                    <FormControl.HelpText>
+                      Editors can choose the locale in the sidebar. The selected locale replaces{' '}
+                      {localePatternToken} in Pattern.
+                    </FormControl.HelpText>
+                  </FormControl>
+                </Stack>
               </Box>
               <Box className={styles.stackedField}>
                 <FormControl marginBottom="none" isInvalid={hasInvalidPattern}>
@@ -419,57 +490,59 @@ const AssignContentTypeRow = (props: Props) => {
                       {unknownPatternMessage}
                     </FormControl.ValidationMessage>
                   )}
+                  {!isMissingPattern &&
+                    unknownPatternTokens.length === 0 &&
+                    missingSelectedPatternTokens.length > 0 && (
+                      <FormControl.ValidationMessage>
+                        {missingSelectedPatternTokensMessage}
+                      </FormControl.ValidationMessage>
+                    )}
                   <FormControl.HelpText>
-                    Use .* when part of the URL can vary. Example: /shop/products/{'{slug}'}
-                    /compare/.*
+                    Use * when part of the URL can vary. Example: /shop/products/{'{product_id}'}
+                    /compare/*
                   </FormControl.HelpText>
                 </FormControl>
-              </Box>
-            </Flex>
-            <Flex className={styles.advancedMatchingBottomRow}>
-              <Box className={styles.compactField}>
-                <FormControl>
-                  <FormControl.Label>
-                    <Flex alignItems="center">
-                      Match against
-                      <Tooltip
-                        placement="top"
-                        content="Choose whether to match just the page path, or the page path plus any query parameters in the URL.">
-                        <Flex marginLeft="spacing2Xs" className={styles.tooltipIcon}>
-                          <HelpCircleIcon />
-                        </Flex>
-                      </Tooltip>
-                    </Flex>
-                  </FormControl.Label>
-                  <Select
-                    id={`matchDimension-${index}`}
-                    name={`matchDimension-${index}`}
-                    testId="matchDimensionSelect"
-                    isDisabled={!contentTypeId || !isContentTypeInOptions}
-                    onChange={(event: React.ChangeEvent<HTMLSelectElement>) => {
-                      const nextMatchDimension = event.target.value;
-                      const nextPattern = getNextAutoPattern(
-                        pathPattern,
-                        additionalFieldIds,
-                        nextMatchDimension
-                      );
+                <Box marginTop="spacingS">
+                  <FormControl marginBottom="none">
+                    <FormControl.Label>
+                      <Flex alignItems="center">
+                        Match against
+                        <Tooltip
+                          placement="top"
+                          content="Choose whether to match just the page path, or the page path plus any query parameters in the URL.">
+                          <Flex marginLeft="spacing2Xs" className={styles.tooltipIcon}>
+                            <HelpCircleIcon />
+                          </Flex>
+                        </Tooltip>
+                      </Flex>
+                    </FormControl.Label>
+                    <Select
+                      id={`matchDimension-${index}`}
+                      name={`matchDimension-${index}`}
+                      testId="matchDimensionSelect"
+                      isDisabled={!contentTypeId || !isContentTypeInOptions}
+                      onChange={(event: React.ChangeEvent<HTMLSelectElement>) => {
+                        const nextMatchDimension = event.target.value;
+                        const nextPattern = getNextAutoPattern(
+                          pathPattern,
+                          additionalFieldIds,
+                          nextMatchDimension
+                        );
 
-                      onContentTypeRuleChange(ruleId, {
-                        matchDimension: nextMatchDimension,
-                        pathPattern: nextPattern,
-                        matchType: inferMatchTypeFromPattern(nextPattern),
-                      });
-                    }}
-                    value={matchDimension}>
-                    <Select.Option value="unifiedPagePathScreen">Page path</Select.Option>
-                    <Select.Option value="pagePathPlusQueryString">
-                      Page path + query string
-                    </Select.Option>
-                  </Select>
-                </FormControl>
-              </Box>
-              <Box className={styles.compactField}>
-                <Box />
+                        onContentTypeRuleChange(ruleId, {
+                          matchDimension: nextMatchDimension,
+                          pathPattern: nextPattern,
+                          matchType: inferMatchTypeFromPattern(nextPattern),
+                        });
+                      }}
+                      value={matchDimension}>
+                      <Select.Option value="unifiedPagePathScreen">Page path</Select.Option>
+                      <Select.Option value="pagePathPlusQueryString">
+                        Page path + query string
+                      </Select.Option>
+                    </Select>
+                  </FormControl>
+                </Box>
               </Box>
             </Flex>
           </Box>

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeRow.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeRow.tsx
@@ -4,7 +4,6 @@ import {
   Checkbox,
   Flex,
   FormControl,
-  Note,
   Select,
   Stack,
   Text,
@@ -32,6 +31,8 @@ interface Props {
   allContentTypeEntries: AllContentTypeEntries;
   contentTypeRules: ContentTypeRules;
   isMissingPattern: boolean;
+  unknownPatternTokens: string[];
+  isDuplicateConfiguration: boolean;
   onContentTypeChange: (ruleId: string, newContentTypeId: string) => void;
   onContentTypeFieldChange: (
     ruleId: string,
@@ -53,6 +54,8 @@ const AssignContentTypeRow = (props: Props) => {
     allContentTypeEntries,
     contentTypeRules,
     isMissingPattern,
+    unknownPatternTokens,
+    isDuplicateConfiguration,
     onContentTypeChange,
     onContentTypeFieldChange,
     onContentTypeRuleChange,
@@ -138,16 +141,6 @@ const AssignContentTypeRow = (props: Props) => {
     return value;
   };
 
-  const resetAdvancedMatching = () => {
-    onContentTypeRuleChange(ruleId, {
-      enableAdvancedMatching: false,
-      additionalFieldIds: [],
-      pathPattern: '',
-      matchDimension: 'unifiedPagePathScreen',
-      matchType: 'EXACT',
-    });
-  };
-
   const selectableAdditionalFields =
     contentTypeId && allContentTypes[contentTypeId]?.fields
       ? allContentTypes[contentTypeId].fields.filter((field) => field.id !== slugField)
@@ -157,6 +150,15 @@ const AssignContentTypeRow = (props: Props) => {
     selectedFieldIds = additionalFieldIds,
     selectedMatchDimension = matchDimension
   ) => buildDefaultPathPattern(urlPrefix, selectedFieldIds, selectedMatchDimension);
+
+  const suggestedPattern = getGeneratedPattern();
+  const hasInvalidPattern = isMissingPattern || unknownPatternTokens.length > 0;
+  const unknownPatternMessage =
+    unknownPatternTokens.length === 1
+      ? `Pattern contains an unknown variable: {${unknownPatternTokens[0]}}. Use {slug} and the variables shown in Additional page properties.`
+      : `Pattern contains unknown variables: ${unknownPatternTokens
+          .map((token) => `{${token}}`)
+          .join(', ')}. Use {slug} and the variables shown in Additional page properties.`;
 
   return (
     <Stack
@@ -249,12 +251,13 @@ const AssignContentTypeRow = (props: Props) => {
                 if (nextIsAdvanced) {
                   onContentTypeRuleChange(ruleId, {
                     enableAdvancedMatching: true,
-                    pathPattern: pathPattern.trim() ? pathPattern : getGeneratedPattern(),
                   });
                   return;
                 }
 
-                resetAdvancedMatching();
+                onContentTypeRuleChange(ruleId, {
+                  enableAdvancedMatching: false,
+                });
               }}>
               Advanced
             </Checkbox>
@@ -265,14 +268,17 @@ const AssignContentTypeRow = (props: Props) => {
             </TextLink>
           </Box>
         </Flex>
+        {isDuplicateConfiguration && (
+          <FormControl isInvalid marginBottom="none">
+            <FormControl.ValidationMessage>
+              This rule duplicates another configuration. Remove one of them or change one of the
+              values before saving.
+            </FormControl.ValidationMessage>
+          </FormControl>
+        )}
       </Box>
       {showAdvancedMatching && (
         <Box className={styles.advancedMatchingPanel} testId="advancedMatchingPanel">
-          {isMissingPattern && (
-            <Note variant="negative" title="Fix this before saving">
-              Add a pattern for this advanced rule before saving.
-            </Note>
-          )}
           <Text fontColor="gray600" className={styles.advancedMatchingIntro}>
             Build a custom URL pattern for query strings, extra path segments, or variable prefixes.
           </Text>
@@ -295,17 +301,6 @@ const AssignContentTypeRow = (props: Props) => {
                               : additionalFieldIds.filter(
                                   (selectedFieldId) => selectedFieldId !== field.id
                                 );
-                            const currentGeneratedPattern = getGeneratedPattern();
-                            const nextGeneratedPattern = getGeneratedPattern(nextSelectedFields);
-
-                            if (!pathPattern.trim() || pathPattern === currentGeneratedPattern) {
-                              onContentTypeRuleChange(ruleId, {
-                                additionalFieldIds: nextSelectedFields,
-                                pathPattern: nextGeneratedPattern,
-                              });
-                              return;
-                            }
-
                             onContentTypeFieldChange(
                               ruleId,
                               'additionalFieldIds',
@@ -327,29 +322,45 @@ const AssignContentTypeRow = (props: Props) => {
                     )}
                   </Stack>
                   <FormControl.HelpText>
-                    Select extra fields to include in the URL. Use the placeholder shown next to
-                    each field in the pattern.
+                    Select extra fields to include in the URL. Use the variable shown next to each
+                    field in the pattern.
                   </FormControl.HelpText>
                 </FormControl>
               </Box>
               <Box className={styles.stackedField}>
-                <FormControl marginBottom="none">
-                  <FormControl.Label>Pattern</FormControl.Label>
+                <FormControl marginBottom="none" isInvalid={hasInvalidPattern}>
+                  <FormControl.Label>
+                    <Flex alignItems="center">
+                      Pattern
+                      <Tooltip
+                        placement="top"
+                        content="Start with the suggested pattern shown in the field. Use {slug} for the value from the selected slug field. Enter your own pattern if you need a different URL structure or want to use variables from the left.">
+                        <Flex marginLeft="spacing2Xs" className={styles.tooltipIcon}>
+                          <HelpCircleIcon />
+                        </Flex>
+                      </Tooltip>
+                    </Flex>
+                  </FormControl.Label>
                   <TextInput
                     id={`pathPattern-${index}`}
                     name={`pathPattern-${index}`}
                     testId="pathPatternInput"
                     isDisabled={!contentTypeId || !isContentTypeInOptions}
-                    placeholder="/blog/{slug}"
+                    isInvalid={hasInvalidPattern}
+                    placeholder={suggestedPattern}
                     onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
                       onContentTypeFieldChange(ruleId, 'pathPattern', event.target.value)
                     }
                     value={pathPattern}
                   />
-                  <FormControl.HelpText>
-                    A pattern is generated for you automatically. Edit it if you need a different
-                    URL structure or want to use placeholders from the left.
-                  </FormControl.HelpText>
+                  {isMissingPattern && (
+                    <FormControl.ValidationMessage>
+                      Pattern is required. Enter a value for the Pattern field before saving.
+                    </FormControl.ValidationMessage>
+                  )}
+                  {!isMissingPattern && unknownPatternTokens.length > 0 && (
+                    <FormControl.ValidationMessage>{unknownPatternMessage}</FormControl.ValidationMessage>
+                  )}
                 </FormControl>
               </Box>
             </Flex>
@@ -373,24 +384,9 @@ const AssignContentTypeRow = (props: Props) => {
                     name={`matchDimension-${index}`}
                     testId="matchDimensionSelect"
                     isDisabled={!contentTypeId || !isContentTypeInOptions}
-                    onChange={(event: React.ChangeEvent<HTMLSelectElement>) => {
-                      const nextMatchDimension = event.target.value;
-                      const currentGeneratedPattern = getGeneratedPattern();
-                      const nextGeneratedPattern = getGeneratedPattern(
-                        additionalFieldIds,
-                        nextMatchDimension as ContentTypeValue['matchDimension']
-                      );
-
-                      if (!pathPattern.trim() || pathPattern === currentGeneratedPattern) {
-                        onContentTypeRuleChange(ruleId, {
-                          matchDimension: nextMatchDimension,
-                          pathPattern: nextGeneratedPattern,
-                        });
-                        return;
-                      }
-
-                      onContentTypeFieldChange(ruleId, 'matchDimension', nextMatchDimension);
-                    }}
+                    onChange={(event: React.ChangeEvent<HTMLSelectElement>) =>
+                      onContentTypeFieldChange(ruleId, 'matchDimension', event.target.value)
+                    }
                     value={matchDimension}>
                     <Select.Option value="unifiedPagePathScreen">Page path</Select.Option>
                     <Select.Option value="pagePathPlusQueryString">
@@ -406,7 +402,7 @@ const AssignContentTypeRow = (props: Props) => {
                       Matching mode
                       <Tooltip
                         placement="top"
-                        content="Use Literal for one exact URL pattern. Use Flexible match when part of the URL can vary, like different category prefixes.">
+                        content="Use Literal for one exact URL pattern. Use Regex match when part of the URL can vary. Regex match uses regular expression syntax, so use .* when you want wildcard-style matching.">
                         <Flex marginLeft="spacing2Xs" className={styles.tooltipIcon}>
                           <HelpCircleIcon />
                         </Flex>
@@ -423,7 +419,7 @@ const AssignContentTypeRow = (props: Props) => {
                     }
                     value={matchType}>
                     <Select.Option value="EXACT">Literal</Select.Option>
-                    <Select.Option value="PARTIAL_REGEXP">Flexible match</Select.Option>
+                    <Select.Option value="PARTIAL_REGEXP">Regex match</Select.Option>
                   </Select>
                 </FormControl>
               </Box>

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeRow.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeRow.tsx
@@ -152,6 +152,35 @@ const AssignContentTypeRow = (props: Props) => {
     selectedMatchDimension = matchDimension
   ) => buildDefaultPathPattern('', selectedFieldIds, selectedMatchDimension, '');
 
+  const appendFieldVariableToPattern = (
+    currentPattern: string,
+    fieldId: string,
+    selectedMatchDimension = matchDimension
+  ) => {
+    const trimmedPattern = currentPattern.trim();
+    const fieldVariable = `{${fieldId}}`;
+
+    if (!trimmedPattern) {
+      return getGeneratedPattern([fieldId], selectedMatchDimension);
+    }
+
+    if (trimmedPattern.includes(fieldVariable)) {
+      return currentPattern;
+    }
+
+    if (selectedMatchDimension === 'pagePathPlusQueryString') {
+      if (trimmedPattern.includes('?')) {
+        return `${currentPattern}&${fieldId}=${fieldVariable}`;
+      }
+
+      return `${currentPattern}?${fieldId}=${fieldVariable}`;
+    }
+
+    const separator = trimmedPattern.endsWith('/') || trimmedPattern.endsWith('?') ? '' : '/';
+
+    return `${currentPattern}${separator}${fieldVariable}`;
+  };
+
   const getNextAutoPattern = (
     currentPattern: string,
     nextSelectedFieldIds = additionalFieldIds,
@@ -306,7 +335,9 @@ const AssignContentTypeRow = (props: Props) => {
             <Flex className={styles.advancedMatchingTopRow}>
               <Box className={styles.stackedField}>
                 <FormControl marginBottom="none">
-                  <FormControl.Label>Entry fields used to build URL pattern</FormControl.Label>
+                  <FormControl.Label>
+                    Add an entry fields used to build URL pattern
+                  </FormControl.Label>
                   <Stack spacing="spacing2Xs" flexDirection="column" alignItems="flex-start">
                     {contentTypeFields.length ? (
                       contentTypeFields.map((field) => (
@@ -321,10 +352,13 @@ const AssignContentTypeRow = (props: Props) => {
                                 : additionalFieldIds.filter(
                                     (selectedFieldId) => selectedFieldId !== field.id
                                   );
-                              const nextPattern = getNextAutoPattern(
-                                pathPattern,
-                                nextSelectedFields
-                              );
+                              const nextPattern = checked
+                                ? appendFieldVariableToPattern(
+                                    pathPattern,
+                                    field.id,
+                                    matchDimension
+                                  )
+                                : getNextAutoPattern(pathPattern, nextSelectedFields);
                               onContentTypeRuleChange(ruleId, {
                                 additionalFieldIds: nextSelectedFields,
                                 pathPattern: nextPattern,
@@ -385,6 +419,10 @@ const AssignContentTypeRow = (props: Props) => {
                       {unknownPatternMessage}
                     </FormControl.ValidationMessage>
                   )}
+                  <FormControl.HelpText>
+                    Use .* when part of the URL can vary. Example: /shop/products/{'{slug}'}
+                    /compare/.*
+                  </FormControl.HelpText>
                 </FormControl>
               </Box>
             </Flex>
@@ -431,10 +469,7 @@ const AssignContentTypeRow = (props: Props) => {
                 </FormControl>
               </Box>
               <Box className={styles.compactField}>
-                <Text fontColor="gray600">
-                  Use <code>.*</code> when part of the URL can vary. Example:{' '}
-                  <code>/shop/products/{'{slug}'}/compare/.*</code>
-                </Text>
+                <Box />
               </Box>
             </Flex>
           </Box>

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeRow.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeRow.tsx
@@ -23,6 +23,7 @@ import {
 } from 'types';
 import ContentTypeWarning from 'components/config-screen/assign-content-type/ContentTypeWarning';
 import { buildDefaultPathPattern } from 'utils/getReportSlug';
+import { getPatternTokens, inferMatchTypeFromPattern } from 'utils/contentTypeMatching';
 
 interface Props {
   contentTypeRule: ContentTypeRule;
@@ -75,7 +76,6 @@ const AssignContentTypeRow = (props: Props) => {
       pathPattern = '',
       additionalFieldIds = [],
       matchDimension = 'unifiedPagePathScreen',
-      matchType = 'EXACT',
     },
   ] = [contentTypeRule.id, contentTypeRule];
 
@@ -141,24 +141,39 @@ const AssignContentTypeRow = (props: Props) => {
     return value;
   };
 
-  const selectableAdditionalFields =
+  const contentTypeFields =
     contentTypeId && allContentTypes[contentTypeId]?.fields
-      ? allContentTypes[contentTypeId].fields.filter((field) => field.id !== slugField)
+      ? allContentTypes[contentTypeId].fields
       : [];
+  const requiresSlugField = !enableAdvancedMatching;
 
   const getGeneratedPattern = (
     selectedFieldIds = additionalFieldIds,
     selectedMatchDimension = matchDimension
-  ) => buildDefaultPathPattern(urlPrefix, selectedFieldIds, selectedMatchDimension);
+  ) => buildDefaultPathPattern('', selectedFieldIds, selectedMatchDimension, '');
 
-  const suggestedPattern = getGeneratedPattern();
+  const getNextAutoPattern = (
+    currentPattern: string,
+    nextSelectedFieldIds = additionalFieldIds,
+    nextMatchDimension = matchDimension
+  ) => {
+    const currentGeneratedPattern = getGeneratedPattern(additionalFieldIds, matchDimension);
+    const nextGeneratedPattern = getGeneratedPattern(nextSelectedFieldIds, nextMatchDimension);
+    const shouldUpdatePattern =
+      !currentPattern.trim() || currentPattern === currentGeneratedPattern;
+
+    return shouldUpdatePattern ? nextGeneratedPattern : currentPattern;
+  };
+
   const hasInvalidPattern = isMissingPattern || unknownPatternTokens.length > 0;
+  const availableVariableHint =
+    'Use the variables shown in Entry fields used to build URL pattern.';
   const unknownPatternMessage =
     unknownPatternTokens.length === 1
-      ? `Pattern contains an unknown variable: {${unknownPatternTokens[0]}}. Use {slug} and the variables shown in Additional page properties.`
+      ? `Pattern contains an unknown variable: {${unknownPatternTokens[0]}}. ${availableVariableHint}`
       : `Pattern contains unknown variables: ${unknownPatternTokens
           .map((token) => `{${token}}`)
-          .join(', ')}. Use {slug} and the variables shown in Additional page properties.`;
+          .join(', ')}. ${availableVariableHint}`;
 
   return (
     <Stack
@@ -174,6 +189,7 @@ const AssignContentTypeRow = (props: Props) => {
       <ContentTypeWarning
         contentTypeId={contentTypeId}
         slugField={slugField}
+        requiresSlugField={requiresSlugField}
         isSaved={isSaved}
         isInSidebar={isInSidebar}
         isContentTypeInOptions={isContentTypeInOptions}
@@ -202,25 +218,29 @@ const AssignContentTypeRow = (props: Props) => {
             </Select>
           </Box>
           <Box className={styles.contentTypeItem}>
-            <Select
-              id={`slugField-${index}`}
-              name={`slugField-${index}`}
-              testId="slugFieldSelect"
-              isDisabled={!contentTypeId || !isContentTypeInOptions}
-              onChange={(event: React.ChangeEvent<HTMLSelectElement>) =>
-                onContentTypeFieldChange(ruleId, 'slugField', event.target.value)
-              }
-              value={validateSelectedOption(contentTypeId, slugField)}>
-              <Select.Option value="" isDisabled>
-                Select slug field
-              </Select.Option>
-              {contentTypeId &&
-                allContentTypes[contentTypeId]?.fields?.map((field) => (
-                  <Select.Option key={`${contentTypeId}.${field.id}`} value={field.id}>
-                    {field.name}
-                  </Select.Option>
-                ))}
-            </Select>
+            {!showAdvancedMatching ? (
+              <Select
+                id={`slugField-${index}`}
+                name={`slugField-${index}`}
+                testId="slugFieldSelect"
+                isDisabled={!contentTypeId || !isContentTypeInOptions}
+                onChange={(event: React.ChangeEvent<HTMLSelectElement>) =>
+                  onContentTypeFieldChange(ruleId, 'slugField', event.target.value)
+                }
+                value={validateSelectedOption(contentTypeId, slugField)}>
+                <Select.Option value="" isDisabled>
+                  Select slug field
+                </Select.Option>
+                {contentTypeId &&
+                  allContentTypes[contentTypeId]?.fields?.map((field) => (
+                    <Select.Option key={`${contentTypeId}.${field.id}`} value={field.id}>
+                      {field.name}
+                    </Select.Option>
+                  ))}
+              </Select>
+            ) : (
+              <></>
+            )}
           </Box>
           <Box className={styles.urlPrefixItem}>
             {!showAdvancedMatching ? (
@@ -235,7 +255,7 @@ const AssignContentTypeRow = (props: Props) => {
                 value={urlPrefix}
               />
             ) : (
-              <Text fontColor="gray500">Configured below</Text>
+              <></>
             )}
           </Box>
           <Box className={styles.toggleItem}>
@@ -280,40 +300,40 @@ const AssignContentTypeRow = (props: Props) => {
       {showAdvancedMatching && (
         <Box className={styles.advancedMatchingPanel} testId="advancedMatchingPanel">
           <Text fontColor="gray600" className={styles.advancedMatchingIntro}>
-            Build a custom URL pattern for query strings, extra path segments, or variable prefixes.
+            Build a custom URL pattern for the URL that uses the entry being edited.
           </Text>
           <Box className={styles.advancedMatchingFields}>
             <Flex className={styles.advancedMatchingTopRow}>
               <Box className={styles.stackedField}>
                 <FormControl marginBottom="none">
-                  <FormControl.Label>Additional page properties</FormControl.Label>
+                  <FormControl.Label>Entry fields used to build URL pattern</FormControl.Label>
                   <Stack spacing="spacing2Xs" flexDirection="column" alignItems="flex-start">
-                    {selectableAdditionalFields.length ? (
-                      selectableAdditionalFields.map((field) => (
-                        <Checkbox
-                          key={`${contentTypeId}.${field.id}`}
-                          testId={`additionalFieldOption-${field.id}`}
-                          isChecked={additionalFieldIds.includes(field.id)}
-                          onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                            const checked = event.target.checked;
-                            const nextSelectedFields = checked
-                              ? [...additionalFieldIds, field.id]
-                              : additionalFieldIds.filter(
-                                  (selectedFieldId) => selectedFieldId !== field.id
-                                );
-                            onContentTypeFieldChange(
-                              ruleId,
-                              'additionalFieldIds',
-                              nextSelectedFields
-                            );
-                          }}>
-                          <Flex alignItems="center" gap="spacing2Xs">
-                            <Text as="span">{field.name}</Text>
-                            <Text as="span" fontColor="gray600">
-                              {`{${field.id}}`}
-                            </Text>
-                          </Flex>
-                        </Checkbox>
+                    {contentTypeFields.length ? (
+                      contentTypeFields.map((field) => (
+                        <Flex key={`${contentTypeId}.${field.id}`} alignItems="center">
+                          <Checkbox
+                            testId={`additionalFieldOption-${field.id}`}
+                            isChecked={additionalFieldIds.includes(field.id)}
+                            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                              const checked = event.target.checked;
+                              const nextSelectedFields = checked
+                                ? [...additionalFieldIds, field.id]
+                                : additionalFieldIds.filter(
+                                    (selectedFieldId) => selectedFieldId !== field.id
+                                  );
+                              const nextPattern = getNextAutoPattern(
+                                pathPattern,
+                                nextSelectedFields
+                              );
+                              onContentTypeRuleChange(ruleId, {
+                                additionalFieldIds: nextSelectedFields,
+                                pathPattern: nextPattern,
+                                matchType: inferMatchTypeFromPattern(nextPattern),
+                              });
+                            }}>
+                            {field.name} {`{${field.id}}`}
+                          </Checkbox>
+                        </Flex>
                       ))
                     ) : (
                       <Text fontColor="gray500">
@@ -322,8 +342,7 @@ const AssignContentTypeRow = (props: Props) => {
                     )}
                   </Stack>
                   <FormControl.HelpText>
-                    Select extra fields to include in the URL. Use the variable shown next to each
-                    field in the pattern.
+                    Select the entry fields you want to use in the pattern.
                   </FormControl.HelpText>
                 </FormControl>
               </Box>
@@ -334,7 +353,7 @@ const AssignContentTypeRow = (props: Props) => {
                       Pattern
                       <Tooltip
                         placement="top"
-                        content="Start with the suggested pattern shown in the field. Use {slug} for the value from the selected slug field. Enter your own pattern if you need a different URL structure or want to use variables from the left.">
+                        content="Use the variables from the entry fields list to build the URL pattern.">
                         <Flex marginLeft="spacing2Xs" className={styles.tooltipIcon}>
                           <HelpCircleIcon />
                         </Flex>
@@ -347,10 +366,13 @@ const AssignContentTypeRow = (props: Props) => {
                     testId="pathPatternInput"
                     isDisabled={!contentTypeId || !isContentTypeInOptions}
                     isInvalid={hasInvalidPattern}
-                    placeholder={suggestedPattern}
-                    onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
-                      onContentTypeFieldChange(ruleId, 'pathPattern', event.target.value)
-                    }
+                    onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                      const nextPattern = event.target.value;
+                      onContentTypeRuleChange(ruleId, {
+                        pathPattern: nextPattern,
+                        matchType: inferMatchTypeFromPattern(nextPattern),
+                      });
+                    }}
                     value={pathPattern}
                   />
                   {isMissingPattern && (
@@ -359,7 +381,9 @@ const AssignContentTypeRow = (props: Props) => {
                     </FormControl.ValidationMessage>
                   )}
                   {!isMissingPattern && unknownPatternTokens.length > 0 && (
-                    <FormControl.ValidationMessage>{unknownPatternMessage}</FormControl.ValidationMessage>
+                    <FormControl.ValidationMessage>
+                      {unknownPatternMessage}
+                    </FormControl.ValidationMessage>
                   )}
                 </FormControl>
               </Box>
@@ -384,9 +408,20 @@ const AssignContentTypeRow = (props: Props) => {
                     name={`matchDimension-${index}`}
                     testId="matchDimensionSelect"
                     isDisabled={!contentTypeId || !isContentTypeInOptions}
-                    onChange={(event: React.ChangeEvent<HTMLSelectElement>) =>
-                      onContentTypeFieldChange(ruleId, 'matchDimension', event.target.value)
-                    }
+                    onChange={(event: React.ChangeEvent<HTMLSelectElement>) => {
+                      const nextMatchDimension = event.target.value;
+                      const nextPattern = getNextAutoPattern(
+                        pathPattern,
+                        additionalFieldIds,
+                        nextMatchDimension
+                      );
+
+                      onContentTypeRuleChange(ruleId, {
+                        matchDimension: nextMatchDimension,
+                        pathPattern: nextPattern,
+                        matchType: inferMatchTypeFromPattern(nextPattern),
+                      });
+                    }}
                     value={matchDimension}>
                     <Select.Option value="unifiedPagePathScreen">Page path</Select.Option>
                     <Select.Option value="pagePathPlusQueryString">
@@ -396,32 +431,10 @@ const AssignContentTypeRow = (props: Props) => {
                 </FormControl>
               </Box>
               <Box className={styles.compactField}>
-                <FormControl>
-                  <FormControl.Label>
-                    <Flex alignItems="center">
-                      Matching mode
-                      <Tooltip
-                        placement="top"
-                        content="Use Literal for one exact URL pattern. Use Regex match when part of the URL can vary. Regex match uses regular expression syntax, so use .* when you want wildcard-style matching.">
-                        <Flex marginLeft="spacing2Xs" className={styles.tooltipIcon}>
-                          <HelpCircleIcon />
-                        </Flex>
-                      </Tooltip>
-                    </Flex>
-                  </FormControl.Label>
-                  <Select
-                    id={`matchType-${index}`}
-                    name={`matchType-${index}`}
-                    testId="matchTypeSelect"
-                    isDisabled={!contentTypeId || !isContentTypeInOptions}
-                    onChange={(event: React.ChangeEvent<HTMLSelectElement>) =>
-                      onContentTypeFieldChange(ruleId, 'matchType', event.target.value)
-                    }
-                    value={matchType}>
-                    <Select.Option value="EXACT">Literal</Select.Option>
-                    <Select.Option value="PARTIAL_REGEXP">Regex match</Select.Option>
-                  </Select>
-                </FormControl>
+                <Text fontColor="gray600">
+                  Use <code>.*</code> when part of the URL can vary. Example:{' '}
+                  <code>/shop/products/{'{slug}'}/compare/.*</code>
+                </Text>
               </Box>
             </Flex>
           </Box>

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeRow.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeRow.tsx
@@ -268,7 +268,7 @@ const AssignContentTypeRow = (props: Props) => {
                   ))}
               </Select>
             ) : (
-              <></>
+              <Box className={styles.hiddenColumnSpacer} />
             )}
           </Box>
           <Box className={styles.urlPrefixItem}>
@@ -284,7 +284,7 @@ const AssignContentTypeRow = (props: Props) => {
                 value={urlPrefix}
               />
             ) : (
-              <></>
+              <Box className={styles.hiddenColumnSpacer} />
             )}
           </Box>
           <Box className={styles.toggleItem}>

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.spec.tsx
@@ -21,6 +21,7 @@ describe('Assign Content Type Section for Config Screen', () => {
         currentEditorInterface={{}}
         originalContentTypes={{}}
         originalContentTypeRules={[]}
+        showPatternValidation={false}
       />
     );
 
@@ -52,12 +53,100 @@ describe('Assign Content Type Section for Config Screen', () => {
         currentEditorInterface={{}}
         originalContentTypes={{}}
         originalContentTypeRules={[]}
+        showPatternValidation={true}
       />
     );
 
     expect(
-      await screen.findByText('Add a pattern for this advanced rule before saving.')
+      await screen.findByText(
+        'Pattern is required. Enter a value for the Pattern field before saving.'
+      )
     ).toBeVisible();
+
+    await waitFor(() => expect(onIsValidContentTypeAssignment).toHaveBeenLastCalledWith(false));
+  });
+
+  it('marks advanced rules with unknown pattern variables as invalid', async () => {
+    const onIsValidContentTypeAssignment = vi.fn();
+
+    render(
+      <AssignContentTypeSection
+        mergeSdkParameters={() => {}}
+        onIsValidContentTypeAssignment={onIsValidContentTypeAssignment}
+        parameters={{
+          contentTypeRules: [
+            {
+              id: 'rule-1',
+              contentTypeId: 'searchPage',
+              slugField: 'slug',
+              urlPrefix: '',
+              enableAdvancedMatching: true,
+              pathPattern: '/search/{sectoinSlug}/{slug}',
+              additionalFieldIds: ['sectionSlug'],
+              matchDimension: 'unifiedPagePathScreen',
+              matchType: 'EXACT',
+            },
+          ],
+        }}
+        currentEditorInterface={{}}
+        originalContentTypes={{}}
+        originalContentTypeRules={[]}
+        showPatternValidation={true}
+      />
+    );
+
+    expect(
+      await screen.findByText(
+        'Pattern contains an unknown variable: {sectoinSlug}. Use {slug} and the variables shown in Additional page properties.'
+      )
+    ).toBeVisible();
+
+    await waitFor(() => expect(onIsValidContentTypeAssignment).toHaveBeenLastCalledWith(false));
+  });
+
+  it('marks exact duplicate rules as invalid', async () => {
+    const onIsValidContentTypeAssignment = vi.fn();
+
+    render(
+      <AssignContentTypeSection
+        mergeSdkParameters={() => {}}
+        onIsValidContentTypeAssignment={onIsValidContentTypeAssignment}
+        parameters={{
+          contentTypeRules: [
+            {
+              id: 'rule-1',
+              contentTypeId: 'blogPost',
+              slugField: 'slug',
+              urlPrefix: '/blog/',
+              enableAdvancedMatching: false,
+              pathPattern: '',
+              matchDimension: 'unifiedPagePathScreen',
+              matchType: 'EXACT',
+            },
+            {
+              id: 'rule-2',
+              contentTypeId: 'blogPost',
+              slugField: 'slug',
+              urlPrefix: '/blog/',
+              enableAdvancedMatching: false,
+              pathPattern: '',
+              matchDimension: 'unifiedPagePathScreen',
+              matchType: 'EXACT',
+            },
+          ],
+        }}
+        currentEditorInterface={{}}
+        originalContentTypes={{}}
+        originalContentTypeRules={[]}
+        showPatternValidation={true}
+      />
+    );
+
+    expect(
+      await screen.findAllByText(
+        'This rule duplicates another configuration. Remove one of them or change one of the values before saving.'
+      )
+    ).toHaveLength(2);
 
     await waitFor(() => expect(onIsValidContentTypeAssignment).toHaveBeenLastCalledWith(false));
   });
@@ -85,6 +174,7 @@ describe('Assign Content Type Section for Config Screen', () => {
         currentEditorInterface={{}}
         originalContentTypes={{}}
         originalContentTypeRules={[]}
+        showPatternValidation={false}
       />
     );
 

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.spec.tsx
@@ -28,7 +28,7 @@ describe('Assign Content Type Section for Config Screen', () => {
     expect(screen.getByText('Content type configuration')).toBeVisible();
     expect(
       screen.getByText(
-        'Configure the content types whose entries should show Google Analytics data in the editor sidebar. For each content type, define how the app should match the entry to a page path: use a slug field and optional prefix for standard paths, or enable advanced matching to build a custom path pattern with entry field values and wildcards.'
+        'Configure the content types whose entries should show Google Analytics data in the editor sidebar. For each content type, define how the app should match the entry to a page path: use a slug field and optional prefix for standard paths, or enable advanced matching to build a custom path pattern with entry field values, a locale, and wildcards.'
       )
     ).toBeVisible();
     expect(screen.getByText('Append a trailing slash to all page paths')).toBeVisible();

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.spec.tsx
@@ -81,7 +81,7 @@ describe('Assign Content Type Section for Config Screen', () => {
               slugField: 'slug',
               urlPrefix: '',
               enableAdvancedMatching: true,
-              pathPattern: '/search/{sectoinSlug}/{slug}',
+              pathPattern: '/search/{sectoinSlug}/{sectionSlug}',
               additionalFieldIds: ['sectionSlug'],
               matchDimension: 'unifiedPagePathScreen',
               matchType: 'EXACT',
@@ -97,7 +97,7 @@ describe('Assign Content Type Section for Config Screen', () => {
 
     expect(
       await screen.findByText(
-        'Pattern contains an unknown variable: {sectoinSlug}. Use {slug} and the variables shown in Additional page properties.'
+        'Pattern contains an unknown variable: {sectoinSlug}. Use the variables shown in Entry fields used to build URL pattern.'
       )
     ).toBeVisible();
 

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.spec.tsx
@@ -26,7 +26,12 @@ describe('Assign Content Type Section for Config Screen', () => {
     );
 
     expect(screen.getByText('Content type configuration')).toBeVisible();
-    expect(screen.getByText('Use trailing slash for all page paths')).toBeVisible();
+    expect(
+      screen.getByText(
+        'Configure the content types whose entries should show Google Analytics data in the editor sidebar. For each content type, define how the app should match the entry to a page path: use a slug field and optional prefix for standard paths, or enable advanced matching to build a custom path pattern with entry field values and wildcards.'
+      )
+    ).toBeVisible();
+    expect(screen.getByText('Append a trailing slash to all page paths')).toBeVisible();
   });
 
   it('marks advanced rules without a pattern as invalid', async () => {
@@ -97,11 +102,149 @@ describe('Assign Content Type Section for Config Screen', () => {
 
     expect(
       await screen.findByText(
-        'Pattern contains an unknown variable: {sectoinSlug}. Use the variables shown in Entry fields used to build URL pattern.'
+        'Pattern contains an unknown variable: {sectoinSlug}. Use the variables shown on the left.'
       )
     ).toBeVisible();
 
     await waitFor(() => expect(onIsValidContentTypeAssignment).toHaveBeenLastCalledWith(false));
+  });
+
+  it('marks advanced rules with selected fields missing from the pattern as invalid', async () => {
+    const onIsValidContentTypeAssignment = vi.fn();
+
+    render(
+      <AssignContentTypeSection
+        mergeSdkParameters={() => {}}
+        onIsValidContentTypeAssignment={onIsValidContentTypeAssignment}
+        parameters={{
+          contentTypeRules: [
+            {
+              id: 'rule-1',
+              contentTypeId: 'searchPage',
+              slugField: 'slug',
+              urlPrefix: '',
+              enableAdvancedMatching: true,
+              pathPattern: '/search/{slug}',
+              additionalFieldIds: ['sectionSlug', 'articleId'],
+              matchDimension: 'unifiedPagePathScreen',
+              matchType: 'EXACT',
+            },
+          ],
+        }}
+        currentEditorInterface={{}}
+        originalContentTypes={{}}
+        originalContentTypeRules={[]}
+        showPatternValidation={true}
+      />
+    );
+
+    expect(
+      await screen.findByText(
+        'Pattern is missing substitution tags for selected entry fields: {sectionSlug}, {articleId}. Add the tags to Pattern or uncheck those fields.'
+      )
+    ).toBeVisible();
+
+    await waitFor(() => expect(onIsValidContentTypeAssignment).toHaveBeenLastCalledWith(false));
+  });
+
+
+  it('allows advanced rules to use the locale token', async () => {
+    const onIsValidContentTypeAssignment = vi.fn();
+
+    render(
+      <AssignContentTypeSection
+        mergeSdkParameters={() => {}}
+        onIsValidContentTypeAssignment={onIsValidContentTypeAssignment}
+        parameters={{
+          contentTypeRules: [
+            {
+              id: 'rule-1',
+              contentTypeId: 'searchPage',
+              slugField: 'slug',
+              urlPrefix: '',
+              enableAdvancedMatching: true,
+              pathPattern: '/{locale}/{slug}',
+              additionalFieldIds: [],
+              matchDimension: 'unifiedPagePathScreen',
+              matchType: 'EXACT',
+            },
+          ],
+        }}
+        currentEditorInterface={{}}
+        originalContentTypes={{}}
+        originalContentTypeRules={[]}
+        showPatternValidation={true}
+      />
+    );
+
+    await waitFor(() => expect(onIsValidContentTypeAssignment).toHaveBeenLastCalledWith(true));
+    expect(screen.queryByText(/Pattern contains an unknown variable/)).not.toBeInTheDocument();
+  });
+
+  it('allows advanced rules to use the configured slug token', async () => {
+    const onIsValidContentTypeAssignment = vi.fn();
+
+    render(
+      <AssignContentTypeSection
+        mergeSdkParameters={() => {}}
+        onIsValidContentTypeAssignment={onIsValidContentTypeAssignment}
+        parameters={{
+          contentTypeRules: [
+            {
+              id: 'rule-1',
+              contentTypeId: 'searchPage',
+              slugField: 'slug',
+              urlPrefix: '',
+              enableAdvancedMatching: true,
+              pathPattern: '/search/{slug}/{sectionSlug}',
+              additionalFieldIds: ['sectionSlug'],
+              matchDimension: 'unifiedPagePathScreen',
+              matchType: 'EXACT',
+            },
+          ],
+        }}
+        currentEditorInterface={{}}
+        originalContentTypes={{}}
+        originalContentTypeRules={[]}
+        showPatternValidation={true}
+      />
+    );
+
+    await waitFor(() => expect(onIsValidContentTypeAssignment).toHaveBeenLastCalledWith(true));
+    expect(screen.queryByText(/Pattern contains an unknown variable/)).not.toBeInTheDocument();
+  });
+
+  it('ignores hidden advanced pattern tokens when advanced matching is disabled', async () => {
+    const onIsValidContentTypeAssignment = vi.fn();
+
+    render(
+      <AssignContentTypeSection
+        mergeSdkParameters={() => {}}
+        onIsValidContentTypeAssignment={onIsValidContentTypeAssignment}
+        parameters={{
+          contentTypeRules: [
+            {
+              id: 'rule-1',
+              contentTypeId: 'searchPage',
+              slugField: 'slug',
+              urlPrefix: '',
+              enableAdvancedMatching: false,
+              pathPattern: '/search/{staleToken}',
+              additionalFieldIds: [],
+              matchDimension: 'unifiedPagePathScreen',
+              matchType: 'EXACT',
+            },
+          ],
+        }}
+        currentEditorInterface={{}}
+        originalContentTypes={{}}
+        originalContentTypeRules={[]}
+        showPatternValidation={true}
+      />
+    );
+
+    await waitFor(() => expect(onIsValidContentTypeAssignment).toHaveBeenLastCalledWith(true));
+    expect(screen.queryByText(/Pattern contains an unknown variable/)).not.toBeInTheDocument();
   });
 
   it('marks exact duplicate rules as invalid', async () => {
@@ -180,10 +323,10 @@ describe('Assign Content Type Section for Config Screen', () => {
 
     expect(
       await screen.findByText(
-        'Applies to standard configurations only. Advanced patterns are used exactly as written.'
+        'Trailing slash applies to standard configurations only. Advanced patterns are used exactly as written.'
       )
     ).toBeVisible();
-    expect(screen.getByLabelText('Use trailing slash for all page paths')).toBeEnabled();
-    expect(screen.getByLabelText('Use trailing slash for all page paths')).toBeChecked();
+    expect(screen.getByLabelText('Append a trailing slash to all page paths')).toBeEnabled();
+    expect(screen.getByLabelText('Append a trailing slash to all page paths')).toBeChecked();
   });
 });

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.tsx
@@ -100,7 +100,7 @@ const AssignContentTypeSection = (props: Props) => {
     contentTypeRules
       .map((rule) => [
         rule.id,
-        getUnknownPatternTokens(rule.pathPattern, rule.additionalFieldIds),
+        getUnknownPatternTokens(rule.pathPattern, rule.additionalFieldIds, rule.slugField),
       ] as const)
       .filter(([, unknownTokens]) => unknownTokens.length > 0)
   );

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.tsx
@@ -26,9 +26,11 @@ import AssignContentTypeCard from 'components/config-screen/assign-content-type/
 import { sortAndFormatAllContentTypes } from 'helpers/contentTypeHelpers/contentTypeHelpers';
 import {
   createDefaultRule,
+  getDuplicateRuleIds,
   getUniqueContentTypeIds,
   normalizeContentTypeRules,
 } from 'helpers/contentTypeRules/contentTypeRules';
+import { getUnknownPatternTokens } from 'utils/contentTypeMatching';
 interface Props {
   mergeSdkParameters: Function;
   onIsValidContentTypeAssignment: Function;
@@ -36,6 +38,7 @@ interface Props {
   currentEditorInterface: Partial<EditorInterface>;
   originalContentTypes: ContentTypes;
   originalContentTypeRules: ContentTypeRules;
+  showPatternValidation: boolean;
 }
 
 const AssignContentTypeSection = (props: Props) => {
@@ -46,6 +49,7 @@ const AssignContentTypeSection = (props: Props) => {
     currentEditorInterface,
     originalContentTypes,
     originalContentTypeRules,
+    showPatternValidation,
   } = props;
 
   const [forceTrailingSlash, setForceTrailingSlash] = useState<boolean>(false);
@@ -92,7 +96,21 @@ const AssignContentTypeSection = (props: Props) => {
       .map((rule) => rule.id)
   );
 
-  const isContentTypeAssignmentValid = rulesMissingPattern.size === 0;
+  const rulesWithUnknownPatternTokens = new Map(
+    contentTypeRules
+      .map((rule) => [
+        rule.id,
+        getUnknownPatternTokens(rule.pathPattern, rule.additionalFieldIds),
+      ] as const)
+      .filter(([, unknownTokens]) => unknownTokens.length > 0)
+  );
+
+  const duplicateRuleIds = getDuplicateRuleIds(contentTypeRules);
+
+  const isContentTypeAssignmentValid =
+    rulesMissingPattern.size === 0 &&
+    rulesWithUnknownPatternTokens.size === 0 &&
+    duplicateRuleIds.size === 0;
 
   useEffect(() => {
     onIsValidContentTypeAssignment(isContentTypeAssignmentValid);
@@ -245,6 +263,9 @@ const AssignContentTypeSection = (props: Props) => {
               currentEditorInterface={currentEditorInterface}
               originalContentTypeRules={originalContentTypeRules}
               rulesMissingPattern={rulesMissingPattern}
+              rulesWithUnknownPatternTokens={rulesWithUnknownPatternTokens}
+              duplicateRuleIds={duplicateRuleIds}
+              showPatternValidation={showPatternValidation}
             />
           )}
           {contentTypeRules.length < Object.keys(allContentTypes).length * 5 && (

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.tsx
@@ -241,7 +241,7 @@ const AssignContentTypeSection = (props: Props) => {
           Configure the content types whose entries should show Google Analytics data in the editor
           sidebar. For each content type, define how the app should match the entry to a page path:
           use a slug field and optional prefix for standard paths, or enable advanced matching to
-          build a custom path pattern with entry field values and wildcards.
+          build a custom path pattern with entry field values, a locale, and wildcards.
         </Paragraph>
         <Paragraph>
           <TextLink

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.tsx
@@ -30,7 +30,11 @@ import {
   getUniqueContentTypeIds,
   normalizeContentTypeRules,
 } from 'helpers/contentTypeRules/contentTypeRules';
-import { getUnknownPatternTokens } from 'utils/contentTypeMatching';
+import {
+  getMissingSelectedPatternTokens,
+  getUnknownPatternTokens,
+} from 'utils/contentTypeMatching';
+
 interface Props {
   mergeSdkParameters: Function;
   onIsValidContentTypeAssignment: Function;
@@ -98,6 +102,7 @@ const AssignContentTypeSection = (props: Props) => {
 
   const rulesWithUnknownPatternTokens = new Map(
     contentTypeRules
+      .filter((rule) => rule.enableAdvancedMatching)
       .map((rule) => [
         rule.id,
         getUnknownPatternTokens(rule.pathPattern, rule.additionalFieldIds, rule.slugField),
@@ -105,11 +110,22 @@ const AssignContentTypeSection = (props: Props) => {
       .filter(([, unknownTokens]) => unknownTokens.length > 0)
   );
 
+  const rulesWithMissingSelectedPatternTokens = new Map(
+    contentTypeRules
+      .filter((rule) => rule.enableAdvancedMatching)
+      .map((rule) => [
+        rule.id,
+        getMissingSelectedPatternTokens(rule.pathPattern, rule.additionalFieldIds),
+      ] as const)
+      .filter(([, missingTokens]) => missingTokens.length > 0)
+  );
+
   const duplicateRuleIds = getDuplicateRuleIds(contentTypeRules);
 
   const isContentTypeAssignmentValid =
     rulesMissingPattern.size === 0 &&
     rulesWithUnknownPatternTokens.size === 0 &&
+    rulesWithMissingSelectedPatternTokens.size === 0 &&
     duplicateRuleIds.size === 0;
 
   useEffect(() => {
@@ -222,12 +238,10 @@ const AssignContentTypeSection = (props: Props) => {
       <Box>
         <Subheading marginBottom="spacingXs">Content type configuration</Subheading>
         <Paragraph>
-          Configure content types below that are connected to pages on your website where you're
-          tracking Google Analytics data. You'll need to specify the "slug" field used to generate
-          the page path in your website's URL, and optionally a "prefix" if one exists in front of
-          the URL page path. Additionally, you can check the box below to append a trailing slash to
-          all URLs if needed. The app will automatically be added to the sidebar of associated
-          content types on save of the configuration.
+          Configure the content types whose entries should show Google Analytics data in the editor
+          sidebar. For each content type, define how the app should match the entry to a page path:
+          use a slug field and optional prefix for standard paths, or enable advanced matching to
+          build a custom path pattern with entry field values and wildcards.
         </Paragraph>
         <Paragraph>
           <TextLink
@@ -243,10 +257,10 @@ const AssignContentTypeSection = (props: Props) => {
           id="use-trailing-slash"
           isChecked={forceTrailingSlash}
           onChange={trailingSlashHandler}>
-          Use trailing slash for all page paths
+          Append a trailing slash to all page paths
         </Checkbox>
         <Paragraph marginTop="spacing2Xs" marginBottom="none">
-          Applies to standard configurations only. Advanced patterns are used exactly as written.
+          Trailing slash applies to standard configurations only. Advanced patterns are used exactly as written.
         </Paragraph>
       </Box>
       {!loadingContentTypes && !loadingAllContentTypes ? (
@@ -264,6 +278,7 @@ const AssignContentTypeSection = (props: Props) => {
               originalContentTypeRules={originalContentTypeRules}
               rulesMissingPattern={rulesMissingPattern}
               rulesWithUnknownPatternTokens={rulesWithUnknownPatternTokens}
+              rulesWithMissingSelectedPatternTokens={rulesWithMissingSelectedPatternTokens}
               duplicateRuleIds={duplicateRuleIds}
               showPatternValidation={showPatternValidation}
             />

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/ContentTypeWarning.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/ContentTypeWarning.spec.tsx
@@ -14,6 +14,7 @@ describe('Content Type Warning for Config Screen', () => {
       <ContentTypeWarning
         contentTypeId={'test'}
         slugField={'slug'}
+        requiresSlugField={true}
         isSaved={false}
         isInSidebar={false}
         isContentTypeInOptions={true}
@@ -30,6 +31,7 @@ describe('Content Type Warning for Config Screen', () => {
       <ContentTypeWarning
         contentTypeId={'test'}
         slugField={'slug'}
+        requiresSlugField={true}
         isSaved={true}
         isInSidebar={false}
         isContentTypeInOptions={false}
@@ -50,6 +52,7 @@ describe('Content Type Warning for Config Screen', () => {
       <ContentTypeWarning
         contentTypeId={'test'}
         slugField={''}
+        requiresSlugField={true}
         isSaved={false}
         isInSidebar={true}
         isContentTypeInOptions={true}
@@ -70,6 +73,7 @@ describe('Content Type Warning for Config Screen', () => {
       <ContentTypeWarning
         contentTypeId={'test'}
         slugField={'slug'}
+        requiresSlugField={true}
         isSaved={true}
         isInSidebar={true}
         isContentTypeInOptions={true}
@@ -92,6 +96,7 @@ describe('Content Type Warning for Config Screen Flakey', () => {
       <ContentTypeWarning
         contentTypeId={'test'}
         slugField={'slug'}
+        requiresSlugField={true}
         isSaved={true}
         isInSidebar={false}
         isContentTypeInOptions={true}
@@ -103,5 +108,21 @@ describe('Content Type Warning for Config Screen Flakey', () => {
     await user.hover(screen.getByTestId('cf-ui-icon'));
 
     expect(screen.getByRole('tooltip').textContent).toBe(REMOVED_FROM_SIDEBAR_WARNING_MSG);
+  });
+
+  it('does not warn about a missing slug field when advanced matching does not use {slug}', () => {
+    render(
+      <ContentTypeWarning
+        contentTypeId={'test'}
+        slugField={''}
+        requiresSlugField={false}
+        isSaved={false}
+        isInSidebar={true}
+        isContentTypeInOptions={true}
+        isSlugFieldInOptions={false}
+      />
+    );
+
+    expect(screen.getByTestId('noStatus')).toBeInTheDocument();
   });
 });

--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/ContentTypeWarning.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/ContentTypeWarning.tsx
@@ -13,6 +13,7 @@ import WarningDisplay from 'components/config-screen/WarningDisplay/WarningDispl
 interface Props {
   contentTypeId: string;
   slugField: string;
+  requiresSlugField: boolean;
   isSaved: boolean;
   isInSidebar: boolean;
   isContentTypeInOptions: boolean;
@@ -23,6 +24,7 @@ const ContentTypeWarning = (props: Props) => {
   const {
     contentTypeId,
     slugField,
+    requiresSlugField,
     isSaved,
     isInSidebar,
     isContentTypeInOptions,
@@ -36,7 +38,7 @@ const ContentTypeWarning = (props: Props) => {
     let content = '';
 
     // Warning states
-    if (contentTypeId && !slugField) {
+    if (requiresSlugField && contentTypeId && !slugField) {
       setWarningType(WarningTypes.Warning);
       content += NO_SLUG_WARNING_MSG;
     }
@@ -46,7 +48,13 @@ const ContentTypeWarning = (props: Props) => {
       content += REMOVED_FROM_SIDEBAR_WARNING_MSG;
     }
 
-    if (contentTypeId && isContentTypeInOptions && slugField && !isSlugFieldInOptions) {
+    if (
+      requiresSlugField &&
+      contentTypeId &&
+      isContentTypeInOptions &&
+      slugField &&
+      !isSlugFieldInOptions
+    ) {
       setWarningType(WarningTypes.Warning);
       content += getSlugFieldDeletedMsg(contentTypeId, slugField);
     }
@@ -65,6 +73,7 @@ const ContentTypeWarning = (props: Props) => {
   }, [
     contentTypeId,
     slugField,
+    requiresSlugField,
     isSaved,
     isInSidebar,
     isContentTypeInOptions,

--- a/apps/google-analytics-4/frontend/src/components/config-screen/header/AboutSection.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/header/AboutSection.spec.tsx
@@ -6,5 +6,10 @@ describe('About header for the Analytics Config Page', () => {
     render(<AboutSection />);
 
     expect(screen.getByText('About Google Analytics 4 for Contentful')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'The Google Analytics 4 app displays real-time page-based analytics data from your organization’s Google Analytics 4 properties in the editor sidebar of configured content entries.'
+      )
+    ).toBeInTheDocument();
   });
 });

--- a/apps/google-analytics-4/frontend/src/components/config-screen/header/AboutSection.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/header/AboutSection.tsx
@@ -7,7 +7,8 @@ export default function AboutSection() {
       <Heading>About Google Analytics 4 for Contentful</Heading>
       <Paragraph>
         The Google Analytics 4 app displays real-time page-based analytics data from your
-        organization’s Google Analytics 4 properties alongside relevant content entries.
+        organization’s Google Analytics 4 properties in the editor sidebar of configured content
+        entries.
       </Paragraph>
     </Box>
   );

--- a/apps/google-analytics-4/frontend/src/components/main-app/AnalyticsApp/AnalyticsApp.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/AnalyticsApp/AnalyticsApp.spec.tsx
@@ -5,6 +5,7 @@ import { mockSdk, mockCma, validServiceKeyId } from '../../../../test/mocks';
 import runReportResponseHasViews from '../../../../../lambda/public/sampleData/runReportResponseHasViews.json';
 import runReportResponseNoView from '../../../../../lambda/public/sampleData/runReportResponseNoViews.json';
 import {
+  ANALYTICS_DATA_LOAD_ERROR_MSG,
   EMPTY_DATA_MSG,
   getContentTypeSpecificMsg,
 } from 'components/main-app/constants/noteMessages';
@@ -105,11 +106,14 @@ describe('AnalyticsApp with correct content types configured', () => {
 
     const dropdowns = await findAllByTestId(SELECT_TEST_ID);
     const warningNote = getByTestId(NOTE_TEST_ID);
-    const noteText = getByText('api error');
+    const noteText = getByText(
+      ANALYTICS_DATA_LOAD_ERROR_MSG.replace('contact support.', '').trim()
+    );
 
     expect(dropdowns).toHaveLength(2);
     expect(warningNote).toBeVisible();
     expect(noteText).toBeVisible();
+    expect(screen.queryByText('api error')).toBeNull();
   });
 
   it('renders nothing when it has no response', async () => {

--- a/apps/google-analytics-4/frontend/src/components/main-app/AnalyticsApp/AnalyticsApp.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/AnalyticsApp/AnalyticsApp.tsx
@@ -14,6 +14,7 @@ import { Skeleton } from '@contentful/f36-components';
 import { isEmpty } from 'lodash';
 import { RunReportData } from 'apis/apiTypes';
 import { useSidebarRules } from 'hooks/useSidebarRules/useSidebarRules';
+import { convertWildcardPatternToRegex } from 'utils/contentTypeMatching';
 import SlugWarningDisplay from 'components/main-app/SlugWarningDisplay/SlugWarningDisplay';
 import AnalyticsMetricDisplay from 'components/main-app/AnalyticsMetricDisplays/AnalyticsMetricDisplay';
 
@@ -69,6 +70,9 @@ const AnalyticsApp = (props: Props) => {
     warningRule,
     haveLoadedFieldValues,
     haveLoadedPublicationState,
+    localeOptions,
+    selectedLocale,
+    handleLocaleChange,
   } = useSidebarRules(slugFieldRules);
 
   useAutoResizer();
@@ -90,7 +94,10 @@ const AnalyticsApp = (props: Props) => {
               propertyId,
               dimensions: ['date'],
               metrics: [selectedMetric],
-              slug: rule.reportSlug,
+              slug:
+                rule.enableAdvancedMatching && rule.matchType === 'PARTIAL_REGEXP'
+                  ? convertWildcardPatternToRegex(rule.reportSlug)
+                  : rule.reportSlug,
               matchDimension: rule.enableAdvancedMatching ? rule.matchDimension : undefined,
               matchType: rule.enableAdvancedMatching ? rule.matchType : undefined,
             })
@@ -185,6 +192,9 @@ const AnalyticsApp = (props: Props) => {
         selectedDateRange={dateRange}
         selectedMetric={selectedMetric}
         isLoading={loading && !pendingData}
+        localeOptions={localeOptions}
+        selectedLocale={selectedLocale}
+        handleLocaleChange={handleLocaleChange}
       />
     );
   };

--- a/apps/google-analytics-4/frontend/src/components/main-app/AnalyticsMetricDisplays/AnalyticsMetricDisplay.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/AnalyticsMetricDisplays/AnalyticsMetricDisplay.spec.tsx
@@ -37,4 +37,24 @@ describe('Analytics metric display components for the analytics app', () => {
     expect(slug).toBeVisible();
     expect(chart).toBeVisible();
   });
+
+  it('uses the selected metric label when report data has not loaded a metric name', () => {
+    render(
+      <AnalyticsMetricDisplay
+        handleDateRangeChange={() => {}}
+        handleMetricChange={() => {}}
+        handleCustomRangeRequest={() => {}}
+        pageViews={0}
+        metricName=""
+        runReportResponse={runReportResponseHasViews}
+        reportSlug="/en-US"
+        propertyId=""
+        startEndDates={{ start: '2023-03-26', end: '2023-03-27' }}
+        selectedMetric="activeUsers"
+      />
+    );
+
+    expect(getByText('Unique Views')).toBeVisible();
+    expect(screen.queryByText('Undetermined metric')).toBeNull();
+  });
 });

--- a/apps/google-analytics-4/frontend/src/components/main-app/AnalyticsMetricDisplays/AnalyticsMetricDisplay.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/AnalyticsMetricDisplays/AnalyticsMetricDisplay.tsx
@@ -1,7 +1,13 @@
 import ChartFooter from 'components/main-app/ChartFooter/ChartFooter';
 import ChartHeader from 'components/main-app/ChartHeader/ChartHeader';
 import ChartContent from '../ChartContent/ChartContent';
-import { AnalyticsMetricType, RunReportResponse, StartEndDates, DateRangeType } from 'types';
+import {
+  AnalyticsMetricType,
+  RunReportResponse,
+  StartEndDates,
+  DateRangeType,
+  LocaleOption,
+} from 'types';
 import { getExternalUrl } from 'helpers/externalUrlHelpers/externalUrlHelpers';
 
 interface Props {
@@ -20,6 +26,9 @@ interface Props {
   selectedDateRange?: DateRangeType;
   selectedMetric?: AnalyticsMetricType;
   isLoading?: boolean;
+  localeOptions?: LocaleOption[];
+  selectedLocale?: string;
+  handleLocaleChange?: (locale: string) => void;
 }
 
 const AnalyticsMetricDisplay = (props: Props) => {
@@ -39,6 +48,9 @@ const AnalyticsMetricDisplay = (props: Props) => {
     selectedDateRange,
     selectedMetric,
     isLoading = false,
+    localeOptions = [],
+    selectedLocale,
+    handleLocaleChange,
   } = props;
   const safePageViews = Number.isFinite(pageViews) ? pageViews : 0;
 
@@ -50,7 +62,7 @@ const AnalyticsMetricDisplay = (props: Props) => {
   return (
     <>
       <ChartHeader
-        metricName={metricName ? metricName : ''}
+        metricName={metricName || selectedMetric || 'screenPageViews'}
         metricValue={Intl.NumberFormat('en', { notation: 'compact' }).format(safePageViews)}
         handleChange={handleDateRangeChange}
         handleMetricChange={handleMetricChange}
@@ -58,6 +70,9 @@ const AnalyticsMetricDisplay = (props: Props) => {
         startEndDates={startEndDates}
         selectedDateRange={selectedDateRange}
         selectedMetric={selectedMetric}
+        localeOptions={localeOptions}
+        selectedLocale={selectedLocale}
+        handleLocaleChange={handleLocaleChange}
       />
 
       <ChartContent error={error} pageViewData={runReportResponse} isLoading={isLoading} />

--- a/apps/google-analytics-4/frontend/src/components/main-app/ChartContent/ChartContent.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/ChartContent/ChartContent.spec.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import { mockSdk } from '../../../../test/mocks';
 import runReportResponseHasViews from '../../../../../lambda/public/sampleData/runReportResponseHasViews.json';
 import runReportResponseNoView from '../../../../../lambda/public/sampleData/runReportResponseNoViews.json';
-import { EMPTY_DATA_MSG } from '../constants/noteMessages';
+import { ANALYTICS_DATA_LOAD_ERROR_MSG, EMPTY_DATA_MSG } from '../constants/noteMessages';
 import { vi } from 'vitest';
 
 vi.mock('@contentful/react-apps-toolkit', () => ({
@@ -27,9 +27,10 @@ describe('ChartContent component', () => {
       <ChartContent pageViewData={runReportResponseHasViews} error={new Error('api error')} />
     );
 
-    const noteText = getByText('api error');
+    const noteText = getByText(ANALYTICS_DATA_LOAD_ERROR_MSG.replace('contact support.', '').trim());
 
     expect(noteText).toBeVisible();
+    expect(screen.queryByText('api error')).toBeNull();
   });
 
   it('mounts with warning message if empty data', () => {

--- a/apps/google-analytics-4/frontend/src/components/main-app/ChartHeader/ChartHeader.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/ChartHeader/ChartHeader.spec.tsx
@@ -1,5 +1,5 @@
 import ChartHeader from './ChartHeader';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 
 const mockMetricName = 'pageviews';
 const mockMetricValue = '150';
@@ -44,7 +44,33 @@ describe('Chart Header for the analytics app', () => {
     expect(screen.getByRole('option', { name: 'Custom range' })).toBeVisible();
   });
 
-  it('renders custom range summary and action when custom range is selected', () => {
+
+  it('renders a locale selector when locale options are provided', () => {
+    render(
+      <ChartHeader
+        metricName={mockMetricName}
+        metricValue={mockMetricValue}
+        handleChange={handleChange}
+        handleMetricChange={handleMetricChange}
+        handleCustomRangeRequest={handleCustomRangeRequest}
+        startEndDates={startEndDates}
+        selectedLocale="en-US"
+        handleLocaleChange={() => {}}
+        localeOptions={[
+          { code: 'en-US', label: 'English (en-US)' },
+          { code: 'fr-FR', label: 'French (fr-FR)' },
+        ]}
+      />
+    );
+
+    const localeSelect = screen.getByRole('combobox', { name: 'Locale' });
+
+    expect(localeSelect).toHaveValue('en-US');
+    expect(within(localeSelect).getByRole('option', { name: 'English (en-US)' })).toBeVisible();
+    expect(within(localeSelect).getByRole('option', { name: 'French (fr-FR)' })).toBeVisible();
+  });
+
+  it('renders the custom range action without displaying the selected dates', () => {
     render(
       <ChartHeader
         metricName={mockMetricName}
@@ -57,8 +83,8 @@ describe('Chart Header for the analytics app', () => {
       />
     );
 
-    expect(screen.getByText('2026-4-3 to 2026-4-10')).toBeVisible();
     expect(screen.getByRole('button', { name: 'Choose dates' })).toBeVisible();
+    expect(screen.queryByText('2026-4-3 to 2026-4-10')).toBeNull();
   });
 
   it('renders unique views label when active users metric is selected', () => {

--- a/apps/google-analytics-4/frontend/src/components/main-app/ChartHeader/ChartHeader.styles.ts
+++ b/apps/google-analytics-4/frontend/src/components/main-app/ChartHeader/ChartHeader.styles.ts
@@ -18,7 +18,6 @@ export const styles = {
     flexDirection: 'column',
     alignItems: 'flex-end',
     width: '168px',
-    minHeight: '52px',
   }),
   customRangeRowVisible: css({
     visibility: 'visible',
@@ -26,10 +25,6 @@ export const styles = {
   customRangeRowHidden: css({
     visibility: 'hidden',
     pointerEvents: 'none',
-  }),
-  customRangeSummary: css({
-    fontSize: tokens.fontSizeS,
-    textAlign: 'right',
   }),
   customRangeButton: css({
     width: '168px',

--- a/apps/google-analytics-4/frontend/src/components/main-app/ChartHeader/ChartHeader.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/ChartHeader/ChartHeader.tsx
@@ -6,9 +6,8 @@ import {
   Flex,
   Paragraph,
   Select,
-  Text,
 } from '@contentful/f36-components';
-import { AnalyticsMetricType, DateRangeType, StartEndDates } from 'types';
+import { AnalyticsMetricType, DateRangeType, LocaleOption, StartEndDates } from 'types';
 import { DATE_RANGE_SELECT_OPTIONS, DateRange } from 'helpers/DateRangeHelpers/DateRangeHelpers';
 import { styles } from './ChartHeader.styles';
 
@@ -21,6 +20,9 @@ interface Props {
   startEndDates: StartEndDates;
   selectedDateRange?: DateRangeType;
   selectedMetric?: AnalyticsMetricType;
+  localeOptions?: LocaleOption[];
+  selectedLocale?: string;
+  handleLocaleChange?: (locale: string) => void;
 }
 
 const getMetricDisplayString = (_metricName: string) => {
@@ -30,7 +32,7 @@ const getMetricDisplayString = (_metricName: string) => {
     case 'activeUsers':
       return 'Unique Views';
     default:
-      return 'Undetermined metric';
+      return 'Total Views';
   }
 };
 
@@ -41,9 +43,11 @@ const ChartHeader = (props: Props) => {
     handleChange,
     handleMetricChange,
     handleCustomRangeRequest,
-    startEndDates,
     selectedDateRange,
     selectedMetric = 'screenPageViews',
+    localeOptions = [],
+    selectedLocale = '',
+    handleLocaleChange,
   } = props;
   const [dateSelection, setDateSelection] = useState<DateRangeType>('lastWeek');
   const [metricSelection, setMetricSelection] = useState<AnalyticsMetricType>(selectedMetric);
@@ -63,6 +67,10 @@ const ChartHeader = (props: Props) => {
     const nextMetric = event.target.value as AnalyticsMetricType;
     setMetricSelection(nextMetric);
     handleMetricChange(nextMetric);
+  };
+
+  const handleLocaleSelect = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    handleLocaleChange?.(event.target.value);
   };
 
   useEffect(() => {
@@ -86,6 +94,21 @@ const ChartHeader = (props: Props) => {
         <Paragraph marginBottom="none">{getMetricDisplayString(metricName)}</Paragraph>
       </Box>
       <Flex flexDirection="column" className={styles.controls}>
+        {localeOptions.length > 0 && handleLocaleChange && (
+          <Select
+            className={styles.root}
+            id="locale"
+            name="locale"
+            aria-label="Locale"
+            value={selectedLocale}
+            onChange={handleLocaleSelect}>
+            {localeOptions.map((option) => (
+              <Select.Option key={option.code} value={option.code}>
+                {option.label}
+              </Select.Option>
+            ))}
+          </Select>
+        )}
         <Select
           className={styles.root}
           id="metric"
@@ -113,9 +136,6 @@ const ChartHeader = (props: Props) => {
               ? styles.customRangeRowVisible
               : styles.customRangeRowHidden
           }`}>
-          <Text fontColor="gray700" className={styles.customRangeSummary}>
-            {startEndDates.start} to {startEndDates.end}
-          </Text>
           <Button
             size="small"
             variant="secondary"

--- a/apps/google-analytics-4/frontend/src/components/main-app/ErrorDisplay/CommonErrorDisplays.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/ErrorDisplay/CommonErrorDisplays.tsx
@@ -15,9 +15,13 @@ export const AppConfigPageHyperLink = (props: AppConfigPageHyperLinkProps) => {
   return <HyperLink body={bodyMsg} substring="app configuration page." onClick={openConfigPage} />;
 };
 
-export const SupportHyperLink = () => (
+interface SupportHyperLinkProps {
+  bodyMsg?: string;
+}
+
+export const SupportHyperLink = ({ bodyMsg = DEFAULT_ERR_MSG }: SupportHyperLinkProps) => (
   <HyperLink
-    body={DEFAULT_ERR_MSG}
+    body={bodyMsg}
     substring="contact support."
     hyperLinkHref="https://www.contentful.com/support/?utm_source=webapp&utm_medium=help-menu&utm_campaign=in-app-help"
   />

--- a/apps/google-analytics-4/frontend/src/components/main-app/ErrorDisplay/ErrorDisplay.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/ErrorDisplay/ErrorDisplay.spec.tsx
@@ -2,7 +2,7 @@ import ErrorDisplay from './ErrorDisplay';
 import { render, screen } from '@testing-library/react';
 import { mockSdk } from '../../../../test/mocks';
 import {
-  DEFAULT_ERR_MSG,
+  ANALYTICS_DATA_LOAD_ERROR_MSG,
   INVALID_ARGUMENT_MSG,
   INVALID_SERVICE_ACCOUNT,
   PERMISSION_DENIED_MSG,
@@ -72,7 +72,9 @@ describe('ErrorDisplay', () => {
       />
     );
 
-    const warningMsg = await findByText(DEFAULT_ERR_MSG.replace(HYPER_LINK_COPY, '').trim());
+    const warningMsg = await findByText(
+      ANALYTICS_DATA_LOAD_ERROR_MSG.replace(HYPER_LINK_COPY, '').trim()
+    );
     const hyperLink = getByTestId('cf-ui-text-link');
 
     expect(warningMsg).toBeVisible();
@@ -127,7 +129,8 @@ describe('ErrorDisplay', () => {
     expect(hyperLink).toBeVisible();
   });
 
-  it('mounts with correct msg when error is of ApiError class but not an Error type explicitely handled', async () => {
+  it('shows a user-facing support message for unhandled API errors', async () => {
+    const HYPER_LINK_COPY = 'contact support.';
     const INTERNAL_ERR_MSG = 'Internal Server Error';
     render(
       <ErrorDisplay
@@ -142,17 +145,28 @@ describe('ErrorDisplay', () => {
       />
     );
 
-    const warningMsg = await findByText(INTERNAL_ERR_MSG);
+    const warningMsg = await findByText(
+      ANALYTICS_DATA_LOAD_ERROR_MSG.replace(HYPER_LINK_COPY, '').trim()
+    );
+    const hyperLink = getByTestId('cf-ui-text-link');
 
     expect(warningMsg).toBeVisible();
+    expect(hyperLink).toBeVisible();
+    expect(screen.queryByText(INTERNAL_ERR_MSG)).toBeNull();
   });
 
-  it('mounts with correct msg when error is not a specified Api Error Type ', async () => {
-    const ERR_MSG = 'random error';
+  it('shows a user-facing support message for unexpected errors', async () => {
+    const HYPER_LINK_COPY = 'contact support.';
+    const ERR_MSG = 'Request does not have a valid request signature.';
     render(<ErrorDisplay error={new Error(ERR_MSG)} />);
 
-    const warningMsg = await findByText(ERR_MSG);
+    const warningMsg = await findByText(
+      ANALYTICS_DATA_LOAD_ERROR_MSG.replace(HYPER_LINK_COPY, '').trim()
+    );
+    const hyperLink = getByTestId('cf-ui-text-link');
 
     expect(warningMsg).toBeVisible();
+    expect(hyperLink).toBeVisible();
+    expect(screen.queryByText(ERR_MSG)).toBeNull();
   });
 });

--- a/apps/google-analytics-4/frontend/src/components/main-app/ErrorDisplay/ErrorDisplay.tsx
+++ b/apps/google-analytics-4/frontend/src/components/main-app/ErrorDisplay/ErrorDisplay.tsx
@@ -5,6 +5,7 @@ import {
   INVALID_ARGUMENT_MSG,
   PERMISSION_DENIED_MSG,
   INVALID_SERVICE_ACCOUNT,
+  ANALYTICS_DATA_LOAD_ERROR_MSG,
 } from 'components/main-app/constants/noteMessages';
 import { AppConfigPageHyperLink, SupportHyperLink } from './CommonErrorDisplays';
 
@@ -22,12 +23,14 @@ const ErrorDisplay = (props: Props) => {
   const [errorBody, setErrorBody] = useState<HyperLinkErrorDisplays | string>('');
 
   const hyperLinkErrorDisplays = {
-    supportHyperLink: <SupportHyperLink />,
+    supportHyperLink: <SupportHyperLink bodyMsg={ANALYTICS_DATA_LOAD_ERROR_MSG} />,
     appConfigPageHyperLink: <AppConfigPageHyperLink bodyMsg={INVALID_ARGUMENT_MSG} />,
     invalidServiceAccount: <AppConfigPageHyperLink bodyMsg={INVALID_SERVICE_ACCOUNT} />,
   };
 
   useEffect(() => {
+    const hideRawError = () => setErrorBody('supportHyperLink');
+
     const handleApiError = (e: ApiErrorType) => {
       switch (e.errorType) {
         case ERROR_TYPE_MAP.invalidProperty:
@@ -44,19 +47,19 @@ const ErrorDisplay = (props: Props) => {
           setErrorBody('invalidServiceAccount');
           break;
         default:
-          setErrorBody(e.message || 'supportHyperLink');
+          hideRawError();
       }
     };
     if (isApiErrorType(error)) handleApiError(error);
     else {
-      setErrorBody(error.message || 'supportHyperLink');
+      hideRawError();
     }
   }, [error]);
 
   return (
     <Note
       body={hyperLinkErrorDisplays[errorBody as HyperLinkErrorDisplays] ?? errorBody}
-      variant="negative"
+      variant="warning"
     />
   );
 };

--- a/apps/google-analytics-4/frontend/src/components/main-app/constants/noteMessages.ts
+++ b/apps/google-analytics-4/frontend/src/components/main-app/constants/noteMessages.ts
@@ -1,5 +1,7 @@
 export const DEFAULT_ERR_MSG =
   'An unknown error has occurred. Please try again or contact support.';
+export const ANALYTICS_DATA_LOAD_ERROR_MSG =
+  "We couldn't load Google Analytics data. Please try again, or contact support.";
 export const EMPTY_DATA_MSG =
   'There are no page views to show for this range. If this is not expected, ensure the URL prefix and slug value accurately reflect a page path within your Google Analytics account.';
 export const INVALID_ARGUMENT_MSG =

--- a/apps/google-analytics-4/frontend/src/helpers/contentTypeHelpers/contentTypeHelpers.spec.ts
+++ b/apps/google-analytics-4/frontend/src/helpers/contentTypeHelpers/contentTypeHelpers.spec.ts
@@ -76,9 +76,7 @@ describe('contentTypeHelpers', () => {
     const fields = result['layout'].fields;
 
     expect(Object.keys(result).length).toEqual(1);
-    // Fields that are not short text or short text list should be removed
-    expect(fields.length).toEqual(3);
-    // Fields should be sorted alphabetically
-    expect(fields[0].id).toEqual('slug');
+    // Fields that cannot be represented in URLs should be removed
+    expect(fields.map((field) => field.id)).toEqual(['duration', 'slug', 'tags', 'title']);
   });
 });

--- a/apps/google-analytics-4/frontend/src/helpers/contentTypeHelpers/contentTypeHelpers.ts
+++ b/apps/google-analytics-4/frontend/src/helpers/contentTypeHelpers/contentTypeHelpers.ts
@@ -7,6 +7,11 @@ interface FieldItem {
   type: string;
 }
 
+interface CompatibleField {
+  type: string;
+  items?: FieldItem;
+}
+
 export const generateEditorInterfaceAssignments = (
   currentEditorInterface: Partial<EditorInterface>,
   contentTypeIds: string[],
@@ -41,10 +46,14 @@ export const generateEditorInterfaceAssignments = (
   return { ...newAssignments, ...assignmentsToAdd };
 };
 
-// only include short text and short text list fields in the slug field dropdown
-const isCompatibleFieldType = (field: ContentTypeField): boolean => {
+export const isSlugFieldType = (field: CompatibleField): boolean => {
   const isArray = field.type === 'Array';
-  return field.type === 'Symbol' || (isArray && (field.items as FieldItem).type === 'Symbol');
+  return field.type === 'Symbol' || (isArray && field.items?.type === 'Symbol');
+};
+
+// only include fields that can be represented in URL path or query segments
+export const isUrlPatternFieldType = (field: CompatibleField): boolean => {
+  return isSlugFieldType(field) || field.type === 'Integer';
 };
 
 export const sortAndFormatAllContentTypes = (
@@ -53,7 +62,7 @@ export const sortAndFormatAllContentTypes = (
   const sortedContentTypes = sortBy(contentTypeItems, ['name']);
 
   const formattedContentTypes = sortedContentTypes.reduce((acc: AllContentTypes, contentType) => {
-    const fields = sortBy(contentType.fields.filter(isCompatibleFieldType), ['name']);
+    const fields = sortBy(contentType.fields.filter(isUrlPatternFieldType), ['name']);
 
     if (fields.length) {
       acc[contentType.sys.id] = {

--- a/apps/google-analytics-4/frontend/src/helpers/contentTypeRules/contentTypeRules.spec.ts
+++ b/apps/google-analytics-4/frontend/src/helpers/contentTypeRules/contentTypeRules.spec.ts
@@ -61,7 +61,7 @@ describe('contentTypeRules normalization', () => {
         slugField: '',
         urlPrefix: '',
         enableAdvancedMatching: true,
-        pathPattern: '/shop/products/{slug}/compare/.*',
+        pathPattern: '/shop/products/{slug}/compare/*',
         additionalFieldIds: ['slug'],
         matchDimension: 'unifiedPagePathScreen',
         matchType: 'EXACT',

--- a/apps/google-analytics-4/frontend/src/helpers/contentTypeRules/contentTypeRules.spec.ts
+++ b/apps/google-analytics-4/frontend/src/helpers/contentTypeRules/contentTypeRules.spec.ts
@@ -2,6 +2,25 @@ import { describe, expect, it } from 'vitest';
 import { normalizeContentTypeRules } from './contentTypeRules';
 
 describe('contentTypeRules normalization', () => {
+  it('preserves an explicitly disabled advanced rule even when advanced values are present', () => {
+    const [rule] = normalizeContentTypeRules([
+      {
+        id: 'saved-rule',
+        contentTypeId: 'searchPage',
+        slugField: 'slug',
+        urlPrefix: '',
+        enableAdvancedMatching: false,
+        pathPattern: '/search/{slug}?category={category}',
+        additionalFieldIds: ['category'],
+        matchDimension: 'pagePathPlusQueryString',
+        matchType: 'EXACT',
+      },
+    ]);
+
+    expect(rule.enableAdvancedMatching).toBe(false);
+    expect(rule.pathPattern).toBe('/search/{slug}?category={category}');
+  });
+
   it('marks legacy advanced-looking content type rules as advanced', () => {
     const [rule] = normalizeContentTypeRules([
       {
@@ -9,7 +28,6 @@ describe('contentTypeRules normalization', () => {
         contentTypeId: 'searchPage',
         slugField: 'slug',
         urlPrefix: '',
-        enableAdvancedMatching: false,
         pathPattern: '/search/{slug}?category={category}',
         additionalFieldIds: ['category'],
         matchDimension: 'pagePathPlusQueryString',

--- a/apps/google-analytics-4/frontend/src/helpers/contentTypeRules/contentTypeRules.spec.ts
+++ b/apps/google-analytics-4/frontend/src/helpers/contentTypeRules/contentTypeRules.spec.ts
@@ -52,4 +52,22 @@ describe('contentTypeRules normalization', () => {
 
     expect(rule.enableAdvancedMatching).toBe(true);
   });
+
+  it('infers regex matching from advanced patterns during normalization', () => {
+    const [rule] = normalizeContentTypeRules([
+      {
+        id: 'regex-rule',
+        contentTypeId: 'comparePage',
+        slugField: '',
+        urlPrefix: '',
+        enableAdvancedMatching: true,
+        pathPattern: '/shop/products/{slug}/compare/.*',
+        additionalFieldIds: ['slug'],
+        matchDimension: 'unifiedPagePathScreen',
+        matchType: 'EXACT',
+      },
+    ]);
+
+    expect(rule.matchType).toBe('PARTIAL_REGEXP');
+  });
 });

--- a/apps/google-analytics-4/frontend/src/helpers/contentTypeRules/contentTypeRules.ts
+++ b/apps/google-analytics-4/frontend/src/helpers/contentTypeRules/contentTypeRules.ts
@@ -1,5 +1,8 @@
 import { ContentTypeRule, ContentTypeRules, ContentTypes, ContentTypeValue } from 'types';
-import { hasAdvancedMatchingConfigured } from 'utils/contentTypeMatching';
+import {
+  hasAdvancedMatchingConfigured,
+  inferMatchTypeFromPattern,
+} from 'utils/contentTypeMatching';
 
 const createRuleId = () =>
   typeof crypto !== 'undefined' && 'randomUUID' in crypto
@@ -30,7 +33,10 @@ export const createRuleFromContentType = (
   enableAdvancedMatching: hasAdvancedMatchingConfigured(value),
   pathPattern: value.pathPattern || '',
   matchDimension: value.matchDimension || 'unifiedPagePathScreen',
-  matchType: value.matchType || 'EXACT',
+  matchType:
+    hasAdvancedMatchingConfigured(value) && value.pathPattern
+      ? inferMatchTypeFromPattern(value.pathPattern)
+      : value.matchType || 'EXACT',
 });
 
 export const migrateContentTypesToRules = (contentTypes?: ContentTypes): ContentTypeRules => {
@@ -55,6 +61,10 @@ export const normalizeContentTypeRules = (
 
         return {
           ...normalizedRule,
+          matchType:
+            normalizedRule.enableAdvancedMatching && normalizedRule.pathPattern
+              ? inferMatchTypeFromPattern(normalizedRule.pathPattern)
+              : normalizedRule.matchType ?? 'EXACT',
           enableAdvancedMatching:
             rule.enableAdvancedMatching ?? hasAdvancedMatchingConfigured(normalizedRule),
         };
@@ -74,20 +84,24 @@ export const getUniqueContentTypeIds = (contentTypeRules: ContentTypeRules) =>
   );
 
 const getRuleValidationSignature = (rule: ContentTypeRule) => {
-  if (!rule.contentTypeId || !rule.slugField) {
+  if (!rule.contentTypeId) {
     return null;
   }
 
   if (rule.enableAdvancedMatching) {
     return JSON.stringify({
       contentTypeId: rule.contentTypeId,
-      slugField: rule.slugField,
+      slugField: rule.slugField || '',
       enableAdvancedMatching: true,
       pathPattern: rule.pathPattern?.trim() ?? '',
       additionalFieldIds: [...(rule.additionalFieldIds ?? [])].sort(),
       matchDimension: rule.matchDimension ?? 'unifiedPagePathScreen',
-      matchType: rule.matchType ?? 'EXACT',
+      matchType: inferMatchTypeFromPattern(rule.pathPattern ?? ''),
     });
+  }
+
+  if (!rule.slugField) {
+    return null;
   }
 
   return JSON.stringify({

--- a/apps/google-analytics-4/frontend/src/helpers/contentTypeRules/contentTypeRules.ts
+++ b/apps/google-analytics-4/frontend/src/helpers/contentTypeRules/contentTypeRules.ts
@@ -55,7 +55,8 @@ export const normalizeContentTypeRules = (
 
         return {
           ...normalizedRule,
-          enableAdvancedMatching: hasAdvancedMatchingConfigured(normalizedRule),
+          enableAdvancedMatching:
+            rule.enableAdvancedMatching ?? hasAdvancedMatchingConfigured(normalizedRule),
         };
       })(),
       id: rule.id || createRuleId(),
@@ -71,3 +72,49 @@ export const getUniqueContentTypeIds = (contentTypeRules: ContentTypeRules) =>
       contentTypeRules.map((rule) => rule.contentTypeId).filter((contentTypeId) => contentTypeId)
     )
   );
+
+const getRuleValidationSignature = (rule: ContentTypeRule) => {
+  if (!rule.contentTypeId || !rule.slugField) {
+    return null;
+  }
+
+  if (rule.enableAdvancedMatching) {
+    return JSON.stringify({
+      contentTypeId: rule.contentTypeId,
+      slugField: rule.slugField,
+      enableAdvancedMatching: true,
+      pathPattern: rule.pathPattern?.trim() ?? '',
+      additionalFieldIds: [...(rule.additionalFieldIds ?? [])].sort(),
+      matchDimension: rule.matchDimension ?? 'unifiedPagePathScreen',
+      matchType: rule.matchType ?? 'EXACT',
+    });
+  }
+
+  return JSON.stringify({
+    contentTypeId: rule.contentTypeId,
+    slugField: rule.slugField,
+    enableAdvancedMatching: false,
+    urlPrefix: rule.urlPrefix?.trim() ?? '',
+  });
+};
+
+export const getDuplicateRuleIds = (contentTypeRules: ContentTypeRules) => {
+  const signatureToRuleIds = new Map<string, string[]>();
+
+  contentTypeRules.forEach((rule) => {
+    const signature = getRuleValidationSignature(rule);
+
+    if (!signature) {
+      return;
+    }
+
+    const existingRuleIds = signatureToRuleIds.get(signature) ?? [];
+    signatureToRuleIds.set(signature, [...existingRuleIds, rule.id]);
+  });
+
+  return new Set(
+    Array.from(signatureToRuleIds.values())
+      .filter((ruleIds) => ruleIds.length > 1)
+      .flat()
+  );
+};

--- a/apps/google-analytics-4/frontend/src/hooks/useSidebarRules/useSidebarRules.spec.tsx
+++ b/apps/google-analytics-4/frontend/src/hooks/useSidebarRules/useSidebarRules.spec.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { useSDK } from '@contentful/react-apps-toolkit';
+import { ContentTypeRule } from 'types';
+import { useSidebarRules } from './useSidebarRules';
+import { vi } from 'vitest';
+
+vi.mock('@contentful/react-apps-toolkit', () => ({ useSDK: vi.fn() }));
+
+const localeRule: ContentTypeRule = {
+  id: 'rule-1',
+  contentTypeId: 'article',
+  slugField: 'slug',
+  urlPrefix: '',
+  enableAdvancedMatching: true,
+  pathPattern: '/{locale}/{slug}',
+  additionalFieldIds: [],
+  matchDimension: 'unifiedPagePathScreen',
+  matchType: 'EXACT',
+};
+
+const defaultRules = [localeRule];
+
+const TestComponent = ({ rules = defaultRules }: { rules?: ContentTypeRule[] }) => {
+  const { validRules, selectedLocale, localeOptions } = useSidebarRules(rules);
+
+  return (
+    <>
+      <div>selectedLocale: {selectedLocale}</div>
+      <div>reportSlug: {validRules[0]?.reportSlug || ''}</div>
+      <div>localeOptions: {localeOptions.map((option) => option.label).join('|')}</div>
+    </>
+  );
+};
+
+const createMockSdk = ({ focused, active }: { focused?: string; active?: string[] }) => ({
+  parameters: {
+    installation: {
+      forceTrailingSlash: false,
+    },
+  },
+  locales: {
+    available: ['fr-FR', 'en-US', 'de-DE'],
+    default: 'en-US',
+    names: {
+      'fr-FR': 'French',
+      'en-US': 'English',
+      'de-DE': 'German',
+    },
+    fallbacks: {},
+    optional: {},
+    direction: {},
+  },
+  editor: {
+    getLocaleSettings: vi.fn(() => ({ focused, active })),
+    onLocaleSettingsChanged: vi.fn((callback) => {
+      callback({ focused, active });
+      return vi.fn();
+    }),
+  },
+  entry: {
+    onSysChanged: vi.fn((callback) => {
+      callback({ publishedAt: '2026-04-16T00:00:00.000Z' });
+      return vi.fn();
+    }),
+    fields: {
+      slug: {
+        locales: ['en-US', 'fr-FR', 'de-DE'],
+        getValue: vi.fn((locale?: string) => {
+          if (locale === 'de-DE') return 'produkt';
+          if (locale === 'fr-FR') return 'produit';
+          return 'product';
+        }),
+        onValueChanged: vi.fn(() => vi.fn()),
+      },
+    },
+  },
+});
+
+describe('useSidebarRules', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses the focused editor locale for locale pattern tokens', async () => {
+    vi.mocked(useSDK).mockReturnValue(
+      createMockSdk({ focused: 'de-DE', active: ['fr-FR'] }) as any
+    );
+
+    render(<TestComponent />);
+
+    expect(await screen.findByText('selectedLocale: de-DE')).toBeVisible();
+    expect(await screen.findByText('reportSlug: /de-DE/produkt')).toBeVisible();
+  });
+
+  it('falls back to the active editor locale and sorts locale options alphabetically', async () => {
+    vi.mocked(useSDK).mockReturnValue(createMockSdk({ active: ['fr-FR'] }) as any);
+
+    render(<TestComponent />);
+
+    expect(await screen.findByText('selectedLocale: fr-FR')).toBeVisible();
+    expect(await screen.findByText('reportSlug: /fr-FR/produit')).toBeVisible();
+    expect(
+      screen.getByText('localeOptions: English (en-US)|French (fr-FR)|German (de-DE)')
+    ).toBeVisible();
+  });
+});

--- a/apps/google-analytics-4/frontend/src/hooks/useSidebarRules/useSidebarRules.tsx
+++ b/apps/google-analytics-4/frontend/src/hooks/useSidebarRules/useSidebarRules.tsx
@@ -1,13 +1,18 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useSDK } from '@contentful/react-apps-toolkit';
-import { ContentEntitySys, SidebarExtensionSDK } from '@contentful/app-sdk';
-import { AppInstallationParameters, ContentTypeRule } from 'types';
+import {
+  ContentEntitySys,
+  EditorLocaleSettings,
+  LocalesAPI,
+  SidebarExtensionSDK,
+} from '@contentful/app-sdk';
+import { AppInstallationParameters, ContentTypeRule, LocaleOption } from 'types';
 import { getPatternTokens } from 'utils/contentTypeMatching';
 import { getReportSlug } from 'utils/getReportSlug';
 
 interface ResolvedSidebarRule extends ContentTypeRule {
   reportSlug: string;
-  slugFieldValue: string | object;
+  slugFieldValue: string | number | object;
   slugFieldIsConfigured: boolean;
   contentTypeHasSlugField: boolean;
   contentTypeHasAllFields: boolean;
@@ -15,34 +20,130 @@ interface ResolvedSidebarRule extends ContentTypeRule {
 }
 
 const SLUG_FIELD_INPUT_DELAY = 500;
+const LOCALE_PATTERN_TOKEN = 'locale';
+const SLUG_PATTERN_TOKEN = 'slug';
+const RESERVED_PATTERN_TOKENS = new Set([LOCALE_PATTERN_TOKEN, SLUG_PATTERN_TOKEN]);
+
+const getPatternFieldTokens = (rule: ContentTypeRule) =>
+  rule.enableAdvancedMatching
+    ? getPatternTokens(rule.pathPattern).filter((token) => !RESERVED_PATTERN_TOKENS.has(token))
+    : [];
+
+const getSortedLocaleOptions = (locales?: LocalesAPI): LocaleOption[] =>
+  [...(locales?.available || [])]
+    .map((code) => ({
+      code,
+      label: locales?.names?.[code] ? `${locales.names[code]} (${code})` : code,
+    }))
+    .sort((left, right) => left.label.localeCompare(right.label));
+
+const getPreferredLocale = (
+  localeSettings: EditorLocaleSettings | undefined,
+  locales?: LocalesAPI
+) => {
+  const availableLocales = locales?.available || [];
+  const availableLocaleSet = new Set(availableLocales);
+  const candidateLocales = [
+    localeSettings?.focused,
+    ...(localeSettings?.active || []),
+    locales?.default,
+    ...availableLocales,
+  ].filter((locale): locale is string => Boolean(locale));
+
+  return (
+    candidateLocales.find(
+      (locale) => availableLocaleSet.size === 0 || availableLocaleSet.has(locale)
+    ) || ''
+  );
+};
+
+const readFieldValue = (fieldApi: any, selectedLocale: string) => {
+  const hasSelectedLocale =
+    selectedLocale && Array.isArray(fieldApi.locales) && fieldApi.locales.includes(selectedLocale);
+
+  if (hasSelectedLocale) {
+    return fieldApi.getValue(selectedLocale) ?? '';
+  }
+
+  return fieldApi.getValue() ?? '';
+};
+
+const onFieldValueChanged = (
+  fieldApi: any,
+  selectedLocale: string,
+  callback: (value: string | number | object) => void
+) => {
+  const hasSelectedLocale =
+    selectedLocale && Array.isArray(fieldApi.locales) && fieldApi.locales.includes(selectedLocale);
+
+  if (hasSelectedLocale) {
+    return fieldApi.onValueChanged(selectedLocale, callback);
+  }
+
+  return fieldApi.onValueChanged(callback);
+};
 
 export const useSidebarRules = (slugFieldRules: ContentTypeRule[]) => {
   const sdk = useSDK<SidebarExtensionSDK>();
   const { forceTrailingSlash } = sdk.parameters.installation as AppInstallationParameters;
   const entryFields = sdk.entry?.fields ?? {};
+  const localeOptions = useMemo(() => getSortedLocaleOptions(sdk.locales), [sdk.locales]);
+  const [selectedLocale, setSelectedLocale] = useState(() =>
+    getPreferredLocale(sdk.editor?.getLocaleSettings?.(), sdk.locales)
+  );
 
   const [isPublished, setIsPublished] = useState(false);
   const [haveLoadedPublicationState, setHaveLoadedPublicationState] = useState(false);
-  const [fieldValues, setFieldValues] = useState<Record<string, string | object>>({});
-  const [debouncedFieldValues, setDebouncedFieldValues] = useState<Record<string, string | object>>(
-    {}
-  );
+  const [fieldValues, setFieldValues] = useState<Record<string, string | number | object>>({});
+  const [debouncedFieldValues, setDebouncedFieldValues] = useState<
+    Record<string, string | number | object>
+  >({});
   const [haveLoadedFieldValues, setHaveLoadedFieldValues] = useState(false);
+  const usesLocaleToken = useMemo(
+    () =>
+      slugFieldRules.some(
+        (rule) =>
+          rule.enableAdvancedMatching &&
+          getPatternTokens(rule.pathPattern).includes(LOCALE_PATTERN_TOKEN)
+      ),
+    [slugFieldRules]
+  );
   const relevantFieldIds = useMemo(
     () =>
       Array.from(
         new Set(
           slugFieldRules
-            .flatMap((rule) => [
-              rule.slugField,
-              ...(rule.additionalFieldIds || []),
-              ...(rule.enableAdvancedMatching ? getPatternTokens(rule.pathPattern) : []),
-            ])
+            .flatMap((rule) => {
+              const patternTokens = rule.enableAdvancedMatching
+                ? getPatternTokens(rule.pathPattern)
+                : [];
+              const usesSlugToken =
+                !rule.enableAdvancedMatching || patternTokens.includes(SLUG_PATTERN_TOKEN);
+
+              return [
+                usesSlugToken ? rule.slugField : '',
+                ...(rule.additionalFieldIds || []),
+                ...getPatternFieldTokens(rule),
+              ];
+            })
             .filter((fieldId) => fieldId)
         )
       ),
     [slugFieldRules]
   );
+
+  useEffect(() => {
+    if (!sdk.editor?.onLocaleSettingsChanged) {
+      const fallbackLocale = getPreferredLocale(sdk.editor?.getLocaleSettings?.(), sdk.locales);
+      if (fallbackLocale) setSelectedLocale(fallbackLocale);
+      return;
+    }
+
+    return sdk.editor.onLocaleSettingsChanged((localeSettings) => {
+      const nextLocale = getPreferredLocale(localeSettings, sdk.locales);
+      if (nextLocale) setSelectedLocale(nextLocale);
+    });
+  }, [sdk.editor, sdk.locales]);
 
   useEffect(() => {
     const timeout = setTimeout(() => setDebouncedFieldValues(fieldValues), SLUG_FIELD_INPUT_DELAY);
@@ -64,7 +165,7 @@ export const useSidebarRules = (slugFieldRules: ContentTypeRule[]) => {
 
   useEffect(() => {
     const unsubscribers: Array<() => void> = [];
-    const initialFieldValues: Record<string, string | object> = {};
+    const initialFieldValues: Record<string, string | number | object> = {};
 
     setHaveLoadedFieldValues(false);
 
@@ -73,11 +174,11 @@ export const useSidebarRules = (slugFieldRules: ContentTypeRule[]) => {
       if (!fieldApi) return;
 
       if (typeof fieldApi.getValue === 'function') {
-        initialFieldValues[fieldId] = fieldApi.getValue() ?? '';
+        initialFieldValues[fieldId] = readFieldValue(fieldApi, selectedLocale);
       }
 
       if (typeof fieldApi.onValueChanged === 'function') {
-        const detach = fieldApi.onValueChanged((value: string | object) => {
+        const detach = onFieldValueChanged(fieldApi, selectedLocale, (value) => {
           setFieldValues((prev) => ({ ...prev, [fieldId]: value ?? '' }));
         });
         if (typeof detach === 'function') unsubscribers.push(detach);
@@ -89,16 +190,21 @@ export const useSidebarRules = (slugFieldRules: ContentTypeRule[]) => {
     setHaveLoadedFieldValues(true);
 
     return () => unsubscribers.forEach((unsubscribe) => unsubscribe());
-  }, [entryFields, relevantFieldIds]);
+  }, [entryFields, relevantFieldIds, selectedLocale]);
 
   const resolvedRules = useMemo<ResolvedSidebarRule[]>(
     () =>
       slugFieldRules.map((rule) => {
-        const slugFieldValue = debouncedFieldValues[rule.slugField] ?? '';
+        const patternTokens = rule.enableAdvancedMatching
+          ? getPatternTokens(rule.pathPattern)
+          : [];
+        const requiresSlugField =
+          !rule.enableAdvancedMatching || patternTokens.includes(SLUG_PATTERN_TOKEN);
+        const slugFieldValue = requiresSlugField ? debouncedFieldValues[rule.slugField] ?? '' : '';
         const slugFieldIsConfigured = Boolean(rule.slugField);
-        const contentTypeHasSlugField = !rule.slugField || rule.slugField in entryFields;
+        const contentTypeHasSlugField =
+          !requiresSlugField || !rule.slugField || rule.slugField in entryFields;
         const additionalFieldIds = rule.additionalFieldIds || [];
-        const patternTokens = rule.enableAdvancedMatching ? getPatternTokens(rule.pathPattern) : [];
         const requiredFieldIds = new Set(additionalFieldIds);
 
         if (!rule.enableAdvancedMatching && rule.slugField) {
@@ -113,7 +219,9 @@ export const useSidebarRules = (slugFieldRules: ContentTypeRule[]) => {
             fieldId,
             debouncedFieldValues[fieldId] ?? '',
           ])
-        ) as Record<string, string | object>;
+        ) as Record<string, string | number | object>;
+
+        tokenValues.locale = selectedLocale;
 
         if (rule.slugField && !('slug' in tokenValues)) {
           tokenValues.slug = slugFieldValue;
@@ -122,7 +230,9 @@ export const useSidebarRules = (slugFieldRules: ContentTypeRule[]) => {
         const requiredTokenValues = rule.enableAdvancedMatching
           ? patternTokens.map((token) => tokenValues[token as keyof typeof tokenValues] ?? '')
           : [slugFieldValue];
-        const hasAllRequiredTokenValues = requiredTokenValues.every((value) => Boolean(value));
+        const hasAllRequiredTokenValues = requiredTokenValues.every(
+          (value) => value !== undefined && value !== null && value !== ''
+        );
         const isValidRule = rule.enableAdvancedMatching
           ? contentTypeHasAllFields && hasAllRequiredTokenValues && isPublished
           : slugFieldIsConfigured &&
@@ -140,7 +250,14 @@ export const useSidebarRules = (slugFieldRules: ContentTypeRule[]) => {
           reportSlug: getReportSlug(rule, tokenValues, forceTrailingSlash),
         };
       }),
-    [debouncedFieldValues, entryFields, forceTrailingSlash, isPublished, slugFieldRules]
+    [
+      debouncedFieldValues,
+      entryFields,
+      forceTrailingSlash,
+      isPublished,
+      selectedLocale,
+      slugFieldRules,
+    ]
   );
 
   const validRules = useMemo(
@@ -165,5 +282,8 @@ export const useSidebarRules = (slugFieldRules: ContentTypeRule[]) => {
     summaryLabel,
     isContentTypeWarning: validRules.length === 0,
     warningRule: fallbackRule,
+    localeOptions: usesLocaleToken ? localeOptions : [],
+    selectedLocale,
+    handleLocaleChange: setSelectedLocale,
   };
 };

--- a/apps/google-analytics-4/frontend/src/hooks/useSidebarRules/useSidebarRules.tsx
+++ b/apps/google-analytics-4/frontend/src/hooks/useSidebarRules/useSidebarRules.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useSDK } from '@contentful/react-apps-toolkit';
 import { ContentEntitySys, SidebarExtensionSDK } from '@contentful/app-sdk';
 import { AppInstallationParameters, ContentTypeRule } from 'types';
+import { getPatternTokens } from 'utils/contentTypeMatching';
 import { getReportSlug } from 'utils/getReportSlug';
 
 interface ResolvedSidebarRule extends ContentTypeRule {
@@ -32,7 +33,11 @@ export const useSidebarRules = (slugFieldRules: ContentTypeRule[]) => {
       Array.from(
         new Set(
           slugFieldRules
-            .flatMap((rule) => [rule.slugField, ...(rule.additionalFieldIds || [])])
+            .flatMap((rule) => [
+              rule.slugField,
+              ...(rule.additionalFieldIds || []),
+              ...(rule.enableAdvancedMatching ? getPatternTokens(rule.pathPattern) : []),
+            ])
             .filter((fieldId) => fieldId)
         )
       ),
@@ -91,21 +96,39 @@ export const useSidebarRules = (slugFieldRules: ContentTypeRule[]) => {
       slugFieldRules.map((rule) => {
         const slugFieldValue = debouncedFieldValues[rule.slugField] ?? '';
         const slugFieldIsConfigured = Boolean(rule.slugField);
-        const contentTypeHasSlugField = rule.slugField in entryFields;
+        const contentTypeHasSlugField = !rule.slugField || rule.slugField in entryFields;
         const additionalFieldIds = rule.additionalFieldIds || [];
+        const patternTokens = rule.enableAdvancedMatching ? getPatternTokens(rule.pathPattern) : [];
+        const requiredFieldIds = new Set(additionalFieldIds);
+
+        if (!rule.enableAdvancedMatching && rule.slugField) {
+          requiredFieldIds.add(rule.slugField);
+        }
+
         const contentTypeHasAllFields =
-          contentTypeHasSlugField && additionalFieldIds.every((fieldId) => fieldId in entryFields);
-        const tokenValues = {
-          slug: slugFieldValue,
-          ...Object.fromEntries(
-            additionalFieldIds.map((fieldId) => [fieldId, debouncedFieldValues[fieldId] ?? ''])
-          ),
-        };
-        const isValidRule =
-          slugFieldIsConfigured &&
-          contentTypeHasAllFields &&
-          Object.values(tokenValues).every((value) => Boolean(value)) &&
-          isPublished;
+          contentTypeHasSlugField &&
+          Array.from(requiredFieldIds).every((fieldId) => fieldId in entryFields);
+        const tokenValues = Object.fromEntries(
+          Array.from(requiredFieldIds).map((fieldId) => [
+            fieldId,
+            debouncedFieldValues[fieldId] ?? '',
+          ])
+        ) as Record<string, string | object>;
+
+        if (rule.slugField && !('slug' in tokenValues)) {
+          tokenValues.slug = slugFieldValue;
+        }
+
+        const requiredTokenValues = rule.enableAdvancedMatching
+          ? patternTokens.map((token) => tokenValues[token as keyof typeof tokenValues] ?? '')
+          : [slugFieldValue];
+        const hasAllRequiredTokenValues = requiredTokenValues.every((value) => Boolean(value));
+        const isValidRule = rule.enableAdvancedMatching
+          ? contentTypeHasAllFields && hasAllRequiredTokenValues && isPublished
+          : slugFieldIsConfigured &&
+            contentTypeHasAllFields &&
+            hasAllRequiredTokenValues &&
+            isPublished;
 
         return {
           ...rule,

--- a/apps/google-analytics-4/frontend/src/locations/Sidebar.tsx
+++ b/apps/google-analytics-4/frontend/src/locations/Sidebar.tsx
@@ -38,7 +38,7 @@ const Sidebar = () => {
     const result = await sdk.dialogs.openCurrentApp({
       title: 'Custom date range',
       width: 'medium',
-      minHeight: '560px',
+      minHeight: '280px',
       shouldCloseOnOverlayClick: true,
       shouldCloseOnEscapePress: true,
       parameters: {

--- a/apps/google-analytics-4/frontend/src/types.ts
+++ b/apps/google-analytics-4/frontend/src/types.ts
@@ -104,6 +104,11 @@ export type DateRangeType =
 
 export type AnalyticsMetricType = 'screenPageViews' | 'activeUsers';
 
+export interface LocaleOption {
+  code: string;
+  label: string;
+}
+
 export interface StartEndDates {
   start: string;
   end: string;

--- a/apps/google-analytics-4/frontend/src/utils/contentTypeMatching.spec.ts
+++ b/apps/google-analytics-4/frontend/src/utils/contentTypeMatching.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import {
+  convertWildcardPatternToRegex,
+  getMissingSelectedPatternTokens,
+  getUnknownPatternTokens,
+  inferMatchTypeFromPattern,
+} from './contentTypeMatching';
+
+describe('contentTypeMatching', () => {
+  it('infers flexible matching from wildcard syntax', () => {
+    expect(inferMatchTypeFromPattern('/shop/products/{slug}/compare/*')).toBe('PARTIAL_REGEXP');
+  });
+
+  it('converts wildcard syntax to a GA4 regular expression', () => {
+    expect(convertWildcardPatternToRegex('/shop/products/example/compare/*')).toBe(
+      '/shop/products/example/compare/.*'
+    );
+  });
+
+  it('escapes query-string punctuation when converting wildcard syntax', () => {
+    expect(convertWildcardPatternToRegex('/search?category=*')).toBe('/search\\?category=.*');
+  });
+
+
+  it('allows the locale token in patterns', () => {
+    expect(getUnknownPatternTokens('/{locale}/{slug}', [], 'slug')).toEqual([]);
+  });
+
+  it('returns selected field tokens that are missing from the pattern', () => {
+    expect(
+      getMissingSelectedPatternTokens('/shop/products/{slug}/compare/*', [
+        'product_id',
+        'variant_id',
+      ])
+    ).toEqual(['product_id', 'variant_id']);
+  });
+
+  it('allows selected field tokens anywhere in the pattern', () => {
+    expect(
+      getMissingSelectedPatternTokens('/shop/products/{product_id}?variant={variant_id}', [
+        'product_id',
+        'variant_id',
+      ])
+    ).toEqual([]);
+  });
+
+  it('continues to support legacy regex wildcard syntax', () => {
+    expect(convertWildcardPatternToRegex('/shop/products/example/compare/.*')).toBe(
+      '/shop/products/example/compare/.*'
+    );
+  });
+});

--- a/apps/google-analytics-4/frontend/src/utils/contentTypeMatching.ts
+++ b/apps/google-analytics-4/frontend/src/utils/contentTypeMatching.ts
@@ -1,6 +1,7 @@
-import { ContentTypeValue } from 'types';
+import { ContentTypeValue, GAStringMatchType } from 'types';
 
 const TOKEN_REGEX = /\{([^}]+)\}/g;
+const REGEX_INDICATORS = [/\.\*/, /\(/, /\[/, /\|/, /\+/, /\^/, /\$/];
 
 export const hasAdvancedMatchingConfigured = (contentTypeValue: ContentTypeValue) =>
   Boolean(
@@ -13,11 +14,20 @@ export const hasAdvancedMatchingConfigured = (contentTypeValue: ContentTypeValue
 export const getPatternTokens = (pathPattern = '') =>
   Array.from(pathPattern.matchAll(TOKEN_REGEX), ([, token]) => token);
 
+export const inferMatchTypeFromPattern = (pathPattern = ''): GAStringMatchType => {
+  const normalizedPattern = pathPattern.replace(TOKEN_REGEX, '');
+
+  return REGEX_INDICATORS.some((pattern) => pattern.test(normalizedPattern))
+    ? 'PARTIAL_REGEXP'
+    : 'EXACT';
+};
+
 export const getUnknownPatternTokens = (
   pathPattern = '',
-  additionalFieldIds: string[] = []
+  additionalFieldIds: string[] = [],
+  _slugField = ''
 ) => {
-  const allowedTokens = new Set(['slug', ...additionalFieldIds]);
+  const allowedTokens = new Set([...additionalFieldIds]);
 
   return getPatternTokens(pathPattern).filter((token) => !allowedTokens.has(token));
 };

--- a/apps/google-analytics-4/frontend/src/utils/contentTypeMatching.ts
+++ b/apps/google-analytics-4/frontend/src/utils/contentTypeMatching.ts
@@ -1,5 +1,7 @@
 import { ContentTypeValue } from 'types';
 
+const TOKEN_REGEX = /\{([^}]+)\}/g;
+
 export const hasAdvancedMatchingConfigured = (contentTypeValue: ContentTypeValue) =>
   Boolean(
     contentTypeValue.enableAdvancedMatching ||
@@ -7,3 +9,15 @@ export const hasAdvancedMatchingConfigured = (contentTypeValue: ContentTypeValue
       contentTypeValue.matchDimension === 'pagePathPlusQueryString' ||
       contentTypeValue.matchType === 'PARTIAL_REGEXP'
   );
+
+export const getPatternTokens = (pathPattern = '') =>
+  Array.from(pathPattern.matchAll(TOKEN_REGEX), ([, token]) => token);
+
+export const getUnknownPatternTokens = (
+  pathPattern = '',
+  additionalFieldIds: string[] = []
+) => {
+  const allowedTokens = new Set(['slug', ...additionalFieldIds]);
+
+  return getPatternTokens(pathPattern).filter((token) => !allowedTokens.has(token));
+};

--- a/apps/google-analytics-4/frontend/src/utils/contentTypeMatching.ts
+++ b/apps/google-analytics-4/frontend/src/utils/contentTypeMatching.ts
@@ -1,7 +1,10 @@
 import { ContentTypeValue, GAStringMatchType } from 'types';
 
 const TOKEN_REGEX = /\{([^}]+)\}/g;
-const REGEX_INDICATORS = [/\.\*/, /\(/, /\[/, /\|/, /\+/, /\^/, /\$/];
+const REGEX_INDICATORS = [/\*/, /\(/, /\[/, /\|/, /\+/, /\^/, /\$/];
+const LEGACY_WILDCARD_TOKEN = '__CONTENTFUL_GA4_WILDCARD__';
+const REGEX_SPECIAL_CHARACTERS = /[\\^$+?.()|[\]{}]/g;
+export const RESERVED_PATTERN_TOKENS = ['locale'] as const;
 
 export const hasAdvancedMatchingConfigured = (contentTypeValue: ContentTypeValue) =>
   Boolean(
@@ -22,12 +25,33 @@ export const inferMatchTypeFromPattern = (pathPattern = ''): GAStringMatchType =
     : 'EXACT';
 };
 
+export const convertWildcardPatternToRegex = (pathPattern = '') => {
+  return pathPattern
+    .replace(/\.\*/g, LEGACY_WILDCARD_TOKEN)
+    .replace(REGEX_SPECIAL_CHARACTERS, '\\$&')
+    .replace(/\*/g, '.*')
+    .replace(new RegExp(LEGACY_WILDCARD_TOKEN, 'g'), '.*');
+};
+
 export const getUnknownPatternTokens = (
   pathPattern = '',
   additionalFieldIds: string[] = [],
-  _slugField = ''
+  slugField = ''
 ) => {
-  const allowedTokens = new Set([...additionalFieldIds]);
+  const allowedTokens = new Set([
+    ...additionalFieldIds,
+    ...RESERVED_PATTERN_TOKENS,
+    ...(slugField ? ['slug'] : []),
+  ]);
 
   return getPatternTokens(pathPattern).filter((token) => !allowedTokens.has(token));
+};
+
+export const getMissingSelectedPatternTokens = (
+  pathPattern = '',
+  additionalFieldIds: string[] = []
+) => {
+  const patternTokens = new Set(getPatternTokens(pathPattern));
+
+  return additionalFieldIds.filter((fieldId) => !patternTokens.has(fieldId));
 };

--- a/apps/google-analytics-4/frontend/src/utils/getReportSlug.spec.ts
+++ b/apps/google-analytics-4/frontend/src/utils/getReportSlug.spec.ts
@@ -41,6 +41,25 @@ describe('getReportSlug', () => {
     expect(reportSlug).toBe('/north-america/denver/luxury-homes/');
   });
 
+  it('supports integer field tokens in advanced patterns', () => {
+    const reportSlug = getReportSlug(
+      {
+        slugField: 'slug',
+        urlPrefix: '',
+        enableAdvancedMatching: true,
+        additionalFieldIds: ['articleId'],
+        pathPattern: '/article?articleId={articleId}',
+      },
+      {
+        slug: 'article-title',
+        articleId: 360054483454,
+      },
+      true
+    );
+
+    expect(reportSlug).toBe('/article?articleId=360054483454');
+  });
+
   it('does not append a trailing slash after query string patterns', () => {
     const reportSlug = getReportSlug(
       {

--- a/apps/google-analytics-4/frontend/src/utils/getReportSlug.spec.ts
+++ b/apps/google-analytics-4/frontend/src/utils/getReportSlug.spec.ts
@@ -79,4 +79,8 @@ describe('getReportSlug', () => {
       '/search/{slug}?category={category}'
     );
   });
+
+  it('builds a default advanced pattern without {slug} when no slug token is provided', () => {
+    expect(buildDefaultPathPattern('', ['title'], 'unifiedPagePathScreen', '')).toBe('/{title}');
+  });
 });

--- a/apps/google-analytics-4/frontend/src/utils/getReportSlug.spec.ts
+++ b/apps/google-analytics-4/frontend/src/utils/getReportSlug.spec.ts
@@ -18,7 +18,7 @@ describe('getReportSlug', () => {
       true
     );
 
-    expect(reportSlug).toBe('/guides/market-insights/');
+    expect(reportSlug).toBe('/guides/market-insights');
   });
 
   it('supports deeper composed paths with multiple selected properties', () => {
@@ -38,7 +38,54 @@ describe('getReportSlug', () => {
       true
     );
 
-    expect(reportSlug).toBe('/north-america/denver/luxury-homes/');
+    expect(reportSlug).toBe('/north-america/denver/luxury-homes');
+  });
+
+  it('preserves an authored trailing slash in advanced patterns', () => {
+    const reportSlug = getReportSlug(
+      {
+        slugField: 'slug',
+        urlPrefix: '',
+        enableAdvancedMatching: true,
+        pathPattern: '/interviews/{slug}/',
+      },
+      {
+        slug: 'my-post',
+      },
+      false
+    );
+
+    expect(reportSlug).toBe('/interviews/my-post/');
+  });
+
+  it('does not apply the global trailing slash setting to advanced wildcard patterns', () => {
+    const reportSlug = getReportSlug(
+      {
+        slugField: 'slug',
+        urlPrefix: '',
+        enableAdvancedMatching: true,
+        pathPattern: '/shop/products/{slug}/compare/*',
+      },
+      {
+        slug: 'example-product',
+      },
+      true
+    );
+
+    expect(reportSlug).toBe('/shop/products/example-product/compare/*');
+  });
+
+  it('applies the global trailing slash setting to standard patterns', () => {
+    const reportSlug = getReportSlug(
+      {
+        slugField: 'slug',
+        urlPrefix: '/blog/',
+      },
+      'my-post',
+      true
+    );
+
+    expect(reportSlug).toBe('/blog/my-post/');
   });
 
   it('supports integer field tokens in advanced patterns', () => {

--- a/apps/google-analytics-4/frontend/src/utils/getReportSlug.ts
+++ b/apps/google-analytics-4/frontend/src/utils/getReportSlug.ts
@@ -5,7 +5,7 @@ import { pathJoin } from 'utils/pathJoin';
 const SLUG_TOKEN = '{slug}';
 const TOKEN_REGEX = /\{([^}]+)\}/g;
 
-type FieldValueMap = Record<string, string | object | undefined>;
+type FieldValueMap = Record<string, string | number | object | undefined>;
 
 const getPatternValue = (token: string, fieldValues: FieldValueMap) => {
   const normalizedFieldValue = token === 'slug' ? fieldValues.slug : fieldValues[token];
@@ -48,7 +48,7 @@ export const buildDefaultPathPattern = (
 
 export const getReportSlug = (
   contentTypeValue: ContentTypeValue,
-  slugFieldValue: string | object,
+  slugFieldValue: string | number | object,
   forceTrailingSlash: boolean
 ) => {
   const { pathPattern, urlPrefix } = contentTypeValue;

--- a/apps/google-analytics-4/frontend/src/utils/getReportSlug.ts
+++ b/apps/google-analytics-4/frontend/src/utils/getReportSlug.ts
@@ -28,16 +28,14 @@ const applyTrailingSlash = (path: string, forceTrailingSlash: boolean) => {
 export const buildDefaultPathPattern = (
   urlPrefix = '',
   additionalFieldIds: string[] = [],
-  matchDimension: ContentTypeValue['matchDimension'] = 'unifiedPagePathScreen'
+  matchDimension: ContentTypeValue['matchDimension'] = 'unifiedPagePathScreen',
+  primaryToken = SLUG_TOKEN
 ) => {
+  const pathTokens = primaryToken ? [...additionalFieldIds.map((fieldId) => `{${fieldId}}`), primaryToken] : additionalFieldIds.map((fieldId) => `{${fieldId}}`);
   const basePath =
     matchDimension === 'pagePathPlusQueryString'
-      ? `/${pathJoin(urlPrefix, SLUG_TOKEN)}`
-      : `/${pathJoin(
-          urlPrefix,
-          ...additionalFieldIds.map((fieldId) => `{${fieldId}}`),
-          SLUG_TOKEN
-        )}`;
+      ? `/${pathJoin(urlPrefix, primaryToken)}`
+      : `/${pathJoin(urlPrefix, ...pathTokens)}`;
 
   if (matchDimension !== 'pagePathPlusQueryString' || additionalFieldIds.length === 0) {
     return basePath;

--- a/apps/google-analytics-4/frontend/src/utils/getReportSlug.ts
+++ b/apps/google-analytics-4/frontend/src/utils/getReportSlug.ts
@@ -17,6 +17,10 @@ const normalizePattern = (pathPattern: string, fieldValues: FieldValueMap) => {
   return pathPattern.replace(TOKEN_REGEX, (_match, token) => getPatternValue(token, fieldValues));
 };
 
+const ensureLeadingSlash = (path: string) => {
+  return path.startsWith('/') ? path : `/${path}`;
+};
+
 const applyTrailingSlash = (path: string, forceTrailingSlash: boolean) => {
   if (!forceTrailingSlash || path.includes('?')) {
     return path;
@@ -31,7 +35,9 @@ export const buildDefaultPathPattern = (
   matchDimension: ContentTypeValue['matchDimension'] = 'unifiedPagePathScreen',
   primaryToken = SLUG_TOKEN
 ) => {
-  const pathTokens = primaryToken ? [...additionalFieldIds.map((fieldId) => `{${fieldId}}`), primaryToken] : additionalFieldIds.map((fieldId) => `{${fieldId}}`);
+  const pathTokens = primaryToken
+    ? [...additionalFieldIds.map((fieldId) => `{${fieldId}}`), primaryToken]
+    : additionalFieldIds.map((fieldId) => `{${fieldId}}`);
   const basePath =
     matchDimension === 'pagePathPlusQueryString'
       ? `/${pathJoin(urlPrefix, primaryToken)}`
@@ -52,16 +58,20 @@ export const getReportSlug = (
   forceTrailingSlash: boolean
 ) => {
   const { pathPattern, urlPrefix } = contentTypeValue;
+  const hasAdvancedPattern =
+    hasAdvancedMatchingConfigured(contentTypeValue) && Boolean(pathPattern?.trim());
   const fieldValues =
     typeof slugFieldValue === 'object' && !Array.isArray(slugFieldValue)
       ? ({ slug: '', ...slugFieldValue } as FieldValueMap)
       : ({ slug: slugFieldValue } as FieldValueMap);
-  const basePath =
-    hasAdvancedMatchingConfigured(contentTypeValue) && pathPattern?.trim()
-      ? normalizePattern(pathPattern, fieldValues)
-      : pathJoin(urlPrefix || '', fieldValues.slug || '');
 
-  return `/${applyTrailingSlash(pathJoin(basePath), forceTrailingSlash)}`;
+  if (hasAdvancedPattern) {
+    return ensureLeadingSlash(normalizePattern(pathPattern!, fieldValues).trim());
+  }
+
+  const basePath = pathJoin(urlPrefix || '', fieldValues.slug || '');
+
+  return `/${applyTrailingSlash(basePath, forceTrailingSlash)}`;
 };
 
 export const pathPatternPreview = (pathPattern: string, additionalFieldIds: string[] = []) => {

--- a/apps/google-analytics-4/frontend/src/utils/pathJoin.spec.ts
+++ b/apps/google-analytics-4/frontend/src/utils/pathJoin.spec.ts
@@ -21,6 +21,11 @@ describe('pathJoin', () => {
     expect(result).toEqual('a/b/c');
   });
 
+  it('handles numbers as inputs', () => {
+    const result = pathJoin('/article/', 360054483454);
+    expect(result).toEqual('article/360054483454');
+  });
+
   it('handles arrays as inputs', () => {
     const result = pathJoin(['a', 'b'], ['c', 'd']);
     expect(result).toEqual('a/b/c/d');

--- a/apps/google-analytics-4/frontend/src/utils/pathJoin.ts
+++ b/apps/google-analytics-4/frontend/src/utils/pathJoin.ts
@@ -1,11 +1,13 @@
-const trimAndRemoveSlashes = (item: string) => {
-  return item.trim().replace(/(^[/]*|[/]*$)/g, '');
+const trimAndRemoveSlashes = (item: string | number) => {
+  return String(item).trim().replace(/(^[/]*|[/]*$)/g, '');
 };
 
-const handlePartsByType = (part: string | object | undefined) => {
+type PathPart = string | number | object | undefined;
+
+const handlePartsByType = (part: PathPart) => {
   let result = '';
 
-  if (typeof part === 'string') {
+  if (typeof part === 'string' || typeof part === 'number') {
     result = trimAndRemoveSlashes(part);
   }
 
@@ -16,7 +18,7 @@ const handlePartsByType = (part: string | object | undefined) => {
   return result;
 };
 
-export const pathJoin = (...parts: (string | object | undefined)[]): string => {
+export const pathJoin = (...parts: PathPart[]): string => {
   return parts
     .map(handlePartsByType)
     .filter((part) => part.length)


### PR DESCRIPTION
## Summary
- Deliver this [BRD](https://docs.google.com/document/d/1ndrxY_r5UQZ-5FL5AIJ9wp-vxmfMysflBpfln8bwYhs/edit?tab=t.0) 
-  refine the GA4 advanced configuration UI based on follow-up feedback
- simplify advanced pattern building around entry fields and wildcard guidance
- preserve layout consistency and validation behavior while keeping local-only lambda config out of git

## Validation
- npm run test:ci -- src/components/config-screen/assign-content-type/AssignContentTypeRow.spec.tsx src/components/config-screen/assign-content-type/AssignContentTypeSection.spec.tsx src/components/config-screen/assign-content-type/ContentTypeWarning.spec.tsx src/components/config-screen/assign-content-type/AssignContentTypeCard.spec.tsx src/helpers/contentTypeRules/contentTypeRules.spec.ts src/utils/getReportSlug.spec.ts
- local validation on http://localhost:3000
