### PR TITLE
feat(content-insights): performance improvements [MAPS-256]

### DIFF
--- a/apps/content-insights/package-lock.json
+++ b/apps/content-insights/package-lock.json
@@ -16,7 +16,7 @@
         "@tanstack/react-query": "^5.90.12",
         "@tanstack/react-query-devtools": "^5.91.1",
         "@testing-library/user-event": "^14.6.1",
-        "contentful-management": "11.63.1",
+        "contentful-management": "11.76.0",
         "dayjs": "^1.11.19",
         "emotion": "10.0.27",
         "happy-dom": "^20.0.11",
@@ -85,7 +85,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -377,7 +376,6 @@
       "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.25.0.tgz",
       "integrity": "sha512-Aw5Yq3zduwHonNJPQtBTNzZ4MC17UtH8zaSnq8cdbDLfyJOYiTgPDDh15AzgwAkfyOovoXCBcyajjra9Cm45Qg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "contentful-management": ">=7.30.0"
       }
@@ -1528,34 +1526,6 @@
         "react-dom": ">=16.8.0"
       }
     },
-    "node_modules/@contentful/field-editor-date/node_modules/contentful-management": {
-      "version": "11.67.0",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.67.0.tgz",
-      "integrity": "sha512-Al6Dm9eBoLfBERl1nkYWLHGMSR98CCTPdsh466k2tjjlSGDAT3B2D/BnNTzpzidW5vYGIoVjRezGvcedV3vxfg==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/rich-text-types": "^16.6.1",
-        "axios": "^1.12.2",
-        "contentful-sdk-core": "^9.0.1",
-        "fast-copy": "^3.0.0",
-        "globals": "^15.15.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@contentful/field-editor-date/node_modules/globals": {
-      "version": "15.15.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
-      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@contentful/react-apps-toolkit": {
       "version": "1.2.16",
       "resolved": "https://registry.npmjs.org/@contentful/react-apps-toolkit/-/react-apps-toolkit-1.2.16.tgz",
@@ -2456,6 +2426,7 @@
       "resolved": "https://registry.npmjs.org/@lingui/message-utils/-/message-utils-5.7.0.tgz",
       "integrity": "sha512-yJKzPjJCLz8EkjqExxEBrioiKZtgxgLubOwzjSiZ8n1omuoyeRAqdKkmeOP/fPW2QpkQv33qLqfLtBhrIVJkeg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@messageformat/parser": "^5.0.0",
         "js-sha256": "^0.10.1"
@@ -2492,6 +2463,7 @@
       "resolved": "https://registry.npmjs.org/@messageformat/parser/-/parser-5.1.1.tgz",
       "integrity": "sha512-3p0YRGCcTUCYvBKLIxtDDyrJ0YijGIwrTRu1DT8gIviIDZru8H23+FkY6MJBzM1n9n20CiM4VeDYuBsrrwnLjg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "moo": "^0.5.1"
       }
@@ -2514,7 +2486,6 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -3062,9 +3033,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.55.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.55.1.tgz",
-      "integrity": "sha512-a8G4wiQxQG2BAvo+gU6XrReRRqj+pLS2NGXKm8io19goR+K8lw269eTrPkSdDTALwMmJp4th2Uh0D8J9bEV1vg==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
       "cpu": [
         "x64"
       ],
@@ -3237,7 +3208,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.12.tgz",
       "integrity": "sha512-graRZspg7EoEaw0a8faiUASCyJrqjKPdqJ9EwuDRUF9mEYJ1YPczI9H+/agJ0mOJkPCJDk0lsz5QTrLZ/jQ2rg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.90.12"
       },
@@ -3358,7 +3328,8 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3506,7 +3477,6 @@
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -3539,7 +3509,6 @@
       "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -3571,7 +3540,6 @@
       "integrity": "sha512-X63hI1bxl5ohelzr0LY5coufyl0LJNthld+abwxpCoo6Gq+hSqhKwci7MUWkXo67mzgUK6YFByhmaHmUcuBJmA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
         "@typescript-eslint/scope-manager": "8.48.1",
@@ -3602,7 +3570,6 @@
       "integrity": "sha512-PC0PDZfJg8sP7cmKe6L3QIL8GZwU5aRvUFedqSIpw3B+QjRSUZeeITC2M5XKeMXEzL6wccN196iy3JLwKNvDVA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.1",
         "@typescript-eslint/types": "8.48.1",
