### PR TITLE
fix(security): bump node-apps-toolkit to v4 in slack lambda [AIS-50]

### DIFF
--- a/apps/slack/lambda/.npmrc
+++ b/apps/slack/lambda/.npmrc
@@ -1,0 +1,1 @@
+@contentful:registry=https://registry.npmjs.org/

--- a/apps/slack/lambda/.npmrc
+++ b/apps/slack/lambda/.npmrc
@@ -1,1 +1,3 @@
+engine-strict = true
+ignore-scripts=true
 @contentful:registry=https://registry.npmjs.org/

--- a/apps/slack/lambda/package-lock.json
+++ b/apps/slack/lambda/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "slack-lambda",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "slack-lambda",
-      "version": "1.1.9",
+      "version": "1.1.10",
       "license": "MIT",
       "dependencies": {
-        "@contentful/node-apps-toolkit": "^2.8.2",
+        "@contentful/node-apps-toolkit": "^4.0.1",
         "@slack/events-api": "3.0.1",
         "@slack/web-api": "^6.13.0",
         "@types/cors": "^2.8.19",
@@ -460,54 +460,97 @@
       }
     },
     "node_modules/@contentful/node-apps-toolkit": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/@contentful/node-apps-toolkit/-/node-apps-toolkit-2.8.2.tgz",
-      "integrity": "sha512-KgdMC8F5UUO8NoVdlrtyF3MMDY0m3zq9d3Kcs+GDLoE9Tbnm+osAQHN49CeyOw6OczryEg5ITXqXq44bF0MVZw==",
+      "version": "4.0.1",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/node-apps-toolkit/4.0.1/95d49f937550bad18f75e45f09c7fca5f811fbeb",
+      "integrity": "sha512-GLyqVtYQ5qqVz0XX22QF4zoU4uTtQou/P+zyr+bAVAhJRVg7LiyzScDVhbVnLu6zLlX/Udil5fhxCFqc5axU2A==",
+      "license": "MIT",
       "dependencies": {
         "@types/debug": "^4.1.5",
-        "contentful-management": "^11.6.1",
+        "contentful-management": "^12.0.0",
         "debug": "^4.2.0",
         "got": "^11.7.0",
         "jsonwebtoken": "^9.0.0",
-        "node-cache": "^5.1.2",
+        "lru-cache": "^10.4.3",
         "runtypes": "^5.0.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@contentful/node-apps-toolkit/node_modules/contentful-management": {
-      "version": "11.6.1",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.6.1.tgz",
-      "integrity": "sha512-ORocz/bupmrSUUcw5LAIL+RpabqALoDcqqb4KBC847uiFXfTrDkzLPEGuB46zR+8Fh08Lltz1tDw/TwRrXBVpQ==",
+      "version": "12.8.0",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-12.8.0.tgz",
+      "integrity": "sha512-lARtEZYn2MYf80hz9nCYiLbJWvg95TTnOWmCZouMZtgNS1273dN27Vaz7weHQ3oSQuk7LeYXaXdGFhFPKlpilw==",
+      "license": "MIT",
       "dependencies": {
-        "@contentful/rich-text-types": "^16.3.0",
-        "@types/json-patch": "0.0.30",
-        "axios": "^1.6.2",
-        "contentful-sdk-core": "^8.1.0",
+        "@contentful/rich-text-types": "^16.6.1",
+        "axios": "^1.15.0",
+        "contentful-sdk-core": "^9.4.4",
         "fast-copy": "^3.0.0",
-        "lodash.isplainobject": "^4.0.6",
-        "type-fest": "^4.0.0"
+        "globals": "^15.15.0",
+        "process": "^0.11.10"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@contentful/node-apps-toolkit/node_modules/contentful-sdk-core": {
+      "version": "9.4.5",
+      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-9.4.5.tgz",
+      "integrity": "sha512-8eGTMO11LXFAiosaiV38bjvW6cjoQFtNE38pNtVilZTXpmGFinClljihH0eriv11Ispd4q82TqtsXMJPYD/C+A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-copy": "^3.0.2",
+        "lodash": "^4.17.23",
+        "process": "^0.11.10",
+        "qs": "^6.15.0"
       },
       "engines": {
         "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-linux-x64-gnu": "^4.18.0"
       }
     },
-    "node_modules/@contentful/node-apps-toolkit/node_modules/type-fest": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.8.3.tgz",
-      "integrity": "sha512-//BaTm14Q/gHBn09xlnKNqfI8t6bmdzx2DXYfPBNofN0WUybCEUDcbCWcTa0oF09lzLjZgPphXAsvRiMK0V6Bw==",
+    "node_modules/@contentful/node-apps-toolkit/node_modules/globals": {
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+      "license": "MIT",
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@contentful/node-apps-toolkit/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/@contentful/node-apps-toolkit/node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/@contentful/rich-text-types": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.3.0.tgz",
-      "integrity": "sha512-OfQmAu5bxE0CgQA3WlUleVej+ifFG/iXmB2DmUl4EyWyFue1aiIvfjxQhcDRSH4n1jUNMJ6L1wInZL8uV5m3TQ==",
+      "version": "16.8.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/rich-text-types/16.8.5/832c8b428612f5181908bc1033c6ef9f48f1ce83",
+      "integrity": "sha512-q18RJuJCOuYveGiCIjE5xLCQc5lZ3L2Qgxrlg/H2YEobDFqdtmklazRi1XwEWaK3tMg6yVXBzKKkQfLB4qW14A==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1103,6 +1146,22 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/@serverless/dashboard-plugin": {
       "version": "6.2.3",
@@ -3648,14 +3707,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/clone": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/clone-response": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
@@ -5575,9 +5626,10 @@
       }
     },
     "node_modules/fast-copy": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.0.tgz",
-      "integrity": "sha512-4HzS+9pQ5Yxtv13Lhs1Z1unMXamBdn5nA4bEi1abYpDNSpSp7ODYQ1KPMF6nTatfEzgH6/zPvXKU1zvHiUjWlA=="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.2.tgz",
+      "integrity": "sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -8207,17 +8259,6 @@
         "isarray": "0.0.1"
       }
     },
