### PR TITLE
feat: support nested references in Locale Field Populator [MAPS-255]

### DIFF
--- a/apps/locale-field-populator/src/components/preview/ReferenceEntrySection.styles.ts
+++ b/apps/locale-field-populator/src/components/preview/ReferenceEntrySection.styles.ts
@@ -1,6 +1,11 @@
 import { css } from 'emotion';
 import tokens from '@contentful/f36-tokens';
 
+export const depthIndent = (depth: number) =>
+  css({
+    marginLeft: depth > 1 ? `${(depth - 1) * 24}px` : undefined,
+  });
+
 export const styles = {
   accordionContainer: css({
     borderLeft: `1px solid ${tokens.gray300}`,

--- a/apps/locale-field-populator/src/components/preview/ReferenceEntrySection.tsx
+++ b/apps/locale-field-populator/src/components/preview/ReferenceEntrySection.tsx
@@ -4,7 +4,7 @@ import { ContentTypeProps, EntryProps } from 'contentful-management';
 import { useMemo } from 'react';
 import { isEntryArrayField, isEntryField } from '../../utils/fieldTypes';
 import PreviewFieldRow from './PreviewFieldRow';
-import { styles } from './ReferenceEntrySection.styles';
+import { depthIndent, styles } from './ReferenceEntrySection.styles';
 import { ArrowSquareOutIcon } from '@contentful/f36-icons';
 
 interface ReferenceEntrySectionProps {
@@ -19,6 +19,7 @@ interface ReferenceEntrySectionProps {
   isSelfReference: boolean;
   baseUrl: string;
   isDisabled?: boolean;
+  depth?: number;
 }
 
 const getEntryTitle = (
@@ -49,6 +50,7 @@ const ReferenceEntrySection = ({
   isSelfReference,
   baseUrl,
   isDisabled = false,
+  depth = 1,
 }: ReferenceEntrySectionProps) => {
   const localizedFields = useMemo(() => {
     return (contentType.fields as ContentTypeField[]).filter(
@@ -72,7 +74,7 @@ const ReferenceEntrySection = ({
 
   if (isSelfReference) {
     return (
-      <Box marginTop="spacingM" className={styles.accordionContainer}>
+      <Box marginTop="spacingM" className={`${styles.accordionContainer} ${depthIndent(depth)}`}>
         <Accordion>
           <Accordion.Item
             title={
@@ -94,7 +96,7 @@ const ReferenceEntrySection = ({
 
   if (fieldCount === 0) {
     return (
-      <Box className={styles.accordionContainer}>
+      <Box className={`${styles.accordionContainer} ${depthIndent(depth)}`}>
         <Accordion>
           <Accordion.Item
             title={
@@ -114,7 +116,7 @@ const ReferenceEntrySection = ({
   }
 
   return (
-    <Box className={styles.accordionContainer}>
+    <Box className={`${styles.accordionContainer} ${depthIndent(depth)}`}>
       <Accordion>
         <Accordion.Item
           title={

--- a/apps/locale-field-populator/src/components/steps/PreviewStep.tsx
+++ b/apps/locale-field-populator/src/components/steps/PreviewStep.tsx
@@ -6,6 +6,7 @@ import {
   Flex,
   FormControl,
   List,
+  Note,
   Paragraph,
   Select,
   Subheading,
@@ -20,6 +21,7 @@ import {
   setAllEntryFieldsAdopted,
   setFieldAdopted,
 } from '../../utils/adoptedFields';
+import { MAX_TOTAL_ENTRIES } from '../../utils/entry';
 import { isEntryArrayField, isEntryField } from '../../utils/fieldTypes';
 import { SimplifiedLocale } from '../../utils/locales';
 import PreviewBox from '../preview/PreviewBox';
@@ -234,6 +236,12 @@ const PreviewStepComponent = ({
 
         {/* Referenced entries (all depths, rendered in traversal order) */}
         <Flex flexDirection="column" gap="spacingS" marginTop="spacingM">
+          {referencedEntries.length >= MAX_TOTAL_ENTRIES && (
+            <Note variant="warning">
+              Some referenced entries were not included. Try reducing the reference depth to see all
+              entries.
+            </Note>
+          )}
           {referencedEntries.map((referenceData) => (
             <ReferenceEntrySection
               key={`${referenceData.depth}-${referenceData.fieldId}-${referenceData.entry.sys.id}`}

--- a/apps/locale-field-populator/src/components/steps/PreviewStep.tsx
+++ b/apps/locale-field-populator/src/components/steps/PreviewStep.tsx
@@ -205,33 +205,11 @@ const PreviewStepComponent = ({
           </Flex>
         </Flex>
 
-        {/* Field rows */}
+        {/* Main entry field rows */}
         <Flex flexDirection="column" gap="spacingS">
           {contentType.fields.map((field) => {
             if (isEntryField(field) || isEntryArrayField(field)) {
-              const fieldReferences = referencedEntries.filter(
-                (referenceData) => referenceData.fieldId === field.id
-              );
-              return fieldReferences.map((referenceData) => (
-                <ReferenceEntrySection
-                  key={`${referenceData.fieldId}-${referenceData.entry.sys.id}`}
-                  entry={referenceData.entry}
-                  contentType={referenceData.contentType}
-                  fieldName={referenceData.fieldName}
-                  sourceLocale={sourceLocale}
-                  targetLocale={selectedTargetLocale}
-                  adoptedFields={adoptedFields[referenceData.entry.sys.id] || {}}
-                  onAdoptedFieldChange={(fieldId, adopted) =>
-                    handleFieldAdopted(referenceData.entry.sys.id, fieldId, adopted)
-                  }
-                  onAdoptAllChange={(adopted) =>
-                    handleAdoptAll(referenceData.entry.sys.id, referenceData.contentType, adopted)
-                  }
-                  isSelfReference={referenceData.isSelfReference}
-                  isDisabled={isDisabled}
-                  baseUrl={baseUrl}
-                />
-              ));
+              return null;
             }
 
             if (field.localized) {
@@ -250,9 +228,33 @@ const PreviewStepComponent = ({
               );
             }
 
-            // Non-localized, non-reference fields are not displayed
             return null;
           })}
+        </Flex>
+
+        {/* Referenced entries (all depths, rendered in traversal order) */}
+        <Flex flexDirection="column" gap="spacingS" marginTop="spacingM">
+          {referencedEntries.map((referenceData) => (
+            <ReferenceEntrySection
+              key={`${referenceData.depth}-${referenceData.fieldId}-${referenceData.entry.sys.id}`}
+              entry={referenceData.entry}
+              contentType={referenceData.contentType}
+              fieldName={referenceData.fieldName}
+              sourceLocale={sourceLocale}
+              targetLocale={selectedTargetLocale}
+              adoptedFields={adoptedFields[referenceData.entry.sys.id] || {}}
+              onAdoptedFieldChange={(fieldId, adopted) =>
+                handleFieldAdopted(referenceData.entry.sys.id, fieldId, adopted)
+              }
+              onAdoptAllChange={(adopted) =>
+                handleAdoptAll(referenceData.entry.sys.id, referenceData.contentType, adopted)
+              }
+              isSelfReference={referenceData.isSelfReference}
+              isDisabled={isDisabled}
+              baseUrl={baseUrl}
+              depth={referenceData.depth}
+            />
+          ))}
         </Flex>
       </Box>
     </Flex>

--- a/apps/locale-field-populator/src/locations/ConfigScreen.tsx
+++ b/apps/locale-field-populator/src/locations/ConfigScreen.tsx
@@ -1,12 +1,15 @@
 import { ConfigAppSDK, AppState } from '@contentful/app-sdk';
-import { Flex, Heading, Paragraph, FormControl } from '@contentful/f36-components';
+import { Flex, Heading, Paragraph, FormControl, Select } from '@contentful/f36-components';
 import { useSDK } from '@contentful/react-apps-toolkit';
 import { useCallback, useEffect, useState } from 'react';
 import { ContentTypeProps } from 'contentful-management';
 import ContentTypeMultiSelect from '../components/ContentTypeMultiSelect';
+import { MAX_REFERENCE_DEPTH } from '../utils/entry';
 import { styles } from './ConfigScreen.styles';
 
-export type AppInstallationParameters = Record<string, unknown>;
+export interface AppInstallationParameters {
+  maxReferenceDepth?: number;
+}
 
 const ConfigScreen = () => {
   const [parameters, setParameters] = useState<AppInstallationParameters>({});
@@ -134,6 +137,35 @@ const ConfigScreen = () => {
               onSelectionChange={setSelectedContentTypes}
               isDisabled={allContentTypes.length === 0}
             />
+          </FormControl>
+        </Flex>
+        <Flex flexDirection="column" alignItems="flex-start" marginTop="spacing2Xl">
+          <Heading as="h3" marginBottom="spacingXs">
+            Reference depth
+          </Heading>
+          <Paragraph marginBottom="spacingL">
+            Control how many levels of nested references are included when populating locales. A
+            depth of 1 includes only direct references. Higher values traverse deeper into the
+            content graph.
+          </Paragraph>
+          <FormControl id="maxReferenceDepth">
+            <FormControl.Label>Maximum reference depth</FormControl.Label>
+            <Select
+              id="maxReferenceDepth"
+              name="maxReferenceDepth"
+              value={String(parameters.maxReferenceDepth ?? MAX_REFERENCE_DEPTH)}
+              onChange={(e) =>
+                setParameters({ ...parameters, maxReferenceDepth: Number(e.target.value) })
+              }>
+              <Select.Option value="0">None (main entry only)</Select.Option>
+              <Select.Option value="1">1 (direct references)</Select.Option>
+              <Select.Option value="2">2</Select.Option>
+              <Select.Option value="3">3 (default)</Select.Option>
+              <Select.Option value="5">5</Select.Option>
+            </Select>
+            <FormControl.HelpText>
+              Higher depths may increase loading time for entries with many references.
+            </FormControl.HelpText>
           </FormControl>
         </Flex>
       </Flex>

--- a/apps/locale-field-populator/src/locations/Dialog.tsx
+++ b/apps/locale-field-populator/src/locations/Dialog.tsx
@@ -11,9 +11,11 @@ import { SimplifiedLocale, mapLocaleNamesToSimplifiedLocales } from '../utils/lo
 import {
   fetchEntryAndContentType,
   fetchReferencesForLocale,
+  MAX_REFERENCE_DEPTH,
   updateEntries,
   UpdateResult,
 } from '../utils/entry';
+import { AppInstallationParameters } from './ConfigScreen';
 import { styles } from './Dialog.styles';
 
 type DialogStep = 'locale-selection' | 'preview' | 'confirmation';
@@ -26,6 +28,8 @@ interface InvocationParameters {
 const Dialog = () => {
   const sdk = useSDK<DialogAppSDK>();
   const invocationParams = sdk.parameters.invocation as unknown as InvocationParameters;
+  const installParams = sdk.parameters.installation as unknown as AppInstallationParameters;
+  const maxDepth = installParams?.maxReferenceDepth ?? MAX_REFERENCE_DEPTH;
 
   const [currentStep, setCurrentStep] = useState<DialogStep>('locale-selection');
 
@@ -86,7 +90,8 @@ const Dialog = () => {
         sdk.cma,
         entry,
         contentType,
-        selectedSourceLocale
+        selectedSourceLocale,
+        maxDepth
       );
       setReferencedEntries(references);
       setCurrentStep('preview');

--- a/apps/locale-field-populator/src/utils/adoptedFields.ts
+++ b/apps/locale-field-populator/src/utils/adoptedFields.ts
@@ -9,7 +9,6 @@ export interface ReferencedEntryData {
   fieldName: string;
   isSelfReference: boolean;
   depth: number;
-  parentEntryId: string;
 }
 
 export function hasAnyAdoptedFields(adoptedFieldsMap: AdoptedFieldsMap): boolean {

--- a/apps/locale-field-populator/src/utils/adoptedFields.ts
+++ b/apps/locale-field-populator/src/utils/adoptedFields.ts
@@ -8,6 +8,8 @@ export interface ReferencedEntryData {
   fieldId: string;
   fieldName: string;
   isSelfReference: boolean;
+  depth: number;
+  parentEntryId: string;
 }
 
 export function hasAnyAdoptedFields(adoptedFieldsMap: AdoptedFieldsMap): boolean {

--- a/apps/locale-field-populator/src/utils/entry.ts
+++ b/apps/locale-field-populator/src/utils/entry.ts
@@ -114,7 +114,7 @@ export const fetchEntryAndContentType = async (
 };
 
 export const MAX_REFERENCE_DEPTH = 3;
-const MAX_TOTAL_ENTRIES = 50;
+export const MAX_TOTAL_ENTRIES = 50;
 
 export const fetchReferencesForLocale = async (
   cma: CMAClient,
@@ -138,8 +138,7 @@ export const fetchReferencesForLocale = async (
     maxDepth,
     visited,
     allReferences,
-    contentTypeCache,
-    entry.sys.id
+    contentTypeCache
   );
 
   return allReferences;
@@ -154,9 +153,9 @@ const collectReferencesRecursive = async (
   maxDepth: number,
   visited: Set<string>,
   results: ReferencedEntryData[],
-  contentTypeCache: Record<string, ContentTypeProps>,
-  parentEntryId: string
+  contentTypeCache: Record<string, ContentTypeProps>
 ): Promise<void> => {
+  if (currentDepth > maxDepth) return;
   if (results.length >= MAX_TOTAL_ENTRIES) return;
 
   const referencesToProcess = collectReferences(parentEntry, parentContentType, sourceLocale);
@@ -206,7 +205,6 @@ const collectReferencesRecursive = async (
           fieldName: field.name,
           isSelfReference: true,
           depth: currentDepth,
-          parentEntryId,
         });
       }
       continue;
@@ -227,7 +225,6 @@ const collectReferencesRecursive = async (
       fieldName: field.name,
       isSelfReference: false,
       depth: currentDepth,
-      parentEntryId,
     });
 
     if (currentDepth < maxDepth) {
@@ -246,8 +243,7 @@ const collectReferencesRecursive = async (
       maxDepth,
       visited,
       results,
-      contentTypeCache,
-      refEntry.sys.id
+      contentTypeCache
     );
   }
 };

--- a/apps/locale-field-populator/src/utils/entry.ts
+++ b/apps/locale-field-populator/src/utils/entry.ts
@@ -113,45 +113,143 @@ export const fetchEntryAndContentType = async (
   return { entry, contentType };
 };
 
+export const MAX_REFERENCE_DEPTH = 3;
+const MAX_TOTAL_ENTRIES = 50;
+
 export const fetchReferencesForLocale = async (
   cma: CMAClient,
   entry: EntryProps,
   contentType: ContentTypeProps,
-  sourceLocale: string
+  sourceLocale: string,
+  maxDepth: number = MAX_REFERENCE_DEPTH
 ): Promise<ReferencedEntryData[]> => {
-  const entryId = entry.sys.id;
-  const referencesToProcess = collectReferences(entry, contentType, sourceLocale);
+  const visited = new Set<string>([entry.sys.id]);
+  const allReferences: ReferencedEntryData[] = [];
+  const contentTypeCache: Record<string, ContentTypeProps> = {
+    [contentType.sys.id]: contentType,
+  };
 
-  const entryMap = await fetchReferenceEntries(cma, referencesToProcess, entryId);
+  await collectReferencesRecursive(
+    cma,
+    entry,
+    contentType,
+    sourceLocale,
+    1,
+    maxDepth,
+    visited,
+    allReferences,
+    contentTypeCache,
+    entry.sys.id
+  );
 
-  const contentTypeMap = await fetchContentTypes(cma, entryMap, contentType.sys.id, contentType);
+  return allReferences;
+};
 
-  return referencesToProcess.flatMap(({ referenceEntryId, field }) => {
-    if (referenceEntryId === entryId) {
-      return {
-        entry,
-        contentType,
-        fieldId: field.id,
-        fieldName: field.name,
-        isSelfReference: true,
-      };
+const collectReferencesRecursive = async (
+  cma: CMAClient,
+  parentEntry: EntryProps,
+  parentContentType: ContentTypeProps,
+  sourceLocale: string,
+  currentDepth: number,
+  maxDepth: number,
+  visited: Set<string>,
+  results: ReferencedEntryData[],
+  contentTypeCache: Record<string, ContentTypeProps>,
+  parentEntryId: string
+): Promise<void> => {
+  if (results.length >= MAX_TOTAL_ENTRIES) return;
+
+  const referencesToProcess = collectReferences(parentEntry, parentContentType, sourceLocale);
+  if (referencesToProcess.length === 0) return;
+
+  const unvisitedIds = [
+    ...new Set(referencesToProcess.map((r) => r.referenceEntryId).filter((id) => !visited.has(id))),
+  ];
+
+  const entryMap: Record<string, EntryProps> = {};
+  if (unvisitedIds.length > 0) {
+    const entriesResponse = await cma.entry.getMany({
+      query: { 'sys.id[in]': unvisitedIds.join(',') },
+    });
+    for (const fetchedEntry of entriesResponse.items) {
+      entryMap[fetchedEntry.sys.id] = fetchedEntry;
     }
+  }
+
+  const newContentTypeIds = [
+    ...new Set(
+      Object.values(entryMap)
+        .map((e) => e.sys.contentType.sys.id)
+        .filter((id) => !contentTypeCache[id])
+    ),
+  ];
+  if (newContentTypeIds.length > 0) {
+    const ctResponse = await cma.contentType.getMany({
+      query: { 'sys.id[in]': newContentTypeIds.join(',') },
+    });
+    for (const ct of ctResponse.items) {
+      contentTypeCache[ct.sys.id] = ct;
+    }
+  }
+
+  const entriesToRecurse: { entry: EntryProps; contentType: ContentTypeProps }[] = [];
+
+  for (const { referenceEntryId, field } of referencesToProcess) {
+    if (results.length >= MAX_TOTAL_ENTRIES) break;
+
+    if (visited.has(referenceEntryId)) {
+      if (referenceEntryId === parentEntry.sys.id) {
+        results.push({
+          entry: parentEntry,
+          contentType: parentContentType,
+          fieldId: field.id,
+          fieldName: field.name,
+          isSelfReference: true,
+          depth: currentDepth,
+          parentEntryId,
+        });
+      }
+      continue;
+    }
+
+    visited.add(referenceEntryId);
 
     const referenceEntry = entryMap[referenceEntryId];
-    if (!referenceEntry) {
-      return [];
-    }
+    if (!referenceEntry) continue;
 
-    const referenceContentType = contentTypeMap[referenceEntry.sys.contentType.sys.id];
+    const referenceContentType = contentTypeCache[referenceEntry.sys.contentType.sys.id];
+    if (!referenceContentType) continue;
 
-    return {
+    results.push({
       entry: referenceEntry,
       contentType: referenceContentType,
       fieldId: field.id,
       fieldName: field.name,
       isSelfReference: false,
-    };
-  });
+      depth: currentDepth,
+      parentEntryId,
+    });
+
+    if (currentDepth < maxDepth) {
+      entriesToRecurse.push({ entry: referenceEntry, contentType: referenceContentType });
+    }
+  }
+
+  for (const { entry: refEntry, contentType: refCt } of entriesToRecurse) {
+    if (results.length >= MAX_TOTAL_ENTRIES) break;
+    await collectReferencesRecursive(
+      cma,
+      refEntry,
+      refCt,
+      sourceLocale,
+      currentDepth + 1,
+      maxDepth,
+      visited,
+      results,
+      contentTypeCache,
+      refEntry.sys.id
+    );
+  }
 };
 
 const collectReferences = (
@@ -197,57 +295,4 @@ const collectReferences = (
   }
 
   return referencesToProcess;
-};
-
-const fetchReferenceEntries = async (
-  cma: CMAClient,
-  referencesToProcess: { referenceEntryId: string; field: ContentTypeField }[],
-  entryId: string
-): Promise<Record<string, EntryProps>> => {
-  const uniqueEntryIds = [
-    ...new Set(
-      referencesToProcess
-        .map((reference) => reference.referenceEntryId)
-        .filter((id) => id !== entryId)
-    ),
-  ];
-
-  const entryMap: Record<string, EntryProps> = {};
-
-  if (uniqueEntryIds.length > 0) {
-    const entriesResponse = await cma.entry.getMany({
-      query: { 'sys.id[in]': uniqueEntryIds.join(',') },
-    });
-    for (const fetchedEntry of entriesResponse.items) {
-      entryMap[fetchedEntry.sys.id] = fetchedEntry;
-    }
-  }
-
-  return entryMap;
-};
-
-const fetchContentTypes = async (
-  cma: CMAClient,
-  entryMap: Record<string, EntryProps>,
-  contentTypeId: string,
-  mainEntryContentType: ContentTypeProps
-): Promise<Record<string, ContentTypeProps>> => {
-  const contentTypeMap: Record<string, ContentTypeProps> = {
-    [contentTypeId]: mainEntryContentType,
-  };
-
-  const uniqueContentTypeIds = [
-    ...new Set(Object.values(entryMap).map((e) => e.sys.contentType.sys.id)),
-  ].filter((id) => !contentTypeMap[id]);
-
-  if (uniqueContentTypeIds.length > 0) {
-    const contentTypesResponse = await cma.contentType.getMany({
-      query: { 'sys.id[in]': uniqueContentTypeIds.join(',') },
-    });
-    for (const ct of contentTypesResponse.items) {
-      contentTypeMap[ct.sys.id] = ct;
-    }
-  }
-
-  return contentTypeMap;
 };


### PR DESCRIPTION
### Summary

- Locale Field Populator now recursively traverses nested entry references (not just direct refs from the main entry)
- Adds configurable max depth (default 3) in the app config screen
- Includes cycle detection and a hard cap of 50 entries to prevent runaway API calls
- Nested references render with indentation in the preview step so users can see the hierarchy

Tickets: MAPS-255, ES-183

### Context

While triaging a support issue, we discovered the app only populated localized fields on direct references. Entries linked deeper in the content graph were silently skipped. This is a common pattern for customers with modular content models (e.g., Page -> Section -> Item).

### Changes

| File | What |
|------|------|
| `utils/entry.ts` | Replaced flat reference fetch with recursive `collectReferencesRecursive` |
| `utils/adoptedFields.ts` | Added `depth` and `parentEntryId` to `ReferencedEntryData` |
| `locations/ConfigScreen.tsx` | Added "Reference depth" dropdown (0-5) |
| `locations/Dialog.tsx` | Reads `maxReferenceDepth` from install params |
| `components/steps/PreviewStep.tsx` | Renders references in traversal order with depth prop |
| `components/preview/ReferenceEntrySection.tsx` | Accepts `depth`, applies indentation |
| `components/preview/ReferenceEntrySection.styles.ts` | `depthIndent` utility |

### Test plan

- [x] Install app on a space with nested content (Page -> Section -> Item pattern)
- [x] Verify depth-1 references still render as before
- [x] Verify depth-2+ references appear indented in preview
- [x] Confirm circular references are detected and shown with the self-reference warning
- [x] Change max depth in config screen, verify it limits traversal
- [x] Confirm "Adopt all fields" and per-field toggles work for nested entries
- [x] Run `tsc --noEmit`, `vite build`, `eslint .` -- all pass locally

### Screenshots

New setting in the app configuration page:

> <img width="880" height="246" alt="Screenshot 2026-05-06 at 9 20 33 AM" src="https://github.com/user-attachments/assets/d47dc99f-dc7f-4871-88b2-3a951d82ab7f" />

Nested references showing at the bottom of the modal:

> <img width="2478" height="931" alt="Screenshot 2026-05-06 at 8 55 14 AM" src="https://github.com/user-attachments/assets/98d1c866-a5c9-4a4f-8618-e5695b2dcdee" />

Reference accordion items expanded in the modal:

> <img width="2476" height="1202" alt="Screenshot 2026-05-06 at 8 55 32 AM" src="https://github.com/user-attachments/assets/77e07521-c5af-4c72-8faa-324db0686e6c" />