### PR TITLE
fix(rich-text-versioning): bump field-editor-rich-text to 6.3.9 [ES-262] [ES-319]

### DIFF
--- a/apps/rich-text-versioning/package-lock.json
+++ b/apps/rich-text-versioning/package-lock.json
@@ -13,7 +13,7 @@
         "@contentful/f36-components": "4.81.1",
         "@contentful/f36-multiselect": "^4.81.1",
         "@contentful/f36-tokens": "4.2.0",
-        "@contentful/field-editor-rich-text": "4.16.0",
+        "@contentful/field-editor-rich-text": "6.3.9",
         "@contentful/react-apps-toolkit": "1.2.16",
         "@contentful/rich-text-html-renderer": "^17.1.0",
         "@contentful/rich-text-react-renderer": "^16.1.0",
@@ -296,9 +296,10 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
-      "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -414,11 +415,12 @@
       }
     },
     "node_modules/@contentful/contentful-slatejs-adapter": {
-      "version": "15.18.11",
-      "resolved": "https://registry.npmjs.org/@contentful/contentful-slatejs-adapter/-/contentful-slatejs-adapter-15.18.11.tgz",
-      "integrity": "sha512-smV7HuOCeFeNljGff653jWW+0hLV6RKPMx25CHx5Hn719xZCZTVPBGU9UkZOfuMADFvggJlxjaMi4PhyQrDtkg==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/contentful-slatejs-adapter/-/contentful-slatejs-adapter-16.2.1.tgz",
+      "integrity": "sha512-mil+xbUSQIEwf9XeYxK3OTmIAzYiCHQxk4uHcl3/SJf8+MTiot2dMQuf5m+DyFkpDDP4tc51c8H00sDc/frbXw==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/rich-text-types": "^16.8.5"
+        "@contentful/rich-text-types": "^17.2.7"
       },
       "engines": {
         "node": ">=6.0.0"
@@ -830,182 +832,249 @@
       }
     },
     "node_modules/@contentful/f36-layout": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-layout/-/f36-layout-5.6.0.tgz",
-      "integrity": "sha512-mA1mxDqq1p/cCde4mnkzUy/oqW41WotPtvPkc2ekgLfBUl8bZjKssXuLzZRycUYLg2duB6++iiEkhVS1nBnyFQ==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-layout/-/f36-layout-6.11.1.tgz",
+      "integrity": "sha512-igMiDoFFaKzd3NXPm1BW5mXCOcGmp/jd2S+znskKonA3Ebe7wMP8Q0zQAeQmOExqYshtZzxVUhxtfSl7J3BjDg==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-header": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-header": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-layout/node_modules/@contentful/f36-button": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-5.6.0.tgz",
-      "integrity": "sha512-JGXADlfIbtbVPUeUvVhFr2yt+5b758T6layvgFK52JV7dWyitOdA2HQ7K1/EtLQXmk0pk2zfvV9X4gQpFotZxw==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-6.11.1.tgz",
+      "integrity": "sha512-vqpIcE5aarFJmgQFSwz6wZg2uB+xKXC/hGBzMUHYd2Ny/aj/2n/KLQwMye4lWLV/NKTOeZX2Il1K5FxlDUVaKg==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-spinner": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.6.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-spinner": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-tooltip": "^6.11.1",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-layout/node_modules/@contentful/f36-core": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-5.6.0.tgz",
-      "integrity": "sha512-O9t4UzEEyjbYs637uUfiTGHwNwvqfMPYkrgW47g03XPwo1gRoXNaJzMNJLemkW/8ZqjrgBsEE4Q6QvKtOdDb0A==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-6.11.1.tgz",
+      "integrity": "sha512-1XaG6AA2aWw+BgXzqpJdj2T7lf0bVW6i1tQa05e7vHEf/RSFVPNN6W2KjPC4KX2lZx5GUSjhWU0rET5Nuq6yiQ==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-tokens": "^5.1.0",
-        "@emotion/core": "^10.1.1",
-        "@emotion/is-prop-valid": "^1.2.0",
-        "csstype": "^3.1.1",
-        "emotion": "^10.0.17"
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5",
+        "@emotion/react": "^11.14.0",
+        "csstype": "^3.1.1"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-layout/node_modules/@contentful/f36-header": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-header/-/f36-header-5.6.0.tgz",
-      "integrity": "sha512-bY7uhrdv3O7GfQ1soJkkn0BOox6HuJhk1Vc0xorEpnI/o4QdiO5tMW7XO0A++dzEtZfYffYRCBenPmn+M840YQ==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-header/-/f36-header-6.11.1.tgz",
+      "integrity": "sha512-OuCVUcDC0odL7hK5NklP1EfpRcyTRoEAVfjGrZKOZONJDzuF8jJtZIC1rU1LcVdsbOrYh3rMlkrYw0SCqSlMOg==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-button": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-layout/node_modules/@contentful/f36-icon": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-5.6.0.tgz",
-      "integrity": "sha512-VoyKI+rQGK5a3XyFvNG5PMa5FsGdo23XTB0Mj8ukIIvm6ZEBPTHqCGoKnPdl+s2+txIiMSbAmJslEbJR6KZiBg==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-6.11.1.tgz",
+      "integrity": "sha512-J/TBh1T2+15FsigCjcR5ZVjzsIBs5nPsUHIOdo8Y4XfKO6uo2tp+IdV8n/JMDB+vifJBno8iX7r2zuvMZut94g==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@phosphor-icons/react": "2.1.8",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5",
+        "@phosphor-icons/react": "2.1.8"
       },
       "engines": {
         "node": ">=16"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-layout/node_modules/@contentful/f36-icons": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-5.6.0.tgz",
-      "integrity": "sha512-YM2KNFbmGAkqY6iug8ja8TCBpLxZm2jECZDujRweHyRnTRfHpoIjuP+14LO0iv/ilJEK6DedJoAflz0QJ20a8w==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-6.11.1.tgz",
+      "integrity": "sha512-o2OHFUyikwEtoZC8WEU+26pWYpSnoLUDJ3ryYYkCCgfP9Y/TtmaZxox79lWvVcSS5vHX19Sd7WZqbFD23vzhIA==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icon": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@phosphor-icons/react": "2.1.8",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icon": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5",
+        "@phosphor-icons/react": "2.1.8"
       },
       "engines": {
         "node": ">=16"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-layout/node_modules/@contentful/f36-spinner": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-5.6.0.tgz",
-      "integrity": "sha512-NmH/bNol+e7AarybNgv8B8lodF2hOFlF32H6QAEhsHmq76dxOQ6LlgjlxIttNpIrGgHYU29yWAH5LhTu/BAE7g==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-6.11.1.tgz",
+      "integrity": "sha512-3JDRcduSJQmXWCDYx0dtOcZoBzvdvLUSrvKFJbhZCUUcw2fhEHPoAXbyMqwakzKxySJDAboB3NnM32aiI+oThQ==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-layout/node_modules/@contentful/f36-tokens": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-5.1.0.tgz",
-      "integrity": "sha512-7++MPQiizK6qLhPkilWIKqM5Mhdr199tK7dL4iZ689iTwA82uvXXOojJr+0wVOurG2Odb+6/3WLe1XdveDZHEA==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.1.3.tgz",
+      "integrity": "sha512-3q1IHaCn7zY1ZEyN8LeMlm4R+lvQgEmFR2B5sqIx4Z+Rsr1HRDP+iUYf0ZSXTMETiPd/DP8uiR0RGAvBWeceww==",
       "license": "MIT"
     },
     "node_modules/@contentful/f36-layout/node_modules/@contentful/f36-tooltip": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-5.6.0.tgz",
-      "integrity": "sha512-e4z+eysp95u4ASheQgkJJM+RXyZv/KyMi4bqqez2ydvkFtFViI7E+wkzxIbB5L2EzHqIGL6/IcgQ8GC6io/Fsw==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-6.11.1.tgz",
+      "integrity": "sha512-5FGWpcJBMGoMADkEMUIqGOf72qRSMzJw/w70RzIl1LZKHr6BjFWeQYQkx3d2lbW7l939c12L5BbiD5sfDIifXA==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "@popperjs/core": "^2.11.5",
-        "csstype": "^3.1.1",
-        "emotion": "^10.0.17",
-        "react-popper": "^2.3.0"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5",
+        "@floating-ui/dom": "^1.7.4",
+        "@floating-ui/react": "^0.27.16"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-layout/node_modules/@contentful/f36-typography": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-5.6.0.tgz",
-      "integrity": "sha512-v8myIeJnpZ6g2WRmL9oOOLrjip3+80Y+LQ4PwOzcJatL5AdwSYVExtlFMMVO5/JNt6qEpT2sd5579LPA17yiVg==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-6.11.1.tgz",
+      "integrity": "sha512-TRXk7xHQJ4m32kvw78XnRPwQudUdwwM87qxCbWLtpihu1ilq1b0iqP7rxBNCsXkj7SOIgP+BPHN/iUDSXsD/9A==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-layout/node_modules/@contentful/f36-utils": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-utils/-/f36-utils-5.2.0.tgz",
-      "integrity": "sha512-0YWsKAdU2HeNz5DwuOCR0lnlHVhlXiDkqtYaH8hHqT9HlQKHDSBPQUI9Vk5OrPDRJ3uLVoyGOJcvUDf27tTopA==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-utils/-/f36-utils-6.1.2.tgz",
+      "integrity": "sha512-gaG+q5NHVEfDzCEGoK12/+8Y1VODPO8k/DyrZjCIOTxTK9rXZ5l1xESMbnMAbwHnz2zXoLkkzI0QGCChW6xrpw==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-tokens": "^5.1.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-tokens": "^6.1.2",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
+    },
+    "node_modules/@contentful/f36-layout/node_modules/@emotion/cache": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@contentful/f36-layout/node_modules/@emotion/css": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.13.5.tgz",
+      "integrity": "sha512-wQdD0Xhkn3Qy2VNcIzbLP9MR8TafI0MJb7BEAXKp+w4+XqErksWR4OXomuDzPsN4InLdGhVe6EYcn2ZIUCpB8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.13.5",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2"
+      }
+    },
+    "node_modules/@contentful/f36-layout/node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-layout/node_modules/@emotion/serialize": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@contentful/f36-layout/node_modules/@emotion/sheet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-layout/node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-layout/node_modules/@emotion/utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-layout/node_modules/@emotion/weak-memoize": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
+      "license": "MIT"
     },
     "node_modules/@contentful/f36-list": {
       "version": "4.81.1",
@@ -1103,41 +1172,109 @@
       }
     },
     "node_modules/@contentful/f36-navlist": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-navlist/-/f36-navlist-5.6.0.tgz",
-      "integrity": "sha512-DEIN+DBCZ4yLwf/KOWgd27oY+ztc/sHXxAAmKPRd0QebwtwSwRCr4YI2H5jbPUGZbmw+vQyvX1apsPP6bwCI1A==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-navlist/-/f36-navlist-6.11.1.tgz",
+      "integrity": "sha512-hJEjK99zOIB2ykh5KChuE0c7zNIULg7AO8NcsFsmTGgwwM93wPkrd/qJbDGRMkOyJPStu+GuCqlg20yzgSkFbw==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-navlist/node_modules/@contentful/f36-core": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-5.6.0.tgz",
-      "integrity": "sha512-O9t4UzEEyjbYs637uUfiTGHwNwvqfMPYkrgW47g03XPwo1gRoXNaJzMNJLemkW/8ZqjrgBsEE4Q6QvKtOdDb0A==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-6.11.1.tgz",
+      "integrity": "sha512-1XaG6AA2aWw+BgXzqpJdj2T7lf0bVW6i1tQa05e7vHEf/RSFVPNN6W2KjPC4KX2lZx5GUSjhWU0rET5Nuq6yiQ==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-tokens": "^5.1.0",
-        "@emotion/core": "^10.1.1",
-        "@emotion/is-prop-valid": "^1.2.0",
-        "csstype": "^3.1.1",
-        "emotion": "^10.0.17"
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5",
+        "@emotion/react": "^11.14.0",
+        "csstype": "^3.1.1"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-navlist/node_modules/@contentful/f36-tokens": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-5.1.0.tgz",
-      "integrity": "sha512-7++MPQiizK6qLhPkilWIKqM5Mhdr199tK7dL4iZ689iTwA82uvXXOojJr+0wVOurG2Odb+6/3WLe1XdveDZHEA==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.1.3.tgz",
+      "integrity": "sha512-3q1IHaCn7zY1ZEyN8LeMlm4R+lvQgEmFR2B5sqIx4Z+Rsr1HRDP+iUYf0ZSXTMETiPd/DP8uiR0RGAvBWeceww==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-navlist/node_modules/@emotion/cache": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@contentful/f36-navlist/node_modules/@emotion/css": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.13.5.tgz",
+      "integrity": "sha512-wQdD0Xhkn3Qy2VNcIzbLP9MR8TafI0MJb7BEAXKp+w4+XqErksWR4OXomuDzPsN4InLdGhVe6EYcn2ZIUCpB8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.13.5",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2"
+      }
+    },
+    "node_modules/@contentful/f36-navlist/node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-navlist/node_modules/@emotion/serialize": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@contentful/f36-navlist/node_modules/@emotion/sheet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-navlist/node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-navlist/node_modules/@emotion/utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-navlist/node_modules/@emotion/weak-memoize": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
       "license": "MIT"
     },
     "node_modules/@contentful/f36-note": {
@@ -1231,166 +1368,233 @@
       }
     },
     "node_modules/@contentful/f36-progress-stepper": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-progress-stepper/-/f36-progress-stepper-5.6.0.tgz",
-      "integrity": "sha512-oFdoZU3jY8OUn9Br3sZWHOkOtuaKWRA2G/bDsGoxY5NpdCrAg0nfsAJ9qConkeF9bQY04elV9+4bcW+R3B55zw==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-progress-stepper/-/f36-progress-stepper-6.11.1.tgz",
+      "integrity": "sha512-uew3ibk4h7htY0QK/iIlgfmO/Y4MQT0P+jTaGozb4IMxT67Ust4ZywyWhiHg/6HdqgSKcL8Hrykj18Rgv5cjiQ==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-button": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-progress-stepper/node_modules/@contentful/f36-button": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-5.6.0.tgz",
-      "integrity": "sha512-JGXADlfIbtbVPUeUvVhFr2yt+5b758T6layvgFK52JV7dWyitOdA2HQ7K1/EtLQXmk0pk2zfvV9X4gQpFotZxw==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-6.11.1.tgz",
+      "integrity": "sha512-vqpIcE5aarFJmgQFSwz6wZg2uB+xKXC/hGBzMUHYd2Ny/aj/2n/KLQwMye4lWLV/NKTOeZX2Il1K5FxlDUVaKg==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-spinner": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.6.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-spinner": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-tooltip": "^6.11.1",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-progress-stepper/node_modules/@contentful/f36-core": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-5.6.0.tgz",
-      "integrity": "sha512-O9t4UzEEyjbYs637uUfiTGHwNwvqfMPYkrgW47g03XPwo1gRoXNaJzMNJLemkW/8ZqjrgBsEE4Q6QvKtOdDb0A==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-6.11.1.tgz",
+      "integrity": "sha512-1XaG6AA2aWw+BgXzqpJdj2T7lf0bVW6i1tQa05e7vHEf/RSFVPNN6W2KjPC4KX2lZx5GUSjhWU0rET5Nuq6yiQ==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-tokens": "^5.1.0",
-        "@emotion/core": "^10.1.1",
-        "@emotion/is-prop-valid": "^1.2.0",
-        "csstype": "^3.1.1",
-        "emotion": "^10.0.17"
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5",
+        "@emotion/react": "^11.14.0",
+        "csstype": "^3.1.1"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-progress-stepper/node_modules/@contentful/f36-icon": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-5.6.0.tgz",
-      "integrity": "sha512-VoyKI+rQGK5a3XyFvNG5PMa5FsGdo23XTB0Mj8ukIIvm6ZEBPTHqCGoKnPdl+s2+txIiMSbAmJslEbJR6KZiBg==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-6.11.1.tgz",
+      "integrity": "sha512-J/TBh1T2+15FsigCjcR5ZVjzsIBs5nPsUHIOdo8Y4XfKO6uo2tp+IdV8n/JMDB+vifJBno8iX7r2zuvMZut94g==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@phosphor-icons/react": "2.1.8",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5",
+        "@phosphor-icons/react": "2.1.8"
       },
       "engines": {
         "node": ">=16"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-progress-stepper/node_modules/@contentful/f36-icons": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-5.6.0.tgz",
-      "integrity": "sha512-YM2KNFbmGAkqY6iug8ja8TCBpLxZm2jECZDujRweHyRnTRfHpoIjuP+14LO0iv/ilJEK6DedJoAflz0QJ20a8w==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-6.11.1.tgz",
+      "integrity": "sha512-o2OHFUyikwEtoZC8WEU+26pWYpSnoLUDJ3ryYYkCCgfP9Y/TtmaZxox79lWvVcSS5vHX19Sd7WZqbFD23vzhIA==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icon": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@phosphor-icons/react": "2.1.8",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icon": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5",
+        "@phosphor-icons/react": "2.1.8"
       },
       "engines": {
         "node": ">=16"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-progress-stepper/node_modules/@contentful/f36-spinner": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-5.6.0.tgz",
-      "integrity": "sha512-NmH/bNol+e7AarybNgv8B8lodF2hOFlF32H6QAEhsHmq76dxOQ6LlgjlxIttNpIrGgHYU29yWAH5LhTu/BAE7g==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-6.11.1.tgz",
+      "integrity": "sha512-3JDRcduSJQmXWCDYx0dtOcZoBzvdvLUSrvKFJbhZCUUcw2fhEHPoAXbyMqwakzKxySJDAboB3NnM32aiI+oThQ==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-progress-stepper/node_modules/@contentful/f36-tokens": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-5.1.0.tgz",
-      "integrity": "sha512-7++MPQiizK6qLhPkilWIKqM5Mhdr199tK7dL4iZ689iTwA82uvXXOojJr+0wVOurG2Odb+6/3WLe1XdveDZHEA==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.1.3.tgz",
+      "integrity": "sha512-3q1IHaCn7zY1ZEyN8LeMlm4R+lvQgEmFR2B5sqIx4Z+Rsr1HRDP+iUYf0ZSXTMETiPd/DP8uiR0RGAvBWeceww==",
       "license": "MIT"
     },
     "node_modules/@contentful/f36-progress-stepper/node_modules/@contentful/f36-tooltip": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-5.6.0.tgz",
