### PR TITLE
fix(phosphor-icon): remove org-scoped app installations query [EXT-7458]

### DIFF
--- a/apps/phosphor-icon/src/locations/Field.spec.tsx
+++ b/apps/phosphor-icon/src/locations/Field.spec.tsx
@@ -15,34 +15,15 @@ describe('Field', () => {
     mockSdk = createMockFieldSdk();
   });
 
-  it('opens the dialog with the latest installation parameters', async () => {
+  it('opens the dialog with installation parameters from the SDK', async () => {
     const fieldSdk = createMockFieldSdk({
       installationParameters: {
-        enabledWeights: JSON.stringify(['regular']),
-        positionOptions: JSON.stringify(['start']),
-        iconAvailabilityMode: 'all',
-      },
-      liveInstallationParameters: {
         enabledWeights: JSON.stringify(['bold', 'duotone']),
         positionOptions: JSON.stringify(['end', 'top']),
         iconAvailabilityMode: 'specific',
         selectedIconNames: JSON.stringify(['airplane', 'anchor']),
       },
     });
-    fieldSdk.cma = {
-      appInstallation: {
-        get: vi.fn(() =>
-          Promise.resolve({
-            parameters: {
-              enabledWeights: JSON.stringify(['bold', 'duotone']),
-              positionOptions: JSON.stringify(['end', 'top']),
-              iconAvailabilityMode: 'specific',
-              selectedIconNames: JSON.stringify(['airplane', 'anchor']),
-            },
-          })
-        ),
-      },
-    } as never;
     mockSdk = fieldSdk;
 
     render(<Field />);
@@ -75,25 +56,7 @@ describe('Field', () => {
         positionOptions: JSON.stringify(['start']),
         iconAvailabilityMode: 'all',
       },
-      liveInstallationParameters: {
-        enabledWeights: JSON.stringify(['regular']),
-        positionOptions: JSON.stringify(['start']),
-        iconAvailabilityMode: 'all',
-      },
     });
-    fieldSdk.cma = {
-      appInstallation: {
-        get: vi.fn(() =>
-          Promise.resolve({
-            parameters: {
-              enabledWeights: JSON.stringify(['regular']),
-              positionOptions: JSON.stringify(['start']),
-              iconAvailabilityMode: 'all',
-            },
-          })
-        ),
-      },
-    } as never;
     mockSdk = fieldSdk;
 
     render(<Field />);

--- a/apps/phosphor-icon/src/locations/Field.tsx
+++ b/apps/phosphor-icon/src/locations/Field.tsx
@@ -4,7 +4,7 @@ import { css } from 'emotion';
 import { FieldAppSDK } from '@contentful/app-sdk';
 import { useSDK } from '@contentful/react-apps-toolkit';
 import { IconPreview } from '../components/IconPreview/IconPreview';
-import type { IconFieldValue, IconWeight } from '../types/icon';
+import type { IconFieldValue } from '../types/icon';
 import { ICON_WEIGHT_LABELS } from '../types/icon';
 import type { AppInstallationParameters, DialogInvocationParameters } from '../types/parameters';
 import {
@@ -39,8 +39,8 @@ const Field = () => {
   const sdk = useSDK<FieldAppSDK>();
   const [value, setValue] = useState<IconFieldValue | null>(sdk.field.getValue() ?? null);
   const [isOpeningDialog, setIsOpeningDialog] = useState(false);
-  const [enabledWeights, setEnabledWeights] = useState<IconWeight[]>(
-    parseEnabledWeights((sdk.parameters.installation as AppInstallationParameters)?.enabledWeights)
+  const enabledWeights = parseEnabledWeights(
+    (sdk.parameters.installation as AppInstallationParameters)?.enabledWeights
   );
 
   useEffect(() => {
@@ -55,71 +55,9 @@ const Field = () => {
     return () => detach();
   }, [sdk.field]);
 
-  const fetchLatestInstallationParameters =
-    useCallback(async (): Promise<AppInstallationParameters> => {
-      try {
-        if (!sdk.ids.app) {
-          throw new Error('Required app ID not available');
-        }
-
-        if (
-          sdk.cma?.appInstallation &&
-          typeof sdk.cma.appInstallation.getForOrganization === 'function' &&
-          sdk.ids.organization &&
-          sdk.ids.space &&
-          sdk.ids.environment
-        ) {
-          const appInstallation = await sdk.cma.appInstallation.getForOrganization({
-            appDefinitionId: sdk.ids.app,
-            organizationId: sdk.ids.organization,
-          });
-
-          const currentInstallation = appInstallation.items.find(
-            (installation) =>
-              installation.sys.space.sys.id === sdk.ids.space &&
-              installation.sys.environment.sys.id === sdk.ids.environment
-          );
-
-          if (currentInstallation?.parameters) {
-            return currentInstallation.parameters as AppInstallationParameters;
-          }
-        }
-
-        if (sdk.cma?.appInstallation && typeof sdk.cma.appInstallation.get === 'function') {
-          const appInstallation = await sdk.cma.appInstallation.get({
-            appDefinitionId: sdk.ids.app,
-          });
-
-          if (appInstallation?.parameters) {
-            return appInstallation.parameters as AppInstallationParameters;
-          }
-        }
-      } catch (error) {
-        console.warn('Failed to fetch fresh installation parameters from CMA:', error);
-      }
-
-      return (sdk.parameters.installation as AppInstallationParameters) ?? {};
-    }, [sdk]);
-
-  useEffect(() => {
-    let isMounted = true;
-
-    const syncInstallationParameters = async () => {
-      const installationParams = await fetchLatestInstallationParameters();
-
-      if (!isMounted) {
-        return;
-      }
-
-      setEnabledWeights(parseEnabledWeights(installationParams?.enabledWeights));
-    };
-
-    void syncInstallationParameters();
-
-    return () => {
-      isMounted = false;
-    };
-  }, [fetchLatestInstallationParameters]);
+  const getInstallationParameters = useCallback((): AppInstallationParameters => {
+    return (sdk.parameters.installation as AppInstallationParameters) ?? {};
+  }, [sdk.parameters.installation]);
 
   const openDialog = useCallback(async () => {
     if (isOpeningDialog) {
@@ -129,7 +67,7 @@ const Field = () => {
     setIsOpeningDialog(true);
 
     try {
-      const installationParams = await fetchLatestInstallationParameters();
+      const installationParams = getInstallationParameters();
       const enabledWeights = parseEnabledWeights(installationParams?.enabledWeights);
       const positionOptions = parsePositionOptions(installationParams?.positionOptions);
       const allowedIconNames =
@@ -158,7 +96,7 @@ const Field = () => {
     } finally {
       setIsOpeningDialog(false);
     }
-  }, [fetchLatestInstallationParameters, isOpeningDialog, sdk.dialogs, sdk.field, value]);
+  }, [getInstallationParameters, isOpeningDialog, sdk.dialogs, sdk.field, value]);
 
   const handleRemove = useCallback(async () => {
     await sdk.field.removeValue();


### PR DESCRIPTION
## Summary
- **Removes expensive org-scoped CMA calls** from the phosphor-icon Field component that were contributing to elevated 429 rates (INC-1276)
- The `fetchLatestInstallationParameters` callback previously called `appInstallation.getForOrganization()` on mount AND on every dialog open — two org-scoped calls per user interaction
- Replaced with a synchronous read of `sdk.parameters.installation` which already contains the correct parameters without any network overhead

## Context
This is part of the broader effort in EXT-7458 to eliminate unnecessary org-scoped `appInstallation.getForOrganization` queries across marketplace apps. These calls are expensive, hit rate limits, and the SDK already provides the installation parameters synchronously.

## Changes
- `apps/phosphor-icon/src/locations/Field.tsx` — removed `fetchLatestInstallationParameters` async callback and the `useEffect` that synced params on mount; replaced with a simple synchronous `getInstallationParameters` helper that reads from `sdk.parameters.installation`
- `apps/phosphor-icon/src/locations/Field.spec.tsx` — updated tests to reflect that params now come directly from the SDK rather than a CMA fetch

## Test plan
- [x] All 37 existing tests pass (`npm test` in `apps/phosphor-icon`)
- [ ] Verify in staging that the icon picker dialog still opens with correct weights/positions/allowed icons
- [ ] Confirm no org-scoped CMA calls in network tab when loading the field or opening the dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)