### PR TITLE
fix(rich-text-versioning): pin react-query v4 to fix editor load crash []

### DIFF
--- a/apps/rich-text-versioning/package-lock.json
+++ b/apps/rich-text-versioning/package-lock.json
@@ -18,6 +18,7 @@
         "@contentful/rich-text-html-renderer": "^17.1.0",
         "@contentful/rich-text-react-renderer": "^16.1.0",
         "@contentful/rich-text-types": "^16.1.0",
+        "@tanstack/react-query": "4.44.0",
         "contentful": "^11.7.15",
         "contentful-management": "11.54.4",
         "dompurify": "^3.0.8",
@@ -2639,43 +2640,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
       "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
       "license": "MIT"
-    },
-    "node_modules/@contentful/field-editor-reference/node_modules/@tanstack/query-core": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.44.0.tgz",
-      "integrity": "sha512-swSgb7OiPRR3UuIL7NuDrZNSMGmQD+wdtHxPD7j60SvBEnxbXurl5XOirtGEX2gm2hbK6mC8kMV1I+uO3l0UOw==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
-    "node_modules/@contentful/field-editor-reference/node_modules/@tanstack/react-query": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.44.0.tgz",
-      "integrity": "sha512-RuIqHYrS98LrK/8kJJOJMMSQ/BCpojwsXDh7p0fBmp38ZOz6dlk+uyFRRusH+V+t3POoCsDOQ2zhomEYOeReXw==",
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/query-core": "4.44.0",
-        "use-sync-external-store": "^1.6.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-native": "*"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@contentful/field-editor-reference/node_modules/compute-scroll-into-view": {
       "version": "3.1.1",
@@ -6341,31 +6305,40 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.101.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.0.tgz",
-      "integrity": "sha512-cQetA74EB+seWySv1TTKr828TnP0u39m6LykwDXIo84SNortpDkp30TMEjkqtYCNP9c40uT/iwl6MLiufEt0Ow==",
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.44.0.tgz",
+      "integrity": "sha512-swSgb7OiPRR3UuIL7NuDrZNSMGmQD+wdtHxPD7j60SvBEnxbXurl5XOirtGEX2gm2hbK6mC8kMV1I+uO3l0UOw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.101.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.0.tgz",
-      "integrity": "sha512-rLlJXSpkqfizLWgkR5+eLeIk0MvTx/meEIR7LRjxic+qxiQP8zVjq7BqQkiCMNLQBlLfuOLqqr6KO5GtrDlmSg==",
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.44.0.tgz",
+      "integrity": "sha512-RuIqHYrS98LrK/8kJJOJMMSQ/BCpojwsXDh7p0fBmp38ZOz6dlk+uyFRRusH+V+t3POoCsDOQ2zhomEYOeReXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@tanstack/query-core": "5.101.0"
+        "@tanstack/query-core": "4.44.0",
+        "use-sync-external-store": "^1.6.0"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
-        "react": "^18 || ^19"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/@testing-library/dom": {

--- a/apps/rich-text-versioning/package.json
+++ b/apps/rich-text-versioning/package.json
@@ -13,6 +13,7 @@
     "@contentful/rich-text-html-renderer": "^17.1.0",
     "@contentful/rich-text-react-renderer": "^16.1.0",
     "@contentful/rich-text-types": "^16.1.0",
+    "@tanstack/react-query": "4.44.0",
     "contentful": "^11.7.15",
     "contentful-management": "11.54.4",
     "dompurify": "^3.0.8",

--- a/apps/rich-text-versioning/src/components/createOptions.tsx
+++ b/apps/rich-text-versioning/src/components/createOptions.tsx
@@ -1,12 +1,16 @@
 import { AssetCard, Box, EntryCard, InlineEntryCard } from '@contentful/f36-components';
 import { EntryProps, ContentTypeProps, AssetProps } from 'contentful-management';
 import { getEntryTitle } from '../utils';
