### PR TITLE
feat(content-insights): change fetch query to improve performance [MAPS-256]

### DIFF
--- a/apps/content-insights/src/hooks/useEntryTitlesForIds.ts
+++ b/apps/content-insights/src/hooks/useEntryTitlesForIds.ts
@@ -1,0 +1,44 @@
+import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
+import { HomeAppSDK, PageAppSDK } from '@contentful/app-sdk';
+import { useSDK } from '@contentful/react-apps-toolkit';
+import { EntryProps } from 'contentful-management';
+import { fetchEntryTitlesForIds } from '../utils/fetchEntryTitlesForIds';
+import { getEnvironmentId } from '../utils/sdkUtils';
+
+interface UseEntryTitlesForIdsResult {
+  titlesMap: Map<string, EntryProps>;
+  isFetching: boolean;
+  error: Error | null;
+  refetch: () => void;
+}
+
+// Lazy-fetches full entries for a set of ids (typically the 5 visible
+// rows of a table) so titles can be resolved against `entry.fields`.
+// Callers must sort their visible page on `sys.*` data only -- this
+// design assumes the bulk fetch is sys-only and would break for any
+// table that sorts on a `field` value.
+export function useEntryTitlesForIds(ids: string[]): UseEntryTitlesForIdsResult {
+  const sdk = useSDK<HomeAppSDK | PageAppSDK>();
+
+  const { data, isFetching, error, refetch } = useQuery<EntryProps[], Error>({
+    queryKey: ['entryTitles', sdk.ids.space, getEnvironmentId(sdk), [...ids].sort().join(',')],
+    enabled: ids.length > 0,
+    queryFn: () => fetchEntryTitlesForIds(sdk, ids),
+  });
+
+  const titlesMap = useMemo(() => {
+    const map = new Map<string, EntryProps>();
+    (data ?? []).forEach((entry) => {
+      map.set(entry.sys.id, entry);
+    });
+    return map;
+  }, [data]);
+
+  return {
+    titlesMap,
+    isFetching,
+    error: error ?? null,
+    refetch,
+  };
+}

--- a/apps/content-insights/src/hooks/useNeedsUpdateContent.ts
+++ b/apps/content-insights/src/hooks/useNeedsUpdateContent.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { HomeAppSDK, PageAppSDK } from '@contentful/app-sdk';
 import { useSDK } from '@contentful/react-apps-toolkit';
 import { useUsers } from './useUsers';
+import { useEntryTitlesForIds } from './useEntryTitlesForIds';
 import type { AppInstallationParameters } from '../locations/ConfigScreen';
 import { ITEMS_PER_PAGE } from '../utils/consts';
 import { getEntryTitle, getUniqueUserIdsFromEntries } from '../utils/EntryUtils';
@@ -64,36 +65,52 @@ export function useNeedsUpdate(
     error: usersError,
   } = useUsers(userIds);
 
-  const needsUpdateItems = useMemo(() => {
-    return filteredEntries
-      .map((entry) => {
-        return {
-          id: entry.sys.id,
-          title: getEntryTitle(
-            entry,
-            contentTypes.get(entry.sys.contentType?.sys?.id || ''),
-            defaultLocale
-          ),
-          age: calculateAgeInDays(parseDate(entry.sys.updatedAt) || new Date()),
-          publishedDate: entry.sys.publishedAt ?? null,
-          creator: getCreatorFromEntry(entry, usersMap),
-          contentType: contentTypes.get(entry.sys.contentType?.sys?.id || '')?.name || '',
-        };
-      })
-      .sort((a, b) => {
-        return b.age - a.age;
-      });
-  }, [filteredEntries, contentTypes, usersMap, defaultLocale]);
+  // Sort by age (sys-level) before paginating so the visible-id list is
+  // stable and we only fetch titles for the rows actually shown.
+  const sortedEntries = useMemo(() => {
+    return [...filteredEntries].sort((a, b) => {
+      const aUpdated = parseDate(a.sys.updatedAt)?.getTime() ?? 0;
+      const bUpdated = parseDate(b.sys.updatedAt)?.getTime() ?? 0;
+      return aUpdated - bUpdated;
+    });
+  }, [filteredEntries]);
 
   const skip = page * ITEMS_PER_PAGE;
