### PR TITLE
fix(drive-integration): fix field dropdowns closing on selection [INTEG-4040]

### DIFF
--- a/apps/drive-integration/src/locations/Page/components/review/mapping/edit-modals/FieldSelectionDropdown.tsx
+++ b/apps/drive-integration/src/locations/Page/components/review/mapping/edit-modals/FieldSelectionDropdown.tsx
@@ -98,7 +98,7 @@ export const FieldSelectionDropdown = ({
         currentSelection={currentSelection}
         placeholder={placeholder}
         popoverProps={{
-          listMaxHeight: 200,
+          listMaxHeight: 150,
           listRef: multiselectListRef,
           placement: 'bottom',
           isAutoalignmentEnabled: false,


### PR DESCRIPTION
## Purpose

When the edit modal contains more than one field dropdown, selecting an option in the second (or any non-first) dropdown causes it to close immediately. This makes it impossible to select multiple fields in entries below the first one.

## Approach

The root cause is inside \`@contentful/f36-multiselect\`: after a selection, the component internally calls \`focusList()\` which does \`containerDiv.focus()\` without \`preventScroll: true\`. The popover content is rendered as a portal appended to \`document.body\`, so for dropdowns lower on the page the browser auto-scrolls \`window\` to bring the focused element into view. Floating UI's \`useDismiss\` has \`ancestorScroll: true\` hardcoded, it catches that scroll event and closes the popover.

Reducing \`listMaxHeight\` from 200 to 150 keeps the popover portal within the visible viewport, so no auto-scroll fires and the dropdown stays open.

## Testing steps


https://github.com/user-attachments/assets/ba3fd290-aa83-48fe-9139-e8f13939cbc5


https://github.com/user-attachments/assets/07291cf8-4e36-40a1-8529-d8e07ff438a2


## Breaking Changes

No.

## Dependencies and/or References

Link to [INTEG-4040](https://contentful.atlassian.net/jira/software/c/projects/INTEG/boards/454?issueParent=483434&selectedIssue=INTEG-4040).

## Deployment

No.

🤖 Co-authored with [Claude Code](https://claude.ai/code)

[INTEG-4040]: https://contentful.atlassian.net/browse/INTEG-4040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