### PR TITLE
fix(security): sanitize error disclosure in graphql-playground ConfigScreen [ACT-3525]

### DIFF
--- a/apps/graphql-playground/src/components/ConfigScreen.tsx
+++ b/apps/graphql-playground/src/components/ConfigScreen.tsx
@@ -161,7 +161,7 @@ export default class Config extends Component<ConfigProps, ConfigState> {
         },
       };
     } catch (error) {
-      console.error(error);
+      console.error('Failed to configure app:', error instanceof Error ? error.message : 'Unknown error');
     }
   };
 

--- a/apps/graphql-playground/src/components/ConfigScreen.tsx
+++ b/apps/graphql-playground/src/components/ConfigScreen.tsx
@@ -161,7 +161,7 @@ export default class Config extends Component<ConfigProps, ConfigState> {
         },
       };
     } catch (error) {
-      console.error('Failed to configure app:', error instanceof Error ? error.message : 'Unknown error');
+      console.error('Failed to save app configuration.');
     }
   };
 


### PR DESCRIPTION
## Purpose

Remediates Wiz SAST finding [ACT-3525](https://contentful.atlassian.net/browse/ACT-3525) — rule `WS-I002-JAVASCRIPT-00027` (Disclosure of Error Details and Stack Traces).

Wiz issue: https://app.wiz.io/p/production/issues#%7E%28issue%7E%27d56cc137-4b03-426c-a378-7d3d4ecd280c%29

## Approach

The `onConfigure` catch block in `ConfigScreen.tsx` was passing the raw `error` object directly to `console.error`, which can expose internal stack traces and error details.

**Before:**
```typescript
} catch (error) {
  console.error(error);
}
```

**After:**
```typescript
} catch (error) {
  console.error('Failed to configure app:', error instanceof Error ? error.message : 'Unknown error');
}
```

Validity: confirmed — `console.error(error)` at line 164 passes the full error object. No false positive.

> Note: Wiz API token unavailable in this run. Fix derived from rule WS-I002-JAVASCRIPT-00027 + direct code inspection at flagged lines 147–165.

## Testing steps

No functional change — catch block behaviour is unchanged, only the log output is sanitized.

## Breaking Changes

None.

## Dependencies and/or References

- [ACT-3525](https://contentful.atlassian.net/browse/ACT-3525)
- Wiz rule: WS-I002-JAVASCRIPT-00027 — Disclosure of Error Details and Stack Traces

> Note: This PR was created with the wiz-remediation agent on behalf of Tyler Washington. 🤖

[ACT-3525]: https://contentful.atlassian.net/browse/ACT-3525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACT-3525]: https://contentful.atlassian.net/browse/ACT-3525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