-    "node_modules/node-cache": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
-      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
-      "dependencies": {
-        "clone": "2.x"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      }
-    },
     "node_modules/node-dir": {
       "version": "0.1.17",
       "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
@@ -9102,6 +9143,15 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/process-nextick-args": {
@@ -10199,13 +10249,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -10217,12 +10268,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -12222,44 +12274,69 @@
       }
     },
     "@contentful/node-apps-toolkit": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/@contentful/node-apps-toolkit/-/node-apps-toolkit-2.8.2.tgz",
-      "integrity": "sha512-KgdMC8F5UUO8NoVdlrtyF3MMDY0m3zq9d3Kcs+GDLoE9Tbnm+osAQHN49CeyOw6OczryEg5ITXqXq44bF0MVZw==",
+      "version": "4.0.1",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/node-apps-toolkit/4.0.1/95d49f937550bad18f75e45f09c7fca5f811fbeb",
+      "integrity": "sha512-GLyqVtYQ5qqVz0XX22QF4zoU4uTtQou/P+zyr+bAVAhJRVg7LiyzScDVhbVnLu6zLlX/Udil5fhxCFqc5axU2A==",
       "requires": {
         "@types/debug": "^4.1.5",
-        "contentful-management": "^11.6.1",
+        "contentful-management": "^12.0.0",
         "debug": "^4.2.0",
         "got": "^11.7.0",
         "jsonwebtoken": "^9.0.0",
-        "node-cache": "^5.1.2",
+        "lru-cache": "^10.4.3",
         "runtypes": "^5.0.1"
       },
       "dependencies": {
         "contentful-management": {
-          "version": "11.6.1",
-          "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.6.1.tgz",
-          "integrity": "sha512-ORocz/bupmrSUUcw5LAIL+RpabqALoDcqqb4KBC847uiFXfTrDkzLPEGuB46zR+8Fh08Lltz1tDw/TwRrXBVpQ==",
+          "version": "12.8.0",
+          "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-12.8.0.tgz",
+          "integrity": "sha512-lARtEZYn2MYf80hz9nCYiLbJWvg95TTnOWmCZouMZtgNS1273dN27Vaz7weHQ3oSQuk7LeYXaXdGFhFPKlpilw==",
           "requires": {
-            "@contentful/rich-text-types": "^16.3.0",
-            "@types/json-patch": "0.0.30",
-            "axios": ">=1.15.2",
-            "contentful-sdk-core": "^8.1.0",
+            "@contentful/rich-text-types": "^16.6.1",
+            "axios": ">=1.16.0",
+            "contentful-sdk-core": "^9.4.4",
             "fast-copy": "^3.0.0",
-            "lodash.isplainobject": "^4.0.6",
-            "type-fest": "^4.0.0"
+            "globals": "^15.15.0",
+            "process": "^0.11.10"
           }
         },
-        "type-fest": {
-          "version": "4.8.3",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.8.3.tgz",
-          "integrity": "sha512-//BaTm14Q/gHBn09xlnKNqfI8t6bmdzx2DXYfPBNofN0WUybCEUDcbCWcTa0oF09lzLjZgPphXAsvRiMK0V6Bw=="
+        "contentful-sdk-core": {
+          "version": "9.4.5",
+          "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-9.4.5.tgz",
+          "integrity": "sha512-8eGTMO11LXFAiosaiV38bjvW6cjoQFtNE38pNtVilZTXpmGFinClljihH0eriv11Ispd4q82TqtsXMJPYD/C+A==",
+          "requires": {
+            "@rollup/rollup-linux-x64-gnu": "^4.18.0",
+            "fast-copy": "^3.0.2",
+            "lodash": ">=4.18.0",
+            "process": "^0.11.10",
+            "qs": "^6.15.0"
+          }
+        },
+        "globals": {
+          "version": "15.15.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+          "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg=="
+        },
+        "lru-cache": {
+          "version": "10.4.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+          "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
+        },
+        "qs": {
+          "version": "6.15.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+          "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+          "requires": {
+            "es-define-property": "^1.0.1",
+            "side-channel": "^1.1.1"
+          }
         }
       }
     },
     "@contentful/rich-text-types": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.3.0.tgz",