-import { BLOCKS, INLINES } from '@contentful/rich-text-types';
+import { BLOCKS, INLINES, Block, Inline } from '@contentful/rich-text-types';
 import { Options } from '@contentful/rich-text-react-renderer';
 
 const UNKNOWN = 'Unknown';
 const ENTRY_NOT_FOUND = 'Entry missing or inaccessible';
 const ASSET_NOT_FOUND = 'Asset missing or inaccessible';
+
+const getLinkedEntityId = (node: Block | Inline): string | undefined => {
+  return node.data?.target?.sys?.id;
+};
 
 export const createOptions = (
   entries: EntryProps[],
@@ -15,8 +19,17 @@ export const createOptions = (
   locale: string
 ): Options => ({
   renderNode: {
-    [BLOCKS.EMBEDDED_ENTRY]: (node: any) => {
-      const entry = entries.find((e) => e.sys.id === node.data.target.sys.id);
+    [BLOCKS.EMBEDDED_ENTRY]: (node: Block | Inline) => {
+      const targetId = getLinkedEntityId(node);
+      if (!targetId) {
+        return (
+          <Box marginBottom="spacingM">
+            <EntryCard contentType={UNKNOWN} title={ENTRY_NOT_FOUND} />
+          </Box>
+        );
+      }
+
+      const entry = entries.find((e) => e.sys.id === targetId);
       if (!entry) {
         return (
           <Box marginBottom="spacingM">
@@ -24,9 +37,10 @@ export const createOptions = (
           </Box>
         );
       }
-      const contentType = entryContentTypes.find(
-        (ct) => ct.sys.id === entry.sys.contentType.sys.id
-      );
+      const contentTypeId = entry.sys.contentType?.sys?.id;
+      const contentType = contentTypeId
+        ? entryContentTypes.find((ct) => ct.sys.id === contentTypeId)
+        : undefined;
       const contentTypeName = contentType?.name || UNKNOWN;
       const title = getEntryTitle(entry, contentType, locale);
 
@@ -36,23 +50,38 @@ export const createOptions = (
         </Box>
       );
     },
-    [INLINES.EMBEDDED_ENTRY]: (node: any) => {
-      const entry = entries.find((e) => e.sys.id === node.data.target.sys.id);
+    [INLINES.EMBEDDED_ENTRY]: (node: Block | Inline) => {
+      const targetId = getLinkedEntityId(node);
+      if (!targetId) {
+        return <InlineEntryCard contentType={UNKNOWN}>{ENTRY_NOT_FOUND}</InlineEntryCard>;
+      }
+
+      const entry = entries.find((e) => e.sys.id === targetId);
 
       if (!entry) {
         return <InlineEntryCard contentType={UNKNOWN}>{ENTRY_NOT_FOUND}</InlineEntryCard>;
       }
 
-      const contentType = entryContentTypes.find(
-        (ct) => ct.sys.id === entry.sys.contentType.sys.id
-      );
+      const contentTypeId = entry.sys.contentType?.sys?.id;
+      const contentType = contentTypeId
+        ? entryContentTypes.find((ct) => ct.sys.id === contentTypeId)
+        : undefined;
       const contentTypeName = contentType?.name || UNKNOWN;
       const title = getEntryTitle(entry, contentType, locale);
 
       return <InlineEntryCard contentType={contentTypeName}>{title}</InlineEntryCard>;
     },
-    [BLOCKS.EMBEDDED_ASSET]: (node: any) => {
-      const asset = assets.find((a) => a.sys.id === node.data.target.sys.id);
+    [BLOCKS.EMBEDDED_ASSET]: (node: Block | Inline) => {
+      const targetId = getLinkedEntityId(node);
+      if (!targetId) {
+        return (
+          <Box margin="spacingM">
+            <AssetCard title={ASSET_NOT_FOUND} size="small" />
+          </Box>
+        );
+      }
+
+      const asset = assets.find((a) => a.sys.id === targetId);
 
       if (!asset) {
         return (

--- a/apps/rich-text-versioning/src/locations/Dialog.tsx
+++ b/apps/rich-text-versioning/src/locations/Dialog.tsx
@@ -13,7 +13,7 @@ import {
 } from '@contentful/f36-components';
 import { useAutoResizer, useSDK } from '@contentful/react-apps-toolkit';
 import { documentToReactComponents } from '@contentful/rich-text-react-renderer';
-import { BLOCKS, Document, INLINES } from '@contentful/rich-text-types';
+import { BLOCKS, Document, INLINES, TopLevelBlock } from '@contentful/rich-text-types';
 import { useState, useEffect } from 'react';
 import { styles } from './Dialog.styles';
 import HtmlDiffViewer from '../components/HtmlDiffViewer';
@@ -47,11 +47,14 @@ const Dialog = () => {
 
   const getReferenceIdsFromDocument = (doc: Document, types: string[]): Set<string> => {
     const ids: Set<string> = new Set();
-    const getEntryIdsFromNode = (node: any) => {
+    const getEntryIdsFromNode = (node: TopLevelBlock | TopLevelBlock['content'][number]) => {
       if (types.includes(node.nodeType)) {
-        ids.add(node.data.target.sys.id);
+        const targetId = node.data?.target?.sys?.id;
+        if (targetId) {
+          ids.add(targetId);
+        }
       }
-      if ('content' in node) {
+      if ('content' in node && Array.isArray(node.content)) {
         node.content.forEach(getEntryIdsFromNode);
       }
     };
@@ -116,13 +119,23 @@ const Dialog = () => {
         setEntriesFromPublished(fetchedEntriesFromPublished);
 
         try {
-          const allEntries = [...entriesFromCurrent, ...entriesFromPublished];
-          const fetchedContentTypes = await sdk.cma.contentType.getMany({
-            query: {
-              'sys.id[in]': allEntries.map((entry) => entry.sys.contentType.sys.id),
-            },
-          });
-          setEntryContentTypes(fetchedContentTypes.items);
+          const allEntries = [...fetchedEntriesFromCurrent, ...fetchedEntriesFromPublished];
+          const contentTypeIds = [
+            ...new Set(
+              allEntries
+                .map((entry) => entry.sys.contentType?.sys?.id)
+                .filter((contentTypeId): contentTypeId is string => Boolean(contentTypeId))
+            ),
+          ];
+
+          if (contentTypeIds.length > 0) {
+            const fetchedContentTypes = await sdk.cma.contentType.getMany({
+              query: {
+                'sys.id[in]': contentTypeIds.join(','),
+              },
+            });
+            setEntryContentTypes(fetchedContentTypes.items);
+          }
         } catch (error) {
           console.error('Error fetching content types:', error);
         }


### PR DESCRIPTION
## Summary
- Pin `@tanstack/react-query@4.44.0` as a direct dependency so Vite bundles v4 instead of hoisting v5 from `@contentful/field-editor-shared`
- Fixes `Cannot read properties of undefined (reading 'sys')` when loading the rich text editor on fields with embedded entry/asset references
- Harden the version comparison dialog against missing link targets and fix stale state when fetching content types for embedded entries

## Root cause
With react-query v5 hoisted, `FetchingWrappedInlineEntryCard` in `@contentful/field-editor-rich-text@6.3.9` does not treat `'pending'` as a loading state. The success branch renders before entity data is available and accesses `entry.sys`.

## Test plan
- [x] `npm run build` passes in `apps/rich-text-versioning`
- [x] `npm test` passes (32 tests)
- [x] Manual: open an entry with embedded inline/block entry references — editor loads without console errors
- [ ] Manual: Compare versions dialog renders embedded references correctly


Made with [Cursor](https://cursor.com)