### PR TITLE
fix(locale-field-populator): deploy:test script deploys to staging app definition [ES-138]

### DIFF
--- a/apps/locale-field-populator/package.json
+++ b/apps/locale-field-populator/package.json
@@ -32,7 +32,7 @@
     "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./build  --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN",
     "deploy": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEFINITIONS_ORG_ID} --definition-id 2kYWs1ck9ygF8ei2B4cYL8 --token ${CONTENTFUL_CMA_TOKEN}",
     "deploy:staging": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${TEST_ORG_ID} --definition-id 5SjsH1qGRd1m5j27gRJN9s --token ${TEST_CMA_TOKEN}",
-    "deploy:test": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEV_TESTING_ORG_ID} --definition-id ${STAGING_APP_ID} --token ${TEST_CMA_TOKEN}",
+    "deploy:test": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEV_TESTING_ORG_ID} --definition-id 537Gb0QlvPjLKQYgLEY2jr --token ${TEST_CMA_TOKEN}",
     "lint": "eslint .",
     "lint:write": "eslint . --fix"
   },


### PR DESCRIPTION
## Purpose

Fix the Locale Field Populator app's `deploy:test` script to deploy to the Staging app definition: https://app.contentful.com/account/organizations/6xdLsz6lCsk0yPOccSsDK7/apps/definitions/5SjsH1qGRd1m5j27gRJN9s/general

## Approach

The "Deploy apps to staging" workflow runs the `deploy:test` script automatically when a PR is merged
https://github.com/contentful/apps/blob/master/.circleci/config.yml#L127-L135

When I released changes to this app today, the deployment failed because Circle CI doesn't have a `STAGING_APP_ID` env var, so the `deploy:test` script threw an error.
