### PR TITLE
feat&fix(drive-integration): adding no content mapped badge + general fixes [INTEG-3893]

### DIFF
--- a/apps/drive-integration/src/locations/Page/components/overview/OverviewEntryList.styles.ts
+++ b/apps/drive-integration/src/locations/Page/components/overview/OverviewEntryList.styles.ts
@@ -66,3 +66,7 @@ export const treeChildrenList = css({
     pointerEvents: 'none',
   },
 });
+
+export const noMappedContentBadge = css({
+  marginLeft: tokens.spacingS,
+});

--- a/apps/drive-integration/src/locations/Page/components/overview/OverviewEntryList.tsx
+++ b/apps/drive-integration/src/locations/Page/components/overview/OverviewEntryList.tsx
@@ -1,4 +1,4 @@
-import { Box, Card, Checkbox, Flex, Paragraph, Text } from '@contentful/f36-components';
+import { Badge, Box, Card, Checkbox, Flex, Paragraph, Text } from '@contentful/f36-components';
 import tokens from '@contentful/f36-tokens';
 import { cx } from '@emotion/css';
 import type { EntryListRow as OverviewEntryListRow } from '../../../../utils/overviewEntryList';
@@ -90,6 +90,11 @@ function OverviewEntryRowCard({
                 </Text>
               ) : null}
             </Paragraph>
+            {row.hasNoMappedContent ? (
+              <Badge variant="secondary" size="small">
+                No mapped content
+              </Badge>
+            ) : null}
           </button>
         </Flex>
       </Card>

--- a/apps/drive-integration/src/locations/Page/components/overview/OverviewEntryList.tsx
+++ b/apps/drive-integration/src/locations/Page/components/overview/OverviewEntryList.tsx
@@ -90,11 +90,11 @@ function OverviewEntryRowCard({
                   ({truncateLabel(row.entryTitle, 150)})
                 </Text>
               ) : null}
-              {row.hasNoMappedContent ? (
+              {row.hasNoMappedContent && (
                 <Badge variant="secondary" size="small" className={noMappedContentBadge}>
                   No mapped content
                 </Badge>
-              ) : null}
+              )}
             </Paragraph>
           </button>
         </Flex>

--- a/apps/drive-integration/src/locations/Page/components/overview/OverviewEntryList.tsx
+++ b/apps/drive-integration/src/locations/Page/components/overview/OverviewEntryList.tsx
@@ -3,6 +3,7 @@ import tokens from '@contentful/f36-tokens';
 import { cx } from '@emotion/css';
 import type { EntryListRow as OverviewEntryListRow } from '../../../../utils/overviewEntryList';
 import {
+  noMappedContentBadge,
   treeChildRowBase,
   treeChildRowLast,
   treeChildRowNotLast,
@@ -89,12 +90,12 @@ function OverviewEntryRowCard({
                   ({truncateLabel(row.entryTitle, 150)})
                 </Text>
               ) : null}
+              {row.hasNoMappedContent ? (
+                <Badge variant="secondary" size="small" className={noMappedContentBadge}>
+                  No mapped content
+                </Badge>
+              ) : null}
             </Paragraph>
-            {row.hasNoMappedContent ? (
-              <Badge variant="secondary" size="small">
-                No mapped content
-              </Badge>
-            ) : null}
           </button>
         </Flex>
       </Card>

--- a/apps/drive-integration/src/locations/Page/components/review/mapping/edit-modals/FieldSelectionDropdown.tsx
+++ b/apps/drive-integration/src/locations/Page/components/review/mapping/edit-modals/FieldSelectionDropdown.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useMemo } from 'react';
+import { useEffect, useId, useMemo, useRef } from 'react';
 import { Badge, Flex, FormControl, Text } from '@contentful/f36-components';
 import { Multiselect } from '@contentful/f36-multiselect';
 import type { EditModalFieldMapping, EditModalFieldOption } from '@types';
