### PR TITLE
feat(drive-integration): keyboard accessibility for edit action buttons in review view [INTEG-3889]

### DIFF
--- a/apps/drive-integration/src/hooks/useReviewTextSelection.tsx
+++ b/apps/drive-integration/src/hooks/useReviewTextSelection.tsx
@@ -57,7 +57,7 @@ export interface UseReviewTextSelectionResult {
   selectedText: string;
   selectedRange: Range | null;
   clearSelection: () => void;
-  freezeSelection: () => void;
+  lockSelection: () => void;
 }
 
 export function useReviewTextSelection(
@@ -65,10 +65,10 @@ export function useReviewTextSelection(
 ): UseReviewTextSelectionResult {
   const [selectedText, setSelectedText] = useState('');
   const [selectedRange, setSelectedRange] = useState<Range | null>(null);
-  const frozenRef = useRef(false);
+  const lockSelectionRef = useRef(false);
 
   const updateFromSelection = useCallback(() => {
-    if (frozenRef.current) return;
+    if (lockSelectionRef.current) return;
 
     const root = rootRef.current;
     const currentSelection = window.getSelection();
@@ -89,14 +89,14 @@ export function useReviewTextSelection(
   }, [rootRef]);
 
   const clearSelection = useCallback(() => {
-    frozenRef.current = false;
+    lockSelectionRef.current = false;
     window.getSelection()?.removeAllRanges();
     setSelectedText('');
     setSelectedRange(null);
   }, []);
 
   const freezeSelection = useCallback(() => {
-    frozenRef.current = true;
+    lockSelectionRef.current = true;
   }, []);
 
   const selectionRectangle = selectedRange ? getSelectionViewportRectangle(selectedRange) : null;
@@ -115,5 +115,11 @@ export function useReviewTextSelection(
     };
   }, [rootRef, updateFromSelection]);
 
-  return { selectionRectangle, selectedText, selectedRange, clearSelection, freezeSelection };
+  return {
+    selectionRectangle,
+    selectedText,
+    selectedRange,
+    clearSelection,
+    lockSelection: freezeSelection,
+  };
 }

--- a/apps/drive-integration/src/hooks/useReviewTextSelection.tsx
+++ b/apps/drive-integration/src/hooks/useReviewTextSelection.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, type RefObject } from 'react';
+import { useCallback, useEffect, useRef, useState, type RefObject } from 'react';
 import type { SelectionViewportRectangle } from '../locations/Page/components/review/mapping/selectionViewportRectangle';
 
 const SEGMENT_SURFACE_SELECTOR = '[data-review-segment-surface]';