-      "integrity": "sha512-e4z+eysp95u4ASheQgkJJM+RXyZv/KyMi4bqqez2ydvkFtFViI7E+wkzxIbB5L2EzHqIGL6/IcgQ8GC6io/Fsw==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-6.11.1.tgz",
+      "integrity": "sha512-5FGWpcJBMGoMADkEMUIqGOf72qRSMzJw/w70RzIl1LZKHr6BjFWeQYQkx3d2lbW7l939c12L5BbiD5sfDIifXA==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "@popperjs/core": "^2.11.5",
-        "csstype": "^3.1.1",
-        "emotion": "^10.0.17",
-        "react-popper": "^2.3.0"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5",
+        "@floating-ui/dom": "^1.7.4",
+        "@floating-ui/react": "^0.27.16"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-progress-stepper/node_modules/@contentful/f36-typography": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-5.6.0.tgz",
-      "integrity": "sha512-v8myIeJnpZ6g2WRmL9oOOLrjip3+80Y+LQ4PwOzcJatL5AdwSYVExtlFMMVO5/JNt6qEpT2sd5579LPA17yiVg==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-6.11.1.tgz",
+      "integrity": "sha512-TRXk7xHQJ4m32kvw78XnRPwQudUdwwM87qxCbWLtpihu1ilq1b0iqP7rxBNCsXkj7SOIgP+BPHN/iUDSXsD/9A==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/f36-progress-stepper/node_modules/@contentful/f36-utils": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-utils/-/f36-utils-5.2.0.tgz",
-      "integrity": "sha512-0YWsKAdU2HeNz5DwuOCR0lnlHVhlXiDkqtYaH8hHqT9HlQKHDSBPQUI9Vk5OrPDRJ3uLVoyGOJcvUDf27tTopA==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-utils/-/f36-utils-6.1.2.tgz",
+      "integrity": "sha512-gaG+q5NHVEfDzCEGoK12/+8Y1VODPO8k/DyrZjCIOTxTK9rXZ5l1xESMbnMAbwHnz2zXoLkkzI0QGCChW6xrpw==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-tokens": "^5.1.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-tokens": "^6.1.2",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
+    },
+    "node_modules/@contentful/f36-progress-stepper/node_modules/@emotion/cache": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@contentful/f36-progress-stepper/node_modules/@emotion/css": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.13.5.tgz",
+      "integrity": "sha512-wQdD0Xhkn3Qy2VNcIzbLP9MR8TafI0MJb7BEAXKp+w4+XqErksWR4OXomuDzPsN4InLdGhVe6EYcn2ZIUCpB8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.13.5",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2"
+      }
+    },
+    "node_modules/@contentful/f36-progress-stepper/node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-progress-stepper/node_modules/@emotion/serialize": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@contentful/f36-progress-stepper/node_modules/@emotion/sheet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-progress-stepper/node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-progress-stepper/node_modules/@emotion/utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-progress-stepper/node_modules/@emotion/weak-memoize": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
+      "license": "MIT"
     },
     "node_modules/@contentful/f36-skeleton": {
       "version": "4.81.1",
@@ -1551,262 +1755,245 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/@contentful/field-editor-rich-text": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-rich-text/-/field-editor-rich-text-4.16.0.tgz",
-      "integrity": "sha512-PSpXbCNMJWNf/8sVBEDOKrvrlJvypiHhGDGkVGUS59/iUoE0YQdCMDmiXLan3ugRPottInOoxIxJrW3S0173Bg==",
+    "node_modules/@contentful/field-editor-reference": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-reference/-/field-editor-reference-8.3.2.tgz",
+      "integrity": "sha512-Srlq1wXWnwbRwxmI9XAmrx9SpjM2EsGt8U+g0PBzR6B8M181MAJkDVK9dB2Ojlo2WsIqyRJyU8lb9UBORC6jjQ==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/app-sdk": "^4.42.0",
-        "@contentful/contentful-slatejs-adapter": "^15.16.5",
-        "@contentful/f36-components": "^5.4.1",
-        "@contentful/f36-icons": "^5.4.1",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-utils": "^5.1.0",
-        "@contentful/field-editor-reference": "^6.15.0",
-        "@contentful/field-editor-shared": "^2.16.0",
-        "@contentful/rich-text-plain-text-renderer": "^17.0.0",
-        "@contentful/rich-text-types": "^17.0.0",
-        "@popperjs/core": "^2.11.5",
-        "@udecode/plate-basic-marks": "36.0.0",
-        "@udecode/plate-break": "36.0.0",
-        "@udecode/plate-common": "36.5.9",
-        "@udecode/plate-core": "36.5.9",
-        "@udecode/plate-list": "36.0.0",
-        "@udecode/plate-paragraph": "36.0.0",
-        "@udecode/plate-reset-node": "36.0.0",
-        "@udecode/plate-select": "36.0.0",
-        "@udecode/plate-serializer-docx": "36.0.10",
-        "@udecode/plate-table": "36.5.9",
-        "@udecode/plate-trailing-block": "36.0.0",
+        "@contentful/f36-components": "^6.7.1",
+        "@contentful/f36-icons": "^6.7.1",
+        "@contentful/f36-tokens": "^6.1.2",
+        "@contentful/field-editor-shared": "^4.4.1",
+        "@contentful/mimetype": "^2.2.29",
+        "@dnd-kit/core": "^6.0.8",
+        "@dnd-kit/sortable": "^8.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
+        "@emotion/css": "^11.13.5",
+        "@tanstack/react-query": "^4.3.9",
         "constate": "^3.3.2",
-        "fast-deep-equal": "^3.1.3",
-        "is-hotkey": "^0.2.0",
-        "is-plain-obj": "^3.0.0",
-        "lodash": "^4.17.21",
-        "moment": "^2.20.0",
-        "p-debounce": "^2.1.0",
-        "react-popper": "^2.3.0",
-        "scroll-into-view-if-needed": "^3.1.0",
-        "slate": "0.94.1",
-        "slate-history": "0.100.0",
-        "slate-hyperscript": "0.77.0",
-        "slate-react": "0.102.0"
-      },
-      "peerDependencies": {
-        "@lingui/core": "^5.3.0",
-        "react": ">=16.14.0",
-        "react-dom": ">=16.14.0"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-accordion": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-5.6.0.tgz",
-      "integrity": "sha512-WlKwS5/tMWfn3yrjRDFglVB8Ozc9e0su2rF0t0v4pynEPZ8WJfXYqTQQMoYEBqgBejZjVWkwK+DDaR2XgzlArw==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-collapse": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-asset": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-5.6.0.tgz",
-      "integrity": "sha512-wikvFGMpqdN5IjIUabSQb1nPGCeaPUbV6MiH5SCzaNHAv4ldINUG5Xs/J/Eb9RHs7BV7ZO4Rg/RYwDuT8/23Sw==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icon": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-autocomplete": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-5.6.0.tgz",
-      "integrity": "sha512-WmkivMbLBd+CWjALNVMppYVfRBEPfMxi5JTYGZaNHoQsv3SJ3GO5B74U6mwSlWWz18nSE2pI+TJ1Mz0s2jhxyw==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-forms": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-popover": "^5.6.0",
-        "@contentful/f36-skeleton": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "downshift": "^6.1.12",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-avatar": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-avatar/-/f36-avatar-5.6.0.tgz",
-      "integrity": "sha512-hNtqfAZ5wrlZniiNMAGU9BE/lq9yBiMlgvnsa3fV8qoBo7fRdnVnjuRvEk3DfXYXX44EAj+XIKfDSdsAExr+wA==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-image": "^5.6.0",
-        "@contentful/f36-menu": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.6.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-badge": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-5.6.0.tgz",
-      "integrity": "sha512-vVqdq3kDeiMwmdAT5EEpgUIIQSjQJpzkeOqsF4cIbRh63D7Xaseyj5TJE1O3uFA4zcvLrE/Iyx9lQd5YtViiJg==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-button": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-5.6.0.tgz",
-      "integrity": "sha512-JGXADlfIbtbVPUeUvVhFr2yt+5b758T6layvgFK52JV7dWyitOdA2HQ7K1/EtLQXmk0pk2zfvV9X4gQpFotZxw==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-spinner": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.6.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-card": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-5.6.0.tgz",
-      "integrity": "sha512-gYiirKFMavN+JJErA319hpe6Y0UD8nLOzyZI/GRvG0ugEaIFuXBlFL9U5V5dE/TsctNOAk3dshFlhBTpxpFvGg==",
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/f36-asset": "^5.6.0",
-        "@contentful/f36-badge": "^5.6.0",
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-drag-handle": "^5.6.0",
-        "@contentful/f36-icon": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-menu": "^5.6.0",
-        "@contentful/f36-skeleton": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.6.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "emotion": "^10.0.17",
+        "contentful-management": "^12.3.0",
+        "date-fns": "^2.30.0",
+        "lodash": "^4.17.15",
+        "p-queue": "^4.0.0",
+        "react-intersection-observer": "9.4.0",
         "truncate": "^3.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "@contentful/app-sdk": "^4.41.2",
+        "@lingui/core": "^5.3.0",
+        "react": ">=18.3.1",
+        "react-dom": ">=18.3.1"
       }
     },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-collapse": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-5.6.0.tgz",
-      "integrity": "sha512-4Jq9Jp1rGyHZqdnLS5Vixw5x4pjqxLxHGn+/vHR5xm7LWWijvEGXo95qSLqIp74S8U48GVYvWZvdlu9T2uOhhg==",
+    "node_modules/@contentful/field-editor-reference/node_modules/@contentful/f36-accordion": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-6.11.1.tgz",
+      "integrity": "sha512-+5bGi6jPVVmoe0JB7wFzGiNMVRO3twSX2ecMzDIC27WgKW8NtaAIhsbb6678pGHlqdlqHuez7VwEL+CpEgyJYg==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-collapse": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-components": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-5.6.0.tgz",
-      "integrity": "sha512-vyofnGjXHWjG9OR8Bm9SJLA3kNyFGz1eFnICsJWLK9TBly/MXpcm8xQaA7cR5+Q4dZebNE59j5bdfk2w5jUGNQ==",
+    "node_modules/@contentful/field-editor-reference/node_modules/@contentful/f36-asset": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-6.11.1.tgz",
+      "integrity": "sha512-6IyoylrbLX2qXmRg6E/Dk5gC/o7toR2t5V08xDLmup+GKuXHRLaaP2xF40guumZedX0DNFtbwRG5uarLJ/IXSQ==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-accordion": "^5.6.0",
-        "@contentful/f36-asset": "^5.6.0",
-        "@contentful/f36-autocomplete": "^5.6.0",
-        "@contentful/f36-avatar": "^5.6.0",
-        "@contentful/f36-badge": "^5.6.0",
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-card": "^5.6.0",
-        "@contentful/f36-collapse": "^5.6.0",
-        "@contentful/f36-copybutton": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-datepicker": "^5.6.0",
-        "@contentful/f36-datetime": "^5.6.0",
-        "@contentful/f36-drag-handle": "^5.6.0",
-        "@contentful/f36-empty-state": "^5.6.0",
-        "@contentful/f36-entity-list": "^5.6.0",
-        "@contentful/f36-forms": "^5.6.0",
-        "@contentful/f36-header": "^5.6.0",
-        "@contentful/f36-icon": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-image": "^5.6.0",
-        "@contentful/f36-layout": "^5.6.0",
-        "@contentful/f36-list": "^5.6.0",
-        "@contentful/f36-menu": "^5.6.0",
-        "@contentful/f36-modal": "^5.6.0",
-        "@contentful/f36-multiselect": "^5.6.0",
-        "@contentful/f36-navlist": "^5.6.0",
-        "@contentful/f36-note": "^5.6.0",
-        "@contentful/f36-notification": "^5.6.0",
-        "@contentful/f36-pagination": "^5.6.0",
-        "@contentful/f36-pill": "^5.6.0",
-        "@contentful/f36-popover": "^5.6.0",
-        "@contentful/f36-progress-stepper": "^5.6.0",
-        "@contentful/f36-skeleton": "^5.6.0",
-        "@contentful/f36-spinner": "^5.6.0",
-        "@contentful/f36-table": "^5.6.0",
-        "@contentful/f36-tabs": "^5.6.0",
-        "@contentful/f36-text-link": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.6.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "@contentful/f36-usage-card": "^5.6.0",
-        "@contentful/f36-usage-count": "^5.6.0",
-        "@contentful/f36-utils": "^5.2.0"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icon": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "@types/react": ">=16.8",
-        "@types/react-dom": ">=16.8",
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-reference/node_modules/@contentful/f36-autocomplete": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-6.11.1.tgz",
+      "integrity": "sha512-oHelyxej2RxCpx2AUI8exdnj5ovAM5E/kPeG6mkMN8hE3MNq2/AFpUYkn7BjjdJqrFGjsE3ioZcskr0cktf55w==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-forms": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-popover": "^6.11.1",
+        "@contentful/f36-skeleton": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5",
+        "downshift": "^9.0.10"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-reference/node_modules/@contentful/f36-avatar": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-avatar/-/f36-avatar-6.11.1.tgz",
+      "integrity": "sha512-+WiwJe5pyKjBZFnODNCnv8bljmnWn4AjWhx0u7xA1IN7aY87rY2yTLcO+enb4dJiMSID8EED5PsIPbxKtsBi2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-image": "^6.11.1",
+        "@contentful/f36-menu": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-tooltip": "^6.11.1",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-reference/node_modules/@contentful/f36-badge": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-6.11.1.tgz",
+      "integrity": "sha512-9ASyA33Q1CrAMJnHiqBci87S7LqPbiSdw2JU63cwoTfA4+ovXgaXpOlBCjGKsnlkJiE5NcBgWbWTqOFWV6cikw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-reference/node_modules/@contentful/f36-button": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-6.11.1.tgz",
+      "integrity": "sha512-vqpIcE5aarFJmgQFSwz6wZg2uB+xKXC/hGBzMUHYd2Ny/aj/2n/KLQwMye4lWLV/NKTOeZX2Il1K5FxlDUVaKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-spinner": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-tooltip": "^6.11.1",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-reference/node_modules/@contentful/f36-card": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-6.11.1.tgz",
+      "integrity": "sha512-xhV5wfHvsV/rU6V9fUAg/t6FlFqKqJr4PM17MO0ZXIsXxAciralDYiFquWvQQF4f0XPa5778E8ez6eZleTldLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-asset": "^6.11.1",
+        "@contentful/f36-badge": "^6.11.1",
+        "@contentful/f36-button": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-drag-handle": "^6.11.1",
+        "@contentful/f36-icon": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-menu": "^6.11.1",
+        "@contentful/f36-skeleton": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-tooltip": "^6.11.1",
+        "@contentful/f36-typography": "^6.11.1",
+        "@emotion/css": "^11.13.5",
+        "truncate": "^3.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-reference/node_modules/@contentful/f36-collapse": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-6.11.1.tgz",
+      "integrity": "sha512-Kuz18J7qFQFVdujV1xx0yStrdi4vT6Up3LmvCqnr7RdNdJ4HTo2m+8rOoVmcTgJfyNXFGyikTCHW7elcWUwX0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-reference/node_modules/@contentful/f36-components": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-6.11.1.tgz",
+      "integrity": "sha512-XUOKjRJu2pHAaTOWvv4X5sEtvVUKEq0K1+0saF6YB47qYBsUnlTj5sH2DYr1HZKr3GLP0uOF3lkcBplX6MfdSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-accordion": "^6.11.1",
+        "@contentful/f36-asset": "^6.11.1",
+        "@contentful/f36-autocomplete": "^6.11.1",
+        "@contentful/f36-avatar": "^6.11.1",
+        "@contentful/f36-badge": "^6.11.1",
+        "@contentful/f36-button": "^6.11.1",
+        "@contentful/f36-card": "^6.11.1",
+        "@contentful/f36-collapse": "^6.11.1",
+        "@contentful/f36-copybutton": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-datepicker": "^6.11.1",
+        "@contentful/f36-datetime": "^6.11.1",
+        "@contentful/f36-drag-handle": "^6.11.1",
+        "@contentful/f36-empty-state": "^6.11.1",
+        "@contentful/f36-entity-list": "^6.11.1",
+        "@contentful/f36-forms": "^6.11.1",
+        "@contentful/f36-header": "^6.11.1",
+        "@contentful/f36-icon": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-image": "^6.11.1",
+        "@contentful/f36-layout": "^6.11.1",
+        "@contentful/f36-list": "^6.11.1",
+        "@contentful/f36-menu": "^6.11.1",
+        "@contentful/f36-modal": "^6.11.1",
+        "@contentful/f36-multiselect": "^6.11.1",
+        "@contentful/f36-navlist": "^6.11.1",
+        "@contentful/f36-note": "^6.11.1",
+        "@contentful/f36-notification": "^6.11.1",
+        "@contentful/f36-pagination": "^6.11.1",
+        "@contentful/f36-pill": "^6.11.1",
+        "@contentful/f36-popover": "^6.11.1",
+        "@contentful/f36-progress-stepper": "^6.11.1",
+        "@contentful/f36-skeleton": "^6.11.1",
+        "@contentful/f36-spinner": "^6.11.1",
+        "@contentful/f36-table": "^6.11.1",
+        "@contentful/f36-tabs": "^6.11.1",
+        "@contentful/f36-text-link": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-tooltip": "^6.11.1",
+        "@contentful/f36-typography": "^6.11.1",
+        "@contentful/f36-usage-card": "^6.11.1",
+        "@contentful/f36-usage-count": "^6.11.1",
+        "@contentful/f36-utils": "^6.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.3.0 || >=19.1.0",
+        "@types/react-dom": "^18.3.0 || >=19.1.0",
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -1817,610 +2004,660 @@
         }
       }
     },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-copybutton": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-5.6.0.tgz",
