### PR TITLE
fix(locale-field-populator): remove 50-entry cap [ES-183]

### DIFF
--- a/apps/locale-field-populator/AGENTS.md
+++ b/apps/locale-field-populator/AGENTS.md
@@ -38,10 +38,15 @@ src/
 
 - **Rich-text fields**: copying rich-text between locales requires deep-cloning the Document node, not just assigning the reference. Shared references between locales will cause unexpected mutations.
 - **Field validation**: target locale fields may have different validation rules than the source locale. The copy operation should check for validation failures and surface them before writing.
-- **`sdk.entry.fields[fieldId].setValue(value, localeCode)`**: the locale parameter is required — omitting it writes to the default locale regardless of which locale was selected.
-- Locale data is copied at the time of the operation — it does not create a sync relationship between locales.
+- **`sdk.entry.fields[fieldId].setValue(value, localeCode)`**: the locale parameter is required -- omitting it writes to the default locale regardless of which locale was selected.
+- Locale data is copied at the time of the operation -- it does not create a sync relationship between locales.
+- **Nested reference traversal termination**: `collectReferencesRecursive` in `src/utils/entry.ts` relies on the `visited` Set plus the configurable `maxDepth` to terminate. There is intentionally no total-entry cap -- customers regularly need to process hundreds of entries. Do not re-introduce a hard cap; if you think recursion is unbounded, reverify those two mechanisms first.
+- **CMA `sys.id[in]` filter limit (~100 IDs)**: any `entry.getMany` / `contentType.getMany` call that passes a comma-separated `sys.id[in]` value must chunk the IDs (current chunk size: `BATCH_SIZE = 100`). Passing more in a single request will fail or silently truncate.
+- **CMA write rate limits (~10 req/s)**: `updateEntries` runs writes through `chunkArray(..., UPDATE_CONCURRENCY)` with `UPDATE_CONCURRENCY = 5`. Do not collapse this back into an unbounded `Promise.all` -- at scale (200+ entries) it will exceed the per-second limit even with the SDK's automatic 429 retry.
+- **Preview pagination is UI-only**: `PreviewStep` renders referenced entries in pages (`ENTRIES_PAGE_SIZE`, "Show more" button), but `adoptedFields` and the Confirm-time `updateEntries` call cover ALL referenced entries regardless of what is currently mounted. Do not change `handleConfirm` to operate on the visible slice.
 
 ## Never / Always
 
-- **Never** assign rich-text Document nodes by reference across locales — always deep-clone.
+- **Never** assign rich-text Document nodes by reference across locales -- always deep-clone.
+- **Never** unbatch CMA reads or writes that go through `chunkArray` -- the chunking is load-bearing for both API limits and rate limits.
 - **Always** confirm with the user before overwriting existing locale values (the Dialog handles this).

