### PR TITLE
fix(link-checker): reload page when installation params change on visibility restored [ES-322]

### DIFF
--- a/apps/link-checker/__tests__/locations/Page.spec.tsx
+++ b/apps/link-checker/__tests__/locations/Page.spec.tsx
@@ -308,6 +308,8 @@ describe('Page component', () => {
       writable: true,
     });
 
+    mockSdk.parameters.installation = { selectedContentTypeIds: ['article'] };
+
     mockSdk.cma.appInstallation = {
       getForOrganization: vi.fn().mockResolvedValue({
         items: [
@@ -317,6 +319,42 @@ describe('Page component', () => {
               environment: { sys: { id: mockSdk.ids.environment } },
             },
             parameters: { selectedContentTypeIds: ['article'] },
+          },
+        ],
+      }),
+    };
+
+    render(<Page />);
+
+    triggerVisibilityChange('hidden');
+    triggerVisibilityChange('visible');
+
+    await waitFor(() => {
+      expect(mockSdk.cma.appInstallation.getForOrganization).toHaveBeenCalled();
+    });
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('does not reload when installation parameters match but CMA returns keys in different order', async () => {
+    const reload = vi.fn();
+    Object.defineProperty(window, 'location', {
+      value: { reload },
+      configurable: true,
+      writable: true,
+    });
+
+    mockSdk.parameters.installation = { allowedUrlPatterns: 'example.com', selectedContentTypeIds: ['article'] };
+
+    mockSdk.cma.appInstallation = {
+      getForOrganization: vi.fn().mockResolvedValue({
+        items: [
+          {
+            sys: {
+              space: { sys: { id: mockSdk.ids.space } },
+              environment: { sys: { id: mockSdk.ids.environment } },
+            },
+            // Same values, different key order — must not trigger spurious reload
+            parameters: { selectedContentTypeIds: ['article'], allowedUrlPatterns: 'example.com' },
           },
         ],
       }),

--- a/apps/link-checker/__tests__/locations/Page.spec.tsx
+++ b/apps/link-checker/__tests__/locations/Page.spec.tsx
@@ -343,7 +343,10 @@ describe('Page component', () => {
       writable: true,
     });
 
-    mockSdk.parameters.installation = { allowedUrlPatterns: 'example.com', selectedContentTypeIds: ['article'] };
+    mockSdk.parameters.installation = {
+      allowedUrlPatterns: 'example.com',
+      selectedContentTypeIds: ['article'],
+    };
 
     mockSdk.cma.appInstallation = {
       getForOrganization: vi.fn().mockResolvedValue({

--- a/apps/link-checker/__tests__/locations/Page.spec.tsx
+++ b/apps/link-checker/__tests__/locations/Page.spec.tsx
@@ -281,7 +281,10 @@ describe('Page component', () => {
               space: { sys: { id: mockSdk.ids.space } },
               environment: { sys: { id: mockSdk.ids.environment } },
             },
-            parameters: { selectedContentTypeIds: ['article'], allowedUrlPatterns: 'new-domain.com' },
+            parameters: {
+              selectedContentTypeIds: ['article'],
+              allowedUrlPatterns: 'new-domain.com',
+            },
           },
         ],
       }),

--- a/apps/link-checker/__tests__/locations/Page.spec.tsx
+++ b/apps/link-checker/__tests__/locations/Page.spec.tsx
@@ -274,8 +274,16 @@ describe('Page component', () => {
     });
 
     mockSdk.cma.appInstallation = {
-      get: vi.fn().mockResolvedValue({
-        parameters: { selectedContentTypeIds: ['article'], allowedUrlPatterns: 'new-domain.com' },
+      getForOrganization: vi.fn().mockResolvedValue({
+        items: [
+          {
+            sys: {
+              space: { sys: { id: mockSdk.ids.space } },
+              environment: { sys: { id: mockSdk.ids.environment } },
+            },
+            parameters: { selectedContentTypeIds: ['article'], allowedUrlPatterns: 'new-domain.com' },
+          },
+        ],
       }),
     };
 
@@ -298,8 +306,16 @@ describe('Page component', () => {
     });
 
     mockSdk.cma.appInstallation = {
-      get: vi.fn().mockResolvedValue({
-        parameters: { selectedContentTypeIds: ['article'] },
+      getForOrganization: vi.fn().mockResolvedValue({
+        items: [
+          {
+            sys: {
+              space: { sys: { id: mockSdk.ids.space } },
+              environment: { sys: { id: mockSdk.ids.environment } },
+            },
+            parameters: { selectedContentTypeIds: ['article'] },
+          },
+        ],
       }),
     };
 
@@ -309,7 +325,7 @@ describe('Page component', () => {
     triggerVisibilityChange('visible');
 
     await waitFor(() => {
-      expect(mockSdk.cma.appInstallation.get).toHaveBeenCalled();
+      expect(mockSdk.cma.appInstallation.getForOrganization).toHaveBeenCalled();
     });
     expect(reload).not.toHaveBeenCalled();
   });

--- a/apps/link-checker/__tests__/locations/Page.spec.tsx
+++ b/apps/link-checker/__tests__/locations/Page.spec.tsx
@@ -4,6 +4,11 @@ import { vi } from 'vitest';
 import { mockSdk } from '../mocks';
 import Page from '@/components/locations/Page';
 
+const triggerVisibilityChange = (state: DocumentVisibilityState) => {
+  Object.defineProperty(document, 'visibilityState', { value: state, configurable: true });
+  document.dispatchEvent(new Event('visibilitychange'));
+};
+
 vi.mock('@contentful/react-apps-toolkit', () => ({
   useSDK: () => mockSdk,
 }));
@@ -258,6 +263,55 @@ describe('Page component', () => {
     await waitFor(() => {
       expect(createWithResponse).not.toHaveBeenCalled();
     });
+  });
+
+  it('reloads when installation parameters have changed on visibility restored', async () => {
+    const reload = vi.fn();
+    Object.defineProperty(window, 'location', {
+      value: { reload },
+      configurable: true,
+      writable: true,
+    });
+
+    mockSdk.cma.appInstallation = {
+      get: vi.fn().mockResolvedValue({
+        parameters: { selectedContentTypeIds: ['article'], allowedUrlPatterns: 'new-domain.com' },
+      }),
+    };
+
+    render(<Page />);
+
+    triggerVisibilityChange('hidden');
+    triggerVisibilityChange('visible');
+
+    await waitFor(() => {
+      expect(reload).toHaveBeenCalled();
+    });
+  });
+
+  it('does not reload when installation parameters are unchanged on visibility restored', async () => {
+    const reload = vi.fn();
+    Object.defineProperty(window, 'location', {
+      value: { reload },
+      configurable: true,
+      writable: true,
+    });
+
+    mockSdk.cma.appInstallation = {
+      get: vi.fn().mockResolvedValue({
+        parameters: { selectedContentTypeIds: ['article'] },
+      }),
+    };
+
+    render(<Page />);
+
+    triggerVisibilityChange('hidden');
+    triggerVisibilityChange('visible');
+
+    await waitFor(() => {
+      expect(mockSdk.cma.appInstallation.get).toHaveBeenCalled();
+    });
+    expect(reload).not.toHaveBeenCalled();
   });
 
   it('checks www URLs as absolute https URLs instead of resolving them against the current domain', async () => {

--- a/apps/link-checker/components/locations/Page.tsx
+++ b/apps/link-checker/components/locations/Page.tsx
@@ -174,13 +174,17 @@ export default function Page() {
       if (document.visibilityState !== 'visible') return;
       try {
         const appDefinitionId = sdk.ids.app;
-        if (!appDefinitionId || !sdk.cma?.appInstallation?.get) return;
-        const current = await sdk.cma.appInstallation.get({
-          spaceId: sdk.ids.space,
-          environmentId: sdk.ids.environment,
+        if (!appDefinitionId || !sdk.cma?.appInstallation?.getForOrganization) return;
+        const result = await sdk.cma.appInstallation.getForOrganization({
+          organizationId: sdk.ids.organization,
           appDefinitionId,
         });
-        if (JSON.stringify(current?.parameters) !== JSON.stringify(sdk.parameters.installation)) {
+        const match = result.items.find(
+          (item) =>
+            item.sys.space.sys.id === sdk.ids.space &&
+            item.sys.environment.sys.id === sdk.ids.environment
+        );
+        if (JSON.stringify(match?.parameters) !== JSON.stringify(sdk.parameters.installation)) {
           window.location.reload();
         }
       } catch {

--- a/apps/link-checker/components/locations/Page.tsx
+++ b/apps/link-checker/components/locations/Page.tsx
@@ -28,7 +28,9 @@ function deepEqual(a: unknown, b: unknown): boolean {
   const keysA = Object.keys(a as object).sort();
   const keysB = Object.keys(b as object).sort();
   if (keysA.length !== keysB.length || keysA.some((k, i) => k !== keysB[i])) return false;
-  return keysA.every((k) => deepEqual((a as Record<string, unknown>)[k], (b as Record<string, unknown>)[k]));
+  return keysA.every((k) =>
+    deepEqual((a as Record<string, unknown>)[k], (b as Record<string, unknown>)[k])
+  );
 }
 
 const CHECK_LINK_FUNCTION_ID = 'checkLink';

--- a/apps/link-checker/components/locations/Page.tsx
+++ b/apps/link-checker/components/locations/Page.tsx
@@ -168,6 +168,29 @@ export default function Page() {
 
   const installation = (sdk.parameters.installation || {}) as AppInstallationParameters;
   const hasAssignedContentTypes = Boolean(installation.selectedContentTypeIds?.length);
+
+  useEffect(() => {
+    const handleVisibilityChange = async () => {
+      if (document.visibilityState !== 'visible') return;
+      try {
+        const appDefinitionId = sdk.ids.app;
+        if (!appDefinitionId || !sdk.cma?.appInstallation?.get) return;
+        const current = await sdk.cma.appInstallation.get({
+          spaceId: sdk.ids.space,
+          environmentId: sdk.ids.environment,
+          appDefinitionId,
+        });
+        if (JSON.stringify(current?.parameters) !== JSON.stringify(sdk.parameters.installation)) {
+          window.location.reload();
+        }
+      } catch {
+        // Silently ignore — a failed check should never block the user.
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
+  }, [sdk]);
   const explicitAllowedPatterns = (installation.allowedUrlPatterns || '')
     .split(',')
     .map((p) => normalizeDomainPattern(p))

--- a/apps/link-checker/components/locations/Page.tsx
+++ b/apps/link-checker/components/locations/Page.tsx
@@ -22,6 +22,15 @@ import { normalizeDomainPattern, urlMatchesAnyDomainPattern } from '@/utils/doma
 import { extractUrlsFromEntry, isRelativeUrl, type ExtractedUrl } from '@/utils/extractUrls';
 import { type AppInstallationParameters } from './ConfigScreen';
 
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a === null || b === null || typeof a !== 'object' || typeof b !== 'object') return false;
+  const keysA = Object.keys(a as object).sort();
+  const keysB = Object.keys(b as object).sort();
+  if (keysA.length !== keysB.length || keysA.some((k, i) => k !== keysB[i])) return false;
+  return keysA.every((k) => deepEqual((a as Record<string, unknown>)[k], (b as Record<string, unknown>)[k]));
+}
+
 const CHECK_LINK_FUNCTION_ID = 'checkLink';
 const FETCH_LIMIT = 1000;
 const ENTRY_FETCH_LIMIT = 100;
@@ -184,7 +193,7 @@ export default function Page() {
             item.sys.space.sys.id === sdk.ids.space &&
             item.sys.environment.sys.id === sdk.ids.environment
         );
-        if (JSON.stringify(match?.parameters) !== JSON.stringify(sdk.parameters.installation)) {
+        if (!deepEqual(match?.parameters, sdk.parameters.installation)) {
           window.location.reload();
         }
       } catch {


### PR DESCRIPTION
[ES-322](https://contentful.atlassian.net/browse/ES-322)

## Summary
- `sdk.parameters.installation` is a static snapshot from when the app iframe loaded. If a user updates the allow list in config and returns to the page app without a hard refresh, scans run against stale params — causing valid links to show as "Not on allow list"
- Add a `visibilitychange` listener that fetches current installation parameters from the CMA when the tab becomes visible again and calls `window.location.reload()` if they differ — the in-app equivalent of the hard-refresh workaround given to the customer
- Errors from the CMA fetch are silently swallowed so a failed check never blocks the user

## Test plan
- [ ] Update the allow list in Link Checker config, then navigate back to the page app — it should automatically reload and show the updated results without requiring a manual hard refresh
- [ ] Verify that navigating away and back without changing config does NOT trigger a reload
- [ ] Run `npm test` in `apps/link-checker` — all 60 tests pass including 2 new cases covering the reload and no-reload paths

Generated with [Claude Code](https://claude.com/claude-code)

[ES-322]: https://contentful.atlassian.net/browse/ES-322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