-      "integrity": "sha512-/hQsFUx/kqOZc7NA5VNAyAnEz4Y3KUeEHBCYSYJdnAWXRkbavUgDp25GYIIG8so3x+D7Cz2zh9dMtVwUr1WCkg==",
+    "node_modules/@contentful/field-editor-reference/node_modules/@contentful/f36-copybutton": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-6.11.1.tgz",
+      "integrity": "sha512-QRqFvU0rQtz0UG+qqHZA1B5cdhNlhdaYIOLdHvyIgRllgnCGkbt5UAQAzuzhpHVF8jS7FQp+/3p4ETvUV6riOQ==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.6.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-button": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-tooltip": "^6.11.1",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-core": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-5.6.0.tgz",
-      "integrity": "sha512-O9t4UzEEyjbYs637uUfiTGHwNwvqfMPYkrgW47g03XPwo1gRoXNaJzMNJLemkW/8ZqjrgBsEE4Q6QvKtOdDb0A==",
+    "node_modules/@contentful/field-editor-reference/node_modules/@contentful/f36-core": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-6.11.1.tgz",
+      "integrity": "sha512-1XaG6AA2aWw+BgXzqpJdj2T7lf0bVW6i1tQa05e7vHEf/RSFVPNN6W2KjPC4KX2lZx5GUSjhWU0rET5Nuq6yiQ==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-tokens": "^5.1.0",
-        "@emotion/core": "^10.1.1",
-        "@emotion/is-prop-valid": "^1.2.0",
-        "csstype": "^3.1.1",
-        "emotion": "^10.0.17"
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5",
+        "@emotion/react": "^11.14.0",
+        "csstype": "^3.1.1"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-datepicker": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-5.6.0.tgz",
-      "integrity": "sha512-5afLd3SS6pUS2+YkH6i+P59jaH7zdkx3s2sktJkqaerEfx9Gq+XkuInWbhkKZCcirs9szaeOErhwad9Eggv6rw==",
+    "node_modules/@contentful/field-editor-reference/node_modules/@contentful/f36-datepicker": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-6.11.1.tgz",
+      "integrity": "sha512-vdrktk1nJ/y2cddwMDnYytP03+wWTyEjv2mgXO513A1NPAfSVIfswutRe6xcHgzyPohoSipcW8O4LAXcGW2naA==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-forms": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-popover": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
+        "@contentful/f36-button": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-forms": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-popover": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@emotion/css": "^11.13.5",
         "date-fns": "^2.28.0",
-        "emotion": "^10.0.17",
         "react-day-picker": "^8.7.1",
         "react-focus-lock": "^2.9.1"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-datetime": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-5.6.0.tgz",
-      "integrity": "sha512-PofT+PERLv2fW2xOPxBDsMPYRnYCQ67tvmj/DkP4zh73uHFQBHTgGQ4vzMIOXGD7o5MGAPrLwIYNVtx3Wsp+mg==",
+    "node_modules/@contentful/field-editor-reference/node_modules/@contentful/f36-datetime": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-6.11.1.tgz",
+      "integrity": "sha512-eGJlFs/KUgGyAtiW7pA3SnFhGGwWk66hnsJPoo0OaPpHnQJKUa5KlKH3qud9DTOUvDEQmHV98cJCjTJDHqR26w==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "dayjs": "^1.11.5",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5",
+        "dayjs": "^1.11.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-drag-handle": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-5.6.0.tgz",
-      "integrity": "sha512-iY5uHxKPfhmWvuWNLysptpMQVkbNGhZxphzyW9+NA0XzYCVAkRyAuL2RR5nu/BEysgILD6Zk5JDeBXBmt8CJeQ==",
+    "node_modules/@contentful/field-editor-reference/node_modules/@contentful/f36-drag-handle": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-6.11.1.tgz",
+      "integrity": "sha512-ZEvi5t0LKIPZKQ4oZK8XN8z8nCbfTXJyJJBqev9l7Il2sXd3t28A/jfMLpLcJ8Mr4xbvJy/39YOgm0CZiwhLwA==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-empty-state": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-5.6.0.tgz",
-      "integrity": "sha512-yivozabj58cm6amC/hQeBwFApstqIfGpONzRp5OPIoOe1tludyda37a6fsN35NSKSYrACthS32EOl/2KBH7c0Q==",
+    "node_modules/@contentful/field-editor-reference/node_modules/@contentful/f36-empty-state": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-6.11.1.tgz",
+      "integrity": "sha512-+/A4rbxolIGHRXrrJl93wOq19Vo60qYkQCLaqZsBtChIO0C4Px184D88+Wdwww7qZbfEsVzaPB7qqKf2c4shpA==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-entity-list": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-5.6.0.tgz",
-      "integrity": "sha512-pis/mt7amELmB313VuuYzPF1lLxsox+cfTLTlYTCDWgeh6+yn6vtLXV9RJA78A0H7uuAxRge9KP7jHCYpGvjAw==",
+    "node_modules/@contentful/field-editor-reference/node_modules/@contentful/f36-entity-list": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-6.11.1.tgz",
+      "integrity": "sha512-g1edZZMj4MxjcwpbGv9L+XVj8aDAdGcOzY6mFuNvV256mWD9CCYxe/9rvOmazGuOZPnGQTzKUufZGyFaiRa40w==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-badge": "^5.6.0",
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-drag-handle": "^5.6.0",
-        "@contentful/f36-icon": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-menu": "^5.6.0",
-        "@contentful/f36-skeleton": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-badge": "^6.11.1",
+        "@contentful/f36-button": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-drag-handle": "^6.11.1",
+        "@contentful/f36-icon": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-menu": "^6.11.1",
+        "@contentful/f36-skeleton": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-forms": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-5.6.0.tgz",
-      "integrity": "sha512-nmDIEntL3Y3w0I6hf+ifY3sjI8DMKcGLMyG9kkiJE2fSFb3TJTPgxdk1tDkPFid68Vlcj2NHFwzTInHdYI+j6w==",
+    "node_modules/@contentful/field-editor-reference/node_modules/@contentful/f36-forms": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-6.11.1.tgz",
+      "integrity": "sha512-5JlyGz2qYpz7N4jyd04ZKltcr7Yc7FDMYmyIegNlRZ1BEKft/KgXjhuIrSHizo9vb7Z6D0wGcYnWLKYJmlR9pg==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icon": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-header": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-header/-/f36-header-5.6.0.tgz",
-      "integrity": "sha512-bY7uhrdv3O7GfQ1soJkkn0BOox6HuJhk1Vc0xorEpnI/o4QdiO5tMW7XO0A++dzEtZfYffYRCBenPmn+M840YQ==",
+    "node_modules/@contentful/field-editor-reference/node_modules/@contentful/f36-header": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-header/-/f36-header-6.11.1.tgz",
+      "integrity": "sha512-OuCVUcDC0odL7hK5NklP1EfpRcyTRoEAVfjGrZKOZONJDzuF8jJtZIC1rU1LcVdsbOrYh3rMlkrYw0SCqSlMOg==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-button": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-icon": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-5.6.0.tgz",
-      "integrity": "sha512-VoyKI+rQGK5a3XyFvNG5PMa5FsGdo23XTB0Mj8ukIIvm6ZEBPTHqCGoKnPdl+s2+txIiMSbAmJslEbJR6KZiBg==",
+    "node_modules/@contentful/field-editor-reference/node_modules/@contentful/f36-icon": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-6.11.1.tgz",
+      "integrity": "sha512-J/TBh1T2+15FsigCjcR5ZVjzsIBs5nPsUHIOdo8Y4XfKO6uo2tp+IdV8n/JMDB+vifJBno8iX7r2zuvMZut94g==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@phosphor-icons/react": "2.1.8",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5",
+        "@phosphor-icons/react": "2.1.8"
       },
       "engines": {
         "node": ">=16"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-icons": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-5.6.0.tgz",
-      "integrity": "sha512-YM2KNFbmGAkqY6iug8ja8TCBpLxZm2jECZDujRweHyRnTRfHpoIjuP+14LO0iv/ilJEK6DedJoAflz0QJ20a8w==",
+    "node_modules/@contentful/field-editor-reference/node_modules/@contentful/f36-icons": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-6.11.1.tgz",
+      "integrity": "sha512-o2OHFUyikwEtoZC8WEU+26pWYpSnoLUDJ3ryYYkCCgfP9Y/TtmaZxox79lWvVcSS5vHX19Sd7WZqbFD23vzhIA==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icon": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@phosphor-icons/react": "2.1.8",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icon": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5",
+        "@phosphor-icons/react": "2.1.8"
       },
       "engines": {
         "node": ">=16"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-image": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-image/-/f36-image-5.6.0.tgz",
-      "integrity": "sha512-QY7ZxD3g3Fqr7jzWjSUMpuG1K3XeSvk+xQzHeNPJSqe14GTFB/V9FCHk9Zrmb0dQKUaRLohBraWBT0sMg/yBEA==",
+    "node_modules/@contentful/field-editor-reference/node_modules/@contentful/f36-image": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-image/-/f36-image-6.11.1.tgz",
+      "integrity": "sha512-TD4SpU/YOL5VbLVSTV7lPGKsHkdMWa73wbtn2RaeoRBz06eYu8tIrvf/J3q8n45r+//Y0jsQ76fSuZwwlSr2og==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-skeleton": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-skeleton": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-list": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-5.6.0.tgz",
-      "integrity": "sha512-bu2kZ+XgKKOVD0924Cgd4dDIuvM8yUlsqbpi8hQFS5xH6rLPdBen15m1cpWmVNUL7n/nnznduF8cAG9sQ0d7mw==",
+    "node_modules/@contentful/field-editor-reference/node_modules/@contentful/f36-list": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-6.11.1.tgz",
+      "integrity": "sha512-SlGB/RgXA8NIQPdFOXWjBFUQiHf/4gknPy7qS5igq7zm+BQBcTXoBOeeqF85JIa/0OdeUfWlX4Jok99vqgoT2A==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-menu": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-5.6.0.tgz",
-      "integrity": "sha512-VS0sA41lFgz6j5WZePzVEJTtPij8hGdwva55B3lgGJHKALYxd+Q5GfjUtYuXZbwvFd0mvhz0dWQFBgdATfObyQ==",
+    "node_modules/@contentful/field-editor-reference/node_modules/@contentful/f36-menu": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-6.11.1.tgz",
+      "integrity": "sha512-SS61LL51U//DL9NOCleAF8XkjBzjr110P4KPNaAGtqQOrk4YoeuU4SHTnscVxGbHd6wwEQJTgSkNS3ket07o/g==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-popover": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-popover": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5",
+        "@floating-ui/dom": "^1.7.4",
+        "@floating-ui/react": "^0.27.16"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-modal": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-5.6.0.tgz",
-      "integrity": "sha512-iZOH6q3Sv/f2sxiYadMscYFe6oXMXxAf9xZpQRtYZIglbgpItVf3z7/A27rSXtCmasoMkWfiKOQaDlFllT6RhA==",
+    "node_modules/@contentful/field-editor-reference/node_modules/@contentful/f36-modal": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-6.11.1.tgz",
+      "integrity": "sha512-b91Fk1/lpU9mEm5A3NsUV52FDPOl+vhuDESnLwGEzFv2SODR5nrDDNpgZzyhQGV068rtUUUjlS2GVWXsajqgyw==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "@types/react-modal": "^3.13.1",
-        "emotion": "^10.0.17",
-        "react-modal": "^3.16.1"
+        "@contentful/f36-button": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@emotion/css": "^11.13.5",
+        "@types/react-modal": "^3.16.3",
+        "react-modal": "^3.16.3"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-multiselect": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-multiselect/-/f36-multiselect-5.6.0.tgz",
-      "integrity": "sha512-ioOmQWa/rnaSZ8w0SUKx01iqY1Ls876cHDiH0X3yCsxBd/Q64mnZX2t2yUS4jqzzZHAYowPQKWC0rRWmkazPzg==",
+    "node_modules/@contentful/field-editor-reference/node_modules/@contentful/f36-multiselect": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-multiselect/-/f36-multiselect-6.11.1.tgz",
+      "integrity": "sha512-qU9wOLsyhyupYcvd3ctXs7IyGplNxbjc8IHqLose50UzsdTO9vTSu4dTqiQgG9b/eQVvnqIE22xyL2ogxWZYdw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.27.1",
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-forms": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-popover": "^5.6.0",
-        "@contentful/f36-skeleton": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.6.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "emotion": "^10.0.17",
-        "react-focus-lock": "^2.9.5"
+        "@contentful/f36-button": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-forms": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-popover": "^6.11.1",
+        "@contentful/f36-skeleton": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-tooltip": "^6.11.1",
+        "@contentful/f36-typography": "^6.11.1",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-note": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-5.6.0.tgz",
-      "integrity": "sha512-OmVPwfVctWQ19lUOrWama2/gGcEBdhgIL8GfiUMnC+fcAjzcD3OS8C4PKdXKAT5SS+sCmuwGuSMpoqdtYQx/0A==",
+    "node_modules/@contentful/field-editor-reference/node_modules/@contentful/f36-note": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-6.11.1.tgz",
+      "integrity": "sha512-xCgtdaF7M3kfjOkk/3MjePcHfSIZ261MdyZ2u9uhQNm9Tz3HlWQjqjeaMZOK5leAcDUGA3Gf3owBQl16QPUOxw==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icon": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-button": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icon": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-notification": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-5.6.0.tgz",
-      "integrity": "sha512-gehtdl+KIuGJpVJI8thDI9X6zOoOM+Y905Or9HYZfGf8W7vDr4+slXzIl/JXfQOttJ7425MXsFP0FtzWRNA4hA==",
+    "node_modules/@contentful/field-editor-reference/node_modules/@contentful/f36-notification": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-6.11.1.tgz",
+      "integrity": "sha512-7NmYwEdzK0aaiMpLMBn6dn/NILQhbXJBhrQ9eyszDRW+JAUCpUEZL7HbSsTHp7EZ/AIWuvJWsWRrJ/t97EKe6A==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-text-link": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "emotion": "^10.0.17",
+        "@contentful/f36-button": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-text-link": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@emotion/css": "^11.13.5",
         "react-animate-height": "^3.0.4"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-pagination": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-5.6.0.tgz",
-      "integrity": "sha512-fFiQvoTovb3fuBU2IUkr0M/+aNFM8C1jm7d7SZE5y4i3C2d2RqBiaCo0ShOQTWPhJiNjtqDIUFxkrderRg5ExQ==",
+    "node_modules/@contentful/field-editor-reference/node_modules/@contentful/f36-pagination": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-6.11.1.tgz",
+      "integrity": "sha512-tW8hVPXl8Rhyu6x9ee1Pi/Nj+FHXNKYp2ewsuRygyueMxfcEjmgvz/J5GwSq5ThLkr+uncNVludAvZUg2QUz3Q==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-forms": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-button": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-forms": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-pill": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-5.6.0.tgz",
-      "integrity": "sha512-t7cwf9sdWoW07B26j+cxEzxCZwXGAiyqby2s7vQKr/U1/5m/JlVIIVifMkAA+f+wvtUYb2DMoBl9pJkRiIZsQQ==",
+    "node_modules/@contentful/field-editor-reference/node_modules/@contentful/f36-pill": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-6.11.1.tgz",
+      "integrity": "sha512-RPtQ3juqXlzzzaOMwdeUjwmXv7QpQ8yFP0S0TcqyZOfxDGbKvuLbsLiDtfGFStkkCnoXX2E45AK13asQ94USdA==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-drag-handle": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.6.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-button": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-drag-handle": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-tooltip": "^6.11.1",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-popover": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-5.6.0.tgz",
-      "integrity": "sha512-W8DzlCC5r16W0qDdR0JZQJLss91MjjMIarwMY18soGwA2oyEo8IPiDGDyRgDXL+TY1/SxFEux44Ck5mV62vAtA==",
+    "node_modules/@contentful/field-editor-reference/node_modules/@contentful/f36-popover": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-6.11.1.tgz",
+      "integrity": "sha512-Q4cfFV3ClkNN3xF7YnO6vpb/s5WYEereAswMJkln/NDoKihE00N8sSe5DELt2nBWz9/i/zRcGjHK/YX6wlpcpA==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "@popperjs/core": "^2.11.5",
-        "emotion": "^10.0.17",
-        "react-popper": "^2.3.0"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5",
+        "@floating-ui/dom": "^1.7.4",
+        "@floating-ui/react": "^0.27.16"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-skeleton": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-5.6.0.tgz",
-      "integrity": "sha512-a4nuJKBrYDQiHwk4r+lNTFi6FDXGYxCur2SSTbWcvrerDud+IjptfTARRy+x+K17ic+uody1ualeO7Kktkw7Yg==",
+    "node_modules/@contentful/field-editor-reference/node_modules/@contentful/f36-skeleton": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-6.11.1.tgz",
+      "integrity": "sha512-2yDfkavb8PkvBpVoUvA0vbsfsssoB089YHSzoOk2ulRxqMqE8/okoiDlNK+GiCaw1tsNXq4h8G70IKIEEMBj7w==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-table": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-table": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-spinner": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-5.6.0.tgz",
-      "integrity": "sha512-NmH/bNol+e7AarybNgv8B8lodF2hOFlF32H6QAEhsHmq76dxOQ6LlgjlxIttNpIrGgHYU29yWAH5LhTu/BAE7g==",
+    "node_modules/@contentful/field-editor-reference/node_modules/@contentful/f36-spinner": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-6.11.1.tgz",
+      "integrity": "sha512-3JDRcduSJQmXWCDYx0dtOcZoBzvdvLUSrvKFJbhZCUUcw2fhEHPoAXbyMqwakzKxySJDAboB3NnM32aiI+oThQ==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-table": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-5.6.0.tgz",
-      "integrity": "sha512-1nAfK95DmVhxQb9TZllNE/tF45UN1xMzs3/1v7laH9CymkpAYQefYEpOneQBM42+lp00JX/81Hi0DnZ1xv3i+g==",
+    "node_modules/@contentful/field-editor-reference/node_modules/@contentful/f36-table": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-6.11.1.tgz",
+      "integrity": "sha512-hnocd9GylDkosqDzOXJgsTpOCMHRtfind08BSSzWXmPbJ0ue3kcw/lqg3rszCcUxwm5fPgycAabhtnHWQo3v8A==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-tabs": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-5.6.0.tgz",
-      "integrity": "sha512-+7S+zpUn84uv97XHxTD25186XE13GjIzcASBOzZAZZ1WCVYDMdhUpLaCNRAhVapV6R1qIShPG8DbGgwFTMIOXA==",
+    "node_modules/@contentful/field-editor-reference/node_modules/@contentful/f36-tabs": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-6.11.1.tgz",
+      "integrity": "sha512-8z2ZOmptv2cdOXl5GcKJKizJr+DtBXYnj//ikBWwoKVbgrsPmDejOyMCjcHG6rzsUcmUjg7v0OPIvXpRWWDybw==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@radix-ui/react-tabs": "^1.0.1",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5",
+        "@radix-ui/react-tabs": "^1.1.12"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-text-link": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-5.6.0.tgz",
-      "integrity": "sha512-1Pj/d/0/5+REOLlfJdXAbb2VG7QDls+gI0HH+lTfbqrVoolFRPvnXxMr7+RcxEwHqr73/atvPdx9Q2xWSXEMmQ==",
+    "node_modules/@contentful/field-editor-reference/node_modules/@contentful/f36-text-link": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-6.11.1.tgz",
+      "integrity": "sha512-JlcGrS9mq1380G2d0lPvcwGHfXI54G2yRioabA655XB4ejuIYeBrLe9I2KsWrBP54FfY7J9zZqEmJyMZNlqibA==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-tokens": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-5.1.0.tgz",
-      "integrity": "sha512-7++MPQiizK6qLhPkilWIKqM5Mhdr199tK7dL4iZ689iTwA82uvXXOojJr+0wVOurG2Odb+6/3WLe1XdveDZHEA==",
+    "node_modules/@contentful/field-editor-reference/node_modules/@contentful/f36-tokens": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.1.3.tgz",
+      "integrity": "sha512-3q1IHaCn7zY1ZEyN8LeMlm4R+lvQgEmFR2B5sqIx4Z+Rsr1HRDP+iUYf0ZSXTMETiPd/DP8uiR0RGAvBWeceww==",
       "license": "MIT"
     },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-tooltip": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-5.6.0.tgz",
