### PR TITLE
feat: add bulk-exporter app []

### DIFF
--- a/apps/bulk-exporter/.gitignore
+++ b/apps/bulk-exporter/.gitignore
@@ -1,0 +1,44 @@
+# Dependencies
+node_modules/
+.pnp
+.pnp.js
+
+# Testing
+coverage/
+*.lcov
+.nyc_output
+
+# Production
+dist/
+build/
+
+# Misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.fleet
+.code-workspace
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+
+# Vercel
+.vercel
+
+# Netlify
+.netlify

--- a/apps/bulk-exporter/LICENSE
+++ b/apps/bulk-exporter/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Miles Stauffer
+Copyright (c) 2026 Contentful GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/apps/bulk-exporter/LICENSE
+++ b/apps/bulk-exporter/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Miles Stauffer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/bulk-exporter/README.md
+++ b/apps/bulk-exporter/README.md
@@ -1,21 +1,8 @@
-# Bulk Entry CSV Exporter for Contentful
+# Entry Exporter for Contentful
 
-A powerful Contentful App that allows you to export unlimited entries from any content type to **5 different formats** (CSV, JSON, XLSX, XML, YAML), bypassing the 40-entry limitation of the Contentful web interface.
-
-## One-Click Install
-
-Already a Contentful user? Install the hosted app directly into your space — no clone, build, or upload required:
-
-**[Install Bulk Entry CSV Exporter in Contentful](https://app.contentful.com/deeplink?link=apps&id=79UvsbUCbJnMSGgk7GxrbN)**
-
-After clicking, choose the space you want to install it into and follow Contentful's prompts. The app will appear under **Apps** in your space's navigation.
-
----
+A Contentful App that allows you to export unlimited entries from any content type to **5 different formats** (CSV, JSON, XLSX, XML, YAML), bypassing the 40-entry limitation of the Contentful web interface.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
-[![Install in Contentful](https://img.shields.io/badge/Install-Contentful-2478CC?logo=contentful&logoColor=white)](https://app.contentful.com/deeplink?link=apps&id=79UvsbUCbJnMSGgk7GxrbN)
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/contentful-labs/se-bulk-exporter)
-[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/contentful-labs/se-bulk-exporter)
 
 ## Features
 
@@ -57,16 +44,12 @@ After clicking, choose the space you want to install it into and follow Contentf
 
 ## Quick Start
 
-### Option A: One-Click Install (Recommended)
-
-[Install Bulk Entry CSV Exporter in Contentful](https://app.contentful.com/deeplink?link=apps&id=79UvsbUCbJnMSGgk7GxrbN) — pick your space and follow the prompts. You're done in under a minute.
-
-### Option B: Local Development / Self-Hosted
+### Local Development
 
 1. **Clone the repository**
 ```bash
-git clone https://github.com/contentful-labs/se-bulk-exporter.git
-cd se-bulk-exporter
+git clone https://github.com/contentful/apps.git
+cd apps/apps/bulk-exporter
 ```
 
 2. **Install dependencies**
@@ -92,16 +75,16 @@ The app will be available at `http://localhost:5173`
 
 ### Deploy to Production
 
-#### Option 1: Upload to Contentful (Hosted by Contentful)
+#### Upload to Contentful (Hosted by Contentful)
 
-Contentful can host your app directly. This is the simplest deployment method.
+Contentful can host your app directly.
 
 **Requirements:**
 - Max bundle size: 10MB (this app is ~1.6MB)
 - Max files: 500 (this app has 2 files)
 - Must include `index.html` at the root level
 
-**Manual Upload (Recommended):**
+**Manual Upload:**
 
 1. **Build the app**
    ```bash
@@ -109,72 +92,34 @@ Contentful can host your app directly. This is the simplest deployment method.
    ```
 
 2. **Open your app in Contentful**
-   - Go to https://app.contentful.com/deeplink?link=app-definition-list
-   - Find your "Bulk Entry CSV Exporter" app
+   - Go to your app definition in the Contentful web app
    - Click to open the app details
 
 3. **Upload the bundle**
-   - Click on the **"Bundles"** tab (NOT the "Hosting" tab)
-   - You'll see a drop zone for uploading files
-   - **IMPORTANT**: Open your `dist/` folder locally and **select BOTH files**:
+   - Click on the **"Bundles"** tab
+   - **Select BOTH files** from your `dist/` folder:
      - `index.html`
      - `bundle.js`
    - **Drag and drop these 2 files** directly into the drop zone
-   - Do NOT drag the `dist/` folder itself - only the files inside it
-   - The upload will automatically create a new AppBundle
    - Add a comment when prompted (e.g., "Production release v1.0")
 
 4. **Activate the bundle**
    - After upload completes, click **"Activate"** next to your newly created bundle
-   - Your app is now live!
 
-**CLI Upload (Alternative):**
+**CLI Upload:**
 
 ```bash
-npm run upload -- --organization-id YOUR_ORG_ID --definition-id YOUR_APP_DEF_ID --token YOUR_CMA_TOKEN
+npm run deploy -- --organization-id YOUR_ORG_ID --definition-id YOUR_APP_DEF_ID --token YOUR_CMA_TOKEN
 ```
 
 **Finding your IDs:**
 - **Organization ID**: Found in your Contentful organization settings URL
-- **App Definition ID**: Found in your app's URL in Contentful (the ID in the app management page URL)
+- **App Definition ID**: Found in your app's URL in Contentful
 - **CMA Token**: Create one at https://app.contentful.com/account/profile/cma_tokens
 
 **Troubleshooting:**
 - If the app doesn't load, ensure `index.html` is at the root level (not in a subfolder)
-- Make sure you uploaded the files FROM inside `dist/`, not the `dist/` folder itself
 - The build must use relative paths (already configured with `base: './'` in `vite.config.ts`)
-
-#### Option 2: Deploy to Vercel
-
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/contentful-labs/se-bulk-exporter)
-
-1. Click the button above or manually:
-```bash
-npm install -g vercel
-npm run build
-vercel --prod
-```
-
-2. Update your Contentful app definition with the Vercel URL
-
-#### Option 2: Deploy to Netlify
-
-[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/contentful-labs/se-bulk-exporter)
-
-1. Click the button above or manually:
-```bash
-npm run build
-# Upload the dist/ folder to Netlify
-```
-
-#### Option 3: Other Hosting
-
-Build the app and deploy the `dist` folder to any static hosting provider:
-
-```bash
-npm run build
-# Deploy the dist/ folder
-```
 
 ## Usage
 
@@ -199,7 +144,7 @@ npm run build
 ### Search & Preview
 
 1. Navigate to **Apps** in the Contentful web UI main menu
-2. Select **Bulk Entry CSV Exporter**
+2. Select **Entry Exporter**
 3. Use the tabbed interface to build your query:
 
 #### Filter Tab
@@ -228,26 +173,7 @@ npm run build
    - Use "Select All" to select all visible results
    - Click "Export Selected" button to export only checked entries
 6. Click **Estimate Count** to see the total number of matching entries
-7. Click **Export to CSV** to download all matching entries
-
-### Workflow Options
-
-**Option 1: Select and Export Specific Entries**
-1. Search for entries
-2. Review the results
-3. Check the entries you want
-4. Click "Export Selected (X)" button
-
-**Option 2: Export All Matching Entries**
-1. Configure your filters
-2. Select locales and fields in Output tab
-3. Click "Export to CSV" to export all matching results
-
-**Option 3: Quick Export Without Preview**
-1. Configure your filters
-2. Select locales and fields
-3. Skip the search preview
-4. Click "Export to CSV" directly
+7. Click **Export** to download all matching entries
 
 ## Export Formats
 
@@ -280,7 +206,7 @@ All 5 formats use clean, human-readable formatting with **consistent data struct
 - **Dates**: YYYY-MM-DD format
 - **Rich Text**: Plain text extraction when possible
 - **Objects**: JSON strings for complex data
-- **User Names**: Resolved to full names (e.g., "Miles Stauffer") instead of IDs
+- **User Names**: Resolved to full names instead of IDs
 
 ### Format-Specific Features
 
@@ -310,7 +236,7 @@ All 5 formats use clean, human-readable formatting with **consistent data struct
 **Example CSV output:**
 ```csv
 Entry ID,Created,Updated,Last Updated By,Status,Content Type,Title (en-US),Author,Tags
-abc123,2024-01-01,2024-01-02,Miles Stauffer,Published,Blog Post,Hello World,author456,tech; blog; tips
+abc123,2024-01-01,2024-01-02,Jane Smith,Published,Blog Post,Hello World,author456,tech; blog; tips
 ```
 
 ## Rate Limits
@@ -336,7 +262,7 @@ The Contentful web UI limits CSV exports to 40 entries. This app uses the Conten
 2. **Paginate Efficiently**: Fetch entries at 1000 per page using `skip`/`limit`, then switch to cursor-based pagination (`sys.createdAt[gt]`) after 9000 entries
 3. **Respect Rate Limits**: Throttle requests to ~8 req/s (paid tier) with 4 concurrent in-flight requests
 4. **Retry on Failures**: Automatically retry on `429` responses with exponential backoff (max 3 retries), respecting `X-Contentful-RateLimit-Reset` header
-5. **Flatten Complex Data**: Transform all entry fields (including localized fields, references, rich text, and arrays) into flat CSV rows with clean formatting
+5. **Flatten Complex Data**: Transform all entry fields (including localized fields, references, rich text, and arrays) into flat rows with clean formatting
 
 ## Technical Details
 
@@ -346,6 +272,7 @@ The Contentful web UI limits CSV exports to 40 entries. This app uses the Conten
 - **UI**: Forma 36 (Contentful's design system)
 - **SDK**: Contentful App SDK + React Apps Toolkit
 - **CSV**: PapaParse for serialization
+- **Excel**: ExcelJS for XLSX generation
 - **Testing**: Vitest + React Testing Library
 
 ### Project Structure
@@ -464,26 +391,6 @@ npm run test:coverage
 - Hard refresh your browser (Cmd+Shift+R on Mac, Ctrl+Shift+R on Windows)
 - This clears the cached version and loads the latest code
 
-## Contributing
-
-Contributions are welcome! Please feel free to submit a Pull Request.
-
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
-
 ## License
 
 MIT
-
-## Support
-
-For issues or questions:
-- Open an issue on [GitHub](https://github.com/contentful-labs/se-bulk-exporter/issues)
-- Check the [Troubleshooting](#troubleshooting) section above
-
-## Acknowledgments
-
-Built with the [Contentful App Framework](https://www.contentful.com/developers/docs/extensibility/app-framework/) and [Forma 36](https://f36.contentful.com/).

--- a/apps/bulk-exporter/README.md
+++ b/apps/bulk-exporter/README.md
@@ -62,12 +62,12 @@ npm install
 npm run dev
 ```
 
-The app will be available at `http://localhost:5173`
+The app will be available at `http://localhost:3000`
 
 4. **Configure in Contentful**
    - Go to **Settings** > **Apps** > **Manage apps** > **Create app**
    - Choose **App hosted by you**
-   - Set the app URL to `http://localhost:5173`
+   - Set the app URL to `http://localhost:3000`
    - Enable these locations:
      - **App configuration screen**
      - **Page**

--- a/apps/bulk-exporter/README.md
+++ b/apps/bulk-exporter/README.md
@@ -1,0 +1,489 @@
+# Bulk Entry CSV Exporter for Contentful
+
+A powerful Contentful App that allows you to export unlimited entries from any content type to **5 different formats** (CSV, JSON, XLSX, XML, YAML), bypassing the 40-entry limitation of the Contentful web interface.
+
+## One-Click Install
+
+Already a Contentful user? Install the hosted app directly into your space — no clone, build, or upload required:
+
+**[Install Bulk Entry CSV Exporter in Contentful](https://app.contentful.com/deeplink?link=apps&id=79UvsbUCbJnMSGgk7GxrbN)**
+
+After clicking, choose the space you want to install it into and follow Contentful's prompts. The app will appear under **Apps** in your space's navigation.
+
+---
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
+[![Install in Contentful](https://img.shields.io/badge/Install-Contentful-2478CC?logo=contentful&logoColor=white)](https://app.contentful.com/deeplink?link=apps&id=79UvsbUCbJnMSGgk7GxrbN)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/contentful-labs/se-bulk-exporter)
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/contentful-labs/se-bulk-exporter)
+
+## Features
+
+### Export Formats
+- **5 Export Formats**: CSV, JSON, XLSX (Excel), XML, YAML
+- **Quick Export Dropdown**: One-click export with smart defaults (all locales, all fields)
+- **Advanced Export**: Full control via Output tab (custom locales, fields, filename)
+- **Format-Specific Optimizations**: UTF-8 BOM for CSV/Excel, pretty-printed JSON, compressed XLSX
+
+### Search & Filtering
+- **Contentful-Style Results Table**: Search results display matches Contentful's native interface with:
+  - Entry name (using the content type's display field)
+  - Content type name (human-readable, not ID)
+  - Updated date (YYYY-MM-DD format)
+  - Last updated by (user's full name)
+  - Status (draft/changed/published)
+- **Global Search**: Search across all content types or filter by specific content type
+- **Select Entries**: Check individual entries or select all, then export only your selection
+- **Rich Filtering**:
+  - Full-text search across all fields
+  - Status filters (published, draft, changed, archived)
+  - Date range filters (created and updated dates)
+  - Tag filters (any or all tags)
+  - Taxonomy concept filters (any or all concepts)
+  - Advanced field-level filters with multiple operators
+
+### Export Capabilities
+- **Unlimited Entries**: Export any number of entries from any content type
+- **Smart Field Selection**: Auto-selects the title and key fields when you pick a content type
+- **One-Click Presets**: Essentials, Content, References, All, Clear
+- **Reorderable Columns**: Use up/down arrows to set the exact column order in your export
+- **Field Search**: Filter long field lists by name or ID
+- **Per-User Preferences**: Field selection, format, and filename are saved in your browser via `localStorage` so each user keeps their own settings
+- **Locale Selection**: Export all locales or select specific ones
+- **Clean Output**: Human-readable column headers and formatted data
+- **Rate-Limit Aware**: Automatic throttling (8 req/s for paid tier) and retry logic
+- **Real-Time Progress**: Track export progress with cancel support
+- **Contextual Help**: Tooltips on every control explaining features
+
+## Quick Start
+
+### Option A: One-Click Install (Recommended)
+
+[Install Bulk Entry CSV Exporter in Contentful](https://app.contentful.com/deeplink?link=apps&id=79UvsbUCbJnMSGgk7GxrbN) — pick your space and follow the prompts. You're done in under a minute.
+
+### Option B: Local Development / Self-Hosted
+
+1. **Clone the repository**
+```bash
+git clone https://github.com/contentful-labs/se-bulk-exporter.git
+cd se-bulk-exporter
+```
+
+2. **Install dependencies**
+```bash
+npm install
+```
+
+3. **Start the development server**
+```bash
+npm run dev
+```
+
+The app will be available at `http://localhost:5173`
+
+4. **Configure in Contentful**
+   - Go to **Settings** > **Apps** > **Manage apps** > **Create app**
+   - Choose **App hosted by you**
+   - Set the app URL to `http://localhost:5173`
+   - Enable these locations:
+     - **App configuration screen**
+     - **Page**
+   - Save and install the app to your space
+
+### Deploy to Production
+
+#### Option 1: Upload to Contentful (Hosted by Contentful)
+
+Contentful can host your app directly. This is the simplest deployment method.
+
+**Requirements:**
+- Max bundle size: 10MB (this app is ~1.6MB)
+- Max files: 500 (this app has 2 files)
+- Must include `index.html` at the root level
+
+**Manual Upload (Recommended):**
+
+1. **Build the app**
+   ```bash
+   npm run build
+   ```
+
+2. **Open your app in Contentful**
+   - Go to https://app.contentful.com/deeplink?link=app-definition-list
+   - Find your "Bulk Entry CSV Exporter" app
+   - Click to open the app details
+
+3. **Upload the bundle**
+   - Click on the **"Bundles"** tab (NOT the "Hosting" tab)
+   - You'll see a drop zone for uploading files
+   - **IMPORTANT**: Open your `dist/` folder locally and **select BOTH files**:
+     - `index.html`
+     - `bundle.js`
+   - **Drag and drop these 2 files** directly into the drop zone
+   - Do NOT drag the `dist/` folder itself - only the files inside it
+   - The upload will automatically create a new AppBundle
+   - Add a comment when prompted (e.g., "Production release v1.0")
+
+4. **Activate the bundle**
+   - After upload completes, click **"Activate"** next to your newly created bundle
+   - Your app is now live!
+
+**CLI Upload (Alternative):**
+
+```bash
+npm run upload -- --organization-id YOUR_ORG_ID --definition-id YOUR_APP_DEF_ID --token YOUR_CMA_TOKEN
+```
+
+**Finding your IDs:**
+- **Organization ID**: Found in your Contentful organization settings URL
+- **App Definition ID**: Found in your app's URL in Contentful (the ID in the app management page URL)
+- **CMA Token**: Create one at https://app.contentful.com/account/profile/cma_tokens
+
+**Troubleshooting:**
+- If the app doesn't load, ensure `index.html` is at the root level (not in a subfolder)
+- Make sure you uploaded the files FROM inside `dist/`, not the `dist/` folder itself
+- The build must use relative paths (already configured with `base: './'` in `vite.config.ts`)
+
+#### Option 2: Deploy to Vercel
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/contentful-labs/se-bulk-exporter)
+
+1. Click the button above or manually:
+```bash
+npm install -g vercel
+npm run build
+vercel --prod
+```
+
+2. Update your Contentful app definition with the Vercel URL
+
+#### Option 2: Deploy to Netlify
+
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/contentful-labs/se-bulk-exporter)
+
+1. Click the button above or manually:
+```bash
+npm run build
+# Upload the dist/ folder to Netlify
+```
+
+#### Option 3: Other Hosting
+
+Build the app and deploy the `dist` folder to any static hosting provider:
+
+```bash
+npm run build
+# Deploy the dist/ folder
+```
+
+## Usage
+
+### Two Ways to Export
+
+**Quick Export (Casual Users)**
+1. Set your filters in the Filter tab
+2. Click the **Export** dropdown button
+3. Select your format (CSV, JSON, XLSX, XML, or YAML)
+4. Done! File downloads with smart defaults
+
+**Advanced Export (Power Users)**
+1. Configure filters in Filter tab
+2. Add field-level filters in Advanced tab (optional)
+3. Go to **Output tab** to customize:
+   - Export format
+   - Specific locales
+   - Specific fields
+   - Custom filename
+4. Click **Export** dropdown → **Advanced (use Output tab)**
+
+### Search & Preview
+
+1. Navigate to **Apps** in the Contentful web UI main menu
+2. Select **Bulk Entry CSV Exporter**
+3. Use the tabbed interface to build your query:
+
+#### Filter Tab
+- Select a content type (or "Any" for global search)
+- Enter full-text search terms
+- Choose status (any, published, draft, changed, archived)
+- Set created/updated date ranges
+- Select sort order
+
+#### Tags & Taxonomy Tab
+- Select tags (match any or all)
+- Select taxonomy concepts (match any or all)
+
+#### Advanced Tab
+- Add field-level filters with operators (equals, not equals, exists, contains, etc.)
+- Add multiple filters for complex queries
+
+#### Output Tab
+- Select which locales to include in the export
+- **Choose specific fields** to export (leave empty for all fields)
+- Preview the filename
+
+4. Click **Search & Preview** to see matching entries in a table
+5. **Use checkboxes** to select specific entries you want to export
+   - Check individual rows
+   - Use "Select All" to select all visible results
+   - Click "Export Selected" button to export only checked entries
+6. Click **Estimate Count** to see the total number of matching entries
+7. Click **Export to CSV** to download all matching entries
+
+### Workflow Options
+
+**Option 1: Select and Export Specific Entries**
+1. Search for entries
+2. Review the results
+3. Check the entries you want
+4. Click "Export Selected (X)" button
+
+**Option 2: Export All Matching Entries**
+1. Configure your filters
+2. Select locales and fields in Output tab
+3. Click "Export to CSV" to export all matching results
+
+**Option 3: Quick Export Without Preview**
+1. Configure your filters
+2. Select locales and fields
+3. Skip the search preview
+4. Click "Export to CSV" directly
+
+## Export Formats
+
+All 5 formats use clean, human-readable formatting with **consistent data structure** across all export methods (quick export, advanced export, or selected entries).
+
+### Available Formats
+
+| Format | Best For | File Extension |
+|--------|----------|----------------|
+| **CSV** | Excel, Google Sheets, data analysis | `.csv` |
+| **JSON** | APIs, web applications, JavaScript | `.json` |
+| **XLSX** | Microsoft Excel, formatted spreadsheets | `.xlsx` |
+| **XML** | Enterprise systems, SOAP APIs, legacy integrations | `.xml` |
+| **YAML** | Configuration files, DevOps, CI/CD pipelines | `.yaml` |
+
+### CSV Format Details
+
+#### Column Headers
+- **Entry ID**: Unique identifier for the entry
+- **Created**: Entry creation date (YYYY-MM-DD)
+- **Updated**: Last update date (YYYY-MM-DD)
+- **Last Updated By**: Full name of the user who last updated the entry
+- **Status**: "Draft" or "Published"
+- **Content Type**: Human-readable content type name
+- **Field columns**: Use field names from your content model (e.g., "Title (en-US)", "Author")
+
+#### Data Formatting (CSV)
+- **References**: Just the entry/asset ID (e.g., `abc123`)
+- **Arrays**: Semicolon-separated values (e.g., `tech; blog; tips`)
+- **Dates**: YYYY-MM-DD format
+- **Rich Text**: Plain text extraction when possible
+- **Objects**: JSON strings for complex data
+- **User Names**: Resolved to full names (e.g., "Miles Stauffer") instead of IDs
+
+### Format-Specific Features
+
+**JSON**
+- Pretty-printed with 2-space indentation
+- Array of objects, one per entry
+- Native data types preserved (strings, numbers, booleans)
+
+**XLSX (Excel)**
+- Auto-sized columns based on content
+- Compression enabled for smaller file sizes
+- Single worksheet named "Entries"
+- Opens directly in Microsoft Excel
+
+**XML**
+- Structured with proper XML declaration
+- Root element: `<entries>`
+- Each entry in `<entry>` element with field sub-elements
+- Field names converted to valid XML element names
+
+**YAML**
+- Human-readable with 2-space indentation
+- 120-character line width
+- Array of objects format
+- Perfect for configuration management
+
+**Example CSV output:**
+```csv
+Entry ID,Created,Updated,Last Updated By,Status,Content Type,Title (en-US),Author,Tags
+abc123,2024-01-01,2024-01-02,Miles Stauffer,Published,Blog Post,Hello World,author456,tech; blog; tips
+```
+
+## Rate Limits
+
+Contentful enforces API rate limits:
+
+- **Free tier**: ~7 requests per second
+- **Paid tiers**: ~10 requests per second
+
+This app is configured for paid tier usage and automatically throttles requests to ~8 req/s. It handles `429` responses by:
+
+1. Reading the `X-Contentful-RateLimit-Reset` header (seconds to wait)
+2. Applying exponential backoff if the header is missing
+3. Retrying up to 3 times before failing
+
+Large exports may take several minutes. Progress is shown in real-time.
+
+## How It Works
+
+The Contentful web UI limits CSV exports to 40 entries. This app uses the Content Management API directly to:
+
+1. **Search & Preview**: Build your query using the search form and preview matching entries in a paginated list
+2. **Paginate Efficiently**: Fetch entries at 1000 per page using `skip`/`limit`, then switch to cursor-based pagination (`sys.createdAt[gt]`) after 9000 entries
+3. **Respect Rate Limits**: Throttle requests to ~8 req/s (paid tier) with 4 concurrent in-flight requests
+4. **Retry on Failures**: Automatically retry on `429` responses with exponential backoff (max 3 retries), respecting `X-Contentful-RateLimit-Reset` header
+5. **Flatten Complex Data**: Transform all entry fields (including localized fields, references, rich text, and arrays) into flat CSV rows with clean formatting
+
+## Technical Details
+
+### Tech Stack
+
+- **Framework**: React 18 + TypeScript + Vite
+- **UI**: Forma 36 (Contentful's design system)
+- **SDK**: Contentful App SDK + React Apps Toolkit
+- **CSV**: PapaParse for serialization
+- **Testing**: Vitest + React Testing Library
+
+### Project Structure
+
+```
+src/
+  index.tsx                 # App entry point, location router
+  locations/
+    ConfigScreen.tsx        # App configuration screen
+    Page.tsx                # Main export UI
+  components/
+    ExportForm.tsx          # Search form with filters
+    ProgressPanel.tsx       # Progress bar and status
+    ResultsList.tsx         # Search results table
+  lib/
+    throttle.ts             # Token bucket + 429 retry logic
+    paginate.ts             # CMA pagination (skip + cursor)
+    flatten.ts              # Entry → flat row transformation
+    csv.ts                  # PapaParse wrapper
+    exporter.ts             # Main orchestrator
+    queryBuilder.ts         # Filter query builder
+  lib/__tests__/            # Unit tests
+```
+
+### Key Implementation Details
+
+**Throttling (`lib/throttle.ts`)**
+
+- Token bucket algorithm at ~8 req/s (configured for paid tier)
+- Concurrency limited to 4 simultaneous requests
+- Automatically retries `429` responses
+- Respects `X-Contentful-RateLimit-Reset` header
+
+**Pagination (`lib/paginate.ts`)**
+
+- Uses `skip`/`limit` for the first 9000 entries
+- Switches to `sys.createdAt[gt]` cursor pagination beyond 9000
+- Async generator for memory-efficient streaming
+
+**Flattening (`lib/flatten.ts`)**
+
+- Creates readable column headers ("Title (en-US)" instead of "title.en-US")
+- Formats references as IDs only (cleaner than "Link:Entry:ID")
+- Extracts plain text from rich text when possible
+- Semicolon-separates arrays for better CSV readability
+
+## Development
+
+### Prerequisites
+
+- Node.js 18+ and npm
+- A Contentful space with appropriate permissions
+
+### Setup
+
+```bash
+# Install dependencies
+npm install
+
+# Run development server
+npm run dev
+
+# Run tests
+npm test
+
+# Run tests with UI
+npm run test:ui
+
+# Type check
+npm run type-check
+
+# Build for production
+npm run build
+```
+
+### Running Tests
+
+```bash
+# Run all tests
+npm test
+
+# Run tests in watch mode
+npm run test:watch
+
+# Run tests with coverage
+npm run test:coverage
+```
+
+## Troubleshooting
+
+**Export fails with "Failed to load content types"**
+
+- Ensure the app has the correct permissions in your space
+- Check that you're logged in to Contentful
+
+**Export is very slow**
+
+- Large exports with 10,000+ entries can take several minutes
+- Rate limits are enforced; the app will throttle automatically
+- Consider filtering by date range to reduce the export size
+
+**CSV doesn't open correctly in Excel**
+
+- The CSV includes a UTF-8 BOM for Excel compatibility
+- Try opening with "Import Data" instead of double-clicking
+- Alternatively, use Google Sheets which handles UTF-8 CSVs natively
+
+**"Too many requests" errors**
+
+- The app automatically handles `429` responses
+- If you see this error, wait a minute and try again
+- You may be running other API-heavy operations simultaneously
+
+**Search results show IDs instead of names**
+
+- Hard refresh your browser (Cmd+Shift+R on Mac, Ctrl+Shift+R on Windows)
+- This clears the cached version and loads the latest code
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.
+
+1. Fork the repository
+2. Create your feature branch (`git checkout -b feature/amazing-feature`)
+3. Commit your changes (`git commit -m 'Add some amazing feature'`)
+4. Push to the branch (`git push origin feature/amazing-feature`)
+5. Open a Pull Request
+
+## License
+
+MIT
+
+## Support
+
+For issues or questions:
+- Open an issue on [GitHub](https://github.com/contentful-labs/se-bulk-exporter/issues)
+- Check the [Troubleshooting](#troubleshooting) section above
+
+## Acknowledgments
+
+Built with the [Contentful App Framework](https://www.contentful.com/developers/docs/extensibility/app-framework/) and [Forma 36](https://f36.contentful.com/).

--- a/apps/bulk-exporter/contentful-app.json
+++ b/apps/bulk-exporter/contentful-app.json
@@ -1,0 +1,12 @@
+{
+  "id": "TODO_PROD_APP_DEF_ID",
+  "name": "Entry Exporter",
+  "locations": [
+    {
+      "location": "app-config"
+    },
+    {
+      "location": "page"
+    }
+  ]
+}

--- a/apps/bulk-exporter/eslint.config.js
+++ b/apps/bulk-exporter/eslint.config.js
@@ -1,0 +1,55 @@
+import js from '@eslint/js';
+import typescript from '@typescript-eslint/eslint-plugin';
+import typescriptParser from '@typescript-eslint/parser';
+import react from 'eslint-plugin-react';
+import reactHooks from 'eslint-plugin-react-hooks';
+
+export default [
+  js.configs.recommended,
+  {
+    files: ['src/**/*.{ts,tsx}'],
+    languageOptions: {
+      parser: typescriptParser,
+      parserOptions: {
+        ecmaFeatures: { jsx: true },
+      },
+      globals: {
+        window: 'readonly',
+        document: 'readonly',
+        console: 'readonly',
+        process: 'readonly',
+        HTMLInputElement: 'readonly',
+        setTimeout: 'readonly',
+        setInterval: 'readonly',
+        clearInterval: 'readonly',
+      },
+    },
+    plugins: {
+      '@typescript-eslint': typescript,
+      react,
+      'react-hooks': reactHooks,
+    },
+    rules: {
+      ...typescript.configs['flat/recommended'].rules,
+      ...react.configs.recommended.rules,
+      ...reactHooks.configs.recommended.rules,
+      'react/react-in-jsx-scope': 'off',
+      'react/no-unescaped-entities': 'off',
+      'no-unused-vars': 'off',
+      'react-hooks/exhaustive-deps': 'off',
+    },
+    settings: {
+      react: { version: 'detect' },
+    },
+  },
+  {
+    files: ['src/**/*.spec.{ts,tsx}', 'src/**/*.test.{ts,tsx}'],
+    languageOptions: {
+      globals: {
+        describe: 'readonly',
+        it: 'readonly',
+        expect: 'readonly',
+      },
+    },
+  },
+];

--- a/apps/bulk-exporter/eslint.config.js
+++ b/apps/bulk-exporter/eslint.config.js
@@ -18,6 +18,10 @@ export default [
         document: 'readonly',
         console: 'readonly',
         process: 'readonly',
+        React: 'readonly',
+        Blob: 'readonly',
+        URL: 'readonly',
+        Storage: 'readonly',
         HTMLInputElement: 'readonly',
         setTimeout: 'readonly',
         setInterval: 'readonly',
@@ -36,7 +40,11 @@ export default [
       'react/react-in-jsx-scope': 'off',
       'react/no-unescaped-entities': 'off',
       'no-unused-vars': 'off',
+      'no-undef': 'off',
       'react-hooks/exhaustive-deps': 'off',
+    },
+    linterOptions: {
+      reportUnusedDisableDirectives: false,
     },
     settings: {
       react: { version: 'detect' },

--- a/apps/bulk-exporter/index.html
+++ b/apps/bulk-exporter/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Bulk Entry Exporter</title>
+    <link rel="preconnect" href="https://cdn.f36.contentful.com" />
+    <link rel="stylesheet" href="https://cdn.f36.contentful.com/font/geist/geist.css" />
+    <style>
+      * { box-sizing: border-box; }
+      body { margin: 0; background-color: #ffffff; font-family: 'Geist', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; font-feature-settings: 'ss05' 1; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/index.tsx"></script>
+  </body>
+</html>

--- a/apps/bulk-exporter/package-lock.json
+++ b/apps/bulk-exporter/package-lock.json
@@ -1,0 +1,11208 @@
+{
+  "name": "se-bulk-exporter",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "se-bulk-exporter",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/app-sdk": "^4.32.0",
+        "@contentful/f36-components": "^6.12.0",
+        "@contentful/f36-icons": "^6.12.0",
+        "@contentful/f36-tokens": "^5.1.0",
+        "@contentful/react-apps-toolkit": "^1.2.16",
+        "@emotion/css": "^11.13.5",
+        "emotion": "^11.0.0",
+        "js-yaml": "^4.1.1",
+        "papaparse": "^5.4.1",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "xlsx": "^0.18.5",
+        "xml-js": "^1.6.11"
+      },
+      "devDependencies": {
+        "@contentful/app-scripts": "^1.26.0",
+        "@testing-library/jest-dom": "^6.6.3",
+        "@testing-library/react": "^16.1.0",
+        "@testing-library/user-event": "^14.5.2",
+        "@types/js-yaml": "^4.0.9",
+        "@types/node": "^22.10.2",
+        "@types/papaparse": "^5.3.15",
+        "@types/react": "^18.3.18",
+        "@types/react-dom": "^18.3.5",
+        "@types/xml-js": "^0.9.0",
+        "@typescript-eslint/eslint-plugin": "^8.18.2",
+        "@typescript-eslint/parser": "^8.18.2",
+        "@vitejs/plugin-react": "^4.3.4",
+        "eslint": "^9.18.0",
+        "eslint-plugin-react": "^7.37.3",
+        "eslint-plugin-react-hooks": "^5.1.0",
+        "jsdom": "^25.0.1",
+        "typescript": "^5.7.2",
+        "vite": "^6.0.5",
+        "vitest": "^2.1.8"
+      }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@contentful/app-scripts": {
+      "version": "1.33.2",
+      "resolved": "https://registry.npmjs.org/@contentful/app-scripts/-/app-scripts-1.33.2.tgz",
+      "integrity": "sha512-qn0hd79wUJ+ndWG7S2KokX8WUn9naXxtZMyNrfisX5XERuVDnhF3zveDsKdOZy2gf8+0OrsN45gykurlP7vxDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
+        "@esbuild-plugins/node-modules-polyfill": "^0.2.2",
+        "@segment/analytics-node": "^2.0.0",
+        "adm-zip": "0.5.16",
+        "axios": "^1.7.9",
+        "bottleneck": "2.19.5",
+        "chalk": "4.1.2",
+        "commander": "12.1.0",
+        "contentful-management": "11.47.2",
+        "dotenv": "16.4.7",
+        "esbuild": "^0.25.1",
+        "ignore": "7.0.3",
+        "inquirer": "8.2.6",
+        "lodash": "4.17.21",
+        "merge-options": "^3.0.4",
+        "open": "8.4.2",
+        "ora": "5.4.1",
+        "tiged": "^2.12.7",
+        "zod": "^3.24.1"
+      },
+      "bin": {
+        "contentful-app-scripts": "lib/bin.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/@contentful/app-sdk": {
+      "version": "4.56.0",
+      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.56.0.tgz",
+      "integrity": "sha512-1v3lnDd9Y7fo4d5cOZqTfaWwDzBrMDH/MOCY6zkCozjtPaS8NlLT5HKPYE5r8bjzHCMn51FViHpfWahKWLlejg==",
+      "license": "MIT",
+      "dependencies": {
+        "contentful-management": "^12.3.1"
+      }
+    },
+    "node_modules/@contentful/app-sdk/node_modules/contentful-management": {
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-12.3.2.tgz",
+      "integrity": "sha512-HyajRHdfJ3RIsyRZlbv/EJ+2K9w5VNdskP42KTLKSijnkRIZh/SMq06AT0wuVtt2IYj5JiS6lr0ZhfpV828tqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/rich-text-types": "^16.6.1",
+        "axios": "^1.15.0",
+        "contentful-sdk-core": "^9.4.4",
+        "fast-copy": "^3.0.0",
+        "globals": "^15.15.0",
+        "process": "^0.11.10"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@contentful/app-sdk/node_modules/globals": {
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@contentful/f36-accordion": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-6.12.0.tgz",
+      "integrity": "sha512-O3qak22nRVPX4Id46n9+UUD8jRZEJ3UIAH4xdShq7T9p7MJqEQXU7kTy1zKVU37MeLsfIOFAmK87E8aMXxbMmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-collapse": "^6.12.0",
+        "@contentful/f36-core": "^6.12.0",
+        "@contentful/f36-icons": "^6.12.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.12.0",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-accordion/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-asset": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-6.12.0.tgz",
+      "integrity": "sha512-Nqmxl5BEOrz2YtGYsugP68auMAy7imyCpTmBZh7IuvdhWZ2vr51OXByahZyGnc5Qgy5jgZzDorFpl3rLnNiWQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.12.0",
+        "@contentful/f36-icon": "^6.12.0",
+        "@contentful/f36-icons": "^6.12.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.12.0",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-asset/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-autocomplete": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-6.12.0.tgz",
+      "integrity": "sha512-uxPqOywes2Ut9wlp/OmSFfu8rgFjE9wMRBfgR6B0LhkwmlmsCJYxprNaAwpwk2FVij/eamqXUJPvw+12B0GmEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^6.12.0",
+        "@contentful/f36-core": "^6.12.0",
+        "@contentful/f36-forms": "^6.12.0",
+        "@contentful/f36-icons": "^6.12.0",
+        "@contentful/f36-popover": "^6.12.0",
+        "@contentful/f36-skeleton": "^6.12.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.12.0",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5",
+        "downshift": "^9.0.10"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-autocomplete/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-avatar": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-avatar/-/f36-avatar-6.12.0.tgz",
+      "integrity": "sha512-TgbhsnR+KZdG9bIYkTFo5gDU7blRE1kiBA3MSUdoJUDTdM8E72n4Vma5Z0jT9dJSkkAOQmpe/dAo9sGiY3ZXJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.12.0",
+        "@contentful/f36-image": "^6.12.0",
+        "@contentful/f36-menu": "^6.12.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-tooltip": "^6.12.0",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-avatar/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-badge": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-6.12.0.tgz",
+      "integrity": "sha512-RVE5xTg5ZYaEOcjy4A1FPJ7jh82aps2ENCHbVbZRzosZ/FUGdc2Rj9jEXGT/02wsoBuI3auqKEY+m1I17A5z5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.12.0",
+        "@contentful/f36-icons": "^6.12.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-badge/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-button": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-6.12.0.tgz",
+      "integrity": "sha512-aYf1MRGBjg3SFpMD5QAX87ZUCxdCIUrdUugash8/amo68HJmLhR21oN3ge3tkKVsR7U9LxSG1azdWCUe4L5Y0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.12.0",
+        "@contentful/f36-spinner": "^6.12.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-tooltip": "^6.12.0",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-button/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-card": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-6.12.0.tgz",
+      "integrity": "sha512-U43F6cvnecUTamapQzsPIV7Ky8ZwDeO5eoMkN+XnJOUiBXgsijY4TJ0yl0I3jePZZRAJPSTvibX+B5oUCfzbFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-asset": "^6.12.0",
+        "@contentful/f36-badge": "^6.12.0",
+        "@contentful/f36-button": "^6.12.0",
+        "@contentful/f36-core": "^6.12.0",
+        "@contentful/f36-drag-handle": "^6.12.0",
+        "@contentful/f36-icon": "^6.12.0",
+        "@contentful/f36-icons": "^6.12.0",
+        "@contentful/f36-menu": "^6.12.0",
+        "@contentful/f36-skeleton": "^6.12.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-tooltip": "^6.12.0",
+        "@contentful/f36-typography": "^6.12.0",
+        "@emotion/css": "^11.13.5",
+        "truncate": "^3.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-card/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-collapse": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-6.12.0.tgz",
+      "integrity": "sha512-7E4lIQM3r/hFB56G0m+o+I+FKWuNxZ9OhmSfL5EgYkxikoOgKNTkidEisAame+JijfISEbpdM8IKps2rGDAn6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.12.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-collapse/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-components": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-6.12.0.tgz",
+      "integrity": "sha512-OsBnlanePLqSwRfA3JFiL44RcMl0v2pcRdMD2OYnC1Cu2s19a8oTVomzK8V2amYiMSxpRTHXWVr5HlBjdrTh9w==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-accordion": "^6.12.0",
+        "@contentful/f36-asset": "^6.12.0",
+        "@contentful/f36-autocomplete": "^6.12.0",
+        "@contentful/f36-avatar": "^6.12.0",
+        "@contentful/f36-badge": "^6.12.0",
+        "@contentful/f36-button": "^6.12.0",
+        "@contentful/f36-card": "^6.12.0",
+        "@contentful/f36-collapse": "^6.12.0",
+        "@contentful/f36-copybutton": "^6.12.0",
+        "@contentful/f36-core": "^6.12.0",
+        "@contentful/f36-datepicker": "^6.12.0",
+        "@contentful/f36-datetime": "^6.12.0",
+        "@contentful/f36-drag-handle": "^6.12.0",
+        "@contentful/f36-empty-state": "^6.12.0",
+        "@contentful/f36-entity-list": "^6.12.0",
+        "@contentful/f36-forms": "^6.12.0",
+        "@contentful/f36-header": "^6.12.0",
+        "@contentful/f36-icon": "^6.12.0",
+        "@contentful/f36-icons": "^6.12.0",
+        "@contentful/f36-image": "^6.12.0",
+        "@contentful/f36-layout": "^6.12.0",
+        "@contentful/f36-list": "^6.12.0",
+        "@contentful/f36-menu": "^6.12.0",
+        "@contentful/f36-modal": "^6.12.0",
+        "@contentful/f36-multiselect": "^6.12.0",
+        "@contentful/f36-navlist": "^6.12.0",
+        "@contentful/f36-note": "^6.12.0",
+        "@contentful/f36-notification": "^6.12.0",
+        "@contentful/f36-pagination": "^6.12.0",
+        "@contentful/f36-pill": "^6.12.0",
+        "@contentful/f36-popover": "^6.12.0",
+        "@contentful/f36-progress-stepper": "^6.12.0",
+        "@contentful/f36-skeleton": "^6.12.0",
+        "@contentful/f36-spinner": "^6.12.0",
+        "@contentful/f36-table": "^6.12.0",
+        "@contentful/f36-tabs": "^6.12.0",
+        "@contentful/f36-text-link": "^6.12.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-tooltip": "^6.12.0",
+        "@contentful/f36-typography": "^6.12.0",
+        "@contentful/f36-usage-card": "^6.12.0",
+        "@contentful/f36-usage-count": "^6.12.0",
+        "@contentful/f36-utils": "^6.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.3.0 || >=19.1.0",
+        "@types/react-dom": "^18.3.0 || >=19.1.0",
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-copybutton": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-6.12.0.tgz",
+      "integrity": "sha512-RM8Lr0UEIJxRQKat4VYOr3PFfvNR6AZvAHyjk5KPpTF/CUhcRIKKVA5Kf+JF090NIJe3wTUnfIEaYZfKavPwPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^6.12.0",
+        "@contentful/f36-core": "^6.12.0",
+        "@contentful/f36-icons": "^6.12.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-tooltip": "^6.12.0",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-copybutton/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-core": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-6.12.0.tgz",
+      "integrity": "sha512-0aBKf2KEqz10TsWQ29eS9gtLiqPNrTPGvMUOcb6j92gf0XVcwqfjWtdtat3rIcSF5O1Y0SQQYboGCOCv/7K2Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5",
+        "@emotion/react": "^11.14.0",
+        "csstype": "^3.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-core/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-datepicker": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-6.12.0.tgz",
+      "integrity": "sha512-zOHSwkWTsk7tVRXut5BkqECqFHd5v4+VWY/Fyy1QjaowDjpWeQePUK7maWc5kEOffXzaozw8puD/cTzUjfd+jA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^6.12.0",
+        "@contentful/f36-core": "^6.12.0",
+        "@contentful/f36-forms": "^6.12.0",
+        "@contentful/f36-icons": "^6.12.0",
+        "@contentful/f36-popover": "^6.12.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.12.0",
+        "@emotion/css": "^11.13.5",
+        "date-fns": "^2.28.0",
+        "react-day-picker": "^8.7.1",
+        "react-focus-lock": "^2.9.1"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-datepicker/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-datetime": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-6.12.0.tgz",
+      "integrity": "sha512-1mMna+hcSCgbsNCwCgmtkb8ZKQDwtY8b6BMCNVTkuWW/k2hOuQNvKUyGi5xkaIv1f7n1r1vDlWigPfHQqrDpGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.12.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5",
+        "dayjs": "^1.11.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-datetime/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-drag-handle": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-6.12.0.tgz",
+      "integrity": "sha512-0hALPfsc5nEl8RrPJgoFBDpFl2L/hRHs4roZgCrFATGrectI2sLLMppYNoe9hp51BSMn/sJX8nXLH/W7ggZO6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.12.0",
+        "@contentful/f36-icons": "^6.12.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-drag-handle/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-empty-state": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-6.12.0.tgz",
+      "integrity": "sha512-zvo0fpBBCrmMc4FSMkXlYxunmTcOZDqoRjSPqz4Q0KdTNOoISpIgb0B8FVfFaHrG024FPAYR101ViDeaIJ2l2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.12.0",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-empty-state/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-entity-list": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-6.12.0.tgz",
+      "integrity": "sha512-pWq+QhxBCA9BNFK5F5cbq74grjbiEI6vEVvTDX3aojfg8Xinf+viyokJZBZBNdiXOi8YwvnORML4g85A3fK9+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-badge": "^6.12.0",
+        "@contentful/f36-button": "^6.12.0",
+        "@contentful/f36-core": "^6.12.0",
+        "@contentful/f36-drag-handle": "^6.12.0",
+        "@contentful/f36-icon": "^6.12.0",
+        "@contentful/f36-icons": "^6.12.0",
+        "@contentful/f36-menu": "^6.12.0",
+        "@contentful/f36-skeleton": "^6.12.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.12.0",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-entity-list/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-forms": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-6.12.0.tgz",
+      "integrity": "sha512-TJPpdpPv5Ruyg9ezpnFVfa/XCASPMbLkIfKUhJYnq1f1vJrX3ZrXPWHo1xV96j5z8jzkAu+JfSLz1e8mAnx5qQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.12.0",
+        "@contentful/f36-icon": "^6.12.0",
+        "@contentful/f36-icons": "^6.12.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.12.0",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-forms/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-header": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-header/-/f36-header-6.12.0.tgz",
+      "integrity": "sha512-pZGGZ25ys9Wsb5CWZoxOJWU78DRF/POn7DZXGsQuFd47rnmBJhbSevxn80AUslTGh48Gegn/6zFHdhStKQ+dPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^6.12.0",
+        "@contentful/f36-core": "^6.12.0",
+        "@contentful/f36-icons": "^6.12.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.12.0",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-header/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-icon": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-6.12.0.tgz",
+      "integrity": "sha512-uOqI1OumSA+RMIAodLQ4ZKu9TG6JlCU/ytHO74mgUWaYWSazmNILY9COxHW0oBQhts/twvSRcFFJbGw/cmAF4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.12.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5",
+        "@phosphor-icons/react": "2.1.8"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-icon/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-icons": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-6.12.0.tgz",
+      "integrity": "sha512-aBTQnn/UFdhulbU5aMsUBU3RG5jpO0S65c4lkS6bpbG2LwNB9M0ds2TARfphsy0Bym7z3R4bU7cQP2Ry7DaPsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.12.0",
+        "@contentful/f36-icon": "^6.12.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5",
+        "@phosphor-icons/react": "2.1.8"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-icons/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-image": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-image/-/f36-image-6.12.0.tgz",
+      "integrity": "sha512-WZdlFO3org6UznmtbVj1cjpSOSuRRa9ROLPNwTQnlvi4dXgXmIbnnIKF76K4VPHihVTiPdtzhnu07b5O4BYbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.12.0",
+        "@contentful/f36-skeleton": "^6.12.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-image/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-layout": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-layout/-/f36-layout-6.12.0.tgz",
+      "integrity": "sha512-7Jx7LsuIEvgVFftjspGOBHUntpXyubmufwKqRGpe5n05TFOj8p8junXMzoiSbfNXMYKo/Bs++SeemajNbEGnHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.12.0",
+        "@contentful/f36-header": "^6.12.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-layout/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-list": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-6.12.0.tgz",
+      "integrity": "sha512-JsLfkqzqL2yBAMHeCeFKEStkVWk+TLON4MTMiJcTY+d+VBzTuUGskc7JlRzg8IswsAQfUTztYtHRoc2wali0mA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.12.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-list/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-menu": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-6.12.0.tgz",
+      "integrity": "sha512-zreW4bdjfXid0YDJK0n9HY/aGVjmKxA+W4cRIWbMg9VIr4joT+qcPMO+Re3v0I6vTFPLSYgzehVmmfjj6tQsuw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.12.0",
+        "@contentful/f36-icons": "^6.12.0",
+        "@contentful/f36-popover": "^6.12.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.12.0",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5",
+        "@floating-ui/dom": "^1.7.4",
+        "@floating-ui/react": "^0.27.16"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-menu/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-modal": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-6.12.0.tgz",
+      "integrity": "sha512-Ii/UlfilNM5Ab8txy4jBH8BPjfSqYrJ2W1P3Dk52lQRxw2S0HNKIZovsMBwKmpbWEtmTMvo7te9d/k8vLOAmGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^6.12.0",
+        "@contentful/f36-core": "^6.12.0",
+        "@contentful/f36-icons": "^6.12.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.12.0",
+        "@emotion/css": "^11.13.5",
+        "@types/react-modal": "^3.16.3",
+        "react-modal": "^3.16.3"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-modal/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-multiselect": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-multiselect/-/f36-multiselect-6.12.0.tgz",
+      "integrity": "sha512-oOh0YqHkYy/m8hKYGpni1e6CDLSLZXW3N6VDvWkb1sIWJXB0ll/Y13Wh4nYjtUTHAMqEStIrGLKgZbkOP59+ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.1",
+        "@contentful/f36-button": "^6.12.0",
+        "@contentful/f36-core": "^6.12.0",
+        "@contentful/f36-forms": "^6.12.0",
+        "@contentful/f36-icons": "^6.12.0",
+        "@contentful/f36-popover": "^6.12.0",
+        "@contentful/f36-skeleton": "^6.12.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-tooltip": "^6.12.0",
+        "@contentful/f36-typography": "^6.12.0",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-multiselect/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-navlist": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-navlist/-/f36-navlist-6.12.0.tgz",
+      "integrity": "sha512-EoF02CiTW6EmdfhtyvDxp22WWwkwZctfZ/c0K8Z88VsxjITMHrNCKfDhYELkA87LIROh2bFI1OvYPpVnItJCiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.12.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-navlist/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-note": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-6.12.0.tgz",
+      "integrity": "sha512-n5BoGJN5T/YRt+2nNAGOY2lUmZwGYJy8rq4zBc9JXsAk9zTWcMWgY9qCoOnhXQH+mBcD1KtvXoz8H6C3SI0aYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^6.12.0",
+        "@contentful/f36-core": "^6.12.0",
+        "@contentful/f36-icon": "^6.12.0",
+        "@contentful/f36-icons": "^6.12.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.12.0",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-note/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-notification": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-6.12.0.tgz",
+      "integrity": "sha512-UoZOuT6T5v2GVbVHj6ghKdn2stHyfuNBb+6Ksxos02D/uOrrcLc6zjyUETGRz0MiqESj9Bc/aVoABS0rjdmifQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^6.12.0",
+        "@contentful/f36-core": "^6.12.0",
+        "@contentful/f36-icons": "^6.12.0",
+        "@contentful/f36-text-link": "^6.12.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.12.0",
+        "@emotion/css": "^11.13.5",
+        "react-animate-height": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-notification/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-pagination": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-6.12.0.tgz",
+      "integrity": "sha512-PNM0edjYYTbbJ2wKxQx8dj7l6rcGBswJ3Y8wQblB/+UP4ZDJCxLX44byaC0BcyjTh4BoUO51QdHbF3wNh6sEXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^6.12.0",
+        "@contentful/f36-core": "^6.12.0",
+        "@contentful/f36-forms": "^6.12.0",
+        "@contentful/f36-icons": "^6.12.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.12.0",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-pagination/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-pill": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-6.12.0.tgz",
+      "integrity": "sha512-YI8CwkG7RYLGD1I6dMVks/IgLuW0KV8/6BI7BMAwY7FX+IpMXoct2qatvwaEPh7DZfjDoqMyPJufWccgY0hwbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^6.12.0",
+        "@contentful/f36-core": "^6.12.0",
+        "@contentful/f36-drag-handle": "^6.12.0",
+        "@contentful/f36-icons": "^6.12.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-tooltip": "^6.12.0",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-pill/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-popover": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-6.12.0.tgz",
+      "integrity": "sha512-isYFDK1RKQ+iQq826rv8fm1wxAwADc6xwvSkZPpzCbgg8WxkLwfzqz87Y9UXByerACoShTgxHbTwBYsXKoFnWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.12.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5",
+        "@floating-ui/dom": "^1.7.4",
+        "@floating-ui/react": "^0.27.16"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-popover/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-progress-stepper": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-progress-stepper/-/f36-progress-stepper-6.12.0.tgz",
+      "integrity": "sha512-4T33RwQV3awIVkFmpVFoMhtLZ5wfKpIT5BQQt3lG+ESRSbJTOqf92NHOv6PCNKzuu8/hJgu3t03g4Nqqzy32Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^6.12.0",
+        "@contentful/f36-core": "^6.12.0",
+        "@contentful/f36-icons": "^6.12.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.12.0",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-progress-stepper/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-skeleton": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-6.12.0.tgz",
+      "integrity": "sha512-EP/fVauKqx6MXGOxKn9684XLx6DpyAcANP+p05/XUR24wPsvtKQytTWI+zwaDZ23dwXhVXKpS9W3h1Lx5YjGHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.12.0",
+        "@contentful/f36-table": "^6.12.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-skeleton/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-spinner": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-6.12.0.tgz",
+      "integrity": "sha512-6/lek4/KM4VMJ5gz7Cxv4YJGX1HA22S9F9KcVCJ3qJdgxgEJ07bX0qq7pK4GMP8047fu1H08gsw7cp8pJYju7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.12.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-spinner/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-table": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-6.12.0.tgz",
+      "integrity": "sha512-1u3FsGa5Z4sjYHTPMYjCTKf3Q64tz/qxawcmYPwKFNaoDJlAKd7oc6TT+C1FL9FFbQE1c9LHABn65CPIbsvz/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.12.0",
+        "@contentful/f36-icons": "^6.12.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.12.0",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-table/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-tabs": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-6.12.0.tgz",
+      "integrity": "sha512-Hgbkd+pfF3PoY8dQfNZXp2ptWsZuTQHOZMyCFTq15Xu97yzld/Uy0k35SDv+DTK6lDqrKbUwYg869PJXb6Zaig==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.12.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5",
+        "@radix-ui/react-tabs": "^1.1.12"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-tabs/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-text-link": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-6.12.0.tgz",
+      "integrity": "sha512-l5HF2f3FWOG3+UhN8y/9B5z9aiK8P+AW83sML2Vhm7tK46CHzAOzUVHG+YqpKw2437NtOKtoXxmTjGnFhEsZgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.12.0",
+        "@contentful/f36-icons": "^6.12.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-text-link/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-tokens": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-5.1.0.tgz",
+      "integrity": "sha512-7++MPQiizK6qLhPkilWIKqM5Mhdr199tK7dL4iZ689iTwA82uvXXOojJr+0wVOurG2Odb+6/3WLe1XdveDZHEA==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-tooltip": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-6.12.0.tgz",
+      "integrity": "sha512-mpNzs4BnS66ZuK3TpD/EO2WSa+3iJxlkJIDghWdUyo0K/X6NXTHCHdGmPpeCd5TYTORtjcC4F3AAPS4riZfYBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.12.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5",
+        "@floating-ui/dom": "^1.7.4",
+        "@floating-ui/react": "^0.27.16"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-tooltip/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-typography": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-6.12.0.tgz",
+      "integrity": "sha512-6v6d+BKjQrOB7xWq8xaKXtHzjDb4XMlJVoHLMA5LaJB4WUnoLDN3c57icBTRjTS4Xa+R5ew5XfI9LgULMsSAzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.12.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-typography/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-usage-card": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-usage-card/-/f36-usage-card-6.12.0.tgz",
+      "integrity": "sha512-vyblQmKYzaST0laP9w28mWblc2mANfo5//vYBi2czpYenJgERLT3nU9/EUvLMJnzKrkokJVd66M0yFeizjTXXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-card": "^6.12.0",
+        "@contentful/f36-core": "^6.12.0",
+        "@contentful/f36-icons": "^6.12.0",
+        "@contentful/f36-text-link": "^6.12.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-tooltip": "^6.12.0",
+        "@contentful/f36-typography": "^6.12.0",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-usage-card/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-usage-count": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-usage-count/-/f36-usage-count-6.12.0.tgz",
+      "integrity": "sha512-zcfJDsAVZFXFhU9PfcdpgQlqovLKK8dLcm5ccLJqO+WQmG7bqgq4OX5fmRKp/RtKYaAPEfjATGEDw7JGHH4kEw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.12.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.12.0",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-usage-count/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-utils": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-utils/-/f36-utils-6.1.2.tgz",
+      "integrity": "sha512-gaG+q5NHVEfDzCEGoK12/+8Y1VODPO8k/DyrZjCIOTxTK9rXZ5l1xESMbnMAbwHnz2zXoLkkzI0QGCChW6xrpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-tokens": "^6.1.2",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-utils/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/react-apps-toolkit": {
+      "version": "1.2.22",
+      "resolved": "https://registry.npmjs.org/@contentful/react-apps-toolkit/-/react-apps-toolkit-1.2.22.tgz",
+      "integrity": "sha512-xlVHpHfUTQlwWqCfprJh9Q7nt/hRBNnhdaobyGBlVeiN7qPG4O0vsbIoDt86rB1uryki91g0uLtKLtQNdQWjeA==",
+      "license": "MIT",
+      "dependencies": {
+        "contentful-management": ">=7.30.0"
+      },
+      "peerDependencies": {
+        "@contentful/app-sdk": ">=4.0.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@contentful/rich-text-types": {
+      "version": "16.8.5",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.8.5.tgz",
+      "integrity": "sha512-q18RJuJCOuYveGiCIjE5xLCQc5lZ3L2Qgxrlg/H2YEobDFqdtmklazRi1XwEWaK3tMg6yVXBzKKkQfLB4qW14A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+      "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/serialize": "^1.3.3",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/cache": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/css": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.13.5.tgz",
+      "integrity": "sha512-wQdD0Xhkn3Qy2VNcIzbLP9MR8TafI0MJb7BEAXKp+w4+XqErksWR4OXomuDzPsN4InLdGhVe6EYcn2ZIUCpB8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.13.5",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2"
+      }
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/react": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
+      "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "hoist-non-react-statics": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/serialize": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/sheet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
+      "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emotion/utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/weak-memoize": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
+      "license": "MIT"
+    },
+    "node_modules/@esbuild-plugins/node-globals-polyfill": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-globals-polyfill/-/node-globals-polyfill-0.2.3.tgz",
+      "integrity": "sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "esbuild": "*"
+      }
+    },
+    "node_modules/@esbuild-plugins/node-modules-polyfill": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-modules-polyfill/-/node-modules-polyfill-0.2.2.tgz",
+      "integrity": "sha512-LXV7QsWJxRuMYvKbiznh+U1ilIop3g2TeKRzUxOG5X3YITc8JyyTa90BmLwqqv0YnX4v32CSlG+vsziZp9dMvA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "rollup-plugin-node-polyfills": "^0.2.1"
+      },
+      "peerDependencies": {
+        "esbuild": "*"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.19",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.19.tgz",
+      "integrity": "sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.8",
+        "@floating-ui/utils": "^0.2.11",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@lukeed/csprng": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
+      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@lukeed/uuid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@lukeed/uuid/-/uuid-2.0.1.tgz",
+      "integrity": "sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/csprng": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@phosphor-icons/react": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.1.8.tgz",
+      "integrity": "sha512-RxJlAkErO+t50DsY82ga9RGOULK6Jux0MdmXqvDjtOzG3PYQFz6rjdUU2q06lPMMbJTT+d+qurKYmF7i2Uv74A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8",
+        "react-dom": ">= 16.8"
+      }
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.4.tgz",
+      "integrity": "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.11.tgz",
+      "integrity": "sha512-djW9+zeg137KQdlPtmE8xnaD+K2rcXXMWFrSg0hsmYZ6HRbdTA7tDHFgpaW9+huWVEu0RCabL+985T4TA0BE7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-slot": "1.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.4.tgz",
+      "integrity": "sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.2.tgz",
+      "integrity": "sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz",
+      "integrity": "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.6.tgz",
+      "integrity": "sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.7.tgz",
+      "integrity": "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.14.tgz",
+      "integrity": "sha512-8Qcnx9447tx/aCBgw6Jenfqg4Skq+vqab9mCBmuGNipIS5YXvL275wbKEu7+ICYHIlAPgCduUMJH1XOYewKF6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-collection": "1.1.11",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.0.tgz",
+      "integrity": "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.16.tgz",
+      "integrity": "sha512-v3Ab2l7z6U7tRB4xA0IyKdq0OsqaO1o9ZjsIEoKKnSZ/l96mZz8aCTX0NCXw+YVHJXr8Km4d+Mn6/Q8YjXa+gw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-roving-focus": "1.1.14",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz",
+      "integrity": "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.3.tgz",
+      "integrity": "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
+      "integrity": "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@segment/analytics-core": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-core/-/analytics-core-1.8.2.tgz",
+      "integrity": "sha512-5FDy6l8chpzUfJcNlIcyqYQq4+JTUynlVoCeCUuVz+l+6W0PXg+ljKp34R4yLVCcY5VVZohuW+HH0VLWdwYVAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/uuid": "^2.0.0",
+        "@segment/analytics-generic-utils": "1.2.0",
+        "dset": "^3.1.4",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@segment/analytics-generic-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-generic-utils/-/analytics-generic-utils-1.2.0.tgz",
+      "integrity": "sha512-DfnW6mW3YQOLlDQQdR89k4EqfHb0g/3XvBXkovH1FstUN93eL1kfW9CsDcVQyH3bAC5ZsFyjA/o/1Q2j0QeoWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@segment/analytics-node": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-node/-/analytics-node-2.3.0.tgz",
+      "integrity": "sha512-fOXLL8uY0uAWw/sTLmezze80hj8YGgXXlAfvSS6TUmivk4D/SP0C0sxnbpFdkUzWg2zT64qWIZj26afEtSnxUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/uuid": "^2.0.0",
+        "@segment/analytics-core": "1.8.2",
+        "@segment/analytics-generic-utils": "1.2.0",
+        "buffer": "^6.0.3",
+        "jose": "^5.1.0",
+        "node-fetch": "^2.6.7",
+        "tslib": "^2.4.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/papaparse": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@types/papaparse/-/papaparse-5.5.2.tgz",
+      "integrity": "sha512-gFnFp/JMzLHCwRf7tQHrNnfhN4eYBVYYI897CGX4MY1tzY9l2aLkVyx2IlKZ/SAqDbB3I1AOZW5gTMGGsqWliA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/react-modal": {
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/@types/react-modal/-/react-modal-3.16.3.tgz",
+      "integrity": "sha512-xXuGavyEGaFQDgBv4UVm8/ZsG+qxeQ7f77yNrW3n+1J6XAstUy5rYHeIHPh1KzsGc6IkCIdu6lQ2xWzu1jBTLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/xml-js": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@types/xml-js/-/xml-js-0.9.0.tgz",
+      "integrity": "sha512-HKI9ipjXRCV/gfrSTU+A0J5r4VNOtNVxyPkS1XEqlpWNT9L0vpN0PsB+TTx1y4UR5m9v0y6EzDmke+zUOOcKow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.1.tgz",
+      "integrity": "sha512-BOziFIfE+6osHO9FoJG4zjoHUcvI7fTNBSpdAwrNH0/TLvzjsk2oo8XSSOT2HhqUyhZPfHv4UOffoJ9oEEQ7Ag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.59.1",
+        "@typescript-eslint/type-utils": "8.59.1",
+        "@typescript-eslint/utils": "8.59.1",
+        "@typescript-eslint/visitor-keys": "8.59.1",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.59.1",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.1.tgz",
+      "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.59.1",
+        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/typescript-estree": "8.59.1",
+        "@typescript-eslint/visitor-keys": "8.59.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.1.tgz",
+      "integrity": "sha512-+MuHQlHiEr00Of/IQbE/MmEoi44znZHbR/Pz7Opq4HryUOlRi+/44dro9Ycy8Fyo+/024IWtw8m4JUMCGTYxDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.59.1",
+        "@typescript-eslint/types": "^8.59.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.1.tgz",
+      "integrity": "sha512-LwuHQI4pDOYVKvmH2dkaJo6YZCSgouVgnS/z7yBPKBMvgtBvyLqiLy9Z6b7+m/TRcX1NFYUqZetI5Y+aT4GEfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/visitor-keys": "8.59.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.1.tgz",
+      "integrity": "sha512-/0nEyPbX7gRsk0Uwfe4ALwwgxuA66d/l2mhRDNlAvaj4U3juhUtJNq0DsY8M2AYwwb9rEq2hrC3IcIcEt++iJA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.1.tgz",
+      "integrity": "sha512-klWPBR2ciQHS3f++ug/mVnWKPjBUo7icEL3FAO1lhAR1Z1i5NQYZ1EannMSRYcq5qCv5wNALlXr6fksRHyYl7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/typescript-estree": "8.59.1",
+        "@typescript-eslint/utils": "8.59.1",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.1.tgz",
+      "integrity": "sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.1.tgz",
+      "integrity": "sha512-OUd+vJS05sSkOip+BkZ/2NS8RMxrAAJemsC6vU3kmfLyeaJT0TftHkV9mcx2107MmsBVXXexhVu4F0TZXyMl4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.59.1",
+        "@typescript-eslint/tsconfig-utils": "8.59.1",
+        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/visitor-keys": "8.59.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.1.tgz",
+      "integrity": "sha512-3pIeoXhCeYH9FSCBI8P3iNwJlGuzPlYKkTlen2O9T1DSeeg8UG8jstq6BLk+Mda0qup7mgk4z4XL4OzRaxZ8LA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.59.1",
+        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/typescript-estree": "8.59.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.1.tgz",
+      "integrity": "sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-includes": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.findlast": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
+      "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.tosorted": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
+      "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3",
+        "es-errors": "^1.3.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.24",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.24.tgz",
+      "integrity": "sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/bottleneck": {
+      "version": "2.19.5",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001791",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
+      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/colorette": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
+      "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/compute-scroll-into-view": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
+      "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==",
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/contentful-management": {
+      "version": "11.47.2",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.47.2.tgz",
+      "integrity": "sha512-jAnuiB1LRZugkx97VuiarIy8dlYHHdW2ecnxgtt7tjoi6Z8c3GGabItHjNEJR4O+k/k7/+ERKjRD/Fv+qX5tSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/rich-text-types": "^16.6.1",
+        "axios": "^1.7.9",
+        "contentful-sdk-core": "^9.0.1",
+        "fast-copy": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/contentful-sdk-core": {
+      "version": "9.4.5",
+      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-9.4.5.tgz",
+      "integrity": "sha512-8eGTMO11LXFAiosaiV38bjvW6cjoQFtNE38pNtVilZTXpmGFinClljihH0eriv11Ispd4q82TqtsXMJPYD/C+A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-copy": "^3.0.2",
+        "lodash": "^4.17.23",
+        "process": "^0.11.10",
+        "qs": "^6.15.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-linux-x64-gnu": "^4.18.0"
+      }
+    },
+    "node_modules/contentful-sdk-core/node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
+    },
+    "node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/downshift": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/downshift/-/downshift-9.4.0.tgz",
+      "integrity": "sha512-yIwyzRYzycKwMZhvOahsn4BmRr4Ffi0JymdWOtTDhR+LGDEXCZHTcwgUbNBC/oZLT6YrR46iwJe/BrQUS5ClQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "compute-scroll-into-view": "^3.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^18.2.0",
+        "tslib": "^2.8.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.12.0"
+      }
+    },
+    "node_modules/downshift/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
+    },
+    "node_modules/dset": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
+      "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.344",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
+      "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emotion": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/emotion/-/emotion-11.0.0.tgz",
+      "integrity": "sha512-QW3CRqic3aRw1OBOcnvxaHEpCmxtlGwZ5tM9dV5rY3Rn+F41E8EgTPOqJ5VfsqQ5ZXHDs2zSDyUwGI0ZfC2+5A==",
+      "license": "MIT"
+    },
+    "node_modules/enquirer": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-colors": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-abstract": {
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+      "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-iterator-helpers": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.2.tgz",
+      "integrity": "sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.2",
+        "es-errors": "^1.3.0",
+        "es-set-tostringtag": "^2.1.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.3.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "iterator.prototype": "^1.1.5",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.0.5",
+        "is-symbol": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-react": {
+      "version": "7.37.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
+      "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.8",
+        "array.prototype.findlast": "^1.2.5",
+        "array.prototype.flatmap": "^1.3.3",
+        "array.prototype.tosorted": "^1.1.4",
+        "doctrine": "^2.1.0",
+        "es-iterator-helpers": "^1.2.1",
+        "estraverse": "^5.3.0",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.9",
+        "object.fromentries": "^2.0.8",
+        "object.values": "^1.2.1",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.5",
+        "semver": "^6.3.1",
+        "string.prototype.matchall": "^4.0.12",
+        "string.prototype.repeat": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
+      "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/resolve": {
+      "version": "2.0.0-next.6",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
+      "integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "node-exports-info": "^1.6.0",
+        "object-keys": "^1.1.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/exenv": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+      "integrity": "sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/fast-copy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.2.tgz",
+      "integrity": "sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==",
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/figures/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "license": "MIT"
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/focus-lock": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-1.3.6.tgz",
+      "integrity": "sha512-Ik/6OCk9RQQ0T5Xw+hKNLWrjSMtv51dD4GRmJjbD5a58TIEpI5a5iXagKVl3Z5UuyslMCA8Xwnu76jQob62Yhg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuzzysearch": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fuzzysearch/-/fuzzysearch-1.0.3.tgz",
+      "integrity": "sha512-s+kNWQuI3mo9OALw0HJ6YGmMbLqEufCh2nX/zzV5CrICQ/y4AwPxM+6TIiF9ItFCHXFCyM/BfCCmN57NTIJuPg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/globalyzer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
+      "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ignore": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.3.tgz",
+      "integrity": "sha512-bAH5jbK/F3T3Jls4I0SO1hmPR0dKU0a7+SY6n1yzRtG54FLO8d6w/nxLFX2Nb7dBu6cCWXPaAME6cYqFUMmuCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/inquirer": {
+      "version": "8.2.6",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.6.tgz",
+      "integrity": "sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.1",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.21",
+        "mute-stream": "0.0.8",
+        "ora": "^5.4.1",
+        "run-async": "^2.4.0",
+        "rxjs": "^7.5.5",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6",
+        "wrap-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "license": "MIT"
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/iterator.prototype": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
+      "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "get-proto": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsx-ast-utils": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+      "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "object.assign": "^4.1.4",
+        "object.values": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.6.tgz",
+      "integrity": "sha512-oi1b3MfbyGa7FJMP9GmLTttni5JoICpYBRlq+x5V16fZbLsnL9N3wFqqIm/nIG43FjUFkFh9Epzp/kzUGUnJxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-exports-info": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
+      "integrity": "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array.prototype.flatmap": "^1.3.3",
+        "es-errors": "^1.3.0",
+        "object.entries": "^1.1.9",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/node-exports-info/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.entries": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
+      "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/papaparse": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
+      "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
+      "license": "MIT"
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT"
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-animate-height": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/react-animate-height/-/react-animate-height-3.2.4.tgz",
+      "integrity": "sha512-wcT37yHsFWDx8DmNFMy0AqSrYgNPGAtU9dyEqwIq3kSUXW03DWSi5WqbhlOALvMXcowal8JWUJRXij6TexilGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/react-clientside-effect": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.8.tgz",
+      "integrity": "sha512-ma2FePH0z3px2+WOu6h+YycZcEvFmmxIlAb62cF52bG86eMySciO/EQZeQMXd07kPCYB0a1dWDT5J+KE9mCDUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.13"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/react-day-picker": {
+      "version": "8.10.2",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.10.2.tgz",
+      "integrity": "sha512-LK68OTbHB3oJNhl9cA0qVizzp3o26w61YSjAFkYi67N86iro32wx86kSNeFU/hq+gI8m1yzWhnomMLfZ041RzQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/gpbl"
+      },
+      "peerDependencies": {
+        "date-fns": "^2.28.0 || ^3.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-focus-lock": {
+      "version": "2.13.7",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.13.7.tgz",
+      "integrity": "sha512-20lpZHEQrXPb+pp1tzd4ULL6DyO5D2KnR0G69tTDdydrmNhU7pdFmbQUYVyHUgp+xN29IuFR0PVuhOmvaZL9Og==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "focus-lock": "^1.3.6",
+        "prop-types": "^15.6.2",
+        "react-clientside-effect": "^1.2.7",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
+      "license": "MIT"
+    },
+    "node_modules/react-modal": {
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.16.3.tgz",
+      "integrity": "sha512-yCYRJB5YkeQDQlTt17WGAgFJ7jr2QYcWa1SHqZ3PluDmnKJ/7+tVU+E6uKyZ0nODaeEj+xCpK4LcSnKXLMC0Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "exenv": "^1.2.0",
+        "prop-types": "^15.7.2",
+        "react-lifecycles-compat": "^3.0.0",
+        "warning": "^4.0.3"
+      },
+      "peerDependencies": {
+        "react": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18 || ^19",
+        "react-dom": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup-plugin-inject": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-inject/-/rollup-plugin-inject-3.0.2.tgz",
+      "integrity": "sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==",
+      "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^0.6.1",
+        "magic-string": "^0.25.3",
+        "rollup-pluginutils": "^2.8.1"
+      }
+    },
+    "node_modules/rollup-plugin-node-polyfills": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-polyfills/-/rollup-plugin-node-polyfills-0.2.1.tgz",
+      "integrity": "sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rollup-plugin-inject": "^3.0.0"
+      }
+    },
+    "node_modules/rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^0.6.1"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+      "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string.prototype.matchall": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
+      "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.6",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "regexp.prototype.flags": "^1.5.3",
+        "set-function-name": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.repeat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+      "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tabbable": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
+      "license": "MIT"
+    },
+    "node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tiged": {
+      "version": "2.12.7",
+      "resolved": "https://registry.npmjs.org/tiged/-/tiged-2.12.7.tgz",
+      "integrity": "sha512-6TwlABgdshi1h9atXFRx86IhuDANtNqfD1OuWmZKKdqqwWNEJXHLa2hrRiyve9kLwHPb2ADc8RU3mSc4MVBE5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "colorette": "1.2.1",
+        "enquirer": "2.3.6",
+        "fs-extra": "10.1.0",
+        "fuzzysearch": "1.0.3",
+        "https-proxy-agent": "5.0.0",
+        "mri": "1.1.6",
+        "rimraf": "3.0.2",
+        "tar": "^6.1.11",
+        "tiny-glob": "0.2.8"
+      },
+      "bin": {
+        "degit": "bin.js",
+        "tiged": "bin.js"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/tiged/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/tiged/node_modules/https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/tiny-glob": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.8.tgz",
+      "integrity": "sha512-vkQP7qOslq63XRX9kMswlby99kyO5OvKptw7AMwBVMjXEI7Tb61eoI5DydyEMOseyGS5anDN1VPoVxEvH01q8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "globalyzer": "0.1.0",
+        "globrex": "^0.1.2"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/truncate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/truncate/-/truncate-3.0.0.tgz",
+      "integrity": "sha512-C+0Xojw7wZPl6MDq5UjMTuxZvBPK04mtdFet7k+GSZPINcvLZFCXg+15kWIL4wAqDB7CksIsKiRLbQ1wa7rKdw==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0",
+        "reflect.getprototypeof": "^1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vite-node/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/vitest/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "xml-js": "bin/cli.js"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/apps/bulk-exporter/package.json
+++ b/apps/bulk-exporter/package.json
@@ -24,7 +24,7 @@
     "test:ci": "vitest run",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest --coverage",
-    "lint": "eslint src --ext ts,tsx",
+    "lint": "eslint src",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
@@ -52,6 +52,7 @@
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
     "@types/xml-js": "^0.9.0",
+    "@eslint/js": "^9.18.0",
     "@typescript-eslint/eslint-plugin": "^8.18.2",
     "@typescript-eslint/parser": "^8.18.2",
     "@vitejs/plugin-react": "^4.3.4",

--- a/apps/bulk-exporter/package.json
+++ b/apps/bulk-exporter/package.json
@@ -21,6 +21,7 @@
     "deploy": "contentful-app-scripts upload --bundle-dir ./dist --ci --organization-id ${DEFINITIONS_ORG_ID} --definition-id TODO_PROD_APP_DEF_ID --token ${CONTENTFUL_CMA_TOKEN}",
     "deploy:test": "contentful-app-scripts upload --bundle-dir ./dist --ci --organization-id ${DEV_TESTING_ORG_ID} --definition-id TODO_TEST_APP_DEF_ID --token ${TEST_CMA_TOKEN}",
     "test": "vitest",
+    "test:ci": "vitest run",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest --coverage",
     "lint": "eslint src --ext ts,tsx",

--- a/apps/bulk-exporter/package.json
+++ b/apps/bulk-exporter/package.json
@@ -1,17 +1,9 @@
 {
-  "name": "se-bulk-exporter",
+  "name": "bulk-exporter",
   "version": "1.0.0",
-  "description": "Export unlimited Contentful entries to CSV, JSON, XLSX, XML, or YAML with advanced filtering, smart field selection, and reorderable columns",
-  "author": "Contentful Solution Engineering",
+  "description": "Search, filter, and export Contentful entries to CSV, JSON, XLSX, XML, or YAML",
+  "author": "Contentful",
   "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/contentful-labs/se-bulk-exporter.git"
-  },
-  "homepage": "https://github.com/contentful-labs/se-bulk-exporter#readme",
-  "bugs": {
-    "url": "https://github.com/contentful-labs/se-bulk-exporter/issues"
-  },
   "keywords": [
     "contentful",
     "contentful-app",
@@ -20,13 +12,14 @@
     "bulk-export",
     "content-management"
   ],
-  "private": false,
+  "private": true,
   "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "upload": "contentful-app-scripts upload --bundle-dir ./dist --comment \"Production build\" --ci",
+    "deploy": "contentful-app-scripts upload --bundle-dir ./dist --ci --organization-id ${DEFINITIONS_ORG_ID} --definition-id TODO_PROD_APP_DEF_ID --token ${CONTENTFUL_CMA_TOKEN}",
+    "deploy:test": "contentful-app-scripts upload --bundle-dir ./dist --ci --organization-id ${DEV_TESTING_ORG_ID} --definition-id TODO_TEST_APP_DEF_ID --token ${TEST_CMA_TOKEN}",
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest --coverage",
@@ -37,15 +30,14 @@
     "@contentful/app-sdk": "^4.32.0",
     "@contentful/f36-components": "^6.12.0",
     "@contentful/f36-icons": "^6.12.0",
-    "@contentful/f36-tokens": "^5.1.0",
+    "@contentful/f36-tokens": "^6.1.0",
     "@contentful/react-apps-toolkit": "^1.2.16",
     "@emotion/css": "^11.13.5",
-    "emotion": "^11.0.0",
+    "exceljs": "^4.4.0",
     "js-yaml": "^4.1.1",
     "papaparse": "^5.4.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "xlsx": "^0.18.5",
     "xml-js": "^1.6.11"
   },
   "devDependencies": {

--- a/apps/bulk-exporter/package.json
+++ b/apps/bulk-exporter/package.json
@@ -1,0 +1,73 @@
+{
+  "name": "se-bulk-exporter",
+  "version": "1.0.0",
+  "description": "Export unlimited Contentful entries to CSV, JSON, XLSX, XML, or YAML with advanced filtering, smart field selection, and reorderable columns",
+  "author": "Contentful Solution Engineering",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/contentful-labs/se-bulk-exporter.git"
+  },
+  "homepage": "https://github.com/contentful-labs/se-bulk-exporter#readme",
+  "bugs": {
+    "url": "https://github.com/contentful-labs/se-bulk-exporter/issues"
+  },
+  "keywords": [
+    "contentful",
+    "contentful-app",
+    "csv",
+    "export",
+    "bulk-export",
+    "content-management"
+  ],
+  "private": false,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "upload": "contentful-app-scripts upload --bundle-dir ./dist --comment \"Production build\" --ci",
+    "test": "vitest",
+    "test:ui": "vitest --ui",
+    "test:coverage": "vitest --coverage",
+    "lint": "eslint src --ext ts,tsx",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@contentful/app-sdk": "^4.32.0",
+    "@contentful/f36-components": "^6.12.0",
+    "@contentful/f36-icons": "^6.12.0",
+    "@contentful/f36-tokens": "^5.1.0",
+    "@contentful/react-apps-toolkit": "^1.2.16",
+    "@emotion/css": "^11.13.5",
+    "emotion": "^11.0.0",
+    "js-yaml": "^4.1.1",
+    "papaparse": "^5.4.1",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "xlsx": "^0.18.5",
+    "xml-js": "^1.6.11"
+  },
+  "devDependencies": {
+    "@contentful/app-scripts": "^1.26.0",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.1.0",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/js-yaml": "^4.0.9",
+    "@types/node": "^22.10.2",
+    "@types/papaparse": "^5.3.15",
+    "@types/react": "^18.3.18",
+    "@types/react-dom": "^18.3.5",
+    "@types/xml-js": "^0.9.0",
+    "@typescript-eslint/eslint-plugin": "^8.18.2",
+    "@typescript-eslint/parser": "^8.18.2",
+    "@vitejs/plugin-react": "^4.3.4",
+    "eslint": "^9.18.0",
+    "eslint-plugin-react": "^7.37.3",
+    "eslint-plugin-react-hooks": "^5.1.0",
+    "jsdom": "^25.0.1",
+    "typescript": "^5.7.2",
+    "vite": "^6.0.5",
+    "vitest": "^2.1.8"
+  }
+}

--- a/apps/bulk-exporter/src/components/ExportForm.tsx
+++ b/apps/bulk-exporter/src/components/ExportForm.tsx
@@ -1,0 +1,531 @@
+import { useState, useMemo, useEffect } from 'react';
+import {
+  Button,
+  Datepicker,
+  Flex,
+  FormControl,
+  IconButton,
+  Multiselect,
+  Select,
+  Paragraph,
+  Subheading,
+  TextInput,
+  Tooltip,
+} from '@contentful/f36-components';
+import {
+  InfoIcon,
+  MagnifyingGlassIcon,
+  PlusIcon,
+  TrashSimpleIcon,
+} from '@contentful/f36-icons';
+import { css } from '@emotion/css';
+import tokens from '@contentful/f36-tokens';
+import type { ContentType } from '../lib/flatten';
+import type { EntryStatus, FieldFilter } from '../lib/queryBuilder';
+import type { ExportFormat } from '../lib/exportFormats';
+import {
+  getSpacePreferences,
+  saveSpacePreferences,
+} from '../lib/preferences';
+
+export interface ExportFormData {
+  contentType: ContentType | null;
+  contentTypeId: string;
+  locales: string[];
+  fields?: string[];
+  search?: string;
+  status?: EntryStatus;
+  createdFrom?: string;
+  createdTo?: string;
+  updatedFrom?: string;
+  updatedTo?: string;
+  sort?: string;
+  tags?: string[];
+  tagsMatchAll?: boolean;
+  concepts?: string[];
+  conceptsMatchAll?: boolean;
+  fieldFilters?: FieldFilter[];
+  customFilename?: string;
+  format?: ExportFormat;
+}
+
+export interface ExportFormProps {
+  contentTypes: ContentType[];
+  availableLocales: Array<{ code: string; name: string }>;
+  availableTags: Array<{ sys: { id: string }; name: string }>;
+  availableConcepts: Array<{ sys: { id: string }; prefLabel: Record<string, string> }>;
+  onSubmit: (data: ExportFormData) => void;
+  onEstimate: (data: ExportFormData) => void;
+  onSearch: (data: ExportFormData) => void;
+  onQuickExport?: (data: ExportFormData, format: ExportFormat) => void;
+  isExporting: boolean;
+  isSearching: boolean;
+  estimatedCount: number | null;
+  spaceId: string;
+}
+
+const styles = {
+  card: css({
+    border: `1px solid ${tokens.gray300}`,
+    borderRadius: '6px',
+    backgroundColor: tokens.colorWhite,
+    width: '100%',
+  }),
+  cardHeader: css({
+    padding: `${tokens.spacingM} ${tokens.spacingL}`,
+    borderBottom: `1px solid ${tokens.gray200}`,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  }),
+  cardBody: css({
+    padding: tokens.spacingL,
+  }),
+dateRangeCard: css({
+    border: `1px solid ${tokens.gray200}`,
+    borderRadius: '6px',
+    backgroundColor: tokens.gray100,
+    padding: tokens.spacingM,
+    marginTop: tokens.spacingS,
+  }),
+  fieldFilterRow: css({
+    border: `1px solid ${tokens.gray200}`,
+    borderRadius: '6px',
+    backgroundColor: tokens.gray100,
+    padding: tokens.spacingS,
+    marginTop: tokens.spacingXs,
+  }),
+};
+
+export function ExportForm({
+  contentTypes,
+  availableLocales,
+  availableTags,
+  availableConcepts,
+  onSubmit,
+  onSearch,
+  isExporting,
+  isSearching,
+  spaceId,
+}: ExportFormProps) {
+  const initialSpacePrefs = useMemo(() => getSpacePreferences(spaceId), [spaceId]);
+
+const [contentTypeId, setContentTypeId] = useState('');
+  const [selectedLocales, setSelectedLocales] = useState<string[]>([]);
+  const [search, setSearch] = useState('');
+  const [status, setStatus] = useState<EntryStatus>('any');
+  const [createdFrom, setCreatedFrom] = useState('');
+  const [createdTo, setCreatedTo] = useState('');
+  const [updatedFrom, setUpdatedFrom] = useState('');
+  const [updatedTo, setUpdatedTo] = useState('');
+  const [sort] = useState('sys.createdAt');
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const [tagsMatchAll] = useState(false);
+  const [selectedConcepts, setSelectedConcepts] = useState<string[]>([]);
+  const [conceptsMatchAll] = useState(false);
+  const [fieldFilters, setFieldFilters] = useState<FieldFilter[]>([]);
+  const [format] = useState<ExportFormat>(initialSpacePrefs.format ?? 'csv');
+  const [showCreatedRange, setShowCreatedRange] = useState(false);
+  const [showUpdatedRange, setShowUpdatedRange] = useState(false);
+
+  const selectedContentType = useMemo(
+    () => contentTypes.find(ct => ct.sys.id === contentTypeId) || null,
+    [contentTypes, contentTypeId]
+  );
+
+  useEffect(() => {
+    if (!spaceId) return;
+    saveSpacePreferences(spaceId, { format });
+  }, [format, spaceId]);
+
+  const handleAddFieldFilter = () => {
+    setFieldFilters([...fieldFilters, { fieldId: '', operator: 'equals', value: '' }]);
+  };
+
+  const handleRemoveFieldFilter = (index: number) => {
+    setFieldFilters(fieldFilters.filter((_, i) => i !== index));
+  };
+
+  const handleFieldFilterChange = (index: number, key: keyof FieldFilter, value: string) => {
+    const updated = [...fieldFilters];
+    updated[index] = { ...updated[index], [key]: value };
+    setFieldFilters(updated);
+  };
+
+  const formData: ExportFormData = {
+    contentType: selectedContentType,
+    contentTypeId,
+    locales: selectedLocales.length > 0 ? selectedLocales : availableLocales.map(l => l.code),
+    search,
+    status,
+    createdFrom,
+    createdTo,
+    updatedFrom,
+    updatedTo,
+    sort,
+    tags: selectedTags,
+    tagsMatchAll,
+    concepts: selectedConcepts,
+    conceptsMatchAll,
+    fieldFilters,
+    format,
+  };
+
+  const handleGenerate = () => {
+    onSearch(formData);
+  };
+
+  const handleExport = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit(formData);
+  };
+
+return (
+    <form onSubmit={handleExport} style={{ width: '100%' }}>
+      <div className={styles.card}>
+              <div className={styles.cardHeader}>
+                <Subheading marginBottom="none">Generate entry list</Subheading>
+                <Button
+                  variant="secondary"
+                  size="small"
+                  onClick={handleGenerate}
+                  isDisabled={isExporting || isSearching}
+                  isLoading={isSearching}
+                >
+                  Generate list
+                </Button>
+              </div>
+
+              <div className={styles.cardBody}>
+                <Flex gap="spacingM" alignItems="flex-start" flexWrap="wrap">
+                  {/* Content type */}
+                  <FormControl style={{ width: '220px', marginBottom: 0 }}>
+                    <FormControl.Label>Content type</FormControl.Label>
+                    <Select
+                      value={contentTypeId}
+                      onChange={(e) => setContentTypeId(e.target.value)}
+                      isDisabled={isExporting}
+                    >
+                      <Select.Option value="">All content types</Select.Option>
+                      {contentTypes.map(ct => (
+                        <Select.Option key={ct.sys.id} value={ct.sys.id}>
+                          {ct.name || ct.sys.id}
+                        </Select.Option>
+                      ))}
+                    </Select>
+                  </FormControl>
+
+                  {/* Search entry text */}
+                  <FormControl style={{ flex: '1 1 240px', marginBottom: 0 }}>
+                    <FormControl.Label>Search entry text</FormControl.Label>
+                    <TextInput
+                      placeholder="Search"
+                      icon={<MagnifyingGlassIcon />}
+                      value={search}
+                      onChange={(e) => setSearch(e.target.value)}
+                      isDisabled={isExporting}
+                    />
+                    <FormControl.HelpText>
+                      Search text based fields for specific entry text
+                    </FormControl.HelpText>
+                  </FormControl>
+
+                  {/* Status */}
+                  <FormControl style={{ width: '140px', marginBottom: 0 }}>
+                    <FormControl.Label>Status</FormControl.Label>
+                    <Select
+                      value={status}
+                      onChange={(e) => setStatus(e.target.value as EntryStatus)}
+                      isDisabled={isExporting}
+                    >
+                      <Select.Option value="any">Any</Select.Option>
+                      <Select.Option value="published">Published</Select.Option>
+                      <Select.Option value="draft">Draft</Select.Option>
+                      <Select.Option value="changed">Changed</Select.Option>
+                      <Select.Option value="archived">Archived</Select.Option>
+                    </Select>
+                  </FormControl>
+
+                  {/* Locales */}
+                  <FormControl
+                    isDisabled={!selectedContentType || isExporting}
+                    style={{ flex: '1 1 160px', marginBottom: 0 }}
+                  >
+                    <FormControl.Label>Locales</FormControl.Label>
+                    <Multiselect
+                      currentSelection={selectedLocales}
+                      placeholder="All locales"
+                      triggerButtonProps={{ isDisabled: !selectedContentType || isExporting }}
+                    >
+                      {availableLocales.map(l => (
+                        <Multiselect.Option
+                          key={l.code}
+                          itemId={l.code}
+                          value={l.code}
+                          label={l.name}
+                          onSelectItem={() =>
+                            setSelectedLocales(prev =>
+                              prev.includes(l.code)
+                                ? prev.filter(c => c !== l.code)
+                                : [...prev, l.code]
+                            )
+                          }
+                          isChecked={selectedLocales.includes(l.code)}
+                        />
+                      ))}
+                    </Multiselect>
+                    <FormControl.HelpText>
+                      Select specific locales to include in export
+                    </FormControl.HelpText>
+                  </FormControl>
+
+                  {/* Tags */}
+                  <FormControl style={{ flex: '1 1 180px', marginBottom: 0 }}>
+                    <FormControl.Label>Tags</FormControl.Label>
+                    <Multiselect
+                      currentSelection={selectedTags}
+                      placeholder="Select one or more"
+                    >
+                      {availableTags.map(tag => (
+                        <Multiselect.Option
+                          key={tag.sys.id}
+                          itemId={tag.sys.id}
+                          value={tag.sys.id}
+                          label={tag.name}
+                          onSelectItem={() =>
+                            setSelectedTags(prev =>
+                              prev.includes(tag.sys.id)
+                                ? prev.filter(t => t !== tag.sys.id)
+                                : [...prev, tag.sys.id]
+                            )
+                          }
+                          isChecked={selectedTags.includes(tag.sys.id)}
+                        />
+                      ))}
+                    </Multiselect>
+                  </FormControl>
+
+                  {/* Taxonomy concepts */}
+                  {availableConcepts.length > 0 && (
+                    <FormControl style={{ flex: '1 1 180px', marginBottom: 0 }}>
+                      <FormControl.Label>Taxonomy concepts</FormControl.Label>
+                      <Multiselect
+                        currentSelection={selectedConcepts}
+                        placeholder="Select one or more"
+                      >
+                        {availableConcepts.map(concept => (
+                          <Multiselect.Option
+                            key={concept.sys.id}
+                            itemId={concept.sys.id}
+                            value={concept.sys.id}
+                            label={Object.values(concept.prefLabel)[0] || concept.sys.id}
+                            onSelectItem={() =>
+                              setSelectedConcepts(prev =>
+                                prev.includes(concept.sys.id)
+                                  ? prev.filter(c => c !== concept.sys.id)
+                                  : [...prev, concept.sys.id]
+                              )
+                            }
+                            isChecked={selectedConcepts.includes(concept.sys.id)}
+                          />
+                        ))}
+                      </Multiselect>
+                    </FormControl>
+                  )}
+                </Flex>
+
+                {/* Additive filter buttons */}
+                <Flex gap="spacingS" marginTop="spacingM" flexWrap="wrap">
+                  <Tooltip
+                    content={selectedContentType ? 'Add a filter on a specific field' : 'Select a content type first'}
+                    placement="top"
+                  >
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      size="small"
+                      startIcon={<PlusIcon />}
+                      onClick={handleAddFieldFilter}
+                      isDisabled={isExporting || !selectedContentType}
+                    >
+                      Field filter
+                    </Button>
+                  </Tooltip>
+
+                  {!showCreatedRange && (
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      size="small"
+                      startIcon={<PlusIcon />}
+                      onClick={() => setShowCreatedRange(true)}
+                      isDisabled={isExporting}
+                    >
+                      Created date range
+                    </Button>
+                  )}
+
+                  {!showUpdatedRange && (
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      size="small"
+                      startIcon={<PlusIcon />}
+                      onClick={() => setShowUpdatedRange(true)}
+                      isDisabled={isExporting}
+                    >
+                      Updated date range
+                    </Button>
+                  )}
+                </Flex>
+
+                {/* Field filters */}
+                {fieldFilters.map((filter, index) => (
+                  <div key={index} className={styles.fieldFilterRow}>
+                    <Flex gap="spacingS" alignItems="flex-end" flexWrap="wrap">
+                      <FormControl style={{ flex: 1, minWidth: 0, marginBottom: 0 }}>
+                        <FormControl.Label>Field</FormControl.Label>
+                        <Select
+                          value={filter.fieldId}
+                          onChange={(e) => handleFieldFilterChange(index, 'fieldId', e.target.value)}
+                          isDisabled={isExporting || !selectedContentType}
+                        >
+                          <Select.Option value="">Select field</Select.Option>
+                          {selectedContentType?.fields.map(field => (
+                            <Select.Option key={field.id} value={field.id}>
+                              {field.name || field.id}
+                            </Select.Option>
+                          ))}
+                        </Select>
+                      </FormControl>
+                      <FormControl style={{ flex: 1, minWidth: 0, marginBottom: 0 }}>
+                        <FormControl.Label>Operator</FormControl.Label>
+                        <Select
+                          value={filter.operator}
+                          onChange={(e) => handleFieldFilterChange(index, 'operator', e.target.value)}
+                          isDisabled={isExporting}
+                        >
+                          <Select.Option value="equals">Equals</Select.Option>
+                          <Select.Option value="not_equals">Not equals</Select.Option>
+                          <Select.Option value="contains">Contains</Select.Option>
+                          <Select.Option value="gt">Greater than</Select.Option>
+                          <Select.Option value="gte">Greater than or equal</Select.Option>
+                          <Select.Option value="lt">Less than</Select.Option>
+                          <Select.Option value="lte">Less than or equal</Select.Option>
+                          <Select.Option value="exists">Exists</Select.Option>
+                          <Select.Option value="is_true">Is true</Select.Option>
+                          <Select.Option value="is_false">Is false</Select.Option>
+                          <Select.Option value="links_to">Links to entry ID</Select.Option>
+                        </Select>
+                      </FormControl>
+                      <FormControl style={{ flex: 1, minWidth: 0, marginBottom: 0 }}>
+                        <FormControl.Label>Value</FormControl.Label>
+                        <TextInput
+                          value={filter.value}
+                          onChange={(e) => handleFieldFilterChange(index, 'value', e.target.value)}
+                          isDisabled={isExporting || filter.operator === 'is_true' || filter.operator === 'is_false'}
+                          placeholder="Value"
+                        />
+                      </FormControl>
+                      <IconButton
+                        variant="secondary"
+                        icon={<TrashSimpleIcon />}
+                        aria-label="Remove filter"
+                        size="medium"
+                        onClick={() => handleRemoveFieldFilter(index)}
+                        isDisabled={isExporting}
+                      />
+                    </Flex>
+                  </div>
+                ))}
+
+                {/* Created date range */}
+                {showCreatedRange && (
+                  <div className={styles.dateRangeCard}>
+                    <Flex alignItems="center" gap="spacingXs" marginBottom="spacingS">
+                      <Paragraph marginBottom="none">Created date range</Paragraph>
+                      <Tooltip content="Filter entries created within this date range" placement="top">
+                        <IconButton
+                          variant="transparent"
+                          icon={<InfoIcon />}
+                          aria-label="About created date range"
+                          size="small"
+                        />
+                      </Tooltip>
+                    </Flex>
+                    <Flex gap="spacingS" alignItems="flex-end">
+                      <FormControl style={{ flex: 1, marginBottom: 0 }}>
+                        <FormControl.Label>Start</FormControl.Label>
+                        <Datepicker
+                          selected={createdFrom ? new Date(createdFrom) : undefined}
+                          onSelect={(day) => setCreatedFrom(day ? day.toISOString().split('T')[0] : '')}
+                          inputProps={{ isDisabled: isExporting }}
+                        />
+                      </FormControl>
+                      <FormControl style={{ flex: 1, marginBottom: 0 }}>
+                        <FormControl.Label>End</FormControl.Label>
+                        <Datepicker
+                          selected={createdTo ? new Date(createdTo) : undefined}
+                          onSelect={(day) => setCreatedTo(day ? day.toISOString().split('T')[0] : '')}
+                          inputProps={{ isDisabled: isExporting }}
+                        />
+                      </FormControl>
+                      <IconButton
+                        variant="secondary"
+                        icon={<TrashSimpleIcon />}
+                        aria-label="Remove created date range"
+                        size="medium"
+                        onClick={() => { setShowCreatedRange(false); setCreatedFrom(''); setCreatedTo(''); }}
+                        isDisabled={isExporting}
+                      />
+                    </Flex>
+                  </div>
+                )}
+
+                {/* Updated date range */}
+                {showUpdatedRange && (
+                  <div className={styles.dateRangeCard}>
+                    <Flex alignItems="center" gap="spacingXs" marginBottom="spacingS">
+                      <Paragraph marginBottom="none">Updated date range</Paragraph>
+                      <Tooltip content="Filter entries updated within this date range" placement="top">
+                        <IconButton
+                          variant="transparent"
+                          icon={<InfoIcon />}
+                          aria-label="About updated date range"
+                          size="small"
+                        />
+                      </Tooltip>
+                    </Flex>
+                    <Flex gap="spacingS" alignItems="flex-end">
+                      <FormControl style={{ flex: 1, marginBottom: 0 }}>
+                        <FormControl.Label>Start</FormControl.Label>
+                        <Datepicker
+                          selected={updatedFrom ? new Date(updatedFrom) : undefined}
+                          onSelect={(day) => setUpdatedFrom(day ? day.toISOString().split('T')[0] : '')}
+                          inputProps={{ isDisabled: isExporting }}
+                        />
+                      </FormControl>
+                      <FormControl style={{ flex: 1, marginBottom: 0 }}>
+                        <FormControl.Label>End</FormControl.Label>
+                        <Datepicker
+                          selected={updatedTo ? new Date(updatedTo) : undefined}
+                          onSelect={(day) => setUpdatedTo(day ? day.toISOString().split('T')[0] : '')}
+                          inputProps={{ isDisabled: isExporting }}
+                        />
+                      </FormControl>
+                      <IconButton
+                        variant="secondary"
+                        icon={<TrashSimpleIcon />}
+                        aria-label="Remove updated date range"
+                        size="medium"
+                        onClick={() => { setShowUpdatedRange(false); setUpdatedFrom(''); setUpdatedTo(''); }}
+                        isDisabled={isExporting}
+                      />
+                    </Flex>
+                  </div>
+                )}
+              </div>
+            </div>
+    </form>
+  );
+}

--- a/apps/bulk-exporter/src/components/ExportForm.tsx
+++ b/apps/bulk-exporter/src/components/ExportForm.tsx
@@ -12,21 +12,13 @@ import {
   TextInput,
   Tooltip,
 } from '@contentful/f36-components';
-import {
-  InfoIcon,
-  MagnifyingGlassIcon,
-  PlusIcon,
-  TrashSimpleIcon,
-} from '@contentful/f36-icons';
+import { InfoIcon, MagnifyingGlassIcon, PlusIcon, TrashSimpleIcon } from '@contentful/f36-icons';
 import { css } from '@emotion/css';
 import tokens from '@contentful/f36-tokens';
 import type { ContentType } from '../lib/flatten';
 import type { EntryStatus, FieldFilter } from '../lib/queryBuilder';
 import type { ExportFormat } from '../lib/exportFormats';
-import {
-  getSpacePreferences,
-  saveSpacePreferences,
-} from '../lib/preferences';
+import { getSpacePreferences, saveSpacePreferences } from '../lib/preferences';
 
 export interface ExportFormData {
   contentType: ContentType | null;
@@ -81,7 +73,7 @@ const styles = {
   cardBody: css({
     padding: tokens.spacingL,
   }),
-dateRangeCard: css({
+  dateRangeCard: css({
     border: `1px solid ${tokens.gray200}`,
     borderRadius: '6px',
     backgroundColor: tokens.gray100,
@@ -110,7 +102,7 @@ export function ExportForm({
 }: ExportFormProps) {
   const initialSpacePrefs = useMemo(() => getSpacePreferences(spaceId), [spaceId]);
 
-const [contentTypeId, setContentTypeId] = useState('');
+  const [contentTypeId, setContentTypeId] = useState('');
   const [selectedLocales, setSelectedLocales] = useState<string[]>([]);
   const [search, setSearch] = useState('');
   const [status, setStatus] = useState<EntryStatus>('any');
@@ -129,7 +121,7 @@ const [contentTypeId, setContentTypeId] = useState('');
   const [showUpdatedRange, setShowUpdatedRange] = useState(false);
 
   const selectedContentType = useMemo(
-    () => contentTypes.find(ct => ct.sys.id === contentTypeId) || null,
+    () => contentTypes.find((ct) => ct.sys.id === contentTypeId) || null,
     [contentTypes, contentTypeId]
   );
 
@@ -155,7 +147,7 @@ const [contentTypeId, setContentTypeId] = useState('');
   const formData: ExportFormData = {
     contentType: selectedContentType,
     contentTypeId,
-    locales: selectedLocales.length > 0 ? selectedLocales : availableLocales.map(l => l.code),
+    locales: selectedLocales.length > 0 ? selectedLocales : availableLocales.map((l) => l.code),
     search,
     status,
     createdFrom,
@@ -180,352 +172,347 @@ const [contentTypeId, setContentTypeId] = useState('');
     onSubmit(formData);
   };
 
-return (
+  return (
     <form onSubmit={handleExport} style={{ width: '100%' }}>
       <div className={styles.card}>
-              <div className={styles.cardHeader}>
-                <Subheading marginBottom="none">Generate entry list</Subheading>
-                <Button
-                  variant="secondary"
-                  size="small"
-                  onClick={handleGenerate}
-                  isDisabled={isExporting || isSearching}
-                  isLoading={isSearching}
-                >
-                  Generate list
-                </Button>
-              </div>
+        <div className={styles.cardHeader}>
+          <Subheading marginBottom="none">Generate entry list</Subheading>
+          <Button
+            variant="secondary"
+            size="small"
+            onClick={handleGenerate}
+            isDisabled={isExporting || isSearching}
+            isLoading={isSearching}>
+            Generate list
+          </Button>
+        </div>
 
-              <div className={styles.cardBody}>
-                <Flex gap="spacingM" alignItems="flex-start" flexWrap="wrap">
-                  {/* Content type */}
-                  <FormControl style={{ width: '220px', marginBottom: 0 }}>
-                    <FormControl.Label>Content type</FormControl.Label>
-                    <Select
-                      value={contentTypeId}
-                      onChange={(e) => setContentTypeId(e.target.value)}
-                      isDisabled={isExporting}
-                    >
-                      <Select.Option value="">All content types</Select.Option>
-                      {contentTypes.map(ct => (
-                        <Select.Option key={ct.sys.id} value={ct.sys.id}>
-                          {ct.name || ct.sys.id}
-                        </Select.Option>
-                      ))}
-                    </Select>
-                  </FormControl>
-
-                  {/* Search entry text */}
-                  <FormControl style={{ flex: '1 1 240px', marginBottom: 0 }}>
-                    <FormControl.Label>Search entry text</FormControl.Label>
-                    <TextInput
-                      placeholder="Search"
-                      icon={<MagnifyingGlassIcon />}
-                      value={search}
-                      onChange={(e) => setSearch(e.target.value)}
-                      isDisabled={isExporting}
-                    />
-                    <FormControl.HelpText>
-                      Search text based fields for specific entry text
-                    </FormControl.HelpText>
-                  </FormControl>
-
-                  {/* Status */}
-                  <FormControl style={{ width: '140px', marginBottom: 0 }}>
-                    <FormControl.Label>Status</FormControl.Label>
-                    <Select
-                      value={status}
-                      onChange={(e) => setStatus(e.target.value as EntryStatus)}
-                      isDisabled={isExporting}
-                    >
-                      <Select.Option value="any">Any</Select.Option>
-                      <Select.Option value="published">Published</Select.Option>
-                      <Select.Option value="draft">Draft</Select.Option>
-                      <Select.Option value="changed">Changed</Select.Option>
-                      <Select.Option value="archived">Archived</Select.Option>
-                    </Select>
-                  </FormControl>
-
-                  {/* Locales */}
-                  <FormControl
-                    isDisabled={!selectedContentType || isExporting}
-                    style={{ flex: '1 1 160px', marginBottom: 0 }}
-                  >
-                    <FormControl.Label>Locales</FormControl.Label>
-                    <Multiselect
-                      currentSelection={selectedLocales}
-                      placeholder="All locales"
-                      triggerButtonProps={{ isDisabled: !selectedContentType || isExporting }}
-                    >
-                      {availableLocales.map(l => (
-                        <Multiselect.Option
-                          key={l.code}
-                          itemId={l.code}
-                          value={l.code}
-                          label={l.name}
-                          onSelectItem={() =>
-                            setSelectedLocales(prev =>
-                              prev.includes(l.code)
-                                ? prev.filter(c => c !== l.code)
-                                : [...prev, l.code]
-                            )
-                          }
-                          isChecked={selectedLocales.includes(l.code)}
-                        />
-                      ))}
-                    </Multiselect>
-                    <FormControl.HelpText>
-                      Select specific locales to include in export
-                    </FormControl.HelpText>
-                  </FormControl>
-
-                  {/* Tags */}
-                  <FormControl style={{ flex: '1 1 180px', marginBottom: 0 }}>
-                    <FormControl.Label>Tags</FormControl.Label>
-                    <Multiselect
-                      currentSelection={selectedTags}
-                      placeholder="Select one or more"
-                    >
-                      {availableTags.map(tag => (
-                        <Multiselect.Option
-                          key={tag.sys.id}
-                          itemId={tag.sys.id}
-                          value={tag.sys.id}
-                          label={tag.name}
-                          onSelectItem={() =>
-                            setSelectedTags(prev =>
-                              prev.includes(tag.sys.id)
-                                ? prev.filter(t => t !== tag.sys.id)
-                                : [...prev, tag.sys.id]
-                            )
-                          }
-                          isChecked={selectedTags.includes(tag.sys.id)}
-                        />
-                      ))}
-                    </Multiselect>
-                  </FormControl>
-
-                  {/* Taxonomy concepts */}
-                  {availableConcepts.length > 0 && (
-                    <FormControl style={{ flex: '1 1 180px', marginBottom: 0 }}>
-                      <FormControl.Label>Taxonomy concepts</FormControl.Label>
-                      <Multiselect
-                        currentSelection={selectedConcepts}
-                        placeholder="Select one or more"
-                      >
-                        {availableConcepts.map(concept => (
-                          <Multiselect.Option
-                            key={concept.sys.id}
-                            itemId={concept.sys.id}
-                            value={concept.sys.id}
-                            label={Object.values(concept.prefLabel)[0] || concept.sys.id}
-                            onSelectItem={() =>
-                              setSelectedConcepts(prev =>
-                                prev.includes(concept.sys.id)
-                                  ? prev.filter(c => c !== concept.sys.id)
-                                  : [...prev, concept.sys.id]
-                              )
-                            }
-                            isChecked={selectedConcepts.includes(concept.sys.id)}
-                          />
-                        ))}
-                      </Multiselect>
-                    </FormControl>
-                  )}
-                </Flex>
-
-                {/* Additive filter buttons */}
-                <Flex gap="spacingS" marginTop="spacingM" flexWrap="wrap">
-                  <Tooltip
-                    content={selectedContentType ? 'Add a filter on a specific field' : 'Select a content type first'}
-                    placement="top"
-                  >
-                    <Button
-                      type="button"
-                      variant="secondary"
-                      size="small"
-                      startIcon={<PlusIcon />}
-                      onClick={handleAddFieldFilter}
-                      isDisabled={isExporting || !selectedContentType}
-                    >
-                      Field filter
-                    </Button>
-                  </Tooltip>
-
-                  {!showCreatedRange && (
-                    <Button
-                      type="button"
-                      variant="secondary"
-                      size="small"
-                      startIcon={<PlusIcon />}
-                      onClick={() => setShowCreatedRange(true)}
-                      isDisabled={isExporting}
-                    >
-                      Created date range
-                    </Button>
-                  )}
-
-                  {!showUpdatedRange && (
-                    <Button
-                      type="button"
-                      variant="secondary"
-                      size="small"
-                      startIcon={<PlusIcon />}
-                      onClick={() => setShowUpdatedRange(true)}
-                      isDisabled={isExporting}
-                    >
-                      Updated date range
-                    </Button>
-                  )}
-                </Flex>
-
-                {/* Field filters */}
-                {fieldFilters.map((filter, index) => (
-                  <div key={index} className={styles.fieldFilterRow}>
-                    <Flex gap="spacingS" alignItems="flex-end" flexWrap="wrap">
-                      <FormControl style={{ flex: 1, minWidth: 0, marginBottom: 0 }}>
-                        <FormControl.Label>Field</FormControl.Label>
-                        <Select
-                          value={filter.fieldId}
-                          onChange={(e) => handleFieldFilterChange(index, 'fieldId', e.target.value)}
-                          isDisabled={isExporting || !selectedContentType}
-                        >
-                          <Select.Option value="">Select field</Select.Option>
-                          {selectedContentType?.fields.map(field => (
-                            <Select.Option key={field.id} value={field.id}>
-                              {field.name || field.id}
-                            </Select.Option>
-                          ))}
-                        </Select>
-                      </FormControl>
-                      <FormControl style={{ flex: 1, minWidth: 0, marginBottom: 0 }}>
-                        <FormControl.Label>Operator</FormControl.Label>
-                        <Select
-                          value={filter.operator}
-                          onChange={(e) => handleFieldFilterChange(index, 'operator', e.target.value)}
-                          isDisabled={isExporting}
-                        >
-                          <Select.Option value="equals">Equals</Select.Option>
-                          <Select.Option value="not_equals">Not equals</Select.Option>
-                          <Select.Option value="contains">Contains</Select.Option>
-                          <Select.Option value="gt">Greater than</Select.Option>
-                          <Select.Option value="gte">Greater than or equal</Select.Option>
-                          <Select.Option value="lt">Less than</Select.Option>
-                          <Select.Option value="lte">Less than or equal</Select.Option>
-                          <Select.Option value="exists">Exists</Select.Option>
-                          <Select.Option value="is_true">Is true</Select.Option>
-                          <Select.Option value="is_false">Is false</Select.Option>
-                          <Select.Option value="links_to">Links to entry ID</Select.Option>
-                        </Select>
-                      </FormControl>
-                      <FormControl style={{ flex: 1, minWidth: 0, marginBottom: 0 }}>
-                        <FormControl.Label>Value</FormControl.Label>
-                        <TextInput
-                          value={filter.value}
-                          onChange={(e) => handleFieldFilterChange(index, 'value', e.target.value)}
-                          isDisabled={isExporting || filter.operator === 'is_true' || filter.operator === 'is_false'}
-                          placeholder="Value"
-                        />
-                      </FormControl>
-                      <IconButton
-                        variant="secondary"
-                        icon={<TrashSimpleIcon />}
-                        aria-label="Remove filter"
-                        size="medium"
-                        onClick={() => handleRemoveFieldFilter(index)}
-                        isDisabled={isExporting}
-                      />
-                    </Flex>
-                  </div>
+        <div className={styles.cardBody}>
+          <Flex gap="spacingM" alignItems="flex-start" flexWrap="wrap">
+            {/* Content type */}
+            <FormControl style={{ width: '220px', marginBottom: 0 }}>
+              <FormControl.Label>Content type</FormControl.Label>
+              <Select
+                value={contentTypeId}
+                onChange={(e) => setContentTypeId(e.target.value)}
+                isDisabled={isExporting}>
+                <Select.Option value="">All content types</Select.Option>
+                {contentTypes.map((ct) => (
+                  <Select.Option key={ct.sys.id} value={ct.sys.id}>
+                    {ct.name || ct.sys.id}
+                  </Select.Option>
                 ))}
+              </Select>
+            </FormControl>
 
-                {/* Created date range */}
-                {showCreatedRange && (
-                  <div className={styles.dateRangeCard}>
-                    <Flex alignItems="center" gap="spacingXs" marginBottom="spacingS">
-                      <Paragraph marginBottom="none">Created date range</Paragraph>
-                      <Tooltip content="Filter entries created within this date range" placement="top">
-                        <IconButton
-                          variant="transparent"
-                          icon={<InfoIcon />}
-                          aria-label="About created date range"
-                          size="small"
-                        />
-                      </Tooltip>
-                    </Flex>
-                    <Flex gap="spacingS" alignItems="flex-end">
-                      <FormControl style={{ flex: 1, marginBottom: 0 }}>
-                        <FormControl.Label>Start</FormControl.Label>
-                        <Datepicker
-                          selected={createdFrom ? new Date(createdFrom) : undefined}
-                          onSelect={(day) => setCreatedFrom(day ? day.toISOString().split('T')[0] : '')}
-                          inputProps={{ isDisabled: isExporting }}
-                        />
-                      </FormControl>
-                      <FormControl style={{ flex: 1, marginBottom: 0 }}>
-                        <FormControl.Label>End</FormControl.Label>
-                        <Datepicker
-                          selected={createdTo ? new Date(createdTo) : undefined}
-                          onSelect={(day) => setCreatedTo(day ? day.toISOString().split('T')[0] : '')}
-                          inputProps={{ isDisabled: isExporting }}
-                        />
-                      </FormControl>
-                      <IconButton
-                        variant="secondary"
-                        icon={<TrashSimpleIcon />}
-                        aria-label="Remove created date range"
-                        size="medium"
-                        onClick={() => { setShowCreatedRange(false); setCreatedFrom(''); setCreatedTo(''); }}
-                        isDisabled={isExporting}
-                      />
-                    </Flex>
-                  </div>
-                )}
+            {/* Search entry text */}
+            <FormControl style={{ flex: '1 1 240px', marginBottom: 0 }}>
+              <FormControl.Label>Search entry text</FormControl.Label>
+              <TextInput
+                placeholder="Search"
+                icon={<MagnifyingGlassIcon />}
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                isDisabled={isExporting}
+              />
+              <FormControl.HelpText>
+                Search text based fields for specific entry text
+              </FormControl.HelpText>
+            </FormControl>
 
-                {/* Updated date range */}
-                {showUpdatedRange && (
-                  <div className={styles.dateRangeCard}>
-                    <Flex alignItems="center" gap="spacingXs" marginBottom="spacingS">
-                      <Paragraph marginBottom="none">Updated date range</Paragraph>
-                      <Tooltip content="Filter entries updated within this date range" placement="top">
-                        <IconButton
-                          variant="transparent"
-                          icon={<InfoIcon />}
-                          aria-label="About updated date range"
-                          size="small"
-                        />
-                      </Tooltip>
-                    </Flex>
-                    <Flex gap="spacingS" alignItems="flex-end">
-                      <FormControl style={{ flex: 1, marginBottom: 0 }}>
-                        <FormControl.Label>Start</FormControl.Label>
-                        <Datepicker
-                          selected={updatedFrom ? new Date(updatedFrom) : undefined}
-                          onSelect={(day) => setUpdatedFrom(day ? day.toISOString().split('T')[0] : '')}
-                          inputProps={{ isDisabled: isExporting }}
-                        />
-                      </FormControl>
-                      <FormControl style={{ flex: 1, marginBottom: 0 }}>
-                        <FormControl.Label>End</FormControl.Label>
-                        <Datepicker
-                          selected={updatedTo ? new Date(updatedTo) : undefined}
-                          onSelect={(day) => setUpdatedTo(day ? day.toISOString().split('T')[0] : '')}
-                          inputProps={{ isDisabled: isExporting }}
-                        />
-                      </FormControl>
-                      <IconButton
-                        variant="secondary"
-                        icon={<TrashSimpleIcon />}
-                        aria-label="Remove updated date range"
-                        size="medium"
-                        onClick={() => { setShowUpdatedRange(false); setUpdatedFrom(''); setUpdatedTo(''); }}
-                        isDisabled={isExporting}
-                      />
-                    </Flex>
-                  </div>
-                )}
-              </div>
+            {/* Status */}
+            <FormControl style={{ width: '140px', marginBottom: 0 }}>
+              <FormControl.Label>Status</FormControl.Label>
+              <Select
+                value={status}
+                onChange={(e) => setStatus(e.target.value as EntryStatus)}
+                isDisabled={isExporting}>
+                <Select.Option value="any">Any</Select.Option>
+                <Select.Option value="published">Published</Select.Option>
+                <Select.Option value="draft">Draft</Select.Option>
+                <Select.Option value="changed">Changed</Select.Option>
+                <Select.Option value="archived">Archived</Select.Option>
+              </Select>
+            </FormControl>
+
+            {/* Locales */}
+            <FormControl
+              isDisabled={!selectedContentType || isExporting}
+              style={{ flex: '1 1 160px', marginBottom: 0 }}>
+              <FormControl.Label>Locales</FormControl.Label>
+              <Multiselect
+                currentSelection={selectedLocales}
+                placeholder="All locales"
+                triggerButtonProps={{ isDisabled: !selectedContentType || isExporting }}>
+                {availableLocales.map((l) => (
+                  <Multiselect.Option
+                    key={l.code}
+                    itemId={l.code}
+                    value={l.code}
+                    label={l.name}
+                    onSelectItem={() =>
+                      setSelectedLocales((prev) =>
+                        prev.includes(l.code) ? prev.filter((c) => c !== l.code) : [...prev, l.code]
+                      )
+                    }
+                    isChecked={selectedLocales.includes(l.code)}
+                  />
+                ))}
+              </Multiselect>
+              <FormControl.HelpText>
+                Select specific locales to include in export
+              </FormControl.HelpText>
+            </FormControl>
+
+            {/* Tags */}
+            <FormControl style={{ flex: '1 1 180px', marginBottom: 0 }}>
+              <FormControl.Label>Tags</FormControl.Label>
+              <Multiselect currentSelection={selectedTags} placeholder="Select one or more">
+                {availableTags.map((tag) => (
+                  <Multiselect.Option
+                    key={tag.sys.id}
+                    itemId={tag.sys.id}
+                    value={tag.sys.id}
+                    label={tag.name}
+                    onSelectItem={() =>
+                      setSelectedTags((prev) =>
+                        prev.includes(tag.sys.id)
+                          ? prev.filter((t) => t !== tag.sys.id)
+                          : [...prev, tag.sys.id]
+                      )
+                    }
+                    isChecked={selectedTags.includes(tag.sys.id)}
+                  />
+                ))}
+              </Multiselect>
+            </FormControl>
+
+            {/* Taxonomy concepts */}
+            {availableConcepts.length > 0 && (
+              <FormControl style={{ flex: '1 1 180px', marginBottom: 0 }}>
+                <FormControl.Label>Taxonomy concepts</FormControl.Label>
+                <Multiselect currentSelection={selectedConcepts} placeholder="Select one or more">
+                  {availableConcepts.map((concept) => (
+                    <Multiselect.Option
+                      key={concept.sys.id}
+                      itemId={concept.sys.id}
+                      value={concept.sys.id}
+                      label={Object.values(concept.prefLabel)[0] || concept.sys.id}
+                      onSelectItem={() =>
+                        setSelectedConcepts((prev) =>
+                          prev.includes(concept.sys.id)
+                            ? prev.filter((c) => c !== concept.sys.id)
+                            : [...prev, concept.sys.id]
+                        )
+                      }
+                      isChecked={selectedConcepts.includes(concept.sys.id)}
+                    />
+                  ))}
+                </Multiselect>
+              </FormControl>
+            )}
+          </Flex>
+
+          {/* Additive filter buttons */}
+          <Flex gap="spacingS" marginTop="spacingM" flexWrap="wrap">
+            <Tooltip
+              content={
+                selectedContentType
+                  ? 'Add a filter on a specific field'
+                  : 'Select a content type first'
+              }
+              placement="top">
+              <Button
+                type="button"
+                variant="secondary"
+                size="small"
+                startIcon={<PlusIcon />}
+                onClick={handleAddFieldFilter}
+                isDisabled={isExporting || !selectedContentType}>
+                Field filter
+              </Button>
+            </Tooltip>
+
+            {!showCreatedRange && (
+              <Button
+                type="button"
+                variant="secondary"
+                size="small"
+                startIcon={<PlusIcon />}
+                onClick={() => setShowCreatedRange(true)}
+                isDisabled={isExporting}>
+                Created date range
+              </Button>
+            )}
+
+            {!showUpdatedRange && (
+              <Button
+                type="button"
+                variant="secondary"
+                size="small"
+                startIcon={<PlusIcon />}
+                onClick={() => setShowUpdatedRange(true)}
+                isDisabled={isExporting}>
+                Updated date range
+              </Button>
+            )}
+          </Flex>
+
+          {/* Field filters */}
+          {fieldFilters.map((filter, index) => (
+            <div key={index} className={styles.fieldFilterRow}>
+              <Flex gap="spacingS" alignItems="flex-end" flexWrap="wrap">
+                <FormControl style={{ flex: 1, minWidth: 0, marginBottom: 0 }}>
+                  <FormControl.Label>Field</FormControl.Label>
+                  <Select
+                    value={filter.fieldId}
+                    onChange={(e) => handleFieldFilterChange(index, 'fieldId', e.target.value)}
+                    isDisabled={isExporting || !selectedContentType}>
+                    <Select.Option value="">Select field</Select.Option>
+                    {selectedContentType?.fields.map((field) => (
+                      <Select.Option key={field.id} value={field.id}>
+                        {field.name || field.id}
+                      </Select.Option>
+                    ))}
+                  </Select>
+                </FormControl>
+                <FormControl style={{ flex: 1, minWidth: 0, marginBottom: 0 }}>
+                  <FormControl.Label>Operator</FormControl.Label>
+                  <Select
+                    value={filter.operator}
+                    onChange={(e) => handleFieldFilterChange(index, 'operator', e.target.value)}
+                    isDisabled={isExporting}>
+                    <Select.Option value="equals">Equals</Select.Option>
+                    <Select.Option value="not_equals">Not equals</Select.Option>
+                    <Select.Option value="contains">Contains</Select.Option>
+                    <Select.Option value="gt">Greater than</Select.Option>
+                    <Select.Option value="gte">Greater than or equal</Select.Option>
+                    <Select.Option value="lt">Less than</Select.Option>
+                    <Select.Option value="lte">Less than or equal</Select.Option>
+                    <Select.Option value="exists">Exists</Select.Option>
+                    <Select.Option value="is_true">Is true</Select.Option>
+                    <Select.Option value="is_false">Is false</Select.Option>
+                    <Select.Option value="links_to">Links to entry ID</Select.Option>
+                  </Select>
+                </FormControl>
+                <FormControl style={{ flex: 1, minWidth: 0, marginBottom: 0 }}>
+                  <FormControl.Label>Value</FormControl.Label>
+                  <TextInput
+                    value={filter.value}
+                    onChange={(e) => handleFieldFilterChange(index, 'value', e.target.value)}
+                    isDisabled={
+                      isExporting || filter.operator === 'is_true' || filter.operator === 'is_false'
+                    }
+                    placeholder="Value"
+                  />
+                </FormControl>
+                <IconButton
+                  variant="secondary"
+                  icon={<TrashSimpleIcon />}
+                  aria-label="Remove filter"
+                  size="medium"
+                  onClick={() => handleRemoveFieldFilter(index)}
+                  isDisabled={isExporting}
+                />
+              </Flex>
             </div>
+          ))}
+
+          {/* Created date range */}
+          {showCreatedRange && (
+            <div className={styles.dateRangeCard}>
+              <Flex alignItems="center" gap="spacingXs" marginBottom="spacingS">
+                <Paragraph marginBottom="none">Created date range</Paragraph>
+                <Tooltip content="Filter entries created within this date range" placement="top">
+                  <IconButton
+                    variant="transparent"
+                    icon={<InfoIcon />}
+                    aria-label="About created date range"
+                    size="small"
+                  />
+                </Tooltip>
+              </Flex>
+              <Flex gap="spacingS" alignItems="flex-end">
+                <FormControl style={{ flex: 1, marginBottom: 0 }}>
+                  <FormControl.Label>Start</FormControl.Label>
+                  <Datepicker
+                    selected={createdFrom ? new Date(createdFrom) : undefined}
+                    onSelect={(day) => setCreatedFrom(day ? day.toISOString().split('T')[0] : '')}
+                    inputProps={{ isDisabled: isExporting }}
+                  />
+                </FormControl>
+                <FormControl style={{ flex: 1, marginBottom: 0 }}>
+                  <FormControl.Label>End</FormControl.Label>
+                  <Datepicker
+                    selected={createdTo ? new Date(createdTo) : undefined}
+                    onSelect={(day) => setCreatedTo(day ? day.toISOString().split('T')[0] : '')}
+                    inputProps={{ isDisabled: isExporting }}
+                  />
+                </FormControl>
+                <IconButton
+                  variant="secondary"
+                  icon={<TrashSimpleIcon />}
+                  aria-label="Remove created date range"
+                  size="medium"
+                  onClick={() => {
+                    setShowCreatedRange(false);
+                    setCreatedFrom('');
+                    setCreatedTo('');
+                  }}
+                  isDisabled={isExporting}
+                />
+              </Flex>
+            </div>
+          )}
+
+          {/* Updated date range */}
+          {showUpdatedRange && (
+            <div className={styles.dateRangeCard}>
+              <Flex alignItems="center" gap="spacingXs" marginBottom="spacingS">
+                <Paragraph marginBottom="none">Updated date range</Paragraph>
+                <Tooltip content="Filter entries updated within this date range" placement="top">
+                  <IconButton
+                    variant="transparent"
+                    icon={<InfoIcon />}
+                    aria-label="About updated date range"
+                    size="small"
+                  />
+                </Tooltip>
+              </Flex>
+              <Flex gap="spacingS" alignItems="flex-end">
+                <FormControl style={{ flex: 1, marginBottom: 0 }}>
+                  <FormControl.Label>Start</FormControl.Label>
+                  <Datepicker
+                    selected={updatedFrom ? new Date(updatedFrom) : undefined}
+                    onSelect={(day) => setUpdatedFrom(day ? day.toISOString().split('T')[0] : '')}
+                    inputProps={{ isDisabled: isExporting }}
+                  />
+                </FormControl>
+                <FormControl style={{ flex: 1, marginBottom: 0 }}>
+                  <FormControl.Label>End</FormControl.Label>
+                  <Datepicker
+                    selected={updatedTo ? new Date(updatedTo) : undefined}
+                    onSelect={(day) => setUpdatedTo(day ? day.toISOString().split('T')[0] : '')}
+                    inputProps={{ isDisabled: isExporting }}
+                  />
+                </FormControl>
+                <IconButton
+                  variant="secondary"
+                  icon={<TrashSimpleIcon />}
+                  aria-label="Remove updated date range"
+                  size="medium"
+                  onClick={() => {
+                    setShowUpdatedRange(false);
+                    setUpdatedFrom('');
+                    setUpdatedTo('');
+                  }}
+                  isDisabled={isExporting}
+                />
+              </Flex>
+            </div>
+          )}
+        </div>
+      </div>
     </form>
   );
 }

--- a/apps/bulk-exporter/src/components/ProgressPanel.tsx
+++ b/apps/bulk-exporter/src/components/ProgressPanel.tsx
@@ -52,8 +52,7 @@ export function ProgressPanel({ progress, onCancel }: ProgressPanelProps) {
               backgroundColor: '#e5e8ed',
               borderRadius: '4px',
               overflow: 'hidden',
-            }}
-          >
+            }}>
             <Box
               style={{
                 width: `${percentage}%`,

--- a/apps/bulk-exporter/src/components/ProgressPanel.tsx
+++ b/apps/bulk-exporter/src/components/ProgressPanel.tsx
@@ -1,0 +1,80 @@
+import { Note, Button, Flex, Text, Box } from '@contentful/f36-components';
+import type { ExportProgress } from '../lib/exporter';
+
+export interface ProgressPanelProps {
+  progress: ExportProgress | null;
+  onCancel: () => void;
+}
+
+export function ProgressPanel({ progress, onCancel }: ProgressPanelProps) {
+  if (!progress) return null;
+
+  const { fetched, total, status, message } = progress;
+  const percentage = total > 0 ? Math.round((fetched / total) * 100) : 0;
+
+  if (status === 'error') {
+    return (
+      <Note variant="negative" title="Export Error">
+        {message}
+      </Note>
+    );
+  }
+
+  if (status === 'cancelled') {
+    return (
+      <Note variant="warning" title="Export Cancelled">
+        {message}
+      </Note>
+    );
+  }
+
+  if (status === 'complete') {
+    return (
+      <Note variant="positive" title="Export Complete">
+        {message}
+      </Note>
+    );
+  }
+
+  return (
+    <Flex flexDirection="column" gap="spacingS">
+      <Text>{message}</Text>
+
+      {status === 'fetching' && total > 0 && (
+        <Flex flexDirection="column" gap="spacingXs">
+          <Text>
+            {fetched.toLocaleString()} / {total.toLocaleString()} entries ({percentage}%)
+          </Text>
+          <Box
+            style={{
+              width: '100%',
+              height: '8px',
+              backgroundColor: '#e5e8ed',
+              borderRadius: '4px',
+              overflow: 'hidden',
+            }}
+          >
+            <Box
+              style={{
+                width: `${percentage}%`,
+                height: '100%',
+                backgroundColor: '#0066ff',
+                transition: 'width 0.3s ease',
+              }}
+            />
+          </Box>
+        </Flex>
+      )}
+
+      {(status === 'estimating' || status === 'processing') && (
+        <Note variant="primary">{message}</Note>
+      )}
+
+      {status === 'fetching' && (
+        <Button variant="negative" size="small" onClick={onCancel}>
+          Cancel Export
+        </Button>
+      )}
+    </Flex>
+  );
+}

--- a/apps/bulk-exporter/src/components/ResultsList.tsx
+++ b/apps/bulk-exporter/src/components/ResultsList.tsx
@@ -1,0 +1,861 @@
+import { useState, useMemo, useEffect, useRef } from 'react';
+import { Table, Card, Text, Badge, Button, Spinner, Checkbox, Tooltip, Flex, TextLink, Subheading, Pagination, Modal, FormControl, Select, TextInput, IconButton, Heading } from '@contentful/f36-components';
+import { ArrowSquareOutIcon, SortAscendingIcon, SortDescendingIcon, XIcon } from '@contentful/f36-icons';
+import tokens from '@contentful/f36-tokens';
+import type { ContentType } from '../lib/flatten';
+
+type SortColumn = 'name' | 'contentType' | 'updated' | 'updatedBy' | 'status';
+type SortDirection = 'asc' | 'desc';
+
+interface SortableHeaderProps {
+  column: SortColumn;
+  label: string;
+  activeColumn: SortColumn | null;
+  direction: SortDirection;
+  onSort: (column: SortColumn) => void;
+}
+
+function SortableHeader({ column, label, activeColumn, direction, onSort }: SortableHeaderProps) {
+  const isActive = activeColumn === column;
+  const Icon = isActive && direction === 'desc' ? SortDescendingIcon : SortAscendingIcon;
+  return (
+    <Tooltip
+      content={
+        isActive
+          ? `Sorted by ${label} (${direction === 'asc' ? 'ascending' : 'descending'}) — applies to your next export. Click to flip direction.`
+          : `Sort by ${label}. Applies to the next export too.`
+      }
+      placement="top"
+    >
+      <Flex
+        alignItems="center"
+        gap="spacing2Xs"
+        style={{
+          cursor: 'pointer',
+          userSelect: 'none',
+          padding: '2px 6px',
+          borderRadius: '3px',
+          backgroundColor: isActive ? 'var(--blue-100, rgba(13, 102, 208, 0.08))' : 'transparent',
+          transition: 'background-color 120ms ease',
+        }}
+        onClick={() => onSort(column)}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onSort(column);
+          }
+        }}
+      >
+        <span
+          style={{
+            fontWeight: isActive ? 600 : 500,
+            color: isActive ? 'var(--blue-600)' : 'inherit',
+          }}
+        >
+          {label}
+        </span>
+        <Icon
+          size="tiny"
+          style={{
+            opacity: isActive ? 1 : 0.4,
+            color: isActive ? 'var(--blue-600)' : tokens.gray700,
+          }}
+        />
+      </Flex>
+    </Tooltip>
+  );
+}
+
+interface SearchResult {
+  sys: {
+    id: string;
+    contentType: {
+      sys: {
+        id: string;
+      };
+    };
+    createdAt: string;
+    updatedAt: string;
+    publishedAt?: string;
+    archivedAt?: string;
+    publishedVersion?: number;
+    version?: number;
+    createdBy?: {
+      sys: {
+        id: string;
+        linkType: string;
+      };
+    };
+    updatedBy?: {
+      sys: {
+        id: string;
+        linkType: string;
+      };
+    };
+  };
+  fields?: Record<string, Record<string, unknown>>;
+  metadata?: {
+    tags?: Array<{ sys: { id: string } }>;
+  };
+}
+
+interface ContentTypeMap {
+  [key: string]: {
+    name: string;
+    displayField?: string;
+  };
+}
+
+interface UserMap {
+  [key: string]: string;
+}
+
+export interface ResultsListProps {
+  results: SearchResult[];
+  loading: boolean;
+  onPageChange?: (page: number) => void;
+  activePage?: number;
+  itemsPerPage?: number;
+  totalCount?: number;
+  selectedIds?: string[];
+  onSelectionChange?: (selectedIds: string[]) => void;
+  onExportSelected?: (selectedIds: string[], format: 'csv' | 'json' | 'xlsx' | 'xml' | 'yaml', filename: string) => void;
+  contentTypeMap?: ContentTypeMap;
+  userMap?: UserMap;
+  spaceId?: string;
+  environmentId?: string;
+  isExporting?: boolean;
+  exportProgress?: { fetched: number; total: number; message?: string } | null;
+  onSortChange?: (sort: { column: SortColumn; direction: SortDirection } | null) => void;
+  /** Full content type schema — enables dynamic field columns in the preview */
+  contentTypeSchema?: ContentType | null;
+  /** Ordered field IDs selected in the Output tab */
+  selectedFields?: string[];
+  /** Locales selected in the Output tab — one preview column per field×locale */
+  locales?: string[];
+}
+
+// ─── Styling (mirrors Bulk Edit) ────────────────────────────────────────────
+
+// Fixed column widths — tableLayout: fixed makes these exact, so sticky left
+// values are reliable pixel offsets
+const COL_CHECKBOX = 48;
+const COL_NAME = 260;
+const COL_STATUS = 120;
+const COL_FIELD = 180;
+
+const LEFT_CHECKBOX = 0;
+const LEFT_NAME = COL_CHECKBOX;
+const LEFT_STATUS = COL_CHECKBOX + COL_NAME;
+
+const stickyBase = {
+  position: 'sticky' as const,
+  zIndex: 1,
+};
+
+// Header sticky cells get zIndex 2 so they sit above body sticky cells
+const stickyHeaderCell = (left: number, extraStyle: Record<string, unknown> = {}) => ({
+  ...stickyBase,
+  left,
+  zIndex: 2,
+  background: '#F7F9FA',
+  boxShadow: 'inset 0 0 0 9999px #F7F9FA',
+  ...extraStyle,
+});
+
+const stickyBodyCell = (left: number, extraStyle: Record<string, unknown> = {}) => ({
+  ...stickyBase,
+  left,
+  background: '#fff',
+  // box-shadow inset trick: fills cell with opaque color regardless of
+  // Forma 36 row hover/stripe styles that would otherwise bleed through
+  boxShadow: 'inset 0 0 0 9999px #fff',
+  ...extraStyle,
+});
+
+const fieldHeaderCellStyle = {
+  background: '#F7F9FA',
+  borderRight: '1px solid #E7EBEE',
+  minWidth: COL_FIELD,
+  verticalAlign: 'top' as const,
+  padding: '8px 12px',
+};
+
+const fieldBodyCellStyle = {
+  borderRight: '1px solid #E7EBEE',
+  minWidth: COL_FIELD,
+  verticalAlign: 'middle' as const,
+};
+
+const fixedHeaderCellStyle = {
+  background: '#F7F9FA',
+};
+
+// ─── Field type label (mirrors Bulk Edit's getFieldTypeLabel) ────────────────
+
+type SchemaField = ContentType['fields'][number];
+
+function getFieldTypeLabel(field: SchemaField): string {
+  if (field.type === 'Link') {
+    return field.linkType === 'Asset' ? 'Asset' : 'Reference';
+  }
+  if (field.type === 'Array') {
+    if (field.items?.linkType === 'Entry') return 'Multi-reference';
+    if (field.items?.linkType === 'Asset') return 'Multi-asset';
+    return 'List';
+  }
+  const labels: Record<string, string> = {
+    Symbol: 'Short text',
+    Text: 'Long text',
+    Integer: 'Integer',
+    Number: 'Number',
+    Date: 'Date',
+    Boolean: 'Boolean',
+    Object: 'JSON',
+    RichText: 'Rich text',
+    Location: 'Location',
+  };
+  return labels[field.type] ?? field.type;
+}
+
+// ─── Field value formatter (mirrors Bulk Edit's getFieldDisplayValue) ────────
+
+const TRUNCATE_AT = 40;
+
+function truncate(str: string): string {
+  return str.length > TRUNCATE_AT ? str.slice(0, TRUNCATE_AT) + '…' : str;
+}
+
+function formatFieldValue(
+  field: SchemaField,
+  rawValue: unknown
+): string {
+  if (rawValue === null || rawValue === undefined) return '—';
+
+  switch (field.type) {
+    case 'Symbol':
+    case 'Text':
+      return truncate(String(rawValue));
+
+    case 'Integer':
+    case 'Number':
+      return String(rawValue);
+
+    case 'Date':
+      return String(rawValue).split('T')[0];
+
+    case 'Boolean':
+      return rawValue ? 'Yes' : 'No';
+
+    case 'Object':
+      return truncate(JSON.stringify(rawValue));
+
+    case 'Location': {
+      const loc = rawValue as { lat?: number; lon?: number };
+      return `Lat: ${loc.lat ?? '?'}, Lon: ${loc.lon ?? '?'}`;
+    }
+
+    case 'RichText':
+      return '[Rich text]';
+
+    case 'Link': {
+      const link = rawValue as { sys?: { id: string; linkType?: string } };
+      if (link?.sys?.linkType === 'Asset') return '1 asset';
+      if (link?.sys?.linkType === 'Entry') return '1 reference';
+      return '—';
+    }
+
+    case 'Array': {
+      if (!Array.isArray(rawValue) || rawValue.length === 0) return '—';
+      const first = rawValue[0] as { sys?: { linkType?: string } };
+      if (first?.sys?.linkType === 'Entry') {
+        return `${rawValue.length} ${rawValue.length === 1 ? 'reference' : 'references'}`;
+      }
+      if (first?.sys?.linkType === 'Asset') {
+        return `${rawValue.length} ${rawValue.length === 1 ? 'asset' : 'assets'}`;
+      }
+      return truncate((rawValue as unknown[]).map(String).join(', '));
+    }
+
+    default:
+      return truncate(String(rawValue));
+  }
+}
+
+// ─── Status badge ────────────────────────────────────────────────────────────
+
+const STATUS_VARIANT: Record<string, 'primary' | 'positive' | 'warning' | 'negative'> = {
+  changed: 'primary',
+  published: 'positive',
+  draft: 'warning',
+  archived: 'negative',
+};
+
+function StatusBadge({ status }: { status: string }) {
+  const variant = STATUS_VARIANT[status] ?? 'secondary';
+  return <Badge variant={variant as 'primary' | 'positive' | 'warning' | 'negative' | 'secondary'}>{status}</Badge>;
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export function ResultsList({
+  results,
+  loading,
+  onPageChange,
+  activePage = 0,
+  itemsPerPage = 50,
+  totalCount,
+  selectedIds = [],
+  onSelectionChange,
+  onExportSelected,
+  contentTypeMap = {},
+  userMap = {},
+  spaceId = '',
+  environmentId = 'master',
+  isExporting = false,
+  exportProgress = null,
+  onSortChange,
+  contentTypeSchema,
+  selectedFields,
+  locales = [],
+}: ResultsListProps) {
+  const [sortColumn, setSortColumn] = useState<SortColumn | null>(null);
+  const [sortDirection, setSortDirection] = useState<SortDirection>('asc');
+  const [exportModalOpen, setExportModalOpen] = useState(false);
+  const [exportFormat, setExportFormat] = useState<'csv' | 'json' | 'xlsx' | 'xml' | 'yaml'>('csv');
+  const [exportFilename, setExportFilename] = useState('');
+  const wasExporting = useRef(false);
+
+  // Close modal after export completes
+  useEffect(() => {
+    if (wasExporting.current && !isExporting) {
+      setExportModalOpen(false);
+    }
+    wasExporting.current = isExporting;
+  }, [isExporting]);
+
+  // Build ordered field schema columns when a content type schema is available
+  const fieldColumns = useMemo<SchemaField[]>(() => {
+    if (!contentTypeSchema) return [];
+    const fieldMap = new Map(contentTypeSchema.fields.map((f) => [f.id, f]));
+    const orderedIds =
+      selectedFields && selectedFields.length > 0
+        ? selectedFields
+        : contentTypeSchema.fields.map((f) => f.id);
+    // Exclude any field whose ID is 'status' — publication status is already
+    // shown as a dedicated sticky column, so including it again is redundant.
+    return orderedIds
+      .map((id) => fieldMap.get(id))
+      .filter((f): f is SchemaField => f !== undefined && f.id !== 'status');
+  }, [contentTypeSchema, selectedFields]);
+
+  // Expand to one column per field × locale combination
+  const displayColumns = useMemo(() => {
+    if (fieldColumns.length === 0) return [];
+    const activeLocales = locales.length > 0 ? locales : [''];
+    return fieldColumns.flatMap((field) =>
+      activeLocales.map((locale) => ({ field, locale }))
+    );
+  }, [fieldColumns, locales]);
+
+  const hasFieldColumns = displayColumns.length > 0;
+
+  const sortedResults = useMemo(() => {
+    if (!sortColumn) return results;
+
+    const titleOf = (entry: SearchResult): string => {
+      if (!entry.fields) return entry.sys.id;
+      const contentTypeId = entry.sys.contentType.sys.id;
+      const displayField = contentTypeMap[contentTypeId]?.displayField;
+      if (displayField && entry.fields[displayField]) {
+        const firstValue = Object.values(entry.fields[displayField])[0];
+        if (firstValue && typeof firstValue === 'string') return firstValue;
+      }
+      const titleFields = ['title', 'name', 'displayName', 'label', 'heading', 'internalName'];
+      for (const field of titleFields) {
+        if (entry.fields[field]) {
+          const firstValue = Object.values(entry.fields[field])[0];
+          if (firstValue && typeof firstValue === 'string') return firstValue;
+        }
+      }
+      return entry.sys.id;
+    };
+
+    const contentTypeOf = (entry: SearchResult): string => {
+      const id = entry.sys.contentType.sys.id;
+      return contentTypeMap[id]?.name || id;
+    };
+
+    const updatedByOf = (entry: SearchResult): string => {
+      const id = entry.sys.updatedBy?.sys.id;
+      return id ? (userMap[id] || id) : 'Unknown';
+    };
+
+    const statusOf = (entry: SearchResult): string => {
+      if (entry.sys.archivedAt) return 'archived';
+      const hasPublished = entry.sys.publishedVersion !== undefined;
+      const isChanged =
+        hasPublished &&
+        entry.sys.version !== undefined &&
+        entry.sys.publishedVersion !== undefined &&
+        entry.sys.version > entry.sys.publishedVersion + 1;
+      if (!hasPublished) return 'draft';
+      if (isChanged) return 'changed';
+      return 'published';
+    };
+
+    const accessor = (entry: SearchResult): string => {
+      switch (sortColumn) {
+        case 'name': return titleOf(entry).toLowerCase();
+        case 'contentType': return contentTypeOf(entry).toLowerCase();
+        case 'updated': return entry.sys.updatedAt;
+        case 'updatedBy': return updatedByOf(entry).toLowerCase();
+        case 'status': return statusOf(entry);
+      }
+    };
+
+    const sorted = [...results].sort((a, b) => {
+      const av = accessor(a);
+      const bv = accessor(b);
+      if (av < bv) return -1;
+      if (av > bv) return 1;
+      if (a.sys.updatedAt !== b.sys.updatedAt) {
+        return a.sys.updatedAt < b.sys.updatedAt ? 1 : -1;
+      }
+      return a.sys.id.localeCompare(b.sys.id);
+    });
+
+    return sortDirection === 'desc' ? sorted.reverse() : sorted;
+  }, [results, sortColumn, sortDirection, contentTypeMap, userMap]);
+
+  const handleSortClick = (column: SortColumn) => {
+    if (sortColumn === column) {
+      const nextDir: SortDirection = sortDirection === 'asc' ? 'desc' : 'asc';
+      setSortDirection(nextDir);
+      onSortChange?.({ column, direction: nextDir });
+    } else {
+      setSortColumn(column);
+      setSortDirection('asc');
+      onSortChange?.({ column, direction: 'asc' });
+    }
+  };
+
+  const sortColumnLabels: Record<SortColumn, string> = {
+    name: 'Name',
+    contentType: 'Content Type',
+    updated: 'Updated',
+    updatedBy: 'Last Updated By',
+    status: 'Status',
+  };
+
+  if (loading && results.length === 0) {
+    return (
+      <Card padding="large">
+        <Flex alignItems="center" gap="spacingS">
+          <Spinner />
+          <Text>Loading results...</Text>
+        </Flex>
+      </Card>
+    );
+  }
+
+  if (results.length === 0) {
+    return null;
+  }
+
+  const allCurrentIds = results.map((r) => r.sys.id);
+  const allSelected = allCurrentIds.length > 0 && allCurrentIds.every((id) => selectedIds.includes(id));
+  const someSelected = selectedIds.length > 0 && !allSelected;
+
+  const handleSelectAll = () => {
+    if (!onSelectionChange) return;
+    if (allSelected) {
+      onSelectionChange(selectedIds.filter((id) => !allCurrentIds.includes(id)));
+    } else {
+      const newSelection = [...new Set([...selectedIds, ...allCurrentIds])];
+      onSelectionChange(newSelection);
+    }
+  };
+
+  const handleSelectOne = (id: string) => {
+    if (!onSelectionChange) return;
+    if (selectedIds.includes(id)) {
+      onSelectionChange(selectedIds.filter((selectedId) => selectedId !== id));
+    } else {
+      onSelectionChange([...selectedIds, id]);
+    }
+  };
+
+  const getTitle = (entry: SearchResult): string => {
+    if (!entry.fields) return entry.sys.id;
+    const contentTypeId = entry.sys.contentType.sys.id;
+    const displayField = contentTypeMap[contentTypeId]?.displayField;
+    if (displayField && entry.fields[displayField]) {
+      const firstValue = Object.values(entry.fields[displayField])[0];
+      if (firstValue && typeof firstValue === 'string') return firstValue;
+    }
+    const titleFields = ['title', 'name', 'displayName', 'label', 'heading', 'internalName'];
+    for (const field of titleFields) {
+      if (entry.fields[field]) {
+        const firstValue = Object.values(entry.fields[field])[0];
+        if (firstValue && typeof firstValue === 'string') return firstValue;
+      }
+    }
+    return entry.sys.id;
+  };
+
+  const getStatus = (entry: SearchResult): string => {
+    if (entry.sys.archivedAt) return 'archived';
+    const hasPublished = entry.sys.publishedVersion !== undefined;
+    const isChanged =
+      hasPublished &&
+      entry.sys.version !== undefined &&
+      entry.sys.publishedVersion !== undefined &&
+      entry.sys.version > entry.sys.publishedVersion + 1;
+    if (!hasPublished) return 'draft';
+    if (isChanged) return 'changed';
+    return 'published';
+  };
+
+  const getFieldValue = (entry: SearchResult, field: SchemaField, locale: string): string => {
+    if (!entry.fields?.[field.id]) return '—';
+    const localeMap = entry.fields[field.id];
+    const value = locale
+      ? (localeMap[locale] ?? Object.values(localeMap)[0])
+      : Object.values(localeMap)[0];
+    return formatFieldValue(field, value);
+  };
+
+  const getContentTypeName = (entry: SearchResult): string => {
+    const contentTypeId = entry.sys.contentType.sys.id;
+    return contentTypeMap[contentTypeId]?.name || contentTypeId;
+  };
+
+  const getLastUpdatedBy = (entry: SearchResult): string => {
+    if (entry.sys.updatedBy?.sys.id) {
+      return userMap[entry.sys.updatedBy.sys.id] || entry.sys.updatedBy.sys.id;
+    }
+    return 'Unknown';
+  };
+
+  const formatDate = (dateString: string): string =>
+    new Date(dateString).toISOString().split('T')[0];
+
+  return (
+    <Card data-results-list style={{ overflow: 'hidden', padding: 0 }}>
+      <Flex flexDirection="column">
+        {/* Header */}
+        <Flex justifyContent="space-between" alignItems="flex-start" style={{ padding: '20px 24px 16px' }}>
+          <Flex flexDirection="column" gap="spacing2Xs">
+            <Subheading marginBottom="none">Search results</Subheading>
+            <Flex gap="spacingS" alignItems="center">
+              <Text fontSize="fontSizeS" fontColor="gray600">
+                {totalCount !== undefined ? `${totalCount.toLocaleString()} results` : `${results.length} results`}
+              </Text>
+{sortColumn && (
+                <Tooltip
+                  content="This sort applies to your next export — the file rows will match the order shown below"
+                  placement="top"
+                >
+                  <Badge variant="secondary">
+                    Sorted by {sortColumnLabels[sortColumn]} ({sortDirection === 'asc' ? 'A→Z' : 'Z→A'})
+                  </Badge>
+                </Tooltip>
+              )}
+            </Flex>
+          </Flex>
+        </Flex>
+
+        {/* Selection bar */}
+        {selectedIds.length > 0 && (
+          <div style={{ padding: '0 24px' }}>
+          <Flex
+            alignItems="center"
+            gap="spacingS"
+            style={{
+              padding: '12px 0',
+              borderTop: `1px solid ${tokens.gray200}`,
+              borderBottom: `1px solid ${tokens.gray200}`,
+            }}
+          >
+            <Text fontSize="fontSizeS" fontColor="gray700">
+              {selectedIds.length} {selectedIds.length === 1 ? 'entry' : 'entries'} selected:
+            </Text>
+            {onExportSelected && (
+              <Button
+                size="small"
+                variant="primary"
+                onClick={() => setExportModalOpen(true)}
+                isDisabled={isExporting}
+              >
+                Export
+              </Button>
+            )}
+          </Flex>
+          </div>
+        )}
+
+        {/* Table — horizontal scroll when field columns overflow.
+            tableLayout: fixed lets us set exact column widths so sticky
+            left offsets are reliable pixel values. */}
+        <div style={{ padding: `${selectedIds.length > 0 ? '24px' : '0'} 24px 24px` }}>
+          <div style={{ border: '1px solid #E7EBEE', borderRadius: '6px', overflow: 'hidden' }}>
+          <div style={{ overflowX: 'auto', width: '100%' }}>
+          <Table style={{ borderCollapse: 'separate', borderSpacing: 0, tableLayout: 'fixed', width: '100%' }}>
+            <colgroup>
+              <col style={{ width: COL_CHECKBOX }} />
+              <col style={{ width: COL_NAME }} />
+              <col style={{ width: COL_STATUS }} />
+              {hasFieldColumns
+                ? displayColumns.map(({ field, locale }) => <col key={`${field.id}-${locale}`} style={{ width: COL_FIELD }} />)
+                : <>
+                    <col style={{ width: COL_FIELD }} />
+                    <col style={{ width: COL_FIELD }} />
+                    <col style={{ width: COL_FIELD }} />
+                  </>
+              }
+            </colgroup>
+            <Table.Head>
+              <Table.Row>
+                {/* Checkbox — sticky */}
+                <Table.Cell as="th" style={{ ...stickyHeaderCell(LEFT_CHECKBOX), borderRight: '1px solid #E7EBEE' }}>
+                  {onSelectionChange && (
+                    <Checkbox
+                      isChecked={allSelected}
+                      isIndeterminate={someSelected}
+                      onChange={handleSelectAll}
+                      aria-label="Select all entries on this page"
+                    />
+                  )}
+                </Table.Cell>
+
+                {/* Name — sticky */}
+                <Table.Cell as="th" style={{ ...stickyHeaderCell(LEFT_NAME), minWidth: COL_NAME, borderRight: '1px solid #E7EBEE' }}>
+                  <SortableHeader
+                    column="name"
+                    label="Display name"
+                    activeColumn={sortColumn}
+                    direction={sortDirection}
+                    onSort={handleSortClick}
+                  />
+                </Table.Cell>
+
+                {/* Status — sticky, with shadow on right edge to separate sticky from scrolling */}
+                <Table.Cell as="th" style={{ ...stickyHeaderCell(LEFT_STATUS), minWidth: COL_STATUS, borderRight: '2px solid #CFD9E0', padding: '8px 12px' }}>
+                  <Text fontWeight="fontWeightMedium" fontSize="fontSizeS" fontColor="gray900">
+                    Status
+                  </Text>
+                </Table.Cell>
+
+                {hasFieldColumns ? (
+                  /* Dynamic field columns — one per field × locale */
+                  displayColumns.map(({ field, locale }) => (
+                    <Table.Cell as="th" key={`${field.id}-${locale}`} style={fieldHeaderCellStyle}>
+                      <Flex flexDirection="column" gap="spacing2Xs">
+                        <Text fontWeight="fontWeightMedium" fontSize="fontSizeS" fontColor="gray900">
+                          {locales.length > 1 ? `(${locale}) ${field.name}` : field.name}
+                        </Text>
+                        <Text fontSize="fontSizeS" fontColor="gray600" style={{ fontSize: '11px' }}>
+                          {getFieldTypeLabel(field)}
+                        </Text>
+                      </Flex>
+                    </Table.Cell>
+                  ))
+                ) : (
+                  /* Default metadata columns when no content type selected */
+                  <>
+                    <Table.Cell as="th" style={fixedHeaderCellStyle}>
+                      <SortableHeader
+                        column="contentType"
+                        label="Content Type"
+                        activeColumn={sortColumn}
+                        direction={sortDirection}
+                        onSort={handleSortClick}
+                      />
+                    </Table.Cell>
+                    <Table.Cell as="th" style={fixedHeaderCellStyle}>
+                      <SortableHeader
+                        column="updated"
+                        label="Updated"
+                        activeColumn={sortColumn}
+                        direction={sortDirection}
+                        onSort={handleSortClick}
+                      />
+                    </Table.Cell>
+                    <Table.Cell as="th" style={fixedHeaderCellStyle}>
+                      <SortableHeader
+                        column="updatedBy"
+                        label="Last updated by"
+                        activeColumn={sortColumn}
+                        direction={sortDirection}
+                        onSort={handleSortClick}
+                      />
+                    </Table.Cell>
+                  </>
+                )}
+
+              </Table.Row>
+            </Table.Head>
+
+            <Table.Body>
+              {sortedResults.map((entry) => {
+                const status = getStatus(entry);
+                const entryUrl = `https://app.contentful.com/spaces/${spaceId}/environments/${environmentId}/entries/${entry.sys.id}`;
+                return (
+                  <Table.Row key={entry.sys.id}>
+                    {/* Checkbox — sticky */}
+                    <Table.Cell style={{ ...stickyBodyCell(LEFT_CHECKBOX), borderRight: '1px solid #E7EBEE' }}>
+                      {onSelectionChange && (
+                        <Checkbox
+                          isChecked={selectedIds.includes(entry.sys.id)}
+                          onChange={() => handleSelectOne(entry.sys.id)}
+                          aria-label={`Select ${getTitle(entry)}`}
+                        />
+                      )}
+                    </Table.Cell>
+
+                    {/* Display name — sticky, TextLink like Bulk Edit */}
+                    <Table.Cell style={{ ...stickyBodyCell(LEFT_NAME), minWidth: COL_NAME, borderRight: '1px solid #E7EBEE' }}>
+                      <TextLink
+                        href={entryUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        icon={<ArrowSquareOutIcon />}
+                        alignIcon="end"
+                        style={{ display: 'block', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                      >
+                        {getTitle(entry)}
+                      </TextLink>
+                    </Table.Cell>
+
+                    {/* Status badge — sticky */}
+                    <Table.Cell style={{ ...stickyBodyCell(LEFT_STATUS), minWidth: COL_STATUS, borderRight: '2px solid #CFD9E0' }}>
+                      <StatusBadge status={status} />
+                    </Table.Cell>
+
+                    {hasFieldColumns ? (
+                      /* Field value cells — one per field × locale */
+                      displayColumns.map(({ field, locale }) => (
+                        <Table.Cell key={`${field.id}-${locale}`} style={fieldBodyCellStyle}>
+                          <Text fontSize="fontSizeS" fontColor="gray700">
+                            {getFieldValue(entry, field, locale)}
+                          </Text>
+                        </Table.Cell>
+                      ))
+                    ) : (
+                      /* Default metadata cells */
+                      <>
+                        <Table.Cell>
+                          <Text fontSize="fontSizeS">{getContentTypeName(entry)}</Text>
+                        </Table.Cell>
+                        <Table.Cell>
+                          <Text fontSize="fontSizeS">{formatDate(entry.sys.updatedAt)}</Text>
+                        </Table.Cell>
+                        <Table.Cell>
+                          <Text fontSize="fontSizeS">{getLastUpdatedBy(entry)}</Text>
+                        </Table.Cell>
+                      </>
+                    )}
+
+                  </Table.Row>
+                );
+              })}
+            </Table.Body>
+          </Table>
+          </div>
+          </div>
+        </div>
+
+        {totalCount !== undefined && totalCount > itemsPerPage && (
+          <Flex justifyContent="center" padding="spacingM">
+            <Pagination
+              activePage={activePage}
+              onPageChange={(page) => onPageChange?.(page)}
+              totalItems={totalCount}
+              itemsPerPage={itemsPerPage}
+            />
+          </Flex>
+        )}
+      </Flex>
+
+      <Modal isShown={exportModalOpen} onClose={() => { if (!isExporting) setExportModalOpen(false); }} size="medium">
+        <Modal.Content style={{ padding: 0 }}>
+          {/* Header */}
+          <Flex
+            justifyContent="space-between"
+            alignItems="center"
+            style={{
+              padding: '20px 24px',
+              borderBottom: `1px solid ${tokens.gray200}`,
+            }}
+          >
+            <Heading as="h2" marginBottom="none">File export</Heading>
+            {!isExporting && (
+              <IconButton
+                variant="transparent"
+                icon={<XIcon />}
+                aria-label="Close"
+                size="small"
+                onClick={() => setExportModalOpen(false)}
+              />
+            )}
+          </Flex>
+
+          {/* Fields or progress */}
+          <div style={{ padding: '16px 24px 0' }}>
+            {isExporting ? (
+              <Text>
+                {exportProgress?.message || `Exporting ${selectedIds.length} selected entries`}
+              </Text>
+            ) : (
+              <>
+                <FormControl marginBottom="spacingL">
+                  <FormControl.Label>File type</FormControl.Label>
+                  <Select value={exportFormat} onChange={(e) => setExportFormat(e.target.value as 'csv' | 'json' | 'xlsx' | 'xml' | 'yaml')}>
+                    <Select.Option value="csv">CSV</Select.Option>
+                    <Select.Option value="json">JSON</Select.Option>
+                    <Select.Option value="xlsx">Excel (XLSX)</Select.Option>
+                    <Select.Option value="xml">XML</Select.Option>
+                    <Select.Option value="yaml">YAML</Select.Option>
+                  </Select>
+                </FormControl>
+                <FormControl marginBottom="none">
+                  <FormControl.Label>File name</FormControl.Label>
+                  <TextInput
+                    value={exportFilename}
+                    onChange={(e) => setExportFilename(e.target.value)}
+                    placeholder=""
+                  />
+                </FormControl>
+              </>
+            )}
+          </div>
+
+          {/* Controls */}
+          <Flex justifyContent="flex-end" gap="spacingS" style={{ padding: '16px 24px' }}>
+            {!isExporting && (
+              <Button variant="secondary" size="small" onClick={() => setExportModalOpen(false)}>
+                Cancel
+              </Button>
+            )}
+            <Button
+              variant="positive"
+              size="small"
+              isLoading={isExporting}
+              isDisabled={isExporting}
+              onClick={() => {
+                const today = new Date().toISOString().split('T')[0];
+                const resolvedFilename = exportFilename.trim() || `selected-${selectedIds.length}-entries-${today}`;
+                onExportSelected?.(selectedIds, exportFormat, resolvedFilename);
+              }}
+            >
+              {isExporting ? 'Exporting' : 'Export'}
+            </Button>
+          </Flex>
+        </Modal.Content>
+      </Modal>
+    </Card>
+  );
+}

--- a/apps/bulk-exporter/src/components/ResultsList.tsx
+++ b/apps/bulk-exporter/src/components/ResultsList.tsx
@@ -1,6 +1,30 @@
 import { useState, useMemo, useEffect, useRef } from 'react';
-import { Table, Card, Text, Badge, Button, Spinner, Checkbox, Tooltip, Flex, TextLink, Subheading, Pagination, Modal, FormControl, Select, TextInput, IconButton, Heading } from '@contentful/f36-components';
-import { ArrowSquareOutIcon, SortAscendingIcon, SortDescendingIcon, XIcon } from '@contentful/f36-icons';
+import {
+  Table,
+  Card,
+  Text,
+  Badge,
+  Button,
+  Spinner,
+  Checkbox,
+  Tooltip,
+  Flex,
+  TextLink,
+  Subheading,
+  Pagination,
+  Modal,
+  FormControl,
+  Select,
+  TextInput,
+  IconButton,
+  Heading,
+} from '@contentful/f36-components';
+import {
+  ArrowSquareOutIcon,
+  SortAscendingIcon,
+  SortDescendingIcon,
+  XIcon,
+} from '@contentful/f36-icons';
 import tokens from '@contentful/f36-tokens';
 import type { ContentType } from '../lib/flatten';
 
@@ -22,11 +46,12 @@ function SortableHeader({ column, label, activeColumn, direction, onSort }: Sort
     <Tooltip
       content={
         isActive
-          ? `Sorted by ${label} (${direction === 'asc' ? 'ascending' : 'descending'}) — applies to your next export. Click to flip direction.`
+          ? `Sorted by ${label} (${
+              direction === 'asc' ? 'ascending' : 'descending'
+            }) — applies to your next export. Click to flip direction.`
           : `Sort by ${label}. Applies to the next export too.`
       }
-      placement="top"
-    >
+      placement="top">
       <Flex
         alignItems="center"
         gap="spacing2Xs"
@@ -46,14 +71,12 @@ function SortableHeader({ column, label, activeColumn, direction, onSort }: Sort
             e.preventDefault();
             onSort(column);
           }
-        }}
-      >
+        }}>
         <span
           style={{
             fontWeight: isActive ? 600 : 500,
             color: isActive ? 'var(--blue-600)' : 'inherit',
-          }}
-        >
+          }}>
           {label}
         </span>
         <Icon
@@ -121,7 +144,11 @@ export interface ResultsListProps {
   totalCount?: number;
   selectedIds?: string[];
   onSelectionChange?: (selectedIds: string[]) => void;
-  onExportSelected?: (selectedIds: string[], format: 'csv' | 'json' | 'xlsx' | 'xml' | 'yaml', filename: string) => void;
+  onExportSelected?: (
+    selectedIds: string[],
+    format: 'csv' | 'json' | 'xlsx' | 'xml' | 'yaml',
+    filename: string
+  ) => void;
   contentTypeMap?: ContentTypeMap;
   userMap?: UserMap;
   spaceId?: string;
@@ -228,10 +255,7 @@ function truncate(str: string): string {
   return str.length > TRUNCATE_AT ? str.slice(0, TRUNCATE_AT) + '…' : str;
 }
 
-function formatFieldValue(
-  field: SchemaField,
-  rawValue: unknown
-): string {
+function formatFieldValue(field: SchemaField, rawValue: unknown): string {
   if (rawValue === null || rawValue === undefined) return '—';
 
   switch (field.type) {
@@ -295,7 +319,11 @@ const STATUS_VARIANT: Record<string, 'primary' | 'positive' | 'warning' | 'negat
 
 function StatusBadge({ status }: { status: string }) {
   const variant = STATUS_VARIANT[status] ?? 'secondary';
-  return <Badge variant={variant as 'primary' | 'positive' | 'warning' | 'negative' | 'secondary'}>{status}</Badge>;
+  return (
+    <Badge variant={variant as 'primary' | 'positive' | 'warning' | 'negative' | 'secondary'}>
+      {status}
+    </Badge>
+  );
 }
 
 // ─── Component ───────────────────────────────────────────────────────────────
@@ -355,9 +383,7 @@ export function ResultsList({
   const displayColumns = useMemo(() => {
     if (fieldColumns.length === 0) return [];
     const activeLocales = locales.length > 0 ? locales : [''];
-    return fieldColumns.flatMap((field) =>
-      activeLocales.map((locale) => ({ field, locale }))
-    );
+    return fieldColumns.flatMap((field) => activeLocales.map((locale) => ({ field, locale })));
   }, [fieldColumns, locales]);
 
   const hasFieldColumns = displayColumns.length > 0;
@@ -390,7 +416,7 @@ export function ResultsList({
 
     const updatedByOf = (entry: SearchResult): string => {
       const id = entry.sys.updatedBy?.sys.id;
-      return id ? (userMap[id] || id) : 'Unknown';
+      return id ? userMap[id] || id : 'Unknown';
     };
 
     const statusOf = (entry: SearchResult): string => {
@@ -408,11 +434,16 @@ export function ResultsList({
 
     const accessor = (entry: SearchResult): string => {
       switch (sortColumn) {
-        case 'name': return titleOf(entry).toLowerCase();
-        case 'contentType': return contentTypeOf(entry).toLowerCase();
-        case 'updated': return entry.sys.updatedAt;
-        case 'updatedBy': return updatedByOf(entry).toLowerCase();
-        case 'status': return statusOf(entry);
+        case 'name':
+          return titleOf(entry).toLowerCase();
+        case 'contentType':
+          return contentTypeOf(entry).toLowerCase();
+        case 'updated':
+          return entry.sys.updatedAt;
+        case 'updatedBy':
+          return updatedByOf(entry).toLowerCase();
+        case 'status':
+          return statusOf(entry);
       }
     };
 
@@ -466,7 +497,8 @@ export function ResultsList({
   }
 
   const allCurrentIds = results.map((r) => r.sys.id);
-  const allSelected = allCurrentIds.length > 0 && allCurrentIds.every((id) => selectedIds.includes(id));
+  const allSelected =
+    allCurrentIds.length > 0 && allCurrentIds.every((id) => selectedIds.includes(id));
   const someSelected = selectedIds.length > 0 && !allSelected;
 
   const handleSelectAll = () => {
@@ -523,7 +555,7 @@ export function ResultsList({
     if (!entry.fields?.[field.id]) return '—';
     const localeMap = entry.fields[field.id];
     const value = locale
-      ? (localeMap[locale] ?? Object.values(localeMap)[0])
+      ? localeMap[locale] ?? Object.values(localeMap)[0]
       : Object.values(localeMap)[0];
     return formatFieldValue(field, value);
   };
@@ -547,20 +579,25 @@ export function ResultsList({
     <Card data-results-list style={{ overflow: 'hidden', padding: 0 }}>
       <Flex flexDirection="column">
         {/* Header */}
-        <Flex justifyContent="space-between" alignItems="flex-start" style={{ padding: '20px 24px 16px' }}>
+        <Flex
+          justifyContent="space-between"
+          alignItems="flex-start"
+          style={{ padding: '20px 24px 16px' }}>
           <Flex flexDirection="column" gap="spacing2Xs">
             <Subheading marginBottom="none">Search results</Subheading>
             <Flex gap="spacingS" alignItems="center">
               <Text fontSize="fontSizeS" fontColor="gray600">
-                {totalCount !== undefined ? `${totalCount.toLocaleString()} results` : `${results.length} results`}
+                {totalCount !== undefined
+                  ? `${totalCount.toLocaleString()} results`
+                  : `${results.length} results`}
               </Text>
-{sortColumn && (
+              {sortColumn && (
                 <Tooltip
                   content="This sort applies to your next export — the file rows will match the order shown below"
-                  placement="top"
-                >
+                  placement="top">
                   <Badge variant="secondary">
-                    Sorted by {sortColumnLabels[sortColumn]} ({sortDirection === 'asc' ? 'A→Z' : 'Z→A'})
+                    Sorted by {sortColumnLabels[sortColumn]} (
+                    {sortDirection === 'asc' ? 'A→Z' : 'Z→A'})
                   </Badge>
                 </Tooltip>
               )}
@@ -571,29 +608,27 @@ export function ResultsList({
         {/* Selection bar */}
         {selectedIds.length > 0 && (
           <div style={{ padding: '0 24px' }}>
-          <Flex
-            alignItems="center"
-            gap="spacingS"
-            style={{
-              padding: '12px 0',
-              borderTop: `1px solid ${tokens.gray200}`,
-              borderBottom: `1px solid ${tokens.gray200}`,
-            }}
-          >
-            <Text fontSize="fontSizeS" fontColor="gray700">
-              {selectedIds.length} {selectedIds.length === 1 ? 'entry' : 'entries'} selected:
-            </Text>
-            {onExportSelected && (
-              <Button
-                size="small"
-                variant="primary"
-                onClick={() => setExportModalOpen(true)}
-                isDisabled={isExporting}
-              >
-                Export
-              </Button>
-            )}
-          </Flex>
+            <Flex
+              alignItems="center"
+              gap="spacingS"
+              style={{
+                padding: '12px 0',
+                borderTop: `1px solid ${tokens.gray200}`,
+                borderBottom: `1px solid ${tokens.gray200}`,
+              }}>
+              <Text fontSize="fontSizeS" fontColor="gray700">
+                {selectedIds.length} {selectedIds.length === 1 ? 'entry' : 'entries'} selected:
+              </Text>
+              {onExportSelected && (
+                <Button
+                  size="small"
+                  variant="primary"
+                  onClick={() => setExportModalOpen(true)}
+                  isDisabled={isExporting}>
+                  Export
+                </Button>
+              )}
+            </Flex>
           </div>
         )}
 
@@ -602,169 +637,221 @@ export function ResultsList({
             left offsets are reliable pixel values. */}
         <div style={{ padding: `${selectedIds.length > 0 ? '24px' : '0'} 24px 24px` }}>
           <div style={{ border: '1px solid #E7EBEE', borderRadius: '6px', overflow: 'hidden' }}>
-          <div style={{ overflowX: 'auto', width: '100%' }}>
-          <Table style={{ borderCollapse: 'separate', borderSpacing: 0, tableLayout: 'fixed', width: '100%' }}>
-            <colgroup>
-              <col style={{ width: COL_CHECKBOX }} />
-              <col style={{ width: COL_NAME }} />
-              <col style={{ width: COL_STATUS }} />
-              {hasFieldColumns
-                ? displayColumns.map(({ field, locale }) => <col key={`${field.id}-${locale}`} style={{ width: COL_FIELD }} />)
-                : <>
-                    <col style={{ width: COL_FIELD }} />
-                    <col style={{ width: COL_FIELD }} />
-                    <col style={{ width: COL_FIELD }} />
-                  </>
-              }
-            </colgroup>
-            <Table.Head>
-              <Table.Row>
-                {/* Checkbox — sticky */}
-                <Table.Cell as="th" style={{ ...stickyHeaderCell(LEFT_CHECKBOX), borderRight: '1px solid #E7EBEE' }}>
-                  {onSelectionChange && (
-                    <Checkbox
-                      isChecked={allSelected}
-                      isIndeterminate={someSelected}
-                      onChange={handleSelectAll}
-                      aria-label="Select all entries on this page"
-                    />
+            <div style={{ overflowX: 'auto', width: '100%' }}>
+              <Table
+                style={{
+                  borderCollapse: 'separate',
+                  borderSpacing: 0,
+                  tableLayout: 'fixed',
+                  width: '100%',
+                }}>
+                <colgroup>
+                  <col style={{ width: COL_CHECKBOX }} />
+                  <col style={{ width: COL_NAME }} />
+                  <col style={{ width: COL_STATUS }} />
+                  {hasFieldColumns ? (
+                    displayColumns.map(({ field, locale }) => (
+                      <col key={`${field.id}-${locale}`} style={{ width: COL_FIELD }} />
+                    ))
+                  ) : (
+                    <>
+                      <col style={{ width: COL_FIELD }} />
+                      <col style={{ width: COL_FIELD }} />
+                      <col style={{ width: COL_FIELD }} />
+                    </>
                   )}
-                </Table.Cell>
-
-                {/* Name — sticky */}
-                <Table.Cell as="th" style={{ ...stickyHeaderCell(LEFT_NAME), minWidth: COL_NAME, borderRight: '1px solid #E7EBEE' }}>
-                  <SortableHeader
-                    column="name"
-                    label="Display name"
-                    activeColumn={sortColumn}
-                    direction={sortDirection}
-                    onSort={handleSortClick}
-                  />
-                </Table.Cell>
-
-                {/* Status — sticky, with shadow on right edge to separate sticky from scrolling */}
-                <Table.Cell as="th" style={{ ...stickyHeaderCell(LEFT_STATUS), minWidth: COL_STATUS, borderRight: '2px solid #CFD9E0', padding: '8px 12px' }}>
-                  <Text fontWeight="fontWeightMedium" fontSize="fontSizeS" fontColor="gray900">
-                    Status
-                  </Text>
-                </Table.Cell>
-
-                {hasFieldColumns ? (
-                  /* Dynamic field columns — one per field × locale */
-                  displayColumns.map(({ field, locale }) => (
-                    <Table.Cell as="th" key={`${field.id}-${locale}`} style={fieldHeaderCellStyle}>
-                      <Flex flexDirection="column" gap="spacing2Xs">
-                        <Text fontWeight="fontWeightMedium" fontSize="fontSizeS" fontColor="gray900">
-                          {locales.length > 1 ? `(${locale}) ${field.name}` : field.name}
-                        </Text>
-                        <Text fontSize="fontSizeS" fontColor="gray600" style={{ fontSize: '11px' }}>
-                          {getFieldTypeLabel(field)}
-                        </Text>
-                      </Flex>
-                    </Table.Cell>
-                  ))
-                ) : (
-                  /* Default metadata columns when no content type selected */
-                  <>
-                    <Table.Cell as="th" style={fixedHeaderCellStyle}>
-                      <SortableHeader
-                        column="contentType"
-                        label="Content Type"
-                        activeColumn={sortColumn}
-                        direction={sortDirection}
-                        onSort={handleSortClick}
-                      />
-                    </Table.Cell>
-                    <Table.Cell as="th" style={fixedHeaderCellStyle}>
-                      <SortableHeader
-                        column="updated"
-                        label="Updated"
-                        activeColumn={sortColumn}
-                        direction={sortDirection}
-                        onSort={handleSortClick}
-                      />
-                    </Table.Cell>
-                    <Table.Cell as="th" style={fixedHeaderCellStyle}>
-                      <SortableHeader
-                        column="updatedBy"
-                        label="Last updated by"
-                        activeColumn={sortColumn}
-                        direction={sortDirection}
-                        onSort={handleSortClick}
-                      />
-                    </Table.Cell>
-                  </>
-                )}
-
-              </Table.Row>
-            </Table.Head>
-
-            <Table.Body>
-              {sortedResults.map((entry) => {
-                const status = getStatus(entry);
-                const entryUrl = `https://app.contentful.com/spaces/${spaceId}/environments/${environmentId}/entries/${entry.sys.id}`;
-                return (
-                  <Table.Row key={entry.sys.id}>
+                </colgroup>
+                <Table.Head>
+                  <Table.Row>
                     {/* Checkbox — sticky */}
-                    <Table.Cell style={{ ...stickyBodyCell(LEFT_CHECKBOX), borderRight: '1px solid #E7EBEE' }}>
+                    <Table.Cell
+                      as="th"
+                      style={{
+                        ...stickyHeaderCell(LEFT_CHECKBOX),
+                        borderRight: '1px solid #E7EBEE',
+                      }}>
                       {onSelectionChange && (
                         <Checkbox
-                          isChecked={selectedIds.includes(entry.sys.id)}
-                          onChange={() => handleSelectOne(entry.sys.id)}
-                          aria-label={`Select ${getTitle(entry)}`}
+                          isChecked={allSelected}
+                          isIndeterminate={someSelected}
+                          onChange={handleSelectAll}
+                          aria-label="Select all entries on this page"
                         />
                       )}
                     </Table.Cell>
 
-                    {/* Display name — sticky, TextLink like Bulk Edit */}
-                    <Table.Cell style={{ ...stickyBodyCell(LEFT_NAME), minWidth: COL_NAME, borderRight: '1px solid #E7EBEE' }}>
-                      <TextLink
-                        href={entryUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        icon={<ArrowSquareOutIcon />}
-                        alignIcon="end"
-                        style={{ display: 'block', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
-                      >
-                        {getTitle(entry)}
-                      </TextLink>
+                    {/* Name — sticky */}
+                    <Table.Cell
+                      as="th"
+                      style={{
+                        ...stickyHeaderCell(LEFT_NAME),
+                        minWidth: COL_NAME,
+                        borderRight: '1px solid #E7EBEE',
+                      }}>
+                      <SortableHeader
+                        column="name"
+                        label="Display name"
+                        activeColumn={sortColumn}
+                        direction={sortDirection}
+                        onSort={handleSortClick}
+                      />
                     </Table.Cell>
 
-                    {/* Status badge — sticky */}
-                    <Table.Cell style={{ ...stickyBodyCell(LEFT_STATUS), minWidth: COL_STATUS, borderRight: '2px solid #CFD9E0' }}>
-                      <StatusBadge status={status} />
+                    {/* Status — sticky, with shadow on right edge to separate sticky from scrolling */}
+                    <Table.Cell
+                      as="th"
+                      style={{
+                        ...stickyHeaderCell(LEFT_STATUS),
+                        minWidth: COL_STATUS,
+                        borderRight: '2px solid #CFD9E0',
+                        padding: '8px 12px',
+                      }}>
+                      <Text fontWeight="fontWeightMedium" fontSize="fontSizeS" fontColor="gray900">
+                        Status
+                      </Text>
                     </Table.Cell>
 
                     {hasFieldColumns ? (
-                      /* Field value cells — one per field × locale */
+                      /* Dynamic field columns — one per field × locale */
                       displayColumns.map(({ field, locale }) => (
-                        <Table.Cell key={`${field.id}-${locale}`} style={fieldBodyCellStyle}>
-                          <Text fontSize="fontSizeS" fontColor="gray700">
-                            {getFieldValue(entry, field, locale)}
-                          </Text>
+                        <Table.Cell
+                          as="th"
+                          key={`${field.id}-${locale}`}
+                          style={fieldHeaderCellStyle}>
+                          <Flex flexDirection="column" gap="spacing2Xs">
+                            <Text
+                              fontWeight="fontWeightMedium"
+                              fontSize="fontSizeS"
+                              fontColor="gray900">
+                              {locales.length > 1 ? `(${locale}) ${field.name}` : field.name}
+                            </Text>
+                            <Text
+                              fontSize="fontSizeS"
+                              fontColor="gray600"
+                              style={{ fontSize: '11px' }}>
+                              {getFieldTypeLabel(field)}
+                            </Text>
+                          </Flex>
                         </Table.Cell>
                       ))
                     ) : (
-                      /* Default metadata cells */
+                      /* Default metadata columns when no content type selected */
                       <>
-                        <Table.Cell>
-                          <Text fontSize="fontSizeS">{getContentTypeName(entry)}</Text>
+                        <Table.Cell as="th" style={fixedHeaderCellStyle}>
+                          <SortableHeader
+                            column="contentType"
+                            label="Content Type"
+                            activeColumn={sortColumn}
+                            direction={sortDirection}
+                            onSort={handleSortClick}
+                          />
                         </Table.Cell>
-                        <Table.Cell>
-                          <Text fontSize="fontSizeS">{formatDate(entry.sys.updatedAt)}</Text>
+                        <Table.Cell as="th" style={fixedHeaderCellStyle}>
+                          <SortableHeader
+                            column="updated"
+                            label="Updated"
+                            activeColumn={sortColumn}
+                            direction={sortDirection}
+                            onSort={handleSortClick}
+                          />
                         </Table.Cell>
-                        <Table.Cell>
-                          <Text fontSize="fontSizeS">{getLastUpdatedBy(entry)}</Text>
+                        <Table.Cell as="th" style={fixedHeaderCellStyle}>
+                          <SortableHeader
+                            column="updatedBy"
+                            label="Last updated by"
+                            activeColumn={sortColumn}
+                            direction={sortDirection}
+                            onSort={handleSortClick}
+                          />
                         </Table.Cell>
                       </>
                     )}
-
                   </Table.Row>
-                );
-              })}
-            </Table.Body>
-          </Table>
-          </div>
+                </Table.Head>
+
+                <Table.Body>
+                  {sortedResults.map((entry) => {
+                    const status = getStatus(entry);
+                    const entryUrl = `https://app.contentful.com/spaces/${spaceId}/environments/${environmentId}/entries/${entry.sys.id}`;
+                    return (
+                      <Table.Row key={entry.sys.id}>
+                        {/* Checkbox — sticky */}
+                        <Table.Cell
+                          style={{
+                            ...stickyBodyCell(LEFT_CHECKBOX),
+                            borderRight: '1px solid #E7EBEE',
+                          }}>
+                          {onSelectionChange && (
+                            <Checkbox
+                              isChecked={selectedIds.includes(entry.sys.id)}
+                              onChange={() => handleSelectOne(entry.sys.id)}
+                              aria-label={`Select ${getTitle(entry)}`}
+                            />
+                          )}
+                        </Table.Cell>
+
+                        {/* Display name — sticky, TextLink like Bulk Edit */}
+                        <Table.Cell
+                          style={{
+                            ...stickyBodyCell(LEFT_NAME),
+                            minWidth: COL_NAME,
+                            borderRight: '1px solid #E7EBEE',
+                          }}>
+                          <TextLink
+                            href={entryUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            icon={<ArrowSquareOutIcon />}
+                            alignIcon="end"
+                            style={{
+                              display: 'block',
+                              overflow: 'hidden',
+                              textOverflow: 'ellipsis',
+                              whiteSpace: 'nowrap',
+                            }}>
+                            {getTitle(entry)}
+                          </TextLink>
+                        </Table.Cell>
+
+                        {/* Status badge — sticky */}
+                        <Table.Cell
+                          style={{
+                            ...stickyBodyCell(LEFT_STATUS),
+                            minWidth: COL_STATUS,
+                            borderRight: '2px solid #CFD9E0',
+                          }}>
+                          <StatusBadge status={status} />
+                        </Table.Cell>
+
+                        {hasFieldColumns ? (
+                          /* Field value cells — one per field × locale */
+                          displayColumns.map(({ field, locale }) => (
+                            <Table.Cell key={`${field.id}-${locale}`} style={fieldBodyCellStyle}>
+                              <Text fontSize="fontSizeS" fontColor="gray700">
+                                {getFieldValue(entry, field, locale)}
+                              </Text>
+                            </Table.Cell>
+                          ))
+                        ) : (
+                          /* Default metadata cells */
+                          <>
+                            <Table.Cell>
+                              <Text fontSize="fontSizeS">{getContentTypeName(entry)}</Text>
+                            </Table.Cell>
+                            <Table.Cell>
+                              <Text fontSize="fontSizeS">{formatDate(entry.sys.updatedAt)}</Text>
+                            </Table.Cell>
+                            <Table.Cell>
+                              <Text fontSize="fontSizeS">{getLastUpdatedBy(entry)}</Text>
+                            </Table.Cell>
+                          </>
+                        )}
+                      </Table.Row>
+                    );
+                  })}
+                </Table.Body>
+              </Table>
+            </div>
           </div>
         </div>
 
@@ -780,7 +867,12 @@ export function ResultsList({
         )}
       </Flex>
 
-      <Modal isShown={exportModalOpen} onClose={() => { if (!isExporting) setExportModalOpen(false); }} size="medium">
+      <Modal
+        isShown={exportModalOpen}
+        onClose={() => {
+          if (!isExporting) setExportModalOpen(false);
+        }}
+        size="medium">
         <Modal.Content style={{ padding: 0 }}>
           {/* Header */}
           <Flex
@@ -789,9 +881,10 @@ export function ResultsList({
             style={{
               padding: '20px 24px',
               borderBottom: `1px solid ${tokens.gray200}`,
-            }}
-          >
-            <Heading as="h2" marginBottom="none">File export</Heading>
+            }}>
+            <Heading as="h2" marginBottom="none">
+              File export
+            </Heading>
             {!isExporting && (
               <IconButton
                 variant="transparent"
@@ -813,7 +906,11 @@ export function ResultsList({
               <>
                 <FormControl marginBottom="spacingL">
                   <FormControl.Label>File type</FormControl.Label>
-                  <Select value={exportFormat} onChange={(e) => setExportFormat(e.target.value as 'csv' | 'json' | 'xlsx' | 'xml' | 'yaml')}>
+                  <Select
+                    value={exportFormat}
+                    onChange={(e) =>
+                      setExportFormat(e.target.value as 'csv' | 'json' | 'xlsx' | 'xml' | 'yaml')
+                    }>
                     <Select.Option value="csv">CSV</Select.Option>
                     <Select.Option value="json">JSON</Select.Option>
                     <Select.Option value="xlsx">Excel (XLSX)</Select.Option>
@@ -847,10 +944,10 @@ export function ResultsList({
               isDisabled={isExporting}
               onClick={() => {
                 const today = new Date().toISOString().split('T')[0];
-                const resolvedFilename = exportFilename.trim() || `selected-${selectedIds.length}-entries-${today}`;
+                const resolvedFilename =
+                  exportFilename.trim() || `selected-${selectedIds.length}-entries-${today}`;
                 onExportSelected?.(selectedIds, exportFormat, resolvedFilename);
-              }}
-            >
+              }}>
               {isExporting ? 'Exporting' : 'Export'}
             </Button>
           </Flex>

--- a/apps/bulk-exporter/src/index.tsx
+++ b/apps/bulk-exporter/src/index.tsx
@@ -18,14 +18,14 @@ root.render(
 
 function AppRouter() {
   const sdk = useSDK();
-  
+
   if (sdk.location.is(locations.LOCATION_APP_CONFIG)) {
     return <ConfigScreen />;
   }
-  
+
   if (sdk.location.is(locations.LOCATION_PAGE)) {
     return <Page />;
   }
-  
+
   return null;
 }

--- a/apps/bulk-exporter/src/index.tsx
+++ b/apps/bulk-exporter/src/index.tsx
@@ -1,0 +1,31 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { SDKProvider, useSDK } from '@contentful/react-apps-toolkit';
+import { locations } from '@contentful/app-sdk';
+import ConfigScreen from './locations/ConfigScreen';
+import Page from './locations/Page';
+
+const container = document.getElementById('root');
+const root = createRoot(container!);
+
+root.render(
+  <StrictMode>
+    <SDKProvider>
+      <AppRouter />
+    </SDKProvider>
+  </StrictMode>
+);
+
+function AppRouter() {
+  const sdk = useSDK();
+  
+  if (sdk.location.is(locations.LOCATION_APP_CONFIG)) {
+    return <ConfigScreen />;
+  }
+  
+  if (sdk.location.is(locations.LOCATION_PAGE)) {
+    return <Page />;
+  }
+  
+  return null;
+}

--- a/apps/bulk-exporter/src/lib/__tests__/exportFormats.test.ts
+++ b/apps/bulk-exporter/src/lib/__tests__/exportFormats.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { truncateForXlsx, XLSX_CELL_CHARACTER_LIMIT } from '../exportFormats';
+
+describe('truncateForXlsx', () => {
+  it('returns short strings unchanged', () => {
+    expect(truncateForXlsx('hello')).toBe('hello');
+  });
+
+  it('returns numbers unchanged', () => {
+    expect(truncateForXlsx(123)).toBe(123);
+  });
+
+  it('returns booleans unchanged', () => {
+    expect(truncateForXlsx(true)).toBe(true);
+    expect(truncateForXlsx(false)).toBe(false);
+  });
+
+  it('returns null unchanged', () => {
+    expect(truncateForXlsx(null)).toBeNull();
+  });
+
+  it('returns string at exactly the limit unchanged', () => {
+    const value = 'a'.repeat(XLSX_CELL_CHARACTER_LIMIT);
+    expect(truncateForXlsx(value)).toBe(value);
+  });
+
+  it('truncates strings longer than the limit and appends marker', () => {
+    const value = 'a'.repeat(XLSX_CELL_CHARACTER_LIMIT + 100);
+    const result = truncateForXlsx(value);
+    expect(result.length).toBeLessThanOrEqual(XLSX_CELL_CHARACTER_LIMIT);
+    expect(result.endsWith('[truncated]')).toBe(true);
+  });
+
+  it('truncates very large JSON-stringified blobs without throwing', () => {
+    const huge = JSON.stringify({ content: 'x'.repeat(100_000) });
+    const result = truncateForXlsx(huge);
+    expect(result.length).toBeLessThanOrEqual(XLSX_CELL_CHARACTER_LIMIT);
+  });
+});

--- a/apps/bulk-exporter/src/lib/__tests__/fieldSelection.test.ts
+++ b/apps/bulk-exporter/src/lib/__tests__/fieldSelection.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getSmartDefaults,
+  applyPreset,
+  groupFields,
+  detectPreset,
+} from '../fieldSelection';
+import type { ContentType } from '../flatten';
+
+const blogPost: ContentType = {
+  sys: { id: 'blogPost' },
+  name: 'Blog Post',
+  displayField: 'title',
+  fields: [
+    { id: 'title', name: 'Title', type: 'Symbol', localized: false, required: true },
+    { id: 'slug', name: 'Slug', type: 'Symbol', localized: false, required: true },
+    { id: 'body', name: 'Body', type: 'RichText', localized: false, required: false },
+    { id: 'author', name: 'Author', type: 'Link', linkType: 'Entry', localized: false, required: false },
+    { id: 'tags', name: 'Tags', type: 'Array', items: { type: 'Symbol' }, localized: false, required: false },
+    { id: 'related', name: 'Related', type: 'Array', items: { type: 'Link', linkType: 'Entry' }, localized: false, required: false },
+    { id: 'metadata', name: 'Metadata', type: 'Object', localized: false, required: false },
+  ],
+};
+
+describe('getSmartDefaults', () => {
+  it('selects display field, semantic fields, and required Symbols', () => {
+    const result = getSmartDefaults(blogPost);
+    expect(result).toContain('title');
+    expect(result).toContain('slug');
+    expect(result).not.toContain('body');
+    expect(result).not.toContain('metadata');
+  });
+
+  it('returns at least the display field if defined', () => {
+    const minimal: ContentType = {
+      sys: { id: 'mini' },
+      displayField: 'name',
+      fields: [
+        { id: 'name', name: 'Name', type: 'Symbol', localized: false, required: false },
+        { id: 'foo', name: 'Foo', type: 'Number', localized: false, required: false },
+      ],
+    };
+    expect(getSmartDefaults(minimal)).toEqual(['name']);
+  });
+});
+
+describe('applyPreset', () => {
+  it('essentials matches smart defaults', () => {
+    expect(applyPreset(blogPost, 'essentials')).toEqual(getSmartDefaults(blogPost));
+  });
+
+  it('content includes text-based fields only', () => {
+    const result = applyPreset(blogPost, 'content');
+    expect(result).toContain('title');
+    expect(result).toContain('slug');
+    expect(result).toContain('body');
+    expect(result).toContain('tags'); // Array of Symbol
+    expect(result).not.toContain('author');
+    expect(result).not.toContain('metadata');
+  });
+
+  it('references includes link fields only', () => {
+    const result = applyPreset(blogPost, 'references');
+    expect(result).toContain('author');
+    expect(result).toContain('related');
+    expect(result).not.toContain('title');
+  });
+
+  it('all includes every field', () => {
+    expect(applyPreset(blogPost, 'all')).toHaveLength(blogPost.fields.length);
+  });
+
+  it('custom returns an empty array', () => {
+    expect(applyPreset(blogPost, 'custom')).toEqual([]);
+  });
+});
+
+describe('groupFields', () => {
+  it('groups title, required, and optional fields', () => {
+    const groups = groupFields(blogPost);
+    expect(groups.map(g => g.id)).toEqual(['title', 'required', 'optional']);
+    expect(groups[0].fields[0].id).toBe('title');
+    expect(groups[1].fields.map(f => f.id)).toEqual(['slug']);
+    expect(groups[2].fields.map(f => f.id).sort()).toEqual(
+      ['author', 'body', 'metadata', 'related', 'tags'].sort()
+    );
+  });
+
+  it('filters fields by search term across name and id', () => {
+    const groups = groupFields(blogPost, 'tag');
+    const allIds = groups.flatMap(g => g.fields.map(f => f.id));
+    expect(allIds).toEqual(['tags']);
+  });
+
+  it('hides empty groups when search filters them out', () => {
+    const groups = groupFields(blogPost, 'related');
+    expect(groups.find(g => g.id === 'title')).toBeUndefined();
+    expect(groups.find(g => g.id === 'required')).toBeUndefined();
+    expect(groups.find(g => g.id === 'optional')?.fields).toHaveLength(1);
+  });
+});
+
+describe('detectPreset', () => {
+  it('detects essentials preset', () => {
+    expect(detectPreset(blogPost, applyPreset(blogPost, 'essentials'))).toBe('essentials');
+  });
+
+  it('detects all preset', () => {
+    expect(detectPreset(blogPost, applyPreset(blogPost, 'all'))).toBe('all');
+  });
+
+  it('detects references preset', () => {
+    expect(detectPreset(blogPost, applyPreset(blogPost, 'references'))).toBe('references');
+  });
+
+  it('returns custom when selection does not match any preset', () => {
+    expect(detectPreset(blogPost, ['title', 'metadata'])).toBe('custom');
+  });
+});

--- a/apps/bulk-exporter/src/lib/__tests__/fieldSelection.test.ts
+++ b/apps/bulk-exporter/src/lib/__tests__/fieldSelection.test.ts
@@ -1,10 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import {
-  getSmartDefaults,
-  applyPreset,
-  groupFields,
-  detectPreset,
-} from '../fieldSelection';
+import { getSmartDefaults, applyPreset, groupFields, detectPreset } from '../fieldSelection';
 import type { ContentType } from '../flatten';
 
 const blogPost: ContentType = {
@@ -15,9 +10,30 @@ const blogPost: ContentType = {
     { id: 'title', name: 'Title', type: 'Symbol', localized: false, required: true },
     { id: 'slug', name: 'Slug', type: 'Symbol', localized: false, required: true },
     { id: 'body', name: 'Body', type: 'RichText', localized: false, required: false },
-    { id: 'author', name: 'Author', type: 'Link', linkType: 'Entry', localized: false, required: false },
-    { id: 'tags', name: 'Tags', type: 'Array', items: { type: 'Symbol' }, localized: false, required: false },
-    { id: 'related', name: 'Related', type: 'Array', items: { type: 'Link', linkType: 'Entry' }, localized: false, required: false },
+    {
+      id: 'author',
+      name: 'Author',
+      type: 'Link',
+      linkType: 'Entry',
+      localized: false,
+      required: false,
+    },
+    {
+      id: 'tags',
+      name: 'Tags',
+      type: 'Array',
+      items: { type: 'Symbol' },
+      localized: false,
+      required: false,
+    },
+    {
+      id: 'related',
+      name: 'Related',
+      type: 'Array',
+      items: { type: 'Link', linkType: 'Entry' },
+      localized: false,
+      required: false,
+    },
     { id: 'metadata', name: 'Metadata', type: 'Object', localized: false, required: false },
   ],
 };
@@ -78,25 +94,25 @@ describe('applyPreset', () => {
 describe('groupFields', () => {
   it('groups title, required, and optional fields', () => {
     const groups = groupFields(blogPost);
-    expect(groups.map(g => g.id)).toEqual(['title', 'required', 'optional']);
+    expect(groups.map((g) => g.id)).toEqual(['title', 'required', 'optional']);
     expect(groups[0].fields[0].id).toBe('title');
-    expect(groups[1].fields.map(f => f.id)).toEqual(['slug']);
-    expect(groups[2].fields.map(f => f.id).sort()).toEqual(
+    expect(groups[1].fields.map((f) => f.id)).toEqual(['slug']);
+    expect(groups[2].fields.map((f) => f.id).sort()).toEqual(
       ['author', 'body', 'metadata', 'related', 'tags'].sort()
     );
   });
 
   it('filters fields by search term across name and id', () => {
     const groups = groupFields(blogPost, 'tag');
-    const allIds = groups.flatMap(g => g.fields.map(f => f.id));
+    const allIds = groups.flatMap((g) => g.fields.map((f) => f.id));
     expect(allIds).toEqual(['tags']);
   });
 
   it('hides empty groups when search filters them out', () => {
     const groups = groupFields(blogPost, 'related');
-    expect(groups.find(g => g.id === 'title')).toBeUndefined();
-    expect(groups.find(g => g.id === 'required')).toBeUndefined();
-    expect(groups.find(g => g.id === 'optional')?.fields).toHaveLength(1);
+    expect(groups.find((g) => g.id === 'title')).toBeUndefined();
+    expect(groups.find((g) => g.id === 'required')).toBeUndefined();
+    expect(groups.find((g) => g.id === 'optional')?.fields).toHaveLength(1);
   });
 });
 

--- a/apps/bulk-exporter/src/lib/__tests__/flatten.test.ts
+++ b/apps/bulk-exporter/src/lib/__tests__/flatten.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect } from 'vitest';
+import { flattenEntry, flattenEntries, getColumnHeaders, type Entry, type ContentType } from '../flatten';
+
+describe('flatten', () => {
+  const mockContentType: ContentType = {
+    sys: { id: 'blogPost' },
+    name: 'Blog Post',
+    fields: [
+      { id: 'title', name: 'Title', type: 'Symbol', localized: true },
+      { id: 'slug', name: 'Slug', type: 'Symbol', localized: false },
+      { id: 'body', name: 'Body', type: 'Text', localized: true },
+      { id: 'author', name: 'Author', type: 'Link', localized: false, linkType: 'Entry' },
+      { id: 'tags', name: 'Tags', type: 'Array', localized: false, items: { type: 'Symbol' } },
+      { id: 'relatedPosts', name: 'Related', type: 'Array', localized: false, items: { type: 'Link', linkType: 'Entry' } },
+      { id: 'metadata', name: 'Metadata', type: 'Object', localized: false },
+      { id: 'publishDate', name: 'Publish Date', type: 'Date', localized: false },
+      { id: 'featured', name: 'Featured', type: 'Boolean', localized: false },
+    ],
+  };
+
+  const mockEntry: Entry = {
+    sys: {
+      id: 'entry123',
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-02T00:00:00Z',
+      publishedVersion: 5,
+      contentType: { sys: { id: 'blogPost' } },
+      updatedBy: { sys: { id: 'user123' } },
+    },
+    fields: {
+      title: {
+        'en-US': 'Hello World',
+        'de-DE': 'Hallo Welt',
+      },
+      slug: {
+        'en-US': 'hello-world',
+      },
+      body: {
+        'en-US': 'This is the body',
+        'de-DE': 'Das ist der Körper',
+      },
+      author: {
+        'en-US': {
+          sys: {
+            type: 'Link',
+            linkType: 'Entry',
+            id: 'author123',
+          },
+        },
+      },
+      tags: {
+        'en-US': ['tech', 'blog'],
+      },
+      relatedPosts: {
+        'en-US': [
+          { sys: { type: 'Link', linkType: 'Entry', id: 'post1' } },
+          { sys: { type: 'Link', linkType: 'Entry', id: 'post2' } },
+        ],
+      },
+      metadata: {
+        'en-US': { seo: { description: 'test' } },
+      },
+      publishDate: {
+        'en-US': '2024-01-15',
+      },
+      featured: {
+        'en-US': true,
+      },
+    },
+  };
+
+  describe('flattenEntry', () => {
+    it('should flatten entry with localized fields', () => {
+      const result = flattenEntry(mockEntry, {
+        contentType: mockContentType,
+        locales: ['en-US', 'de-DE'],
+        userMap: { 'user123': 'John Doe' },
+      });
+
+      expect(result['Entry ID']).toBe('entry123');
+      expect(result['Created']).toBe('2024-01-01');
+      expect(result['Updated']).toBe('2024-01-02');
+      expect(result['Last Updated By']).toBe('John Doe');
+      expect(result['Status']).toBe('Published');
+      expect(result['Content Type']).toBe('Blog Post');
+      expect(result['Title (en-US)']).toBe('Hello World');
+      expect(result['Title (de-DE)']).toBe('Hallo Welt');
+      expect(result['Body (en-US)']).toBe('This is the body');
+      expect(result['Body (de-DE)']).toBe('Das ist der Körper');
+    });
+
+    it('should flatten non-localized fields', () => {
+      const result = flattenEntry(mockEntry, {
+        contentType: mockContentType,
+        locales: ['en-US'],
+      });
+
+      expect(result['Slug']).toBe('hello-world');
+      expect(result['Featured']).toBe(true);
+      expect(result['Publish Date']).toBe('2024-01-15');
+    });
+
+    it('should format link fields', () => {
+      const result = flattenEntry(mockEntry, {
+        contentType: mockContentType,
+        locales: ['en-US'],
+      });
+
+      expect(result['Author']).toBe('author123');
+    });
+
+    it('should format array of links', () => {
+      const result = flattenEntry(mockEntry, {
+        contentType: mockContentType,
+        locales: ['en-US'],
+      });
+
+      expect(result['Related']).toBe('post1; post2');
+    });
+
+    it('should format simple arrays with semicolons', () => {
+      const result = flattenEntry(mockEntry, {
+        contentType: mockContentType,
+        locales: ['en-US'],
+      });
+
+      expect(result['Tags']).toBe('tech; blog');
+    });
+
+    it('should JSON stringify objects', () => {
+      const result = flattenEntry(mockEntry, {
+        contentType: mockContentType,
+        locales: ['en-US'],
+      });
+
+      expect(result['Metadata']).toBe('{"seo":{"description":"test"}}');
+    });
+
+    it('should handle missing fields', () => {
+      const entryWithMissingFields: Entry = {
+        sys: mockEntry.sys,
+        fields: {
+          title: { 'en-US': 'Only Title' },
+        },
+      };
+
+      const result = flattenEntry(entryWithMissingFields, {
+        contentType: mockContentType,
+        locales: ['en-US', 'de-DE'],
+      });
+
+      expect(result['Title (en-US)']).toBe('Only Title');
+      expect(result['Title (de-DE)']).toBeNull();
+      expect(result['Slug']).toBeNull();
+      expect(result['Body (en-US)']).toBeNull();
+    });
+
+    it('should respect the order of fields in the fields option', () => {
+      const result = flattenEntry(mockEntry, {
+        contentType: mockContentType,
+        locales: ['en-US'],
+        fields: ['slug', 'title', 'body'],
+      });
+
+      const orderedKeys = Object.keys(result);
+      const slugIdx = orderedKeys.indexOf('Slug');
+      const titleIdx = orderedKeys.indexOf('Title (en-US)');
+      const bodyIdx = orderedKeys.indexOf('Body (en-US)');
+
+      expect(slugIdx).toBeGreaterThan(-1);
+      expect(titleIdx).toBeGreaterThan(slugIdx);
+      expect(bodyIdx).toBeGreaterThan(titleIdx);
+    });
+
+    it('should ignore unknown field IDs in the fields option', () => {
+      const result = flattenEntry(mockEntry, {
+        contentType: mockContentType,
+        locales: ['en-US'],
+        fields: ['title', 'doesNotExist', 'slug'],
+      });
+
+      expect(result['Title (en-US)']).toBe('Hello World');
+      expect(result['Slug']).toBe('hello-world');
+      expect(result['doesNotExist']).toBeUndefined();
+    });
+
+    it('should handle unpublished entries', () => {
+      const unpublishedEntry: Entry = {
+        ...mockEntry,
+        sys: {
+          ...mockEntry.sys,
+          publishedVersion: undefined,
+          updatedBy: undefined,
+        },
+      };
+
+      const result = flattenEntry(unpublishedEntry, {
+        contentType: mockContentType,
+        locales: ['en-US'],
+      });
+
+      expect(result['Status']).toBe('Draft');
+      expect(result['Last Updated By']).toBe('Unknown');
+    });
+  });
+
+  describe('flattenEntries', () => {
+    it('should flatten multiple entries', () => {
+      const entries = [mockEntry, mockEntry];
+      const results = flattenEntries(entries, {
+        contentType: mockContentType,
+        locales: ['en-US'],
+      });
+
+      expect(results).toHaveLength(2);
+      expect(results[0]['Entry ID']).toBe('entry123');
+      expect(results[1]['Entry ID']).toBe('entry123');
+    });
+  });
+
+  describe('getColumnHeaders', () => {
+    it('should generate correct headers', () => {
+      const headers = getColumnHeaders(mockContentType, ['en-US', 'de-DE']);
+
+      expect(headers).toContain('Entry ID');
+      expect(headers).toContain('Created');
+      expect(headers).toContain('Updated');
+      expect(headers).toContain('Last Updated By');
+      expect(headers).toContain('Status');
+      expect(headers).toContain('Content Type');
+      expect(headers).toContain('Title (en-US)');
+      expect(headers).toContain('Title (de-DE)');
+      expect(headers).toContain('Body (en-US)');
+      expect(headers).toContain('Body (de-DE)');
+      expect(headers).toContain('Slug');
+      expect(headers).toContain('Author');
+      expect(headers).toContain('Tags');
+    });
+  });
+});

--- a/apps/bulk-exporter/src/lib/__tests__/flatten.test.ts
+++ b/apps/bulk-exporter/src/lib/__tests__/flatten.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { flattenEntry, flattenEntries, getColumnHeaders, type Entry, type ContentType } from '../flatten';
+import {
+  flattenEntry,
+  flattenEntries,
+  getColumnHeaders,
+  type Entry,
+  type ContentType,
+} from '../flatten';
 
 describe('flatten', () => {
   const mockContentType: ContentType = {
@@ -11,7 +17,13 @@ describe('flatten', () => {
       { id: 'body', name: 'Body', type: 'Text', localized: true },
       { id: 'author', name: 'Author', type: 'Link', localized: false, linkType: 'Entry' },
       { id: 'tags', name: 'Tags', type: 'Array', localized: false, items: { type: 'Symbol' } },
-      { id: 'relatedPosts', name: 'Related', type: 'Array', localized: false, items: { type: 'Link', linkType: 'Entry' } },
+      {
+        id: 'relatedPosts',
+        name: 'Related',
+        type: 'Array',
+        localized: false,
+        items: { type: 'Link', linkType: 'Entry' },
+      },
       { id: 'metadata', name: 'Metadata', type: 'Object', localized: false },
       { id: 'publishDate', name: 'Publish Date', type: 'Date', localized: false },
       { id: 'featured', name: 'Featured', type: 'Boolean', localized: false },
@@ -74,7 +86,7 @@ describe('flatten', () => {
       const result = flattenEntry(mockEntry, {
         contentType: mockContentType,
         locales: ['en-US', 'de-DE'],
-        userMap: { 'user123': 'John Doe' },
+        userMap: { user123: 'John Doe' },
       });
 
       expect(result['Entry ID']).toBe('entry123');

--- a/apps/bulk-exporter/src/lib/__tests__/paginate.test.ts
+++ b/apps/bulk-exporter/src/lib/__tests__/paginate.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi } from 'vitest';
+import { paginateEntries, getEntryCount } from '../paginate';
+
+describe('paginate', () => {
+  describe('paginateEntries', () => {
+    it('should paginate through all entries with skip', async () => {
+      const mockCma = {
+        entry: {
+          getMany: vi.fn()
+            .mockResolvedValueOnce({
+              items: Array(1000).fill({ sys: { id: '1' } }),
+              total: 2500,
+            })
+            .mockResolvedValueOnce({
+              items: Array(1000).fill({ sys: { id: '2' } }),
+              total: 2500,
+            })
+            .mockResolvedValueOnce({
+              items: Array(500).fill({ sys: { id: '3' } }),
+              total: 2500,
+            }),
+        },
+      };
+
+      const throttledFetch = vi.fn((fn) => fn());
+
+      const batches = [];
+      for await (const batch of paginateEntries(
+        mockCma as any,
+        { contentType: 'test' },
+        throttledFetch
+      )) {
+        batches.push(batch);
+      }
+
+      expect(batches).toHaveLength(3);
+      expect(batches[0]).toHaveLength(1000);
+      expect(batches[1]).toHaveLength(1000);
+      expect(batches[2]).toHaveLength(500);
+      expect(mockCma.entry.getMany).toHaveBeenCalledTimes(3);
+    });
+
+    it('should switch to cursor pagination after skip 9000', async () => {
+      const mockCma = {
+        entry: {
+          getMany: vi.fn()
+            .mockImplementation(({ query }) => {
+              if (query.skip !== undefined && query.skip < 9000) {
+                return Promise.resolve({
+                  items: Array(1000).fill({ sys: { id: 'skip', createdAt: '2024-01-01' } }),
+                  total: 12000,
+                });
+              }
+              if (query.skip === 9000) {
+                return Promise.resolve({
+                  items: Array(1000).fill({ sys: { id: 'cursor1', createdAt: '2024-01-10' } }),
+                  total: 12000,
+                });
+              }
+              if (query['sys.createdAt[gt]']) {
+                return Promise.resolve({
+                  items: Array(1000).fill({ sys: { id: 'cursor2', createdAt: '2024-01-20' } }),
+                  total: 12000,
+                });
+              }
+              return Promise.resolve({ items: [], total: 12000 });
+            }),
+        },
+      };
+
+      const throttledFetch = vi.fn((fn) => fn());
+
+      const batches = [];
+      for await (const batch of paginateEntries(
+        mockCma as any,
+        { contentType: 'test' },
+        throttledFetch
+      )) {
+        batches.push(batch);
+        if (batches.length >= 11) break;
+      }
+
+      expect(batches.length).toBeGreaterThanOrEqual(10);
+      
+      const calls = mockCma.entry.getMany.mock.calls;
+      const cursorCalls = calls.filter(call => call[0].query['sys.createdAt[gt]']);
+      expect(cursorCalls.length).toBeGreaterThan(0);
+    });
+
+    it('should stop when no more items', async () => {
+      const mockCma = {
+        entry: {
+          getMany: vi.fn()
+            .mockResolvedValueOnce({
+              items: Array(500).fill({ sys: { id: '1' } }),
+              total: 500,
+            }),
+        },
+      };
+
+      const throttledFetch = vi.fn((fn) => fn());
+
+      const batches = [];
+      for await (const batch of paginateEntries(
+        mockCma as any,
+        { contentType: 'test' },
+        throttledFetch
+      )) {
+        batches.push(batch);
+      }
+
+      expect(batches).toHaveLength(1);
+      expect(batches[0]).toHaveLength(500);
+    });
+  });
+
+  describe('getEntryCount', () => {
+    it('should return total count', async () => {
+      const mockCma = {
+        entry: {
+          getMany: vi.fn().mockResolvedValue({
+            items: [],
+            total: 1234,
+          }),
+        },
+      };
+
+      const count = await getEntryCount(mockCma as any, 'test', {});
+
+      expect(count).toBe(1234);
+      expect(mockCma.entry.getMany).toHaveBeenCalledWith({
+        query: {
+          content_type: 'test',
+          limit: 0,
+        },
+      });
+    });
+
+    it('should pass filters to query', async () => {
+      const mockCma = {
+        entry: {
+          getMany: vi.fn().mockResolvedValue({
+            items: [],
+            total: 100,
+          }),
+        },
+      };
+
+      const filters = {
+        'sys.publishedAt[exists]': true,
+        'sys.createdAt[gte]': '2024-01-01',
+      };
+
+      await getEntryCount(mockCma as any, 'test', filters);
+
+      expect(mockCma.entry.getMany).toHaveBeenCalledWith({
+        query: {
+          content_type: 'test',
+          limit: 0,
+          ...filters,
+        },
+      });
+    });
+  });
+});

--- a/apps/bulk-exporter/src/lib/__tests__/paginate.test.ts
+++ b/apps/bulk-exporter/src/lib/__tests__/paginate.test.ts
@@ -6,7 +6,8 @@ describe('paginate', () => {
     it('should paginate through all entries with skip', async () => {
       const mockCma = {
         entry: {
-          getMany: vi.fn()
+          getMany: vi
+            .fn()
             .mockResolvedValueOnce({
               items: Array(1000).fill({ sys: { id: '1' } }),
               total: 2500,
@@ -43,28 +44,27 @@ describe('paginate', () => {
     it('should switch to cursor pagination after skip 9000', async () => {
       const mockCma = {
         entry: {
-          getMany: vi.fn()
-            .mockImplementation(({ query }) => {
-              if (query.skip !== undefined && query.skip < 9000) {
-                return Promise.resolve({
-                  items: Array(1000).fill({ sys: { id: 'skip', createdAt: '2024-01-01' } }),
-                  total: 12000,
-                });
-              }
-              if (query.skip === 9000) {
-                return Promise.resolve({
-                  items: Array(1000).fill({ sys: { id: 'cursor1', createdAt: '2024-01-10' } }),
-                  total: 12000,
-                });
-              }
-              if (query['sys.createdAt[gt]']) {
-                return Promise.resolve({
-                  items: Array(1000).fill({ sys: { id: 'cursor2', createdAt: '2024-01-20' } }),
-                  total: 12000,
-                });
-              }
-              return Promise.resolve({ items: [], total: 12000 });
-            }),
+          getMany: vi.fn().mockImplementation(({ query }) => {
+            if (query.skip !== undefined && query.skip < 9000) {
+              return Promise.resolve({
+                items: Array(1000).fill({ sys: { id: 'skip', createdAt: '2024-01-01' } }),
+                total: 12000,
+              });
+            }
+            if (query.skip === 9000) {
+              return Promise.resolve({
+                items: Array(1000).fill({ sys: { id: 'cursor1', createdAt: '2024-01-10' } }),
+                total: 12000,
+              });
+            }
+            if (query['sys.createdAt[gt]']) {
+              return Promise.resolve({
+                items: Array(1000).fill({ sys: { id: 'cursor2', createdAt: '2024-01-20' } }),
+                total: 12000,
+              });
+            }
+            return Promise.resolve({ items: [], total: 12000 });
+          }),
         },
       };
 
@@ -81,20 +81,19 @@ describe('paginate', () => {
       }
 
       expect(batches.length).toBeGreaterThanOrEqual(10);
-      
+
       const calls = mockCma.entry.getMany.mock.calls;
-      const cursorCalls = calls.filter(call => call[0].query['sys.createdAt[gt]']);
+      const cursorCalls = calls.filter((call) => call[0].query['sys.createdAt[gt]']);
       expect(cursorCalls.length).toBeGreaterThan(0);
     });
 
     it('should stop when no more items', async () => {
       const mockCma = {
         entry: {
-          getMany: vi.fn()
-            .mockResolvedValueOnce({
-              items: Array(500).fill({ sys: { id: '1' } }),
-              total: 500,
-            }),
+          getMany: vi.fn().mockResolvedValueOnce({
+            items: Array(500).fill({ sys: { id: '1' } }),
+            total: 500,
+          }),
         },
       };
 

--- a/apps/bulk-exporter/src/lib/__tests__/preferences.test.ts
+++ b/apps/bulk-exporter/src/lib/__tests__/preferences.test.ts
@@ -97,14 +97,21 @@ describe('preferences', () => {
     });
 
     it('rejects empty space or content type IDs gracefully', () => {
-      expect(saveFieldPreferences('', 'blogPost', { selectedFields: [], lastPreset: 'all' })).toBe(false);
-      expect(saveFieldPreferences('space1', '', { selectedFields: [], lastPreset: 'all' })).toBe(false);
+      expect(saveFieldPreferences('', 'blogPost', { selectedFields: [], lastPreset: 'all' })).toBe(
+        false
+      );
+      expect(saveFieldPreferences('space1', '', { selectedFields: [], lastPreset: 'all' })).toBe(
+        false
+      );
       expect(getFieldPreferences('', 'blogPost')).toBeNull();
       expect(getFieldPreferences('space1', '')).toBeNull();
     });
 
     it('handles malformed JSON in storage gracefully', () => {
-      window.localStorage.setItem('bulk-entry-exporter:v1:fields:space1:blogPost', 'not valid json');
+      window.localStorage.setItem(
+        'bulk-entry-exporter:v1:fields:space1:blogPost',
+        'not valid json'
+      );
       expect(getFieldPreferences('space1', 'blogPost')).toBeNull();
     });
   });

--- a/apps/bulk-exporter/src/lib/__tests__/preferences.test.ts
+++ b/apps/bulk-exporter/src/lib/__tests__/preferences.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach, beforeAll } from 'vitest';
+import {
+  getFieldPreferences,
+  saveFieldPreferences,
+  clearFieldPreferences,
+  getSpacePreferences,
+  saveSpacePreferences,
+} from '../preferences';
+
+function createLocalStorageMock(): Storage {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => (key in store ? store[key] : null),
+    setItem: (key: string, value: string) => {
+      store[key] = String(value);
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+    key: (index: number) => Object.keys(store)[index] ?? null,
+    get length() {
+      return Object.keys(store).length;
+    },
+  };
+}
+
+describe('preferences', () => {
+  beforeAll(() => {
+    Object.defineProperty(window, 'localStorage', {
+      value: createLocalStorageMock(),
+      configurable: true,
+    });
+  });
+
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  describe('field preferences', () => {
+    it('returns null when nothing is saved', () => {
+      expect(getFieldPreferences('space1', 'blogPost')).toBeNull();
+    });
+
+    it('saves and retrieves field preferences', () => {
+      const ok = saveFieldPreferences('space1', 'blogPost', {
+        selectedFields: ['title', 'slug'],
+        lastPreset: 'essentials',
+      });
+
+      expect(ok).toBe(true);
+
+      const result = getFieldPreferences('space1', 'blogPost');
+      expect(result?.selectedFields).toEqual(['title', 'slug']);
+      expect(result?.lastPreset).toBe('essentials');
+      expect(result?.updatedAt).toBeTruthy();
+    });
+
+    it('isolates preferences per space', () => {
+      saveFieldPreferences('space1', 'blogPost', {
+        selectedFields: ['title'],
+        lastPreset: 'custom',
+      });
+      saveFieldPreferences('space2', 'blogPost', {
+        selectedFields: ['body'],
+        lastPreset: 'custom',
+      });
+
+      expect(getFieldPreferences('space1', 'blogPost')?.selectedFields).toEqual(['title']);
+      expect(getFieldPreferences('space2', 'blogPost')?.selectedFields).toEqual(['body']);
+    });
+
+    it('isolates preferences per content type', () => {
+      saveFieldPreferences('space1', 'blogPost', {
+        selectedFields: ['title'],
+        lastPreset: 'custom',
+      });
+      saveFieldPreferences('space1', 'product', {
+        selectedFields: ['sku'],
+        lastPreset: 'custom',
+      });
+
+      expect(getFieldPreferences('space1', 'blogPost')?.selectedFields).toEqual(['title']);
+      expect(getFieldPreferences('space1', 'product')?.selectedFields).toEqual(['sku']);
+    });
+
+    it('clears field preferences', () => {
+      saveFieldPreferences('space1', 'blogPost', {
+        selectedFields: ['title'],
+        lastPreset: 'essentials',
+      });
+      clearFieldPreferences('space1', 'blogPost');
+
+      expect(getFieldPreferences('space1', 'blogPost')).toBeNull();
+    });
+
+    it('rejects empty space or content type IDs gracefully', () => {
+      expect(saveFieldPreferences('', 'blogPost', { selectedFields: [], lastPreset: 'all' })).toBe(false);
+      expect(saveFieldPreferences('space1', '', { selectedFields: [], lastPreset: 'all' })).toBe(false);
+      expect(getFieldPreferences('', 'blogPost')).toBeNull();
+      expect(getFieldPreferences('space1', '')).toBeNull();
+    });
+
+    it('handles malformed JSON in storage gracefully', () => {
+      window.localStorage.setItem('bulk-entry-exporter:v1:fields:space1:blogPost', 'not valid json');
+      expect(getFieldPreferences('space1', 'blogPost')).toBeNull();
+    });
+  });
+
+  describe('space preferences', () => {
+    it('returns empty object when nothing saved', () => {
+      expect(getSpacePreferences('space1')).toEqual({});
+    });
+
+    it('persists format and filename pattern', () => {
+      saveSpacePreferences('space1', { format: 'json' });
+      saveSpacePreferences('space1', { filenamePattern: 'my-export' });
+
+      const prefs = getSpacePreferences('space1');
+      expect(prefs.format).toBe('json');
+      expect(prefs.filenamePattern).toBe('my-export');
+    });
+
+    it('merges patches without losing other fields', () => {
+      saveSpacePreferences('space1', { format: 'xlsx', filenamePattern: 'first' });
+      saveSpacePreferences('space1', { format: 'yaml' });
+
+      const prefs = getSpacePreferences('space1');
+      expect(prefs.format).toBe('yaml');
+      expect(prefs.filenamePattern).toBe('first');
+    });
+
+    it('isolates space preferences', () => {
+      saveSpacePreferences('space1', { format: 'csv' });
+      saveSpacePreferences('space2', { format: 'json' });
+
+      expect(getSpacePreferences('space1').format).toBe('csv');
+      expect(getSpacePreferences('space2').format).toBe('json');
+    });
+  });
+});

--- a/apps/bulk-exporter/src/lib/__tests__/queryBuilder.test.ts
+++ b/apps/bulk-exporter/src/lib/__tests__/queryBuilder.test.ts
@@ -1,0 +1,327 @@
+import { describe, it, expect } from 'vitest';
+import { buildQuery, type QueryFormData } from '../queryBuilder';
+
+describe('queryBuilder', () => {
+  describe('basic content type', () => {
+    it('should include content_type', () => {
+      const data: QueryFormData = { contentTypeId: 'blogPost' };
+      const result = buildQuery(data);
+      expect(result).toEqual({ content_type: 'blogPost' });
+    });
+  });
+
+  describe('full-text search', () => {
+    it('should add query parameter when search is provided', () => {
+      const data: QueryFormData = {
+        contentTypeId: 'blogPost',
+        search: 'hello world',
+      };
+      const result = buildQuery(data);
+      expect(result.query).toBe('hello world');
+    });
+
+    it('should trim search string', () => {
+      const data: QueryFormData = {
+        contentTypeId: 'blogPost',
+        search: '  hello  ',
+      };
+      const result = buildQuery(data);
+      expect(result.query).toBe('hello');
+    });
+
+    it('should not add query parameter for empty search', () => {
+      const data: QueryFormData = {
+        contentTypeId: 'blogPost',
+        search: '   ',
+      };
+      const result = buildQuery(data);
+      expect(result.query).toBeUndefined();
+    });
+  });
+
+  describe('status filters', () => {
+    it('should filter for published entries', () => {
+      const data: QueryFormData = {
+        contentTypeId: 'blogPost',
+        status: 'published',
+      };
+      const result = buildQuery(data);
+      expect(result['sys.publishedAt[exists]']).toBe(true);
+      expect(result['sys.archivedAt[exists]']).toBe(false);
+    });
+
+    it('should filter for draft entries', () => {
+      const data: QueryFormData = {
+        contentTypeId: 'blogPost',
+        status: 'draft',
+      };
+      const result = buildQuery(data);
+      expect(result['sys.publishedAt[exists]']).toBe(false);
+      expect(result['sys.archivedAt[exists]']).toBe(false);
+    });
+
+    it('should filter for changed entries', () => {
+      const data: QueryFormData = {
+        contentTypeId: 'blogPost',
+        status: 'changed',
+      };
+      const result = buildQuery(data);
+      expect(result['sys.publishedAt[exists]']).toBe(true);
+      expect(result['sys.archivedAt[exists]']).toBe(false);
+      expect(result['sys.publishedVersion[ne]']).toBe('sys.version');
+    });
+
+    it('should filter for archived entries', () => {
+      const data: QueryFormData = {
+        contentTypeId: 'blogPost',
+        status: 'archived',
+      };
+      const result = buildQuery(data);
+      expect(result['sys.archivedAt[exists]']).toBe(true);
+    });
+
+    it('should not add filters for any status', () => {
+      const data: QueryFormData = {
+        contentTypeId: 'blogPost',
+        status: 'any',
+      };
+      const result = buildQuery(data);
+      expect(result['sys.publishedAt[exists]']).toBeUndefined();
+    });
+  });
+
+  describe('date ranges', () => {
+    it('should add created date range', () => {
+      const data: QueryFormData = {
+        contentTypeId: 'blogPost',
+        createdFrom: '2024-01-01',
+        createdTo: '2024-12-31',
+      };
+      const result = buildQuery(data);
+      expect(result['sys.createdAt[gte]']).toBe('2024-01-01');
+      expect(result['sys.createdAt[lte]']).toBe('2024-12-31');
+    });
+
+    it('should add updated date range', () => {
+      const data: QueryFormData = {
+        contentTypeId: 'blogPost',
+        updatedFrom: '2024-06-01',
+        updatedTo: '2024-06-30',
+      };
+      const result = buildQuery(data);
+      expect(result['sys.updatedAt[gte]']).toBe('2024-06-01');
+      expect(result['sys.updatedAt[lte]']).toBe('2024-06-30');
+    });
+
+    it('should handle partial date ranges', () => {
+      const data: QueryFormData = {
+        contentTypeId: 'blogPost',
+        createdFrom: '2024-01-01',
+      };
+      const result = buildQuery(data);
+      expect(result['sys.createdAt[gte]']).toBe('2024-01-01');
+      expect(result['sys.createdAt[lte]']).toBeUndefined();
+    });
+  });
+
+  describe('sort order', () => {
+    it('should add sort parameter', () => {
+      const data: QueryFormData = {
+        contentTypeId: 'blogPost',
+        sort: '-sys.createdAt',
+      };
+      const result = buildQuery(data);
+      expect(result.order).toBe('-sys.createdAt');
+    });
+  });
+
+  describe('tags', () => {
+    it('should add tags with match any (in)', () => {
+      const data: QueryFormData = {
+        contentTypeId: 'blogPost',
+        tags: ['tag1', 'tag2', 'tag3'],
+        tagsMatchAll: false,
+      };
+      const result = buildQuery(data);
+      expect(result['metadata.tags.sys.id[in]']).toBe('tag1,tag2,tag3');
+    });
+
+    it('should add tags with match all', () => {
+      const data: QueryFormData = {
+        contentTypeId: 'blogPost',
+        tags: ['tag1', 'tag2'],
+        tagsMatchAll: true,
+      };
+      const result = buildQuery(data);
+      expect(result['metadata.tags.sys.id[all]']).toBe('tag1,tag2');
+    });
+
+    it('should not add tags parameter if array is empty', () => {
+      const data: QueryFormData = {
+        contentTypeId: 'blogPost',
+        tags: [],
+      };
+      const result = buildQuery(data);
+      expect(result['metadata.tags.sys.id[in]']).toBeUndefined();
+      expect(result['metadata.tags.sys.id[all]']).toBeUndefined();
+    });
+  });
+
+  describe('concepts', () => {
+    it('should add concepts with match any (in)', () => {
+      const data: QueryFormData = {
+        contentTypeId: 'blogPost',
+        concepts: ['concept1', 'concept2'],
+        conceptsMatchAll: false,
+      };
+      const result = buildQuery(data);
+      expect(result['metadata.concepts.sys.id[in]']).toBe('concept1,concept2');
+    });
+
+    it('should add concepts with match all', () => {
+      const data: QueryFormData = {
+        contentTypeId: 'blogPost',
+        concepts: ['concept1', 'concept2'],
+        conceptsMatchAll: true,
+      };
+      const result = buildQuery(data);
+      expect(result['metadata.concepts.sys.id[all]']).toBe('concept1,concept2');
+    });
+  });
+
+  describe('field filters', () => {
+    it('should add equals filter', () => {
+      const data: QueryFormData = {
+        contentTypeId: 'blogPost',
+        fieldFilters: [
+          { fieldId: 'title', operator: 'equals', value: 'Hello' },
+        ],
+      };
+      const result = buildQuery(data);
+      expect(result['fields.title']).toBe('Hello');
+    });
+
+    it('should add not equals filter', () => {
+      const data: QueryFormData = {
+        contentTypeId: 'blogPost',
+        fieldFilters: [
+          { fieldId: 'status', operator: 'not_equals', value: 'draft' },
+        ],
+      };
+      const result = buildQuery(data);
+      expect(result['fields.status[ne]']).toBe('draft');
+    });
+
+    it('should add contains filter', () => {
+      const data: QueryFormData = {
+        contentTypeId: 'blogPost',
+        fieldFilters: [
+          { fieldId: 'body', operator: 'contains', value: 'keyword' },
+        ],
+      };
+      const result = buildQuery(data);
+      expect(result['fields.body[match]']).toBe('keyword');
+    });
+
+    it('should add comparison filters', () => {
+      const data: QueryFormData = {
+        contentTypeId: 'product',
+        fieldFilters: [
+          { fieldId: 'price', operator: 'gte', value: '100' },
+          { fieldId: 'stock', operator: 'lt', value: '10' },
+        ],
+      };
+      const result = buildQuery(data);
+      expect(result['fields.price[gte]']).toBe('100');
+      expect(result['fields.stock[lt]']).toBe('10');
+    });
+
+    it('should add exists filter', () => {
+      const data: QueryFormData = {
+        contentTypeId: 'blogPost',
+        fieldFilters: [
+          { fieldId: 'featuredImage', operator: 'exists', value: 'true' },
+        ],
+      };
+      const result = buildQuery(data);
+      expect(result['fields.featuredImage[exists]']).toBe(true);
+    });
+
+    it('should add boolean filters', () => {
+      const data: QueryFormData = {
+        contentTypeId: 'blogPost',
+        fieldFilters: [
+          { fieldId: 'published', operator: 'is_true', value: '' },
+          { fieldId: 'archived', operator: 'is_false', value: '' },
+        ],
+      };
+      const result = buildQuery(data);
+      expect(result['fields.published']).toBe(true);
+      expect(result['fields.archived']).toBe(false);
+    });
+
+    it('should add links_to filter', () => {
+      const data: QueryFormData = {
+        contentTypeId: 'blogPost',
+        fieldFilters: [
+          { fieldId: 'author', operator: 'links_to', value: 'author123' },
+        ],
+      };
+      const result = buildQuery(data);
+      expect(result['fields.author.sys.id']).toBe('author123');
+    });
+
+    it('should handle multiple field filters', () => {
+      const data: QueryFormData = {
+        contentTypeId: 'product',
+        fieldFilters: [
+          { fieldId: 'category', operator: 'equals', value: 'electronics' },
+          { fieldId: 'price', operator: 'gte', value: '100' },
+          { fieldId: 'inStock', operator: 'is_true', value: '' },
+        ],
+      };
+      const result = buildQuery(data);
+      expect(result['fields.category']).toBe('electronics');
+      expect(result['fields.price[gte]']).toBe('100');
+      expect(result['fields.inStock']).toBe(true);
+    });
+
+    it('should skip filters with missing fieldId or operator', () => {
+      const data: QueryFormData = {
+        contentTypeId: 'blogPost',
+        fieldFilters: [
+          { fieldId: '', operator: 'equals', value: 'test' },
+          { fieldId: 'title', operator: '' as any, value: 'test' },
+        ],
+      };
+      const result = buildQuery(data);
+      expect(Object.keys(result)).toHaveLength(1); // only content_type
+    });
+  });
+
+  describe('combined filters', () => {
+    it('should combine multiple filter types', () => {
+      const data: QueryFormData = {
+        contentTypeId: 'blogPost',
+        search: 'react',
+        status: 'published',
+        tags: ['tech', 'tutorial'],
+        tagsMatchAll: false,
+        createdFrom: '2024-01-01',
+        sort: '-sys.createdAt',
+        fieldFilters: [
+          { fieldId: 'category', operator: 'equals', value: 'programming' },
+        ],
+      };
+      const result = buildQuery(data);
+      
+      expect(result.content_type).toBe('blogPost');
+      expect(result.query).toBe('react');
+      expect(result['sys.publishedAt[exists]']).toBe(true);
+      expect(result['metadata.tags.sys.id[in]']).toBe('tech,tutorial');
+      expect(result['sys.createdAt[gte]']).toBe('2024-01-01');
+      expect(result.order).toBe('-sys.createdAt');
+      expect(result['fields.category']).toBe('programming');
+    });
+  });
+});

--- a/apps/bulk-exporter/src/lib/__tests__/queryBuilder.test.ts
+++ b/apps/bulk-exporter/src/lib/__tests__/queryBuilder.test.ts
@@ -68,7 +68,8 @@ describe('queryBuilder', () => {
       const result = buildQuery(data);
       expect(result['sys.publishedAt[exists]']).toBe(true);
       expect(result['sys.archivedAt[exists]']).toBe(false);
-      expect(result['sys.publishedVersion[ne]']).toBe('sys.version');
+      // changed status is post-filtered client-side; no server-side publishedVersion filter
+      expect(result['sys.publishedVersion[ne]']).toBeUndefined();
     });
 
     it('should filter for archived entries', () => {

--- a/apps/bulk-exporter/src/lib/__tests__/queryBuilder.test.ts
+++ b/apps/bulk-exporter/src/lib/__tests__/queryBuilder.test.ts
@@ -193,9 +193,7 @@ describe('queryBuilder', () => {
     it('should add equals filter', () => {
       const data: QueryFormData = {
         contentTypeId: 'blogPost',
-        fieldFilters: [
-          { fieldId: 'title', operator: 'equals', value: 'Hello' },
-        ],
+        fieldFilters: [{ fieldId: 'title', operator: 'equals', value: 'Hello' }],
       };
       const result = buildQuery(data);
       expect(result['fields.title']).toBe('Hello');
@@ -204,9 +202,7 @@ describe('queryBuilder', () => {
     it('should add not equals filter', () => {
       const data: QueryFormData = {
         contentTypeId: 'blogPost',
-        fieldFilters: [
-          { fieldId: 'status', operator: 'not_equals', value: 'draft' },
-        ],
+        fieldFilters: [{ fieldId: 'status', operator: 'not_equals', value: 'draft' }],
       };
       const result = buildQuery(data);
       expect(result['fields.status[ne]']).toBe('draft');
@@ -215,9 +211,7 @@ describe('queryBuilder', () => {
     it('should add contains filter', () => {
       const data: QueryFormData = {
         contentTypeId: 'blogPost',
-        fieldFilters: [
-          { fieldId: 'body', operator: 'contains', value: 'keyword' },
-        ],
+        fieldFilters: [{ fieldId: 'body', operator: 'contains', value: 'keyword' }],
       };
       const result = buildQuery(data);
       expect(result['fields.body[match]']).toBe('keyword');
@@ -239,9 +233,7 @@ describe('queryBuilder', () => {
     it('should add exists filter', () => {
       const data: QueryFormData = {
         contentTypeId: 'blogPost',
-        fieldFilters: [
-          { fieldId: 'featuredImage', operator: 'exists', value: 'true' },
-        ],
+        fieldFilters: [{ fieldId: 'featuredImage', operator: 'exists', value: 'true' }],
       };
       const result = buildQuery(data);
       expect(result['fields.featuredImage[exists]']).toBe(true);
@@ -263,9 +255,7 @@ describe('queryBuilder', () => {
     it('should add links_to filter', () => {
       const data: QueryFormData = {
         contentTypeId: 'blogPost',
-        fieldFilters: [
-          { fieldId: 'author', operator: 'links_to', value: 'author123' },
-        ],
+        fieldFilters: [{ fieldId: 'author', operator: 'links_to', value: 'author123' }],
       };
       const result = buildQuery(data);
       expect(result['fields.author.sys.id']).toBe('author123');
@@ -309,12 +299,10 @@ describe('queryBuilder', () => {
         tagsMatchAll: false,
         createdFrom: '2024-01-01',
         sort: '-sys.createdAt',
-        fieldFilters: [
-          { fieldId: 'category', operator: 'equals', value: 'programming' },
-        ],
+        fieldFilters: [{ fieldId: 'category', operator: 'equals', value: 'programming' }],
       };
       const result = buildQuery(data);
-      
+
       expect(result.content_type).toBe('blogPost');
       expect(result.query).toBe('react');
       expect(result['sys.publishedAt[exists]']).toBe(true);

--- a/apps/bulk-exporter/src/lib/__tests__/sortRows.test.ts
+++ b/apps/bulk-exporter/src/lib/__tests__/sortRows.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+
+// Re-implement the comparator inline so we can test it without invoking the
+// full Exporter (which needs a CMA client). The shape mirrors the function
+// used in src/lib/exporter.ts -> sortRowsByColumn.
+function sortRowsByColumn<T extends Record<string, string | number | boolean | null>>(
+  rows: T[],
+  column: string,
+  direction: 'asc' | 'desc'
+): T[] {
+  const factor = direction === 'desc' ? -1 : 1;
+  return [...rows].sort((a, b) => {
+    const av = a[column];
+    const bv = b[column];
+
+    if (av == null && bv == null) return 0;
+    if (av == null) return 1;
+    if (bv == null) return -1;
+
+    if (typeof av === 'number' && typeof bv === 'number') {
+      return (av - bv) * factor;
+    }
+
+    return String(av).localeCompare(String(bv), undefined, { numeric: true, sensitivity: 'base' }) * factor;
+  });
+}
+
+describe('sortRowsByColumn (mirror of exporter helper)', () => {
+  const rows = [
+    { Name: 'Charlie', Updated: '2026-01-03' },
+    { Name: 'alice', Updated: '2026-01-01' },
+    { Name: 'Bob', Updated: '2026-01-02' },
+  ];
+
+  it('sorts strings ascending case-insensitively', () => {
+    const result = sortRowsByColumn(rows, 'Name', 'asc');
+    expect(result.map(r => r.Name)).toEqual(['alice', 'Bob', 'Charlie']);
+  });
+
+  it('sorts strings descending', () => {
+    const result = sortRowsByColumn(rows, 'Name', 'desc');
+    expect(result.map(r => r.Name)).toEqual(['Charlie', 'Bob', 'alice']);
+  });
+
+  it('sorts dates ascending by string comparison (ISO format)', () => {
+    const result = sortRowsByColumn(rows, 'Updated', 'asc');
+    expect(result.map(r => r.Updated)).toEqual(['2026-01-01', '2026-01-02', '2026-01-03']);
+  });
+
+  it('puts null/undefined values at the end regardless of direction', () => {
+    const withNulls = [
+      { Name: 'Beta', value: 5 },
+      { Name: 'Alpha', value: null },
+      { Name: 'Gamma', value: 1 },
+    ];
+
+    const asc = sortRowsByColumn(withNulls, 'value', 'asc');
+    expect(asc.map(r => r.Name)).toEqual(['Gamma', 'Beta', 'Alpha']);
+
+    const desc = sortRowsByColumn(withNulls, 'value', 'desc');
+    expect(desc.map(r => r.Name)).toEqual(['Beta', 'Gamma', 'Alpha']);
+  });
+
+  it('does not mutate the input array', () => {
+    const before = rows.map(r => r.Name);
+    sortRowsByColumn(rows, 'Name', 'asc');
+    expect(rows.map(r => r.Name)).toEqual(before);
+  });
+
+  it('sorts numbers numerically (not lexically)', () => {
+    const numbers = [
+      { Name: 'a', count: 2 },
+      { Name: 'b', count: 10 },
+      { Name: 'c', count: 1 },
+    ];
+    const result = sortRowsByColumn(numbers, 'count', 'asc');
+    expect(result.map(r => r.count)).toEqual([1, 2, 10]);
+  });
+});

--- a/apps/bulk-exporter/src/lib/__tests__/sortRows.test.ts
+++ b/apps/bulk-exporter/src/lib/__tests__/sortRows.test.ts
@@ -21,7 +21,10 @@ function sortRowsByColumn<T extends Record<string, string | number | boolean | n
       return (av - bv) * factor;
     }
 
-    return String(av).localeCompare(String(bv), undefined, { numeric: true, sensitivity: 'base' }) * factor;
+    return (
+      String(av).localeCompare(String(bv), undefined, { numeric: true, sensitivity: 'base' }) *
+      factor
+    );
   });
 }
 
@@ -34,17 +37,17 @@ describe('sortRowsByColumn (mirror of exporter helper)', () => {
 
   it('sorts strings ascending case-insensitively', () => {
     const result = sortRowsByColumn(rows, 'Name', 'asc');
-    expect(result.map(r => r.Name)).toEqual(['alice', 'Bob', 'Charlie']);
+    expect(result.map((r) => r.Name)).toEqual(['alice', 'Bob', 'Charlie']);
   });
 
   it('sorts strings descending', () => {
     const result = sortRowsByColumn(rows, 'Name', 'desc');
-    expect(result.map(r => r.Name)).toEqual(['Charlie', 'Bob', 'alice']);
+    expect(result.map((r) => r.Name)).toEqual(['Charlie', 'Bob', 'alice']);
   });
 
   it('sorts dates ascending by string comparison (ISO format)', () => {
     const result = sortRowsByColumn(rows, 'Updated', 'asc');
-    expect(result.map(r => r.Updated)).toEqual(['2026-01-01', '2026-01-02', '2026-01-03']);
+    expect(result.map((r) => r.Updated)).toEqual(['2026-01-01', '2026-01-02', '2026-01-03']);
   });
 
   it('puts null/undefined values at the end regardless of direction', () => {
@@ -55,16 +58,16 @@ describe('sortRowsByColumn (mirror of exporter helper)', () => {
     ];
 
     const asc = sortRowsByColumn(withNulls, 'value', 'asc');
-    expect(asc.map(r => r.Name)).toEqual(['Gamma', 'Beta', 'Alpha']);
+    expect(asc.map((r) => r.Name)).toEqual(['Gamma', 'Beta', 'Alpha']);
 
     const desc = sortRowsByColumn(withNulls, 'value', 'desc');
-    expect(desc.map(r => r.Name)).toEqual(['Beta', 'Gamma', 'Alpha']);
+    expect(desc.map((r) => r.Name)).toEqual(['Beta', 'Gamma', 'Alpha']);
   });
 
   it('does not mutate the input array', () => {
-    const before = rows.map(r => r.Name);
+    const before = rows.map((r) => r.Name);
     sortRowsByColumn(rows, 'Name', 'asc');
-    expect(rows.map(r => r.Name)).toEqual(before);
+    expect(rows.map((r) => r.Name)).toEqual(before);
   });
 
   it('sorts numbers numerically (not lexically)', () => {
@@ -74,6 +77,6 @@ describe('sortRowsByColumn (mirror of exporter helper)', () => {
       { Name: 'c', count: 1 },
     ];
     const result = sortRowsByColumn(numbers, 'count', 'asc');
-    expect(result.map(r => r.count)).toEqual([1, 2, 10]);
+    expect(result.map((r) => r.count)).toEqual([1, 2, 10]);
   });
 });

--- a/apps/bulk-exporter/src/lib/__tests__/throttle.test.ts
+++ b/apps/bulk-exporter/src/lib/__tests__/throttle.test.ts
@@ -103,6 +103,8 @@ describe('Throttler', () => {
     });
 
     const promise = throttler.execute(fn);
+    // suppress unhandled rejection until we await below
+    promise.catch(() => {});
 
     await vi.advanceTimersByTimeAsync(5000);
 

--- a/apps/bulk-exporter/src/lib/__tests__/throttle.test.ts
+++ b/apps/bulk-exporter/src/lib/__tests__/throttle.test.ts
@@ -32,7 +32,7 @@ describe('Throttler', () => {
     const fn = vi.fn(async () => {
       activeCount++;
       maxActive = Math.max(maxActive, activeCount);
-      await new Promise(resolve => setTimeout(resolve, 100));
+      await new Promise((resolve) => setTimeout(resolve, 100));
       activeCount--;
       return 'success';
     });
@@ -52,7 +52,7 @@ describe('Throttler', () => {
 
   it('should retry on 429 with rate limit reset header', async () => {
     const throttler = new Throttler({ requestsPerSecond: 10, maxRetries: 3 });
-    
+
     let callCount = 0;
     const fn = vi.fn(async () => {
       callCount++;
@@ -66,7 +66,7 @@ describe('Throttler', () => {
     });
 
     const promise = throttler.execute(fn);
-    
+
     await vi.advanceTimersByTimeAsync(1500);
     const result = await promise;
 
@@ -76,7 +76,7 @@ describe('Throttler', () => {
 
   it('should use exponential backoff when rate limit reset header is missing', async () => {
     const throttler = new Throttler({ requestsPerSecond: 10, maxRetries: 3 });
-    
+
     let callCount = 0;
     const fn = vi.fn(async () => {
       callCount++;
@@ -87,7 +87,7 @@ describe('Throttler', () => {
     });
 
     const promise = throttler.execute(fn);
-    
+
     await vi.advanceTimersByTimeAsync(1500);
     const result = await promise;
 
@@ -97,15 +97,15 @@ describe('Throttler', () => {
 
   it('should fail after max retries', async () => {
     const throttler = new Throttler({ requestsPerSecond: 10, maxRetries: 2 });
-    
+
     const fn = vi.fn(async () => {
       throw { status: 429 };
     });
 
     const promise = throttler.execute(fn);
-    
+
     await vi.advanceTimersByTimeAsync(5000);
-    
+
     try {
       await promise;
       expect.fail('Should have thrown');
@@ -117,7 +117,7 @@ describe('Throttler', () => {
 
   it('should not retry non-429 errors', async () => {
     const throttler = new Throttler({ requestsPerSecond: 10, maxRetries: 3 });
-    
+
     const fn = vi.fn(async () => {
       throw new Error('Server error');
     });

--- a/apps/bulk-exporter/src/lib/__tests__/throttle.test.ts
+++ b/apps/bulk-exporter/src/lib/__tests__/throttle.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Throttler } from '../throttle';
+
+describe('Throttler', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('should execute requests within rate limit', async () => {
+    const throttler = new Throttler({ requestsPerSecond: 2, maxConcurrent: 1 });
+    const fn = vi.fn().mockResolvedValue('success');
+
+    const promise1 = throttler.execute(fn);
+    const promise2 = throttler.execute(fn);
+
+    await vi.advanceTimersByTimeAsync(100);
+    await Promise.all([promise1, promise2]);
+
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('should respect max concurrent requests', async () => {
+    const throttler = new Throttler({ requestsPerSecond: 10, maxConcurrent: 2 });
+    let activeCount = 0;
+    let maxActive = 0;
+
+    const fn = vi.fn(async () => {
+      activeCount++;
+      maxActive = Math.max(maxActive, activeCount);
+      await new Promise(resolve => setTimeout(resolve, 100));
+      activeCount--;
+      return 'success';
+    });
+
+    const promises = [
+      throttler.execute(fn),
+      throttler.execute(fn),
+      throttler.execute(fn),
+      throttler.execute(fn),
+    ];
+
+    await vi.advanceTimersByTimeAsync(500);
+    await Promise.all(promises);
+
+    expect(maxActive).toBeLessThanOrEqual(2);
+  });
+
+  it('should retry on 429 with rate limit reset header', async () => {
+    const throttler = new Throttler({ requestsPerSecond: 10, maxRetries: 3 });
+    
+    let callCount = 0;
+    const fn = vi.fn(async () => {
+      callCount++;
+      if (callCount === 1) {
+        throw {
+          status: 429,
+          headers: { 'x-contentful-ratelimit-reset': '1' },
+        };
+      }
+      return 'success';
+    });
+
+    const promise = throttler.execute(fn);
+    
+    await vi.advanceTimersByTimeAsync(1500);
+    const result = await promise;
+
+    expect(result).toBe('success');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('should use exponential backoff when rate limit reset header is missing', async () => {
+    const throttler = new Throttler({ requestsPerSecond: 10, maxRetries: 3 });
+    
+    let callCount = 0;
+    const fn = vi.fn(async () => {
+      callCount++;
+      if (callCount === 1) {
+        throw { status: 429 };
+      }
+      return 'success';
+    });
+
+    const promise = throttler.execute(fn);
+    
+    await vi.advanceTimersByTimeAsync(1500);
+    const result = await promise;
+
+    expect(result).toBe('success');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('should fail after max retries', async () => {
+    const throttler = new Throttler({ requestsPerSecond: 10, maxRetries: 2 });
+    
+    const fn = vi.fn(async () => {
+      throw { status: 429 };
+    });
+
+    const promise = throttler.execute(fn);
+    
+    await vi.advanceTimersByTimeAsync(5000);
+    
+    try {
+      await promise;
+      expect.fail('Should have thrown');
+    } catch (error) {
+      expect(error).toMatchObject({ status: 429 });
+      expect(fn).toHaveBeenCalledTimes(3);
+    }
+  });
+
+  it('should not retry non-429 errors', async () => {
+    const throttler = new Throttler({ requestsPerSecond: 10, maxRetries: 3 });
+    
+    const fn = vi.fn(async () => {
+      throw new Error('Server error');
+    });
+
+    await expect(throttler.execute(fn)).rejects.toThrow('Server error');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/bulk-exporter/src/lib/csv.ts
+++ b/apps/bulk-exporter/src/lib/csv.ts
@@ -7,10 +7,7 @@ export interface CsvOptions {
   headers?: string[];
 }
 
-export function serializeToCSV(
-  rows: FlatRow[],
-  options: CsvOptions = {}
-): string {
+export function serializeToCSV(rows: FlatRow[], options: CsvOptions = {}): string {
   const { includeHeaders = true, headers } = options;
 
   const csv = Papa.unparse(rows, {
@@ -21,34 +18,27 @@ export function serializeToCSV(
   return '\uFEFF' + csv;
 }
 
-export function downloadCSV(
-  csv: string,
-  filename: string = 'export.csv'
-): void {
+export function downloadCSV(csv: string, filename: string = 'export.csv'): void {
   const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
   const url = URL.createObjectURL(blob);
-  
+
   const link = document.createElement('a');
   link.href = url;
   link.download = filename;
   link.style.display = 'none';
-  
+
   document.body.appendChild(link);
   link.click();
-  
+
   document.body.removeChild(link);
   URL.revokeObjectURL(url);
 }
 
-export function exportToCSV(
-  rows: FlatRow[],
-  filename: string,
-  headers?: string[]
-): void {
+export function exportToCSV(rows: FlatRow[], filename: string, headers?: string[]): void {
   const csv = serializeToCSV(rows, {
     includeHeaders: true,
     headers,
   });
-  
+
   downloadCSV(csv, filename);
 }

--- a/apps/bulk-exporter/src/lib/csv.ts
+++ b/apps/bulk-exporter/src/lib/csv.ts
@@ -1,0 +1,54 @@
+import Papa from 'papaparse';
+import type { FlatRow } from './flatten';
+
+export interface CsvOptions {
+  filename?: string;
+  includeHeaders?: boolean;
+  headers?: string[];
+}
+
+export function serializeToCSV(
+  rows: FlatRow[],
+  options: CsvOptions = {}
+): string {
+  const { includeHeaders = true, headers } = options;
+
+  const csv = Papa.unparse(rows, {
+    header: includeHeaders,
+    columns: headers,
+  });
+
+  return '\uFEFF' + csv;
+}
+
+export function downloadCSV(
+  csv: string,
+  filename: string = 'export.csv'
+): void {
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  link.style.display = 'none';
+  
+  document.body.appendChild(link);
+  link.click();
+  
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+export function exportToCSV(
+  rows: FlatRow[],
+  filename: string,
+  headers?: string[]
+): void {
+  const csv = serializeToCSV(rows, {
+    includeHeaders: true,
+    headers,
+  });
+  
+  downloadCSV(csv, filename);
+}

--- a/apps/bulk-exporter/src/lib/exportFormats.ts
+++ b/apps/bulk-exporter/src/lib/exportFormats.ts
@@ -1,4 +1,4 @@
-import * as XLSX from 'xlsx';
+import ExcelJS from 'exceljs';
 import * as yaml from 'js-yaml';
 import * as xmljs from 'xml-js';
 import { serializeToCSV } from './csv';
@@ -11,9 +11,8 @@ export interface ExportData {
 }
 
 /**
- * Excel cells have a hard 32,767 character limit. Anything over crashes the
- * xlsx writer. Trim long string values and append a marker so users can tell
- * the value was truncated. Non-string values are passed through unchanged.
+ * Excel cells have a hard 32,767 character limit. Trim long string values and
+ * append a marker so users can tell the value was truncated.
  */
 export const XLSX_CELL_CHARACTER_LIMIT = 32_767;
 const XLSX_TRUNCATE_AT = 31_900;
@@ -37,122 +36,96 @@ function truncateRowsForXlsx(
   });
 }
 
-/**
- * Export data to CSV format
- */
 export function exportToCsv(data: ExportData): void {
   const csv = serializeToCSV(data.rows);
   const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
   downloadBlob(blob, data.filename);
 }
 
-/**
- * Export data to JSON format
- */
 export function exportToJson(data: ExportData): void {
   const json = JSON.stringify(data.rows, null, 2);
   const blob = new Blob([json], { type: 'application/json;charset=utf-8;' });
   downloadBlob(blob, data.filename);
 }
 
-/**
- * Export data to XLSX (Excel) format
- */
-export function exportToXlsx(data: ExportData): void {
-  // Truncate any cell value that exceeds Excel's 32,767-char hard limit so the
-  // xlsx writer doesn't throw "Text length must not exceed 32767 characters".
+export async function exportToXlsx(data: ExportData): Promise<void> {
   const safeRows = truncateRowsForXlsx(data.rows);
 
-  const workbook = XLSX.utils.book_new();
-  const worksheet = XLSX.utils.json_to_sheet(safeRows);
+  const workbook = new ExcelJS.Workbook();
+  const worksheet = workbook.addWorksheet('Entries');
 
-  // Cap column-width estimates so a single very-long cell doesn't blow out
-  // the column width calculation.
-  const columnWidths = Object.keys(safeRows[0] || {}).map(key => ({
-    wch: Math.min(
-      80,
-      Math.max(
-        key.length,
-        ...safeRows.slice(0, 100).map(row =>
-          String(row[key] ?? '').length
+  if (safeRows.length > 0) {
+    const headers = Object.keys(safeRows[0]);
+
+    worksheet.columns = headers.map(header => ({
+      header,
+      key: header,
+      width: Math.min(
+        80,
+        Math.max(
+          header.length + 2,
+          ...safeRows.slice(0, 100).map(row => String(row[header] ?? '').length)
         )
-      )
-    )
-  }));
-  worksheet['!cols'] = columnWidths;
-  
-  // Add worksheet to workbook
-  XLSX.utils.book_append_sheet(workbook, worksheet, 'Entries');
-  
-  // Generate XLSX file
-  const xlsxData = XLSX.write(workbook, { 
-    bookType: 'xlsx', 
-    type: 'array',
-    compression: true
-  });
-  
-  const blob = new Blob([xlsxData], { 
-    type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' 
+      ),
+    }));
+
+    for (const row of safeRows) {
+      worksheet.addRow(row);
+    }
+  }
+
+  const buffer = await workbook.xlsx.writeBuffer();
+  const blob = new Blob([buffer], {
+    type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
   });
   downloadBlob(blob, data.filename);
 }
 
-/**
- * Export data to XML format
- */
 export function exportToXml(data: ExportData): void {
-  // Create XML structure
   const xmlData = {
     _declaration: {
       _attributes: {
         version: '1.0',
-        encoding: 'utf-8'
-      }
+        encoding: 'utf-8',
+      },
     },
     entries: {
       entry: data.rows.map(row => {
-        const entryData: Record<string, any> = {};
+        const entryData: Record<string, { _text: string }> = {};
         for (const [key, value] of Object.entries(row)) {
-          // Convert field names to valid XML element names
           const xmlKey = key.replace(/[^a-zA-Z0-9_-]/g, '_');
           entryData[xmlKey] = {
-            _text: value !== null && value !== undefined ? String(value) : ''
+            _text: value !== null && value !== undefined ? String(value) : '',
           };
         }
         return entryData;
-      })
-    }
+      }),
+    },
   };
-  
-  const xml = xmljs.js2xml(xmlData, { 
-    compact: true, 
+
+  const xml = xmljs.js2xml(xmlData, {
+    compact: true,
     spaces: 2,
-    indentAttributes: false
+    indentAttributes: false,
   });
-  
+
   const blob = new Blob([xml], { type: 'application/xml;charset=utf-8;' });
   downloadBlob(blob, data.filename);
 }
 
-/**
- * Export data to YAML format
- */
 export function exportToYaml(data: ExportData): void {
   const yamlStr = yaml.dump(data.rows, {
     indent: 2,
     lineWidth: 120,
     noRefs: true,
-    sortKeys: false
+    sortKeys: false,
   });
-  
+
   const blob = new Blob([yamlStr], { type: 'text/yaml;charset=utf-8;' });
   downloadBlob(blob, data.filename);
 }
 
-/**
- * Export data in the specified format
- */
-export function exportData(data: ExportData, format: ExportFormat): void {
+export async function exportData(data: ExportData, format: ExportFormat): Promise<void> {
   switch (format) {
     case 'csv':
       exportToCsv(data);
@@ -161,7 +134,7 @@ export function exportData(data: ExportData, format: ExportFormat): void {
       exportToJson(data);
       break;
     case 'xlsx':
-      exportToXlsx(data);
+      await exportToXlsx(data);
       break;
     case 'xml':
       exportToXml(data);
@@ -174,47 +147,27 @@ export function exportData(data: ExportData, format: ExportFormat): void {
   }
 }
 
-/**
- * Get the file extension for a given format
- */
 export function getFileExtension(format: ExportFormat): string {
   switch (format) {
-    case 'csv':
-      return '.csv';
-    case 'json':
-      return '.json';
-    case 'xlsx':
-      return '.xlsx';
-    case 'xml':
-      return '.xml';
-    case 'yaml':
-      return '.yaml';
-    default:
-      return '';
+    case 'csv': return '.csv';
+    case 'json': return '.json';
+    case 'xlsx': return '.xlsx';
+    case 'xml': return '.xml';
+    case 'yaml': return '.yaml';
+    default: return '';
   }
 }
 
-/**
- * Get human-readable format name
- */
 export function getFormatName(format: ExportFormat): string {
   switch (format) {
-    case 'csv':
-      return 'CSV';
-    case 'json':
-      return 'JSON';
-    case 'xlsx':
-      return 'Excel (XLSX)';
-    case 'xml':
-      return 'XML';
-    case 'yaml':
-      return 'YAML';
+    case 'csv': return 'CSV';
+    case 'json': return 'JSON';
+    case 'xlsx': return 'Excel (XLSX)';
+    case 'xml': return 'XML';
+    case 'yaml': return 'YAML';
   }
 }
 
-/**
- * Helper function to download a blob
- */
 function downloadBlob(blob: Blob, filename: string): void {
   const url = URL.createObjectURL(blob);
   const link = document.createElement('a');

--- a/apps/bulk-exporter/src/lib/exportFormats.ts
+++ b/apps/bulk-exporter/src/lib/exportFormats.ts
@@ -24,10 +24,8 @@ export function truncateForXlsx<T extends string | number | boolean | null>(valu
   return (value.slice(0, XLSX_TRUNCATE_AT) + XLSX_TRUNCATE_SUFFIX) as T;
 }
 
-function truncateRowsForXlsx(
-  rows: ExportData['rows']
-): ExportData['rows'] {
-  return rows.map(row => {
+function truncateRowsForXlsx(rows: ExportData['rows']): ExportData['rows'] {
+  return rows.map((row) => {
     const truncated: Record<string, string | number | boolean | null> = {};
     for (const [key, value] of Object.entries(row)) {
       truncated[key] = truncateForXlsx(value);
@@ -57,14 +55,14 @@ export async function exportToXlsx(data: ExportData): Promise<void> {
   if (safeRows.length > 0) {
     const headers = Object.keys(safeRows[0]);
 
-    worksheet.columns = headers.map(header => ({
+    worksheet.columns = headers.map((header) => ({
       header,
       key: header,
       width: Math.min(
         80,
         Math.max(
           header.length + 2,
-          ...safeRows.slice(0, 100).map(row => String(row[header] ?? '').length)
+          ...safeRows.slice(0, 100).map((row) => String(row[header] ?? '').length)
         )
       ),
     }));
@@ -90,7 +88,7 @@ export function exportToXml(data: ExportData): void {
       },
     },
     entries: {
-      entry: data.rows.map(row => {
+      entry: data.rows.map((row) => {
         const entryData: Record<string, { _text: string }> = {};
         for (const [key, value] of Object.entries(row)) {
           const xmlKey = key.replace(/[^a-zA-Z0-9_-]/g, '_');
@@ -149,22 +147,33 @@ export async function exportData(data: ExportData, format: ExportFormat): Promis
 
 export function getFileExtension(format: ExportFormat): string {
   switch (format) {
-    case 'csv': return '.csv';
-    case 'json': return '.json';
-    case 'xlsx': return '.xlsx';
-    case 'xml': return '.xml';
-    case 'yaml': return '.yaml';
-    default: return '';
+    case 'csv':
+      return '.csv';
+    case 'json':
+      return '.json';
+    case 'xlsx':
+      return '.xlsx';
+    case 'xml':
+      return '.xml';
+    case 'yaml':
+      return '.yaml';
+    default:
+      return '';
   }
 }
 
 export function getFormatName(format: ExportFormat): string {
   switch (format) {
-    case 'csv': return 'CSV';
-    case 'json': return 'JSON';
-    case 'xlsx': return 'Excel (XLSX)';
-    case 'xml': return 'XML';
-    case 'yaml': return 'YAML';
+    case 'csv':
+      return 'CSV';
+    case 'json':
+      return 'JSON';
+    case 'xlsx':
+      return 'Excel (XLSX)';
+    case 'xml':
+      return 'XML';
+    case 'yaml':
+      return 'YAML';
   }
 }
 

--- a/apps/bulk-exporter/src/lib/exportFormats.ts
+++ b/apps/bulk-exporter/src/lib/exportFormats.ts
@@ -1,0 +1,227 @@
+import * as XLSX from 'xlsx';
+import * as yaml from 'js-yaml';
+import * as xmljs from 'xml-js';
+import { serializeToCSV } from './csv';
+
+export type ExportFormat = 'csv' | 'json' | 'xlsx' | 'xml' | 'yaml';
+
+export interface ExportData {
+  rows: Array<Record<string, string | number | boolean | null>>;
+  filename: string;
+}
+
+/**
+ * Excel cells have a hard 32,767 character limit. Anything over crashes the
+ * xlsx writer. Trim long string values and append a marker so users can tell
+ * the value was truncated. Non-string values are passed through unchanged.
+ */
+export const XLSX_CELL_CHARACTER_LIMIT = 32_767;
+const XLSX_TRUNCATE_AT = 31_900;
+const XLSX_TRUNCATE_SUFFIX = ' ...[truncated]';
+
+export function truncateForXlsx<T extends string | number | boolean | null>(value: T): T {
+  if (typeof value !== 'string') return value;
+  if (value.length <= XLSX_CELL_CHARACTER_LIMIT) return value;
+  return (value.slice(0, XLSX_TRUNCATE_AT) + XLSX_TRUNCATE_SUFFIX) as T;
+}
+
+function truncateRowsForXlsx(
+  rows: ExportData['rows']
+): ExportData['rows'] {
+  return rows.map(row => {
+    const truncated: Record<string, string | number | boolean | null> = {};
+    for (const [key, value] of Object.entries(row)) {
+      truncated[key] = truncateForXlsx(value);
+    }
+    return truncated;
+  });
+}
+
+/**
+ * Export data to CSV format
+ */
+export function exportToCsv(data: ExportData): void {
+  const csv = serializeToCSV(data.rows);
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  downloadBlob(blob, data.filename);
+}
+
+/**
+ * Export data to JSON format
+ */
+export function exportToJson(data: ExportData): void {
+  const json = JSON.stringify(data.rows, null, 2);
+  const blob = new Blob([json], { type: 'application/json;charset=utf-8;' });
+  downloadBlob(blob, data.filename);
+}
+
+/**
+ * Export data to XLSX (Excel) format
+ */
+export function exportToXlsx(data: ExportData): void {
+  // Truncate any cell value that exceeds Excel's 32,767-char hard limit so the
+  // xlsx writer doesn't throw "Text length must not exceed 32767 characters".
+  const safeRows = truncateRowsForXlsx(data.rows);
+
+  const workbook = XLSX.utils.book_new();
+  const worksheet = XLSX.utils.json_to_sheet(safeRows);
+
+  // Cap column-width estimates so a single very-long cell doesn't blow out
+  // the column width calculation.
+  const columnWidths = Object.keys(safeRows[0] || {}).map(key => ({
+    wch: Math.min(
+      80,
+      Math.max(
+        key.length,
+        ...safeRows.slice(0, 100).map(row =>
+          String(row[key] ?? '').length
+        )
+      )
+    )
+  }));
+  worksheet['!cols'] = columnWidths;
+  
+  // Add worksheet to workbook
+  XLSX.utils.book_append_sheet(workbook, worksheet, 'Entries');
+  
+  // Generate XLSX file
+  const xlsxData = XLSX.write(workbook, { 
+    bookType: 'xlsx', 
+    type: 'array',
+    compression: true
+  });
+  
+  const blob = new Blob([xlsxData], { 
+    type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' 
+  });
+  downloadBlob(blob, data.filename);
+}
+
+/**
+ * Export data to XML format
+ */
+export function exportToXml(data: ExportData): void {
+  // Create XML structure
+  const xmlData = {
+    _declaration: {
+      _attributes: {
+        version: '1.0',
+        encoding: 'utf-8'
+      }
+    },
+    entries: {
+      entry: data.rows.map(row => {
+        const entryData: Record<string, any> = {};
+        for (const [key, value] of Object.entries(row)) {
+          // Convert field names to valid XML element names
+          const xmlKey = key.replace(/[^a-zA-Z0-9_-]/g, '_');
+          entryData[xmlKey] = {
+            _text: value !== null && value !== undefined ? String(value) : ''
+          };
+        }
+        return entryData;
+      })
+    }
+  };
+  
+  const xml = xmljs.js2xml(xmlData, { 
+    compact: true, 
+    spaces: 2,
+    indentAttributes: false
+  });
+  
+  const blob = new Blob([xml], { type: 'application/xml;charset=utf-8;' });
+  downloadBlob(blob, data.filename);
+}
+
+/**
+ * Export data to YAML format
+ */
+export function exportToYaml(data: ExportData): void {
+  const yamlStr = yaml.dump(data.rows, {
+    indent: 2,
+    lineWidth: 120,
+    noRefs: true,
+    sortKeys: false
+  });
+  
+  const blob = new Blob([yamlStr], { type: 'text/yaml;charset=utf-8;' });
+  downloadBlob(blob, data.filename);
+}
+
+/**
+ * Export data in the specified format
+ */
+export function exportData(data: ExportData, format: ExportFormat): void {
+  switch (format) {
+    case 'csv':
+      exportToCsv(data);
+      break;
+    case 'json':
+      exportToJson(data);
+      break;
+    case 'xlsx':
+      exportToXlsx(data);
+      break;
+    case 'xml':
+      exportToXml(data);
+      break;
+    case 'yaml':
+      exportToYaml(data);
+      break;
+    default:
+      throw new Error(`Unsupported export format: ${format}`);
+  }
+}
+
+/**
+ * Get the file extension for a given format
+ */
+export function getFileExtension(format: ExportFormat): string {
+  switch (format) {
+    case 'csv':
+      return '.csv';
+    case 'json':
+      return '.json';
+    case 'xlsx':
+      return '.xlsx';
+    case 'xml':
+      return '.xml';
+    case 'yaml':
+      return '.yaml';
+    default:
+      return '';
+  }
+}
+
+/**
+ * Get human-readable format name
+ */
+export function getFormatName(format: ExportFormat): string {
+  switch (format) {
+    case 'csv':
+      return 'CSV';
+    case 'json':
+      return 'JSON';
+    case 'xlsx':
+      return 'Excel (XLSX)';
+    case 'xml':
+      return 'XML';
+    case 'yaml':
+      return 'YAML';
+  }
+}
+
+/**
+ * Helper function to download a blob
+ */
+function downloadBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}

--- a/apps/bulk-exporter/src/lib/exporter.ts
+++ b/apps/bulk-exporter/src/lib/exporter.ts
@@ -42,7 +42,10 @@ function sortRowsByColumn<T extends Record<string, string | number | boolean | n
       return (av - bv) * factor;
     }
 
-    return String(av).localeCompare(String(bv), undefined, { numeric: true, sensitivity: 'base' }) * factor;
+    return (
+      String(av).localeCompare(String(bv), undefined, { numeric: true, sensitivity: 'base' }) *
+      factor
+    );
   });
 }
 
@@ -72,10 +75,7 @@ export class Exporter {
     this.cancelled = true;
   }
 
-  async start(
-    options: ExportOptions,
-    onProgress: ProgressCallback
-  ): Promise<void> {
+  async start(options: ExportOptions, onProgress: ProgressCallback): Promise<void> {
     this.cancelled = false;
 
     try {
@@ -87,7 +87,11 @@ export class Exporter {
       });
 
       const total = await this.throttler.execute(() =>
-        getEntryCount(this.cma, options.contentTypeId === 'all-content-types' ? undefined : options.contentTypeId, options.filters || {})
+        getEntryCount(
+          this.cma,
+          options.contentTypeId === 'all-content-types' ? undefined : options.contentTypeId,
+          options.filters || {}
+        )
       );
 
       if (this.cancelled) {
@@ -113,7 +117,8 @@ export class Exporter {
       const paginator = paginateEntries(
         this.cma,
         {
-          contentType: options.contentTypeId === 'all-content-types' ? undefined : options.contentTypeId,
+          contentType:
+            options.contentTypeId === 'all-content-types' ? undefined : options.contentTypeId,
           filters: options.filters || {},
         },
         <T>(fn: () => Promise<T>) => this.throttler.execute(fn)
@@ -151,14 +156,16 @@ export class Exporter {
               });
             } else {
               const updatedByUserId = entry.sys.updatedBy?.sys.id;
-              const updatedByName = updatedByUserId ? (options.userMap?.[updatedByUserId] || updatedByUserId) : 'Unknown';
+              const updatedByName = updatedByUserId
+                ? options.userMap?.[updatedByUserId] || updatedByUserId
+                : 'Unknown';
 
               const row: Record<string, string | number | boolean | null> = {
                 'Entry ID': entry.sys.id,
-                'Created': new Date(entry.sys.createdAt).toISOString().split('T')[0],
-                'Updated': new Date(entry.sys.updatedAt).toISOString().split('T')[0],
+                Created: new Date(entry.sys.createdAt).toISOString().split('T')[0],
+                Updated: new Date(entry.sys.updatedAt).toISOString().split('T')[0],
                 'Last Updated By': updatedByName,
-                'Status': entry.sys.publishedVersion ? 'Published' : 'Draft',
+                Status: entry.sys.publishedVersion ? 'Published' : 'Draft',
                 'Content Type': contentTypeId,
               };
 
@@ -174,14 +181,16 @@ export class Exporter {
         } else {
           rows = filteredBatch.map((entry) => {
             const updatedByUserId = entry.sys.updatedBy?.sys.id;
-            const updatedByName = updatedByUserId ? (options.userMap?.[updatedByUserId] || updatedByUserId) : 'Unknown';
+            const updatedByName = updatedByUserId
+              ? options.userMap?.[updatedByUserId] || updatedByUserId
+              : 'Unknown';
 
             return {
               'Entry ID': entry.sys.id,
-              'Created': new Date(entry.sys.createdAt).toISOString().split('T')[0],
-              'Updated': new Date(entry.sys.updatedAt).toISOString().split('T')[0],
+              Created: new Date(entry.sys.createdAt).toISOString().split('T')[0],
+              Updated: new Date(entry.sys.updatedAt).toISOString().split('T')[0],
               'Last Updated By': updatedByName,
-              'Status': entry.sys.publishedVersion ? 'Published' : 'Draft',
+              Status: entry.sys.publishedVersion ? 'Published' : 'Draft',
               'Content Type': entry.sys.contentType.sys.id,
             };
           });
@@ -215,7 +224,9 @@ export class Exporter {
 
       const baseFilename = options.filename || `${options.contentTypeId}-export`;
       const extension = getFileExtension(format);
-      const filename = baseFilename.endsWith(extension) ? baseFilename : `${baseFilename}${extension}`;
+      const filename = baseFilename.endsWith(extension)
+        ? baseFilename
+        : `${baseFilename}${extension}`;
 
       const finalRows = options.sortByColumn
         ? sortRowsByColumn(allRows, options.sortByColumn.column, options.sortByColumn.direction)

--- a/apps/bulk-exporter/src/lib/exporter.ts
+++ b/apps/bulk-exporter/src/lib/exporter.ts
@@ -8,12 +8,12 @@ export interface ExportOptions {
   contentType: ContentType | null;
   contentTypeId: string;
   locales: string[];
-  fields?: string[]; // Optional field filter
+  fields?: string[];
   filters?: Record<string, unknown>;
   filename?: string;
-  format?: ExportFormat; // Export format (csv, json, xlsx, xml, yaml)
-  userMap?: Record<string, string>; // Map of user IDs to names
-  contentTypeMap?: Record<string, ContentType>; // Map of content type IDs to schemas
+  format?: ExportFormat;
+  userMap?: Record<string, string>;
+  contentTypeMap?: Record<string, ContentType>;
   /**
    * Optional in-memory sort applied to all rows after fetching, before the
    * file is written. Driven by the user clicking a column header in the
@@ -34,7 +34,6 @@ function sortRowsByColumn<T extends Record<string, string | number | boolean | n
     const av = a[column];
     const bv = b[column];
 
-    // null/undefined always sort to the end regardless of direction
     if (av == null && bv == null) return 0;
     if (av == null) return 1;
     if (bv == null) return -1;
@@ -92,22 +91,12 @@ export class Exporter {
       );
 
       if (this.cancelled) {
-        onProgress({
-          fetched: 0,
-          total,
-          status: 'cancelled',
-          message: 'Export cancelled',
-        });
+        onProgress({ fetched: 0, total, status: 'cancelled', message: 'Export cancelled' });
         return;
       }
 
       if (total === 0) {
-        onProgress({
-          fetched: 0,
-          total: 0,
-          status: 'complete',
-          message: 'No entries found',
-        });
+        onProgress({ fetched: 0, total: 0, status: 'complete', message: 'No entries found' });
         return;
       }
 
@@ -132,12 +121,7 @@ export class Exporter {
 
       for await (const batch of paginator) {
         if (this.cancelled) {
-          onProgress({
-            fetched,
-            total,
-            status: 'cancelled',
-            message: 'Export cancelled',
-          });
+          onProgress({ fetched, total, status: 'cancelled', message: 'Export cancelled' });
           return;
         }
 
@@ -145,10 +129,8 @@ export class Exporter {
           ? (batch as Entry[]).filter(options.statusPostFilter)
           : (batch as Entry[]);
 
-        // Flatten entries using schema-aware path for all entries
         let rows: Array<Record<string, string | number | boolean | null>>;
         if (options.contentType) {
-          // Single content type export - use the standard path
           rows = flattenEntries(filteredBatch, {
             contentType: options.contentType,
             locales: options.locales,
@@ -156,13 +138,11 @@ export class Exporter {
             userMap: options.userMap,
           });
         } else if (options.contentTypeMap) {
-          // Mixed content type export - look up each entry's content type
           rows = filteredBatch.map((entry) => {
             const contentTypeId = entry.sys.contentType.sys.id;
             const contentType = options.contentTypeMap![contentTypeId];
-            
+
             if (contentType) {
-              // Use the schema-aware flatten for clean columns
               return flattenEntry(entry, {
                 contentType,
                 locales: options.locales,
@@ -170,10 +150,9 @@ export class Exporter {
                 userMap: options.userMap,
               });
             } else {
-              // Fallback for missing content type (rare) - still use clean column names
               const updatedByUserId = entry.sys.updatedBy?.sys.id;
               const updatedByName = updatedByUserId ? (options.userMap?.[updatedByUserId] || updatedByUserId) : 'Unknown';
-              
+
               const row: Record<string, string | number | boolean | null> = {
                 'Entry ID': entry.sys.id,
                 'Created': new Date(entry.sys.createdAt).toISOString().split('T')[0],
@@ -182,23 +161,21 @@ export class Exporter {
                 'Status': entry.sys.publishedVersion ? 'Published' : 'Draft',
                 'Content Type': contentTypeId,
               };
-              
-              // Add all fields as JSON strings since we don't have the schema
+
               if (entry.fields) {
                 for (const [fieldId, fieldValue] of Object.entries(entry.fields)) {
                   row[fieldId] = JSON.stringify(fieldValue);
                 }
               }
-              
+
               return row;
             }
           });
         } else {
-          // No content type map provided - shouldn't happen, but fallback
           rows = filteredBatch.map((entry) => {
             const updatedByUserId = entry.sys.updatedBy?.sys.id;
             const updatedByName = updatedByUserId ? (options.userMap?.[updatedByUserId] || updatedByUserId) : 'Unknown';
-            
+
             return {
               'Entry ID': entry.sys.id,
               'Created': new Date(entry.sys.createdAt).toISOString().split('T')[0],
@@ -222,12 +199,7 @@ export class Exporter {
       }
 
       if (this.cancelled) {
-        onProgress({
-          fetched,
-          total,
-          status: 'cancelled',
-          message: 'Export cancelled',
-        });
+        onProgress({ fetched, total, status: 'cancelled', message: 'Export cancelled' });
         return;
       }
 
@@ -249,7 +221,7 @@ export class Exporter {
         ? sortRowsByColumn(allRows, options.sortByColumn.column, options.sortByColumn.direction)
         : allRows;
 
-      exportData({ rows: finalRows, filename }, format);
+      await exportData({ rows: finalRows, filename }, format);
 
       onProgress({
         fetched,

--- a/apps/bulk-exporter/src/lib/exporter.ts
+++ b/apps/bulk-exporter/src/lib/exporter.ts
@@ -1,0 +1,271 @@
+import type { CMAClient } from '@contentful/app-sdk';
+import { createThrottler } from './throttle';
+import { paginateEntries, getEntryCount } from './paginate';
+import { flattenEntries, flattenEntry, type ContentType, type Entry } from './flatten';
+import { exportData, getFileExtension, type ExportFormat } from './exportFormats';
+
+export interface ExportOptions {
+  contentType: ContentType | null;
+  contentTypeId: string;
+  locales: string[];
+  fields?: string[]; // Optional field filter
+  filters?: Record<string, unknown>;
+  filename?: string;
+  format?: ExportFormat; // Export format (csv, json, xlsx, xml, yaml)
+  userMap?: Record<string, string>; // Map of user IDs to names
+  contentTypeMap?: Record<string, ContentType>; // Map of content type IDs to schemas
+  /**
+   * Optional in-memory sort applied to all rows after fetching, before the
+   * file is written. Driven by the user clicking a column header in the
+   * results preview so the downloaded file matches what they see.
+   */
+  sortByColumn?: { column: string; direction: 'asc' | 'desc' };
+  /** Client-side status post-filter for statuses the CMA can't distinguish server-side. */
+  statusPostFilter?: (entry: Entry) => boolean;
+}
+
+function sortRowsByColumn<T extends Record<string, string | number | boolean | null>>(
+  rows: T[],
+  column: string,
+  direction: 'asc' | 'desc'
+): T[] {
+  const factor = direction === 'desc' ? -1 : 1;
+  return [...rows].sort((a, b) => {
+    const av = a[column];
+    const bv = b[column];
+
+    // null/undefined always sort to the end regardless of direction
+    if (av == null && bv == null) return 0;
+    if (av == null) return 1;
+    if (bv == null) return -1;
+
+    if (typeof av === 'number' && typeof bv === 'number') {
+      return (av - bv) * factor;
+    }
+
+    return String(av).localeCompare(String(bv), undefined, { numeric: true, sensitivity: 'base' }) * factor;
+  });
+}
+
+export interface ExportProgress {
+  fetched: number;
+  total: number;
+  status: 'estimating' | 'fetching' | 'processing' | 'complete' | 'error' | 'cancelled';
+  message?: string;
+}
+
+export type ProgressCallback = (progress: ExportProgress) => void;
+
+export class Exporter {
+  private cma: CMAClient;
+  private throttler = createThrottler({
+    requestsPerSecond: 8,
+    maxConcurrent: 4,
+    maxRetries: 3,
+  });
+  private cancelled = false;
+
+  constructor(cma: CMAClient) {
+    this.cma = cma;
+  }
+
+  cancel(): void {
+    this.cancelled = true;
+  }
+
+  async start(
+    options: ExportOptions,
+    onProgress: ProgressCallback
+  ): Promise<void> {
+    this.cancelled = false;
+
+    try {
+      onProgress({
+        fetched: 0,
+        total: 0,
+        status: 'estimating',
+        message: 'Estimating entry count...',
+      });
+
+      const total = await this.throttler.execute(() =>
+        getEntryCount(this.cma, options.contentTypeId === 'all-content-types' ? undefined : options.contentTypeId, options.filters || {})
+      );
+
+      if (this.cancelled) {
+        onProgress({
+          fetched: 0,
+          total,
+          status: 'cancelled',
+          message: 'Export cancelled',
+        });
+        return;
+      }
+
+      if (total === 0) {
+        onProgress({
+          fetched: 0,
+          total: 0,
+          status: 'complete',
+          message: 'No entries found',
+        });
+        return;
+      }
+
+      onProgress({
+        fetched: 0,
+        total,
+        status: 'fetching',
+        message: `Fetching ${total} entries...`,
+      });
+
+      const allRows: ReturnType<typeof flattenEntries> = [];
+      let fetched = 0;
+
+      const paginator = paginateEntries(
+        this.cma,
+        {
+          contentType: options.contentTypeId === 'all-content-types' ? undefined : options.contentTypeId,
+          filters: options.filters || {},
+        },
+        <T>(fn: () => Promise<T>) => this.throttler.execute(fn)
+      );
+
+      for await (const batch of paginator) {
+        if (this.cancelled) {
+          onProgress({
+            fetched,
+            total,
+            status: 'cancelled',
+            message: 'Export cancelled',
+          });
+          return;
+        }
+
+        const filteredBatch = options.statusPostFilter
+          ? (batch as Entry[]).filter(options.statusPostFilter)
+          : (batch as Entry[]);
+
+        // Flatten entries using schema-aware path for all entries
+        let rows: Array<Record<string, string | number | boolean | null>>;
+        if (options.contentType) {
+          // Single content type export - use the standard path
+          rows = flattenEntries(filteredBatch, {
+            contentType: options.contentType,
+            locales: options.locales,
+            fields: options.fields,
+            userMap: options.userMap,
+          });
+        } else if (options.contentTypeMap) {
+          // Mixed content type export - look up each entry's content type
+          rows = filteredBatch.map((entry) => {
+            const contentTypeId = entry.sys.contentType.sys.id;
+            const contentType = options.contentTypeMap![contentTypeId];
+            
+            if (contentType) {
+              // Use the schema-aware flatten for clean columns
+              return flattenEntry(entry, {
+                contentType,
+                locales: options.locales,
+                fields: options.fields,
+                userMap: options.userMap,
+              });
+            } else {
+              // Fallback for missing content type (rare) - still use clean column names
+              const updatedByUserId = entry.sys.updatedBy?.sys.id;
+              const updatedByName = updatedByUserId ? (options.userMap?.[updatedByUserId] || updatedByUserId) : 'Unknown';
+              
+              const row: Record<string, string | number | boolean | null> = {
+                'Entry ID': entry.sys.id,
+                'Created': new Date(entry.sys.createdAt).toISOString().split('T')[0],
+                'Updated': new Date(entry.sys.updatedAt).toISOString().split('T')[0],
+                'Last Updated By': updatedByName,
+                'Status': entry.sys.publishedVersion ? 'Published' : 'Draft',
+                'Content Type': contentTypeId,
+              };
+              
+              // Add all fields as JSON strings since we don't have the schema
+              if (entry.fields) {
+                for (const [fieldId, fieldValue] of Object.entries(entry.fields)) {
+                  row[fieldId] = JSON.stringify(fieldValue);
+                }
+              }
+              
+              return row;
+            }
+          });
+        } else {
+          // No content type map provided - shouldn't happen, but fallback
+          rows = filteredBatch.map((entry) => {
+            const updatedByUserId = entry.sys.updatedBy?.sys.id;
+            const updatedByName = updatedByUserId ? (options.userMap?.[updatedByUserId] || updatedByUserId) : 'Unknown';
+            
+            return {
+              'Entry ID': entry.sys.id,
+              'Created': new Date(entry.sys.createdAt).toISOString().split('T')[0],
+              'Updated': new Date(entry.sys.updatedAt).toISOString().split('T')[0],
+              'Last Updated By': updatedByName,
+              'Status': entry.sys.publishedVersion ? 'Published' : 'Draft',
+              'Content Type': entry.sys.contentType.sys.id,
+            };
+          });
+        }
+
+        allRows.push(...rows);
+        fetched += batch.length;
+
+        onProgress({
+          fetched,
+          total,
+          status: 'fetching',
+          message: `Fetching entries... ${fetched} / ${total}`,
+        });
+      }
+
+      if (this.cancelled) {
+        onProgress({
+          fetched,
+          total,
+          status: 'cancelled',
+          message: 'Export cancelled',
+        });
+        return;
+      }
+
+      const format = options.format || 'csv';
+      const formatName = format.toUpperCase();
+
+      onProgress({
+        fetched,
+        total,
+        status: 'processing',
+        message: `Generating ${formatName}...`,
+      });
+
+      const baseFilename = options.filename || `${options.contentTypeId}-export`;
+      const extension = getFileExtension(format);
+      const filename = baseFilename.endsWith(extension) ? baseFilename : `${baseFilename}${extension}`;
+
+      const finalRows = options.sortByColumn
+        ? sortRowsByColumn(allRows, options.sortByColumn.column, options.sortByColumn.direction)
+        : allRows;
+
+      exportData({ rows: finalRows, filename }, format);
+
+      onProgress({
+        fetched,
+        total,
+        status: 'complete',
+        message: `Successfully exported ${fetched} entries as ${formatName}`,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      onProgress({
+        fetched: 0,
+        total: 0,
+        status: 'error',
+        message: `Export failed: ${message}`,
+      });
+      throw error;
+    }
+  }
+}

--- a/apps/bulk-exporter/src/lib/fieldSelection.ts
+++ b/apps/bulk-exporter/src/lib/fieldSelection.ts
@@ -1,0 +1,139 @@
+import type { ContentType } from './flatten';
+import type { FieldPreset } from './preferences';
+
+type Field = ContentType['fields'][number];
+
+const SEMANTIC_FIELD_IDS = ['title', 'name', 'slug', 'summary', 'description', 'headline'];
+const TEXT_FIELD_TYPES = new Set(['Symbol', 'Text', 'RichText', 'Date']);
+const LINK_FIELD_TYPES = new Set(['Link']);
+
+function isSemanticField(field: Field): boolean {
+  return SEMANTIC_FIELD_IDS.includes(field.id.toLowerCase());
+}
+
+function isTextField(field: Field): boolean {
+  if (TEXT_FIELD_TYPES.has(field.type)) return true;
+  if (field.type === 'Array' && field.items?.type === 'Symbol') return true;
+  return false;
+}
+
+function isLinkField(field: Field): boolean {
+  if (LINK_FIELD_TYPES.has(field.type)) return true;
+  if (field.type === 'Array' && field.items?.type === 'Link') return true;
+  return false;
+}
+
+/**
+ * Smart defaults: title field + common semantic fields + required Symbol fields.
+ * Used when a content type is selected for the first time (no saved prefs).
+ */
+export function getSmartDefaults(contentType: ContentType): string[] {
+  const ids = new Set<string>();
+
+  if (contentType.displayField) {
+    ids.add(contentType.displayField);
+  }
+
+  for (const field of contentType.fields) {
+    if (isSemanticField(field)) {
+      ids.add(field.id);
+    }
+    if (field.required && field.type === 'Symbol') {
+      ids.add(field.id);
+    }
+  }
+
+  return contentType.fields.filter(f => ids.has(f.id)).map(f => f.id);
+}
+
+/**
+ * Apply a preset to a content type's fields.
+ */
+export function applyPreset(contentType: ContentType, preset: FieldPreset): string[] {
+  switch (preset) {
+    case 'essentials':
+      return getSmartDefaults(contentType);
+
+    case 'content':
+      return contentType.fields.filter(isTextField).map(f => f.id);
+
+    case 'references':
+      return contentType.fields.filter(isLinkField).map(f => f.id);
+
+    case 'all':
+      return contentType.fields.map(f => f.id);
+
+    case 'custom':
+      return [];
+  }
+}
+
+export interface FieldGroup {
+  id: 'title' | 'required' | 'optional';
+  label: string;
+  fields: Field[];
+}
+
+/**
+ * Group fields into Title / Required / Optional sections, sorted alphabetically.
+ */
+export function groupFields(contentType: ContentType, searchTerm = ''): FieldGroup[] {
+  const term = searchTerm.trim().toLowerCase();
+  const matchesSearch = (field: Field): boolean => {
+    if (!term) return true;
+    return (
+      field.name.toLowerCase().includes(term) ||
+      field.id.toLowerCase().includes(term)
+    );
+  };
+
+  const titleField = contentType.displayField
+    ? contentType.fields.find(f => f.id === contentType.displayField)
+    : undefined;
+
+  const required = contentType.fields
+    .filter(f => f.required && f.id !== contentType.displayField)
+    .filter(matchesSearch)
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  const optional = contentType.fields
+    .filter(f => !f.required && f.id !== contentType.displayField)
+    .filter(matchesSearch)
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  const groups: FieldGroup[] = [];
+
+  if (titleField && matchesSearch(titleField)) {
+    groups.push({ id: 'title', label: 'Title Field', fields: [titleField] });
+  }
+
+  if (required.length > 0) {
+    groups.push({ id: 'required', label: 'Required Fields', fields: required });
+  }
+
+  if (optional.length > 0) {
+    groups.push({ id: 'optional', label: 'Optional Fields', fields: optional });
+  }
+
+  return groups;
+}
+
+/**
+ * Detect which preset matches a given selection (or 'custom' if none does).
+ */
+export function detectPreset(contentType: ContentType, selectedFields: string[]): FieldPreset {
+  const sorted = [...selectedFields].sort();
+  const presets: FieldPreset[] = ['essentials', 'content', 'references', 'all'];
+
+  for (const preset of presets) {
+    const presetFields = [...applyPreset(contentType, preset)].sort();
+    if (
+      presetFields.length === sorted.length &&
+      presetFields.every((id, i) => id === sorted[i])
+    ) {
+      return preset;
+    }
+  }
+
+  return 'custom';
+}

--- a/apps/bulk-exporter/src/lib/fieldSelection.ts
+++ b/apps/bulk-exporter/src/lib/fieldSelection.ts
@@ -43,7 +43,7 @@ export function getSmartDefaults(contentType: ContentType): string[] {
     }
   }
 
-  return contentType.fields.filter(f => ids.has(f.id)).map(f => f.id);
+  return contentType.fields.filter((f) => ids.has(f.id)).map((f) => f.id);
 }
 
 /**
@@ -55,13 +55,13 @@ export function applyPreset(contentType: ContentType, preset: FieldPreset): stri
       return getSmartDefaults(contentType);
 
     case 'content':
-      return contentType.fields.filter(isTextField).map(f => f.id);
+      return contentType.fields.filter(isTextField).map((f) => f.id);
 
     case 'references':
-      return contentType.fields.filter(isLinkField).map(f => f.id);
+      return contentType.fields.filter(isLinkField).map((f) => f.id);
 
     case 'all':
-      return contentType.fields.map(f => f.id);
+      return contentType.fields.map((f) => f.id);
 
     case 'custom':
       return [];
@@ -81,23 +81,20 @@ export function groupFields(contentType: ContentType, searchTerm = ''): FieldGro
   const term = searchTerm.trim().toLowerCase();
   const matchesSearch = (field: Field): boolean => {
     if (!term) return true;
-    return (
-      field.name.toLowerCase().includes(term) ||
-      field.id.toLowerCase().includes(term)
-    );
+    return field.name.toLowerCase().includes(term) || field.id.toLowerCase().includes(term);
   };
 
   const titleField = contentType.displayField
-    ? contentType.fields.find(f => f.id === contentType.displayField)
+    ? contentType.fields.find((f) => f.id === contentType.displayField)
     : undefined;
 
   const required = contentType.fields
-    .filter(f => f.required && f.id !== contentType.displayField)
+    .filter((f) => f.required && f.id !== contentType.displayField)
     .filter(matchesSearch)
     .sort((a, b) => a.name.localeCompare(b.name));
 
   const optional = contentType.fields
-    .filter(f => !f.required && f.id !== contentType.displayField)
+    .filter((f) => !f.required && f.id !== contentType.displayField)
     .filter(matchesSearch)
     .sort((a, b) => a.name.localeCompare(b.name));
 
@@ -127,10 +124,7 @@ export function detectPreset(contentType: ContentType, selectedFields: string[])
 
   for (const preset of presets) {
     const presetFields = [...applyPreset(contentType, preset)].sort();
-    if (
-      presetFields.length === sorted.length &&
-      presetFields.every((id, i) => id === sorted[i])
-    ) {
+    if (presetFields.length === sorted.length && presetFields.every((id, i) => id === sorted[i])) {
       return preset;
     }
   }

--- a/apps/bulk-exporter/src/lib/flatten.ts
+++ b/apps/bulk-exporter/src/lib/flatten.ts
@@ -1,0 +1,271 @@
+export interface Entry {
+  sys: {
+    id: string;
+    createdAt: string;
+    updatedAt: string;
+    version?: number;
+    publishedVersion?: number;
+    archivedAt?: string;
+    contentType: {
+      sys: {
+        id: string;
+      };
+    };
+    updatedBy?: {
+      sys: {
+        id: string;
+      };
+    };
+  };
+  fields: Record<string, Record<string, unknown>>;
+}
+
+export interface ContentType {
+  sys: {
+    id: string;
+  };
+  name?: string;
+  displayField?: string;
+  fields: Array<{
+    id: string;
+    name: string;
+    type: string;
+    localized: boolean;
+    required?: boolean;
+    items?: {
+      type: string;
+      linkType?: string;
+    };
+    linkType?: string;
+  }>;
+}
+
+export interface FlattenOptions {
+  contentType: ContentType;
+  locales: string[];
+  fields?: string[]; // Optional field filter
+  resolveReferences?: boolean; // Whether to resolve entry/asset references to names
+  includeContentTypeName?: boolean; // Whether to add content type name column
+  userMap?: Record<string, string>; // Map of user IDs to names
+}
+
+export interface FlatRow {
+  [key: string]: string | number | boolean | null;
+}
+
+export function flattenEntries(
+  entries: Entry[],
+  options: FlattenOptions
+): FlatRow[] {
+  return entries.map(entry => flattenEntry(entry, options));
+}
+
+export function flattenEntry(
+  entry: Entry,
+  options: FlattenOptions
+): FlatRow {
+  const { contentType, locales, fields, includeContentTypeName = true, userMap = {} } = options;
+  
+  const updatedByUserId = entry.sys.updatedBy?.sys.id;
+  const updatedByName = updatedByUserId ? (userMap[updatedByUserId] || updatedByUserId) : 'Unknown';
+  
+  const row: FlatRow = {
+    'Entry ID': entry.sys.id,
+    'Created': formatDate(entry.sys.createdAt),
+    'Updated': formatDate(entry.sys.updatedAt),
+    'Last Updated By': updatedByName,
+    'Status': entry.sys.publishedVersion ? 'Published' : 'Draft',
+  };
+
+  // Add content type name if requested
+  if (includeContentTypeName) {
+    row['Content Type'] = contentType.name || contentType.sys.id;
+  }
+
+  // Filter and order fields. When `fields` is provided, follow the user's
+  // chosen column order; otherwise fall back to the content type's order.
+  const fieldsToProcess = fields && fields.length > 0
+    ? (fields
+        .map(id => contentType.fields.find(f => f.id === id))
+        .filter((f): f is ContentType['fields'][number] => Boolean(f)))
+    : contentType.fields;
+
+  for (const field of fieldsToProcess) {
+    const fieldValues = entry.fields[field.id];
+
+    if (!fieldValues) {
+      for (const locale of locales) {
+        const columnName = field.localized
+          ? `${field.name} (${locale})`
+          : field.name;
+        if (!row[columnName]) {
+          row[columnName] = null;
+        }
+      }
+      continue;
+    }
+
+    if (field.localized) {
+      for (const locale of locales) {
+        const columnName = `${field.name} (${locale})`;
+        const value = fieldValues[locale];
+        row[columnName] = formatFieldValue(value, field);
+      }
+    } else {
+      const locale = Object.keys(fieldValues)[0];
+      const value = fieldValues[locale];
+      row[field.name] = formatFieldValue(value, field);
+    }
+  }
+
+  return row;
+}
+
+function formatDate(dateString: string): string {
+  const date = new Date(dateString);
+  return date.toISOString().split('T')[0]; // YYYY-MM-DD format
+}
+
+function formatFieldValue(
+  value: unknown,
+  field: { type: string; linkType?: string; items?: { type: string; linkType?: string } }
+): string | number | boolean | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (field.type === 'Link') {
+    return formatLink(value);
+  }
+
+  if (field.type === 'Array') {
+    if (Array.isArray(value)) {
+      if (field.items?.type === 'Link') {
+        // Join multiple links with semicolon for better CSV readability
+        return value.map(formatLink).filter(Boolean).join('; ');
+      }
+      if (field.items?.type === 'Symbol') {
+        // Join simple arrays with semicolon
+        return value.join('; ');
+      }
+      return JSON.stringify(value);
+    }
+    return null;
+  }
+
+  if (field.type === 'RichText') {
+    // Extract plain text from rich text if possible
+    if (typeof value === 'object' && value !== null) {
+      const doc = value as any;
+      if (doc.content && Array.isArray(doc.content)) {
+        const text = extractTextFromRichText(doc);
+        return text || JSON.stringify(value);
+      }
+    }
+    return JSON.stringify(value);
+  }
+
+  if (field.type === 'Object' || field.type === 'Location') {
+    return JSON.stringify(value);
+  }
+
+  if (field.type === 'Symbol' || field.type === 'Text') {
+    return String(value);
+  }
+
+  if (field.type === 'Integer' || field.type === 'Number') {
+    return typeof value === 'number' ? value : Number(value);
+  }
+
+  if (field.type === 'Boolean') {
+    return Boolean(value);
+  }
+
+  if (field.type === 'Date') {
+    // Format dates consistently
+    try {
+      const date = new Date(String(value));
+      return date.toISOString().split('T')[0];
+    } catch {
+      return String(value);
+    }
+  }
+
+  return String(value);
+}
+
+function extractTextFromRichText(doc: any): string {
+  if (!doc.content || !Array.isArray(doc.content)) {
+    return '';
+  }
+  
+  const texts: string[] = [];
+  for (const node of doc.content) {
+    if (node.nodeType === 'paragraph' && node.content) {
+      for (const textNode of node.content) {
+        if (textNode.nodeType === 'text' && textNode.value) {
+          texts.push(textNode.value);
+        }
+      }
+    }
+  }
+  
+  return texts.join(' ').trim();
+}
+
+function formatLink(value: unknown): string {
+  if (typeof value === 'object' && value !== null) {
+    const link = value as {
+      sys?: {
+        type?: string;
+        linkType?: string;
+        id?: string;
+      };
+    };
+
+    if (link.sys?.type === 'Link' && link.sys.linkType && link.sys.id) {
+      // More readable format: just show the ID for now
+      // In a future enhancement, we could resolve these to actual entry names
+      return link.sys.id;
+    }
+  }
+
+  return JSON.stringify(value);
+}
+
+export function getColumnHeaders(
+  contentType: ContentType,
+  locales: string[],
+  includeContentTypeName = true,
+  fields?: string[]
+): string[] {
+  const headers = [
+    'Entry ID',
+    'Created',
+    'Updated',
+    'Last Updated By',
+    'Status',
+  ];
+
+  if (includeContentTypeName) {
+    headers.push('Content Type');
+  }
+
+  const fieldsToInclude = fields && fields.length > 0
+    ? (fields
+        .map(id => contentType.fields.find(f => f.id === id))
+        .filter((f): f is ContentType['fields'][number] => Boolean(f)))
+    : contentType.fields;
+
+  for (const field of fieldsToInclude) {
+    if (field.localized) {
+      for (const locale of locales) {
+        headers.push(`${field.name} (${locale})`);
+      }
+    } else {
+      headers.push(field.name);
+    }
+  }
+
+  return headers;
+}

--- a/apps/bulk-exporter/src/lib/flatten.ts
+++ b/apps/bulk-exporter/src/lib/flatten.ts
@@ -1,3 +1,5 @@
+import type { Document, Block, Inline, Text } from '@contentful/rich-text-types';
+
 export interface Entry {
   sys: {
     id: string;
@@ -43,10 +45,10 @@ export interface ContentType {
 export interface FlattenOptions {
   contentType: ContentType;
   locales: string[];
-  fields?: string[]; // Optional field filter
-  resolveReferences?: boolean; // Whether to resolve entry/asset references to names
-  includeContentTypeName?: boolean; // Whether to add content type name column
-  userMap?: Record<string, string>; // Map of user IDs to names
+  fields?: string[];
+  resolveReferences?: boolean;
+  includeContentTypeName?: boolean;
+  userMap?: Record<string, string>;
 }
 
 export interface FlatRow {
@@ -65,10 +67,10 @@ export function flattenEntry(
   options: FlattenOptions
 ): FlatRow {
   const { contentType, locales, fields, includeContentTypeName = true, userMap = {} } = options;
-  
+
   const updatedByUserId = entry.sys.updatedBy?.sys.id;
   const updatedByName = updatedByUserId ? (userMap[updatedByUserId] || updatedByUserId) : 'Unknown';
-  
+
   const row: FlatRow = {
     'Entry ID': entry.sys.id,
     'Created': formatDate(entry.sys.createdAt),
@@ -77,13 +79,10 @@ export function flattenEntry(
     'Status': entry.sys.publishedVersion ? 'Published' : 'Draft',
   };
 
-  // Add content type name if requested
   if (includeContentTypeName) {
     row['Content Type'] = contentType.name || contentType.sys.id;
   }
 
-  // Filter and order fields. When `fields` is provided, follow the user's
-  // chosen column order; otherwise fall back to the content type's order.
   const fieldsToProcess = fields && fields.length > 0
     ? (fields
         .map(id => contentType.fields.find(f => f.id === id))
@@ -122,8 +121,7 @@ export function flattenEntry(
 }
 
 function formatDate(dateString: string): string {
-  const date = new Date(dateString);
-  return date.toISOString().split('T')[0]; // YYYY-MM-DD format
+  return new Date(dateString).toISOString().split('T')[0];
 }
 
 function formatFieldValue(
@@ -141,11 +139,9 @@ function formatFieldValue(
   if (field.type === 'Array') {
     if (Array.isArray(value)) {
       if (field.items?.type === 'Link') {
-        // Join multiple links with semicolon for better CSV readability
         return value.map(formatLink).filter(Boolean).join('; ');
       }
       if (field.items?.type === 'Symbol') {
-        // Join simple arrays with semicolon
         return value.join('; ');
       }
       return JSON.stringify(value);
@@ -154,9 +150,8 @@ function formatFieldValue(
   }
 
   if (field.type === 'RichText') {
-    // Extract plain text from rich text if possible
     if (typeof value === 'object' && value !== null) {
-      const doc = value as any;
+      const doc = value as Document;
       if (doc.content && Array.isArray(doc.content)) {
         const text = extractTextFromRichText(doc);
         return text || JSON.stringify(value);
@@ -182,10 +177,8 @@ function formatFieldValue(
   }
 
   if (field.type === 'Date') {
-    // Format dates consistently
     try {
-      const date = new Date(String(value));
-      return date.toISOString().split('T')[0];
+      return new Date(String(value)).toISOString().split('T')[0];
     } catch {
       return String(value);
     }
@@ -194,22 +187,21 @@ function formatFieldValue(
   return String(value);
 }
 
-function extractTextFromRichText(doc: any): string {
-  if (!doc.content || !Array.isArray(doc.content)) {
-    return '';
-  }
-  
+function extractTextFromRichText(doc: Document): string {
   const texts: string[] = [];
-  for (const node of doc.content) {
-    if (node.nodeType === 'paragraph' && node.content) {
-      for (const textNode of node.content) {
-        if (textNode.nodeType === 'text' && textNode.value) {
-          texts.push(textNode.value);
-        }
+
+  function walk(nodes: (Block | Inline | Text)[]): void {
+    for (const node of nodes) {
+      if (node.nodeType === 'text') {
+        const textNode = node as Text;
+        if (textNode.value) texts.push(textNode.value);
+      } else if ('content' in node && Array.isArray(node.content)) {
+        walk(node.content);
       }
     }
   }
-  
+
+  walk(doc.content);
   return texts.join(' ').trim();
 }
 
@@ -224,8 +216,6 @@ function formatLink(value: unknown): string {
     };
 
     if (link.sys?.type === 'Link' && link.sys.linkType && link.sys.id) {
-      // More readable format: just show the ID for now
-      // In a future enhancement, we could resolve these to actual entry names
       return link.sys.id;
     }
   }

--- a/apps/bulk-exporter/src/lib/flatten.ts
+++ b/apps/bulk-exporter/src/lib/flatten.ts
@@ -55,48 +55,41 @@ export interface FlatRow {
   [key: string]: string | number | boolean | null;
 }
 
-export function flattenEntries(
-  entries: Entry[],
-  options: FlattenOptions
-): FlatRow[] {
-  return entries.map(entry => flattenEntry(entry, options));
+export function flattenEntries(entries: Entry[], options: FlattenOptions): FlatRow[] {
+  return entries.map((entry) => flattenEntry(entry, options));
 }
 
-export function flattenEntry(
-  entry: Entry,
-  options: FlattenOptions
-): FlatRow {
+export function flattenEntry(entry: Entry, options: FlattenOptions): FlatRow {
   const { contentType, locales, fields, includeContentTypeName = true, userMap = {} } = options;
 
   const updatedByUserId = entry.sys.updatedBy?.sys.id;
-  const updatedByName = updatedByUserId ? (userMap[updatedByUserId] || updatedByUserId) : 'Unknown';
+  const updatedByName = updatedByUserId ? userMap[updatedByUserId] || updatedByUserId : 'Unknown';
 
   const row: FlatRow = {
     'Entry ID': entry.sys.id,
-    'Created': formatDate(entry.sys.createdAt),
-    'Updated': formatDate(entry.sys.updatedAt),
+    Created: formatDate(entry.sys.createdAt),
+    Updated: formatDate(entry.sys.updatedAt),
     'Last Updated By': updatedByName,
-    'Status': entry.sys.publishedVersion ? 'Published' : 'Draft',
+    Status: entry.sys.publishedVersion ? 'Published' : 'Draft',
   };
 
   if (includeContentTypeName) {
     row['Content Type'] = contentType.name || contentType.sys.id;
   }
 
-  const fieldsToProcess = fields && fields.length > 0
-    ? (fields
-        .map(id => contentType.fields.find(f => f.id === id))
-        .filter((f): f is ContentType['fields'][number] => Boolean(f)))
-    : contentType.fields;
+  const fieldsToProcess =
+    fields && fields.length > 0
+      ? fields
+          .map((id) => contentType.fields.find((f) => f.id === id))
+          .filter((f): f is ContentType['fields'][number] => Boolean(f))
+      : contentType.fields;
 
   for (const field of fieldsToProcess) {
     const fieldValues = entry.fields[field.id];
 
     if (!fieldValues) {
       for (const locale of locales) {
-        const columnName = field.localized
-          ? `${field.name} (${locale})`
-          : field.name;
+        const columnName = field.localized ? `${field.name} (${locale})` : field.name;
         if (!row[columnName]) {
           row[columnName] = null;
         }
@@ -229,23 +222,18 @@ export function getColumnHeaders(
   includeContentTypeName = true,
   fields?: string[]
 ): string[] {
-  const headers = [
-    'Entry ID',
-    'Created',
-    'Updated',
-    'Last Updated By',
-    'Status',
-  ];
+  const headers = ['Entry ID', 'Created', 'Updated', 'Last Updated By', 'Status'];
 
   if (includeContentTypeName) {
     headers.push('Content Type');
   }
 
-  const fieldsToInclude = fields && fields.length > 0
-    ? (fields
-        .map(id => contentType.fields.find(f => f.id === id))
-        .filter((f): f is ContentType['fields'][number] => Boolean(f)))
-    : contentType.fields;
+  const fieldsToInclude =
+    fields && fields.length > 0
+      ? fields
+          .map((id) => contentType.fields.find((f) => f.id === id))
+          .filter((f): f is ContentType['fields'][number] => Boolean(f))
+      : contentType.fields;
 
   for (const field of fieldsToInclude) {
     if (field.localized) {

--- a/apps/bulk-exporter/src/lib/mockConcepts.ts
+++ b/apps/bulk-exporter/src/lib/mockConcepts.ts
@@ -1,0 +1,10 @@
+export const MOCK_CONCEPTS = [
+  { sys: { id: 'concept-electronics' }, prefLabel: { 'en-US': 'Electronics' } },
+  { sys: { id: 'concept-smartphones' }, prefLabel: { 'en-US': 'Smartphones' } },
+  { sys: { id: 'concept-laptops' }, prefLabel: { 'en-US': 'Laptops & Computers' } },
+  { sys: { id: 'concept-home-appliances' }, prefLabel: { 'en-US': 'Home Appliances' } },
+  { sys: { id: 'concept-sustainability' }, prefLabel: { 'en-US': 'Sustainability' } },
+  { sys: { id: 'concept-enterprise' }, prefLabel: { 'en-US': 'Enterprise Solutions' } },
+  { sys: { id: 'concept-cloud' }, prefLabel: { 'en-US': 'Cloud & Infrastructure' } },
+  { sys: { id: 'concept-security' }, prefLabel: { 'en-US': 'Security & Compliance' } },
+];

--- a/apps/bulk-exporter/src/lib/paginate.ts
+++ b/apps/bulk-exporter/src/lib/paginate.ts
@@ -21,27 +21,27 @@ export async function* paginateEntries(
   throttledFetch: <T>(fn: () => Promise<T>) => Promise<T>
 ): AsyncGenerator<unknown[], void, unknown> {
   const { contentType, filters = {}, order = 'sys.createdAt' } = options;
-  
+
   let skip = 0;
   let total = Infinity;
-  
+
   const queryParams: Record<string, unknown> = {
     limit: PAGE_SIZE,
     skip,
     order,
     ...filters,
   };
-  
+
   if (contentType) {
     queryParams.content_type = contentType;
   }
 
   while (skip < total && skip < MAX_SKIP) {
     queryParams.skip = skip;
-    
-    const result = await throttledFetch(() =>
+
+    const result = (await throttledFetch(() =>
       cma.entry.getMany({ query: queryParams })
-    ) as PaginateResult;
+    )) as PaginateResult;
 
     if (result.items.length === 0) {
       break;
@@ -76,14 +76,14 @@ async function* paginateByCursor(
     order,
     ...filters,
   };
-  
+
   if (contentType) {
     queryParams.content_type = contentType;
   }
 
-  const firstCursorResult = await throttledFetch(() =>
+  const firstCursorResult = (await throttledFetch(() =>
     cma.entry.getMany({ query: queryParams })
-  ) as PaginateResult;
+  )) as PaginateResult;
 
   if (firstCursorResult.items.length === 0) {
     return;
@@ -104,14 +104,14 @@ async function* paginateByCursor(
       'sys.createdAt[gt]': lastItem.sys.createdAt,
       ...filters,
     };
-    
+
     if (contentType) {
       cursorQueryParams.content_type = contentType;
     }
-    
-    const result = await throttledFetch(() =>
+
+    const result = (await throttledFetch(() =>
       cma.entry.getMany({ query: cursorQueryParams })
-    ) as PaginateResult;
+    )) as PaginateResult;
 
     if (result.items.length === 0) {
       break;
@@ -135,14 +135,14 @@ export async function getEntryCount(
     limit: 0,
     ...filters,
   };
-  
+
   if (contentType) {
     queryParams.content_type = contentType;
   }
-  
-  const result = await cma.entry.getMany({
+
+  const result = (await cma.entry.getMany({
     query: queryParams,
-  }) as PaginateResult;
+  })) as PaginateResult;
 
   return result.total;
 }

--- a/apps/bulk-exporter/src/lib/paginate.ts
+++ b/apps/bulk-exporter/src/lib/paginate.ts
@@ -1,0 +1,148 @@
+import type { CMAClient } from '@contentful/app-sdk';
+
+export interface PaginateOptions {
+  contentType?: string;
+  limit?: number;
+  order?: string;
+  filters?: Record<string, unknown>;
+}
+
+export interface PaginateResult {
+  items: unknown[];
+  total: number;
+}
+
+const PAGE_SIZE = 1000;
+const MAX_SKIP = 9000;
+
+export async function* paginateEntries(
+  cma: CMAClient,
+  options: PaginateOptions,
+  throttledFetch: <T>(fn: () => Promise<T>) => Promise<T>
+): AsyncGenerator<unknown[], void, unknown> {
+  const { contentType, filters = {}, order = 'sys.createdAt' } = options;
+  
+  let skip = 0;
+  let total = Infinity;
+  
+  const queryParams: Record<string, unknown> = {
+    limit: PAGE_SIZE,
+    skip,
+    order,
+    ...filters,
+  };
+  
+  if (contentType) {
+    queryParams.content_type = contentType;
+  }
+
+  while (skip < total && skip < MAX_SKIP) {
+    queryParams.skip = skip;
+    
+    const result = await throttledFetch(() =>
+      cma.entry.getMany({ query: queryParams })
+    ) as PaginateResult;
+
+    if (result.items.length === 0) {
+      break;
+    }
+
+    total = result.total;
+    yield result.items;
+
+    skip += PAGE_SIZE;
+
+    if (skip >= total) {
+      return;
+    }
+  }
+
+  if (skip >= MAX_SKIP && skip < total) {
+    yield* paginateByCursor(cma, options, throttledFetch, skip);
+  }
+}
+
+async function* paginateByCursor(
+  cma: CMAClient,
+  options: PaginateOptions,
+  throttledFetch: <T>(fn: () => Promise<T>) => Promise<T>,
+  fetchedSoFar: number
+): AsyncGenerator<unknown[], void, unknown> {
+  const { contentType, filters = {}, order = 'sys.createdAt' } = options;
+
+  const queryParams: Record<string, unknown> = {
+    limit: PAGE_SIZE,
+    skip: MAX_SKIP,
+    order,
+    ...filters,
+  };
+  
+  if (contentType) {
+    queryParams.content_type = contentType;
+  }
+
+  const firstCursorResult = await throttledFetch(() =>
+    cma.entry.getMany({ query: queryParams })
+  ) as PaginateResult;
+
+  if (firstCursorResult.items.length === 0) {
+    return;
+  }
+
+  yield firstCursorResult.items;
+
+  let lastItem = firstCursorResult.items[firstCursorResult.items.length - 1] as {
+    sys: { createdAt: string };
+  };
+  let fetched = fetchedSoFar + firstCursorResult.items.length;
+  const total = firstCursorResult.total;
+
+  while (fetched < total) {
+    const cursorQueryParams: Record<string, unknown> = {
+      limit: PAGE_SIZE,
+      order,
+      'sys.createdAt[gt]': lastItem.sys.createdAt,
+      ...filters,
+    };
+    
+    if (contentType) {
+      cursorQueryParams.content_type = contentType;
+    }
+    
+    const result = await throttledFetch(() =>
+      cma.entry.getMany({ query: cursorQueryParams })
+    ) as PaginateResult;
+
+    if (result.items.length === 0) {
+      break;
+    }
+
+    yield result.items;
+
+    lastItem = result.items[result.items.length - 1] as {
+      sys: { createdAt: string };
+    };
+    fetched += result.items.length;
+  }
+}
+
+export async function getEntryCount(
+  cma: CMAClient,
+  contentType: string | undefined,
+  filters: Record<string, unknown> = {}
+): Promise<number> {
+  const queryParams: Record<string, unknown> = {
+    limit: 0,
+    ...filters,
+  };
+  
+  if (contentType) {
+    queryParams.content_type = contentType;
+  }
+  
+  const result = await cma.entry.getMany({
+    query: queryParams,
+  }) as PaginateResult;
+
+  return result.total;
+}

--- a/apps/bulk-exporter/src/lib/preferences.ts
+++ b/apps/bulk-exporter/src/lib/preferences.ts
@@ -1,0 +1,113 @@
+/**
+ * Browser localStorage helpers for per-user preferences.
+ *
+ * All preferences are scoped to the current browser, so when multiple users
+ * use the app from their own machines they each get their own settings without
+ * any server-side state.
+ *
+ * Storage keys follow the pattern: `bulk-entry-exporter:v1:<scope>:<...ids>`
+ */
+
+import type { ExportFormat } from './exportFormats';
+
+const STORAGE_PREFIX = 'bulk-entry-exporter:v1';
+
+export type FieldPreset = 'essentials' | 'content' | 'references' | 'all' | 'custom';
+
+export interface FieldPreferences {
+  selectedFields: string[];
+  lastPreset?: FieldPreset;
+  updatedAt: string;
+}
+
+interface SpacePreferences {
+  format?: ExportFormat;
+  filenamePattern?: string;
+}
+
+function isStorageAvailable(): boolean {
+  try {
+    return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+  } catch {
+    return false;
+  }
+}
+
+function fieldsKey(spaceId: string, contentTypeId: string): string {
+  return `${STORAGE_PREFIX}:fields:${spaceId}:${contentTypeId}`;
+}
+
+function spaceKey(spaceId: string): string {
+  return `${STORAGE_PREFIX}:space:${spaceId}`;
+}
+
+function safeRead<T>(key: string): T | null {
+  if (!isStorageAvailable()) return null;
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return null;
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+function safeWrite<T>(key: string, value: T): boolean {
+  if (!isStorageAvailable()) return false;
+  try {
+    window.localStorage.setItem(key, JSON.stringify(value));
+    return true;
+  } catch {
+    // QuotaExceededError or serialization failure
+    return false;
+  }
+}
+
+function safeRemove(key: string): void {
+  if (!isStorageAvailable()) return;
+  try {
+    window.localStorage.removeItem(key);
+  } catch {
+    // ignore
+  }
+}
+
+export function getFieldPreferences(
+  spaceId: string,
+  contentTypeId: string
+): FieldPreferences | null {
+  if (!spaceId || !contentTypeId) return null;
+  return safeRead<FieldPreferences>(fieldsKey(spaceId, contentTypeId));
+}
+
+export function saveFieldPreferences(
+  spaceId: string,
+  contentTypeId: string,
+  prefs: Omit<FieldPreferences, 'updatedAt'>
+): boolean {
+  if (!spaceId || !contentTypeId) return false;
+  const payload: FieldPreferences = {
+    ...prefs,
+    updatedAt: new Date().toISOString(),
+  };
+  return safeWrite(fieldsKey(spaceId, contentTypeId), payload);
+}
+
+export function clearFieldPreferences(spaceId: string, contentTypeId: string): void {
+  if (!spaceId || !contentTypeId) return;
+  safeRemove(fieldsKey(spaceId, contentTypeId));
+}
+
+export function getSpacePreferences(spaceId: string): SpacePreferences {
+  if (!spaceId) return {};
+  return safeRead<SpacePreferences>(spaceKey(spaceId)) ?? {};
+}
+
+export function saveSpacePreferences(
+  spaceId: string,
+  patch: Partial<SpacePreferences>
+): boolean {
+  if (!spaceId) return false;
+  const current = getSpacePreferences(spaceId);
+  return safeWrite(spaceKey(spaceId), { ...current, ...patch });
+}

--- a/apps/bulk-exporter/src/lib/preferences.ts
+++ b/apps/bulk-exporter/src/lib/preferences.ts
@@ -103,10 +103,7 @@ export function getSpacePreferences(spaceId: string): SpacePreferences {
   return safeRead<SpacePreferences>(spaceKey(spaceId)) ?? {};
 }
 
-export function saveSpacePreferences(
-  spaceId: string,
-  patch: Partial<SpacePreferences>
-): boolean {
+export function saveSpacePreferences(spaceId: string, patch: Partial<SpacePreferences>): boolean {
   if (!spaceId) return false;
   const current = getSpacePreferences(spaceId);
   return safeWrite(spaceKey(spaceId), { ...current, ...patch });

--- a/apps/bulk-exporter/src/lib/queryBuilder.ts
+++ b/apps/bulk-exporter/src/lib/queryBuilder.ts
@@ -1,0 +1,189 @@
+export type EntryStatus = 'any' | 'published' | 'draft' | 'changed' | 'archived';
+
+export type FieldOperator = 
+  | 'equals'
+  | 'not_equals'
+  | 'contains'
+  | 'gt'
+  | 'gte'
+  | 'lt'
+  | 'lte'
+  | 'exists'
+  | 'is_true'
+  | 'is_false'
+  | 'links_to';
+
+export interface FieldFilter {
+  fieldId: string;
+  operator: FieldOperator;
+  value: string;
+}
+
+export interface QueryFormData {
+  contentTypeId: string;
+  search?: string;
+  status?: EntryStatus;
+  createdFrom?: string;
+  createdTo?: string;
+  updatedFrom?: string;
+  updatedTo?: string;
+  sort?: string;
+  tags?: string[];
+  tagsMatchAll?: boolean;
+  concepts?: string[];
+  conceptsMatchAll?: boolean;
+  fieldFilters?: FieldFilter[];
+}
+
+export function buildQuery(data: QueryFormData): Record<string, unknown> {
+  const query: Record<string, unknown> = {};
+
+  // Content type (optional)
+  if (data.contentTypeId) {
+    query.content_type = data.contentTypeId;
+  }
+
+  // Full-text search
+  if (data.search && data.search.trim()) {
+    query.query = data.search.trim();
+  }
+
+  // Status filters
+  if (data.status && data.status !== 'any') {
+    switch (data.status) {
+      case 'published':
+        query['sys.publishedAt[exists]'] = true;
+        query['sys.archivedAt[exists]'] = false;
+        break;
+      case 'draft':
+        query['sys.publishedAt[exists]'] = false;
+        query['sys.archivedAt[exists]'] = false;
+        break;
+      case 'changed':
+        query['sys.publishedAt[exists]'] = true;
+        query['sys.archivedAt[exists]'] = false;
+        // Can't filter changed vs published server-side — post-filter applied client-side
+        break;
+      case 'archived':
+        query['sys.archivedAt[exists]'] = true;
+        break;
+    }
+  }
+
+  // Created date range
+  if (data.createdFrom) {
+    query['sys.createdAt[gte]'] = data.createdFrom;
+  }
+  if (data.createdTo) {
+    query['sys.createdAt[lte]'] = data.createdTo;
+  }
+
+  // Updated date range
+  if (data.updatedFrom) {
+    query['sys.updatedAt[gte]'] = data.updatedFrom;
+  }
+  if (data.updatedTo) {
+    query['sys.updatedAt[lte]'] = data.updatedTo;
+  }
+
+  // Sort order
+  if (data.sort) {
+    query.order = data.sort;
+  }
+
+  // Tags
+  if (data.tags && data.tags.length > 0) {
+    if (data.tagsMatchAll) {
+      query['metadata.tags.sys.id[all]'] = data.tags.join(',');
+    } else {
+      query['metadata.tags.sys.id[in]'] = data.tags.join(',');
+    }
+  }
+
+  // Concepts (taxonomy)
+  if (data.concepts && data.concepts.length > 0) {
+    if (data.conceptsMatchAll) {
+      query['metadata.concepts.sys.id[all]'] = data.concepts.join(',');
+    } else {
+      query['metadata.concepts.sys.id[in]'] = data.concepts.join(',');
+    }
+  }
+
+  // Field-level filters
+  if (data.fieldFilters && data.fieldFilters.length > 0) {
+    for (const filter of data.fieldFilters) {
+      if (!filter.fieldId || !filter.operator) continue;
+
+      const fieldKey = `fields.${filter.fieldId}`;
+
+      switch (filter.operator) {
+        case 'equals':
+          query[fieldKey] = filter.value;
+          break;
+        case 'not_equals':
+          query[`${fieldKey}[ne]`] = filter.value;
+          break;
+        case 'contains':
+          query[`${fieldKey}[match]`] = filter.value;
+          break;
+        case 'gt':
+          query[`${fieldKey}[gt]`] = filter.value;
+          break;
+        case 'gte':
+          query[`${fieldKey}[gte]`] = filter.value;
+          break;
+        case 'lt':
+          query[`${fieldKey}[lt]`] = filter.value;
+          break;
+        case 'lte':
+          query[`${fieldKey}[lte]`] = filter.value;
+          break;
+        case 'exists':
+          query[`${fieldKey}[exists]`] = filter.value === 'true';
+          break;
+        case 'is_true':
+          query[fieldKey] = true;
+          break;
+        case 'is_false':
+          query[fieldKey] = false;
+          break;
+        case 'links_to':
+          query[`${fieldKey}.sys.id`] = filter.value;
+          break;
+      }
+    }
+  }
+
+  return query;
+}
+
+interface SysVersioned {
+  sys: {
+    version?: number;
+    publishedVersion?: number;
+    archivedAt?: string;
+  };
+}
+
+/**
+ * Returns a client-side predicate for statuses that the CMA cannot distinguish
+ * server-side (published vs changed). Returns null for statuses that are fully
+ * handled by the query params alone.
+ */
+export function getStatusPostFilter(
+  status: EntryStatus
+): ((entry: SysVersioned) => boolean) | null {
+  if (status === 'published') {
+    return (entry) => {
+      const { version, publishedVersion } = entry.sys;
+      return publishedVersion !== undefined && version === publishedVersion + 1;
+    };
+  }
+  if (status === 'changed') {
+    return (entry) => {
+      const { version, publishedVersion } = entry.sys;
+      return publishedVersion !== undefined && version !== undefined && version > publishedVersion + 1;
+    };
+  }
+  return null;
+}

--- a/apps/bulk-exporter/src/lib/queryBuilder.ts
+++ b/apps/bulk-exporter/src/lib/queryBuilder.ts
@@ -1,6 +1,6 @@
 export type EntryStatus = 'any' | 'published' | 'draft' | 'changed' | 'archived';
 
-export type FieldOperator = 
+export type FieldOperator =
   | 'equals'
   | 'not_equals'
   | 'contains'
@@ -182,7 +182,9 @@ export function getStatusPostFilter(
   if (status === 'changed') {
     return (entry) => {
       const { version, publishedVersion } = entry.sys;
-      return publishedVersion !== undefined && version !== undefined && version > publishedVersion + 1;
+      return (
+        publishedVersion !== undefined && version !== undefined && version > publishedVersion + 1
+      );
     };
   }
   return null;

--- a/apps/bulk-exporter/src/lib/throttle.ts
+++ b/apps/bulk-exporter/src/lib/throttle.ts
@@ -1,0 +1,146 @@
+export interface ThrottleOptions {
+  requestsPerSecond?: number;
+  maxConcurrent?: number;
+  maxRetries?: number;
+}
+
+interface ThrottledRequest<T = unknown> {
+  fn: () => Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: unknown) => void;
+  retries: number;
+}
+
+export class Throttler {
+  private requestsPerSecond: number;
+  private maxConcurrent: number;
+  private maxRetries: number;
+  private tokens: number;
+  private lastRefill: number;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private queue: ThrottledRequest<any>[] = [];
+  private activeRequests = 0;
+  private processing = false;
+
+  constructor(options: ThrottleOptions = {}) {
+    this.requestsPerSecond = options.requestsPerSecond ?? 6;
+    this.maxConcurrent = options.maxConcurrent ?? 4;
+    this.maxRetries = options.maxRetries ?? 3;
+    this.tokens = this.requestsPerSecond;
+    this.lastRefill = Date.now();
+  }
+
+  private refillTokens(): void {
+    const now = Date.now();
+    const elapsed = (now - this.lastRefill) / 1000;
+    const tokensToAdd = elapsed * this.requestsPerSecond;
+    
+    if (tokensToAdd >= 1) {
+      this.tokens = Math.min(this.requestsPerSecond, this.tokens + tokensToAdd);
+      this.lastRefill = now;
+    }
+  }
+
+  private async sleep(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+
+  private async processQueue(): Promise<void> {
+    if (this.processing) return;
+    this.processing = true;
+
+    while (this.queue.length > 0) {
+      this.refillTokens();
+
+      if (this.tokens < 1 || this.activeRequests >= this.maxConcurrent) {
+        await this.sleep(100);
+        continue;
+      }
+
+      const request = this.queue.shift();
+      if (!request) continue;
+
+      this.tokens -= 1;
+      this.activeRequests += 1;
+
+      this.executeRequest(request).finally(() => {
+        this.activeRequests -= 1;
+      });
+    }
+
+    this.processing = false;
+  }
+
+  private async executeRequest<T>(request: ThrottledRequest<T>): Promise<void> {
+    try {
+      const result = await request.fn();
+      request.resolve(result);
+    } catch (error) {
+      const is429 = this.is429Error(error);
+      
+      if (is429 && request.retries < this.maxRetries) {
+        const resetSeconds = this.extractRateLimitReset(error);
+        const backoffMs = resetSeconds 
+          ? resetSeconds * 1000 
+          : Math.pow(2, request.retries) * 1000;
+
+        await this.sleep(backoffMs);
+        
+        request.retries += 1;
+        this.queue.unshift(request);
+        
+        if (!this.processing) {
+          this.processQueue();
+        }
+      } else {
+        request.reject(error);
+      }
+    }
+  }
+
+  private is429Error(error: unknown): boolean {
+    if (typeof error === 'object' && error !== null) {
+      const err = error as { status?: number; response?: { status?: number } };
+      return err.status === 429 || err.response?.status === 429;
+    }
+    return false;
+  }
+
+  private extractRateLimitReset(error: unknown): number | null {
+    if (typeof error === 'object' && error !== null) {
+      const err = error as { 
+        headers?: { 'x-contentful-ratelimit-reset'?: string };
+        response?: { headers?: { 'x-contentful-ratelimit-reset'?: string } };
+      };
+      
+      const resetHeader = 
+        err.headers?.['x-contentful-ratelimit-reset'] ||
+        err.response?.headers?.['x-contentful-ratelimit-reset'];
+      
+      if (resetHeader) {
+        const seconds = parseInt(resetHeader, 10);
+        if (!isNaN(seconds)) {
+          return seconds;
+        }
+      }
+    }
+    return null;
+  }
+
+  async execute<T>(fn: () => Promise<T>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      this.queue.push({
+        fn,
+        resolve,
+        reject,
+        retries: 0,
+      });
+
+      this.processQueue();
+    });
+  }
+}
+
+export function createThrottler(options?: ThrottleOptions): Throttler {
+  return new Throttler(options);
+}

--- a/apps/bulk-exporter/src/lib/throttle.ts
+++ b/apps/bulk-exporter/src/lib/throttle.ts
@@ -34,7 +34,7 @@ export class Throttler {
     const now = Date.now();
     const elapsed = (now - this.lastRefill) / 1000;
     const tokensToAdd = elapsed * this.requestsPerSecond;
-    
+
     if (tokensToAdd >= 1) {
       this.tokens = Math.min(this.requestsPerSecond, this.tokens + tokensToAdd);
       this.lastRefill = now;
@@ -42,7 +42,7 @@ export class Throttler {
   }
 
   private async sleep(ms: number): Promise<void> {
-    return new Promise(resolve => setTimeout(resolve, ms));
+    return new Promise((resolve) => setTimeout(resolve, ms));
   }
 
   private async processQueue(): Promise<void> {
@@ -77,18 +77,16 @@ export class Throttler {
       request.resolve(result);
     } catch (error) {
       const is429 = this.is429Error(error);
-      
+
       if (is429 && request.retries < this.maxRetries) {
         const resetSeconds = this.extractRateLimitReset(error);
-        const backoffMs = resetSeconds 
-          ? resetSeconds * 1000 
-          : Math.pow(2, request.retries) * 1000;
+        const backoffMs = resetSeconds ? resetSeconds * 1000 : Math.pow(2, request.retries) * 1000;
 
         await this.sleep(backoffMs);
-        
+
         request.retries += 1;
         this.queue.unshift(request);
-        
+
         if (!this.processing) {
           this.processQueue();
         }
@@ -108,15 +106,15 @@ export class Throttler {
 
   private extractRateLimitReset(error: unknown): number | null {
     if (typeof error === 'object' && error !== null) {
-      const err = error as { 
+      const err = error as {
         headers?: { 'x-contentful-ratelimit-reset'?: string };
         response?: { headers?: { 'x-contentful-ratelimit-reset'?: string } };
       };
-      
-      const resetHeader = 
+
+      const resetHeader =
         err.headers?.['x-contentful-ratelimit-reset'] ||
         err.response?.headers?.['x-contentful-ratelimit-reset'];
-      
+
       if (resetHeader) {
         const seconds = parseInt(resetHeader, 10);
         if (!isNaN(seconds)) {

--- a/apps/bulk-exporter/src/locations/ConfigScreen.tsx
+++ b/apps/bulk-exporter/src/locations/ConfigScreen.tsx
@@ -1,0 +1,103 @@
+import { useEffect } from 'react';
+import { Heading, Paragraph, Note, Flex, Box, List, SectionHeading, Text } from '@contentful/f36-components';
+import { useSDK } from '@contentful/react-apps-toolkit';
+import type { ConfigAppSDK } from '@contentful/app-sdk';
+
+const ConfigScreen = () => {
+  const sdk = useSDK<ConfigAppSDK>();
+  const fullWidth = { width: '100%' };
+
+  useEffect(() => {
+    const configure = async () => {
+      sdk.app.onConfigure(async () => {
+        return {
+          parameters: {},
+          targetState: {
+            EditorInterface: {},
+          },
+        };
+      });
+
+      sdk.app.setReady();
+    };
+
+    configure().catch((error) => {
+      console.error('Configuration error:', error);
+      sdk.notifier.error('Failed to initialize app configuration');
+    });
+  }, [sdk]);
+
+  return (
+    <Box padding="spacingXl" style={{ maxWidth: '900px', margin: '0 auto' }}>
+      <Flex flexDirection="column" gap="spacingXl" alignItems="stretch">
+        <Flex flexDirection="column" gap="spacingS" alignItems="flex-start" style={fullWidth}>
+          <Heading>Bulk Exporter</Heading>
+          <Paragraph>
+            Export entries from Contentful with filters, saved field selections, and multiple file formats.
+            No additional configuration is required before installation.
+          </Paragraph>
+        </Flex>
+
+        <Note variant="positive" title="Ready to install">
+          Bulk Exporter adds a page to the Apps menu. After installation, users with access to this
+          space can open the page and export entries from the content types they are allowed to read.
+        </Note>
+
+        <Flex flexDirection="column" gap="spacingL" alignItems="stretch" style={fullWidth}>
+          <Box style={fullWidth}>
+            <SectionHeading>How exports work</SectionHeading>
+            <Paragraph marginBottom="spacingS">
+              The app uses the Content Management API to paginate through matching entries and build a
+              downloadable file in the browser.
+            </Paragraph>
+            <List>
+              <List.Item>Export one content type or search across all content types.</List.Item>
+              <List.Item>Preview matching entries before creating the export file.</List.Item>
+              <List.Item>Select individual entries when only a subset should be exported.</List.Item>
+            </List>
+          </Box>
+
+          <Box style={fullWidth}>
+            <SectionHeading>Available controls</SectionHeading>
+            <Paragraph marginBottom="spacingS">
+              Users can narrow exports with the same content structure already available in the space.
+            </Paragraph>
+            <List>
+              <List.Item>Status, tag, taxonomy, date range, and field-level filters.</List.Item>
+              <List.Item>Locale selection for localized content.</List.Item>
+              <List.Item>Field presets, custom field selection, and column ordering.</List.Item>
+              <List.Item>CSV, JSON, XLSX, XML, and YAML downloads.</List.Item>
+            </List>
+          </Box>
+
+          <Box style={fullWidth}>
+            <SectionHeading>Before exporting</SectionHeading>
+            <Paragraph marginBottom="spacingS">
+              Large exports can take several minutes depending on entry count, selected fields, and API
+              rate limits.
+            </Paragraph>
+            <List>
+              <List.Item>Keep this browser tab open while an export is running.</List.Item>
+              <List.Item>Use filters or date ranges to reduce very large exports.</List.Item>
+              <List.Item>Verify the preview results before downloading production data.</List.Item>
+            </List>
+          </Box>
+        </Flex>
+
+        <Note variant="primary" title="Permissions">
+          <Flex flexDirection="column" gap="spacingXs" alignItems="flex-start" style={fullWidth}>
+            <Text>
+              Bulk Exporter can only export entries, tags, locales, and taxonomy data that the current
+              user is allowed to access.
+            </Text>
+            <Text>
+              If a user cannot load content types or entries, review their space role and app access.
+            </Text>
+          </Flex>
+        </Note>
+      </Flex>
+    </Box>
+  );
+};
+
+export default ConfigScreen;

--- a/apps/bulk-exporter/src/locations/ConfigScreen.tsx
+++ b/apps/bulk-exporter/src/locations/ConfigScreen.tsx
@@ -1,5 +1,14 @@
 import { useEffect } from 'react';
-import { Heading, Paragraph, Note, Flex, Box, List, SectionHeading, Text } from '@contentful/f36-components';
+import {
+  Heading,
+  Paragraph,
+  Note,
+  Flex,
+  Box,
+  List,
+  SectionHeading,
+  Text,
+} from '@contentful/f36-components';
 import { useSDK } from '@contentful/react-apps-toolkit';
 import type { ConfigAppSDK } from '@contentful/app-sdk';
 
@@ -33,34 +42,38 @@ const ConfigScreen = () => {
         <Flex flexDirection="column" gap="spacingS" alignItems="flex-start" style={fullWidth}>
           <Heading>Bulk Exporter</Heading>
           <Paragraph>
-            Export entries from Contentful with filters, saved field selections, and multiple file formats.
-            No additional configuration is required before installation.
+            Export entries from Contentful with filters, saved field selections, and multiple file
+            formats. No additional configuration is required before installation.
           </Paragraph>
         </Flex>
 
         <Note variant="positive" title="Ready to install">
           Bulk Exporter adds a page to the Apps menu. After installation, users with access to this
-          space can open the page and export entries from the content types they are allowed to read.
+          space can open the page and export entries from the content types they are allowed to
+          read.
         </Note>
 
         <Flex flexDirection="column" gap="spacingL" alignItems="stretch" style={fullWidth}>
           <Box style={fullWidth}>
             <SectionHeading>How exports work</SectionHeading>
             <Paragraph marginBottom="spacingS">
-              The app uses the Content Management API to paginate through matching entries and build a
-              downloadable file in the browser.
+              The app uses the Content Management API to paginate through matching entries and build
+              a downloadable file in the browser.
             </Paragraph>
             <List>
               <List.Item>Export one content type or search across all content types.</List.Item>
               <List.Item>Preview matching entries before creating the export file.</List.Item>
-              <List.Item>Select individual entries when only a subset should be exported.</List.Item>
+              <List.Item>
+                Select individual entries when only a subset should be exported.
+              </List.Item>
             </List>
           </Box>
 
           <Box style={fullWidth}>
             <SectionHeading>Available controls</SectionHeading>
             <Paragraph marginBottom="spacingS">
-              Users can narrow exports with the same content structure already available in the space.
+              Users can narrow exports with the same content structure already available in the
+              space.
             </Paragraph>
             <List>
               <List.Item>Status, tag, taxonomy, date range, and field-level filters.</List.Item>
@@ -73,8 +86,8 @@ const ConfigScreen = () => {
           <Box style={fullWidth}>
             <SectionHeading>Before exporting</SectionHeading>
             <Paragraph marginBottom="spacingS">
-              Large exports can take several minutes depending on entry count, selected fields, and API
-              rate limits.
+              Large exports can take several minutes depending on entry count, selected fields, and
+              API rate limits.
             </Paragraph>
             <List>
               <List.Item>Keep this browser tab open while an export is running.</List.Item>
@@ -87,11 +100,12 @@ const ConfigScreen = () => {
         <Note variant="primary" title="Permissions">
           <Flex flexDirection="column" gap="spacingXs" alignItems="flex-start" style={fullWidth}>
             <Text>
-              Bulk Exporter can only export entries, tags, locales, and taxonomy data that the current
-              user is allowed to access.
+              Bulk Exporter can only export entries, tags, locales, and taxonomy data that the
+              current user is allowed to access.
             </Text>
             <Text>
-              If a user cannot load content types or entries, review their space role and app access.
+              If a user cannot load content types or entries, review their space role and app
+              access.
             </Text>
           </Flex>
         </Note>

--- a/apps/bulk-exporter/src/locations/Page.tsx
+++ b/apps/bulk-exporter/src/locations/Page.tsx
@@ -70,10 +70,15 @@ const Page = () => {
   const ITEMS_PER_PAGE = 50;
   const [lastFormData, setLastFormData] = useState<ExportFormData | null>(null);
   const [selectedEntryIds, setSelectedEntryIds] = useState<string[]>([]);
-  const [contentTypeMap, setContentTypeMap] = useState<Record<string, { name: string; displayField?: string }>>({});
+  const [contentTypeMap, setContentTypeMap] = useState<
+    Record<string, { name: string; displayField?: string }>
+  >({});
   const [contentTypeSchemaMap, setContentTypeSchemaMap] = useState<Record<string, ContentType>>({});
   const [userMap, setUserMap] = useState<Record<string, string>>({});
-  const [columnSort, setColumnSort] = useState<{ column: string; direction: 'asc' | 'desc' } | null>(null);
+  const [columnSort, setColumnSort] = useState<{
+    column: string;
+    direction: 'asc' | 'desc';
+  } | null>(null);
 
   const exporterRef = useRef<Exporter | null>(null);
 
@@ -93,7 +98,7 @@ const Page = () => {
       const ct = contentTypeId ? contentTypeSchemaMap[contentTypeId] : undefined;
       const displayFieldId = ct?.displayField;
       const displayField = displayFieldId
-        ? ct?.fields.find(f => f.id === displayFieldId)
+        ? ct?.fields.find((f) => f.id === displayFieldId)
         : undefined;
       if (displayField) {
         const colName = displayField.localized
@@ -253,7 +258,9 @@ const Page = () => {
 
       const postFilter = getStatusPostFilter(data.status as EntryStatus);
       const items = postFilter
-        ? (response.items as unknown as SearchResult[]).filter(postFilter as (e: SearchResult) => boolean)
+        ? (response.items as unknown as SearchResult[]).filter(
+            postFilter as (e: SearchResult) => boolean
+          )
         : (response.items as unknown as SearchResult[]);
 
       setSearchResults(items);
@@ -273,7 +280,11 @@ const Page = () => {
     }
   };
 
-  const handleExportSelected = async (selectedIds: string[], format: 'csv' | 'json' | 'xlsx' | 'xml' | 'yaml' = 'csv', filename = '') => {
+  const handleExportSelected = async (
+    selectedIds: string[],
+    format: 'csv' | 'json' | 'xlsx' | 'xml' | 'yaml' = 'csv',
+    filename = ''
+  ) => {
     try {
       setIsExporting(true);
       setProgress({
@@ -288,14 +299,14 @@ const Page = () => {
 
       // Fetch all selected entries in one API call using sys.id[in] instead of
       // per-entry requests, which avoids rate-limit issues at large selection sizes.
-      const firstEntry = searchResults.find(r => r.sys.id === selectedIds[0]);
+      const firstEntry = searchResults.find((r) => r.sys.id === selectedIds[0]);
       const contentTypeId = firstEntry?.sys.contentType.sys.id ?? '';
 
       await exporter.start(
         {
-          contentType: contentTypes.find(ct => ct.sys.id === contentTypeId) || null,
+          contentType: contentTypes.find((ct) => ct.sys.id === contentTypeId) || null,
           contentTypeId: contentTypeId || 'selected',
-          locales: locales.map(l => l.code),
+          locales: locales.map((l) => l.code),
           userMap: userMap,
           contentTypeMap: contentTypeSchemaMap,
           format,
@@ -336,7 +347,9 @@ const Page = () => {
 
       const postFilter = getStatusPostFilter(lastFormData?.status as EntryStatus);
       const items = postFilter
-        ? (response.items as unknown as SearchResult[]).filter(postFilter as (e: SearchResult) => boolean)
+        ? (response.items as unknown as SearchResult[]).filter(
+            postFilter as (e: SearchResult) => boolean
+          )
         : (response.items as unknown as SearchResult[]);
 
       setSearchResults(items);
@@ -392,10 +405,11 @@ const Page = () => {
           userMap: userMap,
           contentTypeMap: contentTypeSchemaMap,
           format: data.format || 'csv',
-          filename: data.customFilename ||
-            (data.contentTypeId ?
-              `${data.contentTypeId}-${new Date().toISOString().split('T')[0]}` :
-              `contentful-export-${new Date().toISOString().split('T')[0]}`),
+          filename:
+            data.customFilename ||
+            (data.contentTypeId
+              ? `${data.contentTypeId}-${new Date().toISOString().split('T')[0]}`
+              : `contentful-export-${new Date().toISOString().split('T')[0]}`),
           sortByColumn: buildSortByColumn(data.contentTypeId),
           statusPostFilter: exportStatusPostFilter as ((entry: Entry) => boolean) | undefined,
         },
@@ -424,8 +438,7 @@ const Page = () => {
         justifyContent="center"
         flexDirection="column"
         gap="spacingS"
-        style={{ minHeight: '60vh' }}
-      >
+        style={{ minHeight: '60vh' }}>
         <Spinner />
         <Text fontColor="gray600">Loading content types, locales, and tags...</Text>
       </Flex>
@@ -434,12 +447,7 @@ const Page = () => {
 
   return (
     <Box style={{ maxWidth: '1400px', margin: '0 auto', width: '100%' }}>
-      <Flex
-        flexDirection="column"
-        alignItems="stretch"
-        gap="spacingL"
-        padding="spacingL"
-      >
+      <Flex flexDirection="column" alignItems="stretch" gap="spacingL" padding="spacingL">
         <Box style={{ width: '100%', maxWidth: '1040px' }}>
           <Heading marginBottom="spacingS">Entry Exporter</Heading>
           <Paragraph marginBottom="none" style={{ maxWidth: '700px' }}>
@@ -474,15 +482,17 @@ const Page = () => {
             style={{
               textAlign: 'center',
               padding: '48px 24px',
-            }}
-          >
+            }}>
             <Text fontColor="gray500">List results to export will appear here.</Text>
           </Box>
         )}
 
         {searchResults.length === 0 && !isSearching && lastSearchQuery && (
           <Box style={{ textAlign: 'center', padding: '48px 24px' }}>
-            <Text fontWeight="fontWeightDemiBold" marginBottom="spacingXs" style={{ display: 'block' }}>
+            <Text
+              fontWeight="fontWeightDemiBold"
+              marginBottom="spacingXs"
+              style={{ display: 'block' }}>
               No results.
             </Text>
             <Text fontColor="gray600">Try adjusting your filters and generating a list again.</Text>
@@ -513,7 +523,6 @@ const Page = () => {
           }
           locales={lastFormData?.locales ?? []}
         />
-
       </Flex>
     </Box>
   );

--- a/apps/bulk-exporter/src/locations/Page.tsx
+++ b/apps/bulk-exporter/src/locations/Page.tsx
@@ -1,0 +1,535 @@
+import { useEffect, useState, useRef } from 'react';
+import { Heading, Paragraph, Box, Note, Spinner, Flex, Text } from '@contentful/f36-components';
+import { useSDK, useCMA } from '@contentful/react-apps-toolkit';
+import type { PageAppSDK } from '@contentful/app-sdk';
+import { ExportForm, type ExportFormData } from '../components/ExportForm';
+import { ResultsList } from '../components/ResultsList';
+import { Exporter, type ExportProgress } from '../lib/exporter';
+import { getEntryCount } from '../lib/paginate';
+import { buildQuery, getStatusPostFilter, type EntryStatus } from '../lib/queryBuilder';
+import type { ContentType, Entry } from '../lib/flatten';
+import { MOCK_CONCEPTS } from '../lib/mockConcepts';
+
+interface Locale {
+  code: string;
+  name: string;
+}
+
+interface Tag {
+  sys: { id: string };
+  name: string;
+}
+
+interface Concept {
+  sys: { id: string };
+  prefLabel: Record<string, string>;
+}
+
+interface SearchResult {
+  sys: {
+    id: string;
+    contentType: {
+      sys: {
+        id: string;
+      };
+    };
+    createdAt: string;
+    updatedAt: string;
+    publishedAt?: string;
+  };
+  fields?: Record<string, Record<string, unknown>>;
+}
+
+const Page = () => {
+  const sdk = useSDK<PageAppSDK>();
+  const cma = useCMA();
+
+  const [contentTypes, setContentTypes] = useState<ContentType[]>([]);
+  const [locales, setLocales] = useState<Locale[]>([]);
+  const [tags, setTags] = useState<Tag[]>([]);
+  const [concepts, setConcepts] = useState<Concept[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [estimatedCount, setEstimatedCount] = useState<number | null>(null);
+  const [progress, setProgress] = useState<ExportProgress | null>(null);
+  const [isExporting, setIsExporting] = useState(false);
+  const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [lastSearchQuery, setLastSearchQuery] = useState<Record<string, unknown> | null>(null);
+  const [activePage, setActivePage] = useState(0);
+  const ITEMS_PER_PAGE = 50;
+  const [lastFormData, setLastFormData] = useState<ExportFormData | null>(null);
+  const [selectedEntryIds, setSelectedEntryIds] = useState<string[]>([]);
+  const [contentTypeMap, setContentTypeMap] = useState<Record<string, { name: string; displayField?: string }>>({});
+  const [contentTypeSchemaMap, setContentTypeSchemaMap] = useState<Record<string, ContentType>>({});
+  const [userMap, setUserMap] = useState<Record<string, string>>({});
+  const [columnSort, setColumnSort] = useState<{ column: string; direction: 'asc' | 'desc' } | null>(null);
+
+  const exporterRef = useRef<Exporter | null>(null);
+
+  /**
+   * Translate the result-table SortColumn to the flat-row column name produced
+   * by flatten.ts so the exporter can sort the downloaded file rows. For the
+   * "name" sort there is no fixed column name (flatten.ts emits the display
+   * field's name, e.g. "Title (en-US)"), so we resolve it from the selected
+   * content type when possible and fall back to the Entry ID.
+   */
+  const buildSortByColumn = (
+    contentTypeId: string | undefined
+  ): { column: string; direction: 'asc' | 'desc' } | undefined => {
+    if (!columnSort) return undefined;
+
+    if (columnSort.column === 'name') {
+      const ct = contentTypeId ? contentTypeSchemaMap[contentTypeId] : undefined;
+      const displayFieldId = ct?.displayField;
+      const displayField = displayFieldId
+        ? ct?.fields.find(f => f.id === displayFieldId)
+        : undefined;
+      if (displayField) {
+        const colName = displayField.localized
+          ? `${displayField.name} (${locales[0]?.code ?? 'en-US'})`
+          : displayField.name;
+        return { column: colName, direction: columnSort.direction };
+      }
+      return { column: 'Entry ID', direction: columnSort.direction };
+    }
+
+    const fixed: Record<string, string> = {
+      contentType: 'Content Type',
+      updated: 'Updated',
+      updatedBy: 'Last Updated By',
+      status: 'Status',
+    };
+    const rowKey = fixed[columnSort.column];
+    return rowKey ? { column: rowKey, direction: columnSort.direction } : undefined;
+  };
+
+  useEffect(() => {
+    const loadData = async () => {
+      try {
+        const [ctResponse, localesResponse] = await Promise.all([
+          sdk.cma.contentType.getMany({ query: { limit: 1000 } }),
+          sdk.cma.locale.getMany({ query: { limit: 100 } }),
+        ]);
+
+        const ctItems = (ctResponse.items as unknown as ContentType[]).sort((a, b) =>
+          (a.name || a.sys.id).localeCompare(b.name || b.sys.id)
+        );
+        setContentTypes(ctItems);
+
+        // Build content type map with names and display fields (for UI)
+        const ctMap: Record<string, { name: string; displayField?: string }> = {};
+        // Build content type schema map (for export)
+        const ctSchemaMap: Record<string, ContentType> = {};
+        for (const ct of ctItems) {
+          ctMap[ct.sys.id] = {
+            name: ct.name || ct.sys.id,
+            displayField: ct.displayField,
+          };
+          ctSchemaMap[ct.sys.id] = ct;
+        }
+        setContentTypeMap(ctMap);
+        setContentTypeSchemaMap(ctSchemaMap);
+
+        setLocales(
+          localesResponse.items.map((l: { code: string; name: string }) => ({
+            code: l.code,
+            name: l.name,
+          }))
+        );
+
+        // Load tags (gracefully handle errors)
+        try {
+          const tagsResponse = await sdk.cma.tag.getMany({ query: { limit: 1000 } });
+          setTags(tagsResponse.items as unknown as Tag[]);
+        } catch (error) {
+          console.warn('Tags not available or error loading tags:', error);
+          setTags([]);
+        }
+
+        // Load concepts (gracefully handle errors for spaces without taxonomy)
+        if (import.meta.env.VITE_MOCK_CONCEPTS === 'true') {
+          setConcepts(MOCK_CONCEPTS);
+        } else {
+          try {
+            const conceptsResponse = await (cma as any).concept.getMany({
+              query: { limit: 1000 },
+            });
+            setConcepts(conceptsResponse.items as unknown as Concept[]);
+          } catch (error) {
+            console.warn('Concepts/taxonomy not available:', error);
+            setConcepts([]);
+          }
+        }
+
+        // Load users to map IDs to names
+        try {
+          const spaceId = sdk.ids.space;
+          const usersResponse = await (cma as any).user.getManyForSpace({ spaceId });
+          const uMap: Record<string, string> = {};
+          for (const user of usersResponse.items as any[]) {
+            const firstName = user.firstName || '';
+            const lastName = user.lastName || '';
+            const fullName = `${firstName} ${lastName}`.trim() || user.email || user.sys.id;
+            uMap[user.sys.id] = fullName;
+          }
+          setUserMap(uMap);
+        } catch (error) {
+          console.warn('Unable to load users:', error);
+          setUserMap({});
+        }
+      } catch (error) {
+        sdk.notifier.error('Failed to load content types and locales');
+        console.error(error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadData();
+  }, [sdk, cma]);
+
+  const handleEstimate = async (data: ExportFormData) => {
+    try {
+      setEstimatedCount(null);
+      
+      const query = buildQuery({
+        contentTypeId: data.contentTypeId,
+        search: data.search,
+        status: data.status,
+        createdFrom: data.createdFrom,
+        createdTo: data.createdTo,
+        updatedFrom: data.updatedFrom,
+        updatedTo: data.updatedTo,
+        sort: data.sort,
+        tags: data.tags,
+        tagsMatchAll: data.tagsMatchAll,
+        concepts: data.concepts,
+        conceptsMatchAll: data.conceptsMatchAll,
+        fieldFilters: data.fieldFilters,
+      });
+      
+      const { content_type, ...filters } = query;
+      const count = await getEntryCount(sdk.cma, content_type as string | undefined, filters);
+      setEstimatedCount(count);
+    } catch (error) {
+      sdk.notifier.error('Failed to estimate entry count');
+      console.error(error);
+    }
+  };
+
+  const handleSearch = async (data: ExportFormData) => {
+    try {
+      setIsSearching(true);
+      setSearchResults([]);
+      setSelectedEntryIds([]);
+      setActivePage(0);
+      setLastFormData(data); // Save form data for exports
+      
+      const query = buildQuery({
+        contentTypeId: data.contentTypeId,
+        search: data.search,
+        status: data.status,
+        createdFrom: data.createdFrom,
+        createdTo: data.createdTo,
+        updatedFrom: data.updatedFrom,
+        updatedTo: data.updatedTo,
+        sort: data.sort,
+        tags: data.tags,
+        tagsMatchAll: data.tagsMatchAll,
+        concepts: data.concepts,
+        conceptsMatchAll: data.conceptsMatchAll,
+        fieldFilters: data.fieldFilters,
+      });
+
+      setLastSearchQuery(query);
+
+      const response = await sdk.cma.entry.getMany({
+        query: { ...query, limit: ITEMS_PER_PAGE, skip: 0 },
+      });
+
+      const postFilter = getStatusPostFilter(data.status as EntryStatus);
+      const items = postFilter
+        ? (response.items as unknown as SearchResult[]).filter(postFilter as (e: SearchResult) => boolean)
+        : (response.items as unknown as SearchResult[]);
+
+      setSearchResults(items);
+      setEstimatedCount(response.items.length >= response.total ? items.length : response.total);
+      
+      // Smooth scroll to results
+      setTimeout(() => {
+        const resultsElement = document.querySelector('[data-results-list]');
+        if (resultsElement) {
+          resultsElement.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+      }, 100);
+    } catch (error) {
+      sdk.notifier.error('Failed to search entries');
+      console.error(error);
+    } finally {
+      setIsSearching(false);
+    }
+  };
+
+  const handleExportSelected = async (selectedIds: string[], format: 'csv' | 'json' | 'xlsx' | 'xml' | 'yaml' = 'csv', filename = '') => {
+    try {
+      setIsExporting(true);
+      setProgress({
+        fetched: 0,
+        total: selectedIds.length,
+        status: 'fetching',
+        message: `Exporting ${selectedIds.length} selected entries...`,
+      });
+
+      // Fetch the full entries for selected IDs
+      const entries: SearchResult[] = [];
+      for (const id of selectedIds) {
+        const entry = await sdk.cma.entry.get({ entryId: id });
+        entries.push(entry as unknown as SearchResult);
+      }
+
+      // Get the form data to determine content type and fields
+      const firstEntry = entries[0];
+      const contentTypeId = firstEntry.sys.contentType.sys.id;
+      
+      // For selected entries, use the exporter with pre-fetched data
+      const exporter = new Exporter(sdk.cma);
+      exporterRef.current = exporter;
+
+      // We'll need to modify the exporter to accept pre-fetched entries
+      // For now, use the standard export with sys.id[in] filter
+      const formData = {
+        contentType: contentTypes.find(ct => ct.sys.id === contentTypeId) || null,
+        contentTypeId,
+        locales: locales.map(l => l.code),
+      };
+
+      await exporter.start(
+        {
+          contentType: formData.contentType,
+          contentTypeId: contentTypeId || 'selected',
+          locales: formData.locales,
+          userMap: userMap,
+          contentTypeMap: contentTypeSchemaMap,
+          format,
+          filters: {
+            'sys.id[in]': selectedIds.join(','),
+          },
+          filename,
+          sortByColumn: buildSortByColumn(contentTypeId),
+        },
+        (newProgress) => {
+          setProgress(newProgress);
+        }
+      );
+
+      sdk.notifier.success(`Successfully exported ${selectedIds.length} selected entries!`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      sdk.notifier.error(`Failed to export selected entries: ${message}`);
+      console.error(error);
+    } finally {
+      setIsExporting(false);
+      setProgress(null);
+      exporterRef.current = null;
+    }
+  };
+
+  const handlePageChange = async (page: number) => {
+    if (!lastSearchQuery) return;
+
+    try {
+      setIsSearching(true);
+      setActivePage(page);
+      setSelectedEntryIds([]);
+
+      const response = await sdk.cma.entry.getMany({
+        query: { ...lastSearchQuery, limit: ITEMS_PER_PAGE, skip: page * ITEMS_PER_PAGE },
+      });
+
+      const postFilter = getStatusPostFilter(lastFormData?.status as EntryStatus);
+      const items = postFilter
+        ? (response.items as unknown as SearchResult[]).filter(postFilter as (e: SearchResult) => boolean)
+        : (response.items as unknown as SearchResult[]);
+
+      setSearchResults(items);
+    } catch (error) {
+      sdk.notifier.error('Failed to load results');
+      console.error(error);
+    } finally {
+      setIsSearching(false);
+    }
+  };
+
+  const handleExport = async (data: ExportFormData) => {
+    try {
+      setLastFormData(data); // Save form data
+      setIsExporting(true);
+      setProgress({
+        fetched: 0,
+        total: 0,
+        status: 'estimating',
+        message: 'Starting export...',
+      });
+
+      const query = buildQuery({
+        contentTypeId: data.contentTypeId,
+        search: data.search,
+        status: data.status,
+        createdFrom: data.createdFrom,
+        createdTo: data.createdTo,
+        updatedFrom: data.updatedFrom,
+        updatedTo: data.updatedTo,
+        sort: data.sort,
+        tags: data.tags,
+        tagsMatchAll: data.tagsMatchAll,
+        concepts: data.concepts,
+        conceptsMatchAll: data.conceptsMatchAll,
+        fieldFilters: data.fieldFilters,
+      });
+
+      const { content_type, ...filters } = query;
+
+      const exporter = new Exporter(sdk.cma);
+      exporterRef.current = exporter;
+
+      const exportStatusPostFilter = getStatusPostFilter(data.status as EntryStatus) ?? undefined;
+
+      await exporter.start(
+        {
+          contentType: data.contentType,
+          contentTypeId: data.contentTypeId || 'all-content-types',
+          locales: data.locales,
+          fields: data.fields,
+          filters,
+          userMap: userMap,
+          contentTypeMap: contentTypeSchemaMap,
+          format: data.format || 'csv',
+          filename: data.customFilename ||
+            (data.contentTypeId ?
+              `${data.contentTypeId}-${new Date().toISOString().split('T')[0]}` :
+              `contentful-export-${new Date().toISOString().split('T')[0]}`),
+          sortByColumn: buildSortByColumn(data.contentTypeId),
+          statusPostFilter: exportStatusPostFilter as ((entry: Entry) => boolean) | undefined,
+        },
+        (newProgress) => {
+          setProgress(newProgress);
+        }
+      );
+
+      if (progress?.status === 'complete') {
+        sdk.notifier.success(`Export completed! Downloaded ${progress.fetched} entries.`);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      sdk.notifier.error(`Export failed: ${message}`);
+      console.error(error);
+    } finally {
+      setIsExporting(false);
+      exporterRef.current = null;
+    }
+  };
+
+
+  if (loading) {
+    return (
+      <Flex
+        alignItems="center"
+        justifyContent="center"
+        flexDirection="column"
+        gap="spacingS"
+        style={{ minHeight: '60vh' }}
+      >
+        <Spinner />
+        <Text fontColor="gray600">Loading content types, locales, and tags...</Text>
+      </Flex>
+    );
+  }
+
+  return (
+    <Box style={{ maxWidth: '1400px', margin: '0 auto', width: '100%' }}>
+      <Flex
+        flexDirection="column"
+        alignItems="stretch"
+        gap="spacingL"
+        padding="spacingL"
+      >
+        <Box style={{ width: '100%', maxWidth: '1040px' }}>
+          <Heading marginBottom="spacingS">Entry Exporter</Heading>
+          <Paragraph marginBottom="none" style={{ maxWidth: '700px' }}>
+            Search, preview, and export Contentful entries across one content type or the whole
+            space. Use filters to narrow the result set, then export matching or selected entries.
+          </Paragraph>
+        </Box>
+
+        {contentTypes.length === 0 && (
+          <Note variant="warning" title="No content types found">
+            Add content types to this space before running an export.
+          </Note>
+        )}
+
+        <ExportForm
+          contentTypes={contentTypes}
+          availableLocales={locales}
+          availableTags={tags}
+          availableConcepts={concepts}
+          onSubmit={handleExport}
+          onEstimate={handleEstimate}
+          onSearch={handleSearch}
+          onQuickExport={handleExport}
+          isExporting={isExporting}
+          isSearching={isSearching}
+          estimatedCount={estimatedCount}
+          spaceId={sdk.ids.space}
+        />
+
+        {searchResults.length === 0 && !isSearching && !lastSearchQuery && (
+          <Box
+            style={{
+              textAlign: 'center',
+              padding: '48px 24px',
+            }}
+          >
+            <Text fontColor="gray500">List results to export will appear here.</Text>
+          </Box>
+        )}
+
+        {searchResults.length === 0 && !isSearching && lastSearchQuery && (
+          <Box style={{ textAlign: 'center', padding: '48px 24px' }}>
+            <Text fontWeight="fontWeightDemiBold" marginBottom="spacingXs" style={{ display: 'block' }}>
+              No results.
+            </Text>
+            <Text fontColor="gray600">Try adjusting your filters and generating a list again.</Text>
+          </Box>
+        )}
+
+        <ResultsList
+          results={searchResults}
+          loading={isSearching}
+          onPageChange={handlePageChange}
+          activePage={activePage}
+          itemsPerPage={ITEMS_PER_PAGE}
+          totalCount={estimatedCount ?? undefined}
+          selectedIds={selectedEntryIds}
+          onSelectionChange={setSelectedEntryIds}
+          onExportSelected={handleExportSelected}
+          contentTypeMap={contentTypeMap}
+          userMap={userMap}
+          spaceId={sdk.ids.space}
+          environmentId={sdk.ids.environment}
+          isExporting={isExporting}
+          exportProgress={progress}
+          onSortChange={setColumnSort}
+          contentTypeSchema={
+            lastFormData?.contentTypeId
+              ? contentTypeSchemaMap[lastFormData.contentTypeId] ?? null
+              : null
+          }
+locales={lastFormData?.locales ?? []}
+        />
+
+      </Flex>
+    </Box>
+  );
+};
+
+export default Page;

--- a/apps/bulk-exporter/src/locations/Page.tsx
+++ b/apps/bulk-exporter/src/locations/Page.tsx
@@ -8,7 +8,6 @@ import { Exporter, type ExportProgress } from '../lib/exporter';
 import { getEntryCount } from '../lib/paginate';
 import { buildQuery, getStatusPostFilter, type EntryStatus } from '../lib/queryBuilder';
 import type { ContentType, Entry } from '../lib/flatten';
-import { MOCK_CONCEPTS } from '../lib/mockConcepts';
 
 interface Locale {
   code: string;
@@ -38,6 +37,18 @@ interface SearchResult {
     publishedAt?: string;
   };
   fields?: Record<string, Record<string, unknown>>;
+}
+
+interface CmaUser {
+  sys: { id: string };
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+}
+
+interface CmaWithExtras {
+  concept: { getMany: (opts: { query: Record<string, unknown> }) => Promise<{ items: Concept[] }> };
+  user: { getManyForSpace: (opts: { spaceId: string }) => Promise<{ items: CmaUser[] }> };
 }
 
 const Page = () => {
@@ -116,15 +127,10 @@ const Page = () => {
         );
         setContentTypes(ctItems);
 
-        // Build content type map with names and display fields (for UI)
         const ctMap: Record<string, { name: string; displayField?: string }> = {};
-        // Build content type schema map (for export)
         const ctSchemaMap: Record<string, ContentType> = {};
         for (const ct of ctItems) {
-          ctMap[ct.sys.id] = {
-            name: ct.name || ct.sys.id,
-            displayField: ct.displayField,
-          };
+          ctMap[ct.sys.id] = { name: ct.name || ct.sys.id, displayField: ct.displayField };
           ctSchemaMap[ct.sys.id] = ct;
         }
         setContentTypeMap(ctMap);
@@ -137,7 +143,6 @@ const Page = () => {
           }))
         );
 
-        // Load tags (gracefully handle errors)
         try {
           const tagsResponse = await sdk.cma.tag.getMany({ query: { limit: 1000 } });
           setTags(tagsResponse.items as unknown as Tag[]);
@@ -146,27 +151,26 @@ const Page = () => {
           setTags([]);
         }
 
-        // Load concepts (gracefully handle errors for spaces without taxonomy)
         if (import.meta.env.VITE_MOCK_CONCEPTS === 'true') {
+          const { MOCK_CONCEPTS } = await import('../lib/mockConcepts');
           setConcepts(MOCK_CONCEPTS);
         } else {
           try {
-            const conceptsResponse = await (cma as any).concept.getMany({
-              query: { limit: 1000 },
-            });
-            setConcepts(conceptsResponse.items as unknown as Concept[]);
+            const cmaExtras = cma as unknown as CmaWithExtras;
+            const conceptsResponse = await cmaExtras.concept.getMany({ query: { limit: 1000 } });
+            setConcepts(conceptsResponse.items);
           } catch (error) {
             console.warn('Concepts/taxonomy not available:', error);
             setConcepts([]);
           }
         }
 
-        // Load users to map IDs to names
         try {
           const spaceId = sdk.ids.space;
-          const usersResponse = await (cma as any).user.getManyForSpace({ spaceId });
+          const cmaExtras = cma as unknown as CmaWithExtras;
+          const usersResponse = await cmaExtras.user.getManyForSpace({ spaceId });
           const uMap: Record<string, string> = {};
-          for (const user of usersResponse.items as any[]) {
+          for (const user of usersResponse.items) {
             const firstName = user.firstName || '';
             const lastName = user.lastName || '';
             const fullName = `${firstName} ${lastName}`.trim() || user.email || user.sys.id;
@@ -191,7 +195,7 @@ const Page = () => {
   const handleEstimate = async (data: ExportFormData) => {
     try {
       setEstimatedCount(null);
-      
+
       const query = buildQuery({
         contentTypeId: data.contentTypeId,
         search: data.search,
@@ -207,7 +211,7 @@ const Page = () => {
         conceptsMatchAll: data.conceptsMatchAll,
         fieldFilters: data.fieldFilters,
       });
-      
+
       const { content_type, ...filters } = query;
       const count = await getEntryCount(sdk.cma, content_type as string | undefined, filters);
       setEstimatedCount(count);
@@ -223,8 +227,8 @@ const Page = () => {
       setSearchResults([]);
       setSelectedEntryIds([]);
       setActivePage(0);
-      setLastFormData(data); // Save form data for exports
-      
+      setLastFormData(data);
+
       const query = buildQuery({
         contentTypeId: data.contentTypeId,
         search: data.search,
@@ -254,8 +258,7 @@ const Page = () => {
 
       setSearchResults(items);
       setEstimatedCount(response.items.length >= response.total ? items.length : response.total);
-      
-      // Smooth scroll to results
+
       setTimeout(() => {
         const resultsElement = document.querySelector('[data-results-list]');
         if (resultsElement) {
@@ -280,34 +283,19 @@ const Page = () => {
         message: `Exporting ${selectedIds.length} selected entries...`,
       });
 
-      // Fetch the full entries for selected IDs
-      const entries: SearchResult[] = [];
-      for (const id of selectedIds) {
-        const entry = await sdk.cma.entry.get({ entryId: id });
-        entries.push(entry as unknown as SearchResult);
-      }
-
-      // Get the form data to determine content type and fields
-      const firstEntry = entries[0];
-      const contentTypeId = firstEntry.sys.contentType.sys.id;
-      
-      // For selected entries, use the exporter with pre-fetched data
       const exporter = new Exporter(sdk.cma);
       exporterRef.current = exporter;
 
-      // We'll need to modify the exporter to accept pre-fetched entries
-      // For now, use the standard export with sys.id[in] filter
-      const formData = {
-        contentType: contentTypes.find(ct => ct.sys.id === contentTypeId) || null,
-        contentTypeId,
-        locales: locales.map(l => l.code),
-      };
+      // Fetch all selected entries in one API call using sys.id[in] instead of
+      // per-entry requests, which avoids rate-limit issues at large selection sizes.
+      const firstEntry = searchResults.find(r => r.sys.id === selectedIds[0]);
+      const contentTypeId = firstEntry?.sys.contentType.sys.id ?? '';
 
       await exporter.start(
         {
-          contentType: formData.contentType,
+          contentType: contentTypes.find(ct => ct.sys.id === contentTypeId) || null,
           contentTypeId: contentTypeId || 'selected',
-          locales: formData.locales,
+          locales: locales.map(l => l.code),
           userMap: userMap,
           contentTypeMap: contentTypeSchemaMap,
           format,
@@ -362,7 +350,7 @@ const Page = () => {
 
   const handleExport = async (data: ExportFormData) => {
     try {
-      setLastFormData(data); // Save form data
+      setLastFormData(data);
       setIsExporting(true);
       setProgress({
         fetched: 0,
@@ -428,7 +416,6 @@ const Page = () => {
       exporterRef.current = null;
     }
   };
-
 
   if (loading) {
     return (
@@ -524,7 +511,7 @@ const Page = () => {
               ? contentTypeSchemaMap[lastFormData.contentTypeId] ?? null
               : null
           }
-locales={lastFormData?.locales ?? []}
+          locales={lastFormData?.locales ?? []}
         />
 
       </Flex>

--- a/apps/bulk-exporter/src/test/setup.ts
+++ b/apps/bulk-exporter/src/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/apps/bulk-exporter/src/vite-env.d.ts
+++ b/apps/bulk-exporter/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_MOCK_CONCEPTS?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/apps/bulk-exporter/tsconfig.json
+++ b/apps/bulk-exporter/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/apps/bulk-exporter/tsconfig.node.json
+++ b/apps/bulk-exporter/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/apps/bulk-exporter/vite.config.ts
+++ b/apps/bulk-exporter/vite.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  base: './', // Use relative paths for Contentful hosted apps
+  build: {
+    rollupOptions: {
+      output: {
+        // Single file for Contentful hosted apps
+        inlineDynamicImports: true,
+        entryFileNames: 'bundle.js',
+        assetFileNames: 'bundle.[ext]',
+      },
+    },
+  },
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: './src/test/setup.ts',
+  },
+});

--- a/apps/bulk-exporter/vite.config.ts
+++ b/apps/bulk-exporter/vite.config.ts
@@ -4,6 +4,12 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   plugins: [react()],
   base: './', // Use relative paths for Contentful hosted apps
+  server: {
+    port: 3000,
+  },
+  preview: {
+    port: 3000,
+  },
   build: {
     rollupOptions: {
       output: {

--- a/apps/bulk-exporter/vitest.config.ts
+++ b/apps/bulk-exporter/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: './src/test/setup.ts',
+  },
+});


### PR DESCRIPTION
## Summary
- Adds the Bulk Exporter app to the monorepo under `apps/bulk-exporter`
- Allows users to search, filter, and export Contentful entries across one content type or the whole space
- Supports CSV, JSON, XLSX, XML, and YAML export formats
- Built with Forma 36 v6 components, F36 Datepicker, Multiselect, Pagination, and Modal

## Test plan
- [ ] Run `npm install` in `apps/bulk-exporter`
- [ ] Run `npm run dev` and verify app loads at localhost
- [ ] Install app in a Contentful space and verify the page location loads
- [ ] Generate a list with various filter combinations (content type, status, tags, date ranges)
- [ ] Select entries and export — verify file downloads in selected format
- [ ] Verify locale selector is disabled when "All content types" is selected

Generated with [Claude Code](https://claude.com/claude-code)