### PR TITLE
fix(drive-integration): reduce backend poll timeout to 20 minutes [INTEG-4053]

### DIFF
--- a/apps/drive-integration/src/utils/constants/agent.ts
+++ b/apps/drive-integration/src/utils/constants/agent.ts
@@ -2,7 +2,7 @@ export const WORKFLOW_AGENT_ID = 'google-docs-workflow-agent';
 
 export const POLL_INTERVAL_MS = 10000; // 10 seconds
 
-const MAX_POLL_TIME_MS = 5 * 60 * 1000 * 10; // 50 minutes
+const MAX_POLL_TIME_MS = 20 * 60 * 1000; // 20 minutes
 
 export const MAX_POLL_ATTEMPTS = Math.floor(MAX_POLL_TIME_MS / POLL_INTERVAL_MS);
 


### PR DESCRIPTION
## Summary
- Reduces the workflow agent's max backend poll time from 50 minutes to 20 minutes (`MAX_POLL_TIME_MS` in `src/utils/constants/agent.ts`).
- `MAX_POLL_ATTEMPTS` is derived from this constant, so it now caps at 120 attempts (20 min / 10 s) instead of 300.
- Cleans up the misleading `5 * 60 * 1000 * 10` expression to `20 * 60 * 1000`.

## Test plan
- [ ] Trigger a workflow agent run and confirm polling stops after ~20 minutes if the backend never reaches a terminal state.
- [ ] Confirm normal (sub-20-minute) workflows still complete successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)