### PR TITLE
feat: add focal point aspect ratio previews [CCS-633]

### DIFF
--- a/apps/image-focal-point/src/__snapshots__/index.spec.jsx.snap
+++ b/apps/image-focal-point/src/__snapshots__/index.spec.jsx.snap
@@ -3,43 +3,47 @@
 exports[`App > #render > should render the extension field view 1`] = `
 <div>
   <div
-    class="css-rvp98e"
+    class="css-e585x0"
   >
-    <input
-      aria-describedby="focal-point-validation"
-      aria-invalid="true"
-      class="css-r283cc css-93644d"
-      data-test-id="focal-point"
-      disabled=""
-      id="focal-point"
-      type="text"
-      value="Focal point not set"
-      width="large"
-    />
-    <button
-      class="css-127ixdm css-dp0f2t"
-      data-test-id="cf-ui-button"
-      type="button"
+    <div
+      class="css-imi2tp"
     >
-      <span
-        class="css-40g50j"
+      <input
+        aria-describedby="focal-point-validation"
+        aria-invalid="true"
+        class="css-r283cc css-93644d"
+        data-test-id="focal-point"
+        disabled=""
+        id="focal-point"
+        type="text"
+        value="Focal point not set"
+        width="large"
+      />
+      <button
+        class="css-127ixdm css-9u48bm"
+        data-test-id="cf-ui-button"
+        type="button"
       >
-        Set focal point
-      </span>
-    </button>
-    <button
-      class="css-1ulo0xy"
-      data-test-id="cf-ui-text-link"
-      type="button"
-    >
-      <span
-        class="css-x1sij0"
-      >
-        <span>
-          Reset focal point
+        <span
+          class="css-40g50j"
+        >
+          Set focal point
         </span>
-      </span>
-    </button>
+      </button>
+      <button
+        class="css-1ulo0xy"
+        data-test-id="cf-ui-text-link"
+        type="button"
+      >
+        <span
+          class="css-x1sij0"
+        >
+          <span>
+            Reset focal point
+          </span>
+        </span>
+      </button>
+    </div>
   </div>
 </div>
 `;

--- a/apps/image-focal-point/src/components/AspectRatioPreviewGallery/AspectRatioPreviewGallery.jsx
+++ b/apps/image-focal-point/src/components/AspectRatioPreviewGallery/AspectRatioPreviewGallery.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Subheading } from '@contentful/f36-components';
+
+import { ImagePreviewWithFocalPoint } from '../ImagePreviewWithFocalPoint';
+import { styles } from './styles';
+
+const PREVIEW_RATIOS = [
+  { label: '16:9', width: 160, height: 90 },
+  { label: '4:3', width: 144, height: 108 },
+  { label: '1:1', width: 108, height: 108 },
+];
+
+export const AspectRatioPreviewGallery = ({
+  className = '',
+  file,
+  focalPoint,
+  title = 'Aspect ratio previews',
+}) => {
+  if (!file || !focalPoint) {
+    return null;
+  }
+
+  return (
+    <section className={`${styles.container} ${className}`.trim()} aria-label={title}>
+      {title && <Subheading className={styles.heading}>{title}</Subheading>}
+      <div className={styles.gallery}>
+        {PREVIEW_RATIOS.map(({ label, width, height }) => (
+          <ImagePreviewWithFocalPoint
+            key={label}
+            className={styles.preview}
+            file={file}
+            focalPoint={focalPoint}
+            wrapperWidth={width}
+            wrapperHeight={height}
+            subtitle={label}
+          />
+        ))}
+      </div>
+    </section>
+  );
+};
+
+AspectRatioPreviewGallery.propTypes = {
+  className: PropTypes.string,
+  file: PropTypes.shape({
+    url: PropTypes.string.isRequired,
+    fileName: PropTypes.string.isRequired,
+    details: PropTypes.shape({
+      image: PropTypes.shape({
+        width: PropTypes.number.isRequired,
+        height: PropTypes.number.isRequired,
+      }).isRequired,
+    }).isRequired,
+  }),
+  focalPoint: PropTypes.shape({
+    x: PropTypes.number.isRequired,
+    y: PropTypes.number.isRequired,
+  }),
+  title: PropTypes.string,
+};

