### PR TITLE
fix(google-docs): register OAuth functions as actions in manifest []

### DIFF
--- a/apps/drive-integration/contentful-app-manifest.json
+++ b/apps/drive-integration/contentful-app-manifest.json
@@ -17,12 +17,8 @@
       "description": "Initiates the OAuth flow for Drive Integration",
       "path": "functions/oauth/initiateOauth.js",
       "entryFile": "functions/oauth/initiateOauth.ts",
-      "allowNetworks": [
-        "oauth2.googleapis.com"
-      ],
-      "accepts": [
-        "appaction.call"
-      ]
+      "allowNetworks": ["oauth2.googleapis.com"],
+      "accepts": ["appaction.call"]
     },
     {
       "id": "completeGdocOauth",
@@ -30,12 +26,8 @@
       "description": "Completes the OAuth flow for Drive Integration",
       "path": "functions/oauth/completeOauth.js",
       "entryFile": "functions/oauth/completeOauth.ts",
-      "allowNetworks": [
-        "oauth2.googleapis.com"
-      ],
-      "accepts": [
-        "appaction.call"
-      ]
+      "allowNetworks": ["oauth2.googleapis.com"],
+      "accepts": ["appaction.call"]
     },
     {
       "id": "revokeGdocOauthToken",
@@ -43,12 +35,8 @@
       "description": "Revoke token for the Drive Integration app to disconnect from the app",
       "path": "functions/oauth/disconnect.js",
       "entryFile": "functions/oauth/disconnect.ts",
-      "allowNetworks": [
-        "oauth2.googleapis.com"
-      ],
-      "accepts": [
-        "appaction.call"
-      ]
+      "allowNetworks": ["oauth2.googleapis.com"],
+      "accepts": ["appaction.call"]
     },
     {
       "id": "checkGdocOauthTokenStatus",
@@ -56,13 +44,62 @@
       "description": "Checks the status of the Drive Integration OAuth token to see if it is valid",
       "path": "functions/oauth/checkStatus.js",
       "entryFile": "functions/oauth/checkStatus.ts",
-      "allowNetworks": [
-        "oauth2.googleapis.com"
-      ],
-      "accepts": [
-        "appaction.call"
-      ]
+      "allowNetworks": ["oauth2.googleapis.com"],
+      "accepts": ["appaction.call"]
     }
   ],
-  "actions": []
+  "actions": [
+    {
+      "name": "Initiate Gdoc OAuth Flow",
+      "category": "Custom",
+      "description": "Initiates the OAuth flow for Drive Integration",
+      "type": "function-invocation",
+      "functionId": "initiateGdocOauth",
+      "parametersSchema": {
+        "type": "object"
+      },
+      "resultSchema": {
+        "type": "object"
+      }
+    },
+    {
+      "name": "Complete Gdoc OAuth Flow",
+      "category": "Custom",
+      "description": "Completes the OAuth flow for Drive Integration",
+      "type": "function-invocation",
+      "functionId": "completeGdocOauth",
+      "parametersSchema": {
+        "type": "object"
+      },
+      "resultSchema": {
+        "type": "object"
+      }
+    },
+    {
+      "name": "Revoke Gdoc OAuth Token",
+      "category": "Custom",
+      "description": "Revoke token for the Drive Integration app to disconnect from the app",
+      "type": "function-invocation",
+      "functionId": "revokeGdocOauthToken",
+      "parametersSchema": {
+        "type": "object"
+      },
+      "resultSchema": {
+        "type": "object"
+      }
+    },
+    {
+      "name": "Check Gdoc OAuth Token Status",
+      "category": "Custom",
+      "description": "Checks the status of the Drive Integration OAuth token to see if it is valid",
+      "type": "function-invocation",
+      "functionId": "checkGdocOauthTokenStatus",
+      "parametersSchema": {
+        "type": "object"
+      },
+      "resultSchema": {
+        "type": "object"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
## Purpose
The four OAuth functions (`initiateGdocOauth`, `completeGdocOauth`, `revokeGdocOauthToken`, `checkGdocOauthTokenStatus`) were defined only in the `functions` section of the manifest but not registered as app actions. This caused `getManyForEnvironment` to return an empty list, resulting in a `NotFound` error when the client tried to invoke them.

## Summary
- Added `actions` section to `contentful-app-manifest.json` with all four OAuth functions registered as `function-invocation` type actions linked via `functionId`

## Test plan
- [ ] OAuth connect flow works without `NotFound` error
- [ ] `checkGdocOauthTokenStatus` action is found and invoked successfully on page load
- [ ] Disconnect flow works via `revokeGdocOauthToken`

Generated with [Claude Code](https://claude.com/claude-code)