### PR TITLE
fix(security): bump integration-frontend-toolkit to 1.7.3 [AIS-72]

### DIFF
--- a/apps/microsoft-teams/frontend/package-lock.json
+++ b/apps/microsoft-teams/frontend/package-lock.json
@@ -15,7 +15,7 @@
         "@contentful/f36-components": "4.67.0",
         "@contentful/f36-icons": "^4.27.0",
         "@contentful/f36-tokens": "4.0.5",
-        "@contentful/integration-frontend-toolkit": "^1.5.1",
+        "@contentful/integration-frontend-toolkit": "^1.7.3",
         "@contentful/react-apps-toolkit": "1.2.16",
         "@emotion/css": "^11.13.0",
         "@typescript-eslint/eslint-plugin": "^8.15.0",
@@ -1338,9 +1338,9 @@
       }
     },
     "node_modules/@contentful/integration-frontend-toolkit": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@contentful/integration-frontend-toolkit/-/integration-frontend-toolkit-1.7.1.tgz",
-      "integrity": "sha512-Q0D940/9lSpUqybv6Ep9WcT57/06VUg6ys9wGaiwPFmY9skn6ZJjbPDN1ZzB6VDV07EVNMp4+N2tceOmHWXGTQ==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@contentful/integration-frontend-toolkit/-/integration-frontend-toolkit-1.7.3.tgz",
+      "integrity": "sha512-zvM4eoYTJACkIXTTxuIe30aUUH2NBSwWZjG8DiSdHCqryQTCkU2wfjDt3kztmZbgdhM2eBDB9eRxvt6B/TtoLg==",
       "dependencies": {
         "@contentful/app-sdk": "^4.24.0",
         "@contentful/f36-components": "^4.35.0",
@@ -7040,16 +7040,6 @@
         }
       }
     },
-    "node_modules/msw/node_modules/@types/node": {
-      "version": "24.5.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
-      "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~7.12.0"
-      }
-    },
     "node_modules/msw/node_modules/cli-width": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
@@ -8865,13 +8855,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
-      "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
-      "optional": true,
-      "peer": true
     },
     "node_modules/unfetch": {
       "version": "4.2.0",
@@ -10942,9 +10925,9 @@
       }
     },
     "@contentful/integration-frontend-toolkit": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@contentful/integration-frontend-toolkit/-/integration-frontend-toolkit-1.7.1.tgz",
-      "integrity": "sha512-Q0D940/9lSpUqybv6Ep9WcT57/06VUg6ys9wGaiwPFmY9skn6ZJjbPDN1ZzB6VDV07EVNMp4+N2tceOmHWXGTQ==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@contentful/integration-frontend-toolkit/-/integration-frontend-toolkit-1.7.3.tgz",
+      "integrity": "sha512-zvM4eoYTJACkIXTTxuIe30aUUH2NBSwWZjG8DiSdHCqryQTCkU2wfjDt3kztmZbgdhM2eBDB9eRxvt6B/TtoLg==",
       "requires": {
         "@contentful/app-sdk": "^4.24.0",
         "@contentful/f36-components": "^4.35.0",
@@ -14922,16 +14905,6 @@
           "integrity": "sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw==",
           "requires": {}
         },
-        "@types/node": {
-          "version": "24.5.2",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
-          "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "undici-types": "~7.12.0"
-          }
-        },
         "cli-width": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
@@ -16198,13 +16171,6 @@
         "has-symbols": "^1.1.0",
         "which-boxed-primitive": "^1.1.1"
       }
-    },
-    "undici-types": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
-      "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
-      "optional": true,
-      "peer": true
     },
     "unfetch": {
       "version": "4.2.0",

--- a/apps/microsoft-teams/frontend/package.json
+++ b/apps/microsoft-teams/frontend/package.json
@@ -10,7 +10,7 @@
     "@contentful/f36-components": "4.67.0",
     "@contentful/f36-icons": "^4.27.0",
     "@contentful/f36-tokens": "4.0.5",
-    "@contentful/integration-frontend-toolkit": "^1.5.1",
+    "@contentful/integration-frontend-toolkit": "^1.7.3",
     "@contentful/react-apps-toolkit": "1.2.16",
     "@emotion/css": "^11.13.0",
     "@typescript-eslint/eslint-plugin": "^8.15.0",


### PR DESCRIPTION
## Summary

- Bumps `@contentful/integration-frontend-toolkit` from `^1.5.1` to `^1.7.3` in the Microsoft Teams frontend app
- Patches [CVE-2025-7783](https://nvd.nist.gov/vuln/detail/CVE-2025-7783) (CVSS 9.4) — arbitrary boundary injection in the `form-data` transitive dependency
- Lockfile updated to resolve to the patched version

## Test plan

- [ ] CI passes
- [ ] Microsoft Teams app builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code) on behalf of Tyler Washington (Codex agent)