-      "integrity": "sha512-OfQmAu5bxE0CgQA3WlUleVej+ifFG/iXmB2DmUl4EyWyFue1aiIvfjxQhcDRSH4n1jUNMJ6L1wInZL8uV5m3TQ=="
+      "version": "16.8.5",
+      "resolved": "https://npm.pkg.github.com/download/@contentful/rich-text-types/16.8.5/832c8b428612f5181908bc1033c6ef9f48f1ce83",
+      "integrity": "sha512-q18RJuJCOuYveGiCIjE5xLCQc5lZ3L2Qgxrlg/H2YEobDFqdtmklazRi1XwEWaK3tMg6yVXBzKKkQfLB4qW14A=="
     },
     "@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -12783,6 +12860,12 @@
         "fastq": "^1.6.0"
       }
     },
+    "@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "optional": true
+    },
     "@serverless/dashboard-plugin": {
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/@serverless/dashboard-plugin/-/dashboard-plugin-6.2.3.tgz",
@@ -12874,7 +12957,7 @@
       "requires": {
         "adm-zip": "^0.5.5",
         "archiver": "^5.3.0",
-        "axios": ">=1.15.2",
+        "axios": ">=1.16.0",
         "fast-glob": "^3.2.7",
         "https-proxy-agent": "^5.0.0",
         "ignore": "^5.1.8",
@@ -13159,7 +13242,7 @@
         "@slack/types": "^2.11.0",
         "@types/is-stream": "^1.1.0",
         "@types/node": ">=12.0.0",
-        "axios": ">=1.15.2",
+        "axios": ">=1.16.0",
         "eventemitter3": "^3.1.0",
         "form-data": "^2.5.0",
         "is-electron": "2.2.2",
@@ -14711,11 +14794,6 @@
         }
       }
     },
-    "clone": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="
-    },
     "clone-response": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
@@ -14790,7 +14868,7 @@
       "requires": {
         "@contentful/rich-text-types": "^16.3.0",
         "@types/json-patch": "0.0.30",
-        "axios": ">=1.15.2",
+        "axios": ">=1.16.0",
         "contentful-sdk-core": "^8.1.0",
         "fast-copy": "^3.0.0",
         "lodash.isplainobject": "^4.0.6",
@@ -16220,9 +16298,9 @@
       }
     },
     "fast-copy": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.0.tgz",
-      "integrity": "sha512-4HzS+9pQ5Yxtv13Lhs1Z1unMXamBdn5nA4bEi1abYpDNSpSp7ODYQ1KPMF6nTatfEzgH6/zPvXKU1zvHiUjWlA=="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.2.tgz",
+      "integrity": "sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ=="
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -18236,14 +18314,6 @@
         }
       }
     },
