### PR TITLE
fix(rich-text-versioning): inject reference recommendations into entity picker [ES-262]

### DIFF
--- a/apps/rich-text-versioning/package-lock.json
+++ b/apps/rich-text-versioning/package-lock.json
@@ -9,25 +9,29 @@
       "version": "0.1.0",
       "dependencies": {
         "@ali-tas/htmldiff-js": "^2.0.1",
-        "@contentful/app-sdk": "^4.42.0",
-        "@contentful/f36-components": "4.81.1",
-        "@contentful/f36-multiselect": "^4.81.1",
-        "@contentful/f36-tokens": "4.2.0",
-        "@contentful/field-editor-rich-text": "4.16.0",
-        "@contentful/react-apps-toolkit": "1.2.16",
-        "@contentful/rich-text-html-renderer": "^17.1.0",
-        "@contentful/rich-text-react-renderer": "^16.1.0",
-        "@contentful/rich-text-types": "^16.1.0",
+        "@contentful/app-sdk": "^4.54.0",
+        "@contentful/f36-components": "^6.7.1",
+        "@contentful/f36-multiselect": "^6.7.1",
+        "@contentful/f36-tokens": "^6.1.2",
+        "@contentful/field-editor-rich-text": "6.3.5",
+        "@contentful/react-apps-toolkit": "^2.0.0",
+        "@contentful/rich-text-html-renderer": "^17.2.2",
+        "@contentful/rich-text-react-renderer": "^16.2.1",
+        "@contentful/rich-text-types": "^17.2.5",
+        "@emotion/css": "^11.13.5",
+        "@lingui/core": "^5.3.0",
+        "@tanstack/react-query": "^5.0.0",
         "contentful": "^11.7.15",
-        "contentful-management": "11.54.4",
+        "contentful-management": "^12.3.0",
         "dompurify": "^3.0.8",
-        "emotion": "10.0.27",
         "happy-dom": "^20.0.0",
         "react": "18.3.1",
-        "react-dom": "18.3.1"
+        "react-dom": "18.3.1",
+        "scheduler": "^0.23.2"
       },
       "devDependencies": {
         "@contentful/app-scripts": "^2.5.5",
+        "@testing-library/dom": "^10.0.0",
         "@testing-library/jest-dom": "^6.6.4",
         "@testing-library/react": "16.3.0",
         "@testing-library/user-event": "^14.6.1",
@@ -296,9 +300,10 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
-      "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -379,29 +384,30 @@
         "npm": ">=9"
       }
     },
