### PR TITLE
fix(drive-integration): flaky modal tests caused by react-modal timer leak [INTEG-4213]

### DIFF
--- a/apps/drive-integration/src/setupTests.ts
+++ b/apps/drive-integration/src/setupTests.ts
@@ -4,6 +4,20 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 
+import { beforeEach, afterEach, vi } from 'vitest';
+
+// react-modal schedules a setTimeout to remove its portal on close. Without fake
+// timers that timeout can fire after jsdom is torn down → "document is not defined".
+// shouldAdvanceTime keeps the wall clock running so waitFor still resolves normally.
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+
+afterEach(() => {
+  vi.runAllTimers();
+  vi.useRealTimers();
+});
+
 if (typeof window !== 'undefined' && typeof ResizeObserver === 'undefined') {
   window.ResizeObserver = class ResizeObserver {
     observe() {}

--- a/apps/drive-integration/src/setupTests.ts
+++ b/apps/drive-integration/src/setupTests.ts
@@ -14,8 +14,12 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  vi.runAllTimers();
-  vi.useRealTimers();
+  // Guard needed for tests that call vi.useRealTimers() inline — runAllTimers()
+  // throws if timers are no longer mocked when this afterEach fires.
+  if (vi.isFakeTimers()) {
+    vi.runAllTimers();
+    vi.useRealTimers();
+  }
 });
 
 if (typeof window !== 'undefined' && typeof ResizeObserver === 'undefined') {

--- a/apps/drive-integration/src/setupTests.ts
+++ b/apps/drive-integration/src/setupTests.ts
@@ -4,24 +4,6 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 
-import { beforeEach, afterEach, vi } from 'vitest';
-
-// react-modal schedules a setTimeout to remove its portal on close. Without fake
-// timers that timeout can fire after jsdom is torn down → "document is not defined".
-// shouldAdvanceTime keeps the wall clock running so waitFor still resolves normally.
-beforeEach(() => {
-  vi.useFakeTimers({ shouldAdvanceTime: true });
-});
-
-afterEach(() => {
-  // Guard needed for tests that call vi.useRealTimers() inline — runAllTimers()
-  // throws if timers are no longer mocked when this afterEach fires.
-  if (vi.isFakeTimers()) {
-    vi.runAllTimers();
-    vi.useRealTimers();
-  }
-});
-
 if (typeof window !== 'undefined' && typeof ResizeObserver === 'undefined') {
   window.ResizeObserver = class ResizeObserver {
     observe() {}

--- a/apps/drive-integration/test/locations/Page/components/mainpage/ModalOrchestrator.spec.tsx
+++ b/apps/drive-integration/test/locations/Page/components/mainpage/ModalOrchestrator.spec.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { createRef } from 'react';
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { Box, Button } from '@contentful/f36-components';
@@ -135,6 +135,7 @@ describe('ModalOrchestrator', () => {
   });
 
   afterEach(() => {
+    cleanup();
     vi.runAllTimers();
     vi.useRealTimers();
   });

--- a/apps/drive-integration/test/locations/Page/components/mainpage/ModalOrchestrator.spec.tsx
+++ b/apps/drive-integration/test/locations/Page/components/mainpage/ModalOrchestrator.spec.tsx
@@ -1,6 +1,6 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { createRef } from 'react';
-import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { Box, Button } from '@contentful/f36-components';
 import {
   ModalOrchestrator,
@@ -96,7 +96,6 @@ const mappingReviewSuspendPayload: MappingReviewSuspendPayload = {
 
 describe('ModalOrchestrator', () => {
   beforeEach(() => {
-    vi.useFakeTimers({ shouldAdvanceTime: true });
     vi.clearAllMocks();
     defaultProps.onMappingReviewReady.mockReset();
     defaultProps.onResetToMain.mockReset();
@@ -132,11 +131,6 @@ describe('ModalOrchestrator', () => {
       items: mockContentTypes,
       total: mockContentTypes.length,
     } as any);
-  });
-
-  afterEach(() => {
-    vi.runAllTimers();
-    vi.useRealTimers();
   });
 
   it('shows ContentTypePickerModal after document is picked', async () => {

--- a/apps/drive-integration/test/locations/Page/components/mainpage/ModalOrchestrator.spec.tsx
+++ b/apps/drive-integration/test/locations/Page/components/mainpage/ModalOrchestrator.spec.tsx
@@ -1,6 +1,6 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { createRef } from 'react';
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { Box, Button } from '@contentful/f36-components';
 import {
   ModalOrchestrator,
@@ -96,6 +96,7 @@ const mappingReviewSuspendPayload: MappingReviewSuspendPayload = {
 
 describe('ModalOrchestrator', () => {
   beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
     vi.clearAllMocks();
     defaultProps.onMappingReviewReady.mockReset();
     defaultProps.onResetToMain.mockReset();
@@ -131,6 +132,11 @@ describe('ModalOrchestrator', () => {
       items: mockContentTypes,
       total: mockContentTypes.length,
     } as any);
+  });
+
+  afterEach(() => {
+    vi.runAllTimers();
+    vi.useRealTimers();
   });
 
   it('shows ContentTypePickerModal after document is picked', async () => {

--- a/apps/drive-integration/test/locations/Page/components/modals/ConfirmCancelModal.spec.tsx
+++ b/apps/drive-integration/test/locations/Page/components/modals/ConfirmCancelModal.spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { ConfirmCancelModal } from '../../../../../src/locations/Page/components/modals/ConfirmCancelModal';
 import React from 'react';
@@ -13,6 +13,7 @@ describe('ConfirmCancelModal', () => {
   });
 
   afterEach(() => {
+    cleanup();
     vi.runAllTimers();
     vi.useRealTimers();
   });

--- a/apps/drive-integration/test/locations/Page/components/modals/ConfirmCancelModal.spec.tsx
+++ b/apps/drive-integration/test/locations/Page/components/modals/ConfirmCancelModal.spec.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { ConfirmCancelModal } from '../../../../../src/locations/Page/components/modals/ConfirmCancelModal';
 import React from 'react';
 
@@ -9,6 +9,12 @@ const onCancel = vi.fn();
 describe('ConfirmCancelModal', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.runAllTimers();
+    vi.useRealTimers();
   });
 
   it('renders title and description when open', async () => {

--- a/apps/drive-integration/test/locations/Page/components/modals/ConfirmCancelModal.spec.tsx
+++ b/apps/drive-integration/test/locations/Page/components/modals/ConfirmCancelModal.spec.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { ConfirmCancelModal } from '../../../../../src/locations/Page/components/modals/ConfirmCancelModal';
 import React from 'react';
 
@@ -9,12 +9,6 @@ const onCancel = vi.fn();
 describe('ConfirmCancelModal', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.useFakeTimers({ shouldAdvanceTime: true });
-  });
-
-  afterEach(() => {
-    vi.runAllTimers();
-    vi.useRealTimers();
   });
 
   it('renders title and description when open', async () => {

--- a/apps/drive-integration/test/locations/Page/components/modals/EditModal.spec.tsx
+++ b/apps/drive-integration/test/locations/Page/components/modals/EditModal.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 import { EditModal } from '../../../../../src/locations/Page/components/review/mapping/edit-modals/EditModal';
 import React from 'react';
@@ -44,6 +44,7 @@ describe('EditModal', () => {
   });
 
   afterEach(() => {
+    cleanup();
     vi.runAllTimers();
     vi.useRealTimers();
   });

--- a/apps/drive-integration/test/locations/Page/components/modals/EditModal.spec.tsx
+++ b/apps/drive-integration/test/locations/Page/components/modals/EditModal.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 import { EditModal } from '../../../../../src/locations/Page/components/review/mapping/edit-modals/EditModal';
 import React from 'react';
 
@@ -40,6 +40,12 @@ const baseViewModel = {
 describe('EditModal', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.runAllTimers();
+    vi.useRealTimers();
   });
 
   it('renders the provided title and button label', async () => {

--- a/apps/drive-integration/test/locations/Page/components/modals/EditModal.spec.tsx
+++ b/apps/drive-integration/test/locations/Page/components/modals/EditModal.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react';
-import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { EditModal } from '../../../../../src/locations/Page/components/review/mapping/edit-modals/EditModal';
 import React from 'react';
 
@@ -40,12 +40,6 @@ const baseViewModel = {
 describe('EditModal', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.useFakeTimers({ shouldAdvanceTime: true });
-  });
-
-  afterEach(() => {
-    vi.runAllTimers();
-    vi.useRealTimers();
   });
 
   it('renders the provided title and button label', async () => {

--- a/apps/drive-integration/test/locations/Page/components/modals/ErrorModal.spec.tsx
+++ b/apps/drive-integration/test/locations/Page/components/modals/ErrorModal.spec.tsx
@@ -1,9 +1,18 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { ErrorModal } from '../../../../../src/locations/Page/components/modals/ErrorModal';
 
 describe('ErrorModal', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.runAllTimers();
+    vi.useRealTimers();
+  });
+
   it('renders the provided title and message with the default close action', () => {
     const onClose = vi.fn();
 

--- a/apps/drive-integration/test/locations/Page/components/modals/ErrorModal.spec.tsx
+++ b/apps/drive-integration/test/locations/Page/components/modals/ErrorModal.spec.tsx
@@ -1,18 +1,9 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { ErrorModal } from '../../../../../src/locations/Page/components/modals/ErrorModal';
 
 describe('ErrorModal', () => {
-  beforeEach(() => {
-    vi.useFakeTimers({ shouldAdvanceTime: true });
-  });
-
-  afterEach(() => {
-    vi.runAllTimers();
-    vi.useRealTimers();
-  });
-
   it('renders the provided title and message with the default close action', () => {
     const onClose = vi.fn();
 

--- a/apps/drive-integration/test/locations/Page/components/modals/ErrorModal.spec.tsx
+++ b/apps/drive-integration/test/locations/Page/components/modals/ErrorModal.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { ErrorModal } from '../../../../../src/locations/Page/components/modals/ErrorModal';
 
@@ -9,6 +9,7 @@ describe('ErrorModal', () => {
   });
 
   afterEach(() => {
+    cleanup();
     vi.runAllTimers();
     vi.useRealTimers();
   });

--- a/apps/drive-integration/test/locations/Page/components/modals/SummaryModal.spec.tsx
+++ b/apps/drive-integration/test/locations/Page/components/modals/SummaryModal.spec.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import type { EntryProps } from 'contentful-management';
 import { SummaryModal } from '../../../../../src/locations/Page/components/modals/SummaryModal';
 import { createMockSDK } from '../../../../mocks';
@@ -35,6 +35,12 @@ describe('SummaryModal', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSdk = createMockSDK() as PageAppSDK;
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.runAllTimers();
+    vi.useRealTimers();
   });
 
   it('renders title and success message with entry count', async () => {

--- a/apps/drive-integration/test/locations/Page/components/modals/SummaryModal.spec.tsx
+++ b/apps/drive-integration/test/locations/Page/components/modals/SummaryModal.spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import type { EntryProps } from 'contentful-management';
 import { SummaryModal } from '../../../../../src/locations/Page/components/modals/SummaryModal';
@@ -39,6 +39,7 @@ describe('SummaryModal', () => {
   });
 
   afterEach(() => {
+    cleanup();
     vi.runAllTimers();
     vi.useRealTimers();
   });

--- a/apps/drive-integration/test/locations/Page/components/modals/SummaryModal.spec.tsx
+++ b/apps/drive-integration/test/locations/Page/components/modals/SummaryModal.spec.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
 import type { EntryProps } from 'contentful-management';
 import { SummaryModal } from '../../../../../src/locations/Page/components/modals/SummaryModal';
 import { createMockSDK } from '../../../../mocks';
@@ -35,12 +35,6 @@ describe('SummaryModal', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSdk = createMockSDK() as PageAppSDK;
-    vi.useFakeTimers({ shouldAdvanceTime: true });
-  });
-
-  afterEach(() => {
-    vi.runAllTimers();
-    vi.useRealTimers();
   });
 
   it('renders title and success message with entry count', async () => {

--- a/apps/drive-integration/test/locations/Page/components/modals/step_3/SelectTabsModal.spec.tsx
+++ b/apps/drive-integration/test/locations/Page/components/modals/step_3/SelectTabsModal.spec.tsx
@@ -84,9 +84,9 @@ describe('SelectTabsModal', () => {
   });
 
   afterEach(() => {
+    cleanup();
     vi.runAllTimers();
     vi.useRealTimers();
-    cleanup();
   });
 
   describe('Rendering', () => {

--- a/apps/drive-integration/test/locations/Page/components/modals/step_3/SelectTabsModal.spec.tsx
+++ b/apps/drive-integration/test/locations/Page/components/modals/step_3/SelectTabsModal.spec.tsx
@@ -80,9 +80,12 @@ const selectTab = async (tabId: string) => {
 describe('SelectTabsModal', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
   });
 
   afterEach(() => {
+    vi.runAllTimers();
+    vi.useRealTimers();
     cleanup();
   });
 

--- a/apps/drive-integration/test/locations/Page/components/modals/step_3/SelectTabsModal.spec.tsx
+++ b/apps/drive-integration/test/locations/Page/components/modals/step_3/SelectTabsModal.spec.tsx
@@ -80,12 +80,9 @@ const selectTab = async (tabId: string) => {
 describe('SelectTabsModal', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.useFakeTimers({ shouldAdvanceTime: true });
   });
 
   afterEach(() => {
-    vi.runAllTimers();
-    vi.useRealTimers();
     cleanup();
   });
 

--- a/apps/drive-integration/test/locations/Page/components/modals/step_4/IncludeImagesModal.spec.tsx
+++ b/apps/drive-integration/test/locations/Page/components/modals/step_4/IncludeImagesModal.spec.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { useState } from 'react';
-import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { Modal } from '@contentful/f36-components';
 import { IncludeImagesModal } from '../../../../../../src/locations/Page/components/modals/step_4/IncludeImagesModal';
 import React from 'react';
@@ -34,12 +34,6 @@ const renderModal = (initialIncludeImages: boolean | null = null, props = {}) =>
 describe('IncludeImagesModal', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.useFakeTimers({ shouldAdvanceTime: true });
-  });
-
-  afterEach(() => {
-    vi.runAllTimers();
-    vi.useRealTimers();
   });
 
   it('renders copy and the include/exclude choices', async () => {

--- a/apps/drive-integration/test/locations/Page/components/modals/step_4/IncludeImagesModal.spec.tsx
+++ b/apps/drive-integration/test/locations/Page/components/modals/step_4/IncludeImagesModal.spec.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { useState } from 'react';
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { Modal } from '@contentful/f36-components';
 import { IncludeImagesModal } from '../../../../../../src/locations/Page/components/modals/step_4/IncludeImagesModal';
 import React from 'react';
@@ -34,6 +34,12 @@ const renderModal = (initialIncludeImages: boolean | null = null, props = {}) =>
 describe('IncludeImagesModal', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.runAllTimers();
+    vi.useRealTimers();
   });
 
   it('renders copy and the include/exclude choices', async () => {

--- a/apps/drive-integration/test/locations/Page/components/modals/step_4/IncludeImagesModal.spec.tsx
+++ b/apps/drive-integration/test/locations/Page/components/modals/step_4/IncludeImagesModal.spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { useState } from 'react';
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { Modal } from '@contentful/f36-components';
@@ -38,6 +38,7 @@ describe('IncludeImagesModal', () => {
   });
 
   afterEach(() => {
+    cleanup();
     vi.runAllTimers();
     vi.useRealTimers();
   });


### PR DESCRIPTION
## Purpose

\`react-modal\` internally schedules a \`setTimeout\` to remove its portal from the DOM when a modal closes. In CI, this timer sometimes fires after Vitest tears down the jsdom environment, causing \`ReferenceError: document is not defined\`. The failure is intermittent because it's a race between the timer and environment teardown — faster/slower CI runs tip it either way.

## Approach

Added \`vi.useFakeTimers({ shouldAdvanceTime: true })\` / \`vi.runAllTimers()\` / \`vi.useRealTimers()\`  each test file that uses react modal.

- \`useFakeTimers\` gives Vitest control over pending timers
- \`shouldAdvanceTime: true\` keeps the real wall clock ticking so \`waitFor\` and async assertions still resolve normally
- \`runAllTimers()\` flushes react-modal's cleanup timeout synchronously before jsdom is torn down

## Breaking Changes

No.

## Dependencies and/or References

[INTEG-4213](https://contentful.atlassian.net/browse/INTEG-4213)

## Deployment

No.

🤖 Co-authored with [Claude Code](https://claude.ai/code)

[INTEG-4213]: https://contentful.atlassian.net/browse/INTEG-4213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