--- a/apps/image-focal-point/src/components/AspectRatioPreviewGallery/AspectRatioPreviewGallery.spec.jsx
+++ b/apps/image-focal-point/src/components/AspectRatioPreviewGallery/AspectRatioPreviewGallery.spec.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import mockProps from '../../test/mockProps';
+import { AspectRatioPreviewGallery } from './AspectRatioPreviewGallery';
+
+const props = {
+  file: mockProps.file,
+  focalPoint: mockProps.focalPoint,
+};
+
+describe('AspectRatioPreviewGallery', () => {
+  it('renders focal point previews for common aspect ratios', () => {
+    const { getByText } = render(<AspectRatioPreviewGallery {...props} />);
+
+    expect(getByText('16:9')).toBeDefined();
+    expect(getByText('4:3')).toBeDefined();
+    expect(getByText('1:1')).toBeDefined();
+  });
+
+  it('does not render until an image and focal point are available', () => {
+    const { container } = render(<AspectRatioPreviewGallery file={mockProps.file} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/apps/image-focal-point/src/components/AspectRatioPreviewGallery/index.js
+++ b/apps/image-focal-point/src/components/AspectRatioPreviewGallery/index.js
@@ -1,0 +1,1 @@
+export { AspectRatioPreviewGallery } from './AspectRatioPreviewGallery';

--- a/apps/image-focal-point/src/components/AspectRatioPreviewGallery/styles.js
+++ b/apps/image-focal-point/src/components/AspectRatioPreviewGallery/styles.js
@@ -1,0 +1,27 @@
+import { css } from '@emotion/css';
+import tokens from '@contentful/f36-tokens';
+
+export const styles = {
+  container: css({
+    display: 'flex',
+    flexDirection: 'column',
+  }),
+  heading: css({
+    marginBottom: tokens.spacingXs,
+  }),
+  gallery: css({
+    display: 'flex',
+    alignItems: 'flex-start',
+    flexWrap: 'wrap',
+    gap: tokens.spacingM,
+  }),
+  preview: css({
+    '& > div': {
+      backgroundColor: tokens.gray200,
+      borderRadius: tokens.borderRadiusSmall,
+    },
+    '& img': {
+      display: 'block',
+    },
+  }),
+};

--- a/apps/image-focal-point/src/components/FocalPointDialog/FocalPointDialog.jsx
+++ b/apps/image-focal-point/src/components/FocalPointDialog/FocalPointDialog.jsx
@@ -2,8 +2,8 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Button, Subheading, Modal } from '@contentful/f36-components';
 
+import { AspectRatioPreviewGallery } from '../AspectRatioPreviewGallery';
 import { FocalPoint } from '../FocalPoint';
-import { ImagePreviewWithFocalPoint } from '../ImagePreviewWithFocalPoint';
 
 import { MAX_PREVIEW_WRAPPER_SIZE, styles } from './styles';
 
@@ -120,35 +120,7 @@ export class FocalPointDialog extends Component {
               </div>
             </div>
             <div className={styles.focalPointDemo}>
-              <Subheading className={styles.subheading}>
-                Preview for different screen sizes
-              </Subheading>
-              <div className={styles.displayFlex}>
-                <ImagePreviewWithFocalPoint
-                  file={file}
-                  focalPoint={focalPoint}
-                  wrapperWidth={410}
-                  wrapperHeight={180}
-                  subtitle="Desktop"
-                />
-              </div>
-              <div className={styles.displayFlex}>
-                <ImagePreviewWithFocalPoint
-                  file={file}
-                  focalPoint={focalPoint}
-                  wrapperWidth={280}
-                  wrapperHeight={180}
-                  subtitle="Tablet"
-                />
-                <ImagePreviewWithFocalPoint
-                  className={styles.spacingLeftXs}
-                  file={file}
-                  focalPoint={focalPoint}
-                  wrapperWidth={120}
-                  wrapperHeight={180}
-                  subtitle="Mobile"
-                />
-              </div>
+              <AspectRatioPreviewGallery file={file} focalPoint={focalPoint} />
             </div>
           </div>
         </Modal.Content>

--- a/apps/image-focal-point/src/components/FocalPointView/FocalPointView.jsx
+++ b/apps/image-focal-point/src/components/FocalPointView/FocalPointView.jsx
@@ -2,33 +2,55 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, TextInput, TextLink } from '@contentful/f36-components';
 
+import { AspectRatioPreviewGallery } from '../AspectRatioPreviewGallery';
 import { styles } from './styles';
 
-const FocalPointView = ({ focalPoint = { x: 0, y: 0 }, showFocalPointDialog, resetFocalPoint }) => {
+const DEFAULT_FOCAL_POINT = { x: 0, y: 0 };
+
+const FocalPointView = ({
+  file,
+  focalPoint: selectedFocalPoint,
+  showFocalPointDialog,
+  resetFocalPoint,
+}) => {
+  const focalPoint = selectedFocalPoint === undefined ? DEFAULT_FOCAL_POINT : selectedFocalPoint;
   const value = focalPoint ? `x: ${focalPoint.x}px / y: ${focalPoint.y}px` : 'Focal point not set';
   return (
     <div className={styles.container}>
-      <TextInput
-        className={styles.input}
-        width="large"
-        type="text"
-        id="focal-point"
-        testId="focal-point"
-        value={value}
-        isInvalid={!focalPoint}
-        isDisabled
-      />
-      <Button className={styles.button} variant="secondary" onClick={showFocalPointDialog}>
-        Set focal point
-      </Button>
-      <TextLink as="button" variant="primary" onClick={() => resetFocalPoint()}>
-        Reset focal point
-      </TextLink>
+      <div className={styles.controls}>
+        <TextInput
+          className={styles.input}
+          width="large"
+          type="text"
+          id="focal-point"
+          testId="focal-point"
+          value={value}
+          isInvalid={!focalPoint}
+          isDisabled
+        />
+        <Button className={styles.button} variant="secondary" onClick={showFocalPointDialog}>
+          Set focal point
+        </Button>
+        <TextLink as="button" variant="primary" onClick={() => resetFocalPoint()}>
+          Reset focal point
+        </TextLink>
+      </div>
+      <AspectRatioPreviewGallery file={file} focalPoint={selectedFocalPoint} />
     </div>
   );
 };
 
 FocalPointView.propTypes = {
+  file: PropTypes.shape({
+    url: PropTypes.string.isRequired,
+    fileName: PropTypes.string.isRequired,
+    details: PropTypes.shape({
+      image: PropTypes.shape({
+        width: PropTypes.number.isRequired,
+        height: PropTypes.number.isRequired,
+      }).isRequired,
+    }).isRequired,
+  }),
   focalPoint: PropTypes.shape({
     x: PropTypes.number.isRequired,
     y: PropTypes.number.isRequired,

--- a/apps/image-focal-point/src/components/FocalPointView/FocalPointView.spec.jsx
+++ b/apps/image-focal-point/src/components/FocalPointView/FocalPointView.spec.jsx
@@ -2,9 +2,11 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { vi } from 'vitest';
 
+import mockProps from '../../test/mockProps';
 import { FocalPointView } from './FocalPointView';
 
 const props = {
+  file: mockProps.file,
   focalPoint: {
     x: 10,
     y: 30,
@@ -15,7 +17,11 @@ const props = {
 
 describe('FocalPointView', () => {
   it('should render the focal point field view', () => {
-    const { container } = render(<FocalPointView {...props} />);
+    const { container, getByText } = render(<FocalPointView {...props} />);
+
+    expect(getByText('16:9')).toBeDefined();
+    expect(getByText('4:3')).toBeDefined();
+    expect(getByText('1:1')).toBeDefined();
     expect(container).toBeDefined();
   });
 });

--- a/apps/image-focal-point/src/components/FocalPointView/styles.js
+++ b/apps/image-focal-point/src/components/FocalPointView/styles.js
@@ -4,14 +4,20 @@ import tokens from '@contentful/f36-tokens';
 export const styles = {
   container: css({
     display: 'flex',
+    alignItems: 'flex-start',
+    flexDirection: 'column',
+    gap: tokens.spacingM,
+  }),
+  controls: css({
+    display: 'flex',
     alignItems: 'center',
-    gap: '1rem',
+    flexWrap: 'wrap',
+    gap: tokens.spacingXs,
   }),
   input: css({
     maxWidth: '280px',
   }),
   button: css({
-    marginLeft: tokens.spacingXs,
     marginRight: tokens.spacingXs,
   }),
 };

--- a/apps/image-focal-point/src/index.jsx
+++ b/apps/image-focal-point/src/index.jsx
@@ -24,24 +24,36 @@ export class App extends React.Component {
 
   detachExternalChangeHandler = null;
 
+  detachImageChangeHandler = null;
+
+  isMounted = false;
+
   constructor(props) {
     super(props);
     this.state = {
       value: props.sdk.field.getValue() || { focalPoint: null },
+      imageFile: null,
     };
   }
 
   componentDidMount() {
     const { sdk } = this.props;
+    this.isMounted = true;
     sdk.window.startAutoResizer();
 
     // Handler for external field value changes (e.g. when multiple authors are working on the same entry).
     this.detachExternalChangeHandler = sdk.field.onValueChanged(this.onExternalChange);
+    this.detachImageChangeHandler = this.getImageEntryField()?.onValueChanged?.(this.loadImageFile);
+    this.loadImageFile();
   }
 
   componentWillUnmount() {
+    this.isMounted = false;
     if (this.detachExternalChangeHandler) {
       this.detachExternalChangeHandler();
+    }
+    if (this.detachImageChangeHandler) {
+      this.detachImageChangeHandler();
     }
   }
 
@@ -61,14 +73,49 @@ export class App extends React.Component {
     }
   };
 
-  findProperLocale() {
+  getImageEntryField() {
     const imageFieldId = getImageFieldId(this.props.sdk);
-    const imageField = this.props.sdk.entry.fields[imageFieldId];
+    return this.props.sdk.entry?.fields?.[imageFieldId];
+  }
 
-    return imageField.locales.includes(this.props.sdk.field.locale)
+  findProperLocale() {
+    const imageField = this.getImageEntryField();
+
+    return imageField?.locales?.includes(this.props.sdk.field.locale)
       ? this.props.sdk.field.locale
       : this.props.sdk.locales.default;
   }
+
+  getImageFile = async () => {
+    const { sdk } = this.props;
+    const imageField = this.getImageEntryField();
+    const locale = this.findProperLocale();
+    const assetId = imageField?.getValue?.(locale)?.sys?.id;
+
+    if (!assetId || !sdk.space?.getAsset) {
+      return null;
+    }
+
+    const asset = await sdk.space.getAsset(assetId);
+    const files = asset?.fields?.file || {};
+
+    return files[locale] ?? files[sdk.locales.default] ?? null;
+  };
+
+  isPreviewableImageFile = (file) => !!(file?.url && /image\/.*/.test(file.contentType));
+
+  loadImageFile = async () => {
+    try {
+      const file = await this.getImageFile();
+      if (this.isMounted) {
+        this.setState({ imageFile: this.isPreviewableImageFile(file) ? file : null });
+      }
+    } catch (e) {
+      if (this.isMounted) {
+        this.setState({ imageFile: null });
+      }
+    }
+  };
 
   resetFocalPoint = () => {
     this.setState({ value: { focalPoint: null } });
@@ -89,26 +136,20 @@ export class App extends React.Component {
 
   showFocalPointDialog = async () => {
     const {
-      sdk: { notifier, space, entry },
+      sdk: { notifier },
     } = this.props;
 
     try {
-      const imageFieldId = getImageFieldId(this.props.sdk);
-      const imageField = entry.fields[imageFieldId];
-      const asset = await space.getAsset(imageField.getValue(this.findProperLocale()).sys.id);
-      const file =
-        asset.fields.file[this.findProperLocale()] ??
-        asset.fields.file[this.props.sdk.locales.default];
-      const imageUrl = file.url;
-      const isOfImageMimeType = /image\/.*/.test(file.contentType);
-
-      if (!isOfImageMimeType) {
-        notifier.error('The uploaded asset must be an image');
-        return;
-      }
+      const file = await this.getImageFile();
+      const imageUrl = file?.url;
 
       if (!imageUrl) {
         notifier.error('Add an image to the entry first');
+        return;
+      }
+
+      if (!this.isPreviewableImageFile(file)) {
+        notifier.error('The uploaded asset must be an image');
         return;
       }
 
@@ -140,6 +181,7 @@ export class App extends React.Component {
         <FocalPointView
           showFocalPointDialog={this.showFocalPointDialog}
           focalPoint={this.state.value.focalPoint}
+          file={this.state.imageFile}
           resetFocalPoint={this.resetFocalPoint}
         />
       );

--- a/apps/image-focal-point/src/index.spec.jsx
+++ b/apps/image-focal-point/src/index.spec.jsx
@@ -19,6 +19,7 @@ const sdk = {
 };
 
 vi.mock('./utils', () => ({
+  clamp: (num, min, max) => Math.min(Math.max(num, min), max),
   getField: vi.fn(),
   isCompatibleImageField: () => true,
 }));
@@ -51,6 +52,44 @@ describe('App', () => {
   it('should call startAutoResizer', () => {
     renderComponent(sdk);
     expect(sdk.window.startAutoResizer).toHaveBeenCalled();
+  });
+
+  it('should render aspect ratio previews for the linked image asset', async () => {
+    const imageField = {
+      locales: ['en-US'],
+      getValue: vi.fn(() => ({ sys: { id: 'asset-id' } })),
+      onValueChanged: vi.fn(),
+    };
+    const sdkWithImage = {
+      ...sdk,
+      entry: {
+        fields: {
+          image: imageField,
+        },
+      },
+      field: {
+        ...sdk.field,
+        locale: 'en-US',
+        getValue: vi.fn(() => ({ focalPoint: mockProps.focalPoint })),
+      },
+      space: {
+        getAsset: vi.fn(() =>
+          Promise.resolve({
+            fields: {
+              file: {
+                'en-US': mockProps.file,
+              },
+            },
+          })
+        ),
+      },
+    };
+    const { findByText } = renderComponent(sdkWithImage);
+
+    expect(await findByText('16:9')).toBeDefined();
+    expect(await findByText('4:3')).toBeDefined();
+    expect(await findByText('1:1')).toBeDefined();
+    expect(sdkWithImage.space.getAsset).toHaveBeenCalledWith('asset-id');
   });
 
   describe('#render', () => {


### PR DESCRIPTION
## Summary
- Add an aspect ratio preview gallery for Image Focal Point crops
- Render 16:9, 4:3, and 1:1 previews from the current linked image and selected focal point
- Reuse the same gallery in the focal point dialog

## Validation
- npm run test:ci
- npm run build
- ./.circleci/prettier-check.sh
- npm run verify-config
- Browser harness visual check

## Notes
- Root npm run build was blocked locally before Image Focal Point ran because Lerna also picked up an unrelated dirty google-docs package with missing local test type definitions.