### PR TITLE
fix(drive-integration): fix overscroll-behavior [INTEG-3984]

### DIFF
--- a/apps/drive-integration/src/hooks/useMultiselectReflow.ts
+++ b/apps/drive-integration/src/hooks/useMultiselectReflow.ts
@@ -5,6 +5,12 @@ export const useMultiselectScrollReflow = <T>(selection: T[]): RefObject<HTMLULi
 
   useEffect(() => {
     if (listRef.current) {
+      listRef.current.style.overscrollBehavior = 'contain';
+    }
+  }, []);
+
+  useEffect(() => {
+    if (listRef.current) {
       const element = listRef.current;
       const currentScroll = element.scrollTop;
       const maxScroll = element.scrollHeight - element.clientHeight;

--- a/apps/drive-integration/src/hooks/useMultiselectReflow.ts
+++ b/apps/drive-integration/src/hooks/useMultiselectReflow.ts
@@ -5,12 +5,6 @@ export const useMultiselectScrollReflow = <T>(selection: T[]): RefObject<HTMLULi
 
   useEffect(() => {
     if (listRef.current) {
-      listRef.current.style.overscrollBehavior = 'contain';
-    }
-  }, []);
-
-  useEffect(() => {
-    if (listRef.current) {
       const element = listRef.current;
       const currentScroll = element.scrollTop;
       const maxScroll = element.scrollHeight - element.clientHeight;

--- a/apps/drive-integration/src/locations/Page/components/review/mapping/edit-modals/EditModal.tsx
+++ b/apps/drive-integration/src/locations/Page/components/review/mapping/edit-modals/EditModal.tsx
@@ -36,6 +36,15 @@ export const EditModal = ({
 
   useEffect(() => {
     if (!isOpen) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
     setSelectedFieldIdsByEntry(
       Object.fromEntries(viewModel.newLocations.map((loc) => [loc.id, loc.initialFieldIds]))
     );

--- a/apps/drive-integration/src/locations/Page/components/review/mapping/edit-modals/FieldSelectionDropdown.tsx
+++ b/apps/drive-integration/src/locations/Page/components/review/mapping/edit-modals/FieldSelectionDropdown.tsx
@@ -95,7 +95,7 @@ export const FieldSelectionDropdown = ({
         currentSelection={currentSelection}
         placeholder={placeholder}
         popoverProps={{
-          listMaxHeight: 280,
+          listMaxHeight: 200,
           listRef: multiselectListRef,
           placement: 'bottom',
           isAutoalignmentEnabled: false,


### PR DESCRIPTION
## Purpose

Background scroll leak: scrolling the field selection dropdown caused the page behind the modal to scroll simultaneously. That made the field dropdown portal to be closed when it shouldn't.

## Approach

The f36 Multiselect popover renders via FloatingPortal, appending directly to `<body>`. When the dropdown list hits its scroll boundary, the browser chains the wheel event up the DOM to body, scrolling the page.
- The fix locks document.body overflow to hidden while the modal is open and restores it on close, straightforward and browser-consistent.

## Testing steps

Go to the edit modal, open the field dropdown and scroll, hitting bottom. It should close the portal neither scroll the background page.


https://github.com/user-attachments/assets/b0c6d322-5058-4bd9-b9a3-9b7d02ca5a7f


## Breaking Changes

No.

## Dependencies and/or References

No.

## Deployment

No.