### PR TITLE
fix(security): bump node-apps-toolkit to v4 in netlify lambda [AIS-50]

### DIFF
--- a/apps/netlify/lambda/.npmrc
+++ b/apps/netlify/lambda/.npmrc
@@ -1,0 +1,1 @@
+@contentful:registry=https://registry.npmjs.org/

--- a/apps/netlify/lambda/.npmrc
+++ b/apps/netlify/lambda/.npmrc
@@ -1,1 +1,3 @@
+engine-strict = true
+ignore-scripts=true
 @contentful:registry=https://registry.npmjs.org/

--- a/apps/netlify/lambda/package-lock.json
+++ b/apps/netlify/lambda/package-lock.json
@@ -2176,7 +2176,7 @@
     },
     "node_modules/@contentful/node-apps-toolkit": {
       "version": "4.0.1",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/node-apps-toolkit/4.0.1/95d49f937550bad18f75e45f09c7fca5f811fbeb",
+      "resolved": "https://registry.npmjs.org/@contentful/node-apps-toolkit/-/node-apps-toolkit-4.0.1.tgz",
       "integrity": "sha512-GLyqVtYQ5qqVz0XX22QF4zoU4uTtQou/P+zyr+bAVAhJRVg7LiyzScDVhbVnLu6zLlX/Udil5fhxCFqc5axU2A==",
       "license": "MIT",
       "dependencies": {
@@ -2200,7 +2200,7 @@
     },
     "node_modules/@contentful/rich-text-types": {
       "version": "16.8.5",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/rich-text-types/16.8.5/832c8b428612f5181908bc1033c6ef9f48f1ce83",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.8.5.tgz",
       "integrity": "sha512-q18RJuJCOuYveGiCIjE5xLCQc5lZ3L2Qgxrlg/H2YEobDFqdtmklazRi1XwEWaK3tMg6yVXBzKKkQfLB4qW14A==",
       "license": "MIT",
       "engines": {

--- a/apps/netlify/lambda/package-lock.json
+++ b/apps/netlify/lambda/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@contentful/netlify-build-action-lambda",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@contentful/netlify-build-action-lambda",
-      "version": "1.3.13",
+      "version": "1.3.14",
       "license": "MIT",
       "dependencies": {
-        "@contentful/node-apps-toolkit": "^2.8.2",
+        "@contentful/node-apps-toolkit": "^4.0.1",
         "aws-serverless-express": "3.4.0",
         "express": "4.22.1",
         "lodash.get": "^4.4.2",
@@ -2175,26 +2175,32 @@
       }
     },
     "node_modules/@contentful/node-apps-toolkit": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/@contentful/node-apps-toolkit/-/node-apps-toolkit-2.8.2.tgz",
-      "integrity": "sha512-KgdMC8F5UUO8NoVdlrtyF3MMDY0m3zq9d3Kcs+GDLoE9Tbnm+osAQHN49CeyOw6OczryEg5ITXqXq44bF0MVZw==",
+      "version": "4.0.1",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/node-apps-toolkit/4.0.1/95d49f937550bad18f75e45f09c7fca5f811fbeb",
+      "integrity": "sha512-GLyqVtYQ5qqVz0XX22QF4zoU4uTtQou/P+zyr+bAVAhJRVg7LiyzScDVhbVnLu6zLlX/Udil5fhxCFqc5axU2A==",
       "license": "MIT",
       "dependencies": {
         "@types/debug": "^4.1.5",
-        "contentful-management": "^11.6.1",
+        "contentful-management": "^12.0.0",
         "debug": "^4.2.0",
         "got": "^11.7.0",
         "jsonwebtoken": "^9.0.0",
-        "node-cache": "^5.1.2",
+        "lru-cache": "^10.4.3",
         "runtypes": "^5.0.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
+    },
+    "node_modules/@contentful/node-apps-toolkit/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
     },
     "node_modules/@contentful/rich-text-types": {
       "version": "16.8.5",
-      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.8.5.tgz",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/rich-text-types/16.8.5/832c8b428612f5181908bc1033c6ef9f48f1ce83",
       "integrity": "sha512-q18RJuJCOuYveGiCIjE5xLCQc5lZ3L2Qgxrlg/H2YEobDFqdtmklazRi1XwEWaK3tMg6yVXBzKKkQfLB4qW14A==",
       "license": "MIT",
       "engines": {
@@ -3071,11 +3077,14 @@
       }
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.27.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.27.4.tgz",
-      "integrity": "sha512-Ni8mMtfo+o/G7DVtweXXV/Ol2TFf63KYjTtoZ5f078AUgJTmaIJnj4JFU7TK/9SVWTaSJGxPi5zMDgK4w+Ez7Q==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -6321,15 +6330,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/clone": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/clone-response": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
@@ -6447,37 +6447,66 @@
       }
     },
     "node_modules/contentful-management": {
-      "version": "11.40.0",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.40.0.tgz",
-      "integrity": "sha512-rmPREGAWVpcAQSXeKON/Iv7KbIevhqs89xVuO90EmHoj273szp6yGEtpSqueOMi3M1LQ2rpRWkvgRHAVrVNHvg==",
+      "version": "12.8.0",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-12.8.0.tgz",
+      "integrity": "sha512-lARtEZYn2MYf80hz9nCYiLbJWvg95TTnOWmCZouMZtgNS1273dN27Vaz7weHQ3oSQuk7LeYXaXdGFhFPKlpilw==",
       "license": "MIT",
       "dependencies": {
         "@contentful/rich-text-types": "^16.6.1",
-        "axios": "^1.7.4",
-        "contentful-sdk-core": "^9.0.1",
-        "fast-copy": "^3.0.0"
+        "axios": "^1.15.0",
+        "contentful-sdk-core": "^9.4.4",
+        "fast-copy": "^3.0.0",
+        "globals": "^15.15.0",
+        "process": "^0.11.10"
       },
       "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/contentful-management/node_modules/globals": {
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+      "license": "MIT",
+      "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/contentful-sdk-core": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-9.0.1.tgz",
-      "integrity": "sha512-Ao/5Y74ERPn6kjzb/8okYPuQJnikMtR+dnv0plLw8IvPomwXonLq3qom0rLSyo5KuvQkBMa9AApy1izunxW4mw==",
+      "version": "9.4.5",
+      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-9.4.5.tgz",
+      "integrity": "sha512-8eGTMO11LXFAiosaiV38bjvW6cjoQFtNE38pNtVilZTXpmGFinClljihH0eriv11Ispd4q82TqtsXMJPYD/C+A==",
       "license": "MIT",
       "dependencies": {
         "fast-copy": "^3.0.2",
-        "lodash": "^4.17.21",
-        "p-throttle": "^6.1.0",
+        "lodash": "^4.17.23",
         "process": "^0.11.10",
-        "qs": "^6.12.3"
+        "qs": "^6.15.0"
       },
       "engines": {
         "node": ">=18"
       },
       "optionalDependencies": {
         "@rollup/rollup-linux-x64-gnu": "^4.18.0"
+      }
+    },
+    "node_modules/contentful-sdk-core/node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/convert-source-map": {
@@ -12568,18 +12597,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/node-cache": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
-      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
-      "license": "MIT",
-      "dependencies": {
-        "clone": "2.x"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      }
-    },
     "node_modules/node-dir": {
       "version": "0.1.17",
       "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
@@ -12725,9 +12742,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
-      "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -13036,18 +13053,6 @@
       },
       "engines": {
         "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-throttle": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/p-throttle/-/p-throttle-6.2.0.tgz",
-      "integrity": "sha512-NCKkOVj6PZa6NiTmfvGilDdf6vO1rFCD3KDnkHko8dTOtkpk4cSR/VTAhhLMG9aiQ7/A9HYgEDNmxzf6hxzR3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -14417,14 +14422,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -14436,13 +14441,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"

--- a/apps/netlify/lambda/package.json
+++ b/apps/netlify/lambda/package.json
@@ -20,14 +20,14 @@
     "serverless-domain-manager": "3.3.2"
   },
   "dependencies": {
-    "@contentful/node-apps-toolkit": "^2.8.2",    
+    "@contentful/node-apps-toolkit": "^4.0.1",
     "aws-serverless-express": "3.4.0",
     "express": "4.22.1",
     "lodash.get": "^4.4.2",
     "node-fetch": "2.7.0"
   },
   "overrides": {
-    "axios": ">=1.15.2",
+    "axios": ">=1.16.0",
     "fast-xml-parser": ">=4.5.5",
     "lodash": ">=4.18.0",
     "minimatch": ">=5.1.8",


### PR DESCRIPTION
[AIS-50](https://contentful.atlassian.net/browse/AIS-50)

## Summary
- Bump `@contentful/node-apps-toolkit` `^2.8.2 → ^4.0.1`. The toolkit doesn't depend on `axios` directly — the vulnerable transitive `axios` came via the old `contentful-management`. Toolkit v4 ships `contentful-management@^12`, removing the vulnerable chain at the source. The lockfile now resolves a single `axios@1.18.0` with `contentful-management@12.8.0`.
- Raise the `axios` override floor `>=1.15.2 → >=1.16.0` to match the patched baseline (CVE-2026-44492 and the related axios fixes land in 1.16.0).
- Add an `.npmrc` pinning the `@contentful` scope to the public npm registry so the lockfile resolves these packages from `registry.npmjs.org`.

This Lambda already runs `nodejs22.x`, which satisfies toolkit v4's Node ≥ 20 requirement, so no runtime change is needed.

## Test plan
- [x] `npm test` (jest) passes (10/10)
- [ ] Deploy and re-scan to confirm the toolkit → axios finding clears

[AIS-50]: https://contentful.atlassian.net/browse/AIS-50?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