### PR TITLE
fix(drive-integration): multiselect popover misalignment when list is not scrollable [INTEG-4038]

### DIFF
--- a/apps/drive-integration/src/hooks/useMultiselectReflow.ts
+++ b/apps/drive-integration/src/hooks/useMultiselectReflow.ts
@@ -4,25 +4,10 @@ export const useMultiselectScrollReflow = <T>(selection: T[]): RefObject<HTMLULi
   const listRef = useRef<HTMLUListElement>(null);
 
   useEffect(() => {
-    if (listRef.current) {
-      const element = listRef.current;
-      const currentScroll = element.scrollTop;
-      const maxScroll = element.scrollHeight - element.clientHeight;
-
-      if (maxScroll > 0) {
-        if (currentScroll >= maxScroll) {
-          element.scrollTop = currentScroll - 1;
-        } else {
-          element.scrollTop = currentScroll + 1;
-        }
-        element.scrollTop = currentScroll;
-      } else {
-        // When the filtered list is too short to scroll, the nudge above produces no scroll
-        // event, so Floating UI never repositions the popover. Dispatching a resize event
-        // is the reliable fallback — autoUpdate listens to window resize by default.
-        window.dispatchEvent(new Event('resize'));
-      }
-    }
+    // Floating UI's autoUpdate listens to window resize to reposition the popover.
+    // Dispatching a resize event on selection change ensures the portal realigns
+    // regardless of whether the filtered list is scrollable.
+    window.dispatchEvent(new Event('resize'));
   }, [selection]);
 
   return listRef;

--- a/apps/drive-integration/src/hooks/useMultiselectReflow.ts
+++ b/apps/drive-integration/src/hooks/useMultiselectReflow.ts
@@ -9,13 +9,19 @@ export const useMultiselectScrollReflow = <T>(selection: T[]): RefObject<HTMLULi
       const currentScroll = element.scrollTop;
       const maxScroll = element.scrollHeight - element.clientHeight;
 
-      if (currentScroll >= maxScroll) {
-        element.scrollTop = currentScroll - 1;
+      if (maxScroll > 0) {
+        if (currentScroll >= maxScroll) {
+          element.scrollTop = currentScroll - 1;
+        } else {
+          element.scrollTop = currentScroll + 1;
+        }
+        element.scrollTop = currentScroll;
       } else {
-        element.scrollTop = currentScroll + 1;
+        // When the filtered list is too short to scroll, the nudge above produces no scroll
+        // event, so Floating UI never repositions the popover. Dispatching a resize event
+        // is the reliable fallback — autoUpdate listens to window resize by default.
+        window.dispatchEvent(new Event('resize'));
       }
-
-      element.scrollTop = currentScroll;
     }
   }, [selection]);
 


### PR DESCRIPTION
## Purpose

When a search query filters the multiselect list short enough that it is no longer scrollable, the popover portal loses alignment with the trigger input. The previous reflow hack relied on nudging `scrollTop` to trigger a scroll event — but when `maxScroll === 0`, no scroll event fires and Floating UI never repositions.

## Approach

Replace the scroll-nudge trick in `useMultiselectScrollReflow` with `window.dispatchEvent(new Event('resize'))`. Floating UI's `autoUpdate` subscribes to `window` resize events by default, so this always triggers a position recalculation regardless of list height. The fix is simpler, more robust, and applies uniformly to all three consumers of the hook:

- `step_2/ContentTypePickerModal.tsx`
- `step_3/SelectTabsModal.tsx`
- `review/mapping/edit-modals/FieldSelectionDropdown.tsx`

## Testing steps

1. Open the Drive Integration page app
2. Open the content type picker modal (step 2)
3. Type a search query that narrows the list to a few items (non-scrollable)
4. Select an item — verify the popover stays aligned with the input
5. Clear the search and repeat with a full-length scrollable list — verify alignment still holds
6. Repeat steps 2–5 on the tab selection modal (step 3) and the field selection dropdown in the mapping review screen

Before:


https://github.com/user-attachments/assets/88af0cb7-d6dc-4548-bc72-cf9e3ce0e432



Now:


https://github.com/user-attachments/assets/2b9bf107-3946-4f0c-ae7d-f8e94fc6931d



## Breaking Changes

No.

## Dependencies and/or References

Link to [INTEG-4038](https://contentful.atlassian.net/jira/software/c/projects/INTEG/boards/454?issueParent=483434&selectedIssue=INTEG-4038)

## Deployment

No.

🤖 Co-authored with [Claude Code](https://claude.ai/code)

[INTEG-4038]: https://contentful.atlassian.net/browse/INTEG-4038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