### PR TITLE
fix(wistia-videos): set vite outDir to build [ES-372]

### DIFF
--- a/apps/wistia-videos/vite.config.ts
+++ b/apps/wistia-videos/vite.config.ts
@@ -6,6 +6,9 @@ export default defineConfig(() => ({
   server: {
     port: 3000,
   },
+  build: {
+    outDir: 'build',
+  },
   plugins: [react()],
   test: {
     environment: 'happy-dom',


### PR DESCRIPTION
## Summary

- `npm run deploy` was failing with `ENOENT: no such file or directory, scandir 'build'` because Vite defaults to outputting to `dist/` but the deploy script expected `build/`
- Added `build.outDir: 'build'` to `vite.config.ts` to match the deploy script convention used by all other apps in this repo