-    "node_modules/@contentful/app-sdk": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.45.0.tgz",
-      "integrity": "sha512-3NCLi7B/VL17k3iMA+0hsycFn6mrDyKIE3LZPRfJjFtcFO7OVZwQ4Aysp0e2Hbatrppin3QIc8feTdg59JMNkQ==",
-      "license": "MIT",
-      "dependencies": {
-        "contentful-management": "^11.57.1"
-      }
-    },
-    "node_modules/@contentful/app-sdk/node_modules/contentful-management": {
-      "version": "11.61.1",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.61.1.tgz",
-      "integrity": "sha512-+Shk0fGpudvT0b0CwdNiLDwPoIbb0YdkiiYc6h5aC42zfVFJ0dgJf9JKzYPBPJd0MWGOCQf5yNzt/zBEAUDElw==",
+    "node_modules/@contentful/app-scripts/node_modules/contentful-management": {
+      "version": "11.76.0",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.76.0.tgz",
+      "integrity": "sha512-KsqIZ65q1A6IP55sxTfuAMhBTNJfgGxlVZBoV2ghBuR1LaZZyTqway5vj9KHRDl/Z1uOQQsYSiz+FayMxBXXEw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@contentful/rich-text-types": "^16.6.1",
-        "axios": "^1.12.2",
-        "contentful-sdk-core": "^9.0.1",
+        "axios": "^1.15.0",
+        "contentful-sdk-core": "^9.4.4",
         "fast-copy": "^3.0.0",
         "globals": "^15.15.0"
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@contentful/app-sdk": {
+      "version": "4.57.0",
+      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.57.0.tgz",
+      "integrity": "sha512-GbmOCytf3Ij/2U+hJuQ9QOihIbEhUrgeh1DH3gSdsSG3GP4Rj2WscPDNHwzQsAqk1eTdwT4LfLkCvXo152Thug==",
+      "license": "MIT",
+      "dependencies": {
+        "contentful-management": "^12.3.1"
       }
     },
     "node_modules/@contentful/content-source-maps": {
@@ -414,211 +420,225 @@
       }
     },
     "node_modules/@contentful/contentful-slatejs-adapter": {
-      "version": "15.18.11",
-      "resolved": "https://registry.npmjs.org/@contentful/contentful-slatejs-adapter/-/contentful-slatejs-adapter-15.18.11.tgz",
-      "integrity": "sha512-smV7HuOCeFeNljGff653jWW+0hLV6RKPMx25CHx5Hn719xZCZTVPBGU9UkZOfuMADFvggJlxjaMi4PhyQrDtkg==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/contentful-slatejs-adapter/-/contentful-slatejs-adapter-16.2.1.tgz",
+      "integrity": "sha512-mil+xbUSQIEwf9XeYxK3OTmIAzYiCHQxk4uHcl3/SJf8+MTiot2dMQuf5m+DyFkpDDP4tc51c8H00sDc/frbXw==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/rich-text-types": "^16.8.5"
+        "@contentful/rich-text-types": "^17.2.7"
       },
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@contentful/f36-accordion": {
-      "version": "4.81.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.81.1.tgz",
-      "integrity": "sha512-iQ2ERYurTTxDXp031kPZy5In9qNzSQJ2sc52VRaafUPdKiVnX5igGVqAiMxcK30fPP14RccOOHVz6YnrMjGtvg==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-6.8.0.tgz",
+      "integrity": "sha512-oa9DhWVEe2bIb3K0FcLr1jEhlqdf9zn0g7Q3pjRLlBnsOmtVKlhObyvzUZhxN1Z8EmAQ1lfPQsL6o1Qvz+0a9A==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/f36-collapse": "^4.81.1",
-        "@contentful/f36-core": "^4.81.1",
-        "@contentful/f36-icons": "^4.29.1",
-        "@contentful/f36-tokens": "^4.2.0",
-        "@contentful/f36-typography": "^4.81.1",
-        "emotion": "^10.0.17"
+        "@contentful/f36-collapse": "^6.8.0",
+        "@contentful/f36-core": "^6.8.0",
+        "@contentful/f36-icons": "^6.8.0",
+        "@contentful/f36-tokens": "^6.1.0",
+        "@contentful/f36-typography": "^6.8.0",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-asset": {
-      "version": "4.81.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.81.1.tgz",
-      "integrity": "sha512-1cXdCHhZ+ymCaEHexoeGwfvEWbjDxMU4mNX1TL1LatI4iSW7l8vhwDnVXQMMi0VmhX2U968z2kFZrjsqcgIwOg==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-6.8.0.tgz",
+      "integrity": "sha512-ohQqawQaaMxGAYEB5kdmuVcLMDG9YPczxqll1deRK7HE4bZW30pKofqM1RdczGdr1OxCqkNoWGilts3691h1Cg==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.81.1",
-        "@contentful/f36-icon": "^4.81.1",
-        "@contentful/f36-icons": "^4.29.1",
-        "@contentful/f36-tokens": "^4.2.0",
-        "@contentful/f36-typography": "^4.81.1",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.8.0",
+        "@contentful/f36-icon": "^6.8.0",
+        "@contentful/f36-icons": "^6.8.0",
+        "@contentful/f36-tokens": "^6.1.0",
+        "@contentful/f36-typography": "^6.8.0",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-autocomplete": {
-      "version": "4.81.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.81.1.tgz",
-      "integrity": "sha512-lUwnApdkfgbX16QdHbsxZuaIv2V+Op40m/JlPNhuF/rl5g3ndS1BerjFcaDgDMbJzc/Jl8BNOVJj0Wc7F5M9TQ==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-6.8.0.tgz",
+      "integrity": "sha512-mY9BsHMo8FT7XJUFercjLC3n6NK4nQLHE1sOyMCjKvyalRln8geRIZ8Bu2XJ/c6AOaUllLEBhAYOa9x/18pNzQ==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.81.1",
-        "@contentful/f36-core": "^4.81.1",
-        "@contentful/f36-forms": "^4.81.1",
-        "@contentful/f36-icons": "^4.29.1",
-        "@contentful/f36-popover": "^4.81.1",
-        "@contentful/f36-skeleton": "^4.81.1",
-        "@contentful/f36-tokens": "^4.2.0",
-        "@contentful/f36-typography": "^4.81.1",
-        "@contentful/f36-utils": "^4.24.3",
-        "downshift": "^6.1.12",
-        "emotion": "^10.0.17"
+        "@contentful/f36-button": "^6.8.0",
+        "@contentful/f36-core": "^6.8.0",
+        "@contentful/f36-forms": "^6.8.0",
+        "@contentful/f36-icons": "^6.8.0",
+        "@contentful/f36-popover": "^6.8.0",
+        "@contentful/f36-skeleton": "^6.8.0",
+        "@contentful/f36-tokens": "^6.1.0",
+        "@contentful/f36-typography": "^6.8.0",
+        "@contentful/f36-utils": "^6.1.0",
+        "@emotion/css": "^11.13.5",
+        "downshift": "^9.0.10"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-avatar": {
-      "version": "4.81.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-avatar/-/f36-avatar-4.81.1.tgz",
-      "integrity": "sha512-CBR90BcY/REi0F5ey4jQ2tygTUwvUg4Rpshli7OSDhCflw//Kyv4O97vgq6s9V4pO5XfwDEujKLnbYyJHWorTA==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-avatar/-/f36-avatar-6.8.0.tgz",
+      "integrity": "sha512-ITOFTbizJfJ5uJFzOhU8lxy6Ixx2IlPhtn2e1cZkJtYN+Mx7RFQP6LmtxWVA3jFdi1woZLMduVgEp/c7zaUw/Q==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.81.1",
-        "@contentful/f36-image": "4.81.1",
-        "@contentful/f36-menu": "^4.81.1",
-        "@contentful/f36-tokens": "^4.2.0",
-        "@contentful/f36-tooltip": "^4.81.1",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.8.0",
+        "@contentful/f36-image": "^6.8.0",
+        "@contentful/f36-menu": "^6.8.0",
+        "@contentful/f36-tokens": "^6.1.0",
+        "@contentful/f36-tooltip": "^6.8.0",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-badge": {
-      "version": "4.81.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.81.1.tgz",
-      "integrity": "sha512-yj7ZwuuOIvAhyVqUZdfB68bpgNB2XXnQx6QsRKWaKoM703IkRbqSKrLfeOljkgd5/5kMxTWyrvQfDTx2wfJl1A==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-6.8.0.tgz",
+      "integrity": "sha512-UJmeFnSUP67GGXOcqtA/nqNJDkWngXPxDPFaowXI6MwAtcebwh5T1q3ljwV0jWr3AQCfg3YczJcHtsTHBzvIMA==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.81.1",
-        "@contentful/f36-icons": "^4.29.1",
-        "@contentful/f36-tokens": "^4.2.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.8.0",
+        "@contentful/f36-icons": "^6.8.0",
+        "@contentful/f36-tokens": "^6.1.0",
+        "@contentful/f36-utils": "^6.1.0",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-button": {
-      "version": "4.81.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.81.1.tgz",
-      "integrity": "sha512-qQK9ZQHHSvcXt6hCeqXPbr2/C8MnBk4egPd5w0VPfOi3Sa7obyWeMuAoVP3bLCicvEu/B7FFH6E1orL6+8lUOw==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-6.8.0.tgz",
+      "integrity": "sha512-h8j8t5cPDw4defykoLewqdlZYEb8sXw3eaNifoxUcIxS2BYRrU3mBlCxGHuWQwekN/p2XTxgCYCBoSE6lt8SVQ==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.81.1",
-        "@contentful/f36-spinner": "^4.81.1",
-        "@contentful/f36-tokens": "^4.2.0",
-        "@contentful/f36-tooltip": "^4.81.1",
-        "@contentful/f36-utils": "^4.24.3",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.8.0",
+        "@contentful/f36-spinner": "^6.8.0",
+        "@contentful/f36-tokens": "^6.1.0",
+        "@contentful/f36-tooltip": "^6.8.0",
+        "@contentful/f36-utils": "^6.1.0",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-card": {
-      "version": "4.81.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.81.1.tgz",
-      "integrity": "sha512-dDidZfT31IZ3BwZhKRt0O8VZu0FrU41D8BkxkdUYpwSJJzxEMsTyaiUxB57TUd8FHEEmAbozyGcJwt0ybBqm8w==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-6.8.0.tgz",
+      "integrity": "sha512-c6+DLaC92nMHUZF5BKVNcXH551bLZlYpsyPcL26N/EigpijFoKvAQRliW5wRPKRHRC8zVY/06P1VwGFXrG9FJg==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/f36-asset": "^4.81.1",
-        "@contentful/f36-badge": "^4.81.1",
-        "@contentful/f36-button": "^4.81.1",
-        "@contentful/f36-core": "^4.81.1",
-        "@contentful/f36-drag-handle": "^4.81.1",
-        "@contentful/f36-icon": "^4.81.1",
-        "@contentful/f36-icons": "^4.29.1",
-        "@contentful/f36-menu": "^4.81.1",
-        "@contentful/f36-skeleton": "^4.81.1",
-        "@contentful/f36-tokens": "^4.2.0",
-        "@contentful/f36-tooltip": "^4.81.1",
-        "@contentful/f36-typography": "^4.81.1",
-        "emotion": "^10.0.17",
+        "@contentful/f36-asset": "^6.8.0",
+        "@contentful/f36-badge": "^6.8.0",
+        "@contentful/f36-button": "^6.8.0",
+        "@contentful/f36-core": "^6.8.0",
+        "@contentful/f36-drag-handle": "^6.8.0",
+        "@contentful/f36-icon": "^6.8.0",
+        "@contentful/f36-icons": "^6.8.0",
+        "@contentful/f36-menu": "^6.8.0",
+        "@contentful/f36-skeleton": "^6.8.0",
+        "@contentful/f36-tokens": "^6.1.0",
+        "@contentful/f36-tooltip": "^6.8.0",
+        "@contentful/f36-typography": "^6.8.0",
+        "@emotion/css": "^11.13.5",
         "truncate": "^3.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-collapse": {
-      "version": "4.81.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.81.1.tgz",
-      "integrity": "sha512-KhaM4Z7RXOsRWzPLx5kOPpTtQCR7VmbO7TVZI9x7II0zCv+bBr9hUsy6JN+ktL4ZePXe+GT4O6FGVPMbsVWt2A==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-6.8.0.tgz",
+      "integrity": "sha512-Be9Zxk/9lGO/kl4e1rZMr9G3qKCH7Hi9izj2EDrTj2GMicf5UayOLSTFfUy92vMT6ZKZGp0ewX4d9yOAIAuB4g==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.81.1",
-        "@contentful/f36-tokens": "^4.2.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.8.0",
+        "@contentful/f36-tokens": "^6.1.0",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-components": {
-      "version": "4.81.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.81.1.tgz",
-      "integrity": "sha512-RcVrhVLzQMZW6zuixn2ivD2As/xhx+FwbPElrUzztseq+txf0F8Eqjs7P8FQ42/1RPQ0sR90WerFWCSbe/kMWA==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-6.8.0.tgz",
+      "integrity": "sha512-pfyF2dtbbDhNiQL3DQSqxonZ1Fg2goLq/VVi708wnl+fOmSFIrzu1qYOKWsgPftH/QHjE4CLM4PGbcNdqcBBHw==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/f36-accordion": "^4.81.1",
-        "@contentful/f36-asset": "^4.81.1",
-        "@contentful/f36-autocomplete": "^4.81.1",
-        "@contentful/f36-avatar": "4.81.1",
-        "@contentful/f36-badge": "^4.81.1",
-        "@contentful/f36-button": "^4.81.1",
-        "@contentful/f36-card": "^4.81.1",
-        "@contentful/f36-collapse": "^4.81.1",
-        "@contentful/f36-copybutton": "^4.81.1",
-        "@contentful/f36-core": "^4.81.1",
-        "@contentful/f36-datepicker": "^4.81.1",
-        "@contentful/f36-datetime": "^4.81.1",
-        "@contentful/f36-drag-handle": "^4.81.1",
-        "@contentful/f36-empty-state": "^4.81.1",
-        "@contentful/f36-entity-list": "^4.81.1",
-        "@contentful/f36-forms": "^4.81.1",
-        "@contentful/f36-header": "^4.81.1",
-        "@contentful/f36-icon": "^4.81.1",
-        "@contentful/f36-icons": "^4.29.1",
-        "@contentful/f36-image": "4.81.1",
-        "@contentful/f36-list": "^4.81.1",
-        "@contentful/f36-menu": "^4.81.1",
-        "@contentful/f36-modal": "^4.81.1",
-        "@contentful/f36-navbar": "^4.81.1",
-        "@contentful/f36-note": "^4.81.1",
-        "@contentful/f36-notification": "^4.81.1",
-        "@contentful/f36-pagination": "^4.81.1",
-        "@contentful/f36-pill": "^4.81.1",
-        "@contentful/f36-popover": "^4.81.1",
-        "@contentful/f36-skeleton": "^4.81.1",
-        "@contentful/f36-spinner": "^4.81.1",
-        "@contentful/f36-table": "^4.81.1",
-        "@contentful/f36-tabs": "^4.81.1",
-        "@contentful/f36-text-link": "^4.81.1",
-        "@contentful/f36-tokens": "^4.2.0",
-        "@contentful/f36-tooltip": "^4.81.1",
-        "@contentful/f36-typography": "^4.81.1",
-        "@contentful/f36-usage-card": "^4.0.0",
-        "@contentful/f36-usage-count": "^4.1.0",
-        "@contentful/f36-utils": "^4.24.3"
+        "@contentful/f36-accordion": "^6.8.0",
+        "@contentful/f36-asset": "^6.8.0",
+        "@contentful/f36-autocomplete": "^6.8.0",
+        "@contentful/f36-avatar": "^6.8.0",
+        "@contentful/f36-badge": "^6.8.0",
+        "@contentful/f36-button": "^6.8.0",
+        "@contentful/f36-card": "^6.8.0",
+        "@contentful/f36-collapse": "^6.8.0",
+        "@contentful/f36-copybutton": "^6.8.0",
+        "@contentful/f36-core": "^6.8.0",
+        "@contentful/f36-datepicker": "^6.8.0",
+        "@contentful/f36-datetime": "^6.8.0",
+        "@contentful/f36-drag-handle": "^6.8.0",
+        "@contentful/f36-empty-state": "^6.8.0",
+        "@contentful/f36-entity-list": "^6.8.0",
+        "@contentful/f36-forms": "^6.8.0",
+        "@contentful/f36-header": "^6.8.0",
+        "@contentful/f36-icon": "^6.8.0",
+        "@contentful/f36-icons": "^6.8.0",
+        "@contentful/f36-image": "^6.8.0",
+        "@contentful/f36-layout": "^6.8.0",
+        "@contentful/f36-list": "^6.8.0",
+        "@contentful/f36-menu": "^6.8.0",
+        "@contentful/f36-modal": "^6.8.0",
+        "@contentful/f36-multiselect": "^6.8.0",
+        "@contentful/f36-navlist": "^6.8.0",
+        "@contentful/f36-note": "^6.8.0",
+        "@contentful/f36-notification": "^6.8.0",
+        "@contentful/f36-pagination": "^6.8.0",
+        "@contentful/f36-pill": "^6.8.0",
+        "@contentful/f36-popover": "^6.8.0",
+        "@contentful/f36-progress-stepper": "^6.8.0",
+        "@contentful/f36-skeleton": "^6.8.0",
+        "@contentful/f36-spinner": "^6.8.0",
+        "@contentful/f36-table": "^6.8.0",
+        "@contentful/f36-tabs": "^6.8.0",
+        "@contentful/f36-text-link": "^6.8.0",
+        "@contentful/f36-tokens": "^6.1.0",
+        "@contentful/f36-tooltip": "^6.8.0",
+        "@contentful/f36-typography": "^6.8.0",
+        "@contentful/f36-usage-card": "^6.8.0",
+        "@contentful/f36-usage-count": "^6.8.0",
+        "@contentful/f36-utils": "^6.1.0"
       },
       "peerDependencies": {
-        "@types/react": ">=16.8",
-        "@types/react-dom": ">=16.8",
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "@types/react": "^18.3.0 || >=19.1.0",
+        "@types/react-dom": "^18.3.0 || >=19.1.0",
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -630,1779 +650,641 @@
       }
     },
     "node_modules/@contentful/f36-copybutton": {
-      "version": "4.81.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.81.1.tgz",
-      "integrity": "sha512-6zgcAB9kyYg/KInDa1VCVurSoi6B/RD+MCpXW1Ixtweno1qWersRjHB61k3+3pQFaLT21rlPBv/31rhfOqVsHg==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-6.8.0.tgz",
+      "integrity": "sha512-XRQo9BaJj5LN3Rdbyfb8i6YCBHe0CFtHyDbV1nXwRVG/ROPJpEZPBiiXYkYIOtMmUtDzu/lOdsfgVWpqBE3pzQ==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.81.1",
-        "@contentful/f36-core": "^4.81.1",
-        "@contentful/f36-icons": "^4.29.1",
-        "@contentful/f36-tokens": "^4.2.0",
-        "@contentful/f36-tooltip": "^4.81.1",
-        "emotion": "^10.0.17"
+        "@contentful/f36-button": "^6.8.0",
+        "@contentful/f36-core": "^6.8.0",
+        "@contentful/f36-icons": "^6.8.0",
+        "@contentful/f36-tokens": "^6.1.0",
+        "@contentful/f36-tooltip": "^6.8.0",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-core": {
-      "version": "4.81.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.81.1.tgz",
-      "integrity": "sha512-n1H0bApzFSdL4bInsemSsJVlNkDt4Xhw+g9GMhXZqC7g+K6Yptow1mUSS+93Nmbccmumy/vWyau71wqrHWt3tA==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-6.8.0.tgz",
+      "integrity": "sha512-8XSjrJuBwPN7p2Cgr+a3ZmMF9NLBICVQos5dO8f49iTkW0EpVXEHFgdTM4iv8NmLiZJYZMaqwYEv+ig/mELrxg==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/f36-tokens": "^4.2.0",
-        "@emotion/core": "^10.1.1",
-        "@emotion/is-prop-valid": "^1.2.0",
-        "csstype": "^3.1.1",
-        "emotion": "^10.0.17"
+        "@contentful/f36-tokens": "^6.1.0",
+        "@emotion/css": "^11.13.5",
+        "@emotion/react": "^11.14.0",
+        "csstype": "^3.1.1"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-datepicker": {
-      "version": "4.81.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.81.1.tgz",
-      "integrity": "sha512-LFNfVK1hPqKuGiDUxjwDYcvfHFDPWZ3Ejds//+R5o8iA7xT5/l+7Zyeg0Bo49YCTXVeg5NbsenkM68poUoRjCA==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-6.8.0.tgz",
+      "integrity": "sha512-Ai6xgfz/TsKz3gNEEpW4tGGLiJd3jsbVmuBgL5UpiHGOCbLD2JGof5xcEzwFOCZbq1vtucBYvp4eCzeUoM53Dw==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.81.1",
-        "@contentful/f36-core": "^4.81.1",
-        "@contentful/f36-forms": "^4.81.1",
-        "@contentful/f36-icons": "^4.29.1",
-        "@contentful/f36-popover": "^4.81.1",
-        "@contentful/f36-tokens": "^4.2.0",
-        "@contentful/f36-typography": "^4.81.1",
+        "@contentful/f36-button": "^6.8.0",
+        "@contentful/f36-core": "^6.8.0",
+        "@contentful/f36-forms": "^6.8.0",
+        "@contentful/f36-icons": "^6.8.0",
+        "@contentful/f36-popover": "^6.8.0",
+        "@contentful/f36-tokens": "^6.1.0",
+        "@contentful/f36-typography": "^6.8.0",
+        "@emotion/css": "^11.13.5",
         "date-fns": "^2.28.0",
-        "emotion": "^10.0.17",
         "react-day-picker": "^8.7.1",
         "react-focus-lock": "^2.9.1"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-datetime": {
-      "version": "4.81.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.81.1.tgz",
-      "integrity": "sha512-SIAD2Jl+NE05a6ke5a122VIaBOJsXjD+DXD8pKsRM5NX0zzgtIPSst2NeETuW+p2HXpenwk5PSyNRqPuS7GM/g==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-6.8.0.tgz",
+      "integrity": "sha512-Ua/XfayUPtyviuPKFkzGEEDLbRtqv++IkmonztauRpsxeOnehnlWGDA4iltPDAgN9R5xLBWsKCSu91aO5qpwqg==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.81.1",
-        "@contentful/f36-tokens": "^4.2.0",
-        "dayjs": "^1.11.5",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.8.0",
+        "@contentful/f36-tokens": "^6.1.0",
+        "@emotion/css": "^11.13.5",
+        "dayjs": "^1.11.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-drag-handle": {
-      "version": "4.81.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.81.1.tgz",
-      "integrity": "sha512-S+GnO8wouQj723ws8rk562uZy0DvxWW4TPUt+LVb6tT69kI7RawXyNqYjEOZf06uDDvPId1AhcygT8g8JL+i/w==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-6.8.0.tgz",
+      "integrity": "sha512-faGd91lSxJ0Nbx1cGKlzfAJaZI7+18bXQbOkmWYC6Pvn71hQbgU6TG/uJB7a8CI2zIALjYoYgsiVHi5N/ROgIg==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.81.1",
-        "@contentful/f36-icons": "^4.29.1",
-        "@contentful/f36-tokens": "^4.2.0",
-        "@contentful/f36-utils": "^4.24.3",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.8.0",
+        "@contentful/f36-icons": "^6.8.0",
+        "@contentful/f36-tokens": "^6.1.0",
+        "@contentful/f36-utils": "^6.1.0",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-empty-state": {
-      "version": "4.81.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.81.1.tgz",
-      "integrity": "sha512-x+2AZvK/ZMJtST7AjvdX6/7j9shXjIiXP96iT2LR9+Vwp3vY2ifou2A/PL1oUGVbvADjwGsoVglszQoFKsR2JQ==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-6.8.0.tgz",
+      "integrity": "sha512-OG/9UUXWqpM57O2dSNIcFQ0ktBGS0VsibOx26PwUguv0Pv+ob0c/4dIt50/LLddirbsLAtVoWXCVgFtPN0zGiw==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/f36-tokens": "^4.2.0",
-        "@contentful/f36-typography": "^4.81.1",
-        "emotion": "^10.0.17"
+        "@contentful/f36-tokens": "^6.1.0",
+        "@contentful/f36-typography": "^6.8.0",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-entity-list": {
-      "version": "4.81.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.81.1.tgz",
-      "integrity": "sha512-Wec9rXoGro75TXUi7KvGrZEjSnuyL/lxCcqhOTgtW9la2QXAF9UoXWCSFfTlHqCCmyjWYqNAVVMt8MQ5TTmPUQ==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-6.8.0.tgz",
+      "integrity": "sha512-QSZHuM8RIwXWpiB8nIuYD6jz1fW8tT5ucJIGC8gkbuqnVTgNp1XPW6pOg2rKN4fV/Y4lUMH/GOfonMX1GwyjpQ==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/f36-badge": "^4.81.1",
-        "@contentful/f36-button": "^4.81.1",
-        "@contentful/f36-core": "^4.81.1",
-        "@contentful/f36-drag-handle": "^4.81.1",
-        "@contentful/f36-icon": "^4.81.1",
-        "@contentful/f36-icons": "^4.29.1",
-        "@contentful/f36-menu": "^4.81.1",
-        "@contentful/f36-skeleton": "^4.81.1",
-        "@contentful/f36-tokens": "^4.2.0",
-        "@contentful/f36-typography": "^4.81.1",
-        "emotion": "^10.0.17"
+        "@contentful/f36-badge": "^6.8.0",
+        "@contentful/f36-button": "^6.8.0",
+        "@contentful/f36-core": "^6.8.0",
+        "@contentful/f36-drag-handle": "^6.8.0",
+        "@contentful/f36-icon": "^6.8.0",
+        "@contentful/f36-icons": "^6.8.0",
+        "@contentful/f36-menu": "^6.8.0",
+        "@contentful/f36-skeleton": "^6.8.0",
+        "@contentful/f36-tokens": "^6.1.0",
+        "@contentful/f36-typography": "^6.8.0",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-forms": {
-      "version": "4.81.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.81.1.tgz",
-      "integrity": "sha512-1F2kc81hvGmncQIKdAX8Ij9Xznk3c2+6qcqkw+oBupsPZnCYw8e4P2evlQTxpqGtQQK5QDL57J9YB69dMigehg==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-6.8.0.tgz",
+      "integrity": "sha512-MK2VwxtcvvSeDyYViOFcrLf/nCM3E80G03qJjLbj/3BS/q+XuGYTpt2e84bAFthU+TNAxs7JdP7i7UBhab8xYQ==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.81.1",
-        "@contentful/f36-icons": "^4.29.1",
-        "@contentful/f36-tokens": "^4.2.0",
-        "@contentful/f36-typography": "^4.81.1",
-        "@contentful/f36-utils": "^4.24.3",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.8.0",
+        "@contentful/f36-icon": "^6.8.0",
+        "@contentful/f36-icons": "^6.8.0",
+        "@contentful/f36-tokens": "^6.1.0",
+        "@contentful/f36-typography": "^6.8.0",
+        "@contentful/f36-utils": "^6.1.0",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-header": {
-      "version": "4.81.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-header/-/f36-header-4.81.1.tgz",
-      "integrity": "sha512-obTSg4QbUIga7DjXVOe5n5y2o7T47KM6UGYsU4n3NA5Vsy4qJReOO8oNXBVqxt7CW9hXhXccNPjuOfIhiMXApA==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-header/-/f36-header-6.8.0.tgz",
+      "integrity": "sha512-g7S21ffS+LFzs2b6xf2q/ZiH3EIuS265egFKgiZ5myGA8kRO2IFtCIgLkECBr3OxWSH2SPYPZUROZ+bHk94GMw==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.81.1",
-        "@contentful/f36-core": "^4.81.1",
-        "@contentful/f36-icons": "^4.29.1",
-        "@contentful/f36-tokens": "^4.2.0",
-        "@contentful/f36-typography": "^4.81.1",
-        "emotion": "^10.0.17"
+        "@contentful/f36-button": "^6.8.0",
+        "@contentful/f36-core": "^6.8.0",
+        "@contentful/f36-icons": "^6.8.0",
+        "@contentful/f36-tokens": "^6.1.0",
+        "@contentful/f36-typography": "^6.8.0",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-icon": {
-      "version": "4.81.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.81.1.tgz",
-      "integrity": "sha512-s7rX0BrGvaDnaExaZeAJ24O5Ruyzlvqlq03WlePH2XDXbTC620f4VL1iODd5JJGg0NlPDgkjRk+GG6uj9HOGMA==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-6.8.0.tgz",
+      "integrity": "sha512-29UskCHu13g1DYXslRDegBoJ+D32xeshhh11Tl3XiOzZh0ktINP8hpoeY7g568rqdd4QMzvTr1LarZowDLNu2A==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.81.1",
-        "@contentful/f36-tokens": "^4.2.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.8.0",
+        "@contentful/f36-tokens": "^6.1.0",
+        "@emotion/css": "^11.13.5",
+        "@phosphor-icons/react": "2.1.8"
+      },
+      "engines": {
+        "node": ">=16"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-icons": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-4.29.1.tgz",
-      "integrity": "sha512-Klqewgt+CoU9BgWhVdFDEmQAWgI+KpsFYuYFsgdr7GCaMgHuecFSGN44SdW/bcv1Ijch3A1xEoYIOqTbLUAP7w==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-6.8.0.tgz",
+      "integrity": "sha512-3XFZhFcR+GBrLaCZdpIS/GYxzHV3UWfRs251s/WUV4R0l4s7lXfDxOzAF9VbjIQ0hkQPodRPM3jJMPimU7pYbQ==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.80.4",
-        "@contentful/f36-icon": "^4.80.4",
-        "@contentful/f36-tokens": "^4.0.1",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.8.0",
+        "@contentful/f36-icon": "^6.8.0",
+        "@contentful/f36-tokens": "^6.1.0",
+        "@emotion/css": "^11.13.5",
+        "@phosphor-icons/react": "2.1.8"
+      },
+      "engines": {
+        "node": ">=16"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-image": {
-      "version": "4.81.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-image/-/f36-image-4.81.1.tgz",
-      "integrity": "sha512-D/WoHm08zaaLzzttb26AUT+YvRcsIsdgOqozWtrJoxgAkuiUxfoS8sq0VnkWd5G2IGMnym4hM1pugD3ZasczSg==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-image/-/f36-image-6.8.0.tgz",
+      "integrity": "sha512-QoO7q/rCSLUdrt1IB54WE0vQ6ItleXIHnNabr7F/MNaC44gmZF1g3N3b4BjKGWB0f2gGHSHuu3j3jt3a8eVrsA==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.81.1",
-        "@contentful/f36-skeleton": "^4.81.1",
-        "@contentful/f36-tokens": "^4.2.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.8.0",
+        "@contentful/f36-skeleton": "^6.8.0",
+        "@contentful/f36-tokens": "^6.1.0",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-layout": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-layout/-/f36-layout-5.6.0.tgz",
-      "integrity": "sha512-mA1mxDqq1p/cCde4mnkzUy/oqW41WotPtvPkc2ekgLfBUl8bZjKssXuLzZRycUYLg2duB6++iiEkhVS1nBnyFQ==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-layout/-/f36-layout-6.8.0.tgz",
+      "integrity": "sha512-Zuc+KszqE6jlxd/fCs0HHjF07bBpPTpGWmSDdPC7RhJqHJznVv6autH4i8nV+twa6/UI1JYegcD/cW7VBAZe5w==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-header": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.8.0",
+        "@contentful/f36-header": "^6.8.0",
+        "@contentful/f36-tokens": "^6.1.0",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-layout/node_modules/@contentful/f36-button": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-5.6.0.tgz",
-      "integrity": "sha512-JGXADlfIbtbVPUeUvVhFr2yt+5b758T6layvgFK52JV7dWyitOdA2HQ7K1/EtLQXmk0pk2zfvV9X4gQpFotZxw==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-spinner": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.6.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-layout/node_modules/@contentful/f36-core": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-5.6.0.tgz",
-      "integrity": "sha512-O9t4UzEEyjbYs637uUfiTGHwNwvqfMPYkrgW47g03XPwo1gRoXNaJzMNJLemkW/8ZqjrgBsEE4Q6QvKtOdDb0A==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-tokens": "^5.1.0",
-        "@emotion/core": "^10.1.1",
-        "@emotion/is-prop-valid": "^1.2.0",
-        "csstype": "^3.1.1",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-layout/node_modules/@contentful/f36-header": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-header/-/f36-header-5.6.0.tgz",
-      "integrity": "sha512-bY7uhrdv3O7GfQ1soJkkn0BOox6HuJhk1Vc0xorEpnI/o4QdiO5tMW7XO0A++dzEtZfYffYRCBenPmn+M840YQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-layout/node_modules/@contentful/f36-icon": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-5.6.0.tgz",
-      "integrity": "sha512-VoyKI+rQGK5a3XyFvNG5PMa5FsGdo23XTB0Mj8ukIIvm6ZEBPTHqCGoKnPdl+s2+txIiMSbAmJslEbJR6KZiBg==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@phosphor-icons/react": "2.1.8",
-        "emotion": "^10.0.17"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-layout/node_modules/@contentful/f36-icons": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-5.6.0.tgz",
-      "integrity": "sha512-YM2KNFbmGAkqY6iug8ja8TCBpLxZm2jECZDujRweHyRnTRfHpoIjuP+14LO0iv/ilJEK6DedJoAflz0QJ20a8w==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icon": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@phosphor-icons/react": "2.1.8",
-        "emotion": "^10.0.17"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-layout/node_modules/@contentful/f36-spinner": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-5.6.0.tgz",
-      "integrity": "sha512-NmH/bNol+e7AarybNgv8B8lodF2hOFlF32H6QAEhsHmq76dxOQ6LlgjlxIttNpIrGgHYU29yWAH5LhTu/BAE7g==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-layout/node_modules/@contentful/f36-tokens": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-5.1.0.tgz",
-      "integrity": "sha512-7++MPQiizK6qLhPkilWIKqM5Mhdr199tK7dL4iZ689iTwA82uvXXOojJr+0wVOurG2Odb+6/3WLe1XdveDZHEA==",
-      "license": "MIT"
-    },
-    "node_modules/@contentful/f36-layout/node_modules/@contentful/f36-tooltip": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-5.6.0.tgz",
-      "integrity": "sha512-e4z+eysp95u4ASheQgkJJM+RXyZv/KyMi4bqqez2ydvkFtFViI7E+wkzxIbB5L2EzHqIGL6/IcgQ8GC6io/Fsw==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "@popperjs/core": "^2.11.5",
-        "csstype": "^3.1.1",
-        "emotion": "^10.0.17",
-        "react-popper": "^2.3.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-layout/node_modules/@contentful/f36-typography": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-5.6.0.tgz",
-      "integrity": "sha512-v8myIeJnpZ6g2WRmL9oOOLrjip3+80Y+LQ4PwOzcJatL5AdwSYVExtlFMMVO5/JNt6qEpT2sd5579LPA17yiVg==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-layout/node_modules/@contentful/f36-utils": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-utils/-/f36-utils-5.2.0.tgz",
-      "integrity": "sha512-0YWsKAdU2HeNz5DwuOCR0lnlHVhlXiDkqtYaH8hHqT9HlQKHDSBPQUI9Vk5OrPDRJ3uLVoyGOJcvUDf27tTopA==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-tokens": "^5.1.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-list": {
-      "version": "4.81.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.81.1.tgz",
-      "integrity": "sha512-m/x6LRoeO1d4o+Vm5SsdYaTQebLM959emxdbBa2ryg4TZxTzTW7S13TB758CwEtMbvv1dnmcGiEG8ot6/zV+/g==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-6.8.0.tgz",
+      "integrity": "sha512-X5yyxx15RtJ4Gj769Rn1Mx8FbYV+CVYzg6Ayve5uurxmQ6hIybDQd+bA10oF68eZkR2NJ49fib1yOjxwTte8FQ==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.81.1",
-        "@contentful/f36-tokens": "^4.2.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.8.0",
+        "@contentful/f36-tokens": "^6.1.0",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-menu": {
-      "version": "4.81.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.81.1.tgz",
-      "integrity": "sha512-zEvMlaaM10ULsiVFSTJya+6OVX7mUsrOJ9qwb+ZUpKefTVmD28HesHksRek3BD1fcy1d3UJViT78XA6q9dwS8g==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-6.8.0.tgz",
+      "integrity": "sha512-puvrXZj78C7fMeK8W9ur6mkZyPROotksyJphfn0L57VvpXGl/0m5Cj0Mlh8RyvebmaELGJU4daYDGOr3knVe3w==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.81.1",
-        "@contentful/f36-icons": "^4.29.1",
-        "@contentful/f36-popover": "^4.81.1",
-        "@contentful/f36-tokens": "^4.2.0",
-        "@contentful/f36-typography": "^4.81.1",
-        "@contentful/f36-utils": "^4.24.3",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.8.0",
+        "@contentful/f36-icons": "^6.8.0",
+        "@contentful/f36-popover": "^6.8.0",
+        "@contentful/f36-tokens": "^6.1.0",
+        "@contentful/f36-typography": "^6.8.0",
+        "@contentful/f36-utils": "^6.1.0",
+        "@emotion/css": "^11.13.5",
+        "@floating-ui/dom": "^1.7.4",
+        "@floating-ui/react": "^0.27.16"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-modal": {
-      "version": "4.81.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.81.1.tgz",
-      "integrity": "sha512-m8JN8+Q7hfPdDhSZrCgUb8rn2I1Y5iSHVW5r/P+7pf0AOfMeJSDRyHNNMEkn5UyZudwbUdVEcNFy/l2xDVkaZA==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-6.8.0.tgz",
+      "integrity": "sha512-nasoqHXmXF4V3sL0k+1TtBJxnmdrjqOevzi0WQ6ExIMK9vofdgV7RFxXWt4XHPwh0eGtsalK29qbVdD9V2m+qA==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.81.1",
-        "@contentful/f36-core": "^4.81.1",
-        "@contentful/f36-icons": "^4.29.1",
-        "@contentful/f36-tokens": "^4.2.0",
-        "@contentful/f36-typography": "^4.81.1",
-        "@types/react-modal": "^3.13.1",
-        "emotion": "^10.0.17",
-        "react-modal": "^3.16.1"
+        "@contentful/f36-button": "^6.8.0",
+        "@contentful/f36-core": "^6.8.0",
+        "@contentful/f36-icons": "^6.8.0",
+        "@contentful/f36-tokens": "^6.1.0",
+        "@contentful/f36-typography": "^6.8.0",
+        "@emotion/css": "^11.13.5",
+        "@types/react-modal": "^3.16.3",
+        "react-modal": "^3.16.3"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-multiselect": {
-      "version": "4.81.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-multiselect/-/f36-multiselect-4.81.1.tgz",
-      "integrity": "sha512-MmW96YqZ8/oVoHVJiT9ev8TVNie8taZOcNSkj1p+kKembuhGP7pQh78W+S8bLRvwdFgyoeMl6GKs3jTEeAIDtg==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-multiselect/-/f36-multiselect-6.8.0.tgz",
+      "integrity": "sha512-qaeMPCMUZP/rArZpWEblxEBqXqYR2s/DYQ+sNnOVxv39Ha6bY6foxpgkK0FbEA2iXvE+FIoAbZMesjo9XKK1oQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.27.1",
-        "@contentful/f36-button": "^4.81.1",
-        "@contentful/f36-core": "^4.81.1",
-        "@contentful/f36-forms": "^4.81.1",
-        "@contentful/f36-icons": "^4.20.8",
-        "@contentful/f36-popover": "^4.81.1",
-        "@contentful/f36-skeleton": "^4.81.1",
-        "@contentful/f36-tokens": "^4.0.1",
-        "@contentful/f36-tooltip": "^4.81.1",
-        "@contentful/f36-typography": "^4.81.1",
-        "@contentful/f36-utils": "^4.20.8",
-        "emotion": "^10.0.17",
-        "react-focus-lock": "^2.9.5"
+        "@contentful/f36-button": "^6.8.0",
+        "@contentful/f36-core": "^6.8.0",
+        "@contentful/f36-forms": "^6.8.0",
+        "@contentful/f36-icons": "^6.8.0",
+        "@contentful/f36-popover": "^6.8.0",
+        "@contentful/f36-skeleton": "^6.8.0",
+        "@contentful/f36-tokens": "^6.1.0",
+        "@contentful/f36-tooltip": "^6.8.0",
+        "@contentful/f36-typography": "^6.8.0",
+        "@contentful/f36-utils": "^6.1.0",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-navbar": {
-      "version": "4.81.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-navbar/-/f36-navbar-4.81.1.tgz",
-      "integrity": "sha512-Kfromh5vpleCmbZfXHdvkYymhN8gfZiqVZjeBsx9wPvFBkm4YDx7cc4ijVZdkFekFVNrPT8GQMHSMGR4dYKt2A==",
-      "dependencies": {
-        "@contentful/f36-avatar": "4.81.1",
-        "@contentful/f36-core": "^4.81.1",
-        "@contentful/f36-icon": "^4.81.1",
-        "@contentful/f36-icons": "^4.29.1",
-        "@contentful/f36-menu": "^4.81.1",
-        "@contentful/f36-skeleton": "^4.81.1",
-        "@contentful/f36-tokens": "^4.2.0",
-        "@contentful/f36-utils": "^4.23.2",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-navlist": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-navlist/-/f36-navlist-5.6.0.tgz",
-      "integrity": "sha512-DEIN+DBCZ4yLwf/KOWgd27oY+ztc/sHXxAAmKPRd0QebwtwSwRCr4YI2H5jbPUGZbmw+vQyvX1apsPP6bwCI1A==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-navlist/-/f36-navlist-6.8.0.tgz",
+      "integrity": "sha512-5slnfqNl0iext4XQrkecRy2nffeKWxEz9qMb6lDXWwfLEyUf0KT4USug1/TBWIDPGQkzXQN5S9hyp8n2KHZAcw==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.8.0",
+        "@contentful/f36-tokens": "^6.1.0",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
-    },
-    "node_modules/@contentful/f36-navlist/node_modules/@contentful/f36-core": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-5.6.0.tgz",
-      "integrity": "sha512-O9t4UzEEyjbYs637uUfiTGHwNwvqfMPYkrgW47g03XPwo1gRoXNaJzMNJLemkW/8ZqjrgBsEE4Q6QvKtOdDb0A==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-tokens": "^5.1.0",
-        "@emotion/core": "^10.1.1",
-        "@emotion/is-prop-valid": "^1.2.0",
-        "csstype": "^3.1.1",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-navlist/node_modules/@contentful/f36-tokens": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-5.1.0.tgz",
-      "integrity": "sha512-7++MPQiizK6qLhPkilWIKqM5Mhdr199tK7dL4iZ689iTwA82uvXXOojJr+0wVOurG2Odb+6/3WLe1XdveDZHEA==",
-      "license": "MIT"
     },
     "node_modules/@contentful/f36-note": {
-      "version": "4.81.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.81.1.tgz",
-      "integrity": "sha512-Wd7RYOJ9pa23ZHj95pmxCESTeJV9l3snceFwI/m+gkcdZkwVknHyAyfmo/Jjq1cDWtE6Ul3n+Tk752uFNFRpAg==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-6.8.0.tgz",
+      "integrity": "sha512-zDN5f6Pr6IV0fTIfByvLPeUY9br1NOKq3ullG1LAyKAYtuRWVNPPQR1t7O+SG75UYclJQgldrWLelSEJVDNshA==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.81.1",
-        "@contentful/f36-core": "^4.81.1",
-        "@contentful/f36-icon": "^4.81.1",
-        "@contentful/f36-icons": "^4.29.1",
-        "@contentful/f36-tokens": "^4.2.0",
-        "@contentful/f36-typography": "^4.81.1",
-        "emotion": "^10.0.17"
+        "@contentful/f36-button": "^6.8.0",
+        "@contentful/f36-core": "^6.8.0",
+        "@contentful/f36-icon": "^6.8.0",
+        "@contentful/f36-icons": "^6.8.0",
+        "@contentful/f36-tokens": "^6.1.0",
+        "@contentful/f36-typography": "^6.8.0",
+        "@contentful/f36-utils": "^6.1.0",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-notification": {
-      "version": "4.81.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.81.1.tgz",
-      "integrity": "sha512-767WdLca+Ll+8kGKL3bdnJ3YqZTgeQmqKE4fixEcBzrUwb2eDMolzZzCHu0lHBTvvRC1m/KhcYcEiExqqGmDvA==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-6.8.0.tgz",
+      "integrity": "sha512-2Qpnbfh27sB/D5w4SqmWBWWaF9RaHdurnWL9QiQUJNBtftel22c1NuMKXAisdbRRis2pHKxEAZPIv7VSryG00A==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.81.1",
-        "@contentful/f36-core": "^4.81.1",
-        "@contentful/f36-icons": "^4.29.1",
-        "@contentful/f36-text-link": "^4.81.1",
-        "@contentful/f36-tokens": "^4.2.0",
-        "@contentful/f36-typography": "^4.81.1",
-        "emotion": "^10.0.17",
+        "@contentful/f36-button": "^6.8.0",
+        "@contentful/f36-core": "^6.8.0",
+        "@contentful/f36-icons": "^6.8.0",
+        "@contentful/f36-text-link": "^6.8.0",
+        "@contentful/f36-tokens": "^6.1.0",
+        "@contentful/f36-typography": "^6.8.0",
+        "@emotion/css": "^11.13.5",
         "react-animate-height": "^3.0.4"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-pagination": {
-      "version": "4.81.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.81.1.tgz",
-      "integrity": "sha512-zNtISiRV6Nf3nO1oRNACzknlxwke2JSmEdC6JeUzSjX7MkNiyMvpjq1jFypdlhcpqt1fu54kWCMA2VF+H+SEDA==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-6.8.0.tgz",
+      "integrity": "sha512-QFkfBwpxr8+nS186DmuxeZnoFgekygGKQ9GR16opNgwmSxhotK5GCFxj6hTllAofbp52RuPez5ZiwEuM56dv7A==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.81.1",
-        "@contentful/f36-core": "^4.81.1",
-        "@contentful/f36-forms": "^4.81.1",
-        "@contentful/f36-icons": "^4.29.1",
-        "@contentful/f36-tokens": "^4.2.0",
-        "@contentful/f36-typography": "^4.81.1",
-        "emotion": "^10.0.17"
+        "@contentful/f36-button": "^6.8.0",
+        "@contentful/f36-core": "^6.8.0",
+        "@contentful/f36-forms": "^6.8.0",
+        "@contentful/f36-icons": "^6.8.0",
+        "@contentful/f36-tokens": "^6.1.0",
+        "@contentful/f36-typography": "^6.8.0",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-pill": {
-      "version": "4.81.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.81.1.tgz",
-      "integrity": "sha512-Vn12ryHRjossi/TGmNyQck90bbw3k4zVUPEwKHaZZmIM+VWGIG8BYSKyBGFV1pi93O1bXgxADldZD8lY2U05ng==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-6.8.0.tgz",
+      "integrity": "sha512-d7G5r+b1taDBwIWGk/pg+MkEcQ5PFfGWPjfRokFO982f6q2Z3mHovW8dyTmjs9pmr3YNzBbpylM8OtADB5hvDw==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^4.81.1",
-        "@contentful/f36-core": "^4.81.1",
-        "@contentful/f36-drag-handle": "^4.81.1",
-        "@contentful/f36-icons": "^4.29.1",
-        "@contentful/f36-tokens": "^4.2.0",
-        "@contentful/f36-tooltip": "^4.81.1",
-        "emotion": "^10.0.17"
+        "@contentful/f36-button": "^6.8.0",
+        "@contentful/f36-core": "^6.8.0",
+        "@contentful/f36-drag-handle": "^6.8.0",
+        "@contentful/f36-icons": "^6.8.0",
+        "@contentful/f36-tokens": "^6.1.0",
+        "@contentful/f36-tooltip": "^6.8.0",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-popover": {
-      "version": "4.81.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.81.1.tgz",
-      "integrity": "sha512-3p33rAisFN41seFXgYaED3PKkAYsPvvyIakdBA2Fdxnvvx38oeKSzjIn8X1Z9Oy3m1D5CTjp2egq3/XaY/tczA==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-6.8.0.tgz",
+      "integrity": "sha512-zG3EqUqI4xmLbwZCYtWtujjt+PQSX9RG49WiquTwByuwDz60sMzo1AXxAXhpRSDOTca2QuFjwobxZr4w7gXUmA==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.81.1",
-        "@contentful/f36-tokens": "^4.2.0",
-        "@contentful/f36-utils": "^4.24.3",
-        "@popperjs/core": "^2.11.5",
-        "emotion": "^10.0.17",
-        "react-popper": "^2.3.0"
+        "@contentful/f36-core": "^6.8.0",
+        "@contentful/f36-tokens": "^6.1.0",
+        "@contentful/f36-utils": "^6.1.0",
+        "@emotion/css": "^11.13.5",
+        "@floating-ui/dom": "^1.7.4",
+        "@floating-ui/react": "^0.27.16"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-progress-stepper": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-progress-stepper/-/f36-progress-stepper-5.6.0.tgz",
-      "integrity": "sha512-oFdoZU3jY8OUn9Br3sZWHOkOtuaKWRA2G/bDsGoxY5NpdCrAg0nfsAJ9qConkeF9bQY04elV9+4bcW+R3B55zw==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-progress-stepper/-/f36-progress-stepper-6.8.0.tgz",
+      "integrity": "sha512-/fK6/e4cUK875zseZoVzNVgiWUFf2WayvaIGeHqzr+OeGF3GeuPiP83Ke8eVtHs/nR0NHVlUiswMIloBMBiDSg==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-button": "^6.8.0",
+        "@contentful/f36-core": "^6.8.0",
+        "@contentful/f36-icons": "^6.8.0",
+        "@contentful/f36-tokens": "^6.1.0",
+        "@contentful/f36-typography": "^6.8.0",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-progress-stepper/node_modules/@contentful/f36-button": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-5.6.0.tgz",
-      "integrity": "sha512-JGXADlfIbtbVPUeUvVhFr2yt+5b758T6layvgFK52JV7dWyitOdA2HQ7K1/EtLQXmk0pk2zfvV9X4gQpFotZxw==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-spinner": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.6.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-progress-stepper/node_modules/@contentful/f36-core": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-5.6.0.tgz",
-      "integrity": "sha512-O9t4UzEEyjbYs637uUfiTGHwNwvqfMPYkrgW47g03XPwo1gRoXNaJzMNJLemkW/8ZqjrgBsEE4Q6QvKtOdDb0A==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-tokens": "^5.1.0",
-        "@emotion/core": "^10.1.1",
-        "@emotion/is-prop-valid": "^1.2.0",
-        "csstype": "^3.1.1",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-progress-stepper/node_modules/@contentful/f36-icon": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-5.6.0.tgz",
-      "integrity": "sha512-VoyKI+rQGK5a3XyFvNG5PMa5FsGdo23XTB0Mj8ukIIvm6ZEBPTHqCGoKnPdl+s2+txIiMSbAmJslEbJR6KZiBg==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@phosphor-icons/react": "2.1.8",
-        "emotion": "^10.0.17"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-progress-stepper/node_modules/@contentful/f36-icons": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-5.6.0.tgz",
-      "integrity": "sha512-YM2KNFbmGAkqY6iug8ja8TCBpLxZm2jECZDujRweHyRnTRfHpoIjuP+14LO0iv/ilJEK6DedJoAflz0QJ20a8w==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icon": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@phosphor-icons/react": "2.1.8",
-        "emotion": "^10.0.17"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-progress-stepper/node_modules/@contentful/f36-spinner": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-5.6.0.tgz",
-      "integrity": "sha512-NmH/bNol+e7AarybNgv8B8lodF2hOFlF32H6QAEhsHmq76dxOQ6LlgjlxIttNpIrGgHYU29yWAH5LhTu/BAE7g==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-progress-stepper/node_modules/@contentful/f36-tokens": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-5.1.0.tgz",
-      "integrity": "sha512-7++MPQiizK6qLhPkilWIKqM5Mhdr199tK7dL4iZ689iTwA82uvXXOojJr+0wVOurG2Odb+6/3WLe1XdveDZHEA==",
-      "license": "MIT"
-    },
-    "node_modules/@contentful/f36-progress-stepper/node_modules/@contentful/f36-tooltip": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-5.6.0.tgz",
-      "integrity": "sha512-e4z+eysp95u4ASheQgkJJM+RXyZv/KyMi4bqqez2ydvkFtFViI7E+wkzxIbB5L2EzHqIGL6/IcgQ8GC6io/Fsw==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "@popperjs/core": "^2.11.5",
-        "csstype": "^3.1.1",
-        "emotion": "^10.0.17",
-        "react-popper": "^2.3.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-progress-stepper/node_modules/@contentful/f36-typography": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-5.6.0.tgz",
-      "integrity": "sha512-v8myIeJnpZ6g2WRmL9oOOLrjip3+80Y+LQ4PwOzcJatL5AdwSYVExtlFMMVO5/JNt6qEpT2sd5579LPA17yiVg==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/f36-progress-stepper/node_modules/@contentful/f36-utils": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-utils/-/f36-utils-5.2.0.tgz",
-      "integrity": "sha512-0YWsKAdU2HeNz5DwuOCR0lnlHVhlXiDkqtYaH8hHqT9HlQKHDSBPQUI9Vk5OrPDRJ3uLVoyGOJcvUDf27tTopA==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-tokens": "^5.1.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-skeleton": {
-      "version": "4.81.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.81.1.tgz",
-      "integrity": "sha512-7usgRP/5a9SS1PCKYfQJ/TfIjJu6iF5mXvHT7DnU/jZFX72R3p1b88fm21Gg8Bs6PgnLIuLIsI/ObZp1u84ufA==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-6.8.0.tgz",
+      "integrity": "sha512-7MKq18D/gSDRE3Syc5EIm0MiZ4xxpDzdj2ZEsdD/4DdHjQka+3yV+hc56lPb9gxe1egapz2sjnoCGKFWgZmy6w==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.81.1",
-        "@contentful/f36-table": "^4.81.1",
-        "@contentful/f36-tokens": "^4.2.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.8.0",
+        "@contentful/f36-table": "^6.8.0",
+        "@contentful/f36-tokens": "^6.1.0",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-spinner": {
-      "version": "4.81.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.81.1.tgz",
-      "integrity": "sha512-LX5pu0mZLkrb1gXRBMVHyiyjoXgDLPUFBXc/ZZ9KE1BYnuYp+gFiYfOtGAt+DFaNeknfjqNJf+8o36z+QXwScg==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-6.8.0.tgz",
+      "integrity": "sha512-VTUckTTCduMw/mg/FldOZ75wVtFCvZ7r2nwOLznuOgNxBMT+/F27lcS1k294PMzX1U7uytOcjhNRhjIexvDOug==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.81.1",
-        "@contentful/f36-tokens": "^4.2.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.8.0",
+        "@contentful/f36-tokens": "^6.1.0",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-table": {
-      "version": "4.81.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.81.1.tgz",
-      "integrity": "sha512-C2VcMdVX0VHpG4/oZpRR4UYIdvrXf6E5XbN2RlKL/R8LBiVr8wPFLL8o7HCT/OoYoaEWYr8/EnJyIl2BYpNvgw==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-6.8.0.tgz",
+      "integrity": "sha512-V0xgAWd0gPBzhi+JBZElNKfPhZzUoUgWz5FNuLQznMlWKeF7CwdZmlDwsST+vXE/7OmIXkHENGfEbccA5AST/A==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.81.1",
-        "@contentful/f36-icons": "^4.29.1",
-        "@contentful/f36-tokens": "^4.2.0",
-        "@contentful/f36-typography": "^4.81.1",
-        "@contentful/f36-utils": "^4.24.3",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.8.0",
+        "@contentful/f36-icons": "^6.8.0",
+        "@contentful/f36-tokens": "^6.1.0",
+        "@contentful/f36-typography": "^6.8.0",
+        "@contentful/f36-utils": "^6.1.0",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-tabs": {
-      "version": "4.81.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.81.1.tgz",
-      "integrity": "sha512-+fspt28e3YggyMJ9c+qZeCzFWjL5FBLa5ToQHmPzKO/LGtf8x3QXyLclTLflDvLBJldh8/gJ6YxQYMKhW/XLPA==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-6.8.0.tgz",
+      "integrity": "sha512-JSACq6457TZFC2DUE5+nx0Aeke+NFiT8Gj+jY/zJWa6483RUTVizUj4RCpfsiybk49pf6Uevry9WtkIun3ModA==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.81.1",
-        "@contentful/f36-tokens": "^4.2.0",
-        "@radix-ui/react-tabs": "^1.0.1",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.8.0",
+        "@contentful/f36-tokens": "^6.1.0",
+        "@emotion/css": "^11.13.5",
+        "@radix-ui/react-tabs": "^1.1.12"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-text-link": {
-      "version": "4.81.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.81.1.tgz",
-      "integrity": "sha512-Pf5lnUocJ3fTbK3062IL/vyqBUK+gM4kOeaLR3ugorpU/KqE/mxgzDaKnjAJvZMDflyi4Ejr4KdKeiOWSBZHPA==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-6.8.0.tgz",
+      "integrity": "sha512-1pj6REjnKL+M7aNgj2XRsVwLRqw/n/B4GJzkTTCN2J5l11EaYWJi/SOnM9i8QLp6Va58wXJvfyx/FrIyDNGi9Q==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.81.1",
-        "@contentful/f36-tokens": "^4.2.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.8.0",
+        "@contentful/f36-icons": "^6.8.0",
+        "@contentful/f36-tokens": "^6.1.0",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-tokens": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-4.2.0.tgz",
-      "integrity": "sha512-fB7ZEO8+NJPlcGvx6EHuEoPdhgpaFAeCnymXlgC+xVLTXYKXSk8JJD4WEr9rBLcXpyyS+e3g51kNFv90cDOeEQ=="
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.1.2.tgz",
+      "integrity": "sha512-oj9HC4fDsXkUmUbq5izCX7WJNZoQxpmXqQ1f8gB+oz+wAXtdFq1/iW1vuYhQaNaZVXgb/qU4zvu39SWp8IYMsg==",
+      "license": "MIT"
     },
     "node_modules/@contentful/f36-tooltip": {
-      "version": "4.81.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.81.1.tgz",
-      "integrity": "sha512-VG2fWUdgdUYsz6KuqtYEM+n5UzADak+EY/OGDvWo206AKi5XNn29z5VnbwvMJqjOlmepYiRZ1JFaee0+d5LEtw==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-6.8.0.tgz",
+      "integrity": "sha512-slyLAD284iXeJJn0MiJr8Gu4cIWQ5S7P4Ay5To4C6FZ1w57xXX2EDw+26A0IxZyAUVjzeT/4AhEfHTNCRlpuxQ==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.81.1",
-        "@contentful/f36-tokens": "^4.2.0",
-        "@contentful/f36-utils": "^4.24.3",
-        "@popperjs/core": "^2.11.5",
-        "csstype": "^3.1.1",
-        "emotion": "^10.0.17",
-        "react-popper": "^2.3.0"
+        "@contentful/f36-core": "^6.8.0",
+        "@contentful/f36-tokens": "^6.1.0",
+        "@contentful/f36-utils": "^6.1.0",
+        "@emotion/css": "^11.13.5",
+        "@floating-ui/dom": "^1.7.4",
+        "@floating-ui/react": "^0.27.16"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-typography": {
-      "version": "4.81.1",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.81.1.tgz",
-      "integrity": "sha512-AQNy2/4/rW743vKYOtHdzM8Dz/9CP+QwD1Hm5lCUzPQpbb6XEav/mfSXi9wjLiMMWP09vPQvScBvTDQx+0dRng==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-6.8.0.tgz",
+      "integrity": "sha512-NFWgODV4nE1AvBiNzcg0RhCzbjqcIPd04cPNmhZ2EArYIaf1/R3OQU4MaRurr80szOUGaGrRM+8vicvPm8fxPg==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.81.1",
-        "@contentful/f36-tokens": "^4.2.0",
-        "@contentful/f36-utils": "^4.24.3",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.8.0",
+        "@contentful/f36-tokens": "^6.1.0",
+        "@contentful/f36-utils": "^6.1.0",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-usage-card": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-usage-card/-/f36-usage-card-4.1.0.tgz",
-      "integrity": "sha512-A7iLBKPztyzabcPG4AwncJUWY9kbNXjmpzMnhilBYSQVs6uIpb/daUNe4cV8vSOrbLyCMqmvn+7r/iHt3ml55w==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-usage-card/-/f36-usage-card-6.8.0.tgz",
+      "integrity": "sha512-5e1b3SIslR/opr4I1XIkbUxfDu/yVYtHeIxY5MKrTg9RlYNv4KTlnobQSADzcFdy7Yhn01THEuJ+zZdnGQLwGA==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/f36-card": "^4.80.4",
-        "@contentful/f36-core": "^4.0.0",
-        "@contentful/f36-icons": "^4.29.1",
-        "@contentful/f36-text-link": "^4.80.4",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-tooltip": "^4.80.4",
-        "@contentful/f36-typography": "^4.80.4",
-        "emotion": "^10.0.17"
+        "@contentful/f36-card": "^6.8.0",
+        "@contentful/f36-core": "^6.8.0",
+        "@contentful/f36-icons": "^6.8.0",
+        "@contentful/f36-text-link": "^6.8.0",
+        "@contentful/f36-tokens": "^6.1.0",
+        "@contentful/f36-tooltip": "^6.8.0",
+        "@contentful/f36-typography": "^6.8.0",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-usage-count": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-usage-count/-/f36-usage-count-4.1.0.tgz",
-      "integrity": "sha512-hwtpIv8p3X12tj1bhXk0zbGwW4NnziLgXvFIxVasXyN20oburozgYPq8EQwCiNCXrtsOWYFUHOpZJ4E0f4T4cg==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-usage-count/-/f36-usage-count-6.8.0.tgz",
+      "integrity": "sha512-pNOXJUElPQGGRXZw55OnKyBUkM440ndEXWvDtBcedUZtPvY235DKB8GKG4McdvZtsAeJxl+IbHOKMQ9jHoTbcQ==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^4.0.0",
-        "@contentful/f36-tokens": "^4.0.0",
-        "@contentful/f36-typography": "^4.80.5",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.8.0",
+        "@contentful/f36-tokens": "^6.1.0",
+        "@contentful/f36-typography": "^6.8.0",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-utils": {
-      "version": "4.24.3",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-utils/-/f36-utils-4.24.3.tgz",
-      "integrity": "sha512-9+tyDOCjEhW7m4X7Sam0VYlmcgjhLVMiapCnv1EmRstlMaeI5ti9y0y/2aQ04Na2ScoHwrMTjveoZ6V62J62tA==",
-      "dependencies": {
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-rich-text/-/field-editor-rich-text-4.16.0.tgz",
-      "integrity": "sha512-PSpXbCNMJWNf/8sVBEDOKrvrlJvypiHhGDGkVGUS59/iUoE0YQdCMDmiXLan3ugRPottInOoxIxJrW3S0173Bg==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-utils/-/f36-utils-6.1.1.tgz",
+      "integrity": "sha512-VCOS2uFdv4/HlPPJ32wK1bnOsMPKE0/5u0cNKat0sSXyAZ0zkGXHG+UoXYfi4ipXfPxNgu3vKcWszcQZ8hDb+w==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/app-sdk": "^4.42.0",
-        "@contentful/contentful-slatejs-adapter": "^15.16.5",
-        "@contentful/f36-components": "^5.4.1",
-        "@contentful/f36-icons": "^5.4.1",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-utils": "^5.1.0",
-        "@contentful/field-editor-reference": "^6.15.0",
-        "@contentful/field-editor-shared": "^2.16.0",
-        "@contentful/rich-text-plain-text-renderer": "^17.0.0",
-        "@contentful/rich-text-types": "^17.0.0",
-        "@popperjs/core": "^2.11.5",
-        "@udecode/plate-basic-marks": "36.0.0",
-        "@udecode/plate-break": "36.0.0",
-        "@udecode/plate-common": "36.5.9",
-        "@udecode/plate-core": "36.5.9",
-        "@udecode/plate-list": "36.0.0",
-        "@udecode/plate-paragraph": "36.0.0",
-        "@udecode/plate-reset-node": "36.0.0",
-        "@udecode/plate-select": "36.0.0",
-        "@udecode/plate-serializer-docx": "36.0.10",
-        "@udecode/plate-table": "36.5.9",
-        "@udecode/plate-trailing-block": "36.0.0",
-        "constate": "^3.3.2",
-        "fast-deep-equal": "^3.1.3",
-        "is-hotkey": "^0.2.0",
-        "is-plain-obj": "^3.0.0",
-        "lodash": "^4.17.21",
-        "moment": "^2.20.0",
-        "p-debounce": "^2.1.0",
-        "react-popper": "^2.3.0",
-        "scroll-into-view-if-needed": "^3.1.0",
-        "slate": "0.94.1",
-        "slate-history": "0.100.0",
-        "slate-hyperscript": "0.77.0",
-        "slate-react": "0.102.0"
+        "@contentful/f36-tokens": "^6.1.0",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "@lingui/core": "^5.3.0",
-        "react": ">=16.14.0",
-        "react-dom": ">=16.14.0"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-accordion": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-5.6.0.tgz",
-      "integrity": "sha512-WlKwS5/tMWfn3yrjRDFglVB8Ozc9e0su2rF0t0v4pynEPZ8WJfXYqTQQMoYEBqgBejZjVWkwK+DDaR2XgzlArw==",
+    "node_modules/@contentful/field-editor-reference": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-reference/-/field-editor-reference-8.3.0.tgz",
+      "integrity": "sha512-MOIjO2EHsxWtJDKjSE+D+ijQdUvN8oCdzSAzellM0e2OWuPurAIE+SNGMSxhB0na2yaoBKGYUxQAthVkfCTkPg==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-collapse": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-asset": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-5.6.0.tgz",
-      "integrity": "sha512-wikvFGMpqdN5IjIUabSQb1nPGCeaPUbV6MiH5SCzaNHAv4ldINUG5Xs/J/Eb9RHs7BV7ZO4Rg/RYwDuT8/23Sw==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icon": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-autocomplete": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-5.6.0.tgz",
-      "integrity": "sha512-WmkivMbLBd+CWjALNVMppYVfRBEPfMxi5JTYGZaNHoQsv3SJ3GO5B74U6mwSlWWz18nSE2pI+TJ1Mz0s2jhxyw==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-forms": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-popover": "^5.6.0",
-        "@contentful/f36-skeleton": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "downshift": "^6.1.12",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-avatar": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-avatar/-/f36-avatar-5.6.0.tgz",
-      "integrity": "sha512-hNtqfAZ5wrlZniiNMAGU9BE/lq9yBiMlgvnsa3fV8qoBo7fRdnVnjuRvEk3DfXYXX44EAj+XIKfDSdsAExr+wA==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-image": "^5.6.0",
-        "@contentful/f36-menu": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.6.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-badge": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-5.6.0.tgz",
-      "integrity": "sha512-vVqdq3kDeiMwmdAT5EEpgUIIQSjQJpzkeOqsF4cIbRh63D7Xaseyj5TJE1O3uFA4zcvLrE/Iyx9lQd5YtViiJg==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-button": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-5.6.0.tgz",
-      "integrity": "sha512-JGXADlfIbtbVPUeUvVhFr2yt+5b758T6layvgFK52JV7dWyitOdA2HQ7K1/EtLQXmk0pk2zfvV9X4gQpFotZxw==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-spinner": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.6.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-card": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-5.6.0.tgz",
-      "integrity": "sha512-gYiirKFMavN+JJErA319hpe6Y0UD8nLOzyZI/GRvG0ugEaIFuXBlFL9U5V5dE/TsctNOAk3dshFlhBTpxpFvGg==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-asset": "^5.6.0",
-        "@contentful/f36-badge": "^5.6.0",
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-drag-handle": "^5.6.0",
-        "@contentful/f36-icon": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-menu": "^5.6.0",
-        "@contentful/f36-skeleton": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.6.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "emotion": "^10.0.17",
-        "truncate": "^3.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-collapse": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-5.6.0.tgz",
-      "integrity": "sha512-4Jq9Jp1rGyHZqdnLS5Vixw5x4pjqxLxHGn+/vHR5xm7LWWijvEGXo95qSLqIp74S8U48GVYvWZvdlu9T2uOhhg==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-components": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-5.6.0.tgz",
-      "integrity": "sha512-vyofnGjXHWjG9OR8Bm9SJLA3kNyFGz1eFnICsJWLK9TBly/MXpcm8xQaA7cR5+Q4dZebNE59j5bdfk2w5jUGNQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-accordion": "^5.6.0",
-        "@contentful/f36-asset": "^5.6.0",
-        "@contentful/f36-autocomplete": "^5.6.0",
-        "@contentful/f36-avatar": "^5.6.0",
-        "@contentful/f36-badge": "^5.6.0",
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-card": "^5.6.0",
-        "@contentful/f36-collapse": "^5.6.0",
-        "@contentful/f36-copybutton": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-datepicker": "^5.6.0",
-        "@contentful/f36-datetime": "^5.6.0",
-        "@contentful/f36-drag-handle": "^5.6.0",
-        "@contentful/f36-empty-state": "^5.6.0",
-        "@contentful/f36-entity-list": "^5.6.0",
-        "@contentful/f36-forms": "^5.6.0",
-        "@contentful/f36-header": "^5.6.0",
-        "@contentful/f36-icon": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-image": "^5.6.0",
-        "@contentful/f36-layout": "^5.6.0",
-        "@contentful/f36-list": "^5.6.0",
-        "@contentful/f36-menu": "^5.6.0",
-        "@contentful/f36-modal": "^5.6.0",
-        "@contentful/f36-multiselect": "^5.6.0",
-        "@contentful/f36-navlist": "^5.6.0",
-        "@contentful/f36-note": "^5.6.0",
-        "@contentful/f36-notification": "^5.6.0",
-        "@contentful/f36-pagination": "^5.6.0",
-        "@contentful/f36-pill": "^5.6.0",
-        "@contentful/f36-popover": "^5.6.0",
-        "@contentful/f36-progress-stepper": "^5.6.0",
-        "@contentful/f36-skeleton": "^5.6.0",
-        "@contentful/f36-spinner": "^5.6.0",
-        "@contentful/f36-table": "^5.6.0",
-        "@contentful/f36-tabs": "^5.6.0",
-        "@contentful/f36-text-link": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.6.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "@contentful/f36-usage-card": "^5.6.0",
-        "@contentful/f36-usage-count": "^5.6.0",
-        "@contentful/f36-utils": "^5.2.0"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.8",
-        "@types/react-dom": ">=16.8",
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-copybutton": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-5.6.0.tgz",
-      "integrity": "sha512-/hQsFUx/kqOZc7NA5VNAyAnEz4Y3KUeEHBCYSYJdnAWXRkbavUgDp25GYIIG8so3x+D7Cz2zh9dMtVwUr1WCkg==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.6.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-core": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-5.6.0.tgz",
-      "integrity": "sha512-O9t4UzEEyjbYs637uUfiTGHwNwvqfMPYkrgW47g03XPwo1gRoXNaJzMNJLemkW/8ZqjrgBsEE4Q6QvKtOdDb0A==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-tokens": "^5.1.0",
-        "@emotion/core": "^10.1.1",
-        "@emotion/is-prop-valid": "^1.2.0",
-        "csstype": "^3.1.1",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-datepicker": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-5.6.0.tgz",
-      "integrity": "sha512-5afLd3SS6pUS2+YkH6i+P59jaH7zdkx3s2sktJkqaerEfx9Gq+XkuInWbhkKZCcirs9szaeOErhwad9Eggv6rw==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-forms": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-popover": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "date-fns": "^2.28.0",
-        "emotion": "^10.0.17",
-        "react-day-picker": "^8.7.1",
-        "react-focus-lock": "^2.9.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-datetime": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-5.6.0.tgz",
-      "integrity": "sha512-PofT+PERLv2fW2xOPxBDsMPYRnYCQ67tvmj/DkP4zh73uHFQBHTgGQ4vzMIOXGD7o5MGAPrLwIYNVtx3Wsp+mg==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "dayjs": "^1.11.5",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-drag-handle": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-5.6.0.tgz",
-      "integrity": "sha512-iY5uHxKPfhmWvuWNLysptpMQVkbNGhZxphzyW9+NA0XzYCVAkRyAuL2RR5nu/BEysgILD6Zk5JDeBXBmt8CJeQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-empty-state": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-5.6.0.tgz",
-      "integrity": "sha512-yivozabj58cm6amC/hQeBwFApstqIfGpONzRp5OPIoOe1tludyda37a6fsN35NSKSYrACthS32EOl/2KBH7c0Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-entity-list": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-5.6.0.tgz",
-      "integrity": "sha512-pis/mt7amELmB313VuuYzPF1lLxsox+cfTLTlYTCDWgeh6+yn6vtLXV9RJA78A0H7uuAxRge9KP7jHCYpGvjAw==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-badge": "^5.6.0",
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-drag-handle": "^5.6.0",
-        "@contentful/f36-icon": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-menu": "^5.6.0",
-        "@contentful/f36-skeleton": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-forms": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-5.6.0.tgz",
-      "integrity": "sha512-nmDIEntL3Y3w0I6hf+ifY3sjI8DMKcGLMyG9kkiJE2fSFb3TJTPgxdk1tDkPFid68Vlcj2NHFwzTInHdYI+j6w==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-header": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-header/-/f36-header-5.6.0.tgz",
-      "integrity": "sha512-bY7uhrdv3O7GfQ1soJkkn0BOox6HuJhk1Vc0xorEpnI/o4QdiO5tMW7XO0A++dzEtZfYffYRCBenPmn+M840YQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-icon": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-5.6.0.tgz",
-      "integrity": "sha512-VoyKI+rQGK5a3XyFvNG5PMa5FsGdo23XTB0Mj8ukIIvm6ZEBPTHqCGoKnPdl+s2+txIiMSbAmJslEbJR6KZiBg==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@phosphor-icons/react": "2.1.8",
-        "emotion": "^10.0.17"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-icons": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-5.6.0.tgz",
-      "integrity": "sha512-YM2KNFbmGAkqY6iug8ja8TCBpLxZm2jECZDujRweHyRnTRfHpoIjuP+14LO0iv/ilJEK6DedJoAflz0QJ20a8w==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icon": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@phosphor-icons/react": "2.1.8",
-        "emotion": "^10.0.17"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-image": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-image/-/f36-image-5.6.0.tgz",
-      "integrity": "sha512-QY7ZxD3g3Fqr7jzWjSUMpuG1K3XeSvk+xQzHeNPJSqe14GTFB/V9FCHk9Zrmb0dQKUaRLohBraWBT0sMg/yBEA==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-skeleton": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-list": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-5.6.0.tgz",
-      "integrity": "sha512-bu2kZ+XgKKOVD0924Cgd4dDIuvM8yUlsqbpi8hQFS5xH6rLPdBen15m1cpWmVNUL7n/nnznduF8cAG9sQ0d7mw==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-menu": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-5.6.0.tgz",
-      "integrity": "sha512-VS0sA41lFgz6j5WZePzVEJTtPij8hGdwva55B3lgGJHKALYxd+Q5GfjUtYuXZbwvFd0mvhz0dWQFBgdATfObyQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-popover": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-modal": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-5.6.0.tgz",
-      "integrity": "sha512-iZOH6q3Sv/f2sxiYadMscYFe6oXMXxAf9xZpQRtYZIglbgpItVf3z7/A27rSXtCmasoMkWfiKOQaDlFllT6RhA==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "@types/react-modal": "^3.13.1",
-        "emotion": "^10.0.17",
-        "react-modal": "^3.16.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-multiselect": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-multiselect/-/f36-multiselect-5.6.0.tgz",
-      "integrity": "sha512-ioOmQWa/rnaSZ8w0SUKx01iqY1Ls876cHDiH0X3yCsxBd/Q64mnZX2t2yUS4jqzzZHAYowPQKWC0rRWmkazPzg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.27.1",
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-forms": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-popover": "^5.6.0",
-        "@contentful/f36-skeleton": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.6.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "emotion": "^10.0.17",
-        "react-focus-lock": "^2.9.5"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-note": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-5.6.0.tgz",
-      "integrity": "sha512-OmVPwfVctWQ19lUOrWama2/gGcEBdhgIL8GfiUMnC+fcAjzcD3OS8C4PKdXKAT5SS+sCmuwGuSMpoqdtYQx/0A==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icon": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-notification": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-5.6.0.tgz",
-      "integrity": "sha512-gehtdl+KIuGJpVJI8thDI9X6zOoOM+Y905Or9HYZfGf8W7vDr4+slXzIl/JXfQOttJ7425MXsFP0FtzWRNA4hA==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-text-link": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "emotion": "^10.0.17",
-        "react-animate-height": "^3.0.4"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-pagination": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-5.6.0.tgz",
-      "integrity": "sha512-fFiQvoTovb3fuBU2IUkr0M/+aNFM8C1jm7d7SZE5y4i3C2d2RqBiaCo0ShOQTWPhJiNjtqDIUFxkrderRg5ExQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-forms": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-pill": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-5.6.0.tgz",
-      "integrity": "sha512-t7cwf9sdWoW07B26j+cxEzxCZwXGAiyqby2s7vQKr/U1/5m/JlVIIVifMkAA+f+wvtUYb2DMoBl9pJkRiIZsQQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-drag-handle": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.6.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-popover": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-5.6.0.tgz",
-      "integrity": "sha512-W8DzlCC5r16W0qDdR0JZQJLss91MjjMIarwMY18soGwA2oyEo8IPiDGDyRgDXL+TY1/SxFEux44Ck5mV62vAtA==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "@popperjs/core": "^2.11.5",
-        "emotion": "^10.0.17",
-        "react-popper": "^2.3.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-skeleton": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-5.6.0.tgz",
-      "integrity": "sha512-a4nuJKBrYDQiHwk4r+lNTFi6FDXGYxCur2SSTbWcvrerDud+IjptfTARRy+x+K17ic+uody1ualeO7Kktkw7Yg==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-table": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-spinner": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-5.6.0.tgz",
-      "integrity": "sha512-NmH/bNol+e7AarybNgv8B8lodF2hOFlF32H6QAEhsHmq76dxOQ6LlgjlxIttNpIrGgHYU29yWAH5LhTu/BAE7g==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-table": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-5.6.0.tgz",
-      "integrity": "sha512-1nAfK95DmVhxQb9TZllNE/tF45UN1xMzs3/1v7laH9CymkpAYQefYEpOneQBM42+lp00JX/81Hi0DnZ1xv3i+g==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-tabs": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-5.6.0.tgz",
-      "integrity": "sha512-+7S+zpUn84uv97XHxTD25186XE13GjIzcASBOzZAZZ1WCVYDMdhUpLaCNRAhVapV6R1qIShPG8DbGgwFTMIOXA==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@radix-ui/react-tabs": "^1.0.1",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-text-link": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-5.6.0.tgz",
-      "integrity": "sha512-1Pj/d/0/5+REOLlfJdXAbb2VG7QDls+gI0HH+lTfbqrVoolFRPvnXxMr7+RcxEwHqr73/atvPdx9Q2xWSXEMmQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-tokens": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-5.1.0.tgz",
-      "integrity": "sha512-7++MPQiizK6qLhPkilWIKqM5Mhdr199tK7dL4iZ689iTwA82uvXXOojJr+0wVOurG2Odb+6/3WLe1XdveDZHEA==",
-      "license": "MIT"
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-tooltip": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-5.6.0.tgz",
-      "integrity": "sha512-e4z+eysp95u4ASheQgkJJM+RXyZv/KyMi4bqqez2ydvkFtFViI7E+wkzxIbB5L2EzHqIGL6/IcgQ8GC6io/Fsw==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "@popperjs/core": "^2.11.5",
-        "csstype": "^3.1.1",
-        "emotion": "^10.0.17",
-        "react-popper": "^2.3.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-typography": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-5.6.0.tgz",
-      "integrity": "sha512-v8myIeJnpZ6g2WRmL9oOOLrjip3+80Y+LQ4PwOzcJatL5AdwSYVExtlFMMVO5/JNt6qEpT2sd5579LPA17yiVg==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-usage-card": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-usage-card/-/f36-usage-card-5.6.0.tgz",
-      "integrity": "sha512-Mzt0S8F4onLaCCJn/48uMDmZO/pKMNiqAOgIXGOmPOhk0+8IEjQgx7h487r6KD9xjXhejpCFtG5tfG2DopGZ1w==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-card": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-text-link": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.6.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-usage-count": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-usage-count/-/f36-usage-count-5.6.0.tgz",
-      "integrity": "sha512-bjnrnx52jScH2/Nt55piBVzl5HUZELGQh8NHhWUSGry1hFyxeAh7MyEg6B/ROBnVk67E9ZITRknQmqRO9pnoUg==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-utils": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-utils/-/f36-utils-5.2.0.tgz",
-      "integrity": "sha512-0YWsKAdU2HeNz5DwuOCR0lnlHVhlXiDkqtYaH8hHqT9HlQKHDSBPQUI9Vk5OrPDRJ3uLVoyGOJcvUDf27tTopA==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-tokens": "^5.1.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/field-editor-reference": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-reference/-/field-editor-reference-6.15.0.tgz",
-      "integrity": "sha512-PUUWoqLaJrvpiCWZGkpw6veMnCPAIT+ZOGEcsCwWvcJBOYqtRsdMO0A8ZtfwBGBGcljrfZ14QKwzt9rIGyamQQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-components": "^5.4.1",
-        "@contentful/f36-icons": "^5.4.1",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/field-editor-shared": "^2.16.0",
+        "@contentful/f36-components": "^6.7.1",
+        "@contentful/f36-icons": "^6.7.1",
+        "@contentful/f36-tokens": "^6.1.2",
+        "@contentful/field-editor-shared": "^4.4.0",
         "@contentful/mimetype": "^2.2.29",
         "@dnd-kit/core": "^6.0.8",
         "@dnd-kit/sortable": "^8.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@emotion/css": "^11.13.5",
         "@tanstack/react-query": "^4.3.9",
         "constate": "^3.3.2",
-        "contentful-management": "^11.45.1",
-        "emotion": "^10.0.17",
+        "contentful-management": "^12.3.0",
+        "date-fns": "^2.30.0",
         "lodash": "^4.17.15",
-        "moment": "^2.20.0",
         "p-queue": "^4.0.0",
         "react-intersection-observer": "9.4.0",
         "truncate": "^3.0.0"
@@ -2410,17 +1292,28 @@
       "peerDependencies": {
         "@contentful/app-sdk": "^4.41.2",
         "@lingui/core": "^5.3.0",
-        "react": ">=16.8.0"
+        "react": ">=18.3.1",
+        "react-dom": ">=18.3.1"
       }
     },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/field-editor-reference/node_modules/@tanstack/react-query": {
-      "version": "4.42.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.42.0.tgz",
-      "integrity": "sha512-j0tiofkzE3CSrYKmVRaKuwGgvCE+P2OOEDlhmfjeZf5ufcuFHwYwwgw3j08n4WYPVZ+OpsHblcFYezhKA3jDwg==",
+    "node_modules/@contentful/field-editor-reference/node_modules/@tanstack/query-core": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.44.0.tgz",
+      "integrity": "sha512-swSgb7OiPRR3UuIL7NuDrZNSMGmQD+wdtHxPD7j60SvBEnxbXurl5XOirtGEX2gm2hbK6mC8kMV1I+uO3l0UOw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@contentful/field-editor-reference/node_modules/@tanstack/react-query": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.44.0.tgz",
+      "integrity": "sha512-RuIqHYrS98LrK/8kJJOJMMSQ/BCpojwsXDh7p0fBmp38ZOz6dlk+uyFRRusH+V+t3POoCsDOQ2zhomEYOeReXw==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "4.41.0",
-        "use-sync-external-store": "^1.2.0"
+        "@tanstack/query-core": "4.44.0",
+        "use-sync-external-store": "^1.6.0"
       },
       "funding": {
         "type": "github",
@@ -2440,910 +1333,123 @@
         }
       }
     },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/rich-text-types": {