--- a/apps/locale-field-populator/src/components/steps/PreviewStep.tsx
+++ b/apps/locale-field-populator/src/components/steps/PreviewStep.tsx
@@ -6,7 +6,6 @@ import {
   Flex,
   FormControl,
   List,
-  Note,
   Paragraph,
   Select,
   Subheading,
@@ -21,7 +20,6 @@ import {
   setAllEntryFieldsAdopted,
   setFieldAdopted,
 } from '../../utils/adoptedFields';
-import { MAX_TOTAL_ENTRIES } from '../../utils/entry';
 import { isEntryArrayField, isEntryField } from '../../utils/fieldTypes';
 import { SimplifiedLocale } from '../../utils/locales';
 import PreviewBox from '../preview/PreviewBox';
@@ -236,12 +234,6 @@ const PreviewStepComponent = ({
 
         {/* Referenced entries (all depths, rendered in traversal order) */}
         <Flex flexDirection="column" gap="spacingS" marginTop="spacingM">
-          {referencedEntries.length >= MAX_TOTAL_ENTRIES && (
-            <Note variant="warning">
-              Some referenced entries were not included. Try reducing the reference depth to see all
-              entries.
-            </Note>
-          )}
           {referencedEntries.map((referenceData) => (
             <ReferenceEntrySection
               key={`${referenceData.depth}-${referenceData.fieldId}-${referenceData.entry.sys.id}`}

--- a/apps/locale-field-populator/src/components/steps/PreviewStep.tsx
+++ b/apps/locale-field-populator/src/components/steps/PreviewStep.tsx
@@ -1,11 +1,13 @@
 import { ContentTypeField } from '@contentful/app-sdk';
 import {
   Box,
+  Button,
   Caption,
   Checkbox,
   Flex,
   FormControl,
   List,
+  Note,
   Paragraph,
   Select,
   Subheading,
@@ -87,9 +89,11 @@ const PreviewStepComponent = ({
   baseUrl,
   isDisabled = false,
 }: PreviewStepProps) => {
+  const ENTRIES_PAGE_SIZE = 50;
   const [selectedTargetLocale, setSelectedTargetLocale] = useState<string>(
     targetLocales[0]?.code || ''
   );
+  const [visibleCount, setVisibleCount] = useState(ENTRIES_PAGE_SIZE);
 
   useEffect(() => {
     if (Object.keys(adoptedFields).length === 0) {
@@ -111,6 +115,19 @@ const PreviewStepComponent = ({
   const allFieldsAdopted = useMemo(() => {
     return localizedFields.every((field) => adoptedFields[entry.sys.id]?.[field.id] === true);
   }, [localizedFields, adoptedFields]);
+
+  const totalReferencedFields = useMemo(() => {
+    return referencedEntries.reduce((count, ref) => {
+      if (ref.isSelfReference) return count;
+      const fields = ref.contentType.fields.filter(
+        (f) => f.localized && !isEntryField(f) && !isEntryArrayField(f)
+      );
+      return count + fields.length;
+    }, 0);
+  }, [referencedEntries]);
+
+  const visibleEntries = referencedEntries.slice(0, visibleCount);
+  const hasMore = visibleCount < referencedEntries.length;
 
   const handleAdoptAll = (entryId: string, contentType: ContentTypeProps, adopted: boolean) => {
     const fieldIds = contentType.fields
@@ -234,7 +251,14 @@ const PreviewStepComponent = ({
 
         {/* Referenced entries (all depths, rendered in traversal order) */}
         <Flex flexDirection="column" gap="spacingS" marginTop="spacingM">
-          {referencedEntries.map((referenceData) => (
+          {referencedEntries.length > 0 && (
+            <Note variant="neutral">
+              {referencedEntries.length} referenced{' '}
+              {referencedEntries.length === 1 ? 'entry' : 'entries'} with {totalReferencedFields}{' '}
+              localizable fields
+            </Note>
+          )}
+          {visibleEntries.map((referenceData) => (
             <ReferenceEntrySection
               key={`${referenceData.depth}-${referenceData.fieldId}-${referenceData.entry.sys.id}`}
               entry={referenceData.entry}
@@ -255,6 +279,14 @@ const PreviewStepComponent = ({
               depth={referenceData.depth}
             />
           ))}
+          {hasMore && (
+            <Button
+              variant="secondary"
+              onClick={() => setVisibleCount((prev) => prev + ENTRIES_PAGE_SIZE)}>
+              Show {Math.min(ENTRIES_PAGE_SIZE, referencedEntries.length - visibleCount)} more
+              entries
+            </Button>
+          )}
         </Flex>
       </Box>
     </Flex>

--- a/apps/locale-field-populator/src/utils/entry.ts
+++ b/apps/locale-field-populator/src/utils/entry.ts
@@ -61,26 +61,29 @@ export async function updateEntries(
     Object.values(entryAdoptedFields).some((adopted) => adopted)
   );
 
-  const results = await Promise.all(
-    entriesToUpdate.map(([entryId, entryAdoptedFields]) =>
-      updateSingleEntry(cma, entryId, sourceLocale, targetLocales, entryAdoptedFields)
-    )
-  );
-
   let totalFieldsUpdated = 0;
   let entriesUpdated = 0;
   const errors: string[] = [];
 
-  results.forEach((result, index) => {
-    if (result.success) {
-      totalFieldsUpdated += result.fieldsUpdated;
-      if (result.fieldsUpdated > 0) {
-        entriesUpdated++;
+  const batches = chunkArray(entriesToUpdate, UPDATE_CONCURRENCY);
+  for (const batch of batches) {
+    const results = await Promise.all(
+      batch.map(([entryId, entryAdoptedFields]) =>
+        updateSingleEntry(cma, entryId, sourceLocale, targetLocales, entryAdoptedFields)
+      )
+    );
+
+    results.forEach((result, index) => {
+      if (result.success) {
+        totalFieldsUpdated += result.fieldsUpdated;
+        if (result.fieldsUpdated > 0) {
+          entriesUpdated++;
+        }
+      } else if (result.error) {
+        errors.push(`Entry ${batch[index][0]}: ${result.error}`);
       }
-    } else if (result.error) {
-      errors.push(`Entry ${entriesToUpdate[index][0]}: ${result.error}`);
-    }
-  });
+    });
+  }
 
   if (errors.length > 0) {
     return {
@@ -114,7 +117,17 @@ export const fetchEntryAndContentType = async (
 };
 
 export const MAX_REFERENCE_DEPTH = 3;
-export const MAX_TOTAL_ENTRIES = 50;
+
+const BATCH_SIZE = 100;
+const UPDATE_CONCURRENCY = 5;
+
+function chunkArray<T>(array: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < array.length; i += size) {
+    chunks.push(array.slice(i, i + size));
+  }
+  return chunks;
+}
 
 export const fetchReferencesForLocale = async (
   cma: CMAClient,
@@ -156,7 +169,6 @@ const collectReferencesRecursive = async (
   contentTypeCache: Record<string, ContentTypeProps>
 ): Promise<void> => {
   if (currentDepth > maxDepth) return;
-  if (results.length >= MAX_TOTAL_ENTRIES) return;
 
   const referencesToProcess = collectReferences(parentEntry, parentContentType, sourceLocale);
   if (referencesToProcess.length === 0) return;
@@ -167,11 +179,14 @@ const collectReferencesRecursive = async (
 
   const entryMap: Record<string, EntryProps> = {};
   if (unvisitedIds.length > 0) {
-    const entriesResponse = await cma.entry.getMany({
-      query: { 'sys.id[in]': unvisitedIds.join(',') },
-    });
-    for (const fetchedEntry of entriesResponse.items) {
-      entryMap[fetchedEntry.sys.id] = fetchedEntry;
+    const idChunks = chunkArray(unvisitedIds, BATCH_SIZE);
+    for (const chunk of idChunks) {
+      const entriesResponse = await cma.entry.getMany({
+        query: { 'sys.id[in]': chunk.join(','), limit: BATCH_SIZE },
+      });
+      for (const fetchedEntry of entriesResponse.items) {
+        entryMap[fetchedEntry.sys.id] = fetchedEntry;
+      }
     }
   }
 
@@ -183,19 +198,20 @@ const collectReferencesRecursive = async (
     ),
   ];
   if (newContentTypeIds.length > 0) {
-    const ctResponse = await cma.contentType.getMany({
-      query: { 'sys.id[in]': newContentTypeIds.join(',') },
-    });
-    for (const ct of ctResponse.items) {
-      contentTypeCache[ct.sys.id] = ct;
+    const ctChunks = chunkArray(newContentTypeIds, BATCH_SIZE);
+    for (const chunk of ctChunks) {
+      const ctResponse = await cma.contentType.getMany({
+        query: { 'sys.id[in]': chunk.join(','), limit: BATCH_SIZE },
+      });
+      for (const ct of ctResponse.items) {
+        contentTypeCache[ct.sys.id] = ct;
+      }
     }
   }
 
   const entriesToRecurse: { entry: EntryProps; contentType: ContentTypeProps }[] = [];
 
   for (const { referenceEntryId, field } of referencesToProcess) {
-    if (results.length >= MAX_TOTAL_ENTRIES) break;
-
     if (visited.has(referenceEntryId)) {
       if (referenceEntryId === parentEntry.sys.id) {
         results.push({
@@ -233,7 +249,6 @@ const collectReferencesRecursive = async (
   }
 
   for (const { entry: refEntry, contentType: refCt } of entriesToRecurse) {
-    if (results.length >= MAX_TOTAL_ENTRIES) break;
     await collectReferencesRecursive(
       cma,
       refEntry,

--- a/apps/locale-field-populator/test/Dialog.spec.tsx
+++ b/apps/locale-field-populator/test/Dialog.spec.tsx
@@ -334,7 +334,7 @@ describe('Dialog component', () => {
 
     // Should have fetched ref-en (source locale), not ref-gb
     expect(mockCma.entry.getMany).toHaveBeenCalledWith(
-      expect.objectContaining({ query: { 'sys.id[in]': 'ref-en' } })
+      expect.objectContaining({ query: { 'sys.id[in]': 'ref-en', limit: 100 } })
     );
   });
 


### PR DESCRIPTION
## Purpose

Remove the hard-coded 50-entry cap that prevents customers with large reference graphs from using the Locale Field Populator, and add progressive rendering to keep the preview UI performant at scale.

## Approach
- Removed `MAX_TOTAL_ENTRIES` entirely -- the existing visited-set (cycle prevention) and configurable `maxDepth` already guarantee termination, making the cap redundant
- Added chunked `getMany` calls (batches of 100) and concurrency-limited updates (5 parallel) to stay within CMA rate limits at higher entry counts
- Added a summary banner showing total referenced entries and localizable field counts so users always see the full scope
- Render first 50 entries with incremental "Show more" pagination to avoid mounting hundreds of accordion sections at once

## Screenshots

Showing the summary banner: "61 referenced entries with 64 localizable fields"

> <img width="1980" height="993" alt="Screenshot 2026-05-11 at 10 28 23 AM" src="https://github.com/user-attachments/assets/c0d48e03-1839-495d-9754-8f067141c04f" />

Showing the load more button: "Load 11 more entries"

> <img width="1985" height="1002" alt="Screenshot 2026-05-11 at 10 28 43 AM" src="https://github.com/user-attachments/assets/245ed7dc-e819-4f61-b84e-932b1e92f52d" />
