### PR TITLE
Revert "fix: bump rich-text-editor to latest version [ES-319]"

### DIFF
--- a/apps/rich-text-versioning/package.json
+++ b/apps/rich-text-versioning/package.json
@@ -8,7 +8,7 @@
     "@contentful/f36-components": "4.81.1",
     "@contentful/f36-multiselect": "^4.81.1",
     "@contentful/f36-tokens": "4.2.0",
-    "@contentful/field-editor-rich-text": "6.3.8",
+    "@contentful/field-editor-rich-text": "4.16.0",
     "@contentful/react-apps-toolkit": "1.2.16",
     "@contentful/rich-text-html-renderer": "^17.1.0",
     "@contentful/rich-text-react-renderer": "^16.1.0",


### PR DESCRIPTION
## Summary

Reverts #11007, which bumped `@contentful/field-editor-rich-text` from `4.16.0` → `6.3.8` in the Rich Text Versioning app.

## What broke

The Rich Text editor fails to render in spaces using the Rich Text Versioning app specifically with fields that contain embedded references.
```
Cannot read properties of undefined (reading 'sys')
```

<img width="771" height="285" alt="Screenshot 2026-06-08 at 11 03 29 AM" src="https://github.com/user-attachments/assets/9973060b-20b1-4f15-adac-fee4fddeae20" />