-      "version": "17.2.4",
-      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-17.2.4.tgz",
-      "integrity": "sha512-3y456l+x5aPzqcvjpG6L66sIkfH66rBl1QtGKexgJ3Nvd6k4ORvpAJ6gMDBz3WMAYvXGrVZMyhlFE0e6UdHngA==",
+    "node_modules/@contentful/field-editor-rich-text": {
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-rich-text/-/field-editor-rich-text-6.3.5.tgz",
+      "integrity": "sha512-xGRiFyuWE06+YuY56eIPzwvX1wN6Jzpr1IxRclz94gs9ocOLgRVBeQZo0FYXnc0tqgOyR0XAD9X1G4ZEYkOwDw==",
       "license": "MIT",
       "dependencies": {
-        "@lingui/core": "^5.4.1",
-        "is-plain-obj": "^3.0.0"
+        "@contentful/app-sdk": "^4.42.0",
+        "@contentful/contentful-slatejs-adapter": "^16.1.6",
+        "@contentful/f36-components": "^6.7.1",
+        "@contentful/f36-icon": "^6.7.1",
+        "@contentful/f36-icons": "^6.7.1",
+        "@contentful/f36-tokens": "^6.1.2",
+        "@contentful/f36-utils": "^6.1.0",
+        "@contentful/field-editor-reference": "^8.3.0",
+        "@contentful/field-editor-shared": "^4.4.0",
+        "@contentful/rich-text-plain-text-renderer": "^17.0.0",
+        "@contentful/rich-text-types": "^17.2.5",
+        "@emotion/css": "^11.13.5",
+        "@popperjs/core": "^2.11.5",
+        "@udecode/plate-basic-marks": "36.0.0",
+        "@udecode/plate-break": "36.0.0",
+        "@udecode/plate-common": "36.5.9",
+        "@udecode/plate-core": "36.5.9",
+        "@udecode/plate-list": "36.0.0",
+        "@udecode/plate-paragraph": "36.0.0",
+        "@udecode/plate-reset-node": "36.0.0",
+        "@udecode/plate-select": "36.0.0",
+        "@udecode/plate-serializer-docx": "36.0.10",
+        "@udecode/plate-table": "36.5.9",
+        "@udecode/plate-trailing-block": "36.0.0",
+        "constate": "^3.3.2",
+        "date-fns": "^2.30.0",
+        "fast-deep-equal": "^3.1.3",
+        "is-hotkey": "^0.2.0",
+        "is-plain-obj": "^3.0.0",
+        "lodash": "^4.17.21",
+        "p-debounce": "^2.1.0",
+        "react-popper": "^2.3.0",
+        "slate": "0.94.1",
+        "slate-history": "0.100.0",
+        "slate-hyperscript": "0.77.0",
+        "slate-react": "0.102.0",
+        "use-deep-compare": "^1.3.0"
       },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/contentful-management": {
-      "version": "11.61.1",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.61.1.tgz",
-      "integrity": "sha512-+Shk0fGpudvT0b0CwdNiLDwPoIbb0YdkiiYc6h5aC42zfVFJ0dgJf9JKzYPBPJd0MWGOCQf5yNzt/zBEAUDElw==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/rich-text-types": "^16.6.1",
-        "axios": "^1.12.2",
-        "contentful-sdk-core": "^9.0.1",
-        "fast-copy": "^3.0.0",
-        "globals": "^15.15.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/contentful-management/node_modules/@contentful/rich-text-types": {
-      "version": "16.8.5",
-      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.8.5.tgz",
-      "integrity": "sha512-q18RJuJCOuYveGiCIjE5xLCQc5lZ3L2Qgxrlg/H2YEobDFqdtmklazRi1XwEWaK3tMg6yVXBzKKkQfLB4qW14A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
+      "peerDependencies": {
+        "@lingui/core": "^5.3.0",
+        "@tanstack/react-query": "^4.3.9 || ^5.0.0",
+        "react": ">=18.3.1",
+        "react-dom": ">=18.3.1"
       }
     },
     "node_modules/@contentful/field-editor-shared": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-2.16.0.tgz",
-      "integrity": "sha512-YibgcQxmQZDxVGabVN0GoDb3/CtsMULI2GaCElUjdwfViStnDLi5rc6meFk1w2hiXOO9Rql9yoStpn7vPgPUqg==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-4.4.0.tgz",
+      "integrity": "sha512-EeCic01gvjQ2DvKHFfF18ZFoSXqJCRypCmAFygQCXtVQhAjgjiM/+1BWRNBlHZvC9WAHUPDG+nmOXSIPelud7Q==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-components": "^5.4.1",
-        "@contentful/f36-icons": "^5.4.1",
-        "@contentful/f36-note": "^5.1.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "contentful-management": "^11.60.4",
-        "emotion": "^10.0.17",
+        "@contentful/f36-components": "^6.7.1",
+        "@contentful/f36-icons": "^6.7.1",
+        "@contentful/f36-note": "^6.7.1",
+        "@contentful/f36-tokens": "^6.1.2",
+        "@emotion/css": "^11.13.5",
+        "contentful-management": "^12.3.0",
         "fast-deep-equal": "^3.1.3",
         "lodash": "^4.17.15"
       },
       "peerDependencies": {
         "@contentful/app-sdk": "^4.29.0",
         "@lingui/core": "^5.3.0",
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-accordion": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-5.6.0.tgz",
-      "integrity": "sha512-WlKwS5/tMWfn3yrjRDFglVB8Ozc9e0su2rF0t0v4pynEPZ8WJfXYqTQQMoYEBqgBejZjVWkwK+DDaR2XgzlArw==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-collapse": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-asset": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-5.6.0.tgz",
-      "integrity": "sha512-wikvFGMpqdN5IjIUabSQb1nPGCeaPUbV6MiH5SCzaNHAv4ldINUG5Xs/J/Eb9RHs7BV7ZO4Rg/RYwDuT8/23Sw==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icon": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-autocomplete": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-5.6.0.tgz",
-      "integrity": "sha512-WmkivMbLBd+CWjALNVMppYVfRBEPfMxi5JTYGZaNHoQsv3SJ3GO5B74U6mwSlWWz18nSE2pI+TJ1Mz0s2jhxyw==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-forms": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-popover": "^5.6.0",
-        "@contentful/f36-skeleton": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "downshift": "^6.1.12",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-avatar": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-avatar/-/f36-avatar-5.6.0.tgz",
-      "integrity": "sha512-hNtqfAZ5wrlZniiNMAGU9BE/lq9yBiMlgvnsa3fV8qoBo7fRdnVnjuRvEk3DfXYXX44EAj+XIKfDSdsAExr+wA==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-image": "^5.6.0",
-        "@contentful/f36-menu": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.6.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-badge": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-5.6.0.tgz",
-      "integrity": "sha512-vVqdq3kDeiMwmdAT5EEpgUIIQSjQJpzkeOqsF4cIbRh63D7Xaseyj5TJE1O3uFA4zcvLrE/Iyx9lQd5YtViiJg==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-button": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-5.6.0.tgz",
-      "integrity": "sha512-JGXADlfIbtbVPUeUvVhFr2yt+5b758T6layvgFK52JV7dWyitOdA2HQ7K1/EtLQXmk0pk2zfvV9X4gQpFotZxw==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-spinner": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.6.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-card": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-5.6.0.tgz",
-      "integrity": "sha512-gYiirKFMavN+JJErA319hpe6Y0UD8nLOzyZI/GRvG0ugEaIFuXBlFL9U5V5dE/TsctNOAk3dshFlhBTpxpFvGg==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-asset": "^5.6.0",
-        "@contentful/f36-badge": "^5.6.0",
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-drag-handle": "^5.6.0",
-        "@contentful/f36-icon": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-menu": "^5.6.0",
-        "@contentful/f36-skeleton": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.6.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "emotion": "^10.0.17",
-        "truncate": "^3.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-collapse": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-5.6.0.tgz",
-      "integrity": "sha512-4Jq9Jp1rGyHZqdnLS5Vixw5x4pjqxLxHGn+/vHR5xm7LWWijvEGXo95qSLqIp74S8U48GVYvWZvdlu9T2uOhhg==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-components": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-5.6.0.tgz",
-      "integrity": "sha512-vyofnGjXHWjG9OR8Bm9SJLA3kNyFGz1eFnICsJWLK9TBly/MXpcm8xQaA7cR5+Q4dZebNE59j5bdfk2w5jUGNQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-accordion": "^5.6.0",
-        "@contentful/f36-asset": "^5.6.0",
-        "@contentful/f36-autocomplete": "^5.6.0",
-        "@contentful/f36-avatar": "^5.6.0",
-        "@contentful/f36-badge": "^5.6.0",
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-card": "^5.6.0",
-        "@contentful/f36-collapse": "^5.6.0",
-        "@contentful/f36-copybutton": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-datepicker": "^5.6.0",
-        "@contentful/f36-datetime": "^5.6.0",
-        "@contentful/f36-drag-handle": "^5.6.0",
-        "@contentful/f36-empty-state": "^5.6.0",
-        "@contentful/f36-entity-list": "^5.6.0",
-        "@contentful/f36-forms": "^5.6.0",
-        "@contentful/f36-header": "^5.6.0",
-        "@contentful/f36-icon": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-image": "^5.6.0",
-        "@contentful/f36-layout": "^5.6.0",
-        "@contentful/f36-list": "^5.6.0",
-        "@contentful/f36-menu": "^5.6.0",
-        "@contentful/f36-modal": "^5.6.0",
-        "@contentful/f36-multiselect": "^5.6.0",
-        "@contentful/f36-navlist": "^5.6.0",
-        "@contentful/f36-note": "^5.6.0",
-        "@contentful/f36-notification": "^5.6.0",
-        "@contentful/f36-pagination": "^5.6.0",
-        "@contentful/f36-pill": "^5.6.0",
-        "@contentful/f36-popover": "^5.6.0",
-        "@contentful/f36-progress-stepper": "^5.6.0",
-        "@contentful/f36-skeleton": "^5.6.0",
-        "@contentful/f36-spinner": "^5.6.0",
-        "@contentful/f36-table": "^5.6.0",
-        "@contentful/f36-tabs": "^5.6.0",
-        "@contentful/f36-text-link": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.6.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "@contentful/f36-usage-card": "^5.6.0",
-        "@contentful/f36-usage-count": "^5.6.0",
-        "@contentful/f36-utils": "^5.2.0"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.8",
-        "@types/react-dom": ">=16.8",
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "@tanstack/react-query": "^4.3.9 || ^5.0.0",
+        "react": ">=18.3.1",
+        "react-dom": ">=18.3.1"
       },
       "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
