### PR TITLE
fix(locale-field-populator): display referenced entries in the preview step [ES-138]

### DIFF
--- a/apps/locale-field-populator/src/locations/Dialog.tsx
+++ b/apps/locale-field-populator/src/locations/Dialog.tsx
@@ -8,9 +8,13 @@ import LocaleSelectionStep from '../components/steps/LocaleSelectionStep';
 import PreviewStep from '../components/steps/PreviewStep';
 import { AdoptedFieldsMap, hasAnyAdoptedFields, ReferencedEntryData } from '../utils/adoptedFields';
 import { SimplifiedLocale, mapLocaleNamesToSimplifiedLocales } from '../utils/locales';
-import { updateEntries, UpdateResult } from '../utils/entry';
+import {
+  fetchEntryAndContentType,
+  fetchReferencesForLocale,
+  updateEntries,
+  UpdateResult,
+} from '../utils/entry';
 import { styles } from './Dialog.styles';
-import { fetchEntries } from '../utils/entry';
 
 type DialogStep = 'locale-selection' | 'preview' | 'confirmation';
 
@@ -38,6 +42,7 @@ const Dialog = () => {
 
   const [adoptedFields, setAdoptedFields] = useState<AdoptedFieldsMap>({});
 
+  const [loadingReferences, setLoadingReferences] = useState(false);
   const [isUpdating, setIsUpdating] = useState(false);
   const [updateResult, setUpdateResult] = useState<UpdateResult | null>(null);
 
@@ -49,14 +54,13 @@ const Dialog = () => {
     const fetchData = async () => {
       setLoading(true);
       try {
-        const result = await fetchEntries(
+        const result = await fetchEntryAndContentType(
           sdk.cma,
           invocationParams.entryId,
           invocationParams.contentTypeId
         );
         setEntry(result.entry);
         setContentType(result.contentType);
-        setReferencedEntries(result.referencedEntriesData);
       } catch (error) {
         console.error('Error fetching entry data:', error);
         setError('Failed to fetch entry data');
@@ -67,16 +71,35 @@ const Dialog = () => {
     fetchData();
   }, [sdk.cma, invocationParams.entryId, invocationParams.contentTypeId]);
 
-  const handleNext = () => {
+  const handleNext = async () => {
     if (!selectedSourceLocale || selectedTargetLocales.length === 0) {
       setMissingSourceLocale(!selectedSourceLocale);
       setMissingTargetLocales(selectedTargetLocales.length === 0);
       return;
     }
-    setCurrentStep('preview');
+
+    if (!entry || !contentType) return;
+
+    setLoadingReferences(true);
+    try {
+      const references = await fetchReferencesForLocale(
+        sdk.cma,
+        entry,
+        contentType,
+        selectedSourceLocale
+      );
+      setReferencedEntries(references);
+      setCurrentStep('preview');
+    } catch (error) {
+      console.error('Error fetching references:', error);
+      setError('Failed to fetch referenced entries');
+    } finally {
+      setLoadingReferences(false);
+    }
   };
 
   const handleBack = () => {
+    setAdoptedFields({});
     setCurrentStep('locale-selection');
   };
 
@@ -172,7 +195,11 @@ const Dialog = () => {
             />
             <Flex justifyContent="flex-end" gap="spacingM">
               <Button onClick={() => sdk.close()}>Cancel</Button>
-              <Button variant="primary" onClick={handleNext}>
+              <Button
+                variant="primary"
+                onClick={handleNext}
+                isLoading={loadingReferences}
+                isDisabled={loadingReferences}>
                 Next
               </Button>
             </Flex>

--- a/apps/locale-field-populator/src/utils/entry.ts
+++ b/apps/locale-field-populator/src/utils/entry.ts
@@ -98,69 +98,67 @@ export async function updateEntries(
   };
 }
 
-export const fetchEntries = async (
+export const fetchEntryAndContentType = async (
   cma: CMAClient,
   entryId: string,
   contentTypeId: string
 ): Promise<{
   entry: EntryProps;
   contentType: ContentTypeProps;
-  referencedEntriesData: ReferencedEntryData[];
 }> => {
-  const [mainEntry, mainEntryContentType] = await Promise.all([
+  const [entry, contentType] = await Promise.all([
     cma.entry.get({ entryId }),
     cma.contentType.get({ contentTypeId }),
   ]);
+  return { entry, contentType };
+};
 
-  const referencesToProcess: { referenceEntryId: string; field: ContentTypeField }[] =
-    collectReferences(mainEntry, mainEntryContentType);
+export const fetchReferencesForLocale = async (
+  cma: CMAClient,
+  entry: EntryProps,
+  contentType: ContentTypeProps,
+  sourceLocale: string
+): Promise<ReferencedEntryData[]> => {
+  const entryId = entry.sys.id;
+  const referencesToProcess = collectReferences(entry, contentType, sourceLocale);
 
   const entryMap = await fetchReferenceEntries(cma, referencesToProcess, entryId);
 
-  const contentTypeMap = await fetchContentTypes(
-    cma,
-    entryMap,
-    contentTypeId,
-    mainEntryContentType
-  );
+  const contentTypeMap = await fetchContentTypes(cma, entryMap, contentType.sys.id, contentType);
 
-  const referencedEntriesData: ReferencedEntryData[] = referencesToProcess.flatMap(
-    ({ referenceEntryId, field }) => {
-      if (referenceEntryId === entryId) {
-        return {
-          entry: mainEntry,
-          contentType: mainEntryContentType,
-          fieldId: field.id,
-          fieldName: field.name,
-          isSelfReference: true,
-        };
-      }
-
-      const referenceEntry = entryMap[referenceEntryId];
-      if (!referenceEntry) {
-        return [];
-      }
-
-      const referenceContentType = contentTypeMap[referenceEntry.sys.contentType.sys.id];
-
+  return referencesToProcess.flatMap(({ referenceEntryId, field }) => {
+    if (referenceEntryId === entryId) {
       return {
-        entry: referenceEntry,
-        contentType: referenceContentType,
+        entry,
+        contentType,
         fieldId: field.id,
         fieldName: field.name,
-        isSelfReference: false,
+        isSelfReference: true,
       };
     }
-  );
 
-  return {
-    entry: mainEntry,
-    contentType: mainEntryContentType,
-    referencedEntriesData,
-  };
+    const referenceEntry = entryMap[referenceEntryId];
+    if (!referenceEntry) {
+      return [];
+    }
+
+    const referenceContentType = contentTypeMap[referenceEntry.sys.contentType.sys.id];
+
+    return {
+      entry: referenceEntry,
+      contentType: referenceContentType,
+      fieldId: field.id,
+      fieldName: field.name,
+      isSelfReference: false,
+    };
+  });
 };
 
-const collectReferences = (mainEntry: EntryProps, mainEntryContentType: ContentTypeProps) => {
+const collectReferences = (
+  mainEntry: EntryProps,
+  mainEntryContentType: ContentTypeProps,
+  sourceLocale: string
+) => {
   const referenceFields = mainEntryContentType.fields.filter(
     (field) => isEntryField(field) || isEntryArrayField(field)
   );
@@ -180,7 +178,12 @@ const collectReferences = (mainEntry: EntryProps, mainEntryContentType: ContentT
     const fieldValues = mainEntry.fields[field.id];
     if (!fieldValues) continue;
 
-    const value = Object.values(fieldValues)[0];
+    let value = fieldValues[sourceLocale];
+    // Non-localized reference fields store under a single key (the default locale)
+    if (value === undefined && Object.keys(fieldValues).length === 1) {
+      value = Object.values(fieldValues)[0];
+    }
+    if (value === undefined) continue;
 
     if (isLinkValue(value) && value.sys.linkType === 'Entry') {
       processReference(value, field);

--- a/apps/locale-field-populator/test/Dialog.spec.tsx
+++ b/apps/locale-field-populator/test/Dialog.spec.tsx
@@ -245,6 +245,99 @@ describe('Dialog component', () => {
     expect(mockCma.entry.update).toHaveBeenCalled();
   });
 
+  it('resolves references from the selected source locale, not an arbitrary one', async () => {
+    const user = userEvent.setup();
+
+    mockSdk.locales.names = {
+      'en-US': 'English (United States)',
+      'en-GB': 'English (United Kingdom)',
+    };
+
+    const mainEntry = {
+      sys: {
+        id: 'test-entry',
+        type: 'Entry',
+        contentType: { sys: { id: 'test-content-type' } },
+      },
+      fields: {
+        title: { 'en-US': 'English Title', 'en-GB': 'GB Title' },
+        linkedEntry: {
+          'en-US': { sys: { type: 'Link', linkType: 'Entry', id: 'ref-en' } },
+          'en-GB': { sys: { type: 'Link', linkType: 'Entry', id: 'ref-gb' } },
+        },
+      },
+    };
+
+    const mainContentType = {
+      sys: { id: 'test-content-type', type: 'ContentType' },
+      name: 'Test Content Type',
+      displayField: 'title',
+      fields: [
+        { id: 'title', name: 'Title', type: 'Symbol', localized: true },
+        {
+          id: 'linkedEntry',
+          name: 'Linked Entry',
+          type: 'Link',
+          linkType: 'Entry',
+          localized: true,
+        },
+      ],
+    };
+
+    const refEntryEn = {
+      sys: { id: 'ref-en', type: 'Entry', contentType: { sys: { id: 'ref-ct' } } },
+      fields: { name: { 'en-US': 'English Ref' } },
+    };
+
+    const refContentType = {
+      sys: { id: 'ref-ct', type: 'ContentType' },
+      name: 'Ref CT',
+      displayField: 'name',
+      fields: [{ id: 'name', name: 'Name', type: 'Symbol', localized: true }],
+    };
+
+    mockCma.entry.get.mockResolvedValue(mainEntry);
+    mockCma.contentType.get.mockResolvedValue(mainContentType);
+    mockCma.entry.getMany.mockResolvedValue({ items: [refEntryEn] });
+    mockCma.contentType.getMany.mockResolvedValue({ items: [refContentType] });
+    mockCma.entry.update.mockImplementation((_params: any, entry: any) => Promise.resolve(entry));
+
+    await act(async () => {
+      render(<Dialog />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Next')).toBeInTheDocument();
+    });
+
+    const sourceSelect = screen.getByTestId('source-locale-select');
+    await user.selectOptions(sourceSelect, 'en-US');
+
+    const targetTrigger = await screen.findByText('Select one or more');
+    await user.click(targetTrigger);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('checkbox', { name: 'English (United Kingdom)' })
+      ).toBeInTheDocument();
+    });
+
+    const targetCheckbox = screen.getByRole('checkbox', { name: 'English (United Kingdom)' });
+    await user.click(targetCheckbox);
+
+    const nextButton = screen.getByText('Next');
+    await user.click(nextButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Back')).toBeInTheDocument();
+    });
+
+    // Should have fetched ref-en (source locale), not ref-gb
+    expect(mockCma.entry.getMany).toHaveBeenCalledWith(
+      expect.objectContaining({ query: { 'sys.id[in]': 'ref-en' } })
+    );
+  });
+
   it('completes the full flow with a reference field and updates both main and referenced entry', async () => {
     const user = userEvent.setup();
     const referencedEntryId = 'referenced-entry-id';


### PR DESCRIPTION
## Purpose

Fixes a bug where the Locale Field Populator app can display wrong referenced entries in the preview step. When a reference field is localized (i.e., different entries linked per locale), the app was resolving references from an arbitrary first-available locale instead of the user's selected source locale.

I noticed this bug while troubleshooting ES-138, although it was not the main issue that was being reported.

## Approach

The root cause was `Object.values(fieldValues)[0]` in `collectReferences`, which picks whichever locale happens to be first in the JSON object rather than the selected source locale. Since reference resolution previously ran on mount -- before the user selects a locale -- the source locale wasn't available.

**Fix: two-phase data loading**

1. **On mount:** fetch only the main entry and its content type
2. **On "Next" click:** resolve references using the selected source locale, then transition to the preview step

Changes:
- `entry.ts`: split `fetchEntries` into `fetchEntryAndContentType` and `fetchReferencesForLocale`; `collectReferences` now accepts a `sourceLocale` param
- `Dialog.tsx`: mount effect fetches entry/content type only; `handleNext` is async and fetches references with the correct locale; added loading state on the Next button
- Added a regression test verifying references resolve from the selected source locale

## Test plan

- [x] All 21 existing + new tests pass (`npx vitest run`)
- [x] Manual test: open the app on an entry with a localized reference field that links to different entries per locale; verify the preview shows entries matching the selected source locale ("home" entry on dev space for this app)
- [x] Verify non-localized reference fields still resolve correctly (fallback for single-key fields)
- [x] Verify back/next cycle re-fetches references when source locale changes
