### PR TITLE
feat(content-insights): add content type filter for Needs Update metric [INTEG-4147]

### DIFF
--- a/apps/content-insights/src/components/Dashboard.tsx
+++ b/apps/content-insights/src/components/Dashboard.tsx
@@ -49,6 +49,7 @@ const Dashboard = () => {
 
   const metricsCalculator = new MetricsCalculator(entries, scheduledActions, {
     needsUpdateMonths: installation.needsUpdateMonths,
+    needsUpdateContentTypes: installation.needsUpdateContentTypes,
     recentlyPublishedDays: installation.recentlyPublishedDays,
     timeToPublishDays: installation.timeToPublishDays,
   });

--- a/apps/content-insights/src/components/NeedsUpdateTable.tsx
+++ b/apps/content-insights/src/components/NeedsUpdateTable.tsx
@@ -13,13 +13,20 @@ import { getEnvironmentId } from '../utils/sdkUtils';
 export const NeedsUpdateTable = ({
   entries,
   contentTypes,
+  selectedContentTypeIds,
 }: {
   entries: EntryProps[];
   contentTypes: Map<string, ContentTypeProps>;
+  selectedContentTypeIds?: string[];
 }) => {
   const sdk = useSDK<HomeAppSDK | PageAppSDK>();
   const [currentPage, setCurrentPage] = useState(0);
-  const { items, total, isFetching, error } = useNeedsUpdate(entries, currentPage, contentTypes);
+  const { items, total, isFetching, error } = useNeedsUpdate(
+    entries,
+    currentPage,
+    contentTypes,
+    selectedContentTypeIds
+  );
 
   const columns = useMemo<TableColumn<NeedsUpdateItem>[]>(
     () => [

--- a/apps/content-insights/src/components/ScheduledContentTabs.tsx
+++ b/apps/content-insights/src/components/ScheduledContentTabs.tsx
@@ -86,12 +86,18 @@ export const ScheduledContentTabs = ({
                   initialSelectedIds={installation.needsUpdateContentTypes}
                   disablePills={false}
                 />
-                <FormControl.HelpText>Leave empty to show all content types.</FormControl.HelpText>
+                <FormControl.HelpText>
+                  Leave empty to use the configured default.
+                </FormControl.HelpText>
               </FormControl>
               <NeedsUpdateTable
                 entries={entries}
                 contentTypes={contentTypes}
-                selectedContentTypeIds={selectedNeedsUpdateContentTypes.map((ct) => ct.id)}
+                selectedContentTypeIds={
+                  selectedNeedsUpdateContentTypes.length > 0
+                    ? selectedNeedsUpdateContentTypes.map((ct) => ct.id)
+                    : undefined
+                }
               />
             </TabPanelContent>
           </Tabs.Panel>

--- a/apps/content-insights/src/components/ScheduledContentTabs.tsx
+++ b/apps/content-insights/src/components/ScheduledContentTabs.tsx
@@ -1,13 +1,15 @@
 import { useState } from 'react';
-import { Box, Flex, Tabs, Text } from '@contentful/f36-components';
+import { Box, Flex, FormControl, Tabs, Text } from '@contentful/f36-components';
 import { ScheduledContentTable } from './ScheduledContentTable';
 import { RecentlyPublishedTable } from './RecentlyPublishedTable';
 import { NeedsUpdateTable } from './NeedsUpdateTable';
 import { styles } from './Dashboard.styles';
 import { useSDK } from '@contentful/react-apps-toolkit';
-import { HomeAppSDK, PageAppSDK } from '@contentful/app-sdk';
+import { HomeAppSDK, PageAppSDK, ConfigAppSDK } from '@contentful/app-sdk';
 import { ReactNode } from 'react';
 import { EntryProps, ScheduledActionProps, ContentTypeProps } from 'contentful-management';
+import ContentTypeMultiSelect, { ContentType } from './ContentTypeMultiSelect';
+import type { AppInstallationParameters } from '../locations/ConfigScreen';
 
 interface TabPanelContentProps {
   description: string;
@@ -34,10 +36,15 @@ export const ScheduledContentTabs = ({
   entries: EntryProps[];
   contentTypes: Map<string, ContentTypeProps>;
 }) => {
-  const { parameters } = useSDK<HomeAppSDK | PageAppSDK>();
-  const recentlyPublishedDays = parameters?.installation?.recentlyPublishedDays;
-  const needsUpdateMonths = parameters?.installation?.needsUpdateMonths;
+  const sdk = useSDK<HomeAppSDK | PageAppSDK>();
+  const { parameters } = sdk;
+  const installation = (parameters?.installation ?? {}) as AppInstallationParameters;
+  const recentlyPublishedDays = installation.recentlyPublishedDays;
+  const needsUpdateMonths = installation.needsUpdateMonths;
   const [currentTab, setCurrentTab] = useState('scheduled');
+  const [selectedNeedsUpdateContentTypes, setSelectedNeedsUpdateContentTypes] = useState<
+    ContentType[]
+  >([]);
 
   return (
     <Box marginTop="spacingXl">
@@ -70,7 +77,26 @@ export const ScheduledContentTabs = ({
               description={`Content older than ${needsUpdateMonths} ${
                 needsUpdateMonths === 1 ? 'month' : 'months'
               } will appear here.`}>
-              <NeedsUpdateTable entries={entries} contentTypes={contentTypes} />
+              <FormControl marginBottom="spacingM">
+                <FormControl.Label>Filter by content type</FormControl.Label>
+                <ContentTypeMultiSelect
+                  selectedContentTypes={selectedNeedsUpdateContentTypes}
+                  setSelectedContentTypes={setSelectedNeedsUpdateContentTypes}
+                  sdk={sdk as unknown as ConfigAppSDK}
+                  initialSelectedIds={installation.needsUpdateContentTypes}
+                  disablePills={false}
+                />
+                <FormControl.HelpText>Leave empty to show all content types.</FormControl.HelpText>
+              </FormControl>
+              <NeedsUpdateTable
+                entries={entries}
+                contentTypes={contentTypes}
+                selectedContentTypeIds={
+                  selectedNeedsUpdateContentTypes.length > 0
+                    ? selectedNeedsUpdateContentTypes.map((ct) => ct.id)
+                    : undefined
+                }
+              />
             </TabPanelContent>
           </Tabs.Panel>
         </Tabs>

--- a/apps/content-insights/src/components/ScheduledContentTabs.tsx
+++ b/apps/content-insights/src/components/ScheduledContentTabs.tsx
@@ -91,11 +91,7 @@ export const ScheduledContentTabs = ({
               <NeedsUpdateTable
                 entries={entries}
                 contentTypes={contentTypes}
-                selectedContentTypeIds={
-                  selectedNeedsUpdateContentTypes.length > 0
-                    ? selectedNeedsUpdateContentTypes.map((ct) => ct.id)
-                    : undefined
-                }
+                selectedContentTypeIds={selectedNeedsUpdateContentTypes.map((ct) => ct.id)}
               />
             </TabPanelContent>
           </Tabs.Panel>

--- a/apps/content-insights/src/hooks/useNeedsUpdateContent.ts
+++ b/apps/content-insights/src/hooks/useNeedsUpdateContent.ts
@@ -40,8 +40,9 @@ export function useNeedsUpdate(
   contentTypes: Map<string, ContentTypeProps>
 ): UseNeedsUpdateResult {
   const sdk = useSDK<HomeAppSDK | PageAppSDK>();
-  const needsUpdateMonths =
-    ((sdk.parameters.installation ?? {}) as AppInstallationParameters).needsUpdateMonths ?? 6;
+  const installation = (sdk.parameters.installation ?? {}) as AppInstallationParameters;
+  const needsUpdateMonths = installation.needsUpdateMonths ?? 6;
+  const needsUpdateContentTypes = installation.needsUpdateContentTypes ?? [];
   const defaultLocale = sdk.locales.default;
 
   const filteredEntries = useMemo(
@@ -50,10 +51,16 @@ export function useNeedsUpdate(
         const updatedAt = parseDate(entry?.sys?.updatedAt);
         if (!updatedAt) return false;
         const thresholdDate = subMonths(new Date(), needsUpdateMonths);
+        if (updatedAt.getTime() >= thresholdDate.getTime()) return false;
 
-        return updatedAt.getTime() < thresholdDate.getTime();
+        if (needsUpdateContentTypes.length > 0) {
+          const contentTypeId = entry.sys.contentType?.sys?.id;
+          if (!contentTypeId || !needsUpdateContentTypes.includes(contentTypeId)) return false;
+        }
+
+        return true;
       }),
-    [entries, needsUpdateMonths]
+    [entries, needsUpdateMonths, needsUpdateContentTypes]
   );
 
   const userIds = getUniqueUserIdsFromEntries(filteredEntries);

--- a/apps/content-insights/src/hooks/useNeedsUpdateContent.ts
+++ b/apps/content-insights/src/hooks/useNeedsUpdateContent.ts
@@ -37,12 +37,14 @@ function calculateAgeInDays(date: Date): number {
 export function useNeedsUpdate(
   entries: EntryProps[],
   page: number = 0,
-  contentTypes: Map<string, ContentTypeProps>
+  contentTypes: Map<string, ContentTypeProps>,
+  overrideContentTypeIds?: string[]
 ): UseNeedsUpdateResult {
   const sdk = useSDK<HomeAppSDK | PageAppSDK>();
   const installation = (sdk.parameters.installation ?? {}) as AppInstallationParameters;
   const needsUpdateMonths = installation.needsUpdateMonths ?? 6;
   const needsUpdateContentTypes = installation.needsUpdateContentTypes ?? [];
+  const activeContentTypeIds = overrideContentTypeIds ?? needsUpdateContentTypes;
   const defaultLocale = sdk.locales.default;
 
   const filteredEntries = useMemo(
@@ -53,14 +55,14 @@ export function useNeedsUpdate(
         const thresholdDate = subMonths(new Date(), needsUpdateMonths);
         if (updatedAt.getTime() >= thresholdDate.getTime()) return false;
 
-        if (needsUpdateContentTypes.length > 0) {
+        if (activeContentTypeIds.length > 0) {
           const contentTypeId = entry.sys.contentType?.sys?.id;
-          if (!contentTypeId || !needsUpdateContentTypes.includes(contentTypeId)) return false;
+          if (!contentTypeId || !activeContentTypeIds.includes(contentTypeId)) return false;
         }
 
         return true;
       }),
-    [entries, needsUpdateMonths, needsUpdateContentTypes]
+    [entries, needsUpdateMonths, activeContentTypeIds]
   );
 
   const userIds = getUniqueUserIdsFromEntries(filteredEntries);

--- a/apps/content-insights/src/hooks/useNeedsUpdateContent.ts
+++ b/apps/content-insights/src/hooks/useNeedsUpdateContent.ts
@@ -34,6 +34,8 @@ function calculateAgeInDays(date: Date): number {
   return Math.floor(diffTime / msPerDay);
 }
 
+const EMPTY_CONTENT_TYPES: string[] = [];
+
 export function useNeedsUpdate(
   entries: EntryProps[],
   page: number = 0,
@@ -43,26 +45,29 @@ export function useNeedsUpdate(
   const sdk = useSDK<HomeAppSDK | PageAppSDK>();
   const installation = (sdk.parameters.installation ?? {}) as AppInstallationParameters;
   const needsUpdateMonths = installation.needsUpdateMonths ?? 6;
-  const needsUpdateContentTypes = installation.needsUpdateContentTypes ?? [];
-  const activeContentTypeIds = overrideContentTypeIds ?? needsUpdateContentTypes;
+  const installationContentTypes = installation.needsUpdateContentTypes ?? EMPTY_CONTENT_TYPES;
+  const activeContentTypeIds = overrideContentTypeIds ?? installationContentTypes;
   const defaultLocale = sdk.locales.default;
+
+  const activeContentTypeSet = useMemo(
+    () => (activeContentTypeIds.length > 0 ? new Set(activeContentTypeIds) : null),
+    [activeContentTypeIds]
+  );
 
   const filteredEntries = useMemo(
     () =>
       entries.filter((entry) => {
+        if (activeContentTypeSet !== null) {
+          const contentTypeId = entry.sys.contentType?.sys?.id;
+          if (!contentTypeId || !activeContentTypeSet.has(contentTypeId)) return false;
+        }
+
         const updatedAt = parseDate(entry?.sys?.updatedAt);
         if (!updatedAt) return false;
         const thresholdDate = subMonths(new Date(), needsUpdateMonths);
-        if (updatedAt.getTime() >= thresholdDate.getTime()) return false;
-
-        if (activeContentTypeIds.length > 0) {
-          const contentTypeId = entry.sys.contentType?.sys?.id;
-          if (!contentTypeId || !activeContentTypeIds.includes(contentTypeId)) return false;
-        }
-
-        return true;
+        return updatedAt.getTime() < thresholdDate.getTime();
       }),
-    [entries, needsUpdateMonths, activeContentTypeIds]
+    [entries, needsUpdateMonths, activeContentTypeSet]
   );
 
   const userIds = getUniqueUserIdsFromEntries(filteredEntries);

--- a/apps/content-insights/src/locations/ConfigScreen.tsx
+++ b/apps/content-insights/src/locations/ConfigScreen.tsx
@@ -30,6 +30,7 @@ import TextInputInteger from '../components/TextInputInteger';
 
 export interface AppInstallationParameters {
   defaultContentTypes?: string[];
+  needsUpdateContentTypes?: string[];
   needsUpdateMonths?: number;
   recentlyPublishedDays?: number;
   showUpcomingReleases?: boolean;
@@ -40,6 +41,7 @@ export interface AppInstallationParameters {
 const ConfigScreen = () => {
   const [parameters, setParameters] = useState<AppInstallationParameters>({});
   const [selectedContentTypes, setSelectedContentTypes] = useState<ContentType[]>([]);
+  const [needsUpdateContentTypes, setNeedsUpdateContentTypes] = useState<ContentType[]>([]);
   const sdk = useSDK<ConfigAppSDK>();
 
   const [errors, setErrors] = useState<Record<string, string>>({});
@@ -86,10 +88,11 @@ const ConfigScreen = () => {
       parameters: {
         ...parameters,
         defaultContentTypes: selectedContentTypes.map((ct) => ct.id),
+        needsUpdateContentTypes: needsUpdateContentTypes.map((ct) => ct.id),
       },
       targetState: currentState,
     };
-  }, [parameters, selectedContentTypes, sdk]);
+  }, [parameters, selectedContentTypes, needsUpdateContentTypes, sdk]);
 
   useEffect(() => {
     sdk.app.onConfigure(() => onConfigure());
@@ -178,6 +181,22 @@ const ConfigScreen = () => {
                 Content will be marked as &quot;Needs update&quot; when it hasn&apos;t been updated
                 for this amount of time. Range: {NEEDS_UPDATE_MONTHS_RANGE.min}-
                 {NEEDS_UPDATE_MONTHS_RANGE.max} months.
+              </FormControl.HelpText>
+            </FormControl>
+
+            <FormControl marginBottom="spacingL">
+              <FormControl.Label>
+                Content types included in &quot;Needs update&quot;
+              </FormControl.Label>
+              <ContentTypeMultiSelect
+                selectedContentTypes={needsUpdateContentTypes}
+                setSelectedContentTypes={setNeedsUpdateContentTypes}
+                sdk={sdk}
+                initialSelectedIds={parameters.needsUpdateContentTypes}
+              />
+              <FormControl.HelpText>
+                Only entries of the selected content types will count toward the &quot;Needs
+                update&quot; metric. Leave empty to include all content types.
               </FormControl.HelpText>
             </FormControl>
 

--- a/apps/content-insights/src/metrics/MetricsCalculator.ts
+++ b/apps/content-insights/src/metrics/MetricsCalculator.ts
@@ -12,6 +12,7 @@ export class MetricsCalculator {
   private readonly scheduledActions: ReadonlyArray<ScheduledActionProps>;
   private readonly now: Date; // to maintain all the metrics consistent at the same current time
   private readonly needsUpdateMonths: number;
+  private readonly needsUpdateContentTypes: readonly string[];
   private readonly recentlyPublishedDays: number;
   private readonly timeToPublishDays: number;
 
@@ -20,6 +21,7 @@ export class MetricsCalculator {
     scheduledActions: ReadonlyArray<ScheduledActionProps>,
     options?: {
       needsUpdateMonths?: number;
+      needsUpdateContentTypes?: string[];
       recentlyPublishedDays?: number;
       timeToPublishDays?: number;
     }
@@ -28,6 +30,7 @@ export class MetricsCalculator {
     this.scheduledActions = scheduledActions;
     this.now = new Date();
     this.needsUpdateMonths = options?.needsUpdateMonths ?? NEEDS_UPDATE_MONTHS_RANGE.min;
+    this.needsUpdateContentTypes = options?.needsUpdateContentTypes ?? [];
     this.recentlyPublishedDays =
       options?.recentlyPublishedDays ?? RECENTLY_PUBLISHED_DAYS_RANGE.min;
     this.timeToPublishDays = options?.timeToPublishDays ?? TIME_TO_PUBLISH_DAYS_RANGE.min;
@@ -167,9 +170,14 @@ export class MetricsCalculator {
     for (const entry of this.entries) {
       const updatedAt = parseDate(entry?.sys?.updatedAt);
       if (!updatedAt) continue;
-      if (updatedAt.getTime() < cutoff.getTime()) {
-        count += 1;
+      if (updatedAt.getTime() >= cutoff.getTime()) continue;
+
+      if (this.needsUpdateContentTypes.length > 0) {
+        const contentTypeId = entry.sys.contentType?.sys?.id;
+        if (!contentTypeId || !this.needsUpdateContentTypes.includes(contentTypeId)) continue;
       }
+
+      count += 1;
     }
 
     return {

--- a/apps/content-insights/src/metrics/MetricsCalculator.ts
+++ b/apps/content-insights/src/metrics/MetricsCalculator.ts
@@ -12,7 +12,7 @@ export class MetricsCalculator {
   private readonly scheduledActions: ReadonlyArray<ScheduledActionProps>;
   private readonly now: Date; // to maintain all the metrics consistent at the same current time
   private readonly needsUpdateMonths: number;
-  private readonly needsUpdateContentTypes: readonly string[];
+  private readonly needsUpdateContentTypeSet: ReadonlySet<string>;
   private readonly recentlyPublishedDays: number;
   private readonly timeToPublishDays: number;
 
@@ -30,7 +30,7 @@ export class MetricsCalculator {
     this.scheduledActions = scheduledActions;
     this.now = new Date();
     this.needsUpdateMonths = options?.needsUpdateMonths ?? NEEDS_UPDATE_MONTHS_RANGE.min;
-    this.needsUpdateContentTypes = options?.needsUpdateContentTypes ?? [];
+    this.needsUpdateContentTypeSet = new Set(options?.needsUpdateContentTypes ?? []);
     this.recentlyPublishedDays =
       options?.recentlyPublishedDays ?? RECENTLY_PUBLISHED_DAYS_RANGE.min;
     this.timeToPublishDays = options?.timeToPublishDays ?? TIME_TO_PUBLISH_DAYS_RANGE.min;
@@ -172,9 +172,9 @@ export class MetricsCalculator {
       if (!updatedAt) continue;
       if (updatedAt.getTime() >= cutoff.getTime()) continue;
 
-      if (this.needsUpdateContentTypes.length > 0) {
+      if (this.needsUpdateContentTypeSet.size > 0) {
         const contentTypeId = entry.sys.contentType?.sys?.id;
-        if (!contentTypeId || !this.needsUpdateContentTypes.includes(contentTypeId)) continue;
+        if (!contentTypeId || !this.needsUpdateContentTypeSet.has(contentTypeId)) continue;
       }
 
       count += 1;

--- a/apps/content-insights/src/utils/consts.ts
+++ b/apps/content-insights/src/utils/consts.ts
@@ -4,7 +4,7 @@ import { CreatorViewSetting } from './types';
 export const NEEDS_UPDATE_MONTHS_RANGE = { min: 1, max: 24 };
 export const RECENTLY_PUBLISHED_DAYS_RANGE = { min: 1, max: 30 };
 export const TIME_TO_PUBLISH_DAYS_RANGE = { min: 7, max: 90 };
-export const ITEMS_PER_PAGE = 5;
+export const ITEMS_PER_PAGE = 10;
 
 // Creator view options
 export const CREATOR_VIEW_OPTIONS: { value: CreatorViewSetting; label: string }[] = [

--- a/apps/content-insights/test/hooks/useNeedsUpdateContent.spec.tsx
+++ b/apps/content-insights/test/hooks/useNeedsUpdateContent.spec.tsx
@@ -365,4 +365,135 @@ describe('useNeedsUpdate', () => {
       expect(result.current.total).toBe(1);
     });
   });
+
+  describe('Content type filtering', () => {
+    const setupOldEntries = () => {
+      const thresholdDate = subMonths(new Date(), 6);
+      const oldDate = new Date(thresholdDate);
+      oldDate.setDate(oldDate.getDate() - 1);
+
+      mockUseUsers.mockReturnValue({
+        usersMap: new Map(),
+        isFetching: false,
+        refetch: mockRefetchUsers,
+        error: null,
+      });
+
+      return oldDate;
+    };
+
+    it('filters entries to selected content types when overrideContentTypeIds is provided', async () => {
+      const oldDate = setupOldEntries();
+
+      const entries = [
+        createMockEntry({
+          id: 'entry-1',
+          contentTypeId: 'blogPost',
+          updatedAt: oldDate.toISOString(),
+        }),
+        createMockEntry({
+          id: 'entry-2',
+          contentTypeId: 'navItem',
+          updatedAt: oldDate.toISOString(),
+        }),
+        createMockEntry({
+          id: 'entry-3',
+          contentTypeId: 'blogPost',
+          updatedAt: oldDate.toISOString(),
+        }),
+      ];
+
+      const contentTypes = new Map([
+        ['blogPost', createMockContentType({ id: 'blogPost', name: 'Blog Post' })],
+        ['navItem', createMockContentType({ id: 'navItem', name: 'Nav Item' })],
+      ]);
+
+      const { result } = renderHook(() => useNeedsUpdate(entries, 0, contentTypes, ['blogPost']), {
+        wrapper: createQueryProviderWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.items).toHaveLength(2);
+      });
+
+      expect(result.current.total).toBe(2);
+      expect(result.current.items.every((item) => item.contentType === 'Blog Post')).toBe(true);
+    });
+
+    it('includes all entries when overrideContentTypeIds is empty', async () => {
+      const oldDate = setupOldEntries();
+
+      const entries = [
+        createMockEntry({
+          id: 'entry-1',
+          contentTypeId: 'blogPost',
+          updatedAt: oldDate.toISOString(),
+        }),
+        createMockEntry({
+          id: 'entry-2',
+          contentTypeId: 'navItem',
+          updatedAt: oldDate.toISOString(),
+        }),
+      ];
+
+      const contentTypes = new Map([
+        ['blogPost', createMockContentType({ id: 'blogPost', name: 'Blog Post' })],
+        ['navItem', createMockContentType({ id: 'navItem', name: 'Nav Item' })],
+      ]);
+
+      const { result } = renderHook(() => useNeedsUpdate(entries, 0, contentTypes, []), {
+        wrapper: createQueryProviderWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.items).toHaveLength(2);
+      });
+
+      expect(result.current.total).toBe(2);
+    });
+
+    it('uses installation needsUpdateContentTypes when no override is provided', async () => {
+      mockUseSDK.mockReturnValue({
+        ids: { space: 'test-space', environment: 'test-environment' },
+        locales: { default: 'en-US' },
+        parameters: {
+          installation: {
+            needsUpdateMonths: 6,
+            needsUpdateContentTypes: ['blogPost'],
+          },
+        },
+      });
+
+      const oldDate = setupOldEntries();
+
+      const entries = [
+        createMockEntry({
+          id: 'entry-1',
+          contentTypeId: 'blogPost',
+          updatedAt: oldDate.toISOString(),
+        }),
+        createMockEntry({
+          id: 'entry-2',
+          contentTypeId: 'navItem',
+          updatedAt: oldDate.toISOString(),
+        }),
+      ];
+
+      const contentTypes = new Map([
+        ['blogPost', createMockContentType({ id: 'blogPost', name: 'Blog Post' })],
+        ['navItem', createMockContentType({ id: 'navItem', name: 'Nav Item' })],
+      ]);
+
+      const { result } = renderHook(() => useNeedsUpdate(entries, 0, contentTypes), {
+        wrapper: createQueryProviderWrapper(),
+      });
+
+      await waitFor(() => {
+        expect(result.current.items).toHaveLength(1);
+      });
+
+      expect(result.current.total).toBe(1);
+      expect(result.current.items[0].id).toBe('entry-1');
+    });
+  });
 });

--- a/apps/content-insights/test/hooks/useNeedsUpdateContent.spec.tsx
+++ b/apps/content-insights/test/hooks/useNeedsUpdateContent.spec.tsx
@@ -207,7 +207,7 @@ describe('useNeedsUpdate', () => {
       const oldDate = new Date(thresholdDate);
       oldDate.setDate(oldDate.getDate() - 1);
 
-      const entries = Array.from({ length: 12 }, (_, i) =>
+      const entries = Array.from({ length: 25 }, (_, i) =>
         createMockEntry({
           id: `entry-${i + 1}`,
           contentTypeId: 'blogPost',
@@ -232,10 +232,10 @@ describe('useNeedsUpdate', () => {
       );
 
       await waitFor(() => {
-        expect(resultPage0.current.items).toHaveLength(5);
+        expect(resultPage0.current.items).toHaveLength(10);
       });
 
-      expect(resultPage0.current.total).toBe(12);
+      expect(resultPage0.current.total).toBe(25);
 
       const { result: resultPage1 } = renderHook(
         () => useNeedsUpdate(entries, 1, new Map([['blogPost', contentType]])),
@@ -245,10 +245,10 @@ describe('useNeedsUpdate', () => {
       );
 
       await waitFor(() => {
-        expect(resultPage1.current.items).toHaveLength(5);
+        expect(resultPage1.current.items).toHaveLength(10);
       });
 
-      expect(resultPage1.current.total).toBe(12);
+      expect(resultPage1.current.total).toBe(25);
       expect(resultPage1.current.items[0].id).not.toBe(resultPage0.current.items[0].id);
     });
   });

--- a/apps/content-insights/test/locations/ConfigScreen.spec.tsx
+++ b/apps/content-insights/test/locations/ConfigScreen.spec.tsx
@@ -235,6 +235,7 @@ describe('Config Screen component', () => {
         timeToPublishDays: TIME_TO_PUBLISH_DAYS_RANGE.min,
         showUpcomingReleases: true,
         defaultContentTypes: [],
+        needsUpdateContentTypes: [],
       },
       targetState: {},
     });

--- a/apps/content-insights/test/metrics/MetricsCalculator.spec.ts
+++ b/apps/content-insights/test/metrics/MetricsCalculator.spec.ts
@@ -254,5 +254,61 @@ describe('MetricsCalculator', () => {
 
       expect(metric?.value).toBe('1');
     });
+
+    it('filters by content type when needsUpdateContentTypes is set', () => {
+      const entries: EntryProps[] = [
+        {
+          sys: {
+            updatedAt: daysAgo(200),
+            contentType: { sys: { id: 'blogPost' } },
+          },
+        } as unknown as EntryProps,
+        {
+          sys: {
+            updatedAt: daysAgo(200),
+            contentType: { sys: { id: 'navigationItem' } },
+          },
+        } as unknown as EntryProps,
+        {
+          sys: {
+            updatedAt: daysAgo(200),
+            contentType: { sys: { id: 'blogPost' } },
+          },
+        } as unknown as EntryProps,
+      ];
+
+      const calculator = new MetricsCalculator(entries, [], {
+        needsUpdateMonths: 6,
+        needsUpdateContentTypes: ['blogPost'],
+      });
+      const metric = calculator.getAllMetrics().find((m) => m.title === 'Needs update');
+
+      expect(metric?.value).toBe('2');
+    });
+
+    it('includes all content types when needsUpdateContentTypes is empty', () => {
+      const entries: EntryProps[] = [
+        {
+          sys: {
+            updatedAt: daysAgo(200),
+            contentType: { sys: { id: 'blogPost' } },
+          },
+        } as unknown as EntryProps,
+        {
+          sys: {
+            updatedAt: daysAgo(200),
+            contentType: { sys: { id: 'navigationItem' } },
+          },
+        } as unknown as EntryProps,
+      ];
+
+      const calculator = new MetricsCalculator(entries, [], {
+        needsUpdateMonths: 6,
+        needsUpdateContentTypes: [],
+      });
+      const metric = calculator.getAllMetrics().find((m) => m.title === 'Needs update');
+
+      expect(metric?.value).toBe('2');
+    });
   });
 });


### PR DESCRIPTION
## Summary

- New **Content types included in "Needs update"** multiselect in the config screen sets a persistent default
- Inline **Filter by content type** in the "Needs update" tab lets users adjust the view at runtime
- Empty selection includes all content types (preserves existing behavior)
- Table page size increased from 5 → 10 rows across all tabs

## Context

The "Needs update" metric was reporting 54,000+ entries because it counted all content types, including reusable components (Links, CTAs, Nav items) that don't need periodic review.

## Screenshots
### Before
<img width="1725" height="943" alt="Before" src="https://github.com/user-attachments/assets/d4a919a0-87c0-4d12-bafc-0f72bc09be3f"/>

### After
<img width="1725" height="943" alt="After config" src="https://github.com/user-attachments/assets/c9872d5e-8a90-4440-bdcc-4a11780e9320"/>
<img width="1725" height="967" alt="After tab" src="https://github.com/user-attachments/assets/e36e0538-c23c-47bf-8379-8c18040241a3"/>

https://github.com/user-attachments/assets/1018e13b-e49f-48f0-9e4a-9ae655f1e510

## Test plan

- [ ] All tests pass (`npx vitest --run`)
- [ ] Config screen filter persists and scopes the metric card and table
- [ ] Inline tab filter updates the table in real time
- [ ] Empty selection shows all content types
- [ ] All tabs show 10 rows per page
