### PR TITLE
fix(drive-integration): remove oauth token from LLM user prompt [INTEG-4093]

### DIFF
--- a/apps/drive-integration/src/hooks/useWorkflowAgent.ts
+++ b/apps/drive-integration/src/hooks/useWorkflowAgent.ts
@@ -267,7 +267,9 @@ export const useWorkflowAgent = ({
             parts: [
               {
                 type: 'text' as const,
-                text: `Analyze the following google docs document ${documentId} and extract the Contentful entries and assets for the following content types: ${contentTypeIds.join(', ')}`,
+                text: `Analyze the following google docs document ${documentId} and extract the Contentful entries and assets for the following content types: ${contentTypeIds.join(
+                  ', '
+                )}`,
               },
             ],
           },

--- a/apps/drive-integration/src/hooks/useWorkflowAgent.ts
+++ b/apps/drive-integration/src/hooks/useWorkflowAgent.ts
@@ -267,9 +267,7 @@ export const useWorkflowAgent = ({
             parts: [
               {
                 type: 'text' as const,
-                text: `Analyze the following google docs document ${documentId} and extract the Contentful entries and assets for the following content types: ${contentTypeIds.join(
-                  ', '
-                )} with the following oauth token: ${oauthToken}`,
+                text: `Analyze the following google docs document ${documentId} and extract the Contentful entries and assets for the following content types: ${contentTypeIds.join(', ')}`,
               },
             ],
           },


### PR DESCRIPTION
## Purpose

The Google OAuth token was being included as plain text in the user message sent to the Google Docs Workflow Agent. This caused the raw token to be forwarded to OpenAI's gpt-4o-mini API on every workflow run, which is a security exposure. The token already travels correctly via `metadata.oauthToken` — its presence in the prompt was redundant and unsafe.

## Approach

Removed `with the following oauth token: ${oauthToken}` from the prompt string in `useWorkflowAgent.ts`. The `oauthToken` continues to be passed via `metadata` (unchanged), where the backend reads it securely from `requestContext.metadata` (KMS-encrypted Inngest input path) and strips it from the unencrypted `requestContext` before serialisation.

The companion backend fix lives in `contentful/agents-api` on `fix/google-docs-oauth-token`, which removes `oauthToken` from the `invokeGoogleDocsWorkflow` tool's `inputSchema` entirely — the agent no longer needs it in the prompt at all.

```diff
- text: `Analyze the following google docs document ${documentId} and extract the Contentful entries and assets for the following content types: ${contentTypeIds.join(', ')} with the following oauth token: ${oauthToken}`,
+ text: `Analyze the following google docs document ${documentId} and extract the Contentful entries and assets for the following content types: ${contentTypeIds.join(', ')}`,
```

## Breaking Changes

No.

## Dependencies and/or References

- Companion backend PR: `contentful/agents-api` branch `fix/google-docs-oauth-token`
- [Ticket](https://contentful.atlassian.net/jira/software/c/projects/INTEG/boards/454?issueParent=483434&selectedIssue=INTEG-4093)

## Deployment

No.

🤖 Co-authored with [Claude Code](https://claude.ai/code)