-      "integrity": "sha512-e4z+eysp95u4ASheQgkJJM+RXyZv/KyMi4bqqez2ydvkFtFViI7E+wkzxIbB5L2EzHqIGL6/IcgQ8GC6io/Fsw==",
+    "node_modules/@contentful/field-editor-reference/node_modules/@contentful/f36-tooltip": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-6.11.1.tgz",
+      "integrity": "sha512-5FGWpcJBMGoMADkEMUIqGOf72qRSMzJw/w70RzIl1LZKHr6BjFWeQYQkx3d2lbW7l939c12L5BbiD5sfDIifXA==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "@popperjs/core": "^2.11.5",
-        "csstype": "^3.1.1",
-        "emotion": "^10.0.17",
-        "react-popper": "^2.3.0"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5",
+        "@floating-ui/dom": "^1.7.4",
+        "@floating-ui/react": "^0.27.16"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-typography": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-5.6.0.tgz",
-      "integrity": "sha512-v8myIeJnpZ6g2WRmL9oOOLrjip3+80Y+LQ4PwOzcJatL5AdwSYVExtlFMMVO5/JNt6qEpT2sd5579LPA17yiVg==",
+    "node_modules/@contentful/field-editor-reference/node_modules/@contentful/f36-typography": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-6.11.1.tgz",
+      "integrity": "sha512-TRXk7xHQJ4m32kvw78XnRPwQudUdwwM87qxCbWLtpihu1ilq1b0iqP7rxBNCsXkj7SOIgP+BPHN/iUDSXsD/9A==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-usage-card": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-usage-card/-/f36-usage-card-5.6.0.tgz",
-      "integrity": "sha512-Mzt0S8F4onLaCCJn/48uMDmZO/pKMNiqAOgIXGOmPOhk0+8IEjQgx7h487r6KD9xjXhejpCFtG5tfG2DopGZ1w==",
+    "node_modules/@contentful/field-editor-reference/node_modules/@contentful/f36-usage-card": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-usage-card/-/f36-usage-card-6.11.1.tgz",
+      "integrity": "sha512-YZkSI/836aO7vtMM5GxFcJRh4jRkWlCj9rQ5NzeIMB04Fq7RvTq8iTryWofZJ2juftNEyEq9RsyO/xJ3lGVg6w==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-card": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-text-link": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.6.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-card": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-text-link": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-tooltip": "^6.11.1",
+        "@contentful/f36-typography": "^6.11.1",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-usage-count": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-usage-count/-/f36-usage-count-5.6.0.tgz",
-      "integrity": "sha512-bjnrnx52jScH2/Nt55piBVzl5HUZELGQh8NHhWUSGry1hFyxeAh7MyEg6B/ROBnVk67E9ZITRknQmqRO9pnoUg==",
+    "node_modules/@contentful/field-editor-reference/node_modules/@contentful/f36-usage-count": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-usage-count/-/f36-usage-count-6.11.1.tgz",
+      "integrity": "sha512-diBhL5du4BkiaglrfXFkKfsUwFbEIbjn04oBsxqUvmyeRlyOeCfkJVWc1q7SOH5wzP9I1QE+ikAK7bqRQ6jD9w==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-utils": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-utils/-/f36-utils-5.2.0.tgz",
-      "integrity": "sha512-0YWsKAdU2HeNz5DwuOCR0lnlHVhlXiDkqtYaH8hHqT9HlQKHDSBPQUI9Vk5OrPDRJ3uLVoyGOJcvUDf27tTopA==",
+    "node_modules/@contentful/field-editor-reference/node_modules/@contentful/f36-utils": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-utils/-/f36-utils-6.1.2.tgz",
+      "integrity": "sha512-gaG+q5NHVEfDzCEGoK12/+8Y1VODPO8k/DyrZjCIOTxTK9rXZ5l1xESMbnMAbwHnz2zXoLkkzI0QGCChW6xrpw==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-tokens": "^5.1.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-tokens": "^6.1.2",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/field-editor-reference": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-reference/-/field-editor-reference-6.15.0.tgz",
-      "integrity": "sha512-PUUWoqLaJrvpiCWZGkpw6veMnCPAIT+ZOGEcsCwWvcJBOYqtRsdMO0A8ZtfwBGBGcljrfZ14QKwzt9rIGyamQQ==",
+    "node_modules/@contentful/field-editor-reference/node_modules/@emotion/cache": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-components": "^5.4.1",
-        "@contentful/f36-icons": "^5.4.1",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/field-editor-shared": "^2.16.0",
-        "@contentful/mimetype": "^2.2.29",
-        "@dnd-kit/core": "^6.0.8",
-        "@dnd-kit/sortable": "^8.0.0",
-        "@dnd-kit/utilities": "^3.2.2",
-        "@tanstack/react-query": "^4.3.9",
-        "constate": "^3.3.2",
-        "contentful-management": "^11.45.1",
-        "emotion": "^10.0.17",
-        "lodash": "^4.17.15",
-        "moment": "^2.20.0",
-        "p-queue": "^4.0.0",
-        "react-intersection-observer": "9.4.0",
-        "truncate": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@contentful/app-sdk": "^4.41.2",
-        "@lingui/core": "^5.3.0",
-        "react": ">=16.8.0"
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "stylis": "4.2.0"
       }
     },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/field-editor-reference/node_modules/@tanstack/react-query": {
-      "version": "4.42.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.42.0.tgz",
-      "integrity": "sha512-j0tiofkzE3CSrYKmVRaKuwGgvCE+P2OOEDlhmfjeZf5ufcuFHwYwwgw3j08n4WYPVZ+OpsHblcFYezhKA3jDwg==",
+    "node_modules/@contentful/field-editor-reference/node_modules/@emotion/css": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.13.5.tgz",
+      "integrity": "sha512-wQdD0Xhkn3Qy2VNcIzbLP9MR8TafI0MJb7BEAXKp+w4+XqErksWR4OXomuDzPsN4InLdGhVe6EYcn2ZIUCpB8w==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "4.41.0",
-        "use-sync-external-store": "^1.2.0"
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.13.5",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2"
+      }
+    },
+    "node_modules/@contentful/field-editor-reference/node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/field-editor-reference/node_modules/@emotion/serialize": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@contentful/field-editor-reference/node_modules/@emotion/sheet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/field-editor-reference/node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/field-editor-reference/node_modules/@emotion/utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/field-editor-reference/node_modules/@emotion/weak-memoize": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/field-editor-reference/node_modules/@tanstack/query-core": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.44.0.tgz",
+      "integrity": "sha512-swSgb7OiPRR3UuIL7NuDrZNSMGmQD+wdtHxPD7j60SvBEnxbXurl5XOirtGEX2gm2hbK6mC8kMV1I+uO3l0UOw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@contentful/field-editor-reference/node_modules/@tanstack/react-query": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.44.0.tgz",
+      "integrity": "sha512-RuIqHYrS98LrK/8kJJOJMMSQ/BCpojwsXDh7p0fBmp38ZOz6dlk+uyFRRusH+V+t3POoCsDOQ2zhomEYOeReXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "4.44.0",
+        "use-sync-external-store": "^1.6.0"
       },
       "funding": {
         "type": "github",
@@ -2440,274 +2677,1220 @@
         }
       }
     },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/rich-text-types": {
-      "version": "17.2.4",
-      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-17.2.4.tgz",
-      "integrity": "sha512-3y456l+x5aPzqcvjpG6L66sIkfH66rBl1QtGKexgJ3Nvd6k4ORvpAJ6gMDBz3WMAYvXGrVZMyhlFE0e6UdHngA==",
-      "license": "MIT",
-      "dependencies": {
-        "@lingui/core": "^5.4.1",
-        "is-plain-obj": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
+    "node_modules/@contentful/field-editor-reference/node_modules/compute-scroll-into-view": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
+      "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==",
+      "license": "MIT"
     },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/contentful-management": {