+  const visibleEntries = useMemo(
+    () => sortedEntries.slice(skip, skip + ITEMS_PER_PAGE),
+    [sortedEntries, skip]
+  );
+  const visibleIds = useMemo(() => visibleEntries.map((e) => e.sys.id), [visibleEntries]);
+
+  const {
+    titlesMap,
+    isFetching: isFetchingTitles,
+    refetch: refetchTitles,
+    error: titlesError,
+  } = useEntryTitlesForIds(visibleIds);
+
+  const needsUpdateItems = useMemo(() => {
+    return visibleEntries.map((entry) => {
+      const contentType = contentTypes.get(entry.sys.contentType?.sys?.id || '');
+      return {
+        id: entry.sys.id,
+        title: getEntryTitle(titlesMap.get(entry.sys.id) ?? entry, contentType, defaultLocale),
+        age: calculateAgeInDays(parseDate(entry.sys.updatedAt) || new Date()),
+        publishedDate: entry.sys.publishedAt ?? null,
+        creator: getCreatorFromEntry(entry, usersMap),
+        contentType: contentType?.name || '',
+      };
+    });
+  }, [visibleEntries, contentTypes, usersMap, defaultLocale, titlesMap]);
 
   return {
-    items: needsUpdateItems.slice(skip, skip + ITEMS_PER_PAGE),
-    total: needsUpdateItems.length,
-    isFetching: isFetchingUsers,
-    error: usersError ?? null,
+    items: needsUpdateItems,
+    total: sortedEntries.length,
+    isFetching: isFetchingUsers || isFetchingTitles,
+    error: usersError ?? titlesError ?? null,
     refetch: () => {
       refetchUsers();
+      refetchTitles();
     },
   };
 }

--- a/apps/content-insights/src/hooks/useRecentlyPublishedContent.ts
+++ b/apps/content-insights/src/hooks/useRecentlyPublishedContent.ts
@@ -1,4 +1,5 @@
 import { useUsers } from './useUsers';
+import { useEntryTitlesForIds } from './useEntryTitlesForIds';
 import { ITEMS_PER_PAGE } from '../utils/consts';
 import { EntryProps, ContentTypeProps } from 'contentful-management';
 import { isWithin, parseDate } from '../utils/dateUtils';
