### PR TITLE
fix(content-insights): remove org-scoped app installations query [EXT-7458]

### DIFF
--- a/apps/content-insights/src/hooks/useInstallationParameters.ts
+++ b/apps/content-insights/src/hooks/useInstallationParameters.ts
@@ -1,53 +1,25 @@
-import { useEffect, useState } from 'react';
 import { BaseAppSDK } from '@contentful/app-sdk';
-import { AppInstallationProps, KeyValueMap } from 'contentful-management';
 import { AppInstallationParameters } from '../locations/ConfigScreen';
 
+/**
+ * Returns installation parameters directly from the SDK.
+ *
+ * Previously this hook made an expensive org-scoped CMA call
+ * (`appInstallation.getForOrganization`) on every mount to re-fetch params.
+ * That is unnecessary because `sdk.parameters.installation` already contains
+ * the current installation parameters, and the extra call was contributing to
+ * CMA rate-limit pressure (see INC-1276).
+ *
+ * The return shape `{ installation, refetchInstallationParameters }` is
+ * preserved for backward compatibility; `refetchInstallationParameters` is now
+ * a no-op.
+ */
 export const useInstallationParameters = (sdk: BaseAppSDK) => {
-  const [parameters, setParameters] = useState<KeyValueMap>(sdk.parameters.installation);
-
-  useEffect(() => {
-    const fetch = async () => {
-      const newParameters = await fetchParameters(sdk);
-      setParameters(newParameters);
-    };
-    fetch();
-  }, [sdk]);
+  const installation = (sdk.parameters.installation ?? {}) as AppInstallationParameters;
 
   const refetchInstallationParameters = async () => {
-    const newParameters = await fetchParameters(sdk);
-    setParameters(newParameters);
+    // No-op: parameters are read directly from the SDK at render time.
   };
 
-  const installation = (parameters ?? {}) as AppInstallationParameters;
-
   return { installation, refetchInstallationParameters };
-};
-
-const fetchParameters = async (sdk: BaseAppSDK): Promise<KeyValueMap> => {
-  try {
-    if (!sdk.ids.organization || !sdk.ids.app || !sdk.ids.space || !sdk.ids.environment) {
-      throw new Error('Required SDK IDs not available');
-    }
-
-    const appInstallation = await sdk.cma.appInstallation.getForOrganization({
-      appDefinitionId: sdk.ids.app,
-      organizationId: sdk.ids.organization,
-    });
-
-    const currentInstallation = appInstallation.items.find(
-      (installation: AppInstallationProps) =>
-        installation.sys.space.sys.id === sdk.ids.space &&
-        installation.sys.environment.sys.id === sdk.ids.environment
-    );
-
-    if (currentInstallation?.parameters) {
-      return currentInstallation.parameters as KeyValueMap;
-    }
-    return sdk.parameters.installation;
-  } catch (error) {
-    console.warn('Failed to fetch fresh parameters from CMA:', error);
-  }
-
-  return sdk.parameters.installation;
 };

--- a/apps/content-insights/test/mocks/mockCma.ts
+++ b/apps/content-insights/test/mocks/mockCma.ts
@@ -15,22 +15,7 @@ const mockCma: any = {
   entry: {
     getMany: vi.fn(),
   },
-  appInstallation: {
-    getForOrganization: vi.fn().mockResolvedValue({
-      items: [
-        {
-          sys: {
-            space: {
-              sys: {
-                id: 'test-space',
-              },
-            },
-          },
-          parameters: {},
-        },
-      ],
-    }),
-  },
+  appInstallation: {},
   user: {
     getForSpace: vi.fn().mockResolvedValue({
       sys: {


### PR DESCRIPTION
## Summary

- **Removes an expensive org-scoped CMA call** (`appInstallation.getForOrganization`) that the `useInstallationParameters` hook was making on every component mount. This call fetched all installations across the entire org just to find the current one — completely unnecessary since `sdk.parameters.installation` already has the params.
- **Reduces CMA rate-limit pressure** observed in INC-1276, where content-insights was contributing to elevated API usage on customer orgs with many spaces/environments.
- **Preserves the hook's public API** (`{ installation, refetchInstallationParameters }`) so no callers need updating — `refetchInstallationParameters` becomes a no-op.

## Test plan

- [x] All 162 existing tests pass (24 test files)
- [ ] Verify in a staging environment that the Content Insights dashboard still renders correctly with installation parameters
- [ ] Confirm no `getForOrganization` calls appear in network tab after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)