-      "version": "11.61.1",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.61.1.tgz",
-      "integrity": "sha512-+Shk0fGpudvT0b0CwdNiLDwPoIbb0YdkiiYc6h5aC42zfVFJ0dgJf9JKzYPBPJd0MWGOCQf5yNzt/zBEAUDElw==",
+    "node_modules/@contentful/field-editor-reference/node_modules/contentful-management": {
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-12.5.1.tgz",
+      "integrity": "sha512-na2GEX2a2KJEEXm+10kWHwA5WT0Iz9F+B/ycWzMBbG1Q/Q5mUiaB/TiABS4np4UOiSO/AxO6+xqlgGIpdsAkdg==",
       "license": "MIT",
       "dependencies": {
         "@contentful/rich-text-types": "^16.6.1",
-        "axios": "^1.12.2",
-        "contentful-sdk-core": "^9.0.1",
+        "axios": "^1.15.0",
+        "contentful-sdk-core": "^9.4.4",
         "fast-copy": "^3.0.0",
-        "globals": "^15.15.0"
+        "globals": "^15.15.0",
+        "process": "^0.11.10"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
-    "node_modules/@contentful/field-editor-rich-text/node_modules/contentful-management/node_modules/@contentful/rich-text-types": {
-      "version": "16.8.5",
-      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.8.5.tgz",
-      "integrity": "sha512-q18RJuJCOuYveGiCIjE5xLCQc5lZ3L2Qgxrlg/H2YEobDFqdtmklazRi1XwEWaK3tMg6yVXBzKKkQfLB4qW14A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@contentful/field-editor-shared": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-2.16.0.tgz",
-      "integrity": "sha512-YibgcQxmQZDxVGabVN0GoDb3/CtsMULI2GaCElUjdwfViStnDLi5rc6meFk1w2hiXOO9Rql9yoStpn7vPgPUqg==",
+    "node_modules/@contentful/field-editor-reference/node_modules/downshift": {
+      "version": "9.3.6",
+      "resolved": "https://registry.npmjs.org/downshift/-/downshift-9.3.6.tgz",
+      "integrity": "sha512-xEKP1vbt/k7Siu481TKibmj8EyL6iyBwaRJgb6gCsFyLeiyZ1KEJnApS9R1U71hTdK5ym0R99AOYRROcTz1PeQ==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-components": "^5.4.1",
-        "@contentful/f36-icons": "^5.4.1",
-        "@contentful/f36-note": "^5.1.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "contentful-management": "^11.60.4",
-        "emotion": "^10.0.17",
+        "@babel/runtime": "^7.28.6",
+        "compute-scroll-into-view": "^3.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^18.2.0",
+        "tslib": "^2.8.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.12.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-reference/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/field-editor-rich-text": {
+      "version": "6.3.9",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-rich-text/-/field-editor-rich-text-6.3.9.tgz",
+      "integrity": "sha512-u8bbSc2ggToFC5d9EvIRhkxFKpWCdOpvWs/w7TGVKdoAwM6GpDU3nxX+sGTlnK6PlLF+VVS5HC/XxprsBT/uwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/app-sdk": "^4.42.0",
+        "@contentful/contentful-slatejs-adapter": "^16.1.6",
+        "@contentful/f36-components": "^6.7.1",
+        "@contentful/f36-icon": "^6.7.1",
+        "@contentful/f36-icons": "^6.7.1",
+        "@contentful/f36-tokens": "^6.1.2",
+        "@contentful/f36-utils": "^6.1.0",
+        "@contentful/field-editor-reference": "^8.3.2",
+        "@contentful/field-editor-shared": "^4.4.1",
+        "@contentful/rich-text-plain-text-renderer": "^17.0.0",
+        "@contentful/rich-text-types": "^17.2.5",
+        "@emotion/css": "^11.13.5",
+        "@popperjs/core": "^2.11.5",
+        "@udecode/plate-basic-marks": "36.0.0",
+        "@udecode/plate-break": "36.0.0",
+        "@udecode/plate-common": "36.5.9",
+        "@udecode/plate-core": "36.5.9",
+        "@udecode/plate-list": "36.0.0",
+        "@udecode/plate-paragraph": "36.0.0",
+        "@udecode/plate-reset-node": "36.0.0",
+        "@udecode/plate-select": "36.0.0",
+        "@udecode/plate-serializer-docx": "36.0.10",
+        "@udecode/plate-table": "36.5.9",
+        "@udecode/plate-trailing-block": "36.0.0",
+        "constate": "^3.3.2",
+        "date-fns": "^2.30.0",
+        "fast-deep-equal": "^3.1.3",
+        "is-hotkey": "^0.2.0",
+        "is-plain-obj": "^3.0.0",
+        "lodash": "^4.17.21",
+        "p-debounce": "^2.1.0",
+        "react-popper": "^2.3.0",
+        "slate": "0.94.1",
+        "slate-history": "0.100.0",
+        "slate-hyperscript": "0.77.0",
+        "slate-react": "0.102.0",
+        "use-deep-compare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "@lingui/core": "^5.3.0",
+        "@tanstack/react-query": "^4.3.9 || ^5.0.0",
+        "react": ">=18.3.1",
+        "react-dom": ">=18.3.1"
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-accordion": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-6.11.1.tgz",
+      "integrity": "sha512-+5bGi6jPVVmoe0JB7wFzGiNMVRO3twSX2ecMzDIC27WgKW8NtaAIhsbb6678pGHlqdlqHuez7VwEL+CpEgyJYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-collapse": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-asset": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-6.11.1.tgz",
+      "integrity": "sha512-6IyoylrbLX2qXmRg6E/Dk5gC/o7toR2t5V08xDLmup+GKuXHRLaaP2xF40guumZedX0DNFtbwRG5uarLJ/IXSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icon": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-autocomplete": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-6.11.1.tgz",
+      "integrity": "sha512-oHelyxej2RxCpx2AUI8exdnj5ovAM5E/kPeG6mkMN8hE3MNq2/AFpUYkn7BjjdJqrFGjsE3ioZcskr0cktf55w==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-forms": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-popover": "^6.11.1",
+        "@contentful/f36-skeleton": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5",
+        "downshift": "^9.0.10"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-avatar": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-avatar/-/f36-avatar-6.11.1.tgz",
+      "integrity": "sha512-+WiwJe5pyKjBZFnODNCnv8bljmnWn4AjWhx0u7xA1IN7aY87rY2yTLcO+enb4dJiMSID8EED5PsIPbxKtsBi2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-image": "^6.11.1",
+        "@contentful/f36-menu": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-tooltip": "^6.11.1",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-badge": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-6.11.1.tgz",
+      "integrity": "sha512-9ASyA33Q1CrAMJnHiqBci87S7LqPbiSdw2JU63cwoTfA4+ovXgaXpOlBCjGKsnlkJiE5NcBgWbWTqOFWV6cikw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-button": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-6.11.1.tgz",
+      "integrity": "sha512-vqpIcE5aarFJmgQFSwz6wZg2uB+xKXC/hGBzMUHYd2Ny/aj/2n/KLQwMye4lWLV/NKTOeZX2Il1K5FxlDUVaKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-spinner": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-tooltip": "^6.11.1",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-card": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-6.11.1.tgz",
+      "integrity": "sha512-xhV5wfHvsV/rU6V9fUAg/t6FlFqKqJr4PM17MO0ZXIsXxAciralDYiFquWvQQF4f0XPa5778E8ez6eZleTldLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-asset": "^6.11.1",
+        "@contentful/f36-badge": "^6.11.1",
+        "@contentful/f36-button": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-drag-handle": "^6.11.1",
+        "@contentful/f36-icon": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-menu": "^6.11.1",
+        "@contentful/f36-skeleton": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-tooltip": "^6.11.1",
+        "@contentful/f36-typography": "^6.11.1",
+        "@emotion/css": "^11.13.5",
+        "truncate": "^3.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-collapse": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-6.11.1.tgz",
+      "integrity": "sha512-Kuz18J7qFQFVdujV1xx0yStrdi4vT6Up3LmvCqnr7RdNdJ4HTo2m+8rOoVmcTgJfyNXFGyikTCHW7elcWUwX0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-components": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-6.11.1.tgz",
+      "integrity": "sha512-XUOKjRJu2pHAaTOWvv4X5sEtvVUKEq0K1+0saF6YB47qYBsUnlTj5sH2DYr1HZKr3GLP0uOF3lkcBplX6MfdSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-accordion": "^6.11.1",
+        "@contentful/f36-asset": "^6.11.1",
+        "@contentful/f36-autocomplete": "^6.11.1",
+        "@contentful/f36-avatar": "^6.11.1",
+        "@contentful/f36-badge": "^6.11.1",
+        "@contentful/f36-button": "^6.11.1",
+        "@contentful/f36-card": "^6.11.1",
+        "@contentful/f36-collapse": "^6.11.1",
+        "@contentful/f36-copybutton": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-datepicker": "^6.11.1",
+        "@contentful/f36-datetime": "^6.11.1",
+        "@contentful/f36-drag-handle": "^6.11.1",
+        "@contentful/f36-empty-state": "^6.11.1",
+        "@contentful/f36-entity-list": "^6.11.1",
+        "@contentful/f36-forms": "^6.11.1",
+        "@contentful/f36-header": "^6.11.1",
+        "@contentful/f36-icon": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-image": "^6.11.1",
+        "@contentful/f36-layout": "^6.11.1",
+        "@contentful/f36-list": "^6.11.1",
+        "@contentful/f36-menu": "^6.11.1",
+        "@contentful/f36-modal": "^6.11.1",
+        "@contentful/f36-multiselect": "^6.11.1",
+        "@contentful/f36-navlist": "^6.11.1",
+        "@contentful/f36-note": "^6.11.1",
+        "@contentful/f36-notification": "^6.11.1",
+        "@contentful/f36-pagination": "^6.11.1",
+        "@contentful/f36-pill": "^6.11.1",
+        "@contentful/f36-popover": "^6.11.1",
+        "@contentful/f36-progress-stepper": "^6.11.1",
+        "@contentful/f36-skeleton": "^6.11.1",
+        "@contentful/f36-spinner": "^6.11.1",
+        "@contentful/f36-table": "^6.11.1",
+        "@contentful/f36-tabs": "^6.11.1",
+        "@contentful/f36-text-link": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-tooltip": "^6.11.1",
+        "@contentful/f36-typography": "^6.11.1",
+        "@contentful/f36-usage-card": "^6.11.1",
+        "@contentful/f36-usage-count": "^6.11.1",
+        "@contentful/f36-utils": "^6.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.3.0 || >=19.1.0",
+        "@types/react-dom": "^18.3.0 || >=19.1.0",
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-copybutton": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-6.11.1.tgz",
+      "integrity": "sha512-QRqFvU0rQtz0UG+qqHZA1B5cdhNlhdaYIOLdHvyIgRllgnCGkbt5UAQAzuzhpHVF8jS7FQp+/3p4ETvUV6riOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-tooltip": "^6.11.1",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-core": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-6.11.1.tgz",
+      "integrity": "sha512-1XaG6AA2aWw+BgXzqpJdj2T7lf0bVW6i1tQa05e7vHEf/RSFVPNN6W2KjPC4KX2lZx5GUSjhWU0rET5Nuq6yiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5",
+        "@emotion/react": "^11.14.0",
+        "csstype": "^3.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-datepicker": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-6.11.1.tgz",
+      "integrity": "sha512-vdrktk1nJ/y2cddwMDnYytP03+wWTyEjv2mgXO513A1NPAfSVIfswutRe6xcHgzyPohoSipcW8O4LAXcGW2naA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-forms": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-popover": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@emotion/css": "^11.13.5",
+        "date-fns": "^2.28.0",
+        "react-day-picker": "^8.7.1",
+        "react-focus-lock": "^2.9.1"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-datetime": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-6.11.1.tgz",
+      "integrity": "sha512-eGJlFs/KUgGyAtiW7pA3SnFhGGwWk66hnsJPoo0OaPpHnQJKUa5KlKH3qud9DTOUvDEQmHV98cJCjTJDHqR26w==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5",
+        "dayjs": "^1.11.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-drag-handle": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-6.11.1.tgz",
+      "integrity": "sha512-ZEvi5t0LKIPZKQ4oZK8XN8z8nCbfTXJyJJBqev9l7Il2sXd3t28A/jfMLpLcJ8Mr4xbvJy/39YOgm0CZiwhLwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-empty-state": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-6.11.1.tgz",
+      "integrity": "sha512-+/A4rbxolIGHRXrrJl93wOq19Vo60qYkQCLaqZsBtChIO0C4Px184D88+Wdwww7qZbfEsVzaPB7qqKf2c4shpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-entity-list": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-6.11.1.tgz",
+      "integrity": "sha512-g1edZZMj4MxjcwpbGv9L+XVj8aDAdGcOzY6mFuNvV256mWD9CCYxe/9rvOmazGuOZPnGQTzKUufZGyFaiRa40w==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-badge": "^6.11.1",
+        "@contentful/f36-button": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-drag-handle": "^6.11.1",
+        "@contentful/f36-icon": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-menu": "^6.11.1",
+        "@contentful/f36-skeleton": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-forms": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-6.11.1.tgz",
+      "integrity": "sha512-5JlyGz2qYpz7N4jyd04ZKltcr7Yc7FDMYmyIegNlRZ1BEKft/KgXjhuIrSHizo9vb7Z6D0wGcYnWLKYJmlR9pg==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icon": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-header": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-header/-/f36-header-6.11.1.tgz",
+      "integrity": "sha512-OuCVUcDC0odL7hK5NklP1EfpRcyTRoEAVfjGrZKOZONJDzuF8jJtZIC1rU1LcVdsbOrYh3rMlkrYw0SCqSlMOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-icon": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-6.11.1.tgz",
+      "integrity": "sha512-J/TBh1T2+15FsigCjcR5ZVjzsIBs5nPsUHIOdo8Y4XfKO6uo2tp+IdV8n/JMDB+vifJBno8iX7r2zuvMZut94g==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5",
+        "@phosphor-icons/react": "2.1.8"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-icons": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-6.11.1.tgz",
+      "integrity": "sha512-o2OHFUyikwEtoZC8WEU+26pWYpSnoLUDJ3ryYYkCCgfP9Y/TtmaZxox79lWvVcSS5vHX19Sd7WZqbFD23vzhIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icon": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5",
+        "@phosphor-icons/react": "2.1.8"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-image": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-image/-/f36-image-6.11.1.tgz",
+      "integrity": "sha512-TD4SpU/YOL5VbLVSTV7lPGKsHkdMWa73wbtn2RaeoRBz06eYu8tIrvf/J3q8n45r+//Y0jsQ76fSuZwwlSr2og==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-skeleton": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-list": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-6.11.1.tgz",
+      "integrity": "sha512-SlGB/RgXA8NIQPdFOXWjBFUQiHf/4gknPy7qS5igq7zm+BQBcTXoBOeeqF85JIa/0OdeUfWlX4Jok99vqgoT2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-menu": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-6.11.1.tgz",
+      "integrity": "sha512-SS61LL51U//DL9NOCleAF8XkjBzjr110P4KPNaAGtqQOrk4YoeuU4SHTnscVxGbHd6wwEQJTgSkNS3ket07o/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-popover": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5",
+        "@floating-ui/dom": "^1.7.4",
+        "@floating-ui/react": "^0.27.16"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-modal": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-6.11.1.tgz",
+      "integrity": "sha512-b91Fk1/lpU9mEm5A3NsUV52FDPOl+vhuDESnLwGEzFv2SODR5nrDDNpgZzyhQGV068rtUUUjlS2GVWXsajqgyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@emotion/css": "^11.13.5",
+        "@types/react-modal": "^3.16.3",
+        "react-modal": "^3.16.3"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-multiselect": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-multiselect/-/f36-multiselect-6.11.1.tgz",
+      "integrity": "sha512-qU9wOLsyhyupYcvd3ctXs7IyGplNxbjc8IHqLose50UzsdTO9vTSu4dTqiQgG9b/eQVvnqIE22xyL2ogxWZYdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.1",
+        "@contentful/f36-button": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-forms": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-popover": "^6.11.1",
+        "@contentful/f36-skeleton": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-tooltip": "^6.11.1",
+        "@contentful/f36-typography": "^6.11.1",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-note": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-6.11.1.tgz",
+      "integrity": "sha512-xCgtdaF7M3kfjOkk/3MjePcHfSIZ261MdyZ2u9uhQNm9Tz3HlWQjqjeaMZOK5leAcDUGA3Gf3owBQl16QPUOxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icon": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-notification": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-6.11.1.tgz",
+      "integrity": "sha512-7NmYwEdzK0aaiMpLMBn6dn/NILQhbXJBhrQ9eyszDRW+JAUCpUEZL7HbSsTHp7EZ/AIWuvJWsWRrJ/t97EKe6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-text-link": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@emotion/css": "^11.13.5",
+        "react-animate-height": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-pagination": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-6.11.1.tgz",
+      "integrity": "sha512-tW8hVPXl8Rhyu6x9ee1Pi/Nj+FHXNKYp2ewsuRygyueMxfcEjmgvz/J5GwSq5ThLkr+uncNVludAvZUg2QUz3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-forms": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-pill": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-6.11.1.tgz",
+      "integrity": "sha512-RPtQ3juqXlzzzaOMwdeUjwmXv7QpQ8yFP0S0TcqyZOfxDGbKvuLbsLiDtfGFStkkCnoXX2E45AK13asQ94USdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-drag-handle": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-tooltip": "^6.11.1",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-popover": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-6.11.1.tgz",
+      "integrity": "sha512-Q4cfFV3ClkNN3xF7YnO6vpb/s5WYEereAswMJkln/NDoKihE00N8sSe5DELt2nBWz9/i/zRcGjHK/YX6wlpcpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5",
+        "@floating-ui/dom": "^1.7.4",
+        "@floating-ui/react": "^0.27.16"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-skeleton": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-6.11.1.tgz",
+      "integrity": "sha512-2yDfkavb8PkvBpVoUvA0vbsfsssoB089YHSzoOk2ulRxqMqE8/okoiDlNK+GiCaw1tsNXq4h8G70IKIEEMBj7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-table": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-spinner": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-6.11.1.tgz",
+      "integrity": "sha512-3JDRcduSJQmXWCDYx0dtOcZoBzvdvLUSrvKFJbhZCUUcw2fhEHPoAXbyMqwakzKxySJDAboB3NnM32aiI+oThQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-table": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-6.11.1.tgz",
+      "integrity": "sha512-hnocd9GylDkosqDzOXJgsTpOCMHRtfind08BSSzWXmPbJ0ue3kcw/lqg3rszCcUxwm5fPgycAabhtnHWQo3v8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-tabs": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-6.11.1.tgz",
+      "integrity": "sha512-8z2ZOmptv2cdOXl5GcKJKizJr+DtBXYnj//ikBWwoKVbgrsPmDejOyMCjcHG6rzsUcmUjg7v0OPIvXpRWWDybw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5",
+        "@radix-ui/react-tabs": "^1.1.12"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-text-link": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-6.11.1.tgz",
+      "integrity": "sha512-JlcGrS9mq1380G2d0lPvcwGHfXI54G2yRioabA655XB4ejuIYeBrLe9I2KsWrBP54FfY7J9zZqEmJyMZNlqibA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-tokens": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.1.3.tgz",
+      "integrity": "sha512-3q1IHaCn7zY1ZEyN8LeMlm4R+lvQgEmFR2B5sqIx4Z+Rsr1HRDP+iUYf0ZSXTMETiPd/DP8uiR0RGAvBWeceww==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-tooltip": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-6.11.1.tgz",
+      "integrity": "sha512-5FGWpcJBMGoMADkEMUIqGOf72qRSMzJw/w70RzIl1LZKHr6BjFWeQYQkx3d2lbW7l939c12L5BbiD5sfDIifXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5",
+        "@floating-ui/dom": "^1.7.4",
+        "@floating-ui/react": "^0.27.16"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-typography": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-6.11.1.tgz",
+      "integrity": "sha512-TRXk7xHQJ4m32kvw78XnRPwQudUdwwM87qxCbWLtpihu1ilq1b0iqP7rxBNCsXkj7SOIgP+BPHN/iUDSXsD/9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-usage-card": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-usage-card/-/f36-usage-card-6.11.1.tgz",
+      "integrity": "sha512-YZkSI/836aO7vtMM5GxFcJRh4jRkWlCj9rQ5NzeIMB04Fq7RvTq8iTryWofZJ2juftNEyEq9RsyO/xJ3lGVg6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-card": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-text-link": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-tooltip": "^6.11.1",
+        "@contentful/f36-typography": "^6.11.1",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-usage-count": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-usage-count/-/f36-usage-count-6.11.1.tgz",
+      "integrity": "sha512-diBhL5du4BkiaglrfXFkKfsUwFbEIbjn04oBsxqUvmyeRlyOeCfkJVWc1q7SOH5wzP9I1QE+ikAK7bqRQ6jD9w==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@contentful/f36-utils": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-utils/-/f36-utils-6.1.2.tgz",
+      "integrity": "sha512-gaG+q5NHVEfDzCEGoK12/+8Y1VODPO8k/DyrZjCIOTxTK9rXZ5l1xESMbnMAbwHnz2zXoLkkzI0QGCChW6xrpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-tokens": "^6.1.2",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@emotion/cache": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@emotion/css": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.13.5.tgz",
+      "integrity": "sha512-wQdD0Xhkn3Qy2VNcIzbLP9MR8TafI0MJb7BEAXKp+w4+XqErksWR4OXomuDzPsN4InLdGhVe6EYcn2ZIUCpB8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.13.5",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2"
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@emotion/serialize": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@emotion/sheet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@emotion/utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/@emotion/weak-memoize": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/compute-scroll-into-view": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
+      "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/downshift": {
+      "version": "9.3.6",
+      "resolved": "https://registry.npmjs.org/downshift/-/downshift-9.3.6.tgz",
+      "integrity": "sha512-xEKP1vbt/k7Siu481TKibmj8EyL6iyBwaRJgb6gCsFyLeiyZ1KEJnApS9R1U71hTdK5ym0R99AOYRROcTz1PeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "compute-scroll-into-view": "^3.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^18.2.0",
+        "tslib": "^2.8.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.12.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-rich-text/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/field-editor-shared": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-4.4.1.tgz",
+      "integrity": "sha512-ttQPoYzbhxG9l3X93c5PffSpUf8+FDtXCmKMje3FmG1vo/l88yPgSEXaqX8hkZeAoFs8RiCuqJ7gkU94FOU3Vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-components": "^6.7.1",
+        "@contentful/f36-icons": "^6.7.1",
+        "@contentful/f36-note": "^6.7.1",
+        "@contentful/f36-tokens": "^6.1.2",
+        "@emotion/css": "^11.13.5",
+        "contentful-management": "^12.3.0",
         "fast-deep-equal": "^3.1.3",
         "lodash": "^4.17.15"
       },
       "peerDependencies": {
         "@contentful/app-sdk": "^4.29.0",
         "@lingui/core": "^5.3.0",
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
+        "@tanstack/react-query": "^4.3.9 || ^5.0.0",
+        "react": ">=18.3.1",
+        "react-dom": ">=18.3.1"
+      },
+      "peerDependenciesMeta": {
+        "@tanstack/react-query": {
+          "optional": true
+        }
       }
     },
     "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-accordion": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-5.6.0.tgz",
-      "integrity": "sha512-WlKwS5/tMWfn3yrjRDFglVB8Ozc9e0su2rF0t0v4pynEPZ8WJfXYqTQQMoYEBqgBejZjVWkwK+DDaR2XgzlArw==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-6.11.1.tgz",
+      "integrity": "sha512-+5bGi6jPVVmoe0JB7wFzGiNMVRO3twSX2ecMzDIC27WgKW8NtaAIhsbb6678pGHlqdlqHuez7VwEL+CpEgyJYg==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-collapse": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-collapse": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-asset": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-5.6.0.tgz",
-      "integrity": "sha512-wikvFGMpqdN5IjIUabSQb1nPGCeaPUbV6MiH5SCzaNHAv4ldINUG5Xs/J/Eb9RHs7BV7ZO4Rg/RYwDuT8/23Sw==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-6.11.1.tgz",
+      "integrity": "sha512-6IyoylrbLX2qXmRg6E/Dk5gC/o7toR2t5V08xDLmup+GKuXHRLaaP2xF40guumZedX0DNFtbwRG5uarLJ/IXSQ==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icon": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icon": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-autocomplete": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-5.6.0.tgz",
-      "integrity": "sha512-WmkivMbLBd+CWjALNVMppYVfRBEPfMxi5JTYGZaNHoQsv3SJ3GO5B74U6mwSlWWz18nSE2pI+TJ1Mz0s2jhxyw==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-6.11.1.tgz",
+      "integrity": "sha512-oHelyxej2RxCpx2AUI8exdnj5ovAM5E/kPeG6mkMN8hE3MNq2/AFpUYkn7BjjdJqrFGjsE3ioZcskr0cktf55w==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-forms": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-popover": "^5.6.0",
-        "@contentful/f36-skeleton": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "downshift": "^6.1.12",
-        "emotion": "^10.0.17"
+        "@contentful/f36-button": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-forms": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-popover": "^6.11.1",
+        "@contentful/f36-skeleton": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5",
+        "downshift": "^9.0.10"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-avatar": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-avatar/-/f36-avatar-5.6.0.tgz",
-      "integrity": "sha512-hNtqfAZ5wrlZniiNMAGU9BE/lq9yBiMlgvnsa3fV8qoBo7fRdnVnjuRvEk3DfXYXX44EAj+XIKfDSdsAExr+wA==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-avatar/-/f36-avatar-6.11.1.tgz",
+      "integrity": "sha512-+WiwJe5pyKjBZFnODNCnv8bljmnWn4AjWhx0u7xA1IN7aY87rY2yTLcO+enb4dJiMSID8EED5PsIPbxKtsBi2w==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-image": "^5.6.0",
-        "@contentful/f36-menu": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.6.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-image": "^6.11.1",
+        "@contentful/f36-menu": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-tooltip": "^6.11.1",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-badge": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-5.6.0.tgz",
-      "integrity": "sha512-vVqdq3kDeiMwmdAT5EEpgUIIQSjQJpzkeOqsF4cIbRh63D7Xaseyj5TJE1O3uFA4zcvLrE/Iyx9lQd5YtViiJg==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-6.11.1.tgz",
+      "integrity": "sha512-9ASyA33Q1CrAMJnHiqBci87S7LqPbiSdw2JU63cwoTfA4+ovXgaXpOlBCjGKsnlkJiE5NcBgWbWTqOFWV6cikw==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-button": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-5.6.0.tgz",
-      "integrity": "sha512-JGXADlfIbtbVPUeUvVhFr2yt+5b758T6layvgFK52JV7dWyitOdA2HQ7K1/EtLQXmk0pk2zfvV9X4gQpFotZxw==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-6.11.1.tgz",
+      "integrity": "sha512-vqpIcE5aarFJmgQFSwz6wZg2uB+xKXC/hGBzMUHYd2Ny/aj/2n/KLQwMye4lWLV/NKTOeZX2Il1K5FxlDUVaKg==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-spinner": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.6.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-spinner": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-tooltip": "^6.11.1",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-card": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-5.6.0.tgz",
-      "integrity": "sha512-gYiirKFMavN+JJErA319hpe6Y0UD8nLOzyZI/GRvG0ugEaIFuXBlFL9U5V5dE/TsctNOAk3dshFlhBTpxpFvGg==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-6.11.1.tgz",
+      "integrity": "sha512-xhV5wfHvsV/rU6V9fUAg/t6FlFqKqJr4PM17MO0ZXIsXxAciralDYiFquWvQQF4f0XPa5778E8ez6eZleTldLA==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-asset": "^5.6.0",
-        "@contentful/f36-badge": "^5.6.0",
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-drag-handle": "^5.6.0",
-        "@contentful/f36-icon": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-menu": "^5.6.0",
-        "@contentful/f36-skeleton": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.6.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "emotion": "^10.0.17",
+        "@contentful/f36-asset": "^6.11.1",
+        "@contentful/f36-badge": "^6.11.1",
+        "@contentful/f36-button": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-drag-handle": "^6.11.1",
+        "@contentful/f36-icon": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-menu": "^6.11.1",
+        "@contentful/f36-skeleton": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-tooltip": "^6.11.1",
+        "@contentful/f36-typography": "^6.11.1",
+        "@emotion/css": "^11.13.5",
         "truncate": "^3.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-collapse": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-5.6.0.tgz",
-      "integrity": "sha512-4Jq9Jp1rGyHZqdnLS5Vixw5x4pjqxLxHGn+/vHR5xm7LWWijvEGXo95qSLqIp74S8U48GVYvWZvdlu9T2uOhhg==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-6.11.1.tgz",
+      "integrity": "sha512-Kuz18J7qFQFVdujV1xx0yStrdi4vT6Up3LmvCqnr7RdNdJ4HTo2m+8rOoVmcTgJfyNXFGyikTCHW7elcWUwX0g==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-components": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-5.6.0.tgz",
-      "integrity": "sha512-vyofnGjXHWjG9OR8Bm9SJLA3kNyFGz1eFnICsJWLK9TBly/MXpcm8xQaA7cR5+Q4dZebNE59j5bdfk2w5jUGNQ==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-6.11.1.tgz",
+      "integrity": "sha512-XUOKjRJu2pHAaTOWvv4X5sEtvVUKEq0K1+0saF6YB47qYBsUnlTj5sH2DYr1HZKr3GLP0uOF3lkcBplX6MfdSw==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-accordion": "^5.6.0",
-        "@contentful/f36-asset": "^5.6.0",
-        "@contentful/f36-autocomplete": "^5.6.0",
-        "@contentful/f36-avatar": "^5.6.0",
-        "@contentful/f36-badge": "^5.6.0",
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-card": "^5.6.0",
-        "@contentful/f36-collapse": "^5.6.0",
-        "@contentful/f36-copybutton": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-datepicker": "^5.6.0",
-        "@contentful/f36-datetime": "^5.6.0",
-        "@contentful/f36-drag-handle": "^5.6.0",
-        "@contentful/f36-empty-state": "^5.6.0",
-        "@contentful/f36-entity-list": "^5.6.0",
-        "@contentful/f36-forms": "^5.6.0",
-        "@contentful/f36-header": "^5.6.0",
-        "@contentful/f36-icon": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-image": "^5.6.0",
-        "@contentful/f36-layout": "^5.6.0",
-        "@contentful/f36-list": "^5.6.0",
-        "@contentful/f36-menu": "^5.6.0",
-        "@contentful/f36-modal": "^5.6.0",
-        "@contentful/f36-multiselect": "^5.6.0",
-        "@contentful/f36-navlist": "^5.6.0",
-        "@contentful/f36-note": "^5.6.0",
-        "@contentful/f36-notification": "^5.6.0",
-        "@contentful/f36-pagination": "^5.6.0",
-        "@contentful/f36-pill": "^5.6.0",
-        "@contentful/f36-popover": "^5.6.0",
-        "@contentful/f36-progress-stepper": "^5.6.0",
-        "@contentful/f36-skeleton": "^5.6.0",
-        "@contentful/f36-spinner": "^5.6.0",
-        "@contentful/f36-table": "^5.6.0",
-        "@contentful/f36-tabs": "^5.6.0",
-        "@contentful/f36-text-link": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.6.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "@contentful/f36-usage-card": "^5.6.0",
-        "@contentful/f36-usage-count": "^5.6.0",
-        "@contentful/f36-utils": "^5.2.0"
+        "@contentful/f36-accordion": "^6.11.1",
+        "@contentful/f36-asset": "^6.11.1",
+        "@contentful/f36-autocomplete": "^6.11.1",
+        "@contentful/f36-avatar": "^6.11.1",
+        "@contentful/f36-badge": "^6.11.1",
+        "@contentful/f36-button": "^6.11.1",
+        "@contentful/f36-card": "^6.11.1",
+        "@contentful/f36-collapse": "^6.11.1",
+        "@contentful/f36-copybutton": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-datepicker": "^6.11.1",
+        "@contentful/f36-datetime": "^6.11.1",
+        "@contentful/f36-drag-handle": "^6.11.1",
+        "@contentful/f36-empty-state": "^6.11.1",
+        "@contentful/f36-entity-list": "^6.11.1",
+        "@contentful/f36-forms": "^6.11.1",
+        "@contentful/f36-header": "^6.11.1",
+        "@contentful/f36-icon": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-image": "^6.11.1",
+        "@contentful/f36-layout": "^6.11.1",
+        "@contentful/f36-list": "^6.11.1",
+        "@contentful/f36-menu": "^6.11.1",
+        "@contentful/f36-modal": "^6.11.1",
+        "@contentful/f36-multiselect": "^6.11.1",
+        "@contentful/f36-navlist": "^6.11.1",
+        "@contentful/f36-note": "^6.11.1",
+        "@contentful/f36-notification": "^6.11.1",
+        "@contentful/f36-pagination": "^6.11.1",
+        "@contentful/f36-pill": "^6.11.1",
+        "@contentful/f36-popover": "^6.11.1",
+        "@contentful/f36-progress-stepper": "^6.11.1",
+        "@contentful/f36-skeleton": "^6.11.1",
+        "@contentful/f36-spinner": "^6.11.1",
+        "@contentful/f36-table": "^6.11.1",
+        "@contentful/f36-tabs": "^6.11.1",
+        "@contentful/f36-text-link": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-tooltip": "^6.11.1",
+        "@contentful/f36-typography": "^6.11.1",
+        "@contentful/f36-usage-card": "^6.11.1",
+        "@contentful/f36-usage-count": "^6.11.1",
+        "@contentful/f36-utils": "^6.1.2"
       },
       "peerDependencies": {
-        "@types/react": ">=16.8",
-        "@types/react-dom": ">=16.8",
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "@types/react": "^18.3.0 || >=19.1.0",
+        "@types/react-dom": "^18.3.0 || >=19.1.0",
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -2719,595 +3902,700 @@
       }
     },
     "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-copybutton": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-5.6.0.tgz",
-      "integrity": "sha512-/hQsFUx/kqOZc7NA5VNAyAnEz4Y3KUeEHBCYSYJdnAWXRkbavUgDp25GYIIG8so3x+D7Cz2zh9dMtVwUr1WCkg==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-6.11.1.tgz",
+      "integrity": "sha512-QRqFvU0rQtz0UG+qqHZA1B5cdhNlhdaYIOLdHvyIgRllgnCGkbt5UAQAzuzhpHVF8jS7FQp+/3p4ETvUV6riOQ==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.6.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-button": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-tooltip": "^6.11.1",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-core": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-5.6.0.tgz",
-      "integrity": "sha512-O9t4UzEEyjbYs637uUfiTGHwNwvqfMPYkrgW47g03XPwo1gRoXNaJzMNJLemkW/8ZqjrgBsEE4Q6QvKtOdDb0A==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-6.11.1.tgz",
+      "integrity": "sha512-1XaG6AA2aWw+BgXzqpJdj2T7lf0bVW6i1tQa05e7vHEf/RSFVPNN6W2KjPC4KX2lZx5GUSjhWU0rET5Nuq6yiQ==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-tokens": "^5.1.0",
-        "@emotion/core": "^10.1.1",
-        "@emotion/is-prop-valid": "^1.2.0",
-        "csstype": "^3.1.1",
-        "emotion": "^10.0.17"
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5",
+        "@emotion/react": "^11.14.0",
+        "csstype": "^3.1.1"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-datepicker": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-5.6.0.tgz",
-      "integrity": "sha512-5afLd3SS6pUS2+YkH6i+P59jaH7zdkx3s2sktJkqaerEfx9Gq+XkuInWbhkKZCcirs9szaeOErhwad9Eggv6rw==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-6.11.1.tgz",
+      "integrity": "sha512-vdrktk1nJ/y2cddwMDnYytP03+wWTyEjv2mgXO513A1NPAfSVIfswutRe6xcHgzyPohoSipcW8O4LAXcGW2naA==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-forms": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-popover": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
+        "@contentful/f36-button": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-forms": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-popover": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@emotion/css": "^11.13.5",
         "date-fns": "^2.28.0",
-        "emotion": "^10.0.17",
         "react-day-picker": "^8.7.1",
         "react-focus-lock": "^2.9.1"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-datetime": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-5.6.0.tgz",
-      "integrity": "sha512-PofT+PERLv2fW2xOPxBDsMPYRnYCQ67tvmj/DkP4zh73uHFQBHTgGQ4vzMIOXGD7o5MGAPrLwIYNVtx3Wsp+mg==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-6.11.1.tgz",
+      "integrity": "sha512-eGJlFs/KUgGyAtiW7pA3SnFhGGwWk66hnsJPoo0OaPpHnQJKUa5KlKH3qud9DTOUvDEQmHV98cJCjTJDHqR26w==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "dayjs": "^1.11.5",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5",
+        "dayjs": "^1.11.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-drag-handle": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-5.6.0.tgz",
-      "integrity": "sha512-iY5uHxKPfhmWvuWNLysptpMQVkbNGhZxphzyW9+NA0XzYCVAkRyAuL2RR5nu/BEysgILD6Zk5JDeBXBmt8CJeQ==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-6.11.1.tgz",
+      "integrity": "sha512-ZEvi5t0LKIPZKQ4oZK8XN8z8nCbfTXJyJJBqev9l7Il2sXd3t28A/jfMLpLcJ8Mr4xbvJy/39YOgm0CZiwhLwA==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-empty-state": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-5.6.0.tgz",
-      "integrity": "sha512-yivozabj58cm6amC/hQeBwFApstqIfGpONzRp5OPIoOe1tludyda37a6fsN35NSKSYrACthS32EOl/2KBH7c0Q==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-6.11.1.tgz",
+      "integrity": "sha512-+/A4rbxolIGHRXrrJl93wOq19Vo60qYkQCLaqZsBtChIO0C4Px184D88+Wdwww7qZbfEsVzaPB7qqKf2c4shpA==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-entity-list": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-5.6.0.tgz",
-      "integrity": "sha512-pis/mt7amELmB313VuuYzPF1lLxsox+cfTLTlYTCDWgeh6+yn6vtLXV9RJA78A0H7uuAxRge9KP7jHCYpGvjAw==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-6.11.1.tgz",
+      "integrity": "sha512-g1edZZMj4MxjcwpbGv9L+XVj8aDAdGcOzY6mFuNvV256mWD9CCYxe/9rvOmazGuOZPnGQTzKUufZGyFaiRa40w==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-badge": "^5.6.0",
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-drag-handle": "^5.6.0",
-        "@contentful/f36-icon": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-menu": "^5.6.0",
-        "@contentful/f36-skeleton": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-badge": "^6.11.1",
+        "@contentful/f36-button": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-drag-handle": "^6.11.1",
+        "@contentful/f36-icon": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-menu": "^6.11.1",
+        "@contentful/f36-skeleton": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-forms": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-5.6.0.tgz",
-      "integrity": "sha512-nmDIEntL3Y3w0I6hf+ifY3sjI8DMKcGLMyG9kkiJE2fSFb3TJTPgxdk1tDkPFid68Vlcj2NHFwzTInHdYI+j6w==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-6.11.1.tgz",
+      "integrity": "sha512-5JlyGz2qYpz7N4jyd04ZKltcr7Yc7FDMYmyIegNlRZ1BEKft/KgXjhuIrSHizo9vb7Z6D0wGcYnWLKYJmlR9pg==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icon": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-header": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-header/-/f36-header-5.6.0.tgz",
-      "integrity": "sha512-bY7uhrdv3O7GfQ1soJkkn0BOox6HuJhk1Vc0xorEpnI/o4QdiO5tMW7XO0A++dzEtZfYffYRCBenPmn+M840YQ==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-header/-/f36-header-6.11.1.tgz",
+      "integrity": "sha512-OuCVUcDC0odL7hK5NklP1EfpRcyTRoEAVfjGrZKOZONJDzuF8jJtZIC1rU1LcVdsbOrYh3rMlkrYw0SCqSlMOg==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-button": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-icon": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-5.6.0.tgz",
-      "integrity": "sha512-VoyKI+rQGK5a3XyFvNG5PMa5FsGdo23XTB0Mj8ukIIvm6ZEBPTHqCGoKnPdl+s2+txIiMSbAmJslEbJR6KZiBg==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-6.11.1.tgz",
+      "integrity": "sha512-J/TBh1T2+15FsigCjcR5ZVjzsIBs5nPsUHIOdo8Y4XfKO6uo2tp+IdV8n/JMDB+vifJBno8iX7r2zuvMZut94g==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@phosphor-icons/react": "2.1.8",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5",
+        "@phosphor-icons/react": "2.1.8"
       },
       "engines": {
         "node": ">=16"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-icons": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-5.6.0.tgz",
-      "integrity": "sha512-YM2KNFbmGAkqY6iug8ja8TCBpLxZm2jECZDujRweHyRnTRfHpoIjuP+14LO0iv/ilJEK6DedJoAflz0QJ20a8w==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-6.11.1.tgz",
+      "integrity": "sha512-o2OHFUyikwEtoZC8WEU+26pWYpSnoLUDJ3ryYYkCCgfP9Y/TtmaZxox79lWvVcSS5vHX19Sd7WZqbFD23vzhIA==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icon": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@phosphor-icons/react": "2.1.8",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icon": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5",
+        "@phosphor-icons/react": "2.1.8"
       },
       "engines": {
         "node": ">=16"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-image": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-image/-/f36-image-5.6.0.tgz",
-      "integrity": "sha512-QY7ZxD3g3Fqr7jzWjSUMpuG1K3XeSvk+xQzHeNPJSqe14GTFB/V9FCHk9Zrmb0dQKUaRLohBraWBT0sMg/yBEA==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-image/-/f36-image-6.11.1.tgz",
+      "integrity": "sha512-TD4SpU/YOL5VbLVSTV7lPGKsHkdMWa73wbtn2RaeoRBz06eYu8tIrvf/J3q8n45r+//Y0jsQ76fSuZwwlSr2og==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-skeleton": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-skeleton": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-list": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-5.6.0.tgz",
-      "integrity": "sha512-bu2kZ+XgKKOVD0924Cgd4dDIuvM8yUlsqbpi8hQFS5xH6rLPdBen15m1cpWmVNUL7n/nnznduF8cAG9sQ0d7mw==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-6.11.1.tgz",
+      "integrity": "sha512-SlGB/RgXA8NIQPdFOXWjBFUQiHf/4gknPy7qS5igq7zm+BQBcTXoBOeeqF85JIa/0OdeUfWlX4Jok99vqgoT2A==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-menu": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-5.6.0.tgz",
-      "integrity": "sha512-VS0sA41lFgz6j5WZePzVEJTtPij8hGdwva55B3lgGJHKALYxd+Q5GfjUtYuXZbwvFd0mvhz0dWQFBgdATfObyQ==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-6.11.1.tgz",
+      "integrity": "sha512-SS61LL51U//DL9NOCleAF8XkjBzjr110P4KPNaAGtqQOrk4YoeuU4SHTnscVxGbHd6wwEQJTgSkNS3ket07o/g==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-popover": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-popover": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5",
+        "@floating-ui/dom": "^1.7.4",
+        "@floating-ui/react": "^0.27.16"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-modal": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-5.6.0.tgz",
-      "integrity": "sha512-iZOH6q3Sv/f2sxiYadMscYFe6oXMXxAf9xZpQRtYZIglbgpItVf3z7/A27rSXtCmasoMkWfiKOQaDlFllT6RhA==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-6.11.1.tgz",
+      "integrity": "sha512-b91Fk1/lpU9mEm5A3NsUV52FDPOl+vhuDESnLwGEzFv2SODR5nrDDNpgZzyhQGV068rtUUUjlS2GVWXsajqgyw==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "@types/react-modal": "^3.13.1",
-        "emotion": "^10.0.17",
-        "react-modal": "^3.16.1"
+        "@contentful/f36-button": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@emotion/css": "^11.13.5",
+        "@types/react-modal": "^3.16.3",
+        "react-modal": "^3.16.3"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-multiselect": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-multiselect/-/f36-multiselect-5.6.0.tgz",
-      "integrity": "sha512-ioOmQWa/rnaSZ8w0SUKx01iqY1Ls876cHDiH0X3yCsxBd/Q64mnZX2t2yUS4jqzzZHAYowPQKWC0rRWmkazPzg==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-multiselect/-/f36-multiselect-6.11.1.tgz",
+      "integrity": "sha512-qU9wOLsyhyupYcvd3ctXs7IyGplNxbjc8IHqLose50UzsdTO9vTSu4dTqiQgG9b/eQVvnqIE22xyL2ogxWZYdw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.27.1",
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-forms": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-popover": "^5.6.0",
-        "@contentful/f36-skeleton": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.6.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "emotion": "^10.0.17",
-        "react-focus-lock": "^2.9.5"
+        "@contentful/f36-button": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-forms": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-popover": "^6.11.1",
+        "@contentful/f36-skeleton": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-tooltip": "^6.11.1",
+        "@contentful/f36-typography": "^6.11.1",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-note": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-5.6.0.tgz",
-      "integrity": "sha512-OmVPwfVctWQ19lUOrWama2/gGcEBdhgIL8GfiUMnC+fcAjzcD3OS8C4PKdXKAT5SS+sCmuwGuSMpoqdtYQx/0A==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-6.11.1.tgz",
+      "integrity": "sha512-xCgtdaF7M3kfjOkk/3MjePcHfSIZ261MdyZ2u9uhQNm9Tz3HlWQjqjeaMZOK5leAcDUGA3Gf3owBQl16QPUOxw==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icon": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-button": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icon": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-notification": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-5.6.0.tgz",
-      "integrity": "sha512-gehtdl+KIuGJpVJI8thDI9X6zOoOM+Y905Or9HYZfGf8W7vDr4+slXzIl/JXfQOttJ7425MXsFP0FtzWRNA4hA==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-6.11.1.tgz",
+      "integrity": "sha512-7NmYwEdzK0aaiMpLMBn6dn/NILQhbXJBhrQ9eyszDRW+JAUCpUEZL7HbSsTHp7EZ/AIWuvJWsWRrJ/t97EKe6A==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-text-link": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "emotion": "^10.0.17",
+        "@contentful/f36-button": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-text-link": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@emotion/css": "^11.13.5",
         "react-animate-height": "^3.0.4"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-pagination": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-5.6.0.tgz",
-      "integrity": "sha512-fFiQvoTovb3fuBU2IUkr0M/+aNFM8C1jm7d7SZE5y4i3C2d2RqBiaCo0ShOQTWPhJiNjtqDIUFxkrderRg5ExQ==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-6.11.1.tgz",
+      "integrity": "sha512-tW8hVPXl8Rhyu6x9ee1Pi/Nj+FHXNKYp2ewsuRygyueMxfcEjmgvz/J5GwSq5ThLkr+uncNVludAvZUg2QUz3Q==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-forms": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-button": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-forms": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-pill": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-5.6.0.tgz",
-      "integrity": "sha512-t7cwf9sdWoW07B26j+cxEzxCZwXGAiyqby2s7vQKr/U1/5m/JlVIIVifMkAA+f+wvtUYb2DMoBl9pJkRiIZsQQ==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-6.11.1.tgz",
+      "integrity": "sha512-RPtQ3juqXlzzzaOMwdeUjwmXv7QpQ8yFP0S0TcqyZOfxDGbKvuLbsLiDtfGFStkkCnoXX2E45AK13asQ94USdA==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-button": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-drag-handle": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.6.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-button": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-drag-handle": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-tooltip": "^6.11.1",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-popover": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-5.6.0.tgz",
-      "integrity": "sha512-W8DzlCC5r16W0qDdR0JZQJLss91MjjMIarwMY18soGwA2oyEo8IPiDGDyRgDXL+TY1/SxFEux44Ck5mV62vAtA==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-6.11.1.tgz",
+      "integrity": "sha512-Q4cfFV3ClkNN3xF7YnO6vpb/s5WYEereAswMJkln/NDoKihE00N8sSe5DELt2nBWz9/i/zRcGjHK/YX6wlpcpA==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "@popperjs/core": "^2.11.5",
-        "emotion": "^10.0.17",
-        "react-popper": "^2.3.0"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5",
+        "@floating-ui/dom": "^1.7.4",
+        "@floating-ui/react": "^0.27.16"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-skeleton": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-5.6.0.tgz",
-      "integrity": "sha512-a4nuJKBrYDQiHwk4r+lNTFi6FDXGYxCur2SSTbWcvrerDud+IjptfTARRy+x+K17ic+uody1ualeO7Kktkw7Yg==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-6.11.1.tgz",
+      "integrity": "sha512-2yDfkavb8PkvBpVoUvA0vbsfsssoB089YHSzoOk2ulRxqMqE8/okoiDlNK+GiCaw1tsNXq4h8G70IKIEEMBj7w==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-table": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-table": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-spinner": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-5.6.0.tgz",
-      "integrity": "sha512-NmH/bNol+e7AarybNgv8B8lodF2hOFlF32H6QAEhsHmq76dxOQ6LlgjlxIttNpIrGgHYU29yWAH5LhTu/BAE7g==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-6.11.1.tgz",
+      "integrity": "sha512-3JDRcduSJQmXWCDYx0dtOcZoBzvdvLUSrvKFJbhZCUUcw2fhEHPoAXbyMqwakzKxySJDAboB3NnM32aiI+oThQ==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-table": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-5.6.0.tgz",
-      "integrity": "sha512-1nAfK95DmVhxQb9TZllNE/tF45UN1xMzs3/1v7laH9CymkpAYQefYEpOneQBM42+lp00JX/81Hi0DnZ1xv3i+g==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-6.11.1.tgz",
+      "integrity": "sha512-hnocd9GylDkosqDzOXJgsTpOCMHRtfind08BSSzWXmPbJ0ue3kcw/lqg3rszCcUxwm5fPgycAabhtnHWQo3v8A==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-tabs": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-5.6.0.tgz",
-      "integrity": "sha512-+7S+zpUn84uv97XHxTD25186XE13GjIzcASBOzZAZZ1WCVYDMdhUpLaCNRAhVapV6R1qIShPG8DbGgwFTMIOXA==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-6.11.1.tgz",
+      "integrity": "sha512-8z2ZOmptv2cdOXl5GcKJKizJr+DtBXYnj//ikBWwoKVbgrsPmDejOyMCjcHG6rzsUcmUjg7v0OPIvXpRWWDybw==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@radix-ui/react-tabs": "^1.0.1",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5",
+        "@radix-ui/react-tabs": "^1.1.12"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-text-link": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-5.6.0.tgz",
-      "integrity": "sha512-1Pj/d/0/5+REOLlfJdXAbb2VG7QDls+gI0HH+lTfbqrVoolFRPvnXxMr7+RcxEwHqr73/atvPdx9Q2xWSXEMmQ==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-6.11.1.tgz",
+      "integrity": "sha512-JlcGrS9mq1380G2d0lPvcwGHfXI54G2yRioabA655XB4ejuIYeBrLe9I2KsWrBP54FfY7J9zZqEmJyMZNlqibA==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-tokens": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-5.1.0.tgz",
-      "integrity": "sha512-7++MPQiizK6qLhPkilWIKqM5Mhdr199tK7dL4iZ689iTwA82uvXXOojJr+0wVOurG2Odb+6/3WLe1XdveDZHEA==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.1.3.tgz",
+      "integrity": "sha512-3q1IHaCn7zY1ZEyN8LeMlm4R+lvQgEmFR2B5sqIx4Z+Rsr1HRDP+iUYf0ZSXTMETiPd/DP8uiR0RGAvBWeceww==",
       "license": "MIT"
     },
     "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-tooltip": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-5.6.0.tgz",
-      "integrity": "sha512-e4z+eysp95u4ASheQgkJJM+RXyZv/KyMi4bqqez2ydvkFtFViI7E+wkzxIbB5L2EzHqIGL6/IcgQ8GC6io/Fsw==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-6.11.1.tgz",
+      "integrity": "sha512-5FGWpcJBMGoMADkEMUIqGOf72qRSMzJw/w70RzIl1LZKHr6BjFWeQYQkx3d2lbW7l939c12L5BbiD5sfDIifXA==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "@popperjs/core": "^2.11.5",
-        "csstype": "^3.1.1",
-        "emotion": "^10.0.17",
-        "react-popper": "^2.3.0"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5",
+        "@floating-ui/dom": "^1.7.4",
+        "@floating-ui/react": "^0.27.16"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-typography": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-5.6.0.tgz",
-      "integrity": "sha512-v8myIeJnpZ6g2WRmL9oOOLrjip3+80Y+LQ4PwOzcJatL5AdwSYVExtlFMMVO5/JNt6qEpT2sd5579LPA17yiVg==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-6.11.1.tgz",
+      "integrity": "sha512-TRXk7xHQJ4m32kvw78XnRPwQudUdwwM87qxCbWLtpihu1ilq1b0iqP7rxBNCsXkj7SOIgP+BPHN/iUDSXsD/9A==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-utils": "^5.2.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-usage-card": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-usage-card/-/f36-usage-card-5.6.0.tgz",
-      "integrity": "sha512-Mzt0S8F4onLaCCJn/48uMDmZO/pKMNiqAOgIXGOmPOhk0+8IEjQgx7h487r6KD9xjXhejpCFtG5tfG2DopGZ1w==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-usage-card/-/f36-usage-card-6.11.1.tgz",
+      "integrity": "sha512-YZkSI/836aO7vtMM5GxFcJRh4jRkWlCj9rQ5NzeIMB04Fq7RvTq8iTryWofZJ2juftNEyEq9RsyO/xJ3lGVg6w==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-card": "^5.6.0",
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-icons": "^5.6.0",
-        "@contentful/f36-text-link": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-tooltip": "^5.6.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-card": "^6.11.1",
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-icons": "^6.11.1",
+        "@contentful/f36-text-link": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-tooltip": "^6.11.1",
+        "@contentful/f36-typography": "^6.11.1",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-usage-count": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-usage-count/-/f36-usage-count-5.6.0.tgz",
-      "integrity": "sha512-bjnrnx52jScH2/Nt55piBVzl5HUZELGQh8NHhWUSGry1hFyxeAh7MyEg6B/ROBnVk67E9ZITRknQmqRO9pnoUg==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-usage-count/-/f36-usage-count-6.11.1.tgz",
+      "integrity": "sha512-diBhL5du4BkiaglrfXFkKfsUwFbEIbjn04oBsxqUvmyeRlyOeCfkJVWc1q7SOH5wzP9I1QE+ikAK7bqRQ6jD9w==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-core": "^5.6.0",
-        "@contentful/f36-tokens": "^5.1.0",
-        "@contentful/f36-typography": "^5.6.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-core": "^6.11.1",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.11.1",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
     "node_modules/@contentful/field-editor-shared/node_modules/@contentful/f36-utils": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-utils/-/f36-utils-5.2.0.tgz",
-      "integrity": "sha512-0YWsKAdU2HeNz5DwuOCR0lnlHVhlXiDkqtYaH8hHqT9HlQKHDSBPQUI9Vk5OrPDRJ3uLVoyGOJcvUDf27tTopA==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-utils/-/f36-utils-6.1.2.tgz",
+      "integrity": "sha512-gaG+q5NHVEfDzCEGoK12/+8Y1VODPO8k/DyrZjCIOTxTK9rXZ5l1xESMbnMAbwHnz2zXoLkkzI0QGCChW6xrpw==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/f36-tokens": "^5.1.0",
-        "emotion": "^10.0.17"
+        "@contentful/f36-tokens": "^6.1.2",
+        "@emotion/css": "^11.13.5"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
       }
     },
