### PR TITLE
chore: prevent future deployment issue []

### DIFF
--- a/apps/homebase/package.json
+++ b/apps/homebase/package.json
@@ -27,7 +27,7 @@
     "upload": "contentful-app-scripts upload --bundle-dir ./build",
     "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./build  --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN",
     "deploy": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEFINITIONS_ORG_ID} --definition-id GKgzLlXl7oRMOmTr9XYQy --token ${CONTENTFUL_CMA_TOKEN}",
-    "deploy:test": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEV_TESTING_ORG_ID} --definition-id ${STAGING_APP_ID} --token ${TEST_CMA_TOKEN}",
+    "deploy:test": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEV_TESTING_ORG_ID} --definition-id m51aPn2LVb5dMkbxi0dQ0 --token ${TEST_CMA_TOKEN}",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "lint:write": "eslint . --ext .js,.jsx,.ts,.tsx --fix"
   },

--- a/apps/phosphor-icon/package.json
+++ b/apps/phosphor-icon/package.json
@@ -29,7 +29,7 @@
     "upload": "contentful-app-scripts upload --bundle-dir ./build",
     "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN",
     "deploy": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEFINITIONS_ORG_ID} --definition-id mTgsS49vytEQZvNWn2hXO --token ${CONTENTFUL_CMA_TOKEN}",
-    "deploy:test": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEV_TESTING_ORG_ID} --definition-id ${STAGING_APP_ID} --token ${TEST_CMA_TOKEN}"
+    "deploy:test": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEV_TESTING_ORG_ID} --definition-id 20o2aVcpFAEr1mn2X4ofXP --token ${TEST_CMA_TOKEN}"
   },
   "eslintConfig": {
     "extends": "react-app"


### PR DESCRIPTION
## Purpose

Prevent a future deployment issue due to Circle CI not having a `STAGING_APP_ID` env var, and then throwing an error `AppDefinition does not exist.` when it tries to run the `deploy:test` script