@@ -31,13 +32,15 @@ export function useRecentlyPublishedContent(
   contentTypes: Map<string, ContentTypeProps>
 ): UseRecentlyPublishedResult {
   const skip = page * ITEMS_PER_PAGE;
-  const now = new Date();
 
-  const recentlyPublishedEntries = entries.filter((entry) => {
-    const publishedAt = parseDate(entry?.sys?.publishedAt);
-    if (!publishedAt) return false;
-    return isWithin(publishedAt, recentlyPublishedDate, now);
-  });
+  const recentlyPublishedEntries = useMemo(() => {
+    const now = new Date();
+    return entries.filter((entry) => {
+      const publishedAt = parseDate(entry?.sys?.publishedAt);
+      if (!publishedAt) return false;
+      return isWithin(publishedAt, recentlyPublishedDate, now);
+    });
+  }, [entries, recentlyPublishedDate]);
 
   const userIds = getUniqueUserIdsFromEntries(recentlyPublishedEntries);
 
@@ -48,32 +51,40 @@ export function useRecentlyPublishedContent(
     error: usersError,
   } = useUsers(userIds);
 
-  const recentlyPublishedItems = useMemo(() => {
-    const items: RecentlyPublishedItem[] = [];
-    recentlyPublishedEntries.forEach((entry) => {
-      const contentType = contentTypes.get(entry.sys.contentType?.sys?.id || '');
+  const visibleEntries = useMemo(
+    () => recentlyPublishedEntries.slice(skip, skip + ITEMS_PER_PAGE),
+    [recentlyPublishedEntries, skip]
+  );
+  const visibleIds = useMemo(() => visibleEntries.map((e) => e.sys.id), [visibleEntries]);
 
-      items.push({
+  const {
+    titlesMap,
+    isFetching: isFetchingTitles,
+    refetch: refetchTitles,
+    error: titlesError,
+  } = useEntryTitlesForIds(visibleIds);
+
+  const recentlyPublishedItems = useMemo(() => {
+    return visibleEntries.map<RecentlyPublishedItem>((entry) => {
+      const contentType = contentTypes.get(entry.sys.contentType?.sys?.id || '');
+      return {
         id: entry.sys.id,
-        title: getEntryTitle(entry, contentType, defaultLocale),
+        title: getEntryTitle(titlesMap.get(entry.sys.id) ?? entry, contentType, defaultLocale),
         contentType: contentType?.name || '',
         creator: getCreatorFromEntry(entry, usersMap),
         publishedDate: entry.sys.publishedAt || null,
-      });
+      };
     });
-
-    return items;
-  }, [recentlyPublishedEntries, contentTypes, usersMap, defaultLocale]);
-
-  const isFetching = isFetchingUsers;
+  }, [visibleEntries, contentTypes, usersMap, defaultLocale, titlesMap]);
 
   return {
-    items: recentlyPublishedItems.slice(skip, skip + ITEMS_PER_PAGE),
-    total: recentlyPublishedItems.length,
-    isFetching,
+    items: recentlyPublishedItems,
+    total: recentlyPublishedEntries.length,
+    isFetching: isFetchingUsers || isFetchingTitles,
     refetch: () => {
       refetchUsers();
+      refetchTitles();
     },
-    error: usersError ?? null,
+    error: usersError ?? titlesError ?? null,
   };
 }

--- a/apps/content-insights/src/hooks/useScheduledContent.ts
+++ b/apps/content-insights/src/hooks/useScheduledContent.ts
@@ -5,6 +5,7 @@ import { ScheduledContentItem } from '../utils/types';
 import { getCreatorFromEntry } from '../utils/UserUtils';
 import { getEntryStatus, getEntryTitle, getUniqueUserIdsFromEntries } from '../utils/EntryUtils';
 import { useUsers } from './useUsers';
+import { useEntryTitlesForIds } from './useEntryTitlesForIds';
 import { ITEMS_PER_PAGE } from '../utils/consts';
 
 interface UseScheduledContentResult {
@@ -41,18 +42,40 @@ export function useScheduledContent(
     error: fetchingUsersError,
   } = useUsers(userIds);
 
-  const scheduledItems = useMemo(() => {
-    const items: ScheduledContentItem[] = [];
-
+  // Unlike useNeedsUpdateContent / useRecentlyPublishedContent, ordering
+  // is driven by scheduledActions (not by entries). Build the
+  // action->entry pair list in action order, then paginate, so titles
+  // are only fetched for the visible page.
+  const orderedPairs = useMemo(() => {
+    const pairs: { entry: EntryProps; action: ScheduledActionProps }[] = [];
     scheduledActions.forEach((action) => {
       const entry = scheduledEntries.find((e) => e.sys.id === action.entity.sys.id);
-      if (!entry) return;
+      if (entry) {
+        pairs.push({ entry, action });
+      }
+    });
+    return pairs;
+  }, [scheduledActions, scheduledEntries]);
 
+  const visiblePairs = useMemo(
+    () => orderedPairs.slice(skip, skip + ITEMS_PER_PAGE),
+    [orderedPairs, skip]
+  );
+  const visibleIds = useMemo(() => visiblePairs.map((p) => p.entry.sys.id), [visiblePairs]);
+
+  const {
+    titlesMap,
+    isFetching: isFetchingTitles,
+    refetch: refetchTitles,
+    error: titlesError,
+  } = useEntryTitlesForIds(visibleIds);
+
+  const scheduledItems = useMemo(() => {
+    return visiblePairs.map<ScheduledContentItem>(({ entry, action }) => {
       const contentType = contentTypes.get(entry.sys.contentType?.sys?.id || '');
-
-      items.push({
+      return {
         id: entry.sys.id,
-        title: getEntryTitle(entry, contentType, defaultLocale),
+        title: getEntryTitle(titlesMap.get(entry.sys.id) ?? entry, contentType, defaultLocale),
         contentType: contentType?.name || '',
         creator: getCreatorFromEntry(entry, usersMap),
         publishedDate: entry.sys.publishedAt || null,
@@ -61,31 +84,31 @@ export function useScheduledContent(
           datetime: action.scheduledFor.datetime,
           timezone: action.scheduledFor.timezone,
         },
-      });
+      };
     });
-
-    return items;
-  }, [scheduledActions, scheduledEntries, contentTypes, usersMap, defaultLocale]);
+  }, [visiblePairs, contentTypes, usersMap, defaultLocale, titlesMap]);
 
   if (!scheduledActions.length) {
     return {
       items: [],
       total: 0,
-      isFetching: isFetchingUsers,
+      isFetching: isFetchingUsers || isFetchingTitles,
       error: null,
       refetch: () => {
         refetchUsers();
+        refetchTitles();
       },
     };
   }
 
   return {
-    items: scheduledItems.slice(skip, skip + ITEMS_PER_PAGE),
-    total: scheduledItems.length,
-    isFetching: isFetchingUsers,
-    error: fetchingUsersError ?? null,
+    items: scheduledItems,
+    total: orderedPairs.length,
+    isFetching: isFetchingUsers || isFetchingTitles,
+    error: fetchingUsersError ?? titlesError ?? null,
     refetch: () => {
       refetchUsers();
+      refetchTitles();
     },
   };
 }

--- a/apps/content-insights/src/utils/fetchAllEntries.ts
+++ b/apps/content-insights/src/utils/fetchAllEntries.ts
@@ -21,6 +21,10 @@ export async function fetchAllEntries(sdk: BaseAppSDK): Promise<FetchAllEntriesR
         query: {
           skip: batchSkip,
           limit: batchSize,
+          // sys-only projection -- strips fields and metadata from the
+          // response, shrinking payload 10-50x. Titles are lazy-loaded
+          // per visible page via useEntryTitlesForIds.
+          select: 'sys',
         },
       });
 