+    "node_modules/@contentful/field-editor-shared/node_modules/@emotion/cache": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@contentful/field-editor-shared/node_modules/@emotion/css": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.13.5.tgz",
+      "integrity": "sha512-wQdD0Xhkn3Qy2VNcIzbLP9MR8TafI0MJb7BEAXKp+w4+XqErksWR4OXomuDzPsN4InLdGhVe6EYcn2ZIUCpB8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.13.5",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2"
+      }
+    },
+    "node_modules/@contentful/field-editor-shared/node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/field-editor-shared/node_modules/@emotion/serialize": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@contentful/field-editor-shared/node_modules/@emotion/sheet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/field-editor-shared/node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/field-editor-shared/node_modules/@emotion/utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/field-editor-shared/node_modules/@emotion/weak-memoize": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/field-editor-shared/node_modules/compute-scroll-into-view": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
+      "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==",
+      "license": "MIT"
+    },
     "node_modules/@contentful/field-editor-shared/node_modules/contentful-management": {
-      "version": "11.61.1",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.61.1.tgz",
-      "integrity": "sha512-+Shk0fGpudvT0b0CwdNiLDwPoIbb0YdkiiYc6h5aC42zfVFJ0dgJf9JKzYPBPJd0MWGOCQf5yNzt/zBEAUDElw==",
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-12.5.1.tgz",
+      "integrity": "sha512-na2GEX2a2KJEEXm+10kWHwA5WT0Iz9F+B/ycWzMBbG1Q/Q5mUiaB/TiABS4np4UOiSO/AxO6+xqlgGIpdsAkdg==",
       "license": "MIT",
       "dependencies": {
         "@contentful/rich-text-types": "^16.6.1",
-        "axios": "^1.12.2",
-        "contentful-sdk-core": "^9.0.1",
+        "axios": "^1.15.0",
+        "contentful-sdk-core": "^9.4.4",
         "fast-copy": "^3.0.0",
-        "globals": "^15.15.0"
+        "globals": "^15.15.0",
+        "process": "^0.11.10"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
-    "node_modules/@contentful/mimetype": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@contentful/mimetype/-/mimetype-2.6.1.tgz",
-      "integrity": "sha512-YcLyzuV/6+LQiKmDHLSgvYMD7oKrpb9CY6E5so6TLOp9v5b8TJUqCnuOBBABdOLF6Sg/Z92Rx21u5z7YByfL0A==",
+    "node_modules/@contentful/field-editor-shared/node_modules/downshift": {
+      "version": "9.3.6",
+      "resolved": "https://registry.npmjs.org/downshift/-/downshift-9.3.6.tgz",
+      "integrity": "sha512-xEKP1vbt/k7Siu481TKibmj8EyL6iyBwaRJgb6gCsFyLeiyZ1KEJnApS9R1U71hTdK5ym0R99AOYRROcTz1PeQ==",
       "license": "MIT",
       "dependencies": {
-        "lodash": "^4.17.20"
+        "@babel/runtime": "^7.28.6",
+        "compute-scroll-into-view": "^3.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^18.2.0",
+        "tslib": "^2.8.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.12.0"
       }
+    },
+    "node_modules/@contentful/field-editor-shared/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/mimetype": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/@contentful/mimetype/-/mimetype-2.6.5.tgz",
+      "integrity": "sha512-Raf+xYKctjzrA5/reT51AUjCpYgVKV2C20fj9l+5LrT4rx+jwp9hlhsUK2jvCN5j1t9fqgd/Q6qGMv/qBexHbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.18.1"
+      }
+    },
+    "node_modules/@contentful/mimetype/node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/@contentful/react-apps-toolkit": {
       "version": "1.2.16",
@@ -3570,6 +4858,102 @@
         "react": ">=16.8.0"
       }
     },
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+      "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/serialize": "^1.3.3",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/@emotion/serialize": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/@emotion/utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/@emotion/cache": {
       "version": "10.0.29",
       "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
@@ -3625,6 +5009,86 @@
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
       "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ=="
     },
