### PR TITLE
fix(drive-integration): show actionable error when app not installed in environment []

### DIFF
--- a/apps/drive-integration/src/hooks/useWorkflowAgent.ts
+++ b/apps/drive-integration/src/hooks/useWorkflowAgent.ts
@@ -127,6 +127,14 @@ const getBackendWorkflowFailureReason = (runData: AgentRunData): WorkflowFailure
     return WorkflowFailureReason.GOOGLE_DOCS_NOT_FOUND;
   }
 
+  if (workflowFailure.code === WorkflowFailureReason.AI_SERVICE_UNAVAILABLE) {
+    return WorkflowFailureReason.AI_SERVICE_UNAVAILABLE;
+  }
+
+  if (workflowFailure.code === WorkflowFailureReason.APP_NOT_INSTALLED) {
+    return WorkflowFailureReason.APP_NOT_INSTALLED;
+  }
+
   if (workflowFailure.code === WorkflowFailureReason.GENERIC) {
     return WorkflowFailureReason.GENERIC;
   }
@@ -144,6 +152,14 @@ const getWorkflowFailureMessage = (
 
   if (failureReason === WorkflowFailureReason.GOOGLE_DOCS_NOT_FOUND) {
     return ERROR_MESSAGES.GOOGLE_DOCS_NOT_FOUND;
+  }
+
+  if (failureReason === WorkflowFailureReason.AI_SERVICE_UNAVAILABLE) {
+    return ERROR_MESSAGES.AI_SERVICE_UNAVAILABLE;
+  }
+
+  if (failureReason === WorkflowFailureReason.APP_NOT_INSTALLED) {
+    return ERROR_MESSAGES.APP_NOT_INSTALLED;
   }
 
   return getRunErrorMessage(runData);

--- a/apps/drive-integration/src/locations/Page/components/mainpage/ModalOrchestrator.tsx
+++ b/apps/drive-integration/src/locations/Page/components/mainpage/ModalOrchestrator.tsx
@@ -175,6 +175,30 @@ export const ModalOrchestrator = forwardRef<ModalOrchestratorHandle, ModalOrches
         return;
       }
 
+      if (
+        error instanceof WorkflowRunError &&
+        error.reason === WorkflowFailureReason.AI_SERVICE_UNAVAILABLE
+      ) {
+        setPreviewErrorState({
+          reason: WorkflowFailureReason.AI_SERVICE_UNAVAILABLE,
+          title: 'AI service temporarily unavailable',
+          message: ERROR_MESSAGES.AI_SERVICE_UNAVAILABLE,
+        });
+        return;
+      }
+
+      if (
+        error instanceof WorkflowRunError &&
+        error.reason === WorkflowFailureReason.APP_NOT_INSTALLED
+      ) {
+        setPreviewErrorState({
+          reason: WorkflowFailureReason.APP_NOT_INSTALLED,
+          title: 'App not installed in this environment',
+          message: ERROR_MESSAGES.APP_NOT_INSTALLED,
+        });
+        return;
+      }
+
       setPreviewErrorState({
         reason: WorkflowFailureReason.GENERIC,
         title: 'Unable to generate preview',

--- a/apps/drive-integration/src/types/workflow.ts
+++ b/apps/drive-integration/src/types/workflow.ts
@@ -14,6 +14,8 @@ export enum WorkflowFailureReason {
   GENERIC = 'generic',
   GOOGLE_DRIVE_AUTH_EXPIRED = 'google-drive-auth-expired',
   GOOGLE_DOCS_NOT_FOUND = 'google-docs-not-found',
+  AI_SERVICE_UNAVAILABLE = 'ai-service-unavailable',
+  APP_NOT_INSTALLED = 'app-not-installed',
 }
 
 export interface WorkflowFailure {

--- a/apps/drive-integration/src/utils/constants/messages.ts
+++ b/apps/drive-integration/src/utils/constants/messages.ts
@@ -13,7 +13,7 @@ export const ERROR_MESSAGES = {
   AI_SERVICE_UNAVAILABLE:
     'The AI service is temporarily unavailable. Please try again in a few minutes.',
   APP_NOT_INSTALLED:
-    'The Drive Integration app is not installed in this space. Install it via Apps > Manage apps and try again.',
+    'The Drive Integration app is not installed in this environment. Install it via Apps > Manage apps and try again.',
 } as const;
 
 export const SUCCESS_MESSAGES = {

--- a/apps/drive-integration/src/utils/constants/messages.ts
+++ b/apps/drive-integration/src/utils/constants/messages.ts
@@ -13,7 +13,7 @@ export const ERROR_MESSAGES = {
   AI_SERVICE_UNAVAILABLE:
     'The AI service is temporarily unavailable. Please try again in a few minutes.',
   APP_NOT_INSTALLED:
-    'The Drive Integration app is not installed in this environment. Install it via Apps > Manage apps and try again.',
+    'The Drive Integration app is not installed in this space. Install it via Apps > Manage apps and try again.',
 } as const;
 
 export const SUCCESS_MESSAGES = {

--- a/apps/drive-integration/src/utils/constants/messages.ts
+++ b/apps/drive-integration/src/utils/constants/messages.ts
@@ -10,6 +10,10 @@ export const ERROR_MESSAGES = {
     'Your Drive connection has expired or is no longer valid. Reconnect your account to continue generating a preview.',
   GOOGLE_DOCS_NOT_FOUND:
     'Google Doc not found. Make sure the document exists and your Google account has access to it.',
+  AI_SERVICE_UNAVAILABLE:
+    'The AI service is temporarily unavailable. Please try again in a few minutes.',
+  APP_NOT_INSTALLED:
+    'The Drive Integration app is not installed in this environment. Install it via Apps > Manage apps and try again.',
 } as const;
 
 export const SUCCESS_MESSAGES = {


### PR DESCRIPTION
## Problem

When a Google Drive import fails due to the app not being installed in a space, users see a generic "This preview could not be completed. Please start again." message with no actionable guidance.

## Fix

Adds frontend handling for two new failure codes surfaced by agents-api:

- `app-not-installed` — shown when the app is not installed in the space (after the master env fallback in agents-api also finds nothing). Message: "The Drive Integration app is not installed in this space. Install it via Apps > Manage apps and try again."
- `ai-service-unavailable` — shown when the AI service is temporarily unavailable. Message: "The AI service is temporarily unavailable. Please try again in a few minutes."

Both codes are handled in `useWorkflowAgent`, `WorkflowFailureReason`, and `ModalOrchestrator`.

## Test plan

- [ ] Verify `APP_NOT_INSTALLED` error modal appears with correct title and message
- [ ] Verify `AI_SERVICE_UNAVAILABLE` error modal appears with correct title and message
- [ ] Verify generic error still shows for unrecognized failure codes

**Related:** contentful/agents-api#615

🤖 Generated with [Claude Code](https://claude.com/claude-code)