### PR TITLE
fix(drive-integration): select first root entry when entering edit mode [INTEG-3881]

### DIFF
--- a/apps/drive-integration/src/locations/Page/components/review/ReviewPage.tsx
+++ b/apps/drive-integration/src/locations/Page/components/review/ReviewPage.tsx
@@ -209,7 +209,13 @@ export const ReviewPage = ({
     if (mode === 'view') {
       setSelectedEntryIndex(null);
     } else if (mode === 'edit' && selectedEntryIndex === null) {
-      setSelectedEntryIndex(entryBlockGraph.entries.length > 0 ? 0 : null);
+      const assignedChildTempIds = new Set(
+        (payload.referenceGraph.edges ?? []).map((e) => e.to)
+      );
+      const firstRootIndex = entryBlockGraph.entries.findIndex(
+        (e) => !e.tempId || !assignedChildTempIds.has(e.tempId)
+      );
+      setSelectedEntryIndex(firstRootIndex >= 0 ? firstRootIndex : null);
     }
   };
 

--- a/apps/drive-integration/src/locations/Page/components/review/ReviewPage.tsx
+++ b/apps/drive-integration/src/locations/Page/components/review/ReviewPage.tsx
@@ -209,9 +209,7 @@ export const ReviewPage = ({
     if (mode === 'view') {
       setSelectedEntryIndex(null);
     } else if (mode === 'edit' && selectedEntryIndex === null) {
-      const assignedChildTempIds = new Set(
-        (payload.referenceGraph.edges ?? []).map((e) => e.to)
-      );
+      const assignedChildTempIds = new Set((payload.referenceGraph.edges ?? []).map((e) => e.to));
       const firstRootIndex = entryBlockGraph.entries.findIndex(
         (e) => !e.tempId || !assignedChildTempIds.has(e.tempId)
       );


### PR DESCRIPTION
## Purpose

When switching to edit mode, the app auto-selects the first entry to display in the mapping editor. The default was always `entries[0]` (the first entry in the raw array), but the AI doesn't guarantee parents appear before children. If a child entry happened to be at index 0, the editor would open on that child while the overview panel showed a different entry (the root) at the top — a visible mismatch.

## Approach

Instead of hardcoding index `0`, derive which entries are children by collecting all `edge.to` tempIds from `payload.referenceGraph.edges`, then find the first entry whose tempId is not in that set (i.e. the first root):

```ts
const assignedChildTempIds = new Set(
  (payload.referenceGraph.edges ?? []).map((e) => e.to)
);
const firstRootIndex = entryBlockGraph.entries.findIndex(
  (e) => !e.tempId || !assignedChildTempIds.has(e.tempId)
);
setSelectedEntryIndex(firstRootIndex >= 0 ? firstRootIndex : null);
```

This mirrors the same logic `buildEntryListFromEntryBlockGraph` uses to determine root entries, so the auto-selected entry in the editor always matches what the user sees at the top of the overview list.

## Testing steps

Switch to edit mode with a payload where a child entry appears before its parent in the `entries` array (e.g. `blogPost_1` at index 0, `page_1` at index 1 referencing it). Verify the editor opens on `page_1` (the root) instead of `blogPost_1`.



https://github.com/user-attachments/assets/6a24306e-2c32-4467-b615-5c4b8f386bb7



## Breaking Changes

No.

## Dependencies and/or References

Link to [INTEG-3881](https://contentful.atlassian.net/jira/software/c/projects/INTEG/boards/454?selectedIssue=INTEG-3881)

## Deployment

No.

[INTEG-3881]: https://contentful.atlassian.net/browse/INTEG-3881