### PR TITLE
refactor(google-docs): View only highlighting updates [INTEG-3886]

### DIFF
--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.styles.ts
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.styles.ts
@@ -1,0 +1,30 @@
+import { css } from '@emotion/css';
+import tokens from '@contentful/f36-tokens';
+
+const mappingGroupSurfaceBase = css({
+  borderRadius: tokens.borderRadiusMedium,
+  padding: tokens.spacing2Xs,
+});
+
+export const mappingGroupSurfaceView = css([
+  mappingGroupSurfaceBase,
+  {
+    border: `1px solid ${tokens.green500}`,
+    transition: 'border-color 120ms ease, border-width 120ms ease',
+  },
+]);
+
+export const mappingGroupSurfaceViewHovered = css([
+  mappingGroupSurfaceBase,
+  {
+    border: `2px solid ${tokens.green600}`,
+    transition: 'border-color 120ms ease, border-width 120ms ease',
+  },
+]);
+
+export const mappingGroupSurfaceEdit = css([
+  mappingGroupSurfaceBase,
+  {
+    backgroundColor: tokens.green100,
+  },
+]);

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -15,7 +15,12 @@ import type {
   SourceRef,
   TableTextSourceRef,
 } from '@types';
-import { isBlockImageSourceRef, isTableImageSourceRef, isTableTextSourceRef } from '@types';
+import {
+  isBlockImageSourceRef,
+  isTableImageSourceRef,
+  isTableTextSourceRef,
+  isTextSourceRef,
+} from '@types';
 import { FileTextIcon, LightbulbIcon } from '@contentful/f36-icons';
 import { useReviewTextSelection } from '@hooks/useReviewTextSelection';
 import { getEntryTitleFromFieldMappings } from '../../../../../utils/getEntryTitle';
@@ -38,10 +43,15 @@ import { EditModal } from './edit-modals/EditModal';
 import { RichTextSelectionPreview } from './edit-modals/RichTextSelectionPreview';
 
 import { EditMappingButton } from './EditMappingButton';
+import {
+  mappingGroupSurfaceEdit,
+  mappingGroupSurfaceView,
+  mappingGroupSurfaceViewHovered,
+} from './MappingView.styles';
 import { buildSourceRefKey } from './sourceRefUtils';
 import { MappingEntryCards } from './MappingEntryCards';
 import { NormalizedDocumentSection } from './NormalizedDocumentSection';