+        "@tanstack/react-query": {
           "optional": true
         }
       }
     },
-    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-copybutton": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-5.6.0.tgz",
-      "integrity": "sha512-/hQsFUx/kqOZc7NA5VNAyAnEz4Y3KUeEHBCYSYJdnAWXRkbavUgDp25GYIIG8so3x+D7Cz2zh9dMtVwUr1WCkg==",
+    "node_modules/@contentful/mimetype": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/@contentful/mimetype/-/mimetype-2.6.5.tgz",
+      "integrity": "sha512-Raf+xYKctjzrA5/reT51AUjCpYgVKV2C20fj9l+5LrT4rx+jwp9hlhsUK2jvCN5j1t9fqgd/Q6qGMv/qBexHbQ==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.6.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "lodash": "^4.18.1"
       }
     },
-    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-core": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-5.6.0.tgz",
-      "integrity": "sha512-O9t4UzEEyjbYs637uUfiTGHwNwvqfMPYkrgW47g03XPwo1gRoXNaJzMNJLemkW/8ZqjrgBsEE4Q6QvKtOdDb0A==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-tokens": "^5.1.0",
-        "@emotion/core": "^10.1.1",
-        "@emotion/is-prop-valid": "^1.2.0",
-        "csstype": "^3.1.1",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-datepicker": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-5.6.0.tgz",
-      "integrity": "sha512-5afLd3SS6pUS2+YkH6i+P59jaH7zdkx3s2sktJkqaerEfx9Gq+XkuInWbhkKZCcirs9szaeOErhwad9Eggv6rw==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-forms": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-popover": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "date-fns": "^2.28.0",
-        "emotion": "^10.0.17",
-        "react-day-picker": "^8.7.1",
-        "react-focus-lock": "^2.9.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-datetime": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-5.6.0.tgz",
-      "integrity": "sha512-PofT+PERLv2fW2xOPxBDsMPYRnYCQ67tvmj/DkP4zh73uHFQBHTgGQ4vzMIOXGD7o5MGAPrLwIYNVtx3Wsp+mg==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "dayjs": "^1.11.5",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-drag-handle": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-5.6.0.tgz",
-      "integrity": "sha512-iY5uHxKPfhmWvuWNLysptpMQVkbNGhZxphzyW9+NA0XzYCVAkRyAuL2RR5nu/BEysgILD6Zk5JDeBXBmt8CJeQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-empty-state": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-5.6.0.tgz",
-      "integrity": "sha512-yivozabj58cm6amC/hQeBwFApstqIfGpONzRp5OPIoOe1tludyda37a6fsN35NSKSYrACthS32EOl/2KBH7c0Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-entity-list": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-5.6.0.tgz",
-      "integrity": "sha512-pis/mt7amELmB313VuuYzPF1lLxsox+cfTLTlYTCDWgeh6+yn6vtLXV9RJA78A0H7uuAxRge9KP7jHCYpGvjAw==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-badge": "^5.6.0",
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-drag-handle": "^5.6.0",
-        "@contentful/f36-icon": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-menu": "^5.6.0",
-        "@contentful/f36-skeleton": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-forms": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-5.6.0.tgz",
-      "integrity": "sha512-nmDIEntL3Y3w0I6hf+ifY3sjI8DMKcGLMyG9kkiJE2fSFb3TJTPgxdk1tDkPFid68Vlcj2NHFwzTInHdYI+j6w==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-header": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-header/-/f36-header-5.6.0.tgz",
-      "integrity": "sha512-bY7uhrdv3O7GfQ1soJkkn0BOox6HuJhk1Vc0xorEpnI/o4QdiO5tMW7XO0A++dzEtZfYffYRCBenPmn+M840YQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-icon": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-5.6.0.tgz",
-      "integrity": "sha512-VoyKI+rQGK5a3XyFvNG5PMa5FsGdo23XTB0Mj8ukIIvm6ZEBPTHqCGoKnPdl+s2+txIiMSbAmJslEbJR6KZiBg==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@phosphor-icons/react": "2.1.8",
-        "emotion": "^10.0.17"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-icons": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-5.6.0.tgz",
-      "integrity": "sha512-YM2KNFbmGAkqY6iug8ja8TCBpLxZm2jECZDujRweHyRnTRfHpoIjuP+14LO0iv/ilJEK6DedJoAflz0QJ20a8w==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icon": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@phosphor-icons/react": "2.1.8",
-        "emotion": "^10.0.17"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-image": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-image/-/f36-image-5.6.0.tgz",
-      "integrity": "sha512-QY7ZxD3g3Fqr7jzWjSUMpuG1K3XeSvk+xQzHeNPJSqe14GTFB/V9FCHk9Zrmb0dQKUaRLohBraWBT0sMg/yBEA==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-skeleton": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-list": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-5.6.0.tgz",
-      "integrity": "sha512-bu2kZ+XgKKOVD0924Cgd4dDIuvM8yUlsqbpi8hQFS5xH6rLPdBen15m1cpWmVNUL7n/nnznduF8cAG9sQ0d7mw==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-menu": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-5.6.0.tgz",
-      "integrity": "sha512-VS0sA41lFgz6j5WZePzVEJTtPij8hGdwva55B3lgGJHKALYxd+Q5GfjUtYuXZbwvFd0mvhz0dWQFBgdATfObyQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-popover": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-modal": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-5.6.0.tgz",
-      "integrity": "sha512-iZOH6q3Sv/f2sxiYadMscYFe6oXMXxAf9xZpQRtYZIglbgpItVf3z7/A27rSXtCmasoMkWfiKOQaDlFllT6RhA==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "@types/react-modal": "^3.13.1",
-        "emotion": "^10.0.17",
-        "react-modal": "^3.16.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-multiselect": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-multiselect/-/f36-multiselect-5.6.0.tgz",
-      "integrity": "sha512-ioOmQWa/rnaSZ8w0SUKx01iqY1Ls876cHDiH0X3yCsxBd/Q64mnZX2t2yUS4jqzzZHAYowPQKWC0rRWmkazPzg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.27.1",
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-forms": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-popover": "^5.6.0",
-        "@contentful/f36-skeleton": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.6.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "emotion": "^10.0.17",
-        "react-focus-lock": "^2.9.5"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-note": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-5.6.0.tgz",
-      "integrity": "sha512-OmVPwfVctWQ19lUOrWama2/gGcEBdhgIL8GfiUMnC+fcAjzcD3OS8C4PKdXKAT5SS+sCmuwGuSMpoqdtYQx/0A==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icon": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-notification": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-5.6.0.tgz",
-      "integrity": "sha512-gehtdl+KIuGJpVJI8thDI9X6zOoOM+Y905Or9HYZfGf8W7vDr4+slXzIl/JXfQOttJ7425MXsFP0FtzWRNA4hA==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-text-link": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "emotion": "^10.0.17",
-        "react-animate-height": "^3.0.4"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-pagination": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-5.6.0.tgz",
-      "integrity": "sha512-fFiQvoTovb3fuBU2IUkr0M/+aNFM8C1jm7d7SZE5y4i3C2d2RqBiaCo0ShOQTWPhJiNjtqDIUFxkrderRg5ExQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-forms": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-pill": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-5.6.0.tgz",
-      "integrity": "sha512-t7cwf9sdWoW07B26j+cxEzxCZwXGAiyqby2s7vQKr/U1/5m/JlVIIVifMkAA+f+wvtUYb2DMoBl9pJkRiIZsQQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-drag-handle": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.6.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-popover": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-5.6.0.tgz",
-      "integrity": "sha512-W8DzlCC5r16W0qDdR0JZQJLss91MjjMIarwMY18soGwA2oyEo8IPiDGDyRgDXL+TY1/SxFEux44Ck5mV62vAtA==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "@popperjs/core": "^2.11.5",
-        "emotion": "^10.0.17",
-        "react-popper": "^2.3.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-skeleton": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-5.6.0.tgz",
-      "integrity": "sha512-a4nuJKBrYDQiHwk4r+lNTFi6FDXGYxCur2SSTbWcvrerDud+IjptfTARRy+x+K17ic+uody1ualeO7Kktkw7Yg==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-table": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-spinner": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-5.6.0.tgz",
-      "integrity": "sha512-NmH/bNol+e7AarybNgv8B8lodF2hOFlF32H6QAEhsHmq76dxOQ6LlgjlxIttNpIrGgHYU29yWAH5LhTu/BAE7g==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-table": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-5.6.0.tgz",
-      "integrity": "sha512-1nAfK95DmVhxQb9TZllNE/tF45UN1xMzs3/1v7laH9CymkpAYQefYEpOneQBM42+lp00JX/81Hi0DnZ1xv3i+g==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-tabs": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-5.6.0.tgz",
-      "integrity": "sha512-+7S+zpUn84uv97XHxTD25186XE13GjIzcASBOzZAZZ1WCVYDMdhUpLaCNRAhVapV6R1qIShPG8DbGgwFTMIOXA==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@radix-ui/react-tabs": "^1.0.1",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-text-link": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-5.6.0.tgz",
-      "integrity": "sha512-1Pj/d/0/5+REOLlfJdXAbb2VG7QDls+gI0HH+lTfbqrVoolFRPvnXxMr7+RcxEwHqr73/atvPdx9Q2xWSXEMmQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-tokens": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-5.1.0.tgz",
-      "integrity": "sha512-7++MPQiizK6qLhPkilWIKqM5Mhdr199tK7dL4iZ689iTwA82uvXXOojJr+0wVOurG2Odb+6/3WLe1XdveDZHEA==",
+    "node_modules/@contentful/mimetype/node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
-    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-tooltip": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-5.6.0.tgz",
-      "integrity": "sha512-e4z+eysp95u4ASheQgkJJM+RXyZv/KyMi4bqqez2ydvkFtFViI7E+wkzxIbB5L2EzHqIGL6/IcgQ8GC6io/Fsw==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "@popperjs/core": "^2.11.5",
-        "csstype": "^3.1.1",
-        "emotion": "^10.0.17",
-        "react-popper": "^2.3.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-typography": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-5.6.0.tgz",
-      "integrity": "sha512-v8myIeJnpZ6g2WRmL9oOOLrjip3+80Y+LQ4PwOzcJatL5AdwSYVExtlFMMVO5/JNt6qEpT2sd5579LPA17yiVg==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-usage-card": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-usage-card/-/f36-usage-card-5.6.0.tgz",
-      "integrity": "sha512-Mzt0S8F4onLaCCJn/48uMDmZO/pKMNiqAOgIXGOmPOhk0+8IEjQgx7h487r6KD9xjXhejpCFtG5tfG2DopGZ1w==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-card": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-text-link": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.6.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-usage-count": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-usage-count/-/f36-usage-count-5.6.0.tgz",
-      "integrity": "sha512-bjnrnx52jScH2/Nt55piBVzl5HUZELGQh8NHhWUSGry1hFyxeAh7MyEg6B/ROBnVk67E9ZITRknQmqRO9pnoUg==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-utils": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-utils/-/f36-utils-5.2.0.tgz",
-      "integrity": "sha512-0YWsKAdU2HeNz5DwuOCR0lnlHVhlXiDkqtYaH8hHqT9HlQKHDSBPQUI9Vk5OrPDRJ3uLVoyGOJcvUDf27tTopA==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-tokens": "^5.1.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-shared/node_modules/contentful-management": {
-      "version": "11.61.1",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.61.1.tgz",
-      "integrity": "sha512-+Shk0fGpudvT0b0CwdNiLDwPoIbb0YdkiiYc6h5aC42zfVFJ0dgJf9JKzYPBPJd0MWGOCQf5yNzt/zBEAUDElw==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/rich-text-types": "^16.6.1",
-        "axios": "^1.12.2",
-        "contentful-sdk-core": "^9.0.1",
-        "fast-copy": "^3.0.0",
-        "globals": "^15.15.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@contentful/mimetype": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@contentful/mimetype/-/mimetype-2.6.1.tgz",
-      "integrity": "sha512-YcLyzuV/6+LQiKmDHLSgvYMD7oKrpb9CY6E5so6TLOp9v5b8TJUqCnuOBBABdOLF6Sg/Z92Rx21u5z7YByfL0A==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.20"
-      }
-    },
     "node_modules/@contentful/react-apps-toolkit": {
-      "version": "1.2.16",
-      "resolved": "https://registry.npmjs.org/@contentful/react-apps-toolkit/-/react-apps-toolkit-1.2.16.tgz",
-      "integrity": "sha512-vx7+T4h+w1XBbn7OfRoXr8YUTtiyRNLaltF2ziM4xMqBryu/3Y71nBbhbxD6NIfOui3QIo3TR9Q5sPTZvGbIVw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@contentful/react-apps-toolkit/-/react-apps-toolkit-2.0.0.tgz",
+      "integrity": "sha512-OWr1wuIfXxrt7o2uVZHEvAo95e4Vci40Yl4St2Ydtbq3LjOLRBQUDQihAw2HVGVraR958snY5MWoSOAskK+3Wg==",
+      "license": "MIT",
       "dependencies": {
-        "contentful-management": ">=7.30.0"
+        "contentful-management": "^12.3.1"
       },
       "peerDependencies": {
-        "@contentful/app-sdk": ">=4.0.0",
+        "@contentful/app-sdk": ">=4.54.0",
         "react": ">=16.8.0"
       }
     },
     "node_modules/@contentful/rich-text-html-renderer": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@contentful/rich-text-html-renderer/-/rich-text-html-renderer-17.1.0.tgz",