--- a/apps/content-insights/src/utils/fetchEntryTitlesForIds.ts
+++ b/apps/content-insights/src/utils/fetchEntryTitlesForIds.ts
@@ -1,0 +1,27 @@
+import { BaseAppSDK } from '@contentful/app-sdk';
+import { EntryProps } from 'contentful-management';
+
+// Fetches full entries for a small set of ids so callers can resolve
+// titles. Pairs with the `select: 'sys'` bulk fetch in fetchAllEntries:
+// the bulk fetch omits `fields`, and this lazy fetch fills them in only
+// for the visible page of a table.
+//
+// CMA accepts up to 50 ids in `sys.id[in]`, and ITEMS_PER_PAGE is 5, so
+// a single request always covers one table page.
+export async function fetchEntryTitlesForIds(
+  sdk: BaseAppSDK,
+  ids: string[]
+): Promise<EntryProps[]> {
+  if (ids.length === 0) {
+    return [];
+  }
+
+  const response = await sdk.cma.entry.getMany({
+    query: {
+      'sys.id[in]': ids.join(','),
+      limit: ids.length,
+    },
+  });
+
+  return response.items as EntryProps[];
+}

--- a/apps/content-insights/test/hooks/useEntryTitlesForIds.spec.tsx
+++ b/apps/content-insights/test/hooks/useEntryTitlesForIds.spec.tsx
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { EntryProps } from 'contentful-management';
+import { mockSdk } from '../mocks';
+import { useEntryTitlesForIds } from '../../src/hooks/useEntryTitlesForIds';
+import { fetchEntryTitlesForIds } from '../../src/utils/fetchEntryTitlesForIds';
+import { createQueryProviderWrapper } from '../utils/createQueryProviderWrapper';
+
+vi.mock('@contentful/react-apps-toolkit', () => ({
+  useSDK: () => mockSdk,
+}));
+
+vi.mock('../../src/utils/fetchEntryTitlesForIds');
+
+const buildEntry = (id: string, title: string): EntryProps =>
+  ({
+    sys: { id, type: 'Entry', contentType: { sys: { id: 'blogPost' } } } as any,
+    fields: { title: { 'en-US': title } },
+  } as EntryProps);
+
+describe('useEntryTitlesForIds', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns an empty map and does not fetch when ids is empty', async () => {
+    const { result } = renderHook(() => useEntryTitlesForIds([]), {
+      wrapper: createQueryProviderWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isFetching).toBe(false);
+    });
+
+    expect(result.current.titlesMap.size).toBe(0);
+    expect(result.current.error).toBeNull();
+    expect(fetchEntryTitlesForIds).not.toHaveBeenCalled();
+  });
+
+  it('builds a map keyed by entry id from the fetched entries', async () => {
+    const entries = [buildEntry('a', 'Alpha'), buildEntry('b', 'Beta')];
+    vi.mocked(fetchEntryTitlesForIds).mockResolvedValue(entries);
+
+    const { result } = renderHook(() => useEntryTitlesForIds(['a', 'b']), {
+      wrapper: createQueryProviderWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isFetching).toBe(false);
+    });
+
+    expect(result.current.titlesMap.size).toBe(2);
+    expect(result.current.titlesMap.get('a')).toEqual(entries[0]);
+    expect(result.current.titlesMap.get('b')).toEqual(entries[1]);
+    expect(fetchEntryTitlesForIds).toHaveBeenCalledWith(mockSdk, ['a', 'b']);
+  });
+
+  it('passes the original (unsorted) ids through to the fetch util', async () => {
+    vi.mocked(fetchEntryTitlesForIds).mockResolvedValue([buildEntry('a', 'Alpha')]);
+
+    const { result } = renderHook(() => useEntryTitlesForIds(['b', 'a']), {
+      wrapper: createQueryProviderWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
+
+    // The hook sorts ids only for the query key (cache identity); the
+    // CMA call itself receives the caller's order unchanged.
+    expect(fetchEntryTitlesForIds).toHaveBeenCalledWith(mockSdk, ['b', 'a']);
+  });
+
+  it('exposes errors from the fetch util', async () => {
+    const fetchError = new Error('boom');
+    vi.mocked(fetchEntryTitlesForIds).mockRejectedValue(fetchError);
+
+    const { result } = renderHook(() => useEntryTitlesForIds(['a']), {
+      wrapper: createQueryProviderWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isFetching).toBe(false);
+    });
+
+    expect(result.current.error).toEqual(fetchError);
+    expect(result.current.titlesMap.size).toBe(0);
+  });
+});

