### PR TITLE
fix(drive-integration): surface entitlement denial reason in UI []

### DIFF
--- a/apps/drive-integration/src/locations/Page/Page.tsx
+++ b/apps/drive-integration/src/locations/Page/Page.tsx
@@ -12,7 +12,6 @@ import { loadFixtureReviewPayload } from '../../fixtures/googleDocsReview/loadFi
 import type { MappingReviewSuspendPayload } from '@types';
 import { useWorkflowAgent } from '@hooks/useWorkflowAgent';
 import { useGoogleDriveOAuth } from '@hooks/useGoogleDriveOAuth';
-import { ERROR_MESSAGES } from '@constants/messages';
 import { isAiAccessDeniedError } from '../../utils/aiAccess';
 
 const enableMockReviewPayload = import.meta.env.VITE_ENABLE_MOCK_REVIEW_PAYLOAD === 'true';
@@ -20,7 +19,7 @@ const enableMockReviewPayload = import.meta.env.VITE_ENABLE_MOCK_REVIEW_PAYLOAD 
 const Page = () => {
   const sdk = useSDK<PageAppSDK>();
   const modalOrchestratorRef = useRef<ModalOrchestratorHandle>(null);
-  const [isAiAccessDenied, setIsAiAccessDenied] = useState(false);
+  const [aiAccessDeniedMessage, setAiAccessDeniedMessage] = useState<string | null>(null);
   const [mappingReviewState, setMappingReviewState] = useState<{
     payload: MappingReviewSuspendPayload;
     runId?: string;
@@ -60,14 +59,14 @@ const Page = () => {
     modalOrchestratorRef.current?.startFlow();
   };
 
-  const handleAiAccessDenied = () => {
-    setIsAiAccessDenied(true);
+  const handleAiAccessDenied = (message: string) => {
+    setAiAccessDeniedMessage(message);
     setMappingReviewState(null);
   };
 
   const handleAiAccessRestored = () => {
-    if (isAiAccessDenied) {
-      setIsAiAccessDenied(false);
+    if (aiAccessDeniedMessage !== null) {
+      setAiAccessDeniedMessage(null);
     }
   };
 
@@ -105,7 +104,7 @@ const Page = () => {
       await startOAuth();
     } catch (error) {
       if (isAiAccessDeniedError(error)) {
-        handleAiAccessDenied();
+        handleAiAccessDenied(error.message);
       }
     }
   };
@@ -115,12 +114,12 @@ const Page = () => {
       await disconnectOAuth();
     } catch (error) {
       if (isAiAccessDeniedError(error)) {
-        handleAiAccessDenied();
+        handleAiAccessDenied(error.message);
       }
     }
   };
 
-  if (isAiAccessDenied) {
+  if (aiAccessDeniedMessage !== null) {
     return (
       <Layout withBoxShadow={true} offsetTop={10}>
         <Layout.Body>
@@ -129,7 +128,7 @@ const Page = () => {
             gap="spacingM"
             style={{ maxWidth: '900px', margin: '24px auto' }}>
             <Heading marginBottom="none">Drive Integration</Heading>
-            <Note variant="warning">{ERROR_MESSAGES.AI_ACCESS_DENIED}</Note>
+            <Note variant="warning">{aiAccessDeniedMessage}</Note>
           </Flex>
         </Layout.Body>
       </Layout>

--- a/apps/drive-integration/src/locations/Page/components/mainpage/ModalOrchestrator.tsx
+++ b/apps/drive-integration/src/locations/Page/components/mainpage/ModalOrchestrator.tsx
@@ -43,7 +43,7 @@ interface ModalOrchestratorProps {
   isOAuthConnected?: boolean;
   isOAuthBusy?: boolean;
   onReconnectGoogleDrive?: () => Promise<void>;
-  onAiAccessDenied?: () => void;
+  onAiAccessDenied?: (message: string) => void;
   onMappingReviewReady: (payload: MappingReviewSuspendPayload, runId: string) => void;
   onResetToMain: () => void;
 }
@@ -182,7 +182,7 @@ export const ModalOrchestrator = forwardRef<ModalOrchestratorHandle, ModalOrches
       if (isAiAccessDeniedError(error)) {
         resetProgress();
         onResetToMain();
-        onAiAccessDenied?.();
+        onAiAccessDenied?.(error.message);
         return;
       }
 

--- a/apps/drive-integration/src/services/agents-api.ts
+++ b/apps/drive-integration/src/services/agents-api.ts
@@ -92,11 +92,8 @@ export async function getWorkflowRun(
     }
 
     if (!response.ok) {
-      if (response.status === 403) {
-        throw normalizeAiAccessError({ status: response.status });
-      }
-
-      throw new Error(`Failed to poll agent run: ${response.status} ${response.statusText}`);
+      const body = await response.json().catch(() => ({}));
+      throw normalizeAiAccessError({ status: response.status, ...body });
     }
 
     return (await response.json()) as AgentRunData;
@@ -138,13 +135,8 @@ export async function startAgentRun(
     );
 
     if (!response.ok) {
-      if (response.status === 403) {
-        throw normalizeAiAccessError({ status: response.status });
-      }
-
-      throw new Error(
-        `Failed to start workflow agent run: ${response.status} ${response.statusText}`
-      );
+      const body = await response.json().catch(() => ({}));
+      throw normalizeAiAccessError({ status: response.status, ...body });
     }
 
     runData = (await response.json()) as AgentRunData;
@@ -191,11 +183,8 @@ export async function resumeWorkflowRun(
     );
 
     if (!response.ok) {
-      if (response.status === 403) {
-        throw normalizeAiAccessError({ status: response.status });
-      }
-
-      throw new Error(`Failed to resume agent run: ${response.status} ${response.statusText}`);
+      const body = await response.json().catch(() => ({}));
+      throw normalizeAiAccessError({ status: response.status, ...body });
     }
 
     return;

--- a/apps/drive-integration/src/utils/aiAccess.ts
+++ b/apps/drive-integration/src/utils/aiAccess.ts
@@ -55,15 +55,10 @@ export function isAiAccessDeniedError(error: unknown): error is AiAccessDeniedEr
     return false;
   }
 
-  const message = (getReasons(err) ?? err.message ?? '').toLowerCase();
-
   const hasForbiddenStatus = err.status === 403;
   const hasAccessDeniedIdentifier = err.sys?.id === 'AccessDenied';
-  const hasAiAccessDeniedMessage = message
-    .toLowerCase()
-    .includes('ai features have been temporarily disabled');
 
-  return hasForbiddenStatus && hasAccessDeniedIdentifier && hasAiAccessDeniedMessage;
+  return hasForbiddenStatus && hasAccessDeniedIdentifier;
 }
 
 export function normalizeAiAccessError(error: unknown): Error {

--- a/apps/drive-integration/test/utils/aiAccess.test.ts
+++ b/apps/drive-integration/test/utils/aiAccess.test.ts
@@ -6,28 +6,37 @@ import {
 } from '../../src/utils/aiAccess';
 
 describe('aiAccess utils', () => {
-  it('detects AI access denied only when status, identifier, and message all match', () => {
+  it('detects AI access denied when status is 403 and sys.id is AccessDenied', () => {
     expect(
       isAiAccessDeniedError({
         status: 403,
         sys: { id: 'AccessDenied' },
-        message: 'AI features have been temporarily disabled for this space.',
       })
     ).toBe(true);
   });
 
-  it('normalizes 403-style errors into AiAccessDeniedError', () => {
+  it('detects AI access denied regardless of message content', () => {
+    expect(
+      isAiAccessDeniedError({
+        status: 403,
+        sys: { id: 'AccessDenied' },
+        message: 'google-docs-workflow-agent requires a higher plan',
+      })
+    ).toBe(true);
+  });
+
+  it('normalizes 403+AccessDenied errors into AiAccessDeniedError preserving the reason', () => {
     const error = normalizeAiAccessError({
       status: 403,
       sys: { id: 'AccessDenied' },
-      details: { reasons: 'AI features have been temporarily disabled for this space.' },
+      details: { reasons: 'google-docs-workflow-agent is not available for your plan' },
     });
 
     expect(error).toBeInstanceOf(AiAccessDeniedError);
-    expect(error.message).toContain('temporarily disabled');
+    expect(error.message).toContain('not available for your plan');
   });
 
-  it('does not classify generic 403 errors as AI access denied', () => {
+  it('does not classify 403 errors without AccessDenied sys.id as AI access denied', () => {
     const error = normalizeAiAccessError({
       status: 403,
       message: 'Forbidden',


### PR DESCRIPTION
## Summary

- `isAiAccessDeniedError` previously required a specific legacy message string (`"ai features have been temporarily disabled"`) that the agents-api entitlement gate never sends — plan-tier 403s silently fell through as generic errors. Detection now uses `403 + AccessDenied sys.id` only, which is sufficient and unambiguous.
- Local-dev fetch paths in `agents-api.ts` were throwing `{ status: 403 }` with no body, so `sys.id` was never present. They now parse the JSON response body and spread it into the error object before calling `normalizeAiAccessError`.
- `onAiAccessDenied` callback now carries the actual error message string. `Page.tsx` renders it in the warning `Note` instead of the hardcoded generic copy, so users see the real reason (e.g. "google-docs-workflow-agent requires a higher plan").

Companion to agents-api PR #465 which introduced the entitlement gate.

## Test plan

- [ ] Verify a space on a plan without `driveIntegrationApp` entitlement sees the agents-api error message in the warning note rather than the generic "AI features are currently disabled" copy
- [ ] Verify a space with the entitlement still flows through normally
- [ ] Unit tests in `test/utils/aiAccess.test.ts` updated to cover new detection logic and entitlement-specific messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)