### PR TITLE
fix(google-docs): remove X-Contentful-App-Definition-Id from agents API headers [INTEG-3890]

### DIFF
--- a/apps/google-docs/src/services/agents-api.ts
+++ b/apps/google-docs/src/services/agents-api.ts
@@ -12,7 +12,6 @@ import {
 
 const AGENTS_API_HEADERS = {
   'x-contentful-enable-alpha-feature': 'agents-api',
-  'X-Contentful-App-Definition-Id': '653vTnuQw3j5onU1tUoH6t',
 };
 
 export interface AgentGeneratePayload {


### PR DESCRIPTION
## Summary

- `X-Contentful-App-Definition-Id` was included in `AGENTS_API_HEADERS`, sent on every request to the local agents API dev server (`VITE_LOCAL_AGENTS_API_BASE_URL`)
- The agents API does not list this header in `Access-Control-Allow-Headers`, causing all preflight requests to fail with a CORS error when running locally

## Changes

- `apps/google-docs/src/services/agents-api.ts` — removed `X-Contentful-App-Definition-Id` from `AGENTS_API_HEADERS`