### PR TITLE
fix(auto-prefix): remove org-scoped app installations query [EXT-7458]

### DIFF
--- a/apps/auto-prefix/src/hooks/useInstallationParameters.ts
+++ b/apps/auto-prefix/src/hooks/useInstallationParameters.ts
@@ -1,43 +1,12 @@
-import { useEffect, useState } from 'react';
 import { BaseAppSDK } from '@contentful/app-sdk';
-import { AppInstallationProps, KeyValueMap } from 'contentful-management';
+import { KeyValueMap } from 'contentful-management';
+import { AppInstallationParameters } from '../utils/types';
 
-export const useInstallationParameters = (sdk: BaseAppSDK) => {
-  const [parameters, setParameters] = useState<KeyValueMap>(sdk.parameters.installation);
-
-  useEffect(() => {
-    const fetch = async () => {
-      const newParameters = await fetchParameters(sdk);
-      setParameters(newParameters);
-    };
-    fetch();
-  }, [sdk]);
-
-  return parameters;
+const DEFAULT_PARAMETERS: AppInstallationParameters = {
+  separator: '',
+  rules: [],
 };
 
-const fetchParameters = async (sdk: BaseAppSDK): Promise<KeyValueMap> => {
-  try {
-    if (!sdk.ids.organization || !sdk.ids.app || !sdk.ids.space) {
-      throw new Error('Required SDK IDs not available');
-    }
-
-    const appInstallation = await sdk.cma.appInstallation.getForOrganization({
-      appDefinitionId: sdk.ids.app,
-      organizationId: sdk.ids.organization,
-    });
-
-    const currentInstallation = appInstallation.items.find(
-      (installation: AppInstallationProps) => installation.sys.space.sys.id === sdk.ids.space
-    );
-
-    if (currentInstallation?.parameters) {
-      return currentInstallation.parameters as KeyValueMap;
-    }
-    return sdk.parameters.installation;
-  } catch (error) {
-    console.warn('Failed to fetch fresh parameters from CMA:', error);
-  }
-
-  return sdk.parameters.installation;
+export const useInstallationParameters = (sdk: BaseAppSDK): KeyValueMap => {
+  return sdk.parameters.installation ?? DEFAULT_PARAMETERS;
 };

--- a/apps/auto-prefix/test/hooks/useInstallationParameters.spec.ts
+++ b/apps/auto-prefix/test/hooks/useInstallationParameters.spec.ts
@@ -1,160 +1,82 @@
-import { renderHook, waitFor } from '@testing-library/react';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useInstallationParameters } from '../../src/hooks/useInstallationParameters';
 import { createMockSdk } from '../mocks/mockSdk';
-import { createMockCma } from '../mocks/mockCma';
 import { AppInstallationParameters } from '../../src/utils/types';
-import { AppInstallationProps } from 'contentful-management';
 
 describe('useInstallationParameters', () => {
-  let mockCma: ReturnType<typeof createMockCma>;
   let mockSdk: ReturnType<typeof createMockSdk>;
-  const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockCma = createMockCma();
     mockSdk = createMockSdk({
-      ids: {
-        app: 'test-app',
-        space: 'test-space',
-        organization: 'test-org',
-        environment: 'test-environment',
-      },
       parameters: {
         installation: {
           rules: [],
-          separator: '',
+          separator: '-',
         } as AppInstallationParameters,
       },
-      cma: mockCma,
     });
   });
 
-  afterEach(() => {
-    consoleWarnSpy.mockClear();
-  });
+  it('should return sdk.parameters.installation directly', () => {
+    const { result } = renderHook(() => useInstallationParameters(mockSdk));
 
-  describe('Initial state', () => {
-    it('should return initial parameters from sdk.parameters.installation', () => {
-      const { result } = renderHook(() => useInstallationParameters(mockSdk));
-
-      expect(result.current).toEqual({
-        rules: [],
-        separator: '',
-      });
+    expect(result.current).toEqual({
+      rules: [],
+      separator: '-',
     });
   });
 
-  describe('Successful parameter fetch', () => {
-    it('should fetch and return fresh parameters from CMA when installation matches space', async () => {
-      const freshParameters: AppInstallationParameters = {
-        rules: [
-          {
-            id: 'rule-1',
-            parentField: {
-              fieldUniqueId: 'blog-post.slug',
-              fieldId: 'slug',
-              fieldName: 'Slug',
-              contentTypeId: 'blog-post',
-              contentTypeName: 'Blog Post',
-              displayName: 'Slug | Blog Post',
-            },
-            referenceField: {
-              fieldUniqueId: 'blog-post.slug',
-              fieldId: 'slug',
-              fieldName: 'Slug',
-              contentTypeId: 'blog-post',
-              contentTypeName: 'Blog Post',
-              displayName: 'Slug | Blog Post',
-            },
+  it('should return default parameters when sdk.parameters.installation is undefined', () => {
+    mockSdk = createMockSdk({
+      parameters: {
+        installation: undefined,
+      },
+    });
+
+    const { result } = renderHook(() => useInstallationParameters(mockSdk));
+
+    expect(result.current).toEqual({
+      rules: [],
+      separator: '',
+    });
+  });
+
+  it('should return parameters with rules when configured', () => {
+    const configuredParameters: AppInstallationParameters = {
+      rules: [
+        {
+          id: 'rule-1',
+          parentField: {
+            fieldUniqueId: 'blog-post.title',
+            fieldId: 'title',
+            fieldName: 'Title',
+            contentTypeId: 'blog-post',
+            contentTypeName: 'Blog Post',
+            displayName: 'Title | Blog Post',
           },
-        ],
-        separator: '_',
-      };
-
-      const mockInstallation = {
-        sys: {
-          id: 'installation-1',
-          space: {
-            sys: {
-              id: 'test-space',
-              type: 'Link',
-              linkType: 'Space',
-            },
+          referenceField: {
+            fieldUniqueId: 'blog-post.slug',
+            fieldId: 'slug',
+            fieldName: 'Slug',
+            contentTypeId: 'blog-post',
+            contentTypeName: 'Blog Post',
+            displayName: 'Slug | Blog Post',
           },
         },
-        parameters: freshParameters,
-      } as unknown as AppInstallationProps;
+      ],
+      separator: '_',
+    };
 
-      mockCma.appInstallation.getForOrganization = vi.fn().mockResolvedValue({
-        items: [mockInstallation],
-      });
-
-      const { result } = renderHook(() => useInstallationParameters(mockSdk));
-
-      await waitFor(() => {
-        expect(result.current).toEqual(freshParameters);
-      });
-
-      expect(mockCma.appInstallation.getForOrganization).toHaveBeenCalledWith({
-        appDefinitionId: 'test-app',
-        organizationId: 'test-org',
-      });
+    mockSdk = createMockSdk({
+      parameters: {
+        installation: configuredParameters,
+      },
     });
 
-    it('should return sdk parameters when no installation matches the space', async () => {
-      const mockInstallation = {
-        sys: {
-          id: 'installation-1',
-          space: {
-            sys: {
-              id: 'other-space',
-              type: 'Link',
-              linkType: 'Space',
-            },
-          },
-        },
-        parameters: {
-          rules: [],
-          separator: '_',
-        },
-      } as unknown as AppInstallationProps;
+    const { result } = renderHook(() => useInstallationParameters(mockSdk));
 
-      mockCma.appInstallation.getForOrganization = vi.fn().mockResolvedValue({
-        items: [mockInstallation],
-      });
-
-      const { result } = renderHook(() => useInstallationParameters(mockSdk));
-
-      await waitFor(() => {
-        expect(result.current).toEqual({
-          rules: [],
-          separator: '',
-        });
-      });
-    });
-  });
-
-  describe('Error handling', () => {
-    it('should fallback to sdk parameters when CMA fetch fails', async () => {
-      mockCma.appInstallation.getForOrganization = vi
-        .fn()
-        .mockRejectedValue(new Error('Network error'));
-
-      const { result } = renderHook(() => useInstallationParameters(mockSdk));
-
-      await waitFor(() => {
-        expect(result.current).toEqual({
-          rules: [],
-          separator: '',
-        });
-      });
-
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
-        'Failed to fetch fresh parameters from CMA:',
-        expect.any(Error)
-      );
-    });
+    expect(result.current).toEqual(configuredParameters);
   });
 });

--- a/apps/auto-prefix/test/mocks/mockCma.ts
+++ b/apps/auto-prefix/test/mocks/mockCma.ts
@@ -12,9 +12,6 @@ const createMockCma = () => {
     contentType: {
       getMany: vi.fn(),
     },
-    appInstallation: {
-      getForOrganization: vi.fn(),
-    },
   };
 };
 


### PR DESCRIPTION
## Summary

- **Removes expensive org-scoped CMA call** (`appInstallation.getForOrganization()`) that fired on every Field location mount
- **Replaces with synchronous read** of `sdk.parameters.installation` which already contains the current parameters
- **Cleans up** associated test mocks and async test patterns that are no longer needed

## Context

Reported via INC-1276: the `useInstallationParameters` hook in the auto-prefix app was making an org-scoped query to fetch app installations across the entire organization, then filtering to find the current space's installation. This is wholly unnecessary — the App SDK already provides `sdk.parameters.installation` with the exact same data, populated at mount time by the platform.

The org-scoped call is expensive (scales with number of spaces the app is installed in), requires elevated permissions, and adds latency to every field render.

## Test plan

- [x] All 43 existing tests pass (`npm test` in `apps/auto-prefix`)
- [ ] Manual: install auto-prefix app, verify Field location renders with correct parameters
- [ ] Verify no network call to `/app_installations` in browser devtools

🤖 Generated with [Claude Code](https://claude.com/claude-code)