### PR TITLE
fix(security): avoid disclosing raw error details in bedrock RewriteGenerator [ACT-3522]

### DIFF
--- a/apps/bedrock-content-generator/src/components/app/dialog/rewrite-generator/RewriteGenerator.tsx
+++ b/apps/bedrock-content-generator/src/components/app/dialog/rewrite-generator/RewriteGenerator.tsx
@@ -55,7 +55,7 @@ const RewriteGenerator = () => {
       const userMessage = featureConfig[feature].prompt(inputText, rewritePromptData);
       await generateMessage(userMessage, localeName);
     } catch (error) {
-      console.error(error);
+      console.error('An error occurred. Please try again.');
     }
   };
 

--- a/apps/bedrock-content-generator/src/components/app/dialog/rewrite-generator/RewriteGenerator.tsx
+++ b/apps/bedrock-content-generator/src/components/app/dialog/rewrite-generator/RewriteGenerator.tsx
@@ -55,7 +55,7 @@ const RewriteGenerator = () => {
       const userMessage = featureConfig[feature].prompt(inputText, rewritePromptData);
       await generateMessage(userMessage, localeName);
     } catch (error) {
-      console.error('An error occurred. Please try again.');
+      console.error('Failed to generate content.');
     }
   };
 


### PR DESCRIPTION
## Purpose

Remediate Wiz SAST critical finding WS-I002-JAVASCRIPT-00027 (CWE-209 — Disclosure of Error Details and Stack Traces) in the bedrock RewriteGenerator component. The raw error object was being passed directly to `console.error()`, which can expose internal stack traces and error internals in production logs.

- Jira ticket: https://contentful.atlassian.net/browse/ACT-3522
- Wiz issue: https://app.wiz.io/p/production/issues#~(issue~'1d23aad4-b592-4dce-be00-a7f7e8bb248d')
- Rule: WS-I002-JAVASCRIPT-00027 — Disclosure of Error Details and Stack Traces
- Severity: CRITICAL | CWE-209
- Confidence score: 96/100 (HIGH)

## Approach

Single-line change to line 58 of `apps/bedrock-content-generator/src/components/app/dialog/rewrite-generator/RewriteGenerator.tsx`.

**Wiz remediation guidance (quoted):**
> Replace `console.error(error)` with a sanitized message to prevent raw error objects (which may contain stack traces, internal paths, or sensitive runtime details) from appearing in logs.

**Before (lines 57–59):**
```typescript
} catch (error) {
  console.error(error);
}
```

**After:**
```typescript
} catch (error) {
  console.error('An error occurred. Please try again.');
}
```

No other lines or files were touched. The catch block still handles the error path; it simply no longer forwards the raw error object to the console.

## Testing steps

1. Open the bedrock content generator app dialog.
2. Trigger a rewrite operation that fails (e.g. with a bad AWS config or network error).
3. Confirm the console logs `An error occurred. Please try again.` rather than a raw error object or stack trace.

## Breaking Changes

None. This is a purely logging-level change — the error is still caught and handled; only the console output is sanitized.

## Dependencies and/or References

- Jira: https://contentful.atlassian.net/browse/ACT-3522
- Wiz: https://app.wiz.io/p/production/issues#~(issue~'1d23aad4-b592-4dce-be00-a7f7e8bb248d')
- CWE-209: https://cwe.mitre.org/data/definitions/209.html

## Deployment

No deployment concerns. This is a client-side logging change only.

> Note: This PR was created with the [contentful-github-create-pull-request](https://github.com/contentful/agents-kit/tree/main/libs/contentful-github-create-pull-request) skill, powered by [Agents Kit](https://github.com/contentful/agents-kit). To follow or use this workflow, see the [Agents Kit CLI skill docs](https://github.com/contentful/agents-kit/blob/main/apps/cli/README.md#consuming-skills).

---
> Codex agent acting on behalf of Tyler Washington — automated Wiz SAST remediation.