-    "node-cache": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
-      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
-      "requires": {
-        "clone": "2.x"
-      }
-    },
     "node-dir": {
       "version": "0.1.17",
       "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
@@ -18861,6 +18931,11 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
       "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true
+    },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -19673,24 +19748,24 @@
       "dev": true
     },
     "side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "requires": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       }
     },
     "side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "requires": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       }
     },
     "side-channel-map": {

--- a/apps/slack/lambda/package-lock.json
+++ b/apps/slack/lambda/package-lock.json
@@ -461,7 +461,7 @@
     },
     "node_modules/@contentful/node-apps-toolkit": {
       "version": "4.0.1",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/node-apps-toolkit/4.0.1/95d49f937550bad18f75e45f09c7fca5f811fbeb",
+      "resolved": "https://registry.npmjs.org/@contentful/node-apps-toolkit/-/node-apps-toolkit-4.0.1.tgz",
       "integrity": "sha512-GLyqVtYQ5qqVz0XX22QF4zoU4uTtQou/P+zyr+bAVAhJRVg7LiyzScDVhbVnLu6zLlX/Udil5fhxCFqc5axU2A==",
       "license": "MIT",
       "dependencies": {
@@ -548,7 +548,7 @@
     },
     "node_modules/@contentful/rich-text-types": {
       "version": "16.8.5",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/rich-text-types/16.8.5/832c8b428612f5181908bc1033c6ef9f48f1ce83",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.8.5.tgz",
       "integrity": "sha512-q18RJuJCOuYveGiCIjE5xLCQc5lZ3L2Qgxrlg/H2YEobDFqdtmklazRi1XwEWaK3tMg6yVXBzKKkQfLB4qW14A==",
       "license": "MIT",
       "engines": {
@@ -12275,7 +12275,7 @@
     },
     "@contentful/node-apps-toolkit": {
       "version": "4.0.1",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/node-apps-toolkit/4.0.1/95d49f937550bad18f75e45f09c7fca5f811fbeb",
+      "resolved": "https://registry.npmjs.org/@contentful/node-apps-toolkit/-/node-apps-toolkit-4.0.1.tgz",
       "integrity": "sha512-GLyqVtYQ5qqVz0XX22QF4zoU4uTtQou/P+zyr+bAVAhJRVg7LiyzScDVhbVnLu6zLlX/Udil5fhxCFqc5axU2A==",
       "requires": {
         "@types/debug": "^4.1.5",
@@ -12335,7 +12335,7 @@
     },
     "@contentful/rich-text-types": {
       "version": "16.8.5",
-      "resolved": "https://npm.pkg.github.com/download/@contentful/rich-text-types/16.8.5/832c8b428612f5181908bc1033c6ef9f48f1ce83",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.8.5.tgz",
       "integrity": "sha512-q18RJuJCOuYveGiCIjE5xLCQc5lZ3L2Qgxrlg/H2YEobDFqdtmklazRi1XwEWaK3tMg6yVXBzKKkQfLB4qW14A=="
     },
     "@cspotcode/source-map-support": {

--- a/apps/slack/lambda/package.json
+++ b/apps/slack/lambda/package.json
@@ -49,7 +49,7 @@
     "typescript": "^4.9.5"
   },
   "dependencies": {
-    "@contentful/node-apps-toolkit": "^2.8.2",
+    "@contentful/node-apps-toolkit": "^4.0.1",
     "@slack/events-api": "3.0.1",
     "@slack/web-api": "^6.13.0",
     "@types/cors": "^2.8.19",
@@ -63,7 +63,7 @@
     "serverless-http": "^3.1.0"
   },
   "overrides": {
-    "axios": ">=1.15.2",
+    "axios": ">=1.16.0",
     "lodash": ">=4.18.0",
     "minimatch": ">=5.1.8",
     "simple-git": ">=3.36.0",


### PR DESCRIPTION
[AIS-50](https://contentful.atlassian.net/browse/AIS-50)

## Summary
- Bump `@contentful/node-apps-toolkit` `^2.8.2 → ^4.0.1`. The vulnerable transitive `axios` came via the old `contentful-management`; v4 ships `contentful-management@^12`, clearing the chain at the source. The lockfile now resolves a single `axios@1.18.0`.
- Raise the `axios` override floor `>=1.15.2 → >=1.16.0` to match the patched baseline.
- Add an `.npmrc` pinning the `@contentful` scope to the public npm registry so the lockfile resolves these packages from `registry.npmjs.org`.

This Lambda already runs `nodejs22.x` (toolkit v4 requires Node ≥ 20). Its direct `contentful-management@^10` dependency is left as-is — it's outside the toolkit → axios chain and the `axios` override keeps it on a patched version; a CMA major bump is a separate change.

## Test plan
- [x] `npm run build` (tsc) passes
- [x] `npm test` (mocha) passes (56/56)
- [ ] Deploy and re-scan to confirm the toolkit → axios finding clears

[AIS-50]: https://contentful.atlassian.net/browse/AIS-50?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