### PR TITLE
fix(rich-text-versioning): bump @contentful/app-sdk to 4.61.0 []

### DIFF
--- a/apps/rich-text-versioning/package-lock.json
+++ b/apps/rich-text-versioning/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@ali-tas/htmldiff-js": "^2.0.1",
-        "@contentful/app-sdk": "^4.42.0",
+        "@contentful/app-sdk": "^4.61.0",
         "@contentful/f36-components": "4.81.1",
         "@contentful/f36-multiselect": "^4.81.1",
         "@contentful/f36-tokens": "4.2.0",
@@ -381,28 +381,29 @@
       }
     },
     "node_modules/@contentful/app-sdk": {
-      "version": "4.45.0",
-      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.45.0.tgz",
-      "integrity": "sha512-3NCLi7B/VL17k3iMA+0hsycFn6mrDyKIE3LZPRfJjFtcFO7OVZwQ4Aysp0e2Hbatrppin3QIc8feTdg59JMNkQ==",
+      "version": "4.61.0",
+      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.61.0.tgz",
+      "integrity": "sha512-crqSOHUwspEw81qK+HAw5yIWYZQtmTKbb5yw3mAq4qxclnSSzwlUtVByHZXo0q+ApD6szcG8gBonB9V1GT5zQg==",
       "license": "MIT",
       "dependencies": {
-        "contentful-management": "^11.57.1"
+        "contentful-management": "^12.3.1"
       }
     },
     "node_modules/@contentful/app-sdk/node_modules/contentful-management": {
-      "version": "11.61.1",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.61.1.tgz",
-      "integrity": "sha512-+Shk0fGpudvT0b0CwdNiLDwPoIbb0YdkiiYc6h5aC42zfVFJ0dgJf9JKzYPBPJd0MWGOCQf5yNzt/zBEAUDElw==",
+      "version": "12.8.0",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-12.8.0.tgz",
+      "integrity": "sha512-lARtEZYn2MYf80hz9nCYiLbJWvg95TTnOWmCZouMZtgNS1273dN27Vaz7weHQ3oSQuk7LeYXaXdGFhFPKlpilw==",
       "license": "MIT",
       "dependencies": {
         "@contentful/rich-text-types": "^16.6.1",
-        "axios": "^1.12.2",
-        "contentful-sdk-core": "^9.0.1",
+        "axios": "^1.15.0",
+        "contentful-sdk-core": "^9.4.4",
         "fast-copy": "^3.0.0",
-        "globals": "^15.15.0"
+        "globals": "^15.15.0",
+        "process": "^0.11.10"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@contentful/content-source-maps": {

--- a/apps/rich-text-versioning/package.json
+++ b/apps/rich-text-versioning/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@ali-tas/htmldiff-js": "^2.0.1",
-    "@contentful/app-sdk": "^4.42.0",
+    "@contentful/app-sdk": "^4.61.0",
     "@contentful/f36-components": "4.81.1",
     "@contentful/f36-multiselect": "^4.81.1",
     "@contentful/f36-tokens": "4.2.0",


### PR DESCRIPTION
## Summary
- Bumps `@contentful/app-sdk` from `^4.42.0` to `^4.61.0` to pick up `selectSingleResourceEntity`, `selectMultipleResourceEntities`, and `recommendations` support on entry selector dialogs
- Fixes the broken Rich Text Editor (v6.3.9) in the Rich Text Versioning app — that version calls `sdk.dialogs.selectSingleResourceEntity(...)` and passes `recommendations: { searchQuery }` to `selectSingleEntry(...)`, neither of which existed in the old SDK contract
- The SDK fix landed in [contentful/ui-extensions-sdk#2611](https://github.com/contentful/ui-extensions-sdk/pull/2611) and was published as v4.61.0

## Test plan
- [x] `npm run test:ci` — 32 tests passing
- [x] `tsc --noEmit` — no type errors
- [ ] Smoke test: open Rich Text Versioning app in staging, insert a Resource hyperlink (cross-space) and confirm the picker opens
- [ ] Smoke test: insert an Entry hyperlink with text typed — confirm `recommendations.searchQuery` flow works

Generated with [Claude Code](https://claude.com/claude-code)