--- a/apps/content-insights/test/hooks/useNeedsUpdateContent.spec.tsx
+++ b/apps/content-insights/test/hooks/useNeedsUpdateContent.spec.tsx
@@ -19,6 +19,17 @@ vi.mock('../../src/hooks/useUsers', () => ({
   useUsers: (userIds: string[]) => mockUseUsers(userIds),
 }));
 
+const mockRefetchTitles = vi.fn();
+
+vi.mock('../../src/hooks/useEntryTitlesForIds', () => ({
+  useEntryTitlesForIds: () => ({
+    titlesMap: new Map(),
+    isFetching: false,
+    refetch: mockRefetchTitles,
+    error: null,
+  }),
+}));
+
 describe('useNeedsUpdate', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/apps/content-insights/test/hooks/useRecentlyPublishedContent.spec.tsx
+++ b/apps/content-insights/test/hooks/useRecentlyPublishedContent.spec.tsx
@@ -28,6 +28,17 @@ vi.mock('../../src/hooks/useUsers', () => ({
   useUsers: (userIds: string[]) => mockUseUsers(userIds),
 }));
 
+const mockRefetchTitles = vi.fn();
+
+vi.mock('../../src/hooks/useEntryTitlesForIds', () => ({
+  useEntryTitlesForIds: () => ({
+    titlesMap: new Map(),
+    isFetching: false,
+    refetch: mockRefetchTitles,
+    error: null,
+  }),
+}));
+
 describe('useRecentlyPublishedContent', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/apps/content-insights/test/hooks/useScheduledContent.spec.tsx
+++ b/apps/content-insights/test/hooks/useScheduledContent.spec.tsx
@@ -32,6 +32,17 @@ vi.mock('../../src/hooks/useUsers', () => ({
   useUsers: (userIds: string[]) => mockUseUsers(userIds),
 }));
 
+const mockRefetchTitles = vi.fn();
+
+vi.mock('../../src/hooks/useEntryTitlesForIds', () => ({
+  useEntryTitlesForIds: () => ({
+    titlesMap: new Map(),
+    isFetching: false,
+    refetch: mockRefetchTitles,
+    error: null,
+  }),
+}));
+
 describe('useScheduledContent', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/apps/content-insights/test/utils/fetchAllEntries.spec.ts
+++ b/apps/content-insights/test/utils/fetchAllEntries.spec.ts
@@ -42,6 +42,7 @@ describe('fetchAllEntries', () => {
       query: {
         skip: 0,
         limit: 1000,
+        select: 'sys',
       },
     });
   });
@@ -70,12 +71,14 @@ describe('fetchAllEntries', () => {
       query: {
         skip: 0,
         limit: 1000,
+        select: 'sys',
       },
     });
     expect(mockCma.entry.getMany).toHaveBeenNthCalledWith(2, {
       query: {
         skip: 1000,
         limit: 1000,
+        select: 'sys',
       },
     });
   });
