### PR TITLE
fix(ga4): use sdk.cma directly in Sidebar instead of useCMA [AIS-59]

### DIFF
--- a/apps/google-analytics-4/frontend/src/locations/Sidebar.tsx
+++ b/apps/google-analytics-4/frontend/src/locations/Sidebar.tsx
@@ -1,5 +1,5 @@
 import AnalyticsApp from 'components/main-app/AnalyticsApp/AnalyticsApp';
-import { useCMA, useSDK } from '@contentful/react-apps-toolkit';
+import { useSDK } from '@contentful/react-apps-toolkit';
 import { SidebarExtensionSDK } from '@contentful/app-sdk';
 import { useMemo } from 'react';
 import { Skeleton } from '@contentful/f36-components';
@@ -13,7 +13,6 @@ import { contentfulContext } from 'helpers/contentfulContext';
 
 const Sidebar = () => {
   const sdk = useSDK<SidebarExtensionSDK>();
-  const cma = useCMA();
   const installationParameters = sdk.parameters.installation as
     | AppInstallationParameters
     | undefined;
@@ -26,8 +25,8 @@ const Sidebar = () => {
     (rule) => rule.contentTypeId === currentContentType
   );
   const api = useMemo(
-    () => new Api(contentfulContext(sdk), cma, serviceAccountKeyId),
-    [cma, sdk, serviceAccountKeyId]
+    () => new Api(contentfulContext(sdk), sdk.cma, serviceAccountKeyId),
+    [sdk, serviceAccountKeyId]
   );
 
   const hasInstallationParams = serviceAccountKeyId && propertyId;


### PR DESCRIPTION
## Summary

Mirrors the fix from #11037 (config screen) to the GA4 sidebar.

`useCMA()` from `@contentful/react-apps-toolkit` internally calls `createClient()` from `contentful-management`. This creates the same CJS/ESM interop risk that #11037 addressed in `AssignContentTypeSection.tsx` — if `createClient` fails to initialize, the `cma` object is broken, `cma.appSignedRequest.create()` never runs, and the signed request header is never attached to the lambda call. The result is a silent client-side failure that surfaces as the generic "We couldn't load Google Analytics data." error in the sidebar.

`sdk.cma` has been available directly on the SDK instance since app-sdk >= 4.20. The sidebar is already on `app-sdk@4.23.0`, so no version bump is needed.

## Changes

- `Sidebar.tsx`: remove `useCMA` import and usage, pass `sdk.cma` directly to `Api` constructor

## Related

- Follows the same pattern as #11037
- Ticket: [AIS-59](https://contentful.atlassian.net/browse/AIS-59)

## Test plan

- [ ] Open an entry in the Contentful UI with the GA4 app installed and confirm the sidebar loads analytics data without error
- [ ] Confirm no `createClient is not a function` errors in the browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AIS-59]: https://contentful.atlassian.net/browse/AIS-59?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