### PR TITLE
fix(security): remediate WS-I002 error disclosure [ACT-3524]

### DIFF
--- a/apps/bedrock-content-generator/src/components/app/dialog/common-generator/CommonGenerator.tsx
+++ b/apps/bedrock-content-generator/src/components/app/dialog/common-generator/CommonGenerator.tsx
@@ -72,7 +72,7 @@ const CommonGenerator = () => {
       const userMessage = featureConfig[feature].prompt(inputText, localeName);
       await generateMessage(userMessage, localeName);
     } catch (error) {
-      console.error(error);
+      console.error('Generation failed:', error instanceof Error ? error.message : 'Unknown error');
     }
   };
 


### PR DESCRIPTION
## Purpose

Remediates Wiz SAST finding **WS-I002-JAVASCRIPT-00027** (Disclosure of Error Details and Stack Traces) in the Bedrock Content Generator app.

Passing raw error objects to `console.error` can expose internal stack traces, error messages, and implementation details in production logs, which may leak sensitive information.

- **ACT ticket**: https://contentful.atlassian.net/browse/ACT-3524
- **Wiz issue**: https://app.wiz.io/p/production/issues#%7E%28issue%7E%2746da7ad8-bbed-4019-8e22-cd7bb62cfc88%29

## Approach

Single-line change in `CommonGenerator.tsx` at line 75.

**Before:**
```typescript
} catch (error) {
  console.error(error);
}
```

**After:**
```typescript
} catch (error) {
  console.error('Generation failed:', error instanceof Error ? error.message : 'Unknown error');
}
```

The raw error object is replaced with a controlled string. The `error.message` is included (not a stack trace) for debuggability, guarded by an `instanceof Error` check to avoid leaking non-Error throw values.

**Validity assessment**: VALID — line 75 is a textbook match for WS-I002 (`console.error(error)` with raw error object in a catch block, in a non-test file). Confidence: HIGH.

Note: Wiz API was unavailable (`WIZ_API_TOKEN` not set); the fix was inferred from the rule ID and direct code inspection. The pattern is unambiguous.

## Testing steps

1. Open the Bedrock Content Generator app in a Contentful space.
2. Trigger a generation failure (e.g., disconnect network or use an invalid locale).
3. Verify the console shows `Generation failed: <message>` instead of the raw Error object.
4. Run unit tests: `npx nx test bedrock-content-generator`

## Breaking Changes

None. This is a one-line logger message change with no behavior impact on the happy path.

## Dependencies and/or References

- ACT-3524: https://contentful.atlassian.net/browse/ACT-3524
- Wiz issue 46da7ad8-bbed-4019-8e22-cd7bb62cfc88: https://app.wiz.io/p/production/issues#%7E%28issue%7E%2746da7ad8-bbed-4019-8e22-cd7bb62cfc88%29
- Rule: WS-I002-JAVASCRIPT-00027 — Disclosure of Error Details and Stack Traces

## Deployment

No deployment concerns. Logger-only change, no schema or API impact.

> Note: This PR was created with the [contentful-github-create-pull-request](https://github.com/contentful/agents-kit/tree/main/libs/contentful-github-create-pull-request) skill, powered by [Agents Kit](https://github.com/contentful/agents-kit). To follow or use this workflow, see the [Agents Kit CLI skill docs](https://github.com/contentful/agents-kit/blob/main/apps/cli/README.md#consuming-skills).
