### PR TITLE
fix(security): redeploy apps Lambdas to ship vuln remediation [AIS-36]

### DIFF
--- a/apps/ai-image-tagging/lambda/package.json
+++ b/apps/ai-image-tagging/lambda/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contentful/ai-image-tagging-lambda",
   "private": true,
-  "version": "1.4.25",
+  "version": "1.4.26",
   "author": "Contentful GmbH",
   "license": "MIT",
   "scripts": {

--- a/apps/google-analytics-4/lambda/package.json
+++ b/apps/google-analytics-4/lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/google-analytics-4-lambda",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "",
   "main": "index.js",

--- a/apps/netlify/lambda/package.json
+++ b/apps/netlify/lambda/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contentful/netlify-build-action-lambda",
   "private": true,
-  "version": "1.3.13",
+  "version": "1.3.14",
   "author": "Contentful GmbH",
   "license": "MIT",
   "scripts": {

--- a/apps/slack/lambda/package.json
+++ b/apps/slack/lambda/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slack-lambda",
   "private": true,
-  "version": "1.1.9",
+  "version": "1.1.10",
   "main": "index.js",
   "scripts": {
     "build": "rimraf build && tsc",

--- a/apps/smartling/lambda/package.json
+++ b/apps/smartling/lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/smartling-lambda",
-  "version": "1.4.71",
+  "version": "1.4.72",
   "private": true,
   "scripts": {
     "start": "DEPLOY_TIME_UNIX=$(date \"+%s\") LOCAL_DEV=true FRONTEND_URL=http://localhost:3000 ts-node src/index.ts",

--- a/apps/typeform/lambda/package.json
+++ b/apps/typeform/lambda/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contentful/typeform-lambda",
   "private": true,
-  "version": "1.5.74",
+  "version": "1.5.75",
   "author": "Contentful GmbH",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
[AIS-36](https://contentful.atlassian.net/browse/AIS-36)

## Summary
- **Redeploy trigger.** [#11031](https://github.com/contentful/apps/pull/11031) bumped vulnerable deps + added `overrides` floors and merged to `master`, but the prod deploy was a **silent no-op** — it shipped nothing, so the live `$LATEST` Lambdas still carry the vulnerable bundled deps (confirmed in Wiz: GA4 6 crit/53 high, smartling 4/38, slack 1/19, netlify 0/16, + test fns).
- **Root cause.** `build-deploy-prod` runs `lerna run deploy --since=HEAD^`. The `publish` step runs *before* deploy and (because #11031 also bumped the publishable `ecommerce-app-base`) created a `chore: publish [skip ci]` commit that **advanced `HEAD`**. So `--since=HEAD^` diffed publish-commit vs merge-commit and the 6 private lambda packages fell out of the window → `No packages found with the lifecycle script 'deploy'`. ([build 152554](https://circleci.com/gh/contentful/apps/152554))
- **This PR** bumps the patch version of the 6 affected **private** lambda packages so the next master deploy selects them via `--since=HEAD^` and `sls deploy` repackages each with the already-correct override-pinned lockfiles on `master`. All 6 are `private: true`, so `lerna version --no-private` makes **no** publish commit and `HEAD` does not advance — the original no-op cannot recur.
- No source/logic changes; version-line bumps only.

Affected functions redeployed (prd + test): `sls-apps-google-analytics-4`, `sls-apps-smartling`, `sls-apps-slack-backend`, `sls-apps-netlify-build`, `sls-apps-typeform`, `sls-apps-ai-image-tagging`.

> Note: `sls-apps-ecommerce-prd-api` (also Wiz-flagged) has **no deploy source in this repo** — #11031 only bumped the shared `ecommerce-app-base` frontend package, not a lambda. Tracked separately under AIS-35.

## Test plan
- [ ] CI `build-deploy-prod` "Deploy apps to prod" step shows the 6 lambdas selected by lerna (NOT "No packages found")
- [ ] `sls deploy` completes for each of the 6 services
- [ ] Lambda `LastModified` updates in AWS 
- [ ] Wiz findings clear on the `$LATEST` functions after refresh (per AIS-36/42 DoD)

Generated with [Claude Code](https://claude.com/claude-code)

[AIS-36]: https://contentful.atlassian.net/browse/AIS-36?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