@@ -3948,7 +3915,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4267,14 +4233,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
-      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/babel-plugin-emotion": {
@@ -4321,7 +4287,6 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
       "integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "cosmiconfig": "^6.0.0",
@@ -4447,7 +4412,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -4727,14 +4691,14 @@
       "license": "MIT"
     },
     "node_modules/contentful-management": {
-      "version": "11.63.1",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.63.1.tgz",
-      "integrity": "sha512-2EKvO3aP6XkUuGSg6yoCUBF2RyFiG++duDZhEj5BLzlcBGbeRY1Q7FjcRUicg7wjiPmIKKOpsH08XPQHiCSBGw==",
+      "version": "11.76.0",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.76.0.tgz",
+      "integrity": "sha512-KsqIZ65q1A6IP55sxTfuAMhBTNJfgGxlVZBoV2ghBuR1LaZZyTqway5vj9KHRDl/Z1uOQQsYSiz+FayMxBXXEw==",
       "license": "MIT",
       "dependencies": {
         "@contentful/rich-text-types": "^16.6.1",
-        "axios": "^1.12.2",
-        "contentful-sdk-core": "^9.0.1",
+        "axios": "^1.15.0",
+        "contentful-sdk-core": "^9.4.4",
         "fast-copy": "^3.0.0",
         "globals": "^15.15.0"
       },
@@ -4755,16 +4719,15 @@
       }
     },
     "node_modules/contentful-sdk-core": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-9.2.1.tgz",
-      "integrity": "sha512-Y+Qz2tGYE2ia6o42R8DG4uFSMSLJ6qfAbKQLU6p2+KxsqvbK1Fg60wKVKF+FHMShuCnlg2EwToOvxVsM2N+BrQ==",
+      "version": "9.4.5",
+      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-9.4.5.tgz",
+      "integrity": "sha512-8eGTMO11LXFAiosaiV38bjvW6cjoQFtNE38pNtVilZTXpmGFinClljihH0eriv11Ispd4q82TqtsXMJPYD/C+A==",
       "license": "MIT",
       "dependencies": {
         "fast-copy": "^3.0.2",
-        "lodash": "^4.17.21",
-        "p-throttle": "^6.1.0",
+        "lodash": "^4.17.23",
         "process": "^0.11.10",
-        "qs": "^6.12.3"
+        "qs": "^6.15.0"
       },
       "engines": {
         "node": ">=18"
@@ -4772,6 +4735,12 @@
       "optionalDependencies": {
         "@rollup/rollup-linux-x64-gnu": "^4.18.0"
       }
+    },
+    "node_modules/contentful-sdk-core/node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -5025,7 +4994,6 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
       "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.21.0"
       },
@@ -5173,7 +5141,8 @@
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dotenv": {
       "version": "17.2.2",
