### PR TITLE
REVERTED feat(drive-integration): adding remove button redesign [INTEG-4135]

### DIFF
--- a/apps/drive-integration/src/locations/Page/components/review/mapping/EditMappingButton.styles.ts
+++ b/apps/drive-integration/src/locations/Page/components/review/mapping/EditMappingButton.styles.ts
@@ -1,0 +1,60 @@
+import { css } from '@emotion/css';
+import tokens from '@contentful/f36-tokens';
+
+export const BUTTON_ESTIMATE_WIDTH_PX = 280;
+
+const action = css({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: tokens.spacing2Xs,
+  border: 'none',
+  cursor: 'pointer',
+  fontSize: tokens.fontSizeS,
+  fontWeight: tokens.fontWeightMedium,
+  padding: `${tokens.spacing2Xs} ${tokens.spacingS}`,
+  whiteSpace: 'nowrap',
+});
+
+export const editAction = css([
+  action,
+  {
+    color: tokens.gray900,
+    backgroundColor: tokens.colorWhite,
+    '&:hover': {
+      backgroundColor: tokens.gray200,
+    },
+  },
+]);
+
+export const removeAction = css([
+  action,
+  {
+    color: tokens.red600,
+    backgroundColor: tokens.gray100,
+    '&:hover': {
+      backgroundColor: tokens.gray200,
+    },
+  },
+]);
+
+export const divider = css({
+  width: 1,
+  alignSelf: 'stretch',
+  backgroundColor: tokens.gray300,
+});
+
+export const getMenuPosition = (top: number, left: number) =>
+  css({
+    display: 'inline-flex',
+    alignItems: 'stretch',
+    borderRadius: tokens.borderRadiusMedium,
+    border: `1px solid ${tokens.gray300}`,
+    backgroundColor: tokens.colorWhite,
+    boxShadow: '0 2px 6px rgba(0, 0, 0, 0.08)',
+    overflow: 'hidden',
+    position: 'fixed',
+    top,
+    left,
+    transform: 'translateX(-50%)',
+    zIndex: 3,
+  });

--- a/apps/drive-integration/src/locations/Page/components/review/mapping/EditMappingButton.tsx
+++ b/apps/drive-integration/src/locations/Page/components/review/mapping/EditMappingButton.tsx
@@ -1,49 +1,55 @@
-import { forwardRef } from 'react';
-import { Box, Button } from '@contentful/f36-components';
-import { PencilSimpleIcon } from '@contentful/f36-icons';
+import { forwardRef, type FocusEvent } from 'react';
+import { Box } from '@contentful/f36-components';
+import { PencilSimpleIcon, TrashSimpleIcon } from '@contentful/f36-icons';
 import tokens from '@contentful/f36-tokens';
 import type { SelectionViewportRectangle } from './selectionViewportRectangle';
+import {
+  BUTTON_ESTIMATE_WIDTH_PX,
+  divider,
+  editAction,
+  getMenuPosition,
+  removeAction,
+} from './EditMappingButton.styles';
 
 interface EditMappingButtonProps {
   anchorRectangle: SelectionViewportRectangle;
   onEdit: () => void;
+  onRemove?: () => void;
   onBlur?: () => void;
 }
 
