### PR TITLE
refactor(drive-integration): logo rename [INTEG-3974]

### DIFF
--- a/apps/drive-integration/src/locations/Page/components/mainpage/OAuthConnector.tsx
+++ b/apps/drive-integration/src/locations/Page/components/mainpage/OAuthConnector.tsx
@@ -3,7 +3,7 @@ import { type ComponentProps } from 'react';
 import { Button, Flex, Text, Image } from '@contentful/f36-components';
 import tokens from '@contentful/f36-tokens';
 import { CheckCircleIcon } from '@contentful/f36-icons';
-import googleDriveLogo from '../../../../assets/drive-integration.svg';
+import driveLogo from '../../../../assets/drive-integration.svg';
 
 type OAuthConnectorProps = {
   isOAuthConnected: boolean;
@@ -67,7 +67,7 @@ export const OAuthConnector = ({
             borderRadius: tokens.borderRadiusMedium,
             backgroundColor: tokens.gray100,
           }}>
-          <Image src={googleDriveLogo} alt="Drive Integration" height="28px" width="32px" />
+          <Image src={driveLogo} alt="Drive Integration" height="28px" width="32px" />
         </Flex>
         <Text fontSize="fontSizeL" fontWeight="fontWeightMedium" lineHeight="lineHeightL">
           Drive Integration


### PR DESCRIPTION
## Purpose/Approach

The app name is Drive Integration so changed the logo name to match that.

## Testing steps

Don't apply

## Breaking Changes

No

## Dependencies and/or References

No

## Deployment

No