-      "integrity": "sha512-ALyLVFnZZNr5o7at/JuZk5Ve/AjLJfzPllTade66vYiev5J5wVVxHzESTQ3/0Xpg4dCeaB3JvM5YN/iEZoceyA==",
-      "dependencies": {
-        "@contentful/rich-text-types": "^17.1.0",
-        "escape-html": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@contentful/rich-text-html-renderer/node_modules/@contentful/rich-text-types": {
-      "version": "17.2.4",
-      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-17.2.4.tgz",
-      "integrity": "sha512-3y456l+x5aPzqcvjpG6L66sIkfH66rBl1QtGKexgJ3Nvd6k4ORvpAJ6gMDBz3WMAYvXGrVZMyhlFE0e6UdHngA==",
+      "version": "17.2.2",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-html-renderer/-/rich-text-html-renderer-17.2.2.tgz",
+      "integrity": "sha512-Ps5SGrlrgvzJw7n7rawj6RLlv7eZnpDcGrnr8G+0FyOVsvh8y9azwyuQ4MVshgZUUJ02Z2Tc07YiTFYRFCFrlg==",
       "license": "MIT",
       "dependencies": {
-        "@lingui/core": "^5.4.1",
-        "is-plain-obj": "^3.0.0"
+        "@contentful/rich-text-types": "^17.2.7"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@contentful/rich-text-plain-text-renderer": {
@@ -3358,53 +1464,29 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@contentful/rich-text-plain-text-renderer/node_modules/@contentful/rich-text-types": {
-      "version": "17.2.4",
-      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-17.2.4.tgz",
-      "integrity": "sha512-3y456l+x5aPzqcvjpG6L66sIkfH66rBl1QtGKexgJ3Nvd6k4ORvpAJ6gMDBz3WMAYvXGrVZMyhlFE0e6UdHngA==",
+    "node_modules/@contentful/rich-text-react-renderer": {
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-react-renderer/-/rich-text-react-renderer-16.2.1.tgz",
+      "integrity": "sha512-CZTqlaa/Je3T6JfFaHDAaDWuJrDAYBlBEptedlyBml+hojpMFRRz3Vmv5iU7AI7d80BJ1MlXdA7srLXK7ik/HA==",
       "license": "MIT",
       "dependencies": {
-        "@lingui/core": "^5.4.1",
-        "is-plain-obj": "^3.0.0"
+        "@contentful/rich-text-types": "^17.2.7"
       },
       "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@contentful/rich-text-react-renderer": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/@contentful/rich-text-react-renderer/-/rich-text-react-renderer-16.1.0.tgz",
-      "integrity": "sha512-tMhSq6227GJ/bgYYsWyd+KWTPTYD7ZrQVVwzL2ormEYRRfV6NeiGKLo1YOA2zC0U0EBNSJfXrERhH1BA88QOvA==",
-      "dependencies": {
-        "@contentful/rich-text-types": "^17.1.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "react": "^16.8.6 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.6 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@contentful/rich-text-react-renderer/node_modules/@contentful/rich-text-types": {
-      "version": "17.2.4",
-      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-17.2.4.tgz",
-      "integrity": "sha512-3y456l+x5aPzqcvjpG6L66sIkfH66rBl1QtGKexgJ3Nvd6k4ORvpAJ6gMDBz3WMAYvXGrVZMyhlFE0e6UdHngA==",
-      "license": "MIT",
-      "dependencies": {
-        "@lingui/core": "^5.4.1",
-        "is-plain-obj": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@contentful/rich-text-types": {
-      "version": "16.8.5",
-      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.8.5.tgz",
-      "integrity": "sha512-q18RJuJCOuYveGiCIjE5xLCQc5lZ3L2Qgxrlg/H2YEobDFqdtmklazRi1XwEWaK3tMg6yVXBzKKkQfLB4qW14A==",
+      "version": "17.2.7",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-17.2.7.tgz",
+      "integrity": "sha512-aIdozk8vk5gsYcallOrwEiL6+GSlMXZorDOmiVELfpbVaXMJPJPlf2CBw3LUzviAqCw0UPQcKHHCwG7SdY7u5w==",
+      "license": "MIT",
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -3570,107 +1652,138 @@
         "react": ">=16.8.0"
       }
     },
-    "node_modules/@emotion/cache": {
-      "version": "10.0.29",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
-      "integrity": "sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==",
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+      "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+      "license": "MIT",
       "dependencies": {
-        "@emotion/sheet": "0.9.4",
-        "@emotion/stylis": "0.8.5",
-        "@emotion/utils": "0.11.3",
-        "@emotion/weak-memoize": "0.2.5"
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/serialize": "^1.3.3",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.2.0"
       }
     },
-    "node_modules/@emotion/core": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.3.1.tgz",
-      "integrity": "sha512-447aUEjPIm0MnE6QYIaFz9VQOHSXf4Iu6EWOIqq11EAPqinkSZmfymPTmlOE3QjLv846lH4JVZBUOtwGbuQoww==",
+    "node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/cache": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "@emotion/cache": "^10.0.27",
-        "@emotion/css": "^10.0.27",
-        "@emotion/serialize": "^0.11.15",
-        "@emotion/sheet": "0.9.4",
-        "@emotion/utils": "0.11.3"
-      },
-      "peerDependencies": {
-        "react": ">=16.3.0"
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "stylis": "4.2.0"
       }
     },
     "node_modules/@emotion/css": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-10.0.27.tgz",
-      "integrity": "sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==",
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.13.5.tgz",
+      "integrity": "sha512-wQdD0Xhkn3Qy2VNcIzbLP9MR8TafI0MJb7BEAXKp+w4+XqErksWR4OXomuDzPsN4InLdGhVe6EYcn2ZIUCpB8w==",
+      "license": "MIT",
       "dependencies": {
-        "@emotion/serialize": "^0.11.15",
-        "@emotion/utils": "0.11.3",
-        "babel-plugin-emotion": "^10.0.27"
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.13.5",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2"
       }
     },
     "node_modules/@emotion/hash": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
