### PR TITLE
fix(locale-field-populator): handle duplicate references [MAPS-256]

### DIFF
--- a/apps/locale-field-populator/src/components/preview/ReferenceEntrySection.styles.ts
+++ b/apps/locale-field-populator/src/components/preview/ReferenceEntrySection.styles.ts
@@ -21,6 +21,11 @@ export const styles = {
     borderRadius: tokens.borderRadiusSmall,
     marginTop: tokens.spacingS,
   }),
+  noteNeutral: css({
+    padding: tokens.spacingM,
+    borderRadius: tokens.borderRadiusSmall,
+    marginTop: tokens.spacingS,
+  }),
   fieldBox: css({
     border: `1px solid ${tokens.gray300}`,
     borderRadius: tokens.borderRadiusSmall,

--- a/apps/locale-field-populator/src/components/preview/ReferenceEntrySection.tsx
+++ b/apps/locale-field-populator/src/components/preview/ReferenceEntrySection.tsx
@@ -17,6 +17,7 @@ interface ReferenceEntrySectionProps {
   onAdoptedFieldChange: (fieldId: string, adopted: boolean) => void;
   onAdoptAllChange: (adopted: boolean) => void;
   isSelfReference: boolean;
+  isAlreadyIncluded?: boolean;
   baseUrl: string;
   isDisabled?: boolean;
   depth?: number;
@@ -48,6 +49,7 @@ const ReferenceEntrySection = ({
   onAdoptedFieldChange,
   onAdoptAllChange,
   isSelfReference,
+  isAlreadyIncluded = false,
   baseUrl,
   isDisabled = false,
   depth = 1,
@@ -72,6 +74,27 @@ const ReferenceEntrySection = ({
     return entry.fields[fieldId]?.[locale];
   };
 
+  if (isAlreadyIncluded) {
+    return (
+      <Box className={`${styles.accordionContainer} ${depthIndent(depth)}`}>
+        <Accordion>
+          <Accordion.Item
+            title={
+              <Flex className={styles.accordionHeader}>
+                <Text fontSize="fontSizeM" fontWeight="fontWeightDemiBold" fontColor="gray900">
+                  {fieldName}: {entryTitle}
+                </Text>
+              </Flex>
+            }>
+            <Note variant="neutral" className={styles.noteNeutral}>
+              This entry is already included above and will be updated once.
+            </Note>
+          </Accordion.Item>
+        </Accordion>
+      </Box>
+    );
+  }
+
   if (isSelfReference) {
     return (
       <Box marginTop="spacingM" className={`${styles.accordionContainer} ${depthIndent(depth)}`}>
@@ -79,7 +102,7 @@ const ReferenceEntrySection = ({
           <Accordion.Item
             title={
               <Flex className={styles.accordionHeader}>
-                <Text fontSize="fontSizeL" fontWeight="fontWeightDemiBold" fontColor="gray900">
+                <Text fontSize="fontSizeM" fontWeight="fontWeightDemiBold" fontColor="gray900">
                   {fieldName}: {entryTitle}
                 </Text>
               </Flex>
@@ -101,7 +124,7 @@ const ReferenceEntrySection = ({
           <Accordion.Item
             title={
               <Flex className={styles.accordionHeader}>
-                <Text fontSize="fontSizeL" fontWeight="fontWeightDemiBold" fontColor="gray900">
+                <Text fontSize="fontSizeM" fontWeight="fontWeightDemiBold" fontColor="gray900">
                   {fieldName}: {entryTitle}
                 </Text>
               </Flex>

--- a/apps/locale-field-populator/src/components/steps/PreviewStep.tsx
+++ b/apps/locale-field-populator/src/components/steps/PreviewStep.tsx
@@ -47,8 +47,12 @@ function initializeAdoptedFields(
   for (const referenceEntryData of referencedEntries) {
     const referenceEntryId = referenceEntryData.entry.sys.id;
 
-    if (referenceEntryData.isSelfReference || initialAdoptedFields[referenceEntryId]) {
-      // Self reference or already adopted, skip it
+    if (
+      referenceEntryData.isSelfReference ||
+      referenceEntryData.isAlreadyIncluded ||
+      initialAdoptedFields[referenceEntryId]
+    ) {
+      // Self reference, duplicate occurrence, or already adopted -- skip it.
       continue;
     }
 
@@ -118,13 +122,18 @@ const PreviewStepComponent = ({
 
   const totalReferencedFields = useMemo(() => {
     return referencedEntries.reduce((count, ref) => {
-      if (ref.isSelfReference) return count;
+      if (ref.isSelfReference || ref.isAlreadyIncluded) return count;
       const fields = ref.contentType.fields.filter(
         (f) => f.localized && !isEntryField(f) && !isEntryArrayField(f)
       );
       return count + fields.length;
     }, 0);
   }, [referencedEntries]);
+
+  const uniqueReferencedEntryCount = useMemo(
+    () => referencedEntries.filter((ref) => !ref.isAlreadyIncluded).length,
+    [referencedEntries]
+  );
 
   const visibleEntries = referencedEntries.slice(0, visibleCount);
   const hasMore = visibleCount < referencedEntries.length;
@@ -251,10 +260,10 @@ const PreviewStepComponent = ({
 
         {/* Referenced entries (all depths, rendered in traversal order) */}
         <Flex flexDirection="column" gap="spacingS" marginTop="spacingM">
-          {referencedEntries.length > 0 && (
+          {uniqueReferencedEntryCount > 0 && (
             <Note variant="neutral">
-              {referencedEntries.length} referenced{' '}
-              {referencedEntries.length === 1 ? 'entry' : 'entries'} with {totalReferencedFields}{' '}
+              {uniqueReferencedEntryCount} referenced{' '}
+              {uniqueReferencedEntryCount === 1 ? 'entry' : 'entries'} with {totalReferencedFields}{' '}
               localizable fields
             </Note>
           )}
@@ -274,6 +283,7 @@ const PreviewStepComponent = ({
                 handleAdoptAll(referenceData.entry.sys.id, referenceData.contentType, adopted)
               }
               isSelfReference={referenceData.isSelfReference}
+              isAlreadyIncluded={referenceData.isAlreadyIncluded}
               isDisabled={isDisabled}
               baseUrl={baseUrl}
               depth={referenceData.depth}

--- a/apps/locale-field-populator/src/utils/adoptedFields.ts
+++ b/apps/locale-field-populator/src/utils/adoptedFields.ts
@@ -9,6 +9,10 @@ export interface ReferencedEntryData {
   fieldName: string;
   isSelfReference: boolean;
   depth: number;
+  // True when this entry id has already been rendered earlier in the preview list.
+  // The first occurrence owns the localization UI; later occurrences are shown as
+  // pointers back to it so the same entry isn't presented as if it had no fields.
+  isAlreadyIncluded?: boolean;
 }
 
 export function hasAnyAdoptedFields(adoptedFieldsMap: AdoptedFieldsMap): boolean {

--- a/apps/locale-field-populator/src/utils/entry.ts
+++ b/apps/locale-field-populator/src/utils/entry.ts
@@ -138,10 +138,18 @@ export const fetchReferencesForLocale = async (
   sourceLocale: string,
   maxDepth: number = MAX_REFERENCE_DEPTH
 ): Promise<ReferencedEntryData[]> => {
+  // `visited` does double duty: it suppresses re-traversal of a subtree and
+  // it marks which entries already have a "real" entry section in the result
+  // list. When the same entry is reached again from another path we emit a
+  // pointer record instead of dropping it silently or rendering a misleading
+  // empty section.
   const visited = new Set<string>([entry.sys.id]);
   const allReferences: ReferencedEntryData[] = [];
   const contentTypeCache: Record<string, ContentTypeProps> = {
     [contentType.sys.id]: contentType,
+  };
+  const entryCache: Record<string, EntryProps> = {
+    [entry.sys.id]: entry,
   };
 
   await collectReferencesRecursive(
@@ -153,7 +161,8 @@ export const fetchReferencesForLocale = async (
     maxDepth,
     visited,
     allReferences,
-    contentTypeCache
+    contentTypeCache,
+    entryCache
   );
 
   return allReferences;
@@ -168,35 +177,35 @@ const collectReferencesRecursive = async (
   maxDepth: number,
   visited: Set<string>,
   results: ReferencedEntryData[],
-  contentTypeCache: Record<string, ContentTypeProps>
+  contentTypeCache: Record<string, ContentTypeProps>,
+  entryCache: Record<string, EntryProps>
 ): Promise<void> => {
   if (currentDepth > maxDepth) return;
 
   const referencesToProcess = collectReferences(parentEntry, parentContentType, sourceLocale);
   if (referencesToProcess.length === 0) return;
 
-  const unvisitedIds = [
-    ...new Set(referencesToProcess.map((r) => r.referenceEntryId).filter((id) => !visited.has(id))),
+  const unfetchedIds = [
+    ...new Set(referencesToProcess.map((r) => r.referenceEntryId).filter((id) => !entryCache[id])),
   ];
 
-  const entryMap: Record<string, EntryProps> = {};
-  if (unvisitedIds.length > 0) {
-    const idChunks = chunkArray(unvisitedIds, BATCH_SIZE);
+  if (unfetchedIds.length > 0) {
+    const idChunks = chunkArray(unfetchedIds, BATCH_SIZE);
     for (const chunk of idChunks) {
       const entriesResponse = await cma.entry.getMany({
         query: { 'sys.id[in]': chunk.join(','), limit: BATCH_SIZE },
       });
       for (const fetchedEntry of entriesResponse.items) {
-        entryMap[fetchedEntry.sys.id] = fetchedEntry;
+        entryCache[fetchedEntry.sys.id] = fetchedEntry;
       }
     }
   }
 
   const newContentTypeIds = [
     ...new Set(
-      Object.values(entryMap)
-        .map((e) => e.sys.contentType.sys.id)
-        .filter((id) => !contentTypeCache[id])
+      referencesToProcess
+        .map((r) => entryCache[r.referenceEntryId]?.sys.contentType.sys.id)
+        .filter((id): id is string => Boolean(id) && !contentTypeCache[id])
     ),
   ];
   if (newContentTypeIds.length > 0) {
@@ -211,30 +220,57 @@ const collectReferencesRecursive = async (
     }
   }
 
-  const entriesToRecurse: { entry: EntryProps; contentType: ContentTypeProps }[] = [];
+  // Claim every direct reference of this parent before any recursion runs.
+  // Without this, recursing into the first sibling would let it pick up later
+  // siblings as its own descendants, pushing them deeper in the tree than they
+  // actually live (and inverting which occurrence renders the full UI vs. the
+  // "already included" pointer). Self-references are handled in the main loop
+  // below, not here.
+  const ownedRefIds = new Set<string>();
+  for (const { referenceEntryId } of referencesToProcess) {
+    if (referenceEntryId === parentEntry.sys.id) continue;
+    if (visited.has(referenceEntryId)) continue;
+    visited.add(referenceEntryId);
+    ownedRefIds.add(referenceEntryId);
+  }
 
+  // Now walk the references in order. Each owned ref renders its full UI here
+  // and recurses inline so its nested children appear immediately after it,
+  // which is what the depth-based indentation in the render layer expects.
   for (const { referenceEntryId, field } of referencesToProcess) {
-    if (visited.has(referenceEntryId)) {
-      if (referenceEntryId === parentEntry.sys.id) {
-        results.push({
-          entry: parentEntry,
-          contentType: parentContentType,
-          fieldId: field.id,
-          fieldName: field.name,
-          isSelfReference: true,
-          depth: currentDepth,
-        });
-      }
+    if (referenceEntryId === parentEntry.sys.id) {
+      results.push({
+        entry: parentEntry,
+        contentType: parentContentType,
+        fieldId: field.id,
+        fieldName: field.name,
+        isSelfReference: true,
+        depth: currentDepth,
+      });
       continue;
     }
 
-    visited.add(referenceEntryId);
-
-    const referenceEntry = entryMap[referenceEntryId];
+    const referenceEntry = entryCache[referenceEntryId];
     if (!referenceEntry) continue;
 
     const referenceContentType = contentTypeCache[referenceEntry.sys.contentType.sys.id];
     if (!referenceContentType) continue;
+
+    if (!ownedRefIds.has(referenceEntryId)) {
+      // Visited by an ancestor or earlier sibling at a shallower depth -- emit
+      // a pointer record so the user sees the reference exists without a
+      // misleading empty section.
+      results.push({
+        entry: referenceEntry,
+        contentType: referenceContentType,
+        fieldId: field.id,
+        fieldName: field.name,
+        isSelfReference: false,
+        depth: currentDepth,
+        isAlreadyIncluded: true,
+      });
+      continue;
+    }
 
     results.push({
       entry: referenceEntry,
@@ -246,22 +282,19 @@ const collectReferencesRecursive = async (
     });
 
     if (currentDepth < maxDepth) {
-      entriesToRecurse.push({ entry: referenceEntry, contentType: referenceContentType });
+      await collectReferencesRecursive(
+        cma,
+        referenceEntry,
+        referenceContentType,
+        sourceLocale,
+        currentDepth + 1,
+        maxDepth,
+        visited,
+        results,
+        contentTypeCache,
+        entryCache
+      );
     }
-  }
-
-  for (const { entry: refEntry, contentType: refCt } of entriesToRecurse) {
-    await collectReferencesRecursive(
-      cma,
-      refEntry,
-      refCt,
-      sourceLocale,
-      currentDepth + 1,
-      maxDepth,
-      visited,
-      results,
-      contentTypeCache
-    );
   }
 };
 


### PR DESCRIPTION
## Purpose

When an entry is referenced from multiple paths in a content graph (e.g. directly on the main entry and again under a nested entry), the second occurrence rendered with a misleading "This entry has no localized fields" warning, making users think the app was broken.

## Approach

- Treat the highest-level occurrence as the canonical one (full localization UI) and emit subsequent occurrences as explicit "already included above" pointer records, rather than dropping them silently or letting them appear as empty sections.
- Pre-claim every direct reference of a parent before recursing into any sibling, so a sibling's subtree can't steal a later sibling and invert the tree depth.
- Recurse inline so each entry's nested children appear immediately after it in the result list, which is what the depth-based indentation in the preview relies on.
- Skip duplicate records in `initializeAdoptedFields`, the field-count summary, and the headline entry count so the "N referenced entries with M localizable fields" note matches what is actually translatable.
- Unify accordion title font size across linked and unlinked title rows.

## Screenshot

Duplicate referenced entries will show a new "This entry is already included above and will be updated once." banner

<img width="1697" height="1056" alt="Screenshot 2026-05-13 at 11 54 26 AM" src="https://github.com/user-attachments/assets/c223c9e5-3fbb-412f-940e-3f9316f8fd93" />