@@ -121,12 +124,14 @@ describe('fetchAllEntries', () => {
       query: {
         skip: 0,
         limit: 1000,
+        select: 'sys',
       },
     });
     expect(mockCma.entry.getMany).toHaveBeenNthCalledWith(2, {
       query: {
         skip: 0,
         limit: 500, // Reduced batch size
+        select: 'sys',
       },
     });
   });


### PR DESCRIPTION
## Purpose

Cuts initial Content Insights dashboard payload by 10-50x by stripping `fields` and `metadata` from the bulk entries fetch and lazy-loading titles for only the currently visible table rows.

## Approach

- Bulk fetch sends `select: 'sys'` -- safe because metrics, trends, and scheduled-action joins all read sys-only data; `getEntryTitle` is the single `entry.fields` reader app-wide.
- New `useEntryTitlesForIds` hook (mirrors `useUsers`: TanStack Query, sorted-id key, returns `Map<id, EntryProps>`) batches one `sys.id[in]` request per visible page (max 5 ids).
- The three table-feeding hooks now slice to the visible page first, fetch titles for those ids, and resolve via `getEntryTitle(titlesMap.get(id) ?? sysEntry, ...)` -- existing `'Untitled'` fallback handles the loading frame.
- Title-loading is folded into each hook's existing `isFetching` so the table's row skeleton covers it -- no per-cell skeleton, no flash of "Untitled"; cached per sorted-id-set so paging back is instant.
- Defensive bits kept: adaptive batch-size halving on "Response size too big" stays; `DEFAULT_BATCH_SIZE` left at 1000 (CMA's documented max).

## Results

I did manual performance testing, I didn't see a noticeable difference in performance on our 3,000 record data set in our dev space. I'm hoping we'll see a more noticeable difference on larger data sets like the customer's 25,000 entries. However, since this creates the same UX on smaller data sets with much less data being fetched, I think it's a good change either way.

https://github.com/user-attachments/assets/0e994d2f-cba1-4488-844c-49b8bce4e0ee

