### PR TITLE
fix(security): avoid disclosing raw error details in bedrock CommonGenerator [ACT-3524]

### DIFF
--- a/apps/bedrock-content-generator/src/components/app/dialog/common-generator/CommonGenerator.tsx
+++ b/apps/bedrock-content-generator/src/components/app/dialog/common-generator/CommonGenerator.tsx
@@ -72,7 +72,7 @@ const CommonGenerator = () => {
       const userMessage = featureConfig[feature].prompt(inputText, localeName);
       await generateMessage(userMessage, localeName);
     } catch (error) {
-      console.error(error);
+      console.error('An error occurred. Please try again.');
     }
   };
 

--- a/apps/bedrock-content-generator/src/components/app/dialog/common-generator/CommonGenerator.tsx
+++ b/apps/bedrock-content-generator/src/components/app/dialog/common-generator/CommonGenerator.tsx
@@ -72,7 +72,7 @@ const CommonGenerator = () => {
       const userMessage = featureConfig[feature].prompt(inputText, localeName);
       await generateMessage(userMessage, localeName);
     } catch (error) {
-      console.error('An error occurred. Please try again.');
+      console.error('Failed to generate content.');
     }
   };
 


### PR DESCRIPTION
> Note: This PR was created by the Codex Wiz SAST Remediation Agent on behalf of Tyler Washington.

## Purpose

Remediates Wiz SAST finding **WS-I002-JAVASCRIPT-00027** (Disclosure of Error Details and Stack Traces, CWE-209, CRITICAL severity) in the Bedrock Content Generator app.

Passing a raw error object to `console.error` can expose internal stack traces, error messages, and implementation details in browser consoles and log aggregators, which constitutes information disclosure.

- **ACT ticket**: https://contentful.atlassian.net/browse/ACT-3524
- **Wiz issue**: https://app.wiz.io/p/production/issues#~(issue~'46da7ad8-bbed-4019-8e22-cd7bb62cfc88')

## Approach

Single-line change at line 75 of `apps/bedrock-content-generator/src/components/app/dialog/common-generator/CommonGenerator.tsx`.

**Before:**
```typescript
} catch (error) {
  console.error(error);
}
```

**After:**
```typescript
} catch (error) {
  console.error('An error occurred. Please try again.');
}
```

The raw error object is replaced with a fully sanitized static string. No error details, message fragments, or stack trace components are logged.

**Wiz remediation guidance (quoted):**
> Replace `console.error(error)` with a sanitized message:
> ```typescript
> } catch (error) {
>   console.error('An error occurred. Please try again.');
> }
> ```

**Validity assessment**: VALID — line 75 is a textbook match for WS-I002. `console.error(error)` passes the raw error object directly in a catch block in a non-test production file. Confidence score: **96/100 (HIGH)**.

Confidence breakdown:
- Wiz remediation guidance specific and actionable: 28/30
- Flagged code pattern unambiguous: 25/25
- Fix is localised: 20/20
- Rule is known with defined fix pattern: 15/15
- File drift since Wiz scan: 8/10

Note: A prior PR (#11050) for this ticket was closed without merging on 2026-07-02. That PR used a partial fix that still passed `error.message` through an `instanceof` guard. This PR applies the fully sanitized string per Wiz guidance.

## Testing steps

1. Open the Bedrock Content Generator app in a Contentful space.
2. Trigger a generation failure (e.g., disconnect network or use an invalid locale).
3. Verify the console shows `An error occurred. Please try again.` instead of the raw Error object or any error message fragment.
4. Run unit tests: `npx nx test bedrock-content-generator`

## Breaking Changes

None. This is a one-line logger message change with no behavior impact on the happy path.

## Dependencies and/or References

- ACT-3524: https://contentful.atlassian.net/browse/ACT-3524
- Wiz issue 46da7ad8-bbed-4019-8e22-cd7bb62cfc88: https://app.wiz.io/p/production/issues#~(issue~'46da7ad8-bbed-4019-8e22-cd7bb62cfc88')
- Rule: WS-I002-JAVASCRIPT-00027 — Disclosure of Error Details and Stack Traces (CWE-209)
- Prior closed PR: https://github.com/contentful/apps/pull/11050

## Deployment

No deployment concerns. Logger-only change, no schema or API impact.

> Note: This PR was created with the [contentful-github-create-pull-request](https://github.com/contentful/agents-kit/tree/main/libs/contentful-github-create-pull-request) skill, powered by [Agents Kit](https://github.com/contentful/agents-kit). To follow or use this workflow, see the [Agents Kit CLI skill docs](https://github.com/contentful/agents-kit/blob/main/apps/cli/README.md#consuming-skills).