@@ -65,12 +65,15 @@ export const FieldSelectionDropdown = ({
     [fieldOptions, isImageContent, selectedText]
   );
 
+  const onSelectableStateChangeRef = useRef(onSelectableStateChange);
+  onSelectableStateChangeRef.current = onSelectableStateChange;
+
   useEffect(() => {
-    onSelectableStateChange?.({
+    onSelectableStateChangeRef.current?.({
       hasFieldOptions: fieldOptions.length > 0,
       hasSelectableOptions: selectableOptions.length > 0,
     });
-  }, [fieldOptions.length, isImageContent, onSelectableStateChange, selectableOptions.length]);
+  }, [fieldOptions.length, isImageContent, selectableOptions.length]);
 
   const handleSelectField = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { checked, value } = event.target;

--- a/apps/drive-integration/src/utils/overviewEntryList.ts
+++ b/apps/drive-integration/src/utils/overviewEntryList.ts
@@ -13,6 +13,7 @@ export interface EntryListRow {
   entryIndex: number;
   contentTypeName: string;
   entryTitle?: string;
+  hasNoMappedContent?: boolean;
   children: EntryListRow[];
 }
 
@@ -235,11 +236,14 @@ export function buildEntryListFromEntryBlockGraph(
     const contentTypeDisplayInfo = contentTypeDisplayInfoById.get(entry.contentTypeId);
     const entryTitle = getEntryTitleFromFieldMappings(entry, contentTypeDisplayInfo?.displayField);
 
+    const hasNoMappedContent = entry.fieldMappings.every((fm) => fm.sourceRefs.length === 0);
+
     return {
       id,
       entryIndex: index,
       contentTypeName: contentTypeNameById.get(entry.contentTypeId) ?? entry.contentTypeId,
       entryTitle,
+      hasNoMappedContent,
       children: childRows,
     };
   };

--- a/apps/drive-integration/test/locations/Page/Page.spec.tsx
+++ b/apps/drive-integration/test/locations/Page/Page.spec.tsx
@@ -78,7 +78,7 @@ vi.mock('../../../src/locations/Page/components/mainpage/ModalOrchestrator', () 
   ModalOrchestrator: require('react').forwardRef(
     (
       props: {
-        onAiAccessDenied: () => void;
+        onAiAccessDenied: (message: string) => void;
         onMappingReviewReady: (payload: MappingReviewSuspendPayload, runId: string) => void;
         onResetToMain: () => void;
         oauthToken: string;
@@ -109,7 +109,9 @@ vi.mock('../../../src/locations/Page/components/mainpage/ModalOrchestrator', () 
           <button onClick={props.onResetToMain} type="button">
             Trigger Reset To Main
           </button>
-          <button onClick={props.onAiAccessDenied} type="button">
+          <button
+            onClick={() => props.onAiAccessDenied?.('AI features are currently disabled')}
+            type="button">
             Trigger Modal AI Access Denied
           </button>
         </>

--- a/apps/drive-integration/test/locations/Page/components/review/mapping/MappingView.spec.tsx
+++ b/apps/drive-integration/test/locations/Page/components/review/mapping/MappingView.spec.tsx
@@ -866,7 +866,7 @@ describe('MappingView', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Edit content mapping' }));
 
     expect(screen.getByRole('heading', { name: 'Edit content mapping' })).toBeTruthy();
-    expect(screen.getByText('"fresh body text"')).toBeTruthy();
+    expect(screen.getByText('“fresh body text”')).toBeTruthy();
     expect(screen.getByText('Assign to fields')).toBeTruthy();
     expect(screen.getByText('Article: Untitled')).toBeTruthy();
     expect(mockClearSelection).toHaveBeenCalledTimes(1);

--- a/apps/drive-integration/test/utils/overviewEntryList.test.ts
+++ b/apps/drive-integration/test/utils/overviewEntryList.test.ts
@@ -164,6 +164,47 @@ describe('buildEntryListFromEntryBlockGraph', () => {
     expect(rows[0].entryTitle).toBe('Entry title');
   });
 
+  it('sets hasNoMappedContent to true when all fieldMappings have empty sourceRefs', () => {
+    const rows = buildEntryListFromEntryBlockGraph(
+      [
+        {
+          tempId: 'entry-1',
+          contentTypeId: 'article',
+          fieldMappings: [
+            { fieldId: 'title', fieldType: 'Symbol', sourceRefs: [], confidence: 0 },
+            { fieldId: 'body', fieldType: 'Text', sourceRefs: [], confidence: 0 },
+          ],
+        },
+      ],
+      contentTypes
+    );
+
+    expect(rows[0].hasNoMappedContent).toBe(true);
+  });
+
+  it('sets hasNoMappedContent to false when at least one fieldMapping has a sourceRef', () => {
+    const rows = buildEntryListFromEntryBlockGraph(
+      [
+        {
+          tempId: 'entry-1',
+          contentTypeId: 'article',
+          fieldMappings: [
+            {
+              fieldId: 'title',
+              fieldType: 'Symbol',
+              sourceRefs: [createTextSourceRef('Hello')],
+              confidence: 0.9,
+            },
+            { fieldId: 'body', fieldType: 'Text', sourceRefs: [], confidence: 0 },
+          ],
+        },
+      ],
+      contentTypes
+    );
+
+    expect(rows[0].hasNoMappedContent).toBe(false);
+  });
+
   it('truncates long display-field text using the first text source ref only', () => {
     const long = 'a'.repeat(100);
     const rows = buildEntryListFromEntryBlockGraph(


### PR DESCRIPTION
## Purpose
  
  Two independent fixes shipped together:

  1. Infinite re-render loop in EditModal – opening the edit modal caused a silent infinite render loop
  that locked the UI and hung vitest workers before any test could run.
  2. "No mapped content" badge on entry list rows – entries with no field mappings now show a No mapped 
  content badge in the overview entry list so users can spot unmapped entries at a glance.
  3. Fixed some Page and MappingView failing tests.

## Approach

  ### Infinite re-render fix (FieldSelectionDropdown)

  EditModal passes handleSelectableStateChangeForEntry(loc.id) as the onSelectableStateChange prop — a
  curried call made during render, producing a new function reference every render cycle. That reference
  was listed in the useEffect dependency array inside FieldSelectionDropdown, so every render triggered
  the effect → setState in EditModal → new render → new function → effect again → infinite loop.

  The fix stores the callback in a ref so the effect's deps only contain the actual data values
  (fieldOptions.length, isImageContent, selectableOptions.length), breaking the cycle.

  ### "No mapped content" badge

  - Added hasNoMappedContent flag to EntryListRow, computed in buildEntryListFromEntryBlockGraph by
  checking whether every fieldMapping has an empty sourceRefs array.
  - OverviewEntryRowCard renders a secondary Badge inline with the entry title when the flag is set.

## Testing steps

  ### Infinite loop fix:

  - Before:

> https://github.com/user-attachments/assets/601b48aa-0080-424c-a9b0-d33c99de73bd


  - Now:
  

> https://github.com/user-attachments/assets/6a509eca-d888-4042-a2b5-f67ab23a8bc2


  
  ### "No mapped content" badge:

> https://github.com/user-attachments/assets/ae4fb5b4-6a18-416e-9709-47beba07cada

  
## Breaking Changes

  No.

## Dependencies and/or References

  Link to [INTEG-3893](https://contentful.atlassian.net/jira/software/c/projects/INTEG/boards/454?issueParent=476933&selectedIssue=INTEG-3893)

## Deployment
  
  No.

[INTEG-3893]: https://contentful.atlassian.net/browse/INTEG-3893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