+    "node_modules/@emotion/react": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
+      "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "hoist-non-react-statics": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/react/node_modules/@emotion/cache": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/react/node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/react/node_modules/@emotion/serialize": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/react/node_modules/@emotion/sheet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/react/node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/react/node_modules/@emotion/utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/react/node_modules/@emotion/weak-memoize": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
+      "license": "MIT"
+    },
     "node_modules/@emotion/serialize": {
       "version": "0.11.16",
       "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.16.tgz",
@@ -3661,6 +5125,15 @@
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
       "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+    },
+    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
+      "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
     },
     "node_modules/@emotion/utils": {
       "version": "0.11.3",
@@ -4109,6 +5582,59 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.19",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.19.tgz",
+      "integrity": "sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.8",
+        "@floating-ui/utils": "^0.2.11",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
@@ -4815,13 +6341,31 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.41.0.tgz",
-      "integrity": "sha512-193R4Jp9hjvlij6LryxrB5Mpbffd2L9PeWh3KlIy/hJV4SkBOfiQZ+jc5qAZLDCrdbkA5FjGj+UoDYw6TcNnyA==",
+      "version": "5.101.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.0.tgz",
+      "integrity": "sha512-cQetA74EB+seWySv1TTKr828TnP0u39m6LykwDXIo84SNortpDkp30TMEjkqtYCNP9c40uT/iwl6MLiufEt0Ow==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.101.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.0.tgz",
+      "integrity": "sha512-rLlJXSpkqfizLWgkR5+eLeIk0MvTx/meEIR7LRjxic+qxiQP8zVjq7BqQkiCMNLQBlLfuOLqqr6KO5GtrDlmSg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@tanstack/query-core": "5.101.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -5713,14 +7257,40 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.1.tgz",
-      "integrity": "sha512-hU4EGxxt+j7TQijx1oYdAjw4xuIp1wRQSsbMFwSthCWeBQur1eF+qJ5iQ5sN3Tw8YRzQNKb8jszgBdMDVqwJcw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+      "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/babel-plugin-emotion": {
@@ -5932,6 +7502,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "get-intrinsic": "^1.3.0"
@@ -6193,15 +7764,15 @@
       "integrity": "sha512-ozrGwyuCTAy7YgFCua8rmqmytECYk/JYAMXcswOcm0qvGoE3tPb7ivBeIHTOK2DiapBhDZgacIhzhQIKU5TCfA=="
     },
     "node_modules/contentful-sdk-core": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-9.2.0.tgz",
