### PR TITLE
docs(custom-validation): fix misleading setInvalid usage and clarify limitations [DX-1077]

### DIFF
--- a/examples/custom-validation/README.md
+++ b/examples/custom-validation/README.md
@@ -53,7 +53,9 @@ The app itself can be built in many different ways. The approach taken in this e
 
 When the Field app renders, it listens to any change (`sys`, `fields`, `metadata`) of the entry and creates an object of the full entry. Now, the custom validation logic can access every single field to determine whether the entry is valid or not. If the entry is not valid, the app calls `sdk.field.setValue('false')` which updates the field to an invalid state, and publishing is blocked. Once all issues are resolved, the app runs `sdk.field.setValue('true')`.
 
-As we are building custom validation logic, we cannot rely on Contentful's built-in way of showing validation errors. Therefore, it is important to give hints to the current editor, that fields are currently in the wrong shape. This can be either done by rendering a list of error messages and/or by calling `sdk.entry.fields[...].getForLocale(...).setInvalid(true)` to highlight the error state of a specific field.
+As we are building custom validation logic, we cannot rely on Contentful's built-in way of showing validation errors. Therefore, it is important to give hints to the current editor that fields are currently in the wrong shape. This can be done by rendering a list of error messages. You can also call `sdk.field.setInvalid(true)` to add a visual red error bar to the field your app is assigned to.
+
+> **Note:** `setInvalid` is a **visual indicator only** — it does not prevent publishing. Additionally, it only works on the field the app is assigned to; calling it on a different field via `sdk.entry.fields['otherField'].getForLocale(...).setInvalid()` has no effect. To actually prevent publishing, this example uses the `sdk.field.setValue('false')` approach described above.
 
 ## Result
 

--- a/examples/custom-validation/src/locations/Field.tsx
+++ b/examples/custom-validation/src/locations/Field.tsx
@@ -19,10 +19,7 @@ export function Field() {
       const entry = getEntry(sdk);
       const newErrors: string[] = [];
 
-      if ((entry.fields.slug ?? '').startsWith(`${entry.fields.date}-`)) {
-        sdk.entry.fields['slug'].getForLocale(sdk.locales.default).setInvalid(false);
-      } else {
-        sdk.entry.fields['slug'].getForLocale(sdk.locales.default).setInvalid(true);
+      if (!(entry.fields.slug ?? '').startsWith(`${entry.fields.date}-`)) {
         newErrors.push(`Slug must start with "${entry.fields.date}-"`);
       }
 


### PR DESCRIPTION
## Purpose

The `custom-validation` example has been calling `sdk.entry.fields['slug'].getForLocale(...).setInvalid()` from within a different field's location — a pattern that silently does nothing. This has caused confusion for multiple developers ([#3992](https://github.com/contentful/apps/issues/3992)), who expected the call to show a visual error indicator on the slug field.

Two related limitations were not documented anywhere in the example:
- `setInvalid` is **visual only** — it adds/removes the red error bar but does not prevent publishing
- `setInvalid` only affects the field the app is **assigned to** — cross-field calls are no-ops

## Approach

- **`Field.tsx`**: Removed the two cross-field `setInvalid` calls. The publish-blocking logic (`sdk.field.setValue('true'/'false')`) was already correct and is unchanged — this just removes the dead code that was misleading readers.
- **`README.md`**: Updated the description of `setInvalid` to correctly describe it as a visual-only, same-field-only indicator, and explicitly points readers to the `setValue` pattern for preventing publishing.

No functional behavior changes — this is documentation and example cleanup only.

## Testing steps

1. Bootstrap the example: `npx create-contentful-app --example custom-validation`
2. Set up the content type with a `validation` short-text field (must equal `"true"`) per the README
3. Assign the app to the `validation` field via the Appearance tab
4. Enter an invalid slug format — confirm the error message renders in the app UI
5. Confirm the entry **cannot be published** while the slug is invalid
6. Fix the slug format — confirm the entry publishes successfully
7. Confirm **no** red error bar appears on the slug field (the old misleading behavior is gone)

## Breaking Changes

None.

## Dependencies and/or References

- Closes [#3992](https://github.com/contentful/apps/issues/3992)
- [DX-1077](https://contentful.atlassian.net/browse/DX-1077)
- Related: companion PRs in `doc-app` and `ui-extensions-sdk` will add the same clarifications to the developer docs and SDK type definitions

## Deployment

N/A — example and documentation changes only.

[DX-1077]: https://contentful.atlassian.net/browse/DX-1077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