### PR TITLE
fix(wistia-videos): deduplicate videos to prevent double entries in field [ES-372]

### DIFF
--- a/apps/wistia-videos/src/functions/getVideos.ts
+++ b/apps/wistia-videos/src/functions/getVideos.ts
@@ -93,5 +93,12 @@ export const fetchVideos = async (
   );
   // Flatten array of arrays
   const videos = mappedProjects.flat(1);
-  return videos;
+  // Deduplicate by video ID — pagination fetches can return the same video twice
+  // when Wistia ignores the page param and returns all medias on every page
+  const seen = new Set<number>();
+  return videos.filter((v) => {
+    if (seen.has(v.id)) return false;
+    seen.add(v.id);
+    return true;
+  });
 };


### PR DESCRIPTION
## Summary

- Selecting a video in the `wistiaVideo` JSON field was adding 2 copies of each selected video to the field value,
<img width="754" height="90" alt="Screenshot 2026-06-12 at 12 50 18 PM" src="https://github.com/user-attachments/assets/3a72104b-8489-4003-92bb-ac1ffc10089d" />

## Root cause

A Wistia account with more than 500 videos in a single project (`VIDEOS_PER_PAGE = 500`) triggers the pagination logic in `fetchVideos`. It fetches an additional page (`projects/{id}.json?page=2`), but Wistia's project endpoint **ignores the `page` parameter** and returns all medias on every request.

This means `data` ends up with every video duplicated. When `setNewValues` filters `data` by selected IDs, both copies of each selected video pass the filter and get written to the field.

## Fix

Deduplicate videos by `id` after flattening results in `fetchVideos`, before returning to the component.