-      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
-    },
-    "node_modules/@emotion/is-prop-valid": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.3.1.tgz",
-      "integrity": "sha512-/ACwoqx7XQi9knQs/G0qKvv5teDMhD7bXYns9N/wM8ah8iNb8jZ2uNO0YOgiq2o2poIvVtJS2YALasQuMSQ7Kw==",
-      "dependencies": {
-        "@emotion/memoize": "^0.9.0"
-      }
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "license": "MIT"
     },
     "node_modules/@emotion/memoize": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
-      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ=="
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+      "license": "MIT"
     },
-    "node_modules/@emotion/serialize": {
-      "version": "0.11.16",
-      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.16.tgz",
-      "integrity": "sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==",
+    "node_modules/@emotion/react": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
+      "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
+      "license": "MIT",
       "dependencies": {
-        "@emotion/hash": "0.8.0",
-        "@emotion/memoize": "0.7.4",
-        "@emotion/unitless": "0.7.5",
-        "@emotion/utils": "0.11.3",
-        "csstype": "^2.5.7"
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "hoist-non-react-statics": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@emotion/serialize/node_modules/@emotion/memoize": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
-      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
-    },
-    "node_modules/@emotion/serialize/node_modules/csstype": {
-      "version": "2.6.21",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
-      "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w=="
+    "node_modules/@emotion/serialize": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
+        "csstype": "^3.0.2"
+      }
     },
     "node_modules/@emotion/sheet": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.4.tgz",
