### PR TITLE
fix(smartling): use oauthCallback to fix broken OAuth authentication [AIS-82]

### DIFF
--- a/apps/smartling/lambda/src/index.spec.ts
+++ b/apps/smartling/lambda/src/index.spec.ts
@@ -27,7 +27,7 @@ class Client {
     return { code: '1234' };
   }
 
-  async callback() {
+  async oauthCallback() {
     return {
       access_token: 'access-123',
       refresh_token: 'refresh_token-123',

--- a/apps/smartling/lambda/src/index.ts
+++ b/apps/smartling/lambda/src/index.ts
@@ -51,7 +51,7 @@ export function makeApp(fetchFn: any, issuer: any) {
 
     try {
       const params = client.callbackParams(req);
-      const data = await client.callback('', params);
+      const data = await client.oauthCallback('', params);
 
       res.redirect(
         `/frontend/index.html?access_token=${data.access_token}&refresh_token=${data.refresh_token}`


### PR DESCRIPTION
## Summary

- Replaces `client.callback()` with `client.oauthCallback()` in the Smartling Lambda OAuth handler
- Fixes active prod breakage: every user attempting to authenticate with Smartling is hitting `id_token not present in TokenSet`, getting bounced to the error redirect, and seeing the App SDK "outside of Contentful" console error
- Confirmed via CloudWatch logs 

## Root cause

`openid-client`'s `callback()` method calls `validateIdToken()` after the authorization code exchange and throws `id_token not present in TokenSet` when the token response doesn't include an `id_token`. Smartling's SSO (`sso.smartling.com/auth/realms/Smartling`) returns only `access_token` and `refresh_token` — a pure OAuth 2.0 response. `oauthCallback()` performs the identical `authorization_code` grant but skips `id_token` validation entirely, which is correct since the app only ever uses `access_token` and `refresh_token`.

## Test plan

- [ ] Deploy to test stage and complete a Smartling OAuth flow end-to-end
- [ ] Confirm `access_token` and `refresh_token` are returned and the popup closes successfully
- [ ] Confirm no `Smartling OAuth failed` errors in CloudWatch after deploy to prod

> 🤖 Generated with [Claude Code](https://claude.com/claude-code) on behalf of Tyler Washington (Codex agent)