### PR TITLE
feat: add 20-minute wait time message to preview loading modal [INTEG-3843]

### DIFF
--- a/apps/google-docs/src/locations/Page/components/modals/LoadingModal.tsx
+++ b/apps/google-docs/src/locations/Page/components/modals/LoadingModal.tsx
@@ -94,8 +94,10 @@ export const LoadingModal: React.FC<LoadingModalProps> = ({
       <Modal.Header title={title} />
       <Modal.Content>
         {step === 'reviewingContentTypes' ? (
-          <Flex justifyContent="center">
+          <Flex flexDirection="column" alignItems="flex-start" gap="spacingM">
+            <Paragraph marginBottom="none">This can take up to 20 minutes.</Paragraph>
             <Flex
+              alignSelf="center"
               flexDirection="row"
               alignItems="stretch"
               gap="spacingS"


### PR DESCRIPTION
[INTEG-3843](https://contentful.atlassian.net/browse/INTEG-3843)

## Purpose
Users opening the preview generation modal had no indication of expected wait time. This adds a visible message to set expectations upfront.

## Summary
- Added "This can take up to 20 minutes." paragraph below the animated preparing steps in `LoadingModal`
- Changed outer `Flex` on the `reviewingContentTypes` branch to column layout so the message sits naturally below the loading container
## Test
<img width="809" height="411" alt="Captura de pantalla 2026-05-11 a las 3 07 39 p  m" src="https://github.com/user-attachments/assets/a6168f76-605a-48e6-8f65-1feeabc51ea5" />

## Test plan
- [ ] Open the Google Docs app and trigger a preview generation
- [ ] Verify "This can take up to 20 minutes." appears below the animated steps in the loading modal
- [ ] Verify the message does not appear in the `creatingEntries` step

Generated with [Claude Code](https://claude.com/claude-code)

[INTEG-3843]: https://contentful.atlassian.net/browse/INTEG-3843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