### PR TITLE
fix(google-docs): add file type guidance copy to main page [INTEG-3887]

### DIFF
--- a/apps/google-docs/src/locations/Page/components/mainpage/MainPageView.tsx
+++ b/apps/google-docs/src/locations/Page/components/mainpage/MainPageView.tsx
@@ -52,12 +52,13 @@ export const MainPageView = ({
             gap="spacingS"
             style={{ width: '100%' }}>
             <Heading marginBottom="spacingS">Select your file</Heading>
-            <Grid columns="3fr 2fr" style={{ width: '100%' }}>
+            <Grid columns="4fr 1fr" style={{ width: '100%' }}>
               <Grid.Item>
                 <Paragraph>
                   Create entries using existing content types from a Google Drive file.
                   <br />
-                  Get started by selecting the file you would like to use.
+                  Get started by selecting the .doc file you would like to use. Only Google Doc
+                  files are supported. Sheets, Slides, and PDFs will not appear in the file picker.
                 </Paragraph>
               </Grid.Item>
               <Grid.Item justifySelf="end">

--- a/apps/google-docs/test/locations/Page/components/mainpage/MainPageView.spec.tsx
+++ b/apps/google-docs/test/locations/Page/components/mainpage/MainPageView.spec.tsx
@@ -18,16 +18,13 @@ const defaultProps = {
   onSelectFile: vi.fn(),
 };
 
-const renderWithLayout = (ui: React.ReactElement) =>
-  render(<Layout>{ui}</Layout>);
+const renderWithLayout = (ui: React.ReactElement) => render(<Layout>{ui}</Layout>);
 
 describe('MainPageView', () => {
   it('shows file type guidance copy when connected', () => {
     renderWithLayout(<MainPageView {...defaultProps} />);
 
-    expect(
-      screen.getByText(/Only Google Doc files are supported/i)
-    ).toBeTruthy();
+    expect(screen.getByText(/Only Google Doc files are supported/i)).toBeTruthy();
     expect(
       screen.getByText(/Sheets, Slides, and PDFs will not appear in the file picker/i)
     ).toBeTruthy();

--- a/apps/google-docs/test/locations/Page/components/mainpage/MainPageView.spec.tsx
+++ b/apps/google-docs/test/locations/Page/components/mainpage/MainPageView.spec.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { vi, describe, it, expect } from 'vitest';
 import React from 'react';
+import { Layout } from '@contentful/f36-components';
 import { MainPageView } from '../../../../../src/locations/Page/components/mainpage/MainPageView';
 
 vi.mock('../../../../../src/locations/Page/components/mainpage/OAuthConnector', () => ({
@@ -17,27 +18,29 @@ const defaultProps = {
   onSelectFile: vi.fn(),
 };
 
+const renderWithLayout = (ui: React.ReactElement) =>
+  render(<Layout>{ui}</Layout>);
+
 describe('MainPageView', () => {
   it('shows file type guidance copy when connected', () => {
-    render(<MainPageView {...defaultProps} />);
+    renderWithLayout(<MainPageView {...defaultProps} />);
 
     expect(
-      screen.getByText(/Get started by selecting the \.doc file you would like to use\./i)
+      screen.getByText(/Only Google Doc files are supported/i)
     ).toBeTruthy();
-    expect(screen.getByText(/Only Google Doc files are supported\./i)).toBeTruthy();
     expect(
-      screen.getByText(/Sheets, Slides, and PDFs will not appear in the file picker\./i)
+      screen.getByText(/Sheets, Slides, and PDFs will not appear in the file picker/i)
     ).toBeTruthy();
   });
 
   it('shows the existing entries info note', () => {
-    render(<MainPageView {...defaultProps} />);
+    renderWithLayout(<MainPageView {...defaultProps} />);
 
     expect(screen.getByText(/This app only creates new entries\./i)).toBeTruthy();
   });
 
   it('shows warning note when not connected', () => {
-    render(<MainPageView {...defaultProps} isOAuthConnected={false} oauthToken="" />);
+    renderWithLayout(<MainPageView {...defaultProps} isOAuthConnected={false} oauthToken="" />);
 
     expect(
       screen.getByText(/Please connect to Google Drive before selecting your file\./i)
@@ -45,7 +48,7 @@ describe('MainPageView', () => {
   });
 
   it('does not show warning note when connected', () => {
-    render(<MainPageView {...defaultProps} />);
+    renderWithLayout(<MainPageView {...defaultProps} />);
 
     expect(
       screen.queryByText(/Please connect to Google Drive before selecting your file\./i)

--- a/apps/google-docs/test/locations/Page/components/mainpage/MainPageView.spec.tsx
+++ b/apps/google-docs/test/locations/Page/components/mainpage/MainPageView.spec.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import { vi, describe, it, expect } from 'vitest';
+import React from 'react';
+import { MainPageView } from '../../../../../src/locations/Page/components/mainpage/MainPageView';
+
+vi.mock('../../../../../src/locations/Page/components/mainpage/OAuthConnector', () => ({
+  OAuthConnector: () => <div>Mock OAuth Connector</div>,
+}));
+
+const defaultProps = {
+  oauthToken: 'test-token',
+  isOAuthConnected: true,
+  isOAuthLoading: false,
+  isOAuthBusy: false,
+  onConnectGoogleDrive: vi.fn(),
+  onDisconnectGoogleDrive: vi.fn(),
+  onSelectFile: vi.fn(),
+};
+
+describe('MainPageView', () => {
+  it('shows file type guidance copy when connected', () => {
+    render(<MainPageView {...defaultProps} />);
+
+    expect(
+      screen.getByText(/Get started by selecting the \.doc file you would like to use\./i)
+    ).toBeTruthy();
+    expect(screen.getByText(/Only Google Doc files are supported\./i)).toBeTruthy();
+    expect(
+      screen.getByText(/Sheets, Slides, and PDFs will not appear in the file picker\./i)
+    ).toBeTruthy();
+  });
+
+  it('shows the existing entries info note', () => {
+    render(<MainPageView {...defaultProps} />);
+
+    expect(screen.getByText(/This app only creates new entries\./i)).toBeTruthy();
+  });
+
+  it('shows warning note when not connected', () => {
+    render(<MainPageView {...defaultProps} isOAuthConnected={false} oauthToken="" />);
+
+    expect(
+      screen.getByText(/Please connect to Google Drive before selecting your file\./i)
+    ).toBeTruthy();
+  });
+
+  it('does not show warning note when connected', () => {
+    render(<MainPageView {...defaultProps} />);
+
+    expect(
+      screen.queryByText(/Please connect to Google Drive before selecting your file\./i)
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Purpose

This PR addresses some feedback: when the Google Drive file picker returns `no results`, users see a bare "No documents" message with no explanation of why, leaving them confused about whether they're connected to the wrong Drive or simply don't have the right file type.

Original plan

The initial approach was to detect the empty state proactively: before opening the picker, but the OAuth token the app holds is scoped to drive.file, a non-sensitive scope that only grants access to files the app itself created or was explicitly handed via the picker. It does not allow listing pre-existing files in the user's Drive. Additionally, the picker UI itself is rendered by Google in its own iframe. We have no control over what it displays internally and receive no "empty results" callback.

## Approach

Because of those limitations we:
- Updated the main page paragraph copy to clarify that only Google Doc files are supported, Sheets, Slides, and PDFs will not appear in the file picker

## Testing steps

Added several missing tests for the main page.

## Breaking Changes

No

## Dependencies and/or References

[INTEG-3887](https://contentful.atlassian.net/browse/INTEG-3887)

## Deployment

No

[INTEG-3887]: https://contentful.atlassian.net/browse/INTEG-3887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