### PR TITLE
fix(drive-import): handle ai-service-unavailable failure from backend []

### DIFF
--- a/apps/drive-integration/src/hooks/useWorkflowAgent.ts
+++ b/apps/drive-integration/src/hooks/useWorkflowAgent.ts
@@ -127,6 +127,10 @@ const getBackendWorkflowFailureReason = (runData: AgentRunData): WorkflowFailure
     return WorkflowFailureReason.GOOGLE_DOCS_NOT_FOUND;
   }
 
+  if (workflowFailure.code === WorkflowFailureReason.AI_SERVICE_UNAVAILABLE) {
+    return WorkflowFailureReason.AI_SERVICE_UNAVAILABLE;
+  }
+
   if (workflowFailure.code === WorkflowFailureReason.GENERIC) {
     return WorkflowFailureReason.GENERIC;
   }
@@ -144,6 +148,10 @@ const getWorkflowFailureMessage = (
 
   if (failureReason === WorkflowFailureReason.GOOGLE_DOCS_NOT_FOUND) {
     return ERROR_MESSAGES.GOOGLE_DOCS_NOT_FOUND;
+  }
+
+  if (failureReason === WorkflowFailureReason.AI_SERVICE_UNAVAILABLE) {
+    return ERROR_MESSAGES.AI_SERVICE_UNAVAILABLE;
   }
 
   return getRunErrorMessage(runData);

--- a/apps/drive-integration/src/locations/Page/components/mainpage/ModalOrchestrator.tsx
+++ b/apps/drive-integration/src/locations/Page/components/mainpage/ModalOrchestrator.tsx
@@ -175,6 +175,18 @@ export const ModalOrchestrator = forwardRef<ModalOrchestratorHandle, ModalOrches
         return;
       }
 
+      if (
+        error instanceof WorkflowRunError &&
+        error.reason === WorkflowFailureReason.AI_SERVICE_UNAVAILABLE
+      ) {
+        setPreviewErrorState({
+          reason: WorkflowFailureReason.AI_SERVICE_UNAVAILABLE,
+          title: 'AI service temporarily unavailable',
+          message: ERROR_MESSAGES.AI_SERVICE_UNAVAILABLE,
+        });
+        return;
+      }
+
       setPreviewErrorState({
         reason: WorkflowFailureReason.GENERIC,
         title: 'Unable to generate preview',

--- a/apps/drive-integration/src/types/workflow.ts
+++ b/apps/drive-integration/src/types/workflow.ts
@@ -14,6 +14,7 @@ export enum WorkflowFailureReason {
   GENERIC = 'generic',
   GOOGLE_DRIVE_AUTH_EXPIRED = 'google-drive-auth-expired',
   GOOGLE_DOCS_NOT_FOUND = 'google-docs-not-found',
+  AI_SERVICE_UNAVAILABLE = 'ai-service-unavailable',
 }
 
 export interface WorkflowFailure {

--- a/apps/drive-integration/src/utils/constants/messages.ts
+++ b/apps/drive-integration/src/utils/constants/messages.ts
@@ -10,6 +10,8 @@ export const ERROR_MESSAGES = {
     'Your Drive connection has expired or is no longer valid. Reconnect your account to continue generating a preview.',
   GOOGLE_DOCS_NOT_FOUND:
     'Google Doc not found. Make sure the document exists and your Google account has access to it.',
+  AI_SERVICE_UNAVAILABLE:
+    'The AI service is temporarily unavailable. Please try again in a few minutes.',
 } as const;
 
 export const SUCCESS_MESSAGES = {


### PR DESCRIPTION
## Problem

When the AI service timed out or was unavailable during a drive import, users saw:

> "This preview could not be completed. Please start again."

This message is misleading — it implies the user did something wrong when the problem is a transient service issue.

## What changed

- Added `AI_SERVICE_UNAVAILABLE = 'ai-service-unavailable'` to `WorkflowFailureReason` enum
- Added `AI_SERVICE_UNAVAILABLE` error message: "The AI service is temporarily unavailable. Please try again in a few minutes."
- Wired the new failure code through `useWorkflowAgent` and `ModalOrchestrator` so the error modal shows the correct title and message

## Paired PR

contentful/agents-api#539 — backend adds timeout + retry to preview agent and emits the new failure code

🤖 Generated with [Claude Code](https://claude.com/claude-code)