### PR TITLE
fix(ga4, sap, mux): use sdk.cma instead of manual createClient [AIS-59]

### DIFF
--- a/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.tsx
+++ b/apps/google-analytics-4/frontend/src/components/config-screen/assign-content-type/AssignContentTypeSection.tsx
@@ -11,7 +11,7 @@ import {
   Checkbox,
 } from '@contentful/f36-components';
 import { ExternalLinkIcon } from '@contentful/f36-icons';
-import { ContentTypeProps, createClient } from 'contentful-management';
+import { ContentTypeProps } from 'contentful-management';
 import { KnownAppSDK, EditorInterface } from '@contentful/app-sdk';
 import { KeyValueMap } from '@contentful/app-sdk/dist/types/entities';
 import { useSDK } from '@contentful/react-apps-toolkit';
@@ -163,17 +163,13 @@ const AssignContentTypeSection = (props: Props) => {
   }, [isContentTypeAssignmentValid, onIsValidContentTypeAssignment]);
 
   const fetchAllContentTypes = async (sdk: KnownAppSDK): Promise<ContentTypeProps[]> => {
-    const cma = createClient({ apiAdapter: sdk.cmaAdapter });
-    const space = await cma.getSpace(sdk.ids.space);
-    const environment = await space.getEnvironment(sdk.ids.environment);
-
     let allContentTypes: ContentTypeProps[] = [];
     let skip = 0;
     const limit = 100;
     let areMoreContentTypes = true;
 
     while (areMoreContentTypes) {
-      const response = await environment.getContentTypes({ skip, limit });
+      const response = await sdk.cma.contentType.getMany({ query: { skip, limit } });
       if (response.items) {
         allContentTypes = allContentTypes.concat(response.items as ContentTypeProps[]);
         areMoreContentTypes = response.items.length === limit;

--- a/apps/google-analytics-4/frontend/test/mocks/mockSdk.ts
+++ b/apps/google-analytics-4/frontend/test/mocks/mockSdk.ts
@@ -13,29 +13,9 @@ const mockSdk: any = {
     appSignedRequest: {
       create: () => ({}),
     },
-    getSpace: () => ({
-      getEnvironment: () => ({
-        getContentTypes: () => ({
-          description:
-            'A series of lessons designed to teach sets of concepts that enable students to master Contentful.',
-          displayField: 'title',
-          name: 'Course',
-          fields: [
-            {
-              course: {
-                disabled: false,
-                id: 'title',
-                localized: true,
-                name: 'Title',
-                omitted: false,
-                required: true,
-                type: 'Symbol',
-              },
-            },
-          ],
-        }),
-      }),
-    }),
+    contentType: {
+      getMany: vi.fn().mockResolvedValue({ items: [] }),
+    },
   },
   ids: {
     app: 'test-app',

--- a/apps/mux/frontend/src/index.tsx
+++ b/apps/mux/frontend/src/index.tsx
@@ -45,7 +45,7 @@ import {
 } from './util/types';
 
 import './index.css';
-import { createClient, PlainClientAPI } from 'contentful-management';
+import { PlainClientAPI } from 'contentful-management';
 import {
   MuxApiService,
   MuxApiError,
@@ -105,16 +105,7 @@ export class App extends React.Component<AppProps, AppState> {
     const { muxAccessTokenId, muxAccessTokenSecret } = this.props.sdk.parameters
       .installation as InstallationParams;
 
-    this.cmaClient = createClient(
-      { apiAdapter: this.props.sdk.cmaAdapter },
-      {
-        type: 'plain',
-        defaults: {
-          environmentId: this.props.sdk.ids.environmentAlias ?? this.props.sdk.ids.environment,
-          spaceId: this.props.sdk.ids.space,
-        },
-      }
-    );
+    this.cmaClient = this.props.sdk.cma;
 
     const field = props.sdk.field.getValue();
 

--- a/apps/sap-commerce-cloud/frontend/src/components/AppConfig/AppConfig.tsx
+++ b/apps/sap-commerce-cloud/frontend/src/components/AppConfig/AppConfig.tsx
@@ -29,7 +29,6 @@ import { Config, ParameterDefinition, ValidateParametersFn } from '@interfaces';
 
 import { styles } from '@components/AppConfig/AppConfig.styles';
 import { useSDK } from '@contentful/react-apps-toolkit';
-import { createClient } from 'contentful-management';
 
 interface Props {
   parameterDefinitions: ParameterDefinition[];
@@ -83,13 +82,9 @@ export default function AppConfig({
 
   useEffect(() => {
     (async () => {
-      const cma = createClient({ apiAdapter: sdk.cmaAdapter });
-      const space = await cma.getSpace(sdk.ids.space);
-      const environment = await space.getEnvironment(sdk.ids.environment);
-
       const [contentTypesResponse, eisResponse, parameters] = await Promise.all([
-        environment.getContentTypes(),
-        environment.getEditorInterfaces(),
+        sdk.cma.contentType.getMany({}),
+        sdk.cma.editorInterface.getMany({}),
         sdk.app.getParameters(),
       ]);
 


### PR DESCRIPTION
## Summary
- `app-sdk` >=4.58.0 introduces a nested `contentful-management@12` dependency that conflicts with apps' own v11 direct dep when bundled, causing `createClient is not a function` at runtime (same root cause as marketplace-partner-apps#8449 for vwo-fme)
- `google-analytics-4`: `fetchAllContentTypes` rewritten to use `sdk.cma.contentType.getMany` instead of `getSpace().getEnvironment().getContentTypes()`
- `sap-commerce-cloud`: config `useEffect` rewritten to use `sdk.cma.contentType.getMany` and `sdk.cma.editorInterface.getMany`
- `mux`: class component stores `sdk.cma` directly instead of constructing a plain client from `sdk.cmaAdapter`

## Test plan
- [ ] google-analytics-4: install the app and verify the content type assignment section loads and saves correctly
- [ ] sap-commerce-cloud: install the app and verify the config screen loads content types and editor interfaces without error
- [ ] mux: verify video upload and existing video rendering works without console errors
- [ ] No `createClient is not a function` errors in any of the three apps

Generated with [Claude Code](https://claude.com/claude-code)