### PR TITLE
fix(drive-integration): disable confirm cancel button while cancellation is in-flight []

### DIFF
--- a/apps/drive-integration/src/locations/Page/components/mainpage/ModalOrchestrator.tsx
+++ b/apps/drive-integration/src/locations/Page/components/mainpage/ModalOrchestrator.tsx
@@ -134,17 +134,8 @@ export const ModalOrchestrator = forwardRef<ModalOrchestratorHandle, ModalOrches
       onResetToMain();
     }, [onResetToMain]);
 
-    const handleConfirmCancel = async () => {
+    const handleConfirmCancel = () => {
       setIsConfirmCancelModalOpen(false);
-
-      if (activeRunId) {
-        try {
-          await resumeWorkflow(activeRunId, { cancelled: true });
-        } catch (error) {
-          console.error(error);
-        }
-      }
-
       resetProgress();
       onResetToMain();
     };

--- a/apps/drive-integration/src/locations/Page/components/modals/ConfirmCancelModal.tsx
+++ b/apps/drive-integration/src/locations/Page/components/modals/ConfirmCancelModal.tsx
@@ -4,9 +4,15 @@ interface ConfirmCancelModalProps {
   isOpen: boolean;
   onConfirm: () => void;
   onCancel: () => void;
+  isConfirming?: boolean;
 }
 
-export const ConfirmCancelModal = ({ isOpen, onConfirm, onCancel }: ConfirmCancelModalProps) => {
+export const ConfirmCancelModal = ({
+  isOpen,
+  onConfirm,
+  onCancel,
+  isConfirming = false,
+}: ConfirmCancelModalProps) => {
   return (
     <Modal isShown={isOpen} onClose={onCancel} size="medium" shouldCloseOnOverlayClick={false}>
       {() => (
@@ -16,10 +22,14 @@ export const ConfirmCancelModal = ({ isOpen, onConfirm, onCancel }: ConfirmCance
             <Paragraph>No entries will be created and you'll need to start over.</Paragraph>
           </Modal.Content>
           <Modal.Controls>
-            <Button onClick={onCancel} variant="secondary">
+            <Button onClick={onCancel} variant="secondary" isDisabled={isConfirming}>
               Keep creating
             </Button>
-            <Button onClick={onConfirm} variant="primary">
+            <Button
+              onClick={onConfirm}
+              variant="primary"
+              isLoading={isConfirming}
+              isDisabled={isConfirming}>
               Cancel without creating
             </Button>
           </Modal.Controls>

--- a/apps/drive-integration/src/locations/Page/components/review/ReviewPage.tsx
+++ b/apps/drive-integration/src/locations/Page/components/review/ReviewPage.tsx
@@ -280,6 +280,7 @@ export const ReviewPage = ({
         isOpen={isConfirmCancelModalOpen}
         onConfirm={() => void handleConfirmCancel()}
         onCancel={() => !isCancelling && setIsConfirmCancelModalOpen(false)}
+        isConfirming={isCancelling}
       />
       <SummaryModal
         isOpen={isSummaryModalOpen}

--- a/apps/drive-integration/test/locations/Page/components/modals/ConfirmCancelModal.spec.tsx
+++ b/apps/drive-integration/test/locations/Page/components/modals/ConfirmCancelModal.spec.tsx
@@ -72,4 +72,47 @@ describe('ConfirmCancelModal', () => {
       ).toBeNull();
     });
   });
+
+  it('disables both buttons when isConfirming is true', async () => {
+    render(
+      <ConfirmCancelModal
+        isOpen={true}
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+        isConfirming={true}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Keep creating' })).toHaveProperty(
+        'disabled',
+        true
+      );
+      // When isLoading, F36 injects a spinner so the accessible name gains "Loading…".
+      // Query by partial text match to stay resilient to the spinner label.
+      expect(screen.getByRole('button', { name: /Cancel without creating/ })).toHaveProperty(
+        'disabled',
+        true
+      );
+    });
+  });
+
+  it('does not call onConfirm or onCancel when isConfirming is true and buttons are clicked', async () => {
+    render(
+      <ConfirmCancelModal
+        isOpen={true}
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+        isConfirming={true}
+      />
+    );
+
+    await waitFor(() => screen.getByRole('button', { name: 'Keep creating' }));
+
+    fireEvent.click(screen.getByRole('button', { name: /Cancel without creating/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Keep creating' }));
+
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(onCancel).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Purpose
When a user clicked "Cancel without creating" in the confirm cancel modal, the button remained active during the async cancellation, allowing multiple clicks. The `isConfirming` state was also dead code in `ModalOrchestrator` because `activeRunId` is never set at the pre-review stage.

Found this while working on [INTEG-4233](https://contentful.atlassian.net/browse/INTEG-4233)

## Summary
- Added `isConfirming` prop to `ConfirmCancelModal` — disables both buttons and shows a loading spinner on the confirm button while in-flight
- Removed dead `async`/`resumeWorkflow` block from `ModalOrchestrator.handleConfirmCancel` (`activeRunId` is always `null` at that point; it's only set after the workflow reaches `PENDING_REVIEW` and the user is already in `ReviewPage`)
- Wired `isConfirming={isCancelling}` in `ReviewPage`, where the async work actually happens via `onCancelReview`
- Added two tests covering the disabled state and click-blocking behaviour when `isConfirming` is true

## Test plan
 Sync Cancel

https://github.com/user-attachments/assets/cbfc9d3a-0897-4c3e-bdef-84beaf6438db

Async Cancel

https://github.com/user-attachments/assets/04d36b74-b749-497a-b601-1ca56ae23065


Generated with [Claude Code](https://claude.com/claude-code)

[INTEG-4233]: https://contentful.atlassian.net/browse/INTEG-4233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