### PR TITLE
fix: restrict google-docs CODEOWNERS to team-10-pines []

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,6 +16,10 @@ examples/native-external-references-mockshop @contentful/team-entity-architectur
 examples/native-external-references-tmdb @contentful/team-entity-architecture
 function-examples/external-references @contentful/team-entity-architecture
 
+# 10pines solely owns google-docs so they can approve each other's PRs without requiring team-extensibility or team-marketplace
+
+apps/google-docs @contentful/team-10-pines
+
 # package.json and package-lock.json should be unowned so that dependabot can automatically update dependencies
 
 **/package.json


### PR DESCRIPTION
## Summary
- Adds a specific `apps/google-docs` entry in CODEOWNERS pointing only to `@contentful/team-10-pines`
- Without this, the `*` catch-all auto-requests `team-extensibility` and `team-marketplace` on every google-docs PR, requiring their review before merging
- With this change, only 10pines is auto-requested, so one team member can approve another's PR without needing external sign-off

Context: https://contentful.slack.com/archives/C0AJQPU62CU/p1778263501025189

🤖 Generated with [Claude Code](https://claude.com/claude-code)