-      "integrity": "sha512-cUvHbC2u8ouJHhG3tofQhUc0FAmM/QBcalYjiczMtFKrR77BW+eSPcPg+A9DQlhIP0UGcQ/knXxoJpBvrERXTA==",
+      "version": "9.4.5",
+      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-9.4.5.tgz",
+      "integrity": "sha512-8eGTMO11LXFAiosaiV38bjvW6cjoQFtNE38pNtVilZTXpmGFinClljihH0eriv11Ispd4q82TqtsXMJPYD/C+A==",
+      "license": "MIT",
       "dependencies": {
         "fast-copy": "^3.0.2",
-        "lodash": "^4.17.21",
-        "p-throttle": "^6.1.0",
+        "lodash": "^4.17.23",
         "process": "^0.11.10",
-        "qs": "^6.12.3"
+        "qs": "^6.15.0"
       },
       "engines": {
         "node": ">=18"
@@ -6209,6 +7780,12 @@
       "optionalDependencies": {
         "@rollup/rollup-linux-x64-gnu": "^4.18.0"
       }
+    },
+    "node_modules/contentful-sdk-core/node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -6232,9 +7809,9 @@
       }
     },
     "node_modules/cosmiconfig/node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "license": "ISC",
       "engines": {
         "node": ">= 6"
@@ -6634,7 +8211,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -6753,15 +8329,16 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -6777,18 +8354,31 @@
       "integrity": "sha512-k6GAGDyqLe9JaebCsFCoudPPWfihKu8pylYXRlqP1J7ms39iPoTtk2fviNglIeQEwdh0bQeKJ01ZPyuyQvKzwg=="
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/fs-extra": {
@@ -7045,6 +8635,21 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
@@ -7704,15 +9309,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/moment": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/moo": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
@@ -7822,6 +9418,7 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -7927,17 +9524,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/p-throttle": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/p-throttle/-/p-throttle-6.2.0.tgz",
-      "integrity": "sha512-NCKkOVj6PZa6NiTmfvGilDdf6vO1rFCD3KDnkHko8dTOtkpk4cSR/VTAhhLMG9aiQ7/A9HYgEDNmxzf6hxzR3g==",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/parent-module": {
@@ -8123,9 +9709,13 @@
       "license": "MIT"
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/psl": {
       "version": "1.15.0",
@@ -8149,9 +9739,10 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
       },
@@ -8581,13 +10172,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -8599,12 +10191,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8617,6 +10210,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -8634,6 +10228,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -8820,6 +10415,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -8848,6 +10449,12 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
+    },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "license": "MIT"
     },
     "node_modules/tar": {
       "version": "6.2.1",

--- a/apps/rich-text-versioning/package.json
+++ b/apps/rich-text-versioning/package.json
@@ -8,7 +8,7 @@
     "@contentful/f36-components": "4.81.1",
     "@contentful/f36-multiselect": "^4.81.1",
     "@contentful/f36-tokens": "4.2.0",
-    "@contentful/field-editor-rich-text": "4.16.0",
+    "@contentful/field-editor-rich-text": "6.3.9",
     "@contentful/react-apps-toolkit": "1.2.16",
     "@contentful/rich-text-html-renderer": "^17.1.0",
     "@contentful/rich-text-react-renderer": "^16.1.0",


### PR DESCRIPTION
## Summary

Two previous attempts to bump `@contentful/field-editor-rich-text` past `4.16.0` were reverted because they landed before their upstream prerequisites were published:

- **PR #10987** (May 18, reverted May 19): bumped to `6.3.5` — published May 13, before upstream fixes
- **PR #11007** (Jun 5, reverted Jun 8): bumped to `6.3.8` — published May 28, same issue

Both upstream fixes shipped in **`6.3.6` on 2026-05-18**:
- `contentful/experience-packages#3480` — typed CMA methods so entity picker works from apps (ES-262)
- `contentful/field-editors#2159` — react-query v5 pending status fix in fetching cards (ES-262)

`6.3.9` (2026-06-05, current stable) includes both and has been out for 11 days without reports of the `Cannot read properties of undefined (reading 'sys')` crash.

## Test plan
- [ ] Open a rich text versioning entry with **embedded entry references** — confirm no `sys` crash
- [ ] Open a rich text versioning entry with **embedded asset references** — confirm no crash
- [ ] Open entity picker inside rich text field — confirm "Suggested" tab returns results (ES-262)
- [ ] Verify RTL text renders correctly in rich text fields (ES-319)
- [ ] Open a plain rich text field (no embedded references) — confirm no regression

Generated with [Claude Code](https://claude.com/claude-code)