### PR TITLE
test(drive-integration): fix react-modal timer leak in RemoveContentModal spec [INTEG-4036]

### DIFF
--- a/apps/drive-integration/test/locations/Page/components/review/mapping/RemoveContentModal.spec.tsx
+++ b/apps/drive-integration/test/locations/Page/components/review/mapping/RemoveContentModal.spec.tsx
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { RemoveContentModal } from '../../../../../../src/locations/Page/components/review/mapping/edit-modals/RemoveContentModal';
 import type { EditLocationOption } from '../../../../../../src/types/editModal';
 import React from 'react';
@@ -17,8 +17,14 @@ const mockLocation: EditLocationOption = {
 };
 
 describe('RemoveContentModal', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
   afterEach(() => {
     cleanup();
+    vi.runAllTimers();
+    vi.useRealTimers();
     vi.clearAllMocks();
   });
 


### PR DESCRIPTION
## Purpose

`RemoveContentModal.spec.tsx` didn't carry over the fake-timer guard from #11029. `react-modal` uses a `setTimeout` to animate its portal out on close, when jsdom tears down before that timer fires, `document is not defined` and crashes CI.

## Approach

Apply the same `vi.useFakeTimers` / `vi.runAllTimers` pattern used in the other modal specs fixed in #11029:

- `beforeEach`: `vi.useFakeTimers({ shouldAdvanceTime: true })` — intercepts the 200ms portal close timer
- `afterEach`: `cleanup()` → `vi.runAllTimers()` → `vi.useRealTimers()` — flushes all pending timers before jsdom tears down

## Breaking Changes

No.

## Dependencies and/or References

Companion to [INTEG-4036](https://contentful.atlassian.net/browse/INTEG-4036) — same root cause, missed file.

[INTEG-4036]: https://contentful.atlassian.net/browse/INTEG-4036

🤖 Co-authored with [Claude Code](https://claude.ai/code)