-const BUTTON_ESTIMATE_WIDTH_PX = 160;
-
 export const EditMappingButton = forwardRef<HTMLDivElement, EditMappingButtonProps>(
-  ({ anchorRectangle, onEdit, onBlur }, ref) => {
+  ({ anchorRectangle, onEdit, onRemove, onBlur }, ref) => {
     const centerX = (anchorRectangle.left + anchorRectangle.right) / 2;
     const half = BUTTON_ESTIMATE_WIDTH_PX / 2;
     const clampedCenterX = Math.min(Math.max(centerX, 8 + half), window.innerWidth - 8 - half);
 
+    const handleBlur = (event: FocusEvent<HTMLDivElement>) => {
+      if (event.currentTarget.contains(event.relatedTarget as Node | null)) {
+        return;
+      }
+      onBlur?.();
+    };
+
     return (
       <Box
         ref={ref}
-        aria-label="Edit content mapping"
         data-testid="review-selection-menu"
-        style={{
-          position: 'fixed',
-          top: Math.max(anchorRectangle.top - 36, 8),
-          left: clampedCenterX,
-          transform: 'translateX(-50%)',
-          zIndex: 3,
-          display: 'inline-flex',
-          borderRadius: tokens.borderRadiusMedium,
-          border: `1px solid ${tokens.gray300}`,
-          backgroundColor: tokens.colorWhite,
-          width: 'fit-content',
-        }}>
-        <Button
-          variant="secondary"
-          size="small"
-          onClick={onEdit}
-          onBlur={onBlur}
-          startIcon={<PencilSimpleIcon size="small" />}
-          style={{ paddingTop: '2px', paddingBottom: '2px' }}>
+        onBlur={handleBlur}
+        className={getMenuPosition(Math.max(anchorRectangle.top - 36, 8), clampedCenterX)}>
+        <button type="button" className={editAction} onClick={onEdit}>
+          <PencilSimpleIcon size="small" color={tokens.gray700} />
           Edit content mapping
-        </Button>
+        </button>
+        {onRemove ? (
+          <>
+            <span aria-hidden="true" className={divider} />
+            <button type="button" className={removeAction} onClick={onRemove}>
+              <TrashSimpleIcon size="small" color={tokens.red600} />
+              Remove
+            </button>
+          </>
+        ) : null}
       </Box>
     );
   }

--- a/apps/drive-integration/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/drive-integration/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -455,16 +455,16 @@ export const MappingView = ({
     return matches;
   };
 
-  const getLocationsForSelectedText = (): EditLocationOption[] => {
+  const collectMappingKeysFromSelection = (): Set<string> => {
     const root = textSelectionRootRef.current;
     if (!root || !selectedRange) {
-      return [];
+      return new Set();
     }
 
-    const selectedMappedSegments = root.querySelectorAll<HTMLElement>(
-      '[data-review-text-segment="true"][data-is-mapped="true"]'
-    );
     const mappingKeys = new Set<string>();
+    const selectedMappedSegments = root.querySelectorAll<HTMLElement>(
+      '[data-review-text-segment="true"][data-is-mapped="true"], [data-review-image-segment="true"][data-is-mapped="true"]'
+    );
 
     for (const segment of selectedMappedSegments) {
       if (!rangeIntersectsNode(selectedRange, segment)) {
@@ -477,6 +477,15 @@ export const MappingView = ({
         .map((key) => key.trim())
         .filter(Boolean)
         .forEach((key) => mappingKeys.add(key));
+    }
+
+    return mappingKeys;
+  };
+
+  const getLocationsForSelectedText = (): EditLocationOption[] => {
+    const mappingKeys = collectMappingKeysFromSelection();
+    if (!mappingKeys.size) {
+      return [];
     }
 
     const locations = allGroups
@@ -609,14 +618,22 @@ export const MappingView = ({
       textSelectionRootRef.current,
       selectionRange
     );
+    const imageRefs = collectRichTextSourceRefsFromSelection(
+      textSelectionRootRef.current,
+      selectionRange,
+      document,
+      { mappedState: 'mapped' }
+    ).filter(
+      (ref): ref is ImageSourceRef => isBlockImageSourceRef(ref) || isTableImageSourceRef(ref)
+    );
     const locations = getLocationsForSelectedText();
 
-    if (!locations.length || !textRanges.length) {
+    if (!locations.length || (!textRanges.length && !imageRefs.length)) {
       clearSelection();
       return;
     }
 
-    setRemoveModalState({ isOpen: true, locations, textRanges, imageRefs: [] });
+    setRemoveModalState({ isOpen: true, locations, textRanges, imageRefs });
     clearSelection();
   };
 

--- a/apps/drive-integration/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/drive-integration/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -609,22 +609,24 @@ export const MappingView = ({
       textSelectionRootRef.current,
       selectionRange
     );
-    const imageRefs = collectRichTextSourceRefsFromSelection(
-      textSelectionRootRef.current,
-      selectionRange,
-      document
-    ).filter(
-      (ref): ref is ImageSourceRef => isBlockImageSourceRef(ref) || isTableImageSourceRef(ref)
-    );
     const locations = getLocationsForSelectedText();
 
-    if (!locations.length || (!textRanges.length && !imageRefs.length)) {
+    if (!locations.length || !textRanges.length) {
       clearSelection();
       return;
     }
 
-    setRemoveModalState({ isOpen: true, locations, textRanges, imageRefs });
+    setRemoveModalState({ isOpen: true, locations, textRanges, imageRefs: [] });
     clearSelection();
+  };
+
+  const handleRemoveImage = (sourceRef: ImageSourceRef) => {
+    if (isDisabled) return;
+    const locations = getLocationsForSourceRef(sourceRef);
+    if (!locations.length) return;
+
+    setRemoveModalState({ isOpen: true, locations, textRanges: [], imageRefs: [sourceRef] });
+    setHoveredMappingKeys([]);
   };
 
   const closeRemoveModal = () => {
@@ -966,6 +968,7 @@ export const MappingView = ({
                                   isViewMode={isViewMode}
                                   onSetHoveredMappingKeys={setHoveredMappingKeys}
                                   onEditImage={isViewMode ? undefined : handleEditImage}
+                                  onRemoveImage={isViewMode ? undefined : handleRemoveImage}
                                 />
                               ))}
                             </Flex>
@@ -985,6 +988,7 @@ export const MappingView = ({
                                 isViewMode={isViewMode}
                                 onSetHoveredMappingKeys={setHoveredMappingKeys}
                                 onEditImage={isViewMode ? undefined : handleEditImage}
+                                onRemoveImage={isViewMode ? undefined : handleRemoveImage}
                               />
                             ))}
                           </Flex>

--- a/apps/drive-integration/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/drive-integration/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -71,12 +71,27 @@ import {
   collectTextExclusionRangesFromSelection,
   type TextExclusionRange,
 } from './entryBlockGraphExclusion';
+import { RemoveContentModal } from './edit-modals/RemoveContentModal';
 
 interface EditModalState {
   viewModel: EditModalContent;
   title: string;
   primaryButtonLabel: string;
 }
+
+interface RemoveModalState {
+  isOpen: boolean;
+  locations: EditLocationOption[];
+  textRanges: TextExclusionRange[];
+  imageRefs: ImageSourceRef[];
+}
+
+const EMPTY_REMOVE_MODAL: RemoveModalState = {
+  isOpen: false,
+  locations: [],
+  textRanges: [],
+  imageRefs: [],
+};
 
 interface MappingViewProps {
   payload: MappingReviewSuspendPayload;
@@ -170,6 +185,7 @@ export const MappingView = ({
     Record<string, Record<string, number>>
   >({});
   const [editModalState, setEditModalState] = useState<EditModalState>(EMPTY_EDIT_MODAL);
+  const [removeModalState, setRemoveModalState] = useState<RemoveModalState>(EMPTY_REMOVE_MODAL);
   const [pendingTextExclusionRanges, setPendingTextExclusionRanges] = useState<
     TextExclusionRange[] | null
   >(null);
@@ -586,6 +602,62 @@ export const MappingView = ({
     clearSelection();
   };
 
+  const handleRemoveFromSelection = () => {
+    if (isDisabled || !selectedText.trim()) return;
+    const selectionRange = selectedRange ? selectedRange.cloneRange() : null;
+    const textRanges = collectTextExclusionRangesFromSelection(
+      textSelectionRootRef.current,
+      selectionRange
+    );
+    const imageRefs = collectRichTextSourceRefsFromSelection(
+      textSelectionRootRef.current,
+      selectionRange,
+      document
+    ).filter(
+      (ref): ref is ImageSourceRef => isBlockImageSourceRef(ref) || isTableImageSourceRef(ref)
+    );
+    const locations = getLocationsForSelectedText();
+
+    if (!locations.length || (!textRanges.length && !imageRefs.length)) {
+      clearSelection();
+      return;
+    }
+
+    setRemoveModalState({ isOpen: true, locations, textRanges, imageRefs });
+    clearSelection();
+  };
+
+  const closeRemoveModal = () => {
+    setRemoveModalState(EMPTY_REMOVE_MODAL);
+  };
+
+  const handleConfirmRemove = () => {
+    const { locations, textRanges, imageRefs } = removeModalState;
+    let next = entryBlockGraph;
+
+    for (const location of locations) {
+      const locationSourceRefKeys = new Set(
+        (location.sourceRefs?.length ? location.sourceRefs : [location.sourceRef]).map(
+          buildSourceRefKey
+        )
+      );
+
+      if (textRanges.length) {
+        next = applyTextExclusionToEntryBlockGraph(next, location, textRanges);
+      }
+
+      const matchingImages = imageRefs.filter((ref) =>
+        locationSourceRefKeys.has(buildSourceRefKey(ref))
+      );
+      for (const imageRef of matchingImages) {
+        next = applyImageExclusionToEntryBlockGraph(next, location, imageRef);
+      }
+    }
+
+    if (next !== entryBlockGraph) onEntryBlockGraphChange(next);
+    closeRemoveModal();
+  };
+
   const handleEditImage = (sourceRef: ImageSourceRef, label: string) => {
     if (isDisabled) return;
     const currentLocations = getLocationsForSourceRef(sourceRef);
@@ -951,6 +1023,9 @@ export const MappingView = ({
           ref={editButtonRef}
           anchorRectangle={selectionRectangle}
           onEdit={handleEditFromSelection}
+          onRemove={
+            getLocationsForSelectedText().length > 0 ? handleRemoveFromSelection : undefined
+          }
           onBlur={clearSelection}
         />
       ) : null}
@@ -1001,6 +1076,12 @@ export const MappingView = ({
           );
         })()}
         onConfirmPrimary={handleEditModalConfirmPrimary}
+      />
+
+      <RemoveContentModal
+        isOpen={removeModalState.isOpen}
+        onConfirm={handleConfirmRemove}
+        onCancel={closeRemoveModal}
       />
     </>
   );

--- a/apps/drive-integration/src/locations/Page/components/review/mapping/NormalizedDocumentSection.tsx
+++ b/apps/drive-integration/src/locations/Page/components/review/mapping/NormalizedDocumentSection.tsx
@@ -19,6 +19,7 @@ interface ReviewDocumentBodyProps {
   isViewMode: boolean;
   onSetHoveredMappingKeys: (keys: string[]) => void;
   onEditImage?: (sourceRef: ImageSourceRef, label: string) => void;
+  onRemoveImage?: (sourceRef: ImageSourceRef) => void;
 }
 
 export const NormalizedDocumentSection = ({
@@ -33,6 +34,7 @@ export const NormalizedDocumentSection = ({
   isViewMode,
   onSetHoveredMappingKeys,
   onEditImage,
+  onRemoveImage,
 }: ReviewDocumentBodyProps): JSX.Element => {
   return (
     <Box style={{ flex: 2 }}>
@@ -56,6 +58,7 @@ export const NormalizedDocumentSection = ({
               isViewMode={isViewMode}
               onSetHoveredMappingKeys={onSetHoveredMappingKeys}
               onEditImage={onEditImage}
+              onRemoveImage={onRemoveImage}
             />
           ) : (
             <BlockRenderer
@@ -70,6 +73,7 @@ export const NormalizedDocumentSection = ({
               isViewMode={isViewMode}
               onSetHoveredMappingKeys={onSetHoveredMappingKeys}
               onEditImage={onEditImage}
+              onRemoveImage={onRemoveImage}
             />
           )}
         </Box>

--- a/apps/drive-integration/src/locations/Page/components/review/mapping/ReviewImageAssetCard.tsx
+++ b/apps/drive-integration/src/locations/Page/components/review/mapping/ReviewImageAssetCard.tsx
@@ -1,5 +1,5 @@
 import { Box, Card, Flex, Image, MenuItem, Text } from '@contentful/f36-components';
-import { PencilSimpleIcon } from '@contentful/f36-icons';
+import { PencilSimpleIcon, TrashSimpleIcon } from '@contentful/f36-icons';
 import tokens from '@contentful/f36-tokens';
 import type { ImageSourceRef, NormalizedDocumentImage } from '@types';
 import Splitter from '../../mainpage/Splitter';
@@ -18,6 +18,7 @@ export interface ReviewImageAssetCardProps {
   onMouseEnter?: () => void;
   onMouseLeave?: () => void;
   onEdit?: () => void;
+  onRemove?: () => void;
 }
 
 export function getNormalizedImageDisplayName(image: NormalizedDocumentImage): string {
@@ -35,6 +36,7 @@ export function ReviewImageAssetCard({
   onMouseEnter,
   onMouseLeave,
   onEdit,
+  onRemove,
 }: ReviewImageAssetCardProps): JSX.Element {
   const title = getNormalizedImageDisplayName(image);
 
@@ -56,6 +58,25 @@ export function ReviewImageAssetCard({
       : `1px solid ${tokens.gray300}`
     : `1px solid ${isHighlighted ? 'transparent' : tokens.gray300}`;
 
+  const cardActions = [
+    onEdit ? (
+      <MenuItem key="edit" onClick={onEdit}>
+        <Flex alignItems="center" gap="spacing2Xs">
+          <PencilSimpleIcon size="tiny" />
+          <Text>Edit content mapping</Text>
+        </Flex>
+      </MenuItem>
+    ) : null,
+    onRemove ? (
+      <MenuItem key="remove" onClick={onRemove}>
+        <Flex alignItems="center" gap="spacing2Xs">
+          <TrashSimpleIcon size="tiny" color={tokens.red600} />
+          <Text fontColor="red600">Remove</Text>
+        </Flex>
+      </MenuItem>
+    ) : null,
+  ].filter((action): action is JSX.Element => action !== null);
+
   return (
     <Box
       data-testid={`review-image-asset-${buildSourceRefKey(sourceRef)}`}
@@ -74,20 +95,7 @@ export function ReviewImageAssetCard({
         boxSizing: 'border-box',
         padding: tokens.spacingXs,
       }}>
-      <Card
-        ariaLabel={title}
-        actions={
-          onEdit
-            ? [
-                <MenuItem key="edit" onClick={onEdit}>
-                  <Flex alignItems="center" gap="spacing2Xs">
-                    <PencilSimpleIcon size="tiny" />
-                    <Text>Edit content mapping</Text>
-                  </Flex>
-                </MenuItem>,
-              ]
-            : undefined
-        }>
+      <Card ariaLabel={title} actions={cardActions.length ? cardActions : undefined}>
         <Splitter />
         <Box padding="spacingS">
           <Image

--- a/apps/drive-integration/src/locations/Page/components/review/mapping/documentRenderers.tsx
+++ b/apps/drive-integration/src/locations/Page/components/review/mapping/documentRenderers.tsx
@@ -12,6 +12,7 @@ import {
 } from '@contentful/f36-components';
 import tokens from '@contentful/f36-tokens';
 import type {
+  ImageSourceRef,
   NormalizedDocumentContentBlock,
   NormalizedDocumentImage,
   NormalizedDocumentTable,
@@ -154,10 +155,8 @@ interface BlockRendererProps {
   hoveredMappingKeys: string[];
   isViewMode: boolean;
   onSetHoveredMappingKeys: (keys: string[]) => void;
-  onEditImage?: (
-    sourceRef: { type: 'image'; blockId: string; imageId: string },
-    label: string
-  ) => void;
+  onEditImage?: (sourceRef: ImageSourceRef, label: string) => void;
+  onRemoveImage?: (sourceRef: ImageSourceRef) => void;
 }
 
 export const BlockRenderer = ({
@@ -172,6 +171,7 @@ export const BlockRenderer = ({
   isViewMode,
   onSetHoveredMappingKeys,
   onEditImage,
+  onRemoveImage,
 }: BlockRendererProps) => {
   const visibleHighlights = filterByEntry(
     highlightIndex.blockHighlights[block.id] ?? [],
@@ -266,6 +266,9 @@ export const BlockRenderer = ({
                   ? () => onEditImage(imageSourceRef, image.title ?? image.altText ?? image.id)
                   : undefined
               }
+              onRemove={
+                highlighted && onRemoveImage ? () => onRemoveImage(imageSourceRef) : undefined
+              }
             />
           </Box>
         );
@@ -288,17 +291,8 @@ interface TableRendererProps {
   hoveredMappingKeys: string[];
   isViewMode: boolean;
   onSetHoveredMappingKeys: (keys: string[]) => void;
-  onEditImage?: (
-    sourceRef: {
-      type: 'tableImage';
-      tableId: string;
-      rowId: string;
-      cellId: string;
-      partId: string;
-      imageId: string;
-    },
-    label: string
-  ) => void;
+  onEditImage?: (sourceRef: ImageSourceRef, label: string) => void;
+  onRemoveImage?: (sourceRef: ImageSourceRef) => void;
 }
 
 interface TablePartRendererProps {
@@ -314,6 +308,7 @@ interface TablePartRendererProps {
   isViewMode: boolean;
   onSetHoveredMappingKeys: (keys: string[]) => void;
   onEditImage?: TableRendererProps['onEditImage'];
+  onRemoveImage?: TableRendererProps['onRemoveImage'];
 }
 
 const TablePartRenderer = ({
@@ -329,6 +324,7 @@ const TablePartRenderer = ({
   isViewMode,
   onSetHoveredMappingKeys,
   onEditImage,
+  onRemoveImage,
 }: TablePartRendererProps) => {
   if (part.type === 'image') {
     const image = imageById[part.imageId];
@@ -383,6 +379,7 @@ const TablePartRenderer = ({
               ? () => onEditImage(imageSourceRef, image.title ?? image.altText ?? image.id)
               : undefined
           }
+          onRemove={highlighted && onRemoveImage ? () => onRemoveImage(imageSourceRef) : undefined}
         />
       </Box>
     );
@@ -425,6 +422,7 @@ export const TableRenderer = ({
   isViewMode,
   onSetHoveredMappingKeys,
   onEditImage,
+  onRemoveImage,
 }: TableRendererProps) => {
   const borderIndex = fullHighlightIndex ?? highlightIndex;
 
@@ -488,6 +486,7 @@ export const TableRenderer = ({
                           isViewMode={isViewMode}
                           onSetHoveredMappingKeys={onSetHoveredMappingKeys}
                           onEditImage={onEditImage}
+                          onRemoveImage={onRemoveImage}
                         />
                       </Box>
                     );

--- a/apps/drive-integration/src/locations/Page/components/review/mapping/edit-modals/RemoveContentModal.tsx
+++ b/apps/drive-integration/src/locations/Page/components/review/mapping/edit-modals/RemoveContentModal.tsx
@@ -1,0 +1,30 @@
+import { Button, Modal, Paragraph } from '@contentful/f36-components';
+interface RemoveContentModalProps {
+  isOpen: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+export const RemoveContentModal = ({ isOpen, onConfirm, onCancel }: RemoveContentModalProps) => {
+  return (
+    <Modal isShown={isOpen} onClose={onCancel} size="medium" shouldCloseOnOverlayClick={false}>
+      {() => (
+        <>
+          <Modal.Header title="Remove content from entry" onClose={onCancel} />
+          <Modal.Content>
+            <Paragraph>
+              Are you sure you&apos;d like to remove this content from the entry?
+            </Paragraph>
+          </Modal.Content>
+          <Modal.Controls>
+            <Button onClick={onCancel} size="small" variant="secondary">
+              Cancel
+            </Button>
+            <Button onClick={onConfirm} size="small" variant="negative">
+              Remove
+            </Button>
+          </Modal.Controls>
+        </>
+      )}
+    </Modal>
+  );
+};

--- a/apps/drive-integration/test/locations/Page/components/review/mapping/MappingView.spec.tsx
+++ b/apps/drive-integration/test/locations/Page/components/review/mapping/MappingView.spec.tsx
@@ -1,7 +1,8 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MappingReviewSuspendPayload, SourceRef } from '@types';
 import { MappingView } from '../../../../../../src/locations/Page/components/review/mapping/MappingView';
+import React from 'react';
 
 const mockUseReviewTextSelection = vi.fn();
 const mockClearSelection = vi.fn();
@@ -1052,5 +1053,102 @@ describe('MappingView', () => {
 
     expect(screen.getByRole('heading', { name: 'Edit content mapping' })).toBeTruthy();
     expect(screen.getByText('Selected Article: Untitled')).toBeTruthy();
+  });
+
+  it('does not offer Remove in the selection menu for unmapped text', () => {
+    const selectedRange = createDetachedRange('plain text', 0, 5);
+    mockUseReviewTextSelection.mockReturnValue({
+      selectionRectangle: { top: 100, left: 100, right: 160, bottom: 120 },
+      selectedText: 'plain text',
+      selectedRange,
+      clearSelection: mockClearSelection,
+      freezeSelection: vi.fn(),
+    });
+
+    const payload = createPayload();
+    render(
+      <MappingView
+        payload={payload}
+        {...mappingViewGraphProps(payload)}
+        selectedEntryIndex={0}
+        mode="edit"
+      />
+    );
+
+    const menu = screen.getByTestId('review-selection-menu');
+    expect(within(menu).getByRole('button', { name: 'Edit content mapping' })).toBeTruthy();
+    expect(within(menu).queryByRole('button', { name: 'Remove' })).toBeNull();
+  });
+
+  it('removes content mapped to multiple fields of the same entry', () => {
+    const payload = createPayload({
+      fieldMappings: [
+        {
+          fieldId: 'body',
+          fieldType: 'Text',
+          sourceRefs: [createBlockTextSourceRef('block-1', 'Hello world')],
+        },
+        {
+          fieldId: 'summary',
+          fieldType: 'Text',
+          sourceRefs: [createBlockTextSourceRef('block-1', 'Hello world')],
+        },
+      ],
+    });
+
+    let currentGraph = payload.entryBlockGraph;
+    const onEntryBlockGraphChange = vi.fn(
+      (nextGraph: MappingReviewSuspendPayload['entryBlockGraph']) => {
+        currentGraph = nextGraph;
+      }
+    );
+
+    mockUseReviewTextSelection.mockReturnValueOnce({
+      selectionRectangle: null,
+      selectedText: '',
+      selectedRange: null,
+      clearSelection: mockClearSelection,
+      freezeSelection: vi.fn(),
+    });
+
+    const { container, rerender } = render(
+      <MappingView
+        payload={payload}
+        entryBlockGraph={currentGraph}
+        onEntryBlockGraphChange={onEntryBlockGraphChange}
+        selectedEntryIndex={0}
+        mode="edit"
+      />
+    );
+
+    const mappedSegment = container.querySelector('[data-review-text-segment="true"]');
+    const selectedRange = createDomRange(mappedSegment?.firstChild as Text, 0, 11);
+
+    mockUseReviewTextSelection.mockReturnValue({
+      selectionRectangle: { top: 100, left: 100, right: 160, bottom: 120 },
+      selectedText: 'Hello world',
+      selectedRange,
+      clearSelection: mockClearSelection,
+      freezeSelection: vi.fn(),
+    });
+
+    rerender(
+      <MappingView
+        payload={payload}
+        entryBlockGraph={currentGraph}
+        onEntryBlockGraphChange={onEntryBlockGraphChange}
+        selectedEntryIndex={0}
+        mode="edit"
+      />
+    );
+
+    const menu = screen.getByTestId('review-selection-menu');
+    fireEvent.click(within(menu).getByRole('button', { name: 'Remove' }));
+
+    const dialog = screen.getByRole('dialog');
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Remove' }));
+
+    expect(onEntryBlockGraphChange).toHaveBeenCalledTimes(1);
+    expect(currentGraph.entries[0].fieldMappings.map((fm) => fm.fieldId)).toEqual([]);
   });
 });

--- a/apps/drive-integration/test/locations/Page/components/review/mapping/MappingView.spec.tsx
+++ b/apps/drive-integration/test/locations/Page/components/review/mapping/MappingView.spec.tsx
@@ -16,15 +16,22 @@ vi.mock(
   () => ({
     ReviewImageAssetCard: ({
       onEdit,
+      onRemove,
       isHighlighted,
     }: {
       onEdit: () => void;
+      onRemove?: () => void;
       isHighlighted: boolean;
     }) => (
       <div>
         <button type="button" onClick={onEdit}>
           {isHighlighted ? 'Reassign image' : 'Assign image'}
         </button>
+        {onRemove ? (
+          <button type="button" onClick={onRemove}>
+            Remove image
+          </button>
+        ) : null}
       </div>
     ),
   })
@@ -1053,6 +1060,34 @@ describe('MappingView', () => {
 
     expect(screen.getByRole('heading', { name: 'Edit content mapping' })).toBeTruthy();
     expect(screen.getByText('Selected Article: Untitled')).toBeTruthy();
+  });
+
+  it('removes mapped image from the entry via the image card menu', () => {
+    const payload = createImagePayload();
+    let currentGraph = payload.entryBlockGraph;
+    const onEntryBlockGraphChange = vi.fn(
+      (nextGraph: MappingReviewSuspendPayload['entryBlockGraph']) => {
+        currentGraph = nextGraph;
+      }
+    );
+
+    render(
+      <MappingView
+        payload={payload}
+        entryBlockGraph={currentGraph}
+        onEntryBlockGraphChange={onEntryBlockGraphChange}
+        selectedEntryIndex={0}
+        mode="edit"
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove image' }));
+
+    const dialog = screen.getByRole('dialog');
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Remove' }));
+
+    expect(onEntryBlockGraphChange).toHaveBeenCalledTimes(1);
+    expect(currentGraph.entries[0].fieldMappings).toHaveLength(0);
   });
 
   it('does not offer Remove in the selection menu for unmapped text', () => {

--- a/apps/drive-integration/test/locations/Page/components/review/mapping/RemoveContentModal.spec.tsx
+++ b/apps/drive-integration/test/locations/Page/components/review/mapping/RemoveContentModal.spec.tsx
@@ -1,0 +1,48 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { RemoveContentModal } from '../../../../../../src/locations/Page/components/review/mapping/edit-modals/RemoveContentModal';
+import React from 'react';
+
+describe('RemoveContentModal', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('does not render when closed', () => {
+    render(<RemoveContentModal isOpen={false} onConfirm={vi.fn()} onCancel={vi.fn()} />);
+
+    expect(screen.queryByText('Remove content from entry')).toBeNull();
+  });
+
+  it('renders the confirmation copy and controls when open', () => {
+    render(<RemoveContentModal isOpen={true} onConfirm={vi.fn()} onCancel={vi.fn()} />);
+
+    expect(screen.getByRole('heading', { name: 'Remove content from entry' })).toBeTruthy();
+    expect(
+      screen.getByText("Are you sure you'd like to remove this content from the entry?")
+    ).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Remove' })).toBeTruthy();
+  });
+
+  it('calls onConfirm when Remove is clicked', () => {
+    const onConfirm = vi.fn();
+
+    render(<RemoveContentModal isOpen={true} onConfirm={onConfirm} onCancel={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onCancel when Cancel is clicked', () => {
+    const onCancel = vi.fn();
+
+    render(<RemoveContentModal isOpen={true} onConfirm={vi.fn()} onCancel={onCancel} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Purpose

Adds a Remove action to the mapping review selection menu in the drive-integration app, with a confirmation modal before content is unmapped from entry fields.

## Approach

- Selection menu redesign — EditMappingButton is now a split pill bar: `"Edit content mapping"` on the left, a `divider`, and a `"Remove"` action on the right (styles extracted to `EditMappingButton.styles.ts` via Emotion css).
- Remove confirmation modal — New RemoveContentModal asks `"Are you sure you'd like to remove this content from the entry?"` with Cancel / Remove actions.
- Remove flow in MappingView — Selecting mapped text shows Remove only when the selection overlaps mapped content. On confirm, the selected text/images are removed from every mapped field via existing applyTextExclusionToEntryBlockGraph / applyImageExclusionToEntryBlockGraph helpers.
- Multi-field edge case — If the same text is mapped to multiple fields on one entry (e.g. body and summary), removal clears it from all affected fields in one action.

## Testing steps

Automated tests for the Remove modal and the Mapping view added.

https://github.com/user-attachments/assets/93fbae26-7a90-46d7-b4c9-e00dc3a7b727

## Breaking Changes

No.

## Dependencies and/or References

[INTEG-4135](https://contentful.atlassian.net/jira/software/c/projects/INTEG/boards/454?issueParent=483434&selectedIssue=INTEG-4135)

## Deployment

No.

[INTEG-4135]: https://contentful.atlassian.net/browse/INTEG-4135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