@@ -57,6 +57,7 @@ export interface UseReviewTextSelectionResult {
   selectedText: string;
   selectedRange: Range | null;
   clearSelection: () => void;
+  freezeSelection: () => void;
 }
 
 export function useReviewTextSelection(
@@ -64,8 +65,11 @@ export function useReviewTextSelection(
 ): UseReviewTextSelectionResult {
   const [selectedText, setSelectedText] = useState('');
   const [selectedRange, setSelectedRange] = useState<Range | null>(null);
+  const frozenRef = useRef(false);
 
   const updateFromSelection = useCallback(() => {
+    if (frozenRef.current) return;
+
     const root = rootRef.current;
     const currentSelection = window.getSelection();
     if (!root || !currentSelection) {
@@ -85,9 +89,14 @@ export function useReviewTextSelection(
   }, [rootRef]);
 
   const clearSelection = useCallback(() => {
+    frozenRef.current = false;
     window.getSelection()?.removeAllRanges();
     setSelectedText('');
     setSelectedRange(null);
+  }, []);
+
+  const freezeSelection = useCallback(() => {
+    frozenRef.current = true;
   }, []);
 
   const selectionRectangle = selectedRange ? getSelectionViewportRectangle(selectedRange) : null;
@@ -106,5 +115,5 @@ export function useReviewTextSelection(
     };
   }, [rootRef, updateFromSelection]);
 
-  return { selectionRectangle, selectedText, selectedRange, clearSelection };
+  return { selectionRectangle, selectedText, selectedRange, clearSelection, freezeSelection };
 }

--- a/apps/drive-integration/src/locations/Page/components/modals/step_2/ContentTypePickerModal.tsx
+++ b/apps/drive-integration/src/locations/Page/components/modals/step_2/ContentTypePickerModal.tsx
@@ -6,8 +6,8 @@ import {
   Modal,
   Paragraph,
   Pill,
-  Multiselect,
 } from '@contentful/f36-components';
+import { Multiselect } from '@contentful/f36-multiselect';
 import { PageAppSDK } from '@contentful/app-sdk';
 import { ContentTypeProps } from 'contentful-management';
 import { useMultiselectScrollReflow } from '@hooks/useMultiselectReflow';

--- a/apps/drive-integration/src/locations/Page/components/modals/step_2/ContentTypePickerModal.tsx
+++ b/apps/drive-integration/src/locations/Page/components/modals/step_2/ContentTypePickerModal.tsx
@@ -1,12 +1,5 @@
 import { useEffect, useState, type ChangeEvent } from 'react';
-import {
-  Button,
-  Flex,
-  FormControl,
-  Modal,
-  Paragraph,
-  Pill,
-} from '@contentful/f36-components';
+import { Button, Flex, FormControl, Modal, Paragraph, Pill } from '@contentful/f36-components';
 import { Multiselect } from '@contentful/f36-multiselect';
 import { PageAppSDK } from '@contentful/app-sdk';
 import { ContentTypeProps } from 'contentful-management';
@@ -106,6 +99,12 @@ export const ContentTypePickerModal = ({
     return `${selectedContentTypes.length} selected`;
   };
 
+  const handleMultiselectKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key !== 'Enter') return;
+    const target = e.target as HTMLInputElement;
+    if (target.type === 'checkbox') target.click();
+  };
+
   const handleSelectContentType = (e: ChangeEvent<HTMLInputElement>) => {
     const { checked, value } = e.target;
     if (checked) {
@@ -144,30 +143,32 @@ export const ContentTypePickerModal = ({
           isInvalid={showSelectionError || showFetchError}
           marginBottom="none">
           <FormControl.Label>Content type</FormControl.Label>
-          <Multiselect
-            className={multiselect}
-            searchProps={{
-              searchPlaceholder: 'Search content types',
-              onSearchValueChange,
-            }}
-            currentSelection={selectedContentTypes.map((ct) => ct.name)}
-            placeholder={getPlaceholderText()}
-            popoverProps={{
-              listMaxHeight: 300,
-              listRef: multiselectListRef,
-            }}>
-            {filteredContentTypes.map((ct) => (
-              <Multiselect.Option
-                key={ct.sys.id}
-                value={ct.sys.id}
-                itemId={ct.sys.id}
-                isChecked={selectedContentTypes.some((selected) => selected.sys.id === ct.sys.id)}
-                isDisabled={isFetching || isSubmitting}
-                onSelectItem={handleSelectContentType}>
-                {ct.name}
-              </Multiselect.Option>
-            ))}
-          </Multiselect>
+          <div onKeyDown={handleMultiselectKeyDown}>
+            <Multiselect
+              className={multiselect}
+              searchProps={{
+                searchPlaceholder: 'Search content types',
+                onSearchValueChange,
+              }}
+              currentSelection={selectedContentTypes.map((ct) => ct.name)}
+              placeholder={getPlaceholderText()}
+              popoverProps={{
+                listMaxHeight: 300,
+                listRef: multiselectListRef,
+              }}>
+              {filteredContentTypes.map((ct) => (
+                <Multiselect.Option
+                  key={ct.sys.id}
+                  value={ct.sys.id}
+                  itemId={ct.sys.id}
+                  isChecked={selectedContentTypes.some((selected) => selected.sys.id === ct.sys.id)}
+                  isDisabled={isFetching || isSubmitting}
+                  onSelectItem={handleSelectContentType}>
+                  {ct.name}
+                </Multiselect.Option>
+              ))}
+            </Multiselect>
+          </div>
           {showFetchError && (
             <FormControl.ValidationMessage>
               Unable to load content types.

--- a/apps/drive-integration/src/locations/Page/components/modals/step_2/ContentTypePickerModal.tsx
+++ b/apps/drive-integration/src/locations/Page/components/modals/step_2/ContentTypePickerModal.tsx
@@ -6,6 +6,7 @@ import { ContentTypeProps } from 'contentful-management';
 import { useMultiselectScrollReflow } from '@hooks/useMultiselectReflow';
 import { multiselect, pillsContainer } from './ContentTypePickerModal.styles';
 import { truncateLabel } from '../../../../../utils/utils';
+import { handleMultiselectKeyDown } from '../../../../../utils/keyboard';
 
 interface ContentTypePickerModalProps {
   sdk: PageAppSDK;
@@ -97,12 +98,6 @@ export const ContentTypePickerModal = ({
     if (contentTypes.length === 0) return 'No content types in space';
     if (selectedContentTypes.length === 0) return 'Select one or more';
     return `${selectedContentTypes.length} selected`;
-  };
-
-  const handleMultiselectKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key !== 'Enter') return;
-    const target = e.target as HTMLInputElement;
-    if (target.type === 'checkbox') target.click();
   };
 
   const handleSelectContentType = (e: ChangeEvent<HTMLInputElement>) => {

--- a/apps/drive-integration/src/locations/Page/components/modals/step_3/SelectTabsModal.styles.ts
+++ b/apps/drive-integration/src/locations/Page/components/modals/step_3/SelectTabsModal.styles.ts
@@ -5,6 +5,10 @@ export const multiselect = css({
   maxWidth: '68%',
 });
 
+export const multiselectContainer = css({
+  width: '100%',
+});
+
 export const pillsContainer = css({
   marginRight: tokens.spacingXl,
   maxHeight: '100px',

--- a/apps/drive-integration/src/locations/Page/components/modals/step_3/SelectTabsModal.tsx
+++ b/apps/drive-integration/src/locations/Page/components/modals/step_3/SelectTabsModal.tsx
@@ -7,9 +7,9 @@ import {
   Modal,
   Paragraph,
   Pill,
-  Multiselect,
   Radio,
 } from '@contentful/f36-components';
+import { Multiselect } from '@contentful/f36-multiselect';
 import { modalControls, multiselect, pillsContainer } from './SelectTabsModal.styles';
 import { useMultiselectScrollReflow } from '@hooks/useMultiselectReflow';
 import { DocumentTabProps } from '@types';

--- a/apps/drive-integration/src/locations/Page/components/modals/step_3/SelectTabsModal.tsx
+++ b/apps/drive-integration/src/locations/Page/components/modals/step_3/SelectTabsModal.tsx
@@ -10,10 +10,16 @@ import {
   Radio,
 } from '@contentful/f36-components';
 import { Multiselect } from '@contentful/f36-multiselect';
-import { modalControls, multiselect, pillsContainer } from './SelectTabsModal.styles';
+import {
+  modalControls,
+  multiselect,
+  multiselectContainer,
+  pillsContainer,
+} from './SelectTabsModal.styles';
 import { useMultiselectScrollReflow } from '@hooks/useMultiselectReflow';
 import { DocumentTabProps } from '@types';
 import { truncateLabel } from '../../../../../utils/utils';
+import { handleMultiselectKeyDown } from '../../../../../utils/keyboard';
 
 interface SelectTabsModalProps {
   onContinue: (selectedTabs: DocumentTabProps[]) => void;
@@ -51,12 +57,6 @@ export const SelectTabsModal = ({
   useEffect(() => {
     setHasAttemptedSubmit(false);
   }, [availableTabs]);
-
-  const handleMultiselectKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key !== 'Enter') return;
-    const target = e.target as HTMLInputElement;
-    if (target.type === 'checkbox') target.click();
-  };
 
   const handleSelectTab = (e: React.ChangeEvent<HTMLInputElement>) => {
     setHasAttemptedSubmit(false);
@@ -99,7 +99,7 @@ export const SelectTabsModal = ({
                 <FormControl isRequired isInvalid={isInvalidSelectionError} marginBottom="none">
                   <FormControl.Label>Document tabs</FormControl.Label>
                   <Checkbox.Group name="document-tabs" value={selectedTabs.map((t) => t.tabId)}>
-                    <div onKeyDown={handleMultiselectKeyDown}>
+                    <div onKeyDown={handleMultiselectKeyDown} className={multiselectContainer}>
                       <Multiselect
                         className={multiselect}
                         currentSelection={selectedTabs.map((tab) => tab.tabTitle)}

--- a/apps/drive-integration/src/locations/Page/components/modals/step_3/SelectTabsModal.tsx
+++ b/apps/drive-integration/src/locations/Page/components/modals/step_3/SelectTabsModal.tsx
@@ -52,6 +52,12 @@ export const SelectTabsModal = ({
     setHasAttemptedSubmit(false);
   }, [availableTabs]);
 
+  const handleMultiselectKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key !== 'Enter') return;
+    const target = e.target as HTMLInputElement;
+    if (target.type === 'checkbox') target.click();
+  };
+
   const handleSelectTab = (e: React.ChangeEvent<HTMLInputElement>) => {
     setHasAttemptedSubmit(false);
 
@@ -93,25 +99,29 @@ export const SelectTabsModal = ({
                 <FormControl isRequired isInvalid={isInvalidSelectionError} marginBottom="none">
                   <FormControl.Label>Document tabs</FormControl.Label>
                   <Checkbox.Group name="document-tabs" value={selectedTabs.map((t) => t.tabId)}>
-                    <Multiselect
-                      className={multiselect}
-                      currentSelection={selectedTabs.map((tab) => tab.tabTitle)}
-                      placeholder={'Select one or more'}
-                      popoverProps={{
-                        listMaxHeight: 300,
-                        listRef: multiselectListRef,
-                      }}>
-                      {availableTabs.map((tab) => (
-                        <Multiselect.Option
-                          key={tab.tabId}
-                          value={tab.tabId}
-                          itemId={tab.tabId}
-                          isChecked={selectedTabs.some((selected) => selected.tabId === tab.tabId)}
-                          onSelectItem={handleSelectTab}>
-                          {tab.tabTitle}
-                        </Multiselect.Option>
-                      ))}
-                    </Multiselect>
+                    <div onKeyDown={handleMultiselectKeyDown}>
+                      <Multiselect
+                        className={multiselect}
+                        currentSelection={selectedTabs.map((tab) => tab.tabTitle)}
+                        placeholder={'Select one or more'}
+                        popoverProps={{
+                          listMaxHeight: 300,
+                          listRef: multiselectListRef,
+                        }}>
+                        {availableTabs.map((tab) => (
+                          <Multiselect.Option
+                            key={tab.tabId}
+                            value={tab.tabId}
+                            itemId={tab.tabId}
+                            isChecked={selectedTabs.some(
+                              (selected) => selected.tabId === tab.tabId
+                            )}
+                            onSelectItem={handleSelectTab}>
+                            {tab.tabTitle}
+                          </Multiselect.Option>
+                        ))}
+                      </Multiselect>
+                    </div>
                   </Checkbox.Group>
                   {isInvalidSelectionError && (
                     <FormControl.ValidationMessage>

--- a/apps/drive-integration/src/locations/Page/components/overview/OverviewEntryList.tsx
+++ b/apps/drive-integration/src/locations/Page/components/overview/OverviewEntryList.tsx
@@ -64,6 +64,9 @@ function OverviewEntryRowCard({
             isChecked={isEntrySelectedForCreation}
             isDisabled={areEntrySelectionsDisabled}
             onChange={(event) => onToggleEntrySelection(row.id, event.target.checked)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') e.currentTarget.click();
+            }}
           />
           <button
             type="button"

--- a/apps/drive-integration/src/locations/Page/components/review/mapping/EditMappingButton.tsx
+++ b/apps/drive-integration/src/locations/Page/components/review/mapping/EditMappingButton.tsx
@@ -7,12 +7,13 @@ import type { SelectionViewportRectangle } from './selectionViewportRectangle';
 interface EditMappingButtonProps {
   anchorRectangle: SelectionViewportRectangle;
   onEdit: () => void;
+  onBlur?: () => void;
 }
 
 const BUTTON_ESTIMATE_WIDTH_PX = 160;
 
 export const EditMappingButton = forwardRef<HTMLDivElement, EditMappingButtonProps>(
-  ({ anchorRectangle, onEdit }, ref) => {
+  ({ anchorRectangle, onEdit, onBlur }, ref) => {
     const centerX = (anchorRectangle.left + anchorRectangle.right) / 2;
     const half = BUTTON_ESTIMATE_WIDTH_PX / 2;
     const clampedCenterX = Math.min(Math.max(centerX, 8 + half), window.innerWidth - 8 - half);
@@ -38,6 +39,7 @@ export const EditMappingButton = forwardRef<HTMLDivElement, EditMappingButtonPro
           variant="secondary"
           size="small"
           onClick={onEdit}
+          onBlur={onBlur}
           startIcon={<PencilSimpleIcon size="small" />}
           style={{ paddingTop: '2px', paddingBottom: '2px' }}>
           Edit content mapping

--- a/apps/drive-integration/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/drive-integration/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -1,4 +1,11 @@
-import { useLayoutEffect, useMemo, useRef, useState, type RefCallback } from 'react';
+import {
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type RefCallback,
+} from 'react';
 import { Box, Flex, Note, Text } from '@contentful/f36-components';
 import tokens from '@contentful/f36-tokens';
 import {
@@ -179,7 +186,13 @@ export const MappingView = ({
   const cardWrapperRefs = useRef<Record<string, HTMLDivElement | null>>({});
   const document = payload.normalizedDocument;
 
+  const { selectionRectangle, selectedText, selectedRange, clearSelection, freezeSelection } =
+    useReviewTextSelection(textSelectionRootRef);
+
+  const editButtonRef = useRef<HTMLDivElement>(null);
+
   const closeEditModal = () => {
+    clearSelection();
     setEditModalState(EMPTY_EDIT_MODAL);
     setPendingTextExclusionRanges(null);
     setPendingExcludeImageSourceRefs([]);
@@ -188,8 +201,16 @@ export const MappingView = ({
     setPendingPreviewHasTableContent(false);
   };
 
-  const { selectionRectangle, selectedText, selectedRange, clearSelection } =
-    useReviewTextSelection(textSelectionRootRef);
+  const handleDocumentKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Tab' && !e.shiftKey && selectedText.trim()) {
+      const button = editButtonRef.current?.querySelector('button') as HTMLElement | null;
+      if (button) {
+        e.preventDefault();
+        freezeSelection();
+        button.focus();
+      }
+    }
+  };
 
   const highlightIndex = useMemo(
     () => buildMappingHighlightIndex(entryBlockGraph, payload.contentTypes),
@@ -757,9 +778,16 @@ export const MappingView = ({
     <>
       <Flex
         ref={textSelectionRootRef}
+        contentEditable={!isViewMode || undefined}
+        suppressContentEditableWarning
+        onBeforeInput={(e) => e.preventDefault()}
+        onPaste={(e) => e.preventDefault()}
+        onCut={(e) => e.preventDefault()}
+        onDrop={(e) => e.preventDefault()}
+        onKeyDown={handleDocumentKeyDown}
         flexDirection="column"
         gap="spacingS"
-        style={{ marginTop: tokens.spacingM }}>
+        style={{ marginTop: tokens.spacingM, outline: 'none' }}>
         {(isViewMode || selectedEntryRow) && (
           <Flex
             gap="spacingM"
@@ -916,7 +944,12 @@ export const MappingView = ({
       </Flex>
 
       {selectionRectangle && !isDisabled && !isViewMode ? (
-        <EditMappingButton anchorRectangle={selectionRectangle} onEdit={handleEditFromSelection} />
+        <EditMappingButton
+          ref={editButtonRef}
+          anchorRectangle={selectionRectangle}
+          onEdit={handleEditFromSelection}
+          onBlur={clearSelection}
+        />
       ) : null}
 
       <EditModal

--- a/apps/drive-integration/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/drive-integration/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -186,8 +186,13 @@ export const MappingView = ({
   const cardWrapperRefs = useRef<Record<string, HTMLDivElement | null>>({});
   const document = payload.normalizedDocument;
 
-  const { selectionRectangle, selectedText, selectedRange, clearSelection, freezeSelection } =
-    useReviewTextSelection(textSelectionRootRef);
+  const {
+    selectionRectangle,
+    selectedText,
+    selectedRange,
+    clearSelection,
+    lockSelection: freezeSelection,
+  } = useReviewTextSelection(textSelectionRootRef);
 
   const editButtonRef = useRef<HTMLDivElement>(null);
 

--- a/apps/drive-integration/src/locations/Page/components/review/mapping/edit-modals/FieldSelectionDropdown.tsx
+++ b/apps/drive-integration/src/locations/Page/components/review/mapping/edit-modals/FieldSelectionDropdown.tsx
@@ -5,6 +5,7 @@ import type { EditModalFieldMapping, EditModalFieldOption } from '@types';
 import { useMultiselectScrollReflow } from '@hooks/useMultiselectReflow';
 import { isSelectableFieldType } from './utils';
 import { optionRow } from './FieldSelectionDropdown.styles';
+import { handleMultiselectKeyDown } from '../../../../../../utils/keyboard';
 
 interface FieldSelectionDropdownProps {
   selectedText: string;
@@ -74,12 +75,6 @@ export const FieldSelectionDropdown = ({
       hasSelectableOptions: selectableOptions.length > 0,
     });
   }, [fieldOptions.length, isImageContent, selectableOptions.length]);
-
-  const handleMultiselectKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key !== 'Enter') return;
-    const target = e.target as HTMLInputElement;
-    if (target.type === 'checkbox') target.click();
-  };
 
   const handleSelectField = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { checked, value } = event.target;

--- a/apps/drive-integration/src/locations/Page/components/review/mapping/edit-modals/FieldSelectionDropdown.tsx
+++ b/apps/drive-integration/src/locations/Page/components/review/mapping/edit-modals/FieldSelectionDropdown.tsx
@@ -75,6 +75,12 @@ export const FieldSelectionDropdown = ({
     });
   }, [fieldOptions.length, isImageContent, selectableOptions.length]);
 
+  const handleMultiselectKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key !== 'Enter') return;
+    const target = e.target as HTMLInputElement;
+    if (target.type === 'checkbox') target.click();
+  };
+
   const handleSelectField = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { checked, value } = event.target;
 
@@ -93,49 +99,51 @@ export const FieldSelectionDropdown = ({
 
   return (
     <FormControl as="div">
-      <Multiselect
-        key={key}
-        currentSelection={currentSelection}
-        placeholder={placeholder}
-        popoverProps={{
-          listMaxHeight: 150,
-          listRef: multiselectListRef,
-          placement: 'bottom',
-          isAutoalignmentEnabled: false,
-        }}>
-        {fieldOptions.map((option) => {
-          const fieldTypeDisplay = option.fieldDisplayType;
-          const isDisabled = isImageContent
-            ? !isSelectableForImage(option)
-            : !isSelectableFieldType(option, selectedText);
-          const isFilled = filledFieldIds.has(option.id);
-          return (
-            <Multiselect.Option
-              key={`${key}-${option.id}`}
-              value={option.id}
-              itemId={`${key}-${option.id}`}
-              isChecked={selectedFieldIds.includes(option.id)}
-              isDisabled={isDisabled && !selectedFieldIds.includes(option.id)}
-              onSelectItem={handleSelectField}
-              className={optionRow}>
-              <Flex gap="spacing2Xs">
-                <Text as="div" fontColor="gray700" fontWeight="fontWeightDemiBold">
-                  {option.fieldName}
-                </Text>
-                <Text as="div" fontColor="gray700" fontWeight="fontWeightNormal">
-                  ({fieldTypeDisplay})
-                </Text>
-              </Flex>
-              <Badge
-                variant={isFilled ? 'positive' : 'secondary'}
-                size="small"
-                style={{ marginLeft: 'auto' }}>
-                {isFilled ? 'Filled' : 'Empty'}
-              </Badge>
-            </Multiselect.Option>
-          );
-        })}
-      </Multiselect>
+      <div onKeyDown={handleMultiselectKeyDown}>
+        <Multiselect
+          key={key}
+          currentSelection={currentSelection}
+          placeholder={placeholder}
+          popoverProps={{
+            listMaxHeight: 150,
+            listRef: multiselectListRef,
+            placement: 'bottom',
+            isAutoalignmentEnabled: false,
+          }}>
+          {fieldOptions.map((option) => {
+            const fieldTypeDisplay = option.fieldDisplayType;
+            const isDisabled = isImageContent
+              ? !isSelectableForImage(option)
+              : !isSelectableFieldType(option, selectedText);
+            const isFilled = filledFieldIds.has(option.id);
+            return (
+              <Multiselect.Option
+                key={`${key}-${option.id}`}
+                value={option.id}
+                itemId={`${key}-${option.id}`}
+                isChecked={selectedFieldIds.includes(option.id)}
+                isDisabled={isDisabled && !selectedFieldIds.includes(option.id)}
+                onSelectItem={handleSelectField}
+                className={optionRow}>
+                <Flex gap="spacing2Xs">
+                  <Text as="div" fontColor="gray700" fontWeight="fontWeightDemiBold">
+                    {option.fieldName}
+                  </Text>
+                  <Text as="div" fontColor="gray700" fontWeight="fontWeightNormal">
+                    ({fieldTypeDisplay})
+                  </Text>
+                </Flex>
+                <Badge
+                  variant={isFilled ? 'positive' : 'secondary'}
+                  size="small"
+                  style={{ marginLeft: 'auto' }}>
+                  {isFilled ? 'Filled' : 'Empty'}
+                </Badge>
+              </Multiselect.Option>
+            );
+          })}
+        </Multiselect>
+      </div>
     </FormControl>
   );
 };

--- a/apps/drive-integration/src/utils/keyboard.ts
+++ b/apps/drive-integration/src/utils/keyboard.ts
@@ -1,5 +1,8 @@
 export const handleMultiselectKeyDown = (e: React.KeyboardEvent) => {
   if (e.key !== 'Enter') return;
   const target = e.target as HTMLInputElement;
-  if (target.type === 'checkbox') target.click();
+  if (target.type === 'checkbox') {
+    target.click();
+    setTimeout(() => target.focus(), 0);
+  }
 };

--- a/apps/drive-integration/src/utils/keyboard.ts
+++ b/apps/drive-integration/src/utils/keyboard.ts
@@ -1,4 +1,6 @@
-export const handleMultiselectKeyDown = (e: React.KeyboardEvent) => {
+import { KeyboardEvent } from 'react';
+
+export const handleMultiselectKeyDown = (e: KeyboardEvent) => {
   if (e.key !== 'Enter') return;
   const target = e.target as HTMLInputElement;
   if (target.type === 'checkbox') {

--- a/apps/drive-integration/src/utils/keyboard.ts
+++ b/apps/drive-integration/src/utils/keyboard.ts
@@ -1,0 +1,5 @@
+export const handleMultiselectKeyDown = (e: React.KeyboardEvent) => {
+  if (e.key !== 'Enter') return;
+  const target = e.target as HTMLInputElement;
+  if (target.type === 'checkbox') target.click();
+};

--- a/apps/drive-integration/src/utils/keyboard.ts
+++ b/apps/drive-integration/src/utils/keyboard.ts
@@ -2,6 +2,7 @@ export const handleMultiselectKeyDown = (e: React.KeyboardEvent) => {
   if (e.key !== 'Enter') return;
   const target = e.target as HTMLInputElement;
   if (target.type === 'checkbox') {
+    e.preventDefault();
     target.click();
     setTimeout(() => target.focus(), 0);
   }

--- a/apps/drive-integration/test/locations/Page/components/review/mapping/MappingView.spec.tsx
+++ b/apps/drive-integration/test/locations/Page/components/review/mapping/MappingView.spec.tsx
@@ -276,6 +276,7 @@ describe('MappingView', () => {
       selectedText: '',
       selectedRange: null,
       clearSelection: mockClearSelection,
+      freezeSelection: vi.fn(),
     });
   });
 
@@ -805,6 +806,7 @@ describe('MappingView', () => {
       selectedText: '',
       selectedRange: null,
       clearSelection: mockClearSelection,
+      freezeSelection: vi.fn(),
     });
 
     const { container, rerender } = render(
@@ -823,6 +825,7 @@ describe('MappingView', () => {
       selectedText: 'Second',
       selectedRange,
       clearSelection: mockClearSelection,
+      freezeSelection: vi.fn(),
     });
 
     rerender(
@@ -851,6 +854,7 @@ describe('MappingView', () => {
       selectedText: 'fresh body text',
       selectedRange,
       clearSelection: mockClearSelection,
+      freezeSelection: vi.fn(),
     });
 
     const payload = createPayload();
@@ -879,6 +883,7 @@ describe('MappingView', () => {
       selectedText: 'plain text',
       selectedRange,
       clearSelection: mockClearSelection,
+      freezeSelection: vi.fn(),
     });
 
     const payload = createPayload();
@@ -900,6 +905,7 @@ describe('MappingView', () => {
       selectedText: '',
       selectedRange: null,
       clearSelection: mockClearSelection,
+      freezeSelection: vi.fn(),
     });
 
     const payload = createPayload();
@@ -921,6 +927,7 @@ describe('MappingView', () => {
       selectedText: 'selected body text',
       selectedRange,
       clearSelection: mockClearSelection,
+      freezeSelection: vi.fn(),
     });
     rerender(
       <MappingView
@@ -967,6 +974,7 @@ describe('MappingView', () => {
       selectedText: '',
       selectedRange: null,
       clearSelection: mockClearSelection,
+      freezeSelection: vi.fn(),
     });
 
     const { container, rerender } = render(
@@ -992,6 +1000,7 @@ describe('MappingView', () => {
       selectedText: selectedRange.toString(),
       selectedRange,
       clearSelection: mockClearSelection,
+      freezeSelection: vi.fn(),
     });
 
     rerender(


### PR DESCRIPTION
## Purpose

The review view relied entirely on mouse interaction for text selection and edit actions. This PR makes the core editing flow accessible via keyboard.

## Approach

#### Review view (MappingView, EditMappingButton, useReviewTextSelection)
- Document surface is now contentEditable (edit mode only) so Shift+Arrow selects text natively
- Mutations are blocked via onBeforeInput/onPaste/onCut/onDrop — no actual edits possible
- Tab with an active selection moves focus to the floating "Edit content mapping" button
- A freezeSelection ref prevents selectionchange from clearing the selection during that Tab transition
- EditMappingButton accepts onBlur — fires clearSelection when focus leaves the button

#### Overview (OverviewEntryList)
- Entry checkboxes can be toggled with Enter
  
#### Multiselect dropdowns (ContentTypePickerModal, SelectTabsModal, FieldSelectionDropdown)
- All three now use @contentful/f36-multiselect (standalone) for consistent keyboard and focus behaviour. Moreover, f36-multiselect is newer than Multiselect from f36-components.
- Enter key selects options via a shared handleMultiselectKeyDown util in src/utils/keyboard.ts
- Focus is restored to the checked option after selection via setTimeout to counteract the library's  internal focus-reset

## Testing steps

#### Keyboard flow (review view)
1. Click into the document area
2. Shift+Arrow to select text → floating "Edit content mapping" button appears
3. Tab → focus moves to the button (selection preserved via freeze)
4. Enter → edit modal opens
5. Tab past the button (or blur) → button disappears, selection clears

#### Complete workflow run using only the keyboard:


https://github.com/user-attachments/assets/05f34e80-8568-499d-a04a-8a27515b4143


## Breaking Changes

No.

## Dependencies and/or References

Link to [INTEG-3889](https://contentful.atlassian.net/browse/INTEG-3889)

[INTEG-3889]: https://contentful.atlassian.net/browse/INTEG-3889

🤖 Co-authored with [Claude Code](https://claude.ai/code)