-      "integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA=="
-    },
-    "node_modules/@emotion/stylis": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
-      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+      "license": "MIT"
     },
     "node_modules/@emotion/unitless": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
-      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
+      "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
     },
     "node_modules/@emotion/utils": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
-      "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+      "license": "MIT"
     },
     "node_modules/@emotion/weak-memoize": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
-      "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
+      "license": "MIT"
     },
     "node_modules/@esbuild-plugins/node-globals-polyfill": {
       "version": "0.2.3",
@@ -4110,6 +2223,59 @@
         "node": ">=18"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.19",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.19.tgz",
+      "integrity": "sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.8",
+        "@floating-ui/utils": "^0.2.11",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -4232,6 +2398,7 @@
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -4240,12 +2407,14 @@
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
-      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
     },
     "node_modules/@radix-ui/react-collection": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
       "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2",
         "@radix-ui/react-context": "1.1.2",
@@ -4285,6 +2454,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
       "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -4299,6 +2469,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
       "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -4313,6 +2484,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
       "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-layout-effect": "1.1.1"
       },
@@ -4330,6 +2502,7 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
       "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2",
         "@radix-ui/react-use-layout-effect": "1.1.1"
@@ -4353,6 +2526,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
       "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
       "dependencies": {
         "@radix-ui/react-slot": "1.2.3"
       },
@@ -4375,6 +2549,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
       "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.3",
         "@radix-ui/react-collection": "1.1.7",
@@ -4422,6 +2597,7 @@
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
       "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+      "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.3",
         "@radix-ui/react-context": "1.1.2",
@@ -4451,6 +2627,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
       "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -4465,6 +2642,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
       "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-effect-event": "0.0.2",
         "@radix-ui/react-use-layout-effect": "1.1.1"
@@ -4483,6 +2661,7 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
       "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-layout-effect": "1.1.1"
       },
@@ -4500,6 +2679,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
       "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -4815,13 +2995,29 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.41.0.tgz",
-      "integrity": "sha512-193R4Jp9hjvlij6LryxrB5Mpbffd2L9PeWh3KlIy/hJV4SkBOfiQZ+jc5qAZLDCrdbkA5FjGj+UoDYw6TcNnyA==",
+      "version": "5.100.10",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.10.tgz",
+      "integrity": "sha512-8UR0yJR+GiQ40m3lPhUr0xbfAupe6GSQiksSBSa9SM2NjezFyxXCIA69/lz8cSoNKZLrw1/PktIyQBJcVeMi3w==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.100.10",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.10.tgz",
+      "integrity": "sha512-FLaZf2RCrA/Zgp4aiu5tG3TyasTRO7aZ99skxQpr3Hg/zXOhu6yq5FZCYQ/tRaJtM9ylnoK8tFK7PolXQadv6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.100.10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -4829,7 +3025,7 @@
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -4914,7 +3110,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -5004,7 +3200,8 @@
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
-      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="
+      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.1.9",
@@ -5027,6 +3224,7 @@
       "version": "3.16.3",
       "resolved": "https://registry.npmjs.org/@types/react-modal/-/react-modal-3.16.3.tgz",
       "integrity": "sha512-xXuGavyEGaFQDgBv4UVm8/ZsG+qxeQ7f77yNrW3n+1J6XAstUy5rYHeIHPh1KzsGc6IkCIdu6lQ2xWzu1jBTLg==",
+      "license": "MIT",
       "dependencies": {
         "@types/react": "*"
       }
@@ -5713,65 +3911,56 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.1.tgz",
-      "integrity": "sha512-hU4EGxxt+j7TQijx1oYdAjw4xuIp1wRQSsbMFwSthCWeBQur1eF+qJ5iQ5sN3Tw8YRzQNKb8jszgBdMDVqwJcw==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
       }
     },
-    "node_modules/babel-plugin-emotion": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.2.2.tgz",
-      "integrity": "sha512-SMSkGoqTbTyUTDeuVuPIWifPdUGkTk1Kf9BWRiXIOIcuyMfsdp2EjeiiFvOzX8NOBvEh/ypKYvUh2rkgAJMCLA==",
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@emotion/hash": "0.8.0",
-        "@emotion/memoize": "0.7.4",
-        "@emotion/serialize": "^0.11.16",
-        "babel-plugin-macros": "^2.0.0",
-        "babel-plugin-syntax-jsx": "^6.18.0",
-        "convert-source-map": "^1.5.0",
-        "escape-string-regexp": "^1.0.5",
-        "find-root": "^1.1.0",
-        "source-map": "^0.5.7"
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
-    "node_modules/babel-plugin-emotion/node_modules/@emotion/memoize": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
-      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
-    },
-    "node_modules/babel-plugin-emotion/node_modules/convert-source-map": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
-    },
-    "node_modules/babel-plugin-emotion/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
       "engines": {
-        "node": ">=0.8.0"
+        "node": ">= 6"
       }
     },
     "node_modules/babel-plugin-macros": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
-      "integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "cosmiconfig": "^6.0.0",
-        "resolve": "^1.12.0"
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
       }
-    },
-    "node_modules/babel-plugin-syntax-jsx": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-      "integrity": "sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw=="
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -5932,6 +4121,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "get-intrinsic": "^1.3.0"
@@ -5947,6 +4137,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -6125,9 +4316,10 @@
       }
     },
     "node_modules/compute-scroll-into-view": {
-      "version": "1.0.20",
-      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.20.tgz",
-      "integrity": "sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
+      "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==",
+      "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -6162,18 +4354,20 @@
       }
     },
     "node_modules/contentful-management": {
-      "version": "11.54.4",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.54.4.tgz",
-      "integrity": "sha512-h1+aIj0xHVK3aDn6KkDOmCGO5kqwElgEEELel6EZC4skJkBOHU5DACdHc3thkhua5hbSufExNjmwdmN4TLFb8w==",
+      "version": "12.5.0",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-12.5.0.tgz",
+      "integrity": "sha512-RXVuwmBIKlu6gziA06X8kLnQpP4d2PlWSc/4T1ezio2ErE0oKXN6kCagFSme/QUR5HuqAksp1jL8aJ+EFx7gqQ==",
+      "license": "MIT",
       "dependencies": {
         "@contentful/rich-text-types": "^16.6.1",
-        "axios": "^1.11.0",
-        "contentful-sdk-core": "^9.0.1",
+        "axios": "^1.15.0",
+        "contentful-sdk-core": "^9.4.4",
         "fast-copy": "^3.0.0",
-        "globals": "^15.15.0"
+        "globals": "^15.15.0",
+        "process": "^0.11.10"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/contentful-resolve-response": {
@@ -6193,15 +4387,15 @@
       "integrity": "sha512-ozrGwyuCTAy7YgFCua8rmqmytECYk/JYAMXcswOcm0qvGoE3tPb7ivBeIHTOK2DiapBhDZgacIhzhQIKU5TCfA=="
     },
     "node_modules/contentful-sdk-core": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-9.2.0.tgz",
-      "integrity": "sha512-cUvHbC2u8ouJHhG3tofQhUc0FAmM/QBcalYjiczMtFKrR77BW+eSPcPg+A9DQlhIP0UGcQ/knXxoJpBvrERXTA==",
+      "version": "9.4.5",
+      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-9.4.5.tgz",
+      "integrity": "sha512-8eGTMO11LXFAiosaiV38bjvW6cjoQFtNE38pNtVilZTXpmGFinClljihH0eriv11Ispd4q82TqtsXMJPYD/C+A==",
+      "license": "MIT",
       "dependencies": {
         "fast-copy": "^3.0.2",
-        "lodash": "^4.17.21",
-        "p-throttle": "^6.1.0",
+        "lodash": "^4.17.23",
         "process": "^0.11.10",
-        "qs": "^6.12.3"
+        "qs": "^6.15.0"
       },
       "engines": {
         "node": ">=18"
@@ -6210,6 +4404,12 @@
         "@rollup/rollup-linux-x64-gnu": "^4.18.0"
       }
     },
+    "node_modules/contentful-sdk-core/node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -6217,38 +4417,28 @@
       "devOptional": true
     },
     "node_modules/cosmiconfig": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
-      "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "license": "MIT",
       "dependencies": {
         "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.1.0",
+        "import-fresh": "^3.2.1",
         "parse-json": "^5.0.0",
         "path-type": "^4.0.0",
-        "yaml": "^1.7.2"
+        "yaml": "^1.10.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
       }
     },
     "node_modules/cosmiconfig/node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "license": "ISC",
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/create-emotion": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/create-emotion/-/create-emotion-10.0.27.tgz",
-      "integrity": "sha512-fIK73w82HPPn/RsAij7+Zt8eCE8SptcJ3WoRMfxMtjteYxud8GDTKKld7MYwAX2TVhrw29uR1N/bVGxeStHILg==",
-      "dependencies": {
-        "@emotion/cache": "^10.0.27",
-        "@emotion/serialize": "^0.11.15",
-        "@emotion/sheet": "0.9.4",
-        "@emotion/utils": "0.11.3"
       }
     },
     "node_modules/css.escape": {
@@ -6307,6 +4497,7 @@
       "version": "2.30.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
       "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.21.0"
       },
@@ -6319,9 +4510,10 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.13",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
-      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg=="
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.1",
@@ -6395,7 +4587,8 @@
     "node_modules/detect-node-es": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
-      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
     },
     "node_modules/direction": {
       "version": "1.0.4",
@@ -6415,7 +4608,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dompurify": {
       "version": "3.2.6",
@@ -6438,19 +4631,26 @@
       }
     },
     "node_modules/downshift": {
-      "version": "6.1.12",
-      "resolved": "https://registry.npmjs.org/downshift/-/downshift-6.1.12.tgz",
-      "integrity": "sha512-7XB/iaSJVS4T8wGFT3WRXmSF1UlBHAA40DshZtkrIscIN+VC+Lh363skLxFTvJwtNgHxAMDGEHT4xsyQFWL+UA==",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/downshift/-/downshift-9.3.2.tgz",
+      "integrity": "sha512-5VD0WZLQDhipWiDU+K5ili3VDhGrXwlvOlSaSG1Cb0eS4XpssxVuoD09JNgju+bAzxB2Wvlwx+FwTE/FNdrqow==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.14.8",
-        "compute-scroll-into-view": "^1.0.17",
-        "prop-types": "^15.7.2",
-        "react-is": "^17.0.2",
-        "tslib": "^2.3.0"
+        "@babel/runtime": "^7.28.6",
+        "compute-scroll-into-view": "^3.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^18.2.0",
+        "tslib": "^2.8.1"
       },
       "peerDependencies": {
         "react": ">=16.12.0"
       }
+    },
+    "node_modules/downshift/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
     },
     "node_modules/dset": {
       "version": "3.1.4",
@@ -6486,15 +4686,6 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
-    "node_modules/emotion": {
-      "version": "10.0.27",
-      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
-      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
-      "dependencies": {
-        "babel-plugin-emotion": "^10.0.27",
-        "create-emotion": "^10.0.27"
-      }
-    },
     "node_modules/enquirer": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
@@ -6520,9 +4711,10 @@
       }
     },
     "node_modules/error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
@@ -6625,16 +4817,10 @@
         "node": ">=6"
       }
     },
-    "node_modules/escape-html": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
-    },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -6657,7 +4843,8 @@
     "node_modules/exenv": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
-      "integrity": "sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw=="
+      "integrity": "sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/expect-type": {
       "version": "1.2.2",
@@ -6739,12 +4926,14 @@
     "node_modules/find-root": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "license": "MIT"
     },
     "node_modules/focus-lock": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-1.3.6.tgz",
       "integrity": "sha512-Ik/6OCk9RQQ0T5Xw+hKNLWrjSMtv51dD4GRmJjbD5a58TIEpI5a5iXagKVl3Z5UuyslMCA8Xwnu76jQob62Yhg==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.3"
       },
@@ -6753,15 +4942,16 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -6777,9 +4967,10 @@
       "integrity": "sha512-k6GAGDyqLe9JaebCsFCoudPPWfihKu8pylYXRlqP1J7ms39iPoTtk2fviNglIeQEwdh0bQeKJ01ZPyuyQvKzwg=="
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -7036,15 +5227,31 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
@@ -7139,6 +5346,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
       "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -7205,14 +5413,16 @@
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "license": "MIT"
     },
     "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7457,7 +5667,8 @@
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "license": "MIT"
     },
     "node_modules/json-pointer": {
       "version": "0.6.2",
@@ -7499,7 +5710,8 @@
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "license": "MIT"
     },
     "node_modules/lodash": {
       "version": "4.17.21",
@@ -7560,7 +5772,7 @@
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -7704,15 +5916,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/moment": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/moo": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
@@ -7814,6 +6017,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7822,6 +6026,7 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -7929,21 +6134,11 @@
         "node": ">=6"
       }
     },
-    "node_modules/p-throttle": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/p-throttle/-/p-throttle-6.2.0.tgz",
-      "integrity": "sha512-NCKkOVj6PZa6NiTmfvGilDdf6vO1rFCD3KDnkHko8dTOtkpk4cSR/VTAhhLMG9aiQ7/A9HYgEDNmxzf6hxzR3g==",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -7955,6 +6150,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -7992,12 +6188,14 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -8070,7 +6268,7 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -8085,7 +6283,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
-      "peer": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -8105,6 +6303,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -8114,7 +6313,8 @@
     "node_modules/prop-types/node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/proxy-compare": {
       "version": "2.6.0",
@@ -8123,9 +6323,13 @@
       "license": "MIT"
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/psl": {
       "version": "1.15.0",
@@ -8149,9 +6353,10 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
       },
@@ -8180,11 +6385,12 @@
       }
     },
     "node_modules/react-animate-height": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/react-animate-height/-/react-animate-height-3.2.3.tgz",
-      "integrity": "sha512-R6DSvr7ud07oeCixScyvXWEMJY/Mt2+GyOWC1KMaRc69gOBw+SsCg4TJmrp4rKUM1hyd6p+YKw90brjPH93Y2A==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/react-animate-height/-/react-animate-height-3.2.4.tgz",
+      "integrity": "sha512-wcT37yHsFWDx8DmNFMy0AqSrYgNPGAtU9dyEqwIq3kSUXW03DWSi5WqbhlOALvMXcowal8JWUJRXij6TexilGQ==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 12.0.0"
+        "node": ">= 20.0.0"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -8195,6 +6401,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.8.tgz",
       "integrity": "sha512-ma2FePH0z3px2+WOu6h+YycZcEvFmmxIlAb62cF52bG86eMySciO/EQZeQMXd07kPCYB0a1dWDT5J+KE9mCDUw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.13"
       },