-import { buildMappingDisplayGroups } from './buildMappingDisplayGroups';
+import { buildMappingDisplayGroups, type MappingDisplayGroup } from './buildMappingDisplayGroups';
 import { ViewMappingRail, type ViewMappingCardEntry } from './ViewMappingRail';
 import { ViewMappingCard } from './ViewMappingCard';
 import {
@@ -108,6 +118,25 @@ function rangeIntersectsNode(range: Range, node: Node): boolean {
   } catch {
     return false;
   }
+}
+
+function getViewModeGroupSurfaceFlags(
+  isViewMode: boolean,
+  group: MappingDisplayGroup,
+  visibleHighlightsBySegment: Record<string, MappingHighlight[]>
+): { isTableOnlyGroup: boolean; isImageOnlyGroup: boolean } {
+  if (!isViewMode || group.segments.length !== 1) {
+    return { isTableOnlyGroup: false, isImageOnlyGroup: false };
+  }
+
+  const onlySegment = group.segments[0];
+
+  const isTableOnlyGroup = onlySegment?.kind === 'table';
+  const isImageOnlyGroup =
+    onlySegment?.kind === 'block' &&
+    (visibleHighlightsBySegment[onlySegment.id] ?? []).every((h) => !isTextSourceRef(h.sourceRef));
+
+  return { isTableOnlyGroup, isImageOnlyGroup };
 }
 
 export const MappingView = ({
@@ -811,35 +840,27 @@ export const MappingView = ({
 
             <Flex flexDirection="column" gap="spacingS">
               {(groupsByTab[tab.id] ?? []).map((group) => {
-                const activeHighlightIndex = highlightIndex;
-                const firstSegment = group.segments[0];
-                const isTableOnlyGroup =
-                  isViewMode &&
-                  group.segments.length === 1 &&
-                  firstSegment !== undefined &&
-                  firstSegment.kind === 'table';
+                const { isTableOnlyGroup, isImageOnlyGroup } = getViewModeGroupSurfaceFlags(
+                  isViewMode,
+                  group,
+                  visibleHighlightsBySegment
+                );
+
                 const showSurface = isViewMode
-                  ? group.mappingCards.length > 0 && !isTableOnlyGroup
+                  ? group.mappingCards.length > 0 && !isTableOnlyGroup && !isImageOnlyGroup
                   : group.showGroupedSurface;
+
                 const isGroupSurfaceHovered =
                   isViewMode &&
                   group.mappingCards.some((card) =>
                     card.mappingKeys.some((key) => hoveredMappingKeys.includes(key))
                   );
-                const surfaceStyle = isViewMode
-                  ? {
-                      borderRadius: tokens.borderRadiusMedium,
-                      border: `${isGroupSurfaceHovered ? 2 : 1}px solid ${
-                        isGroupSurfaceHovered ? tokens.green600 : tokens.green500
-                      }`,
-                      padding: tokens.spacing2Xs,
-                      transition: 'border-color 120ms ease, border-width 120ms ease',
-                    }
-                  : {
-                      borderRadius: tokens.borderRadiusMedium,
-                      backgroundColor: tokens.green100,
-                      padding: tokens.spacing2Xs,
-                    };
+
+                const surfaceClassName = isViewMode
+                  ? isGroupSurfaceHovered
+                    ? mappingGroupSurfaceViewHovered
+                    : mappingGroupSurfaceView
+                  : mappingGroupSurfaceEdit;
 
                 return (
                   <Box key={group.id}>
@@ -852,13 +873,13 @@ export const MappingView = ({
                         {showSurface ? (
                           <Box
                             data-testid={`mapping-group-surface-${group.id}`}
-                            style={surfaceStyle}>
+                            className={surfaceClassName}>
                             <Flex flexDirection="column" gap="spacing2Xs">
                               {group.segments.map((segment) => (
                                 <NormalizedDocumentSection
                                   key={segment.id}
                                   segment={segment}
-                                  highlightIndex={activeHighlightIndex}
+                                  highlightIndex={highlightIndex}
                                   imageById={imageById}
                                   listMarkers={listMarkers}
                                   excludedSourceRefs={entryBlockGraph.excludedSourceRefs}
@@ -877,7 +898,7 @@ export const MappingView = ({
                               <NormalizedDocumentSection
                                 key={segment.id}
                                 segment={segment}
-                                highlightIndex={activeHighlightIndex}
+                                highlightIndex={highlightIndex}
                                 imageById={imageById}
                                 listMarkers={listMarkers}
                                 excludedSourceRefs={entryBlockGraph.excludedSourceRefs}

--- a/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -812,7 +812,34 @@ export const MappingView = ({
             <Flex flexDirection="column" gap="spacingS">
               {(groupsByTab[tab.id] ?? []).map((group) => {
                 const activeHighlightIndex = highlightIndex;
-                const showSurface = group.showGroupedSurface;
+                const firstSegment = group.segments[0];
+                const isTableOnlyGroup =
+                  isViewMode &&
+                  group.segments.length === 1 &&
+                  firstSegment !== undefined &&
+                  firstSegment.kind === 'table';
+                const showSurface = isViewMode
+                  ? group.mappingCards.length > 0 && !isTableOnlyGroup
+                  : group.showGroupedSurface;
+                const isGroupSurfaceHovered =
+                  isViewMode &&
+                  group.mappingCards.some((card) =>
+                    card.mappingKeys.some((key) => hoveredMappingKeys.includes(key))
+                  );
+                const surfaceStyle = isViewMode
+                  ? {
+                      borderRadius: tokens.borderRadiusMedium,
+                      border: `${isGroupSurfaceHovered ? 2 : 1}px solid ${
+                        isGroupSurfaceHovered ? tokens.green600 : tokens.green500
+                      }`,
+                      padding: tokens.spacing2Xs,
+                      transition: 'border-color 120ms ease, border-width 120ms ease',
+                    }
+                  : {
+                      borderRadius: tokens.borderRadiusMedium,
+                      backgroundColor: tokens.green100,
+                      padding: tokens.spacing2Xs,
+                    };
 
                 return (
                   <Box key={group.id}>
@@ -825,11 +852,7 @@ export const MappingView = ({
                         {showSurface ? (
                           <Box
                             data-testid={`mapping-group-surface-${group.id}`}
-                            style={{
-                              borderRadius: tokens.borderRadiusMedium,
-                              backgroundColor: tokens.green100,
-                              padding: tokens.spacing2Xs,
-                            }}>
+                            style={surfaceStyle}>
                             <Flex flexDirection="column" gap="spacing2Xs">
                               {group.segments.map((segment) => (
                                 <NormalizedDocumentSection
@@ -841,6 +864,7 @@ export const MappingView = ({
                                   excludedSourceRefs={entryBlockGraph.excludedSourceRefs}
                                   selectedEntryIndex={selectedEntryIndex}
                                   hoveredMappingKeys={hoveredMappingKeys}
+                                  isViewMode={isViewMode}
                                   onSetHoveredMappingKeys={setHoveredMappingKeys}
                                   onEditImage={isViewMode ? undefined : handleEditImage}
                                 />
@@ -859,6 +883,7 @@ export const MappingView = ({
                                 excludedSourceRefs={entryBlockGraph.excludedSourceRefs}
                                 selectedEntryIndex={selectedEntryIndex}
                                 hoveredMappingKeys={hoveredMappingKeys}
+                                isViewMode={isViewMode}
                                 onSetHoveredMappingKeys={setHoveredMappingKeys}
                                 onEditImage={isViewMode ? undefined : handleEditImage}
                               />

--- a/apps/google-docs/src/locations/Page/components/review/mapping/NormalizedDocumentSection.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/NormalizedDocumentSection.tsx
@@ -16,6 +16,7 @@ interface ReviewDocumentBodyProps {
   excludedSourceRefs: SourceRef[];
   selectedEntryIndex: number | null;
   hoveredMappingKeys: string[];
+  isViewMode: boolean;
   onSetHoveredMappingKeys: (keys: string[]) => void;
   onEditImage?: (sourceRef: ImageSourceRef, label: string) => void;
 }
@@ -29,6 +30,7 @@ export const NormalizedDocumentSection = ({
   excludedSourceRefs,
   selectedEntryIndex,
   hoveredMappingKeys,
+  isViewMode,
   onSetHoveredMappingKeys,
   onEditImage,
 }: ReviewDocumentBodyProps): JSX.Element => {
@@ -51,6 +53,7 @@ export const NormalizedDocumentSection = ({
               excludedSourceRefs={excludedSourceRefs}
               selectedEntryIndex={selectedEntryIndex}
               hoveredMappingKeys={hoveredMappingKeys}
+              isViewMode={isViewMode}
               onSetHoveredMappingKeys={onSetHoveredMappingKeys}
               onEditImage={onEditImage}
             />
@@ -64,6 +67,7 @@ export const NormalizedDocumentSection = ({
               excludedSourceRefs={excludedSourceRefs}
               selectedEntryIndex={selectedEntryIndex}
               hoveredMappingKeys={hoveredMappingKeys}
+              isViewMode={isViewMode}
               onSetHoveredMappingKeys={onSetHoveredMappingKeys}
               onEditImage={onEditImage}
             />

--- a/apps/google-docs/src/locations/Page/components/review/mapping/ReviewImageAssetCard.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/ReviewImageAssetCard.tsx
@@ -12,6 +12,8 @@ export interface ReviewImageAssetCardProps {
   /** When the mapping rail highlights this image (same as plain `img` hover). */
   hovered?: boolean;
   isExcluded: boolean;
+  /** When true, render a green border without a green fill for highlighted mappings. */
+  isViewMode?: boolean;
   size?: 'small' | 'default';
   onMouseEnter?: () => void;
   onMouseLeave?: () => void;
@@ -28,6 +30,7 @@ export function ReviewImageAssetCard({
   isHighlighted,
   hovered = false,
   isExcluded,
+  isViewMode = false,
   size = 'default',
   onMouseEnter,
   onMouseLeave,
@@ -37,11 +40,21 @@ export function ReviewImageAssetCard({
 
   const imageHeight = size === 'small' ? '180px' : '280px';
 
-  const backgroundColor = isHighlighted
+  // View mode: highlighted images use a green border with no fill; unmapped images are unchanged.
+  // Edit mode (default): highlighted images use a green fill with transparent border.
+  const backgroundColor = isViewMode
+    ? tokens.gray100
+    : isHighlighted
     ? hovered
       ? tokens.green300
       : tokens.green100
     : tokens.gray100;
+
+  const border = isViewMode
+    ? isHighlighted
+      ? `${hovered ? 2 : 1}px solid ${hovered ? tokens.green600 : tokens.green500}`
+      : `1px solid ${tokens.gray300}`
+    : `1px solid ${isHighlighted ? 'transparent' : tokens.gray300}`;
 
   return (
     <Box
@@ -54,9 +67,9 @@ export function ReviewImageAssetCard({
         maxWidth: '100%',
         verticalAlign: 'top',
         borderRadius: tokens.borderRadiusMedium,
-        border: `1px solid ${isHighlighted ? 'transparent' : tokens.gray300}`,
+        border,
         backgroundColor,
-        transition: 'background-color 120ms ease',
+        transition: 'background-color 120ms ease, border-color 120ms ease',
         overflow: 'hidden',
         boxSizing: 'border-box',
         padding: tokens.spacingXs,

--- a/apps/google-docs/src/locations/Page/components/review/mapping/ViewMappingCard.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/ViewMappingCard.tsx
@@ -41,7 +41,7 @@ export const ViewMappingCard = ({
         border: `${isHovered ? 2 : 1}px solid ${isHovered ? tokens.green600 : tokens.green500}`,
         borderRadius: tokens.borderRadiusMedium,
         padding: tokens.spacing2Xs,
-        backgroundColor: tokens.green100,
+        backgroundColor: 'transparent',
         transition: 'border-color 120ms ease, border-width 120ms ease',
         cursor: 'default',
       }}>

--- a/apps/google-docs/src/locations/Page/components/review/mapping/documentRenderers.styles.ts
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/documentRenderers.styles.ts
@@ -1,0 +1,35 @@
+import { css } from '@emotion/css';
+import tokens from '@contentful/f36-tokens';
+
+const tableCellChromeBase = css({
+  display: 'inline-block',
+  width: 'fit-content',
+  maxWidth: '100%',
+  verticalAlign: 'top',
+  boxSizing: 'border-box',
+  borderRadius: tokens.borderRadiusMedium,
+  padding: tokens.spacing2Xs,
+});
+
+export const tableCellChromeMapped = css([
+  tableCellChromeBase,
+  {
+    border: `1px solid ${tokens.green500}`,
+    transition: 'border-color 120ms ease, border-width 120ms ease',
+  },
+]);
+
+export const tableCellChromeMappedHovered = css([
+  tableCellChromeBase,
+  {
+    border: `2px solid ${tokens.green600}`,
+    transition: 'border-color 120ms ease, border-width 120ms ease',
+  },
+]);
+
+export const tableCellChromeUnmapped = css([
+  tableCellChromeBase,
+  {
+    border: `1px solid ${tokens.gray300}`,
+  },
+]);

--- a/apps/google-docs/src/locations/Page/components/review/mapping/documentRenderers.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/documentRenderers.tsx
@@ -41,11 +41,25 @@ function isMappingHovered(keys: string[], hoveredMappingKeys: string[]): boolean
   return keys.some((k) => hoveredMappingKeys.includes(k));
 }
 
-function getHighlightStyle(highlighted: boolean, hovered: boolean) {
-  if (!highlighted) return { border: tokens.gray300, background: 'transparent' };
+function getTextSegmentHighlightCss(
+  highlighted: boolean,
+  hovered: boolean,
+  isViewMode: boolean
+): { background: string; padding: string | undefined; boxShadow: string | undefined } {
+  if (!highlighted) {
+    return { background: 'transparent', padding: undefined, boxShadow: undefined };
+  }
+  if (isViewMode) {
+    return {
+      background: 'transparent',
+      padding: undefined,
+      boxShadow: undefined,
+    };
+  }
   return {
-    border: hovered ? tokens.green600 : tokens.green500,
     background: hovered ? tokens.green300 : tokens.green100,
+    padding: `${tokens.spacing2Xs} 0`,
+    boxShadow: undefined,
   };
 }
 
@@ -68,6 +82,7 @@ interface TextSegmentSpanProps {
   id: string;
   segment: TextSegment;
   hovered: boolean;
+  isViewMode: boolean;
   onSetHoveredMappings: (keys: string[]) => void;
   textScope: 'block' | 'table';
   rangeStart: number;
@@ -83,6 +98,7 @@ const TextSegmentSpan = ({
   id,
   segment,
   hovered,
+  isViewMode,
   onSetHoveredMappings,
   textScope,
   rangeStart,
@@ -93,6 +109,7 @@ const TextSegmentSpan = ({
   cellId,
   partId,
 }: TextSegmentSpanProps) => {
+  const highlightCss = getTextSegmentHighlightCss(segment.highlighted, hovered, isViewMode);
   const content = (
     <Box
       as="span"
@@ -114,8 +131,9 @@ const TextSegmentSpan = ({
       onMouseLeave={segment.highlighted ? () => onSetHoveredMappings([]) : undefined}
       style={{
         ...getTextSegmentStyle(segment.styles),
-        backgroundColor: getHighlightStyle(segment.highlighted, hovered).background,
-        padding: segment.highlighted ? `${tokens.spacing2Xs} 0` : undefined,
+        backgroundColor: highlightCss.background,
+        padding: highlightCss.padding,
+        boxShadow: highlightCss.boxShadow,
         whiteSpace: 'pre-wrap',
         transition: 'background-color 120ms ease',
       }}>
@@ -144,6 +162,7 @@ interface BlockRendererProps {
   excludedSourceRefs: SourceRef[];
   selectedEntryIndex: number | null;
   hoveredMappingKeys: string[];
+  isViewMode: boolean;
   onSetHoveredMappingKeys: (keys: string[]) => void;
   onEditImage?: (
     sourceRef: { type: 'image'; blockId: string; imageId: string },
@@ -160,6 +179,7 @@ export const BlockRenderer = ({
   excludedSourceRefs,
   selectedEntryIndex,
   hoveredMappingKeys,
+  isViewMode,
   onSetHoveredMappingKeys,
   onEditImage,
 }: BlockRendererProps) => {
@@ -178,6 +198,7 @@ export const BlockRenderer = ({
           id={`${block.id}-${index}`}
           segment={seg}
           hovered={isMappingHovered(seg.mappingKeys, hoveredMappingKeys)}
+          isViewMode={isViewMode}
           onSetHoveredMappings={onSetHoveredMappingKeys}
           textScope="block"
           rangeStart={seg.start}
@@ -245,6 +266,7 @@ export const BlockRenderer = ({
               isHighlighted={highlighted}
               hovered={hovered}
               isExcluded={isImageSourceRefExcluded(imageSourceRef, excludedSourceRefs)}
+              isViewMode={isViewMode}
               onMouseEnter={
                 highlighted ? () => onSetHoveredMappingKeys(imageMappingKeys) : undefined
               }
@@ -274,6 +296,7 @@ interface TableRendererProps {
   excludedSourceRefs: SourceRef[];
   selectedEntryIndex: number | null;
   hoveredMappingKeys: string[];
+  isViewMode: boolean;
   onSetHoveredMappingKeys: (keys: string[]) => void;
   onEditImage?: (
     sourceRef: {
@@ -298,6 +321,7 @@ interface TablePartRendererProps {
   imageById: Record<string, NormalizedDocumentImage>;
   excludedSourceRefs: SourceRef[];
   hoveredMappingKeys: string[];
+  isViewMode: boolean;
   onSetHoveredMappingKeys: (keys: string[]) => void;
   onEditImage?: TableRendererProps['onEditImage'];
 }
@@ -312,6 +336,7 @@ const TablePartRenderer = ({
   imageById,
   excludedSourceRefs,
   hoveredMappingKeys,
+  isViewMode,
   onSetHoveredMappingKeys,
   onEditImage,
 }: TablePartRendererProps) => {
@@ -359,6 +384,7 @@ const TablePartRenderer = ({
           isHighlighted={highlighted}
           hovered={hovered}
           isExcluded={isImageSourceRefExcluded(imageSourceRef, excludedSourceRefs)}
+          isViewMode={isViewMode}
           size="small"
           onMouseEnter={highlighted ? () => onSetHoveredMappingKeys(mappingKeys) : undefined}
           onMouseLeave={highlighted ? () => onSetHoveredMappingKeys([]) : undefined}
@@ -382,6 +408,7 @@ const TablePartRenderer = ({
           id={`${part.id}-${index}`}
           segment={seg}
           hovered={isMappingHovered(seg.mappingKeys, hoveredMappingKeys)}
+          isViewMode={isViewMode}
           onSetHoveredMappings={onSetHoveredMappingKeys}
           textScope="table"
           rangeStart={seg.start}
@@ -405,6 +432,7 @@ export const TableRenderer = ({
   excludedSourceRefs,
   selectedEntryIndex,
   hoveredMappingKeys,
+  isViewMode,
   onSetHoveredMappingKeys,
   onEditImage,
 }: TableRendererProps) => {
@@ -425,7 +453,19 @@ export const TableRenderer = ({
         }
       );
     });
-    return keys;
+    return Array.from(new Set(keys));
+  };
+
+  const hasAnyMappedCellInTable =
+    isViewMode &&
+    table.rows.some((r) => r.cells.some((c) => getCellMappingKeys(r.id, c.id).length > 0));
+
+  const tableCellChromeSizing: CSSProperties = {
+    display: 'inline-block',
+    width: 'fit-content',
+    maxWidth: '100%',
+    verticalAlign: 'top',
+    boxSizing: 'border-box',
   };
 
   return (
@@ -445,11 +485,13 @@ export const TableRenderer = ({
             key={row.id}
             id={`row:${table.id}:${row.id}`}
             data-testid={`table-row-${row.id}`}>
-            {row.cells.map((cell) => (
-              <TableCell
-                key={cell.id}
-                data-testid={`table-cell-${cell.id}`}
-                style={{ backgroundColor: 'transparent', verticalAlign: 'top' }}>
+            {row.cells.map((cell) => {
+              const cellMappingKeys = getCellMappingKeys(row.id, cell.id);
+              const hasCellMapping = cellMappingKeys.length > 0;
+              const isCellSurfaceHovered =
+                isViewMode && isMappingHovered(cellMappingKeys, hoveredMappingKeys);
+
+              const cellBody = (
                 <Flex flexDirection="column" gap="spacing2Xs">
                   {cell.parts.map((part) => {
                     const partKey = [table.id, row.id, cell.id, part.id].join(':');
@@ -465,6 +507,7 @@ export const TableRenderer = ({
                           imageById={imageById}
                           excludedSourceRefs={excludedSourceRefs}
                           hoveredMappingKeys={hoveredMappingKeys}
+                          isViewMode={isViewMode}
                           onSetHoveredMappingKeys={onSetHoveredMappingKeys}
                           onEditImage={onEditImage}
                         />
@@ -472,8 +515,46 @@ export const TableRenderer = ({
                     );
                   })}
                 </Flex>
-              </TableCell>
-            ))}
+              );
+
+              const viewModeChrome = hasCellMapping ? (
+                <Box
+                  data-testid={`table-cell-mapping-surface-${cell.id}`}
+                  style={{
+                    ...tableCellChromeSizing,
+                    borderRadius: tokens.borderRadiusMedium,
+                    border: `${isCellSurfaceHovered ? 2 : 1}px solid ${
+                      isCellSurfaceHovered ? tokens.green600 : tokens.green500
+                    }`,
+                    padding: tokens.spacing2Xs,
+                    transition: 'border-color 120ms ease, border-width 120ms ease',
+                  }}>
+                  {cellBody}
+                </Box>
+              ) : hasAnyMappedCellInTable ? (
+                <Box
+                  data-testid={`table-cell-chrome-${cell.id}`}
+                  style={{
+                    ...tableCellChromeSizing,
+                    borderRadius: tokens.borderRadiusMedium,
+                    border: `1px solid ${tokens.gray300}`,
+                    padding: tokens.spacing2Xs,
+                  }}>
+                  {cellBody}
+                </Box>
+              ) : (
+                cellBody
+              );
+
+              return (
+                <TableCell
+                  key={cell.id}
+                  data-testid={`table-cell-${cell.id}`}
+                  style={{ backgroundColor: 'transparent', verticalAlign: 'top' }}>
+                  {isViewMode ? viewModeChrome : cellBody}
+                </TableCell>
+              );
+            })}
           </TableRow>
         ))}
       </TableBody>

--- a/apps/google-docs/src/locations/Page/components/review/mapping/documentRenderers.tsx
+++ b/apps/google-docs/src/locations/Page/components/review/mapping/documentRenderers.tsx
@@ -25,6 +25,11 @@ import type { ListMarker } from './buildListMarkers';
 import { buildTextSegments, type TextSegment } from './buildTextSegments';
 import { ReviewImageAssetCard } from './ReviewImageAssetCard';
 import { isImageSourceRefExcluded } from './sourceRefUtils';
+import {
+  tableCellChromeMapped,
+  tableCellChromeMappedHovered,
+  tableCellChromeUnmapped,
+} from './documentRenderers.styles';
 
 // ─── Shared helpers ─────────────────────────────────────────────────────────
 
@@ -45,21 +50,12 @@ function getTextSegmentHighlightCss(
   highlighted: boolean,
   hovered: boolean,
   isViewMode: boolean
-): { background: string; padding: string | undefined; boxShadow: string | undefined } {
-  if (!highlighted) {
-    return { background: 'transparent', padding: undefined, boxShadow: undefined };
-  }
-  if (isViewMode) {
-    return {
-      background: 'transparent',
-      padding: undefined,
-      boxShadow: undefined,
-    };
-  }
+): Pick<CSSProperties, 'backgroundColor' | 'padding' | 'boxShadow'> {
+  if (!highlighted || isViewMode) return {};
+
   return {
-    background: hovered ? tokens.green300 : tokens.green100,
+    backgroundColor: hovered ? tokens.green300 : tokens.green100,
     padding: `${tokens.spacing2Xs} 0`,
-    boxShadow: undefined,
   };
 }
 
@@ -131,9 +127,7 @@ const TextSegmentSpan = ({
       onMouseLeave={segment.highlighted ? () => onSetHoveredMappings([]) : undefined}
       style={{
         ...getTextSegmentStyle(segment.styles),
-        backgroundColor: highlightCss.background,
-        padding: highlightCss.padding,
-        boxShadow: highlightCss.boxShadow,
+        ...highlightCss,
         whiteSpace: 'pre-wrap',
         transition: 'background-color 120ms ease',
       }}>
@@ -456,18 +450,6 @@ export const TableRenderer = ({
     return Array.from(new Set(keys));
   };
 
-  const hasAnyMappedCellInTable =
-    isViewMode &&
-    table.rows.some((r) => r.cells.some((c) => getCellMappingKeys(r.id, c.id).length > 0));
-
-  const tableCellChromeSizing: CSSProperties = {
-    display: 'inline-block',
-    width: 'fit-content',
-    maxWidth: '100%',
-    verticalAlign: 'top',
-    boxSizing: 'border-box',
-  };
-
   return (
     <Table>
       {table.headers.length > 0 && (
@@ -520,26 +502,9 @@ export const TableRenderer = ({
               const viewModeChrome = hasCellMapping ? (
                 <Box
                   data-testid={`table-cell-mapping-surface-${cell.id}`}
-                  style={{
-                    ...tableCellChromeSizing,
-                    borderRadius: tokens.borderRadiusMedium,
-                    border: `${isCellSurfaceHovered ? 2 : 1}px solid ${
-                      isCellSurfaceHovered ? tokens.green600 : tokens.green500
-                    }`,
-                    padding: tokens.spacing2Xs,
-                    transition: 'border-color 120ms ease, border-width 120ms ease',
-                  }}>
-                  {cellBody}
-                </Box>
-              ) : hasAnyMappedCellInTable ? (
-                <Box
-                  data-testid={`table-cell-chrome-${cell.id}`}
-                  style={{
-                    ...tableCellChromeSizing,
-                    borderRadius: tokens.borderRadiusMedium,
-                    border: `1px solid ${tokens.gray300}`,
-                    padding: tokens.spacing2Xs,
-                  }}>
+                  className={
+                    isCellSurfaceHovered ? tableCellChromeMappedHovered : tableCellChromeMapped
+                  }>
                   {cellBody}
                 </Box>
               ) : (


### PR DESCRIPTION
## Purpose

Update the review page `View only mode` UI so mapped content doesn't have green fills. Only in the "View only" mode, the highlights no longer fill the background, instead, mapping context is shown via green borders and hover emphasis on cards/surfaces.

## Approach

- Switched view-mode presentation from filled green backgrounds to border-only styling across:
  - text highlights (no fill),
  - mapping rail cards (no fill),
  - mapping group surfaces (green border only, thickens/darkens on hover),
  - image mapping cards (green border only, thickens/darkens on hover).
- Kept edit mode behavior intact (existing filled highlight styling remains).
- Improved table rendering in view mode:
  - show per-cell mapping boxes (mapped cells only) with shrink-wrapped width,
  - avoid wrapping the entire table in a single outer surface.
- Prevented “double boxing” for image-only groups by skipping the outer group surface when a view-mode group contains only image mappings.

## Testing steps


https://github.com/user-attachments/assets/80180e67-b4b7-40cd-863c-6188a9dcd6ff


## Breaking Changes

No.

## Dependencies and/or References

This ticket addresses the pending "View only" mode updates from [INTEG-3886](https://contentful.atlassian.net/jira/software/c/projects/INTEG/boards/454?issueParent=476933&selectedIssue=INTEG-3886)

## Deployment

No.

[INTEG-3886]: https://contentful.atlassian.net/browse/INTEG-3886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