@@ -5471,7 +5440,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -5536,7 +5504,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5931,9 +5898,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -7109,7 +7076,6 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -7128,7 +7094,8 @@
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.10.1.tgz",
       "integrity": "sha512-5obBtsz9301ULlsgggLg542s/jqtddfOpV5KJc4hajc9JV8GeY2gZHSVpYBn4nWqAUTJ9v+xwtbJ1mIBgIH5Vw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -7333,6 +7300,7 @@
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -7493,7 +7461,8 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
       "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/mri": {
       "version": "1.1.6",
@@ -7838,18 +7807,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-throttle": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/p-throttle/-/p-throttle-6.2.0.tgz",
-      "integrity": "sha512-NCKkOVj6PZa6NiTmfvGilDdf6vO1rFCD3KDnkHko8dTOtkpk4cSR/VTAhhLMG9aiQ7/A9HYgEDNmxzf6hxzR3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7944,7 +7901,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8021,6 +7977,7 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -8035,6 +7992,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8069,10 +8027,13 @@
       "license": "MIT"
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -8085,9 +8046,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -8104,7 +8065,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -8156,7 +8116,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -8198,8 +8157,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-lifecycles-compat": {
       "version": "3.0.4",
@@ -8243,7 +8201,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -8335,8 +8292,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -9829,7 +9785,6 @@
       "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10038,7 +9993,6 @@
       "integrity": "sha512-tI2l/nFHC5rLh7+5+o7QjKjSR04ivXDF4jcgV0f/bTQ+OJiITy5S6gaynVsEM+7RqzufMnVbIon6Sr5x1SDYaQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",

--- a/apps/content-insights/package.json
+++ b/apps/content-insights/package.json
@@ -11,7 +11,7 @@
     "@tanstack/react-query": "^5.90.12",
     "@tanstack/react-query-devtools": "^5.91.1",
     "@testing-library/user-event": "^14.6.1",
-    "contentful-management": "11.63.1",
+    "contentful-management": "11.76.0",
     "dayjs": "^1.11.19",
     "emotion": "10.0.27",
     "happy-dom": "^20.0.11",

--- a/apps/content-insights/src/components/Dashboard.tsx
+++ b/apps/content-insights/src/components/Dashboard.tsx
@@ -27,14 +27,16 @@ const TIME_RANGE_OPTIONS: { value: TimeRange; label: string }[] = [
 const Dashboard = () => {
   const sdk = useSDK();
   const { installation, refetchInstallationParameters } = useInstallationParameters(sdk);
-  const { entries, isFetchingEntries, fetchingEntriesError, refetchEntries } = useAllEntries();
+  const { contentTypes, isFetchingContentTypes, refetchContentTypes } = useContentTypes();
+  const contentTypeIds = Array.from(contentTypes.keys());
+  const { entries, isFetchingEntries, fetchingEntriesError, refetchEntries } =
+    useAllEntries(contentTypeIds);
   const {
     scheduledActions,
     isFetchingScheduledActions,
     fetchingScheduledActionsError,
     refetchScheduledActions,
   } = useScheduledActions();
-  const { contentTypes, isFetchingContentTypes, refetchContentTypes } = useContentTypes();
   const [timeRange, setTimeRange] = useState<TimeRange>(TimeRange.Year);
 
   const handleRefresh = async () => {
@@ -44,7 +46,7 @@ const Dashboard = () => {
     await refetchInstallationParameters();
   };
 
-  const isRefreshing = isFetchingEntries || isFetchingScheduledActions;
+  const isRefreshing = isFetchingContentTypes || isFetchingEntries || isFetchingScheduledActions;
   const hasError = fetchingEntriesError || fetchingScheduledActionsError;
 
   const metricsCalculator = new MetricsCalculator(entries, scheduledActions, {

--- a/apps/content-insights/src/hooks/useAllEntries.ts
+++ b/apps/content-insights/src/hooks/useAllEntries.ts
@@ -14,12 +14,14 @@ export interface UseAllEntriesResult {
   refetchEntries: () => void;
 }
 
-export function useAllEntries(): UseAllEntriesResult {
+export function useAllEntries(contentTypeIds: string[]): UseAllEntriesResult {
   const sdk = useSDK<PageAppSDK>();
 
+  const sortedIds = [...contentTypeIds].sort();
   const { data, isFetching, error, refetch } = useQuery<FetchAllEntriesResult, Error>({
-    queryKey: ['entries', sdk.ids.space, getEnvironmentId(sdk)],
-    queryFn: () => fetchAllEntries(sdk),
+    queryKey: ['entries', sdk.ids.space, getEnvironmentId(sdk), sortedIds],
+    queryFn: () => fetchAllEntries(sdk, sortedIds),
+    enabled: sortedIds.length > 0,
   });
 
   return {

--- a/apps/content-insights/src/utils/concurrentMap.ts
+++ b/apps/content-insights/src/utils/concurrentMap.ts
@@ -1,0 +1,19 @@
+export async function concurrentMap<T, R>(
+  items: T[],
+  concurrency: number,
+  worker: (item: T, index: number) => Promise<R>
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let nextIndex = 0;
+
+  const runners = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+    while (true) {
+      const i = nextIndex++;
+      if (i >= items.length) return;
+      results[i] = await worker(items[i], i);
+    }
+  });
+
+  await Promise.all(runners);
+  return results;
+}

--- a/apps/content-insights/src/utils/concurrentMap.ts
+++ b/apps/content-insights/src/utils/concurrentMap.ts
@@ -5,12 +5,18 @@ export async function concurrentMap<T, R>(
 ): Promise<R[]> {
   const results: R[] = new Array(items.length);
   let nextIndex = 0;
+  let aborted = false;
 
   const runners = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
-    while (true) {
+    while (!aborted) {
       const i = nextIndex++;
       if (i >= items.length) return;
-      results[i] = await worker(items[i], i);
+      try {
+        results[i] = await worker(items[i], i);
+      } catch (err) {
+        aborted = true;
+        throw err;
+      }
     }
   });
 

--- a/apps/content-insights/src/utils/consts.ts
+++ b/apps/content-insights/src/utils/consts.ts
@@ -29,4 +29,8 @@ export const FETCH_CONFIG = {
   DEFAULT_BATCH_SIZE: 1000,
   // Minimum batch size when reducing due to response size limits
   MIN_BATCH_SIZE: 15,
+  // Max parallel cursor streams; CMA rate limit is ~7 req/s, leave headroom.
+  CONCURRENCY: 5,
+  // sys.id[in] CSV size; CMA accepts up to 50.
+  TITLE_BATCH_SIZE: 50,
 } as const;

--- a/apps/content-insights/src/utils/cursorPaginate.ts
+++ b/apps/content-insights/src/utils/cursorPaginate.ts
@@ -1,0 +1,41 @@
+import { FETCH_CONFIG } from './consts';
+
+interface CursorPage<T> {
+  items: T[];
+  pages?: { next?: string };
+}
+
+export type CursorFetcher<T, Q> = (
+  query: Q & { limit: number; pageNext?: string }
+) => Promise<CursorPage<T>>;
+
+export async function cursorPaginate<T, Q extends Record<string, unknown>>(
+  fetcher: CursorFetcher<T, Q>,
+  baseQuery: Q
+): Promise<T[]> {
+  const out: T[] = [];
+  let pageNext: string | undefined;
+  let limit: number = FETCH_CONFIG.DEFAULT_BATCH_SIZE;
+
+  while (true) {
+    try {
+      const query = { ...baseQuery, limit, ...(pageNext ? { pageNext } : {}) };
+      const page = await fetcher(query);
+
+      out.push(...page.items);
+      pageNext = page.pages?.next;
+      if (!pageNext) return out;
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : '';
+      if (!msg.includes('Response size too big')) throw err;
+
+      if (limit <= FETCH_CONFIG.MIN_BATCH_SIZE) {
+        throw new Error(
+          'Unable to fetch entries: response size too large even with minimal batch size'
+        );
+      }
+      limit = Math.max(FETCH_CONFIG.MIN_BATCH_SIZE, Math.floor(limit / 2));
+      // Retry the same page (do not advance pageNext).
+    }
+  }
+}

--- a/apps/content-insights/src/utils/fetchAllEntries.ts
+++ b/apps/content-insights/src/utils/fetchAllEntries.ts
@@ -1,6 +1,8 @@
 import { BaseAppSDK } from '@contentful/app-sdk';
 import { EntryProps } from 'contentful-management';
 import { FETCH_CONFIG } from './consts';
+import { concurrentMap } from './concurrentMap';
+import { cursorPaginate } from './cursorPaginate';
 
 export interface FetchAllEntriesResult {
   entries: EntryProps[];
@@ -8,60 +10,31 @@ export interface FetchAllEntriesResult {
   fetchedAt: Date;
 }
 
-export async function fetchAllEntries(sdk: BaseAppSDK): Promise<FetchAllEntriesResult> {
-  const allEntries: EntryProps[] = [];
-  let batchSkip = 0;
-  let total = 0;
-  let hasMore = true;
-  let batchSize: number = FETCH_CONFIG.DEFAULT_BATCH_SIZE;
+export async function fetchAllEntries(
+  sdk: BaseAppSDK,
+  contentTypeIds: string[]
+): Promise<FetchAllEntriesResult> {
+  const fetchedAt = new Date();
 
-  while (hasMore) {
-    try {
-      const response = await sdk.cma.entry.getMany({
-        query: {
-          skip: batchSkip,
-          limit: batchSize,
-        },
-      });
-
-      const items = response.items as EntryProps[];
-      const batchTotal = response.total || 0;
-
-      // Set total on first batch
-      if (total === 0) {
-        total = batchTotal;
-      }
-
-      allEntries.push(...items);
-
-      // Check if we should continue fetching
-      hasMore = items.length === batchSize && allEntries.length < total;
-
-      if (hasMore) {
-        batchSkip += batchSize;
-      }
-    } catch (error: any) {
-      // If we hit response size limit, reduce batch size and retry
-      if (error.message && error.message.includes('Response size too big')) {
-        if (batchSize > FETCH_CONFIG.MIN_BATCH_SIZE) {
-          const newBatchSize = Math.floor(batchSize / 2);
-          batchSize = newBatchSize;
-          // Retry with smaller batch size (don't advance batchSkip)
-          continue;
-        } else {
-          throw new Error(
-            'Unable to fetch entries: response size too large even with minimal batch size'
-          );
-        }
-      } else {
-        throw error;
-      }
-    }
+  if (contentTypeIds.length === 0) {
+    return { entries: [], total: 0, fetchedAt };
   }
 
-  return {
-    entries: allEntries,
-    total,
-    fetchedAt: new Date(),
-  };
+  const buckets = await concurrentMap(contentTypeIds, FETCH_CONFIG.CONCURRENCY, (contentTypeId) =>
+    cursorPaginate<EntryProps, { content_type: string }>(
+      async ({ pageNext, ...rest }) => {
+        const response = await sdk.cma.entry.getManyWithCursor({
+          query: pageNext ? { ...rest, pageNext } : rest,
+        });
+        return {
+          items: response.items as EntryProps[],
+          pages: response.pages,
+        };
+      },
+      { content_type: contentTypeId }
+    )
+  );
+
+  const entries = buckets.flat();
+  return { entries, total: entries.length, fetchedAt };
 }

--- a/apps/content-insights/test/mocks/mockCma.ts
+++ b/apps/content-insights/test/mocks/mockCma.ts
@@ -14,6 +14,7 @@ const mockCma: any = {
   },
   entry: {
     getMany: vi.fn(),
+    getManyWithCursor: vi.fn(),
   },
   appInstallation: {
     getForOrganization: vi.fn().mockResolvedValue({
@@ -56,5 +57,11 @@ export const getManyEntries = (entries: EntryProps[], total?: number) => {
     sys: { type: 'Array' },
   };
 };
+
+export const cursorPage = (entries: EntryProps[], next?: string) => ({
+  items: entries,
+  sys: { type: 'Array' },
+  ...(next ? { pages: { next } } : {}),
+});
 
 export { mockCma };

--- a/apps/content-insights/test/utils/concurrentMap.spec.ts
+++ b/apps/content-insights/test/utils/concurrentMap.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest';
+import { concurrentMap } from '../../src/utils/concurrentMap';
+
+describe('concurrentMap', () => {
+  it('returns results in input order', async () => {
+    const result = await concurrentMap([1, 2, 3, 4], 2, async (n) => n * 10);
+    expect(result).toEqual([10, 20, 30, 40]);
+  });
+
+  it('respects the concurrency cap', async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const work = async () => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((r) => setTimeout(r, 5));
+      inFlight--;
+    };
+    await concurrentMap([1, 2, 3, 4, 5, 6, 7, 8], 3, work);
+    expect(maxInFlight).toBe(3);
+  });
+
+  it('handles empty input', async () => {
+    const fn = vi.fn();
+    const result = await concurrentMap<number, number>([], 3, fn);
+    expect(result).toEqual([]);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('rejects when any worker throws', async () => {
+    const fn = async (n: number) => {
+      if (n === 2) throw new Error('boom');
+      return n;
+    };
+    await expect(concurrentMap([1, 2, 3], 2, fn)).rejects.toThrow('boom');
+  });
+});

--- a/apps/content-insights/test/utils/concurrentMap.spec.ts
+++ b/apps/content-insights/test/utils/concurrentMap.spec.ts
@@ -34,4 +34,26 @@ describe('concurrentMap', () => {
     };
     await expect(concurrentMap([1, 2, 3], 2, fn)).rejects.toThrow('boom');
   });
+
+  it('stops pulling new items after a worker throws', async () => {
+    const seen: number[] = [];
+    const fn = async (n: number) => {
+      seen.push(n);
+      // Item 1 throws quickly; all others stall long enough that the abort
+      // flag is set before they finish and pull a new item.
+      if (n === 1) throw new Error('boom');
+      await new Promise((r) => setTimeout(r, 20));
+      return n;
+    };
+
+    await expect(concurrentMap([1, 2, 3, 4, 5, 6, 7, 8], 2, fn)).rejects.toThrow('boom');
+
+    // Wait past the slow workers so any straggler that ignored the abort
+    // would have shown up in `seen` by now.
+    await new Promise((r) => setTimeout(r, 50));
+
+    // With concurrency=2, items 1 and 2 start immediately; once 1 throws,
+    // runner 1 is gone and runner 2 must not pick up 3..8.
+    expect(seen).toEqual([1, 2]);
+  });
 });

--- a/apps/content-insights/test/utils/cursorPaginate.spec.ts
+++ b/apps/content-insights/test/utils/cursorPaginate.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { cursorPaginate, CursorFetcher } from '../../src/utils/cursorPaginate';
+
+describe('cursorPaginate', () => {
+  let fetcher: ReturnType<typeof vi.fn> & CursorFetcher<unknown, Record<string, unknown>>;
+
+  beforeEach(() => {
+    fetcher = vi.fn() as ReturnType<typeof vi.fn> & CursorFetcher<unknown, Record<string, unknown>>;
+  });
+
+  it('returns all items from a single page', async () => {
+    fetcher.mockResolvedValueOnce({ items: [{ id: '1' }, { id: '2' }] });
+    const result = await cursorPaginate(fetcher, { extra: 'flag' });
+    expect(result).toEqual([{ id: '1' }, { id: '2' }]);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(fetcher).toHaveBeenCalledWith({ extra: 'flag', limit: 1000 });
+  });
+
+  it('follows pages.next until empty', async () => {
+    fetcher
+      .mockResolvedValueOnce({ items: [{ id: '1' }], pages: { next: 'cur1' } })
+      .mockResolvedValueOnce({ items: [{ id: '2' }], pages: { next: 'cur2' } })
+      .mockResolvedValueOnce({ items: [{ id: '3' }] });
+    const result = await cursorPaginate(fetcher, {});
+    expect(result.map((e) => (e as any).id)).toEqual(['1', '2', '3']);
+    expect(fetcher).toHaveBeenCalledTimes(3);
+    expect(fetcher).toHaveBeenNthCalledWith(2, { limit: 1000, pageNext: 'cur1' });
+    expect(fetcher).toHaveBeenNthCalledWith(3, { limit: 1000, pageNext: 'cur2' });
+  });
+
+  it('halves batch size on Response size too big', async () => {
+    fetcher
+      .mockRejectedValueOnce(new Error('Response size too big'))
+      .mockResolvedValueOnce({ items: [{ id: '1' }] });
+    const result = await cursorPaginate(fetcher, {});
+    expect(result).toHaveLength(1);
+    expect(fetcher).toHaveBeenNthCalledWith(1, { limit: 1000 });
+    expect(fetcher).toHaveBeenNthCalledWith(2, { limit: 500 });
+  });
+
+  it('throws once batch shrinks below MIN_BATCH_SIZE', async () => {
+    fetcher.mockRejectedValue(new Error('Response size too big'));
+    await expect(cursorPaginate(fetcher, {})).rejects.toThrow(
+      'response size too large even with minimal batch size'
+    );
+  });
+
+  it('rethrows non-size errors', async () => {
+    fetcher.mockRejectedValueOnce(new Error('Network error'));
+    await expect(cursorPaginate(fetcher, {})).rejects.toThrow('Network error');
+  });
+});

--- a/apps/content-insights/test/utils/fetchAllEntries.spec.ts
+++ b/apps/content-insights/test/utils/fetchAllEntries.spec.ts
@@ -2,7 +2,16 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { PageAppSDK } from '@contentful/app-sdk';
 import { EntryProps } from 'contentful-management';
 import { fetchAllEntries } from '../../src/utils/fetchAllEntries';
-import { mockCma, getManyEntries } from '../mocks/mockCma';
+import { mockCma, cursorPage } from '../mocks/mockCma';
+
+const sysOnly = (id: string, contentTypeId: string): EntryProps =>
+  ({
+    sys: {
+      id,
+      type: 'Entry',
+      contentType: { sys: { id: contentTypeId, type: 'Link', linkType: 'ContentType' } },
+    },
+  } as any);
 
 describe('fetchAllEntries', () => {
   let mockSdk: PageAppSDK;
@@ -10,167 +19,52 @@ describe('fetchAllEntries', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSdk = {
-      ids: {
-        space: 'test-space',
-        environment: 'test-environment',
-      },
+      ids: { space: 'test-space', environment: 'test-environment' },
       cma: mockCma,
     } as any;
   });
 
-  it('returns all entries when response fits in single batch', async () => {
-    const mockEntries: EntryProps[] = [
-      {
-        sys: { id: 'entry-1', type: 'Entry' } as any,
-        fields: { title: { 'en-US': 'Entry 1' } },
-      },
-      {
-        sys: { id: 'entry-2', type: 'Entry' } as any,
-        fields: { title: { 'en-US': 'Entry 2' } },
-      },
-    ];
-
-    mockCma.entry.getMany.mockResolvedValueOnce(getManyEntries(mockEntries, 2));
-
-    const result = await fetchAllEntries(mockSdk);
-
-    expect(result.entries).toHaveLength(2);
-    expect(result.total).toBe(2);
-    expect(result.fetchedAt).toBeInstanceOf(Date);
-    expect(mockCma.entry.getMany).toHaveBeenCalledTimes(1);
-    expect(mockCma.entry.getMany).toHaveBeenCalledWith({
-      query: {
-        skip: 0,
-        limit: 1000,
-      },
-    });
-  });
-
-  it('handles pagination correctly with multiple batches', async () => {
-    const batch1: EntryProps[] = Array.from({ length: 1000 }, (_, i) => ({
-      sys: { id: `entry-${i}`, type: 'Entry' } as any,
-      fields: { title: { 'en-US': `Entry ${i}` } },
-    }));
-
-    const batch2: EntryProps[] = Array.from({ length: 500 }, (_, i) => ({
-      sys: { id: `entry-${i + 1000}`, type: 'Entry' } as any,
-      fields: { title: { 'en-US': `Entry ${i + 1000}` } },
-    }));
-
-    mockCma.entry.getMany
-      .mockResolvedValueOnce(getManyEntries(batch1, 1500))
-      .mockResolvedValueOnce(getManyEntries(batch2, 1500));
-
-    const result = await fetchAllEntries(mockSdk);
-
-    expect(result.entries).toHaveLength(1500);
-    expect(result.total).toBe(1500);
-    expect(mockCma.entry.getMany).toHaveBeenCalledTimes(2);
-    expect(mockCma.entry.getMany).toHaveBeenNthCalledWith(1, {
-      query: {
-        skip: 0,
-        limit: 1000,
-      },
-    });
-    expect(mockCma.entry.getMany).toHaveBeenNthCalledWith(2, {
-      query: {
-        skip: 1000,
-        limit: 1000,
-      },
-    });
-  });
-
-  it('returns empty entries array when no entries exist', async () => {
-    mockCma.entry.getMany.mockResolvedValueOnce(getManyEntries([], 0));
-
-    const result = await fetchAllEntries(mockSdk);
-
-    expect(result.entries).toHaveLength(0);
+  it('returns no entries when there are no content types', async () => {
+    const result = await fetchAllEntries(mockSdk, []);
+    expect(result.entries).toEqual([]);
     expect(result.total).toBe(0);
-    expect(result.fetchedAt).toBeInstanceOf(Date);
-    expect(mockCma.entry.getMany).toHaveBeenCalledTimes(1);
+    expect(mockCma.entry.getManyWithCursor).not.toHaveBeenCalled();
   });
 
-  it('throws error for non-size-limit errors', async () => {
-    const testError = new Error('Network error');
-    mockCma.entry.getMany.mockRejectedValueOnce(testError);
+  it('runs one cursor stream per content type', async () => {
+    mockCma.entry.getManyWithCursor
+      .mockResolvedValueOnce(cursorPage([sysOnly('a1', 'blog')]))
+      .mockResolvedValueOnce(cursorPage([sysOnly('b1', 'page')]));
 
-    await expect(fetchAllEntries(mockSdk)).rejects.toThrow('Network error');
-    expect(mockCma.entry.getMany).toHaveBeenCalledTimes(1);
-  });
+    const result = await fetchAllEntries(mockSdk, ['blog', 'page']);
 
-  it('reduces batch size and retries when hitting response size limit', async () => {
-    const smallerBatch: EntryProps[] = Array.from({ length: 500 }, (_, i) => ({
-      sys: { id: `entry-${i}`, type: 'Entry' } as any,
-      fields: { title: { 'en-US': `Entry ${i}` } },
-    }));
+    expect(result.entries.map((e) => e.sys.id).sort()).toEqual(['a1', 'b1']);
+    expect(result.total).toBe(2);
 
-    // First call fails with size limit error
-    const sizeLimitError = new Error('Response size too big');
-    mockCma.entry.getMany
-      .mockRejectedValueOnce(sizeLimitError) // default batch size is 1000
-      .mockResolvedValueOnce(getManyEntries(smallerBatch, 500));
-
-    const result = await fetchAllEntries(mockSdk);
-
-    expect(result.entries).toHaveLength(500);
-    expect(result.total).toBe(500);
-    // Should be called twice: once with 1000 (fails), once with 500 (succeeds)
-    expect(mockCma.entry.getMany).toHaveBeenCalledTimes(2);
-    expect(mockCma.entry.getMany).toHaveBeenNthCalledWith(1, {
-      query: {
-        skip: 0,
-        limit: 1000,
-      },
+    const calls = mockCma.entry.getManyWithCursor.mock.calls.map((c: any[]) => c[0]);
+    expect(calls).toContainEqual({
+      query: { content_type: 'blog', limit: 1000 },
     });
-    expect(mockCma.entry.getMany).toHaveBeenNthCalledWith(2, {
-      query: {
-        skip: 0,
-        limit: 500, // Reduced batch size
-      },
+    expect(calls).toContainEqual({
+      query: { content_type: 'page', limit: 1000 },
     });
   });
 
-  it('throws error when even minimum batch size is too large', async () => {
-    const sizeLimitError = new Error('Response size too big');
+  it('paginates a single content type via pages.next', async () => {
+    mockCma.entry.getManyWithCursor
+      .mockResolvedValueOnce(cursorPage([sysOnly('a1', 'blog')], 'cur1'))
+      .mockResolvedValueOnce(cursorPage([sysOnly('a2', 'blog')]));
 
-    // Mock to fail at 1000, then 500, then 250, then 125, then 100 (minimum) - all fail
-    mockCma.entry.getMany
-      .mockRejectedValueOnce(sizeLimitError) // 1000 fails
-      .mockRejectedValueOnce(sizeLimitError) // 500 fails
-      .mockRejectedValueOnce(sizeLimitError) // 250 fails
-      .mockRejectedValueOnce(sizeLimitError) // 125 fails
-      .mockRejectedValueOnce(sizeLimitError) // 62 fails
-      .mockRejectedValueOnce(sizeLimitError) // 31 fails
-      .mockRejectedValueOnce(sizeLimitError); // 15 (minimum) fails, throws error
+    const result = await fetchAllEntries(mockSdk, ['blog']);
 
-    await expect(fetchAllEntries(mockSdk)).rejects.toThrow(
-      'Unable to fetch entries: response size too large even with minimal batch size'
-    );
-
-    // Should try: 1000 -> 500 -> 250 -> 125 -> 100 (minimum, fails and throws)
-    expect(mockCma.entry.getMany).toHaveBeenCalledTimes(7);
+    expect(result.entries.map((e) => e.sys.id)).toEqual(['a1', 'a2']);
+    expect(mockCma.entry.getManyWithCursor).toHaveBeenNthCalledWith(2, {
+      query: { content_type: 'blog', limit: 1000, pageNext: 'cur1' },
+    });
   });
 
-  it('handles partial batch correctly', async () => {
-    const batch1: EntryProps[] = Array.from({ length: 1000 }, (_, i) => ({
-      sys: { id: `entry-${i}`, type: 'Entry' } as any,
-      fields: { title: { 'en-US': `Entry ${i}` } },
-    }));
-
-    const batch2: EntryProps[] = Array.from({ length: 300 }, (_, i) => ({
-      sys: { id: `entry-${i + 1000}`, type: 'Entry' } as any,
-      fields: { title: { 'en-US': `Entry ${i + 1000}` } },
-    }));
-
-    mockCma.entry.getMany
-      .mockResolvedValueOnce(getManyEntries(batch1, 1300))
-      .mockResolvedValueOnce(getManyEntries(batch2, 1300));
-
-    const result = await fetchAllEntries(mockSdk);
-
-    expect(result.entries).toHaveLength(1300);
-    expect(result.total).toBe(1300);
-    expect(mockCma.entry.getMany).toHaveBeenCalledTimes(2);
+  it('propagates errors from any stream', async () => {
+    mockCma.entry.getManyWithCursor.mockRejectedValueOnce(new Error('Network error'));
+    await expect(fetchAllEntries(mockSdk, ['blog'])).rejects.toThrow('Network error');
   });
 });


### PR DESCRIPTION
## Purpose

Fix Content Insights load times on large spaces by replacing serial offset pagination with parallel cursor streams.

## Approach

- Replace the single `entry.getMany` skip/limit loop with `entry.getManyWithCursor`.
- Fan out one cursor stream per content type with bounded concurrency (`FETCH_CONFIG.CONCURRENCY = 5`, headroom under the ~7 req/s CMA limit) via a small `concurrentMap` worker pool.
- Extract `cursorPaginate` to drain any cursor-paginated CMA endpoint, preserving the existing adaptive batch-shrinking on `Response size too big` (halve down to `MIN_BATCH_SIZE`).
- Lift `useContentTypes` ahead of `useAllEntries` in `Dashboard` and pass content type ids in -- entries fetch is now keyed on the resolved id list.
- Bump `contentful-management` 11.63.1 -> 11.76.0 for `getManyWithCursor`.