@@ -8203,16 +6410,17 @@
       }
     },
     "node_modules/react-day-picker": {
-      "version": "8.10.1",
-      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.10.1.tgz",
-      "integrity": "sha512-TMx7fNbhLk15eqcMt+7Z7S2KF7mfTId/XJDjKE8f+IUcFn0l08/kI4FiYTL/0yuOLmEcbR4Fwe3GJf/NiiMnPA==",
+      "version": "8.10.2",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.10.2.tgz",
+      "integrity": "sha512-LK68OTbHB3oJNhl9cA0qVizzp3o26w61YSjAFkYi67N86iro32wx86kSNeFU/hq+gI8m1yzWhnomMLfZ041RzQ==",
+      "license": "MIT",
       "funding": {
         "type": "individual",
         "url": "https://github.com/sponsors/gpbl"
       },
       "peerDependencies": {
         "date-fns": "^2.28.0 || ^3.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-dom": {
@@ -8227,23 +6435,17 @@
         "react": "^18.3.1"
       }
     },
-    "node_modules/react-dom/node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
-    },
     "node_modules/react-fast-compare": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
-      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+      "license": "MIT"
     },
     "node_modules/react-focus-lock": {
-      "version": "2.13.6",
-      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.13.6.tgz",
-      "integrity": "sha512-ehylFFWyYtBKXjAO9+3v8d0i+cnc1trGS0vlTGhzFW1vbFXVUTmR8s2tt/ZQG8x5hElg6rhENlLG1H3EZK0Llg==",
+      "version": "2.13.7",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.13.7.tgz",
+      "integrity": "sha512-20lpZHEQrXPb+pp1tzd4ULL6DyO5D2KnR0G69tTDdydrmNhU7pdFmbQUYVyHUgp+xN29IuFR0PVuhOmvaZL9Og==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
         "focus-lock": "^1.3.6",
@@ -8284,17 +6486,21 @@
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
+      "license": "MIT"
     },
     "node_modules/react-modal": {
       "version": "3.16.3",
       "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.16.3.tgz",
       "integrity": "sha512-yCYRJB5YkeQDQlTt17WGAgFJ7jr2QYcWa1SHqZ3PluDmnKJ/7+tVU+E6uKyZ0nODaeEj+xCpK4LcSnKXLMC0Nw==",
+      "license": "MIT",
       "dependencies": {
         "exenv": "^1.2.0",
         "prop-types": "^15.7.2",
@@ -8310,6 +6516,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
       "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
+      "license": "MIT",
       "dependencies": {
         "react-fast-compare": "^3.0.1",
         "warning": "^4.0.2"
@@ -8363,11 +6570,13 @@
       "dev": true
     },
     "node_modules/resolve": {
-      "version": "1.22.10",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
-      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.16.0",
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -8385,6 +6594,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -8550,11 +6760,13 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "license": "MIT",
-      "peer": true
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
     },
     "node_modules/scroll-into-view-if-needed": {
       "version": "3.1.0",
@@ -8564,12 +6776,6 @@
       "dependencies": {
         "compute-scroll-into-view": "^3.0.2"
       }
-    },
-    "node_modules/scroll-into-view-if-needed/node_modules/compute-scroll-into-view": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
-      "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==",
-      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -8584,6 +6790,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3",
@@ -8599,12 +6806,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8617,6 +6825,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -8634,6 +6843,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -8721,6 +6931,7 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8820,6 +7031,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -8836,6 +7053,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -8848,6 +7066,12 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
+    },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "license": "MIT"
     },
     "node_modules/tar": {
       "version": "6.2.1",
@@ -9061,6 +7285,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/truncate/-/truncate-3.0.0.tgz",
       "integrity": "sha512-C+0Xojw7wZPl6MDq5UjMTuxZvBPK04mtdFet7k+GSZPINcvLZFCXg+15kWIL4wAqDB7CksIsKiRLbQ1wa7rKdw==",
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -9153,6 +7378,7 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
       "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -9185,6 +7411,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
       "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
       "dependencies": {
         "detect-node-es": "^1.1.0",
         "tslib": "^2.0.0"
@@ -9422,6 +7649,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
       "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.0.0"
       }
@@ -9566,6 +7794,24 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "devOptional": true
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/zod": {
       "version": "3.25.76",

--- a/apps/rich-text-versioning/package.json
+++ b/apps/rich-text-versioning/package.json
@@ -4,22 +4,25 @@
   "private": true,
   "dependencies": {
     "@ali-tas/htmldiff-js": "^2.0.1",
-    "@contentful/app-sdk": "^4.42.0",
-    "@contentful/f36-components": "4.81.1",
-    "@contentful/f36-multiselect": "^4.81.1",
-    "@contentful/f36-tokens": "4.2.0",
-    "@contentful/field-editor-rich-text": "4.16.0",
-    "@contentful/react-apps-toolkit": "1.2.16",
-    "@contentful/rich-text-html-renderer": "^17.1.0",
-    "@contentful/rich-text-react-renderer": "^16.1.0",
-    "@contentful/rich-text-types": "^16.1.0",
+    "@contentful/app-sdk": "^4.54.0",
+    "@contentful/f36-components": "^6.7.1",
+    "@contentful/f36-multiselect": "^6.7.1",
+    "@contentful/f36-tokens": "^6.1.2",
+    "@contentful/field-editor-rich-text": "6.3.5",
+    "@contentful/react-apps-toolkit": "^2.0.0",
+    "@contentful/rich-text-html-renderer": "^17.2.2",
+    "@contentful/rich-text-react-renderer": "^16.2.1",
+    "@contentful/rich-text-types": "^17.2.5",
+    "@emotion/css": "^11.13.5",
+    "@lingui/core": "^5.3.0",
+    "@tanstack/react-query": "^5.0.0",
     "contentful": "^11.7.15",
-    "contentful-management": "11.54.4",
+    "contentful-management": "^12.3.0",
     "dompurify": "^3.0.8",
-    "emotion": "10.0.27",
     "happy-dom": "^20.0.0",
     "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "react-dom": "18.3.1",
+    "scheduler": "^0.23.2"
   },
   "scripts": {
     "start": "vite",
@@ -35,6 +38,7 @@
   },
   "devDependencies": {
     "@contentful/app-scripts": "^2.5.5",
+    "@testing-library/dom": "^10.0.0",
     "@testing-library/jest-dom": "^6.6.4",
     "@testing-library/react": "16.3.0",
     "@testing-library/user-event": "^14.6.1",
@@ -48,7 +52,7 @@
     "vitest": "^3.2.4"
   },
   "overrides": {
-    "@contentful/rich-text-types": "^16.1.0",
+    "@contentful/rich-text-types": "^17.2.5",
     "slate": "0.94.1",
     "slate-react": "0.102.0"
   }

--- a/apps/rich-text-versioning/src/components/HtmlDiffViewer.styles.ts
+++ b/apps/rich-text-versioning/src/components/HtmlDiffViewer.styles.ts
@@ -1,4 +1,4 @@
-import { css } from 'emotion';
+import { css } from '@emotion/css';
 import tokens from '@contentful/f36-tokens';
 
 const styles = css({

--- a/apps/rich-text-versioning/src/locations/ConfigScreen.styles.ts
+++ b/apps/rich-text-versioning/src/locations/ConfigScreen.styles.ts
@@ -1,5 +1,5 @@
 import tokens from '@contentful/f36-tokens';
-import { css } from 'emotion';
+import { css } from '@emotion/css';
 
 export const styles = {
   configScreenContainer: css({

--- a/apps/rich-text-versioning/src/locations/Dialog.styles.ts
+++ b/apps/rich-text-versioning/src/locations/Dialog.styles.ts
@@ -1,4 +1,4 @@
-import { css } from 'emotion';
+import { css } from '@emotion/css';
 import tokens from '@contentful/f36-tokens';
 
 export const styles = {

--- a/apps/rich-text-versioning/src/locations/Field.styles.ts
+++ b/apps/rich-text-versioning/src/locations/Field.styles.ts
@@ -1,4 +1,4 @@
-import { css } from 'emotion';
+import { css } from '@emotion/css';
 
 /**
  * Rich Text Editor - Sticky Toolbar

--- a/apps/rich-text-versioning/src/locations/Field.tsx
+++ b/apps/rich-text-versioning/src/locations/Field.tsx
@@ -2,7 +2,7 @@ import { FieldAppSDK } from '@contentful/app-sdk';
 import { Button, Tooltip } from '@contentful/f36-components';
 import tokens from '@contentful/f36-tokens';
 import { useAutoResizer, useSDK } from '@contentful/react-apps-toolkit';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { RichTextEditor } from '@contentful/field-editor-rich-text';
 import { Document } from '@contentful/rich-text-types';
 import { EntrySys } from '@contentful/app-sdk/dist/types/utils';
@@ -44,6 +44,55 @@ const Field = () => {
 
     return detachValueChangeHandler;
   }, [sdk.entry]);
+
+  // Inject `entityId` + `referenceFieldId` into entity-picker `recommendations`
+  // so the Suggested tab populates inside the marketplace-app iframe. The web
+  // app's rtSdkDecorator only runs around the native rich-text widget, and
+  // field-editor-rich-text itself only sets `searchQuery` (in HyperlinkModal)
+  // -- never `entityId`/`referenceFieldId`. Without this, the picker dialog
+  // never calls /semantic/reference-suggestions. See ES-262.
+  //
+  // The `recommendations` key is not declared on @contentful/app-sdk's
+  // selectSingleEntry/selectMultipleEntries options type, but the host's
+  // dialog channel forwards arbitrary option keys to the picker, which reads
+  // `recommendations` directly. We cast at the wrapper boundary.
+  const decoratedSdk = useMemo<FieldAppSDK>(() => {
+    const recommendationsBase = {
+      entityId: sdk.entry.getSys().id,
+      referenceFieldId: sdk.field.id,
+    };
+
+    type WithRecommendations<T> = T & {
+      recommendations?: Record<string, unknown>;
+    };
+
+    return {
+      ...sdk,
+      dialogs: {
+        ...sdk.dialogs,
+        selectSingleEntry: (options = {}) => {
+          const merged: WithRecommendations<typeof options> = {
+            ...options,
+            recommendations: {
+              ...recommendationsBase,
+              ...((options as WithRecommendations<typeof options>).recommendations ?? {}),
+            },
+          };
+          return sdk.dialogs.selectSingleEntry(merged);
+        },
+        selectMultipleEntries: (options = {}) => {
+          const merged: WithRecommendations<typeof options> = {
+            ...options,
+            recommendations: {
+              ...recommendationsBase,
+              ...((options as WithRecommendations<typeof options>).recommendations ?? {}),
+            },
+          };
+          return sdk.dialogs.selectMultipleEntries(merged);
+        },
+      },
+    };
+  }, [sdk]);
 
   const isChanged = (sys: EntrySys | ReleaseEntrySys) => {
     if ('fieldStatus' in sys && sys.fieldStatus) {
@@ -101,7 +150,7 @@ const Field = () => {
   return (
     <>
       <div className={styles.richTextEditorContainer}>
-        <RichTextEditor sdk={sdk} isInitiallyDisabled={false} />
+        <RichTextEditor sdk={decoratedSdk} isInitiallyDisabled={false} />
       </div>
       <Tooltip
         placement="top"

--- a/apps/rich-text-versioning/test/locations/Field.spec.tsx
+++ b/apps/rich-text-versioning/test/locations/Field.spec.tsx
@@ -4,10 +4,12 @@ import { mockSdk } from '../mocks';
 import Field from '../../src/locations/Field';
 import { Document, BLOCKS } from '@contentful/rich-text-types';
 
+let capturedDecoratedSdk: any = null;
 vi.mock('@contentful/field-editor-rich-text', () => ({
-  RichTextEditor: ({ sdk }: { sdk: any }) => (
-    <div data-testid="rich-text-editor">Rich Text Editor</div>
-  ),
+  RichTextEditor: ({ sdk }: { sdk: any }) => {
+    capturedDecoratedSdk = sdk;
+    return <div data-testid="rich-text-editor">Rich Text Editor</div>;
+  },
 }));
 
 const mockOpenCurrentApp = vi.fn();
@@ -25,6 +27,8 @@ const fieldMockSdk = {
   },
   dialogs: {
     openCurrentApp: mockOpenCurrentApp,
+    selectSingleEntry: vi.fn(),
+    selectMultipleEntries: vi.fn(),
   },
   parameters: {
     installation: {
@@ -174,6 +178,62 @@ describe('Field component', () => {
           errorInfo: {
             hasError: false,
           },
+        },
+      });
+    });
+  });
+
+  describe('SDK decorator for entity-picker recommendations (ES-262)', () => {
+    beforeEach(() => {
+      capturedDecoratedSdk = null;
+      fieldMockSdk.entry.getSys.mockReturnValue({ id: 'test-entry' });
+      fieldMockSdk.field = { ...fieldMockSdk.field, id: 'mainContent' } as any;
+    });
+
+    it('injects entityId and referenceFieldId into selectSingleEntry recommendations', () => {
+      render(<Field />);
+      capturedDecoratedSdk.dialogs.selectSingleEntry({});
+      expect(fieldMockSdk.dialogs.selectSingleEntry).toHaveBeenCalledWith({
+        recommendations: { entityId: 'test-entry', referenceFieldId: 'mainContent' },
+      });
+    });
+
+    it('preserves caller-supplied recommendations keys (e.g. searchQuery from HyperlinkModal)', () => {
+      render(<Field />);
+      capturedDecoratedSdk.dialogs.selectSingleEntry({
+        contentTypes: ['article'],
+        recommendations: { searchQuery: 'how does X work' },
+      });
+      expect(fieldMockSdk.dialogs.selectSingleEntry).toHaveBeenCalledWith({
+        contentTypes: ['article'],
+        recommendations: {
+          entityId: 'test-entry',
+          referenceFieldId: 'mainContent',
+          searchQuery: 'how does X work',
+        },
+      });
+    });
+
+    it('lets caller-supplied recommendations keys override the injected base', () => {
+      render(<Field />);
+      capturedDecoratedSdk.dialogs.selectSingleEntry({
+        recommendations: { entityId: 'override', referenceFieldId: 'override-field' },
+      });
+      expect(fieldMockSdk.dialogs.selectSingleEntry).toHaveBeenCalledWith({
+        recommendations: { entityId: 'override', referenceFieldId: 'override-field' },
+      });
+    });
+
+    it('decorates selectMultipleEntries the same way', () => {
+      render(<Field />);
+      capturedDecoratedSdk.dialogs.selectMultipleEntries({
+        recommendations: { searchQuery: 'q' },
+      });
+      expect(fieldMockSdk.dialogs.selectMultipleEntries).toHaveBeenCalledWith({
+        recommendations: {
+          entityId: 'test-entry',
+          referenceFieldId: 'mainContent',
+          searchQuery: 'q',
         },
       });
     });


### PR DESCRIPTION
## Summary

An issue was reported that inside the Rich Text Versioning marketplace app, the entity picker's "Suggested" tab loads but never returns results. The same picker on the native rich text editor populates correctly.

Root cause: `recommendations.entityId` and `recommendations.referenceFieldId` are required for the picker's `/semantic/reference-suggestions` call, but nothing in this app's path injects them. On the host, `AiEnabledSingleLinkActions` does the injection for plain reference fields, but for marketplace apps in a RichText location, the host has no equivalent. `field-editor-rich-text`'s `HyperlinkModal` only sets `searchQuery`.

## Fix

`Field.tsx` wraps the iframe SDK with a thin decorator that injects `recommendations: { entityId, referenceFieldId }` into `dialogs.selectSingleEntry` and `dialogs.selectMultipleEntries`. Caller-supplied `recommendations` (e.g. `searchQuery` from `HyperlinkModal`) merge on top, so existing behaviour is preserved. The decorated SDK is passed to `<RichTextEditor>` so the embed-block, embed-inline, and hyperlink picker call sites all participate.

The `recommendations` key isn't declared on `@contentful/app-sdk`'s dialog options type, but the host's dialog channel forwards arbitrary option keys to the picker, which reads `recommendations` directly. The wrapper casts at the boundary.

## Required dep bumps

The decorator only takes effect against `field-editor-rich-text >= 4.10.0` (when `HyperlinkModal` started passing `recommendations` through). To stay current and pick up other RT improvements, this PR also bumps:

- `@contentful/field-editor-rich-text`: `4.16.0` -> `6.3.5`
- `@contentful/app-sdk`: `4.42.0` -> `4.54.0`
- `@contentful/f36-components` / `f36-multiselect` / `f36-tokens`: `4.x` -> `6.x`
- `@contentful/react-apps-toolkit`: `1.2.16` -> `2.0.0`
- `@contentful/rich-text-html-renderer` / `react-renderer` / `types`: minor bumps
- `contentful-management`: `11.54.4` -> `^12.3.0`
- `emotion@10` (deprecated single-package style import) -> `@emotion/css@^11`

The emotion package rename touches four `*.styles.ts` files mechanically (only the import statement changes).

`@tanstack/react-query@^5.0.0` is added as a transitive expectation of the newer field-editor packages, and `@lingui/core@^5.3.0` is added because the newer `@contentful/react-apps-toolkit` requires it as a peer.

## Companion / dependent fixes

The decorator only fully unblocks the customer scenario when paired with two upstream fixes that this work surfaced:

- **contentful/experience-packages#3480**: switches `entity-search`'s semantic fetch from `cmaClient.raw.post(...)` to typed CMA methods (`cmaClient.semanticSearch.get`, `cmaClient.semanticReferenceSuggestions.get`). Without this, the marketplace-app CMA adapter rejects the picker's request with "You can not make raw cma requests from an app." See PR for full root cause.
- **contentful/field-editors#2159**: handles react-query v5's `'pending'` status in the `FetchingWrapped*` cards. Surfaces only in vite-bundled marketplace apps that hoist v5 over field-editor-reference's nested v4. Without this, picking an entry from Suggested crashes `WrappedEntryCard`.

This PR is independently shippable: the decorator is the right thing in this app regardless of when the upstream fixes land. End-to-end the customer scenario is unblocked once all three are in production.

## Test plan

- [x] Added decorator unit tests in `test/locations/Field.spec.tsx` covering: base-case injection, caller-supplied `recommendations` merge (e.g. `searchQuery` preservation), caller-supplied keys overriding the injected base, and `selectMultipleEntries` parity.
- [x] Existing tests still pass: `npm run test:ci` (36/36 pass).
- [x] `npm run build` clean.
- [x] Verified end-to-end against production space (via local dev server) with locally-patched dependencies (mirroring the upstream fixes): `/semantic/search` and `/semantic/reference-suggestions` fire with `entityId`/`referenceFieldId`/`searchQuery` in the request body, picker populates with entries, and picking-then-inserting works.
- [ ] Once upstream PRs are released, verify against unpatched deps.
