### PR TITLE
Drive-integration: Add disclaimer to config screen [INTEG-4150]

### DIFF
--- a/apps/drive-integration/src/locations/ConfigScreen/ConfigScreen.tsx
+++ b/apps/drive-integration/src/locations/ConfigScreen/ConfigScreen.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useCallback } from 'react';
-import { Box, Flex, Heading, Paragraph, Note, Text } from '@contentful/f36-components';
+import { Box, Flex, Heading, Paragraph, Text, TextLink } from '@contentful/f36-components';
+import { ArrowSquareOutIcon } from '@contentful/f36-icons';
 import { css } from '@emotion/css';
 import tokens from '@contentful/f36-tokens';
 import { useSDK } from '@contentful/react-apps-toolkit';
@@ -12,6 +13,12 @@ const styles = {
   }),
   heading: css({
     fontWeight: tokens.fontWeightDemiBold,
+  }),
+  disclosure: css({
+    border: `1px solid ${tokens.gray300}`,
+    borderRadius: tokens.borderRadiusMedium,
+    padding: tokens.spacingL,
+    width: '100%',
   }),
 };
 
@@ -62,6 +69,21 @@ const ConfigScreen = () => {
             Connect Drive Integration to Contentful to seamlessly sync content, eliminate
             copy-paste, reduce errors, and speed up your publishing workflow.
           </Paragraph>
+        </Box>
+        <Box className={styles.disclosure}>
+          <Text>
+            <Text fontWeight="fontWeightDemiBold">Disclosure:</Text> The use and transfer of raw or
+            derived user data received from Google Workspace APIs will adhere to the{' '}
+            <TextLink
+              href="https://developers.google.com/terms/api-services-user-data-policy"
+              target="_blank"
+              rel="noopener noreferrer"
+              icon={<ArrowSquareOutIcon />}
+              alignIcon="end">
+              Google API Services User Data Policy
+            </TextLink>
+            , including the Limited Use requirements.
+          </Text>
         </Box>
       </Flex>
     </Flex>


### PR DESCRIPTION
## Summary
  - Adds a disclosure box to the Drive Integration Config Screen stating that user data received from Google Workspace APIs adheres
  to the Google API Services User Data Policy, including Limited Use requirements. 
  - Includes a `TextLink` to the policy with an external-link icon.

  
<img width="1470" height="582" alt="Screenshot 2026-06-09 at 15 30 51" src="https://github.com/user-attachments/assets/add41ed7-bf8f-477c-ae7e-973d58dd2cbf" />
