### PR TITLE
fix: bearer token input read-only on first install [AIS-199]

### DIFF
--- a/apps/wistia-videos/src/components/ConfigScreen.spec.tsx
+++ b/apps/wistia-videos/src/components/ConfigScreen.spec.tsx
@@ -1,10 +1,15 @@
 import React from 'react';
 import ConfigScreen from './ConfigScreen';
-import { render, screen, fireEvent, configure, act } from '@testing-library/react';
+import { render, screen, fireEvent, configure, act, waitFor } from '@testing-library/react';
 import { mockSdk } from '../test/mocks';
 import { AppExtensionSDK } from '@contentful/app-sdk';
+import { vi } from 'vitest';
 
 configure({ testIdAttribute: 'data-test-id' });
+
+vi.mock('../functions/getVideos', () => ({
+  fetchProjects: vi.fn().mockResolvedValue([{ id: 1, hashedId: 'abc123', name: 'My Project' }]),
+}));
 
 describe('Config Screen component', () => {
   it('Component text exists', async () => {
@@ -12,37 +17,87 @@ describe('Config Screen component', () => {
       render(<ConfigScreen sdk={mockSdk as unknown as AppExtensionSDK} />);
     });
 
-    // simulate the user clicking the install button
     await mockSdk.app.onConfigure.mock.calls[0][0];
 
     expect(screen.getByText('Wistia Videos App Configuration')).toBeInTheDocument();
   });
 });
 
-// describe('Config inputs work', () => {
-// it('Values are set correctly', () => {
+describe('Config inputs work', () => {
+  it('bearer token input accepts typed text on first install (no saved token)', async () => {
+    // getParameters returns null → simulates a fresh install with no saved token
+    const freshInstallSdk = {
+      ...mockSdk,
+      app: {
+        ...mockSdk.app,
+        getParameters: vi.fn().mockResolvedValueOnce(null),
+      },
+    };
 
-// render(<ConfigScreen sdk={mockSdk as unknown as AppExtensionSDK} />);
+    await act(async () => {
+      render(<ConfigScreen sdk={freshInstallSdk as unknown as AppExtensionSDK} />);
+    });
 
-// screen.getAllByTestId('cf-ui-text-input').forEach((input, i) => {
-// fireEvent.change(input, {
-// target:{ value: `A test value for input ${i}` }
-// })
-// })
+    const input = screen.getByRole('textbox', { name: /wistia data api access bearer token/i });
 
-// screen.getAllByTestId('cf-ui-text-input').forEach((input, i) => {
-// expect(input).toHaveValue(`A test value for input ${i}`)
-// })
-// });
-// });
+    fireEvent.change(input, { target: { value: 'my-secret-token' } });
 
-// describe('Test connection button works', () => {
-// it('Produces a notification', () => {
-// render(<ConfigScreen sdk={mockSdk as unknown as AppExtensionSDK} />);
+    expect(input).toHaveValue('my-secret-token');
+  });
 
-// const button = screen.getByTestId('cf-ui-button');
+  it('pre-populates saved token on existing install', async () => {
+    const existingInstallSdk = {
+      ...mockSdk,
+      app: {
+        ...mockSdk.app,
+        getParameters: vi.fn().mockResolvedValueOnce({
+          apiBearerToken: 'saved-token-xyz',
+          excludedProjects: [],
+        }),
+      },
+    };
 
-// fireEvent.click(button)
-// expect(screen.getByTestId('cf-ui-notification'))
-// })
-// })
+    await act(async () => {
+      render(<ConfigScreen sdk={existingInstallSdk as unknown as AppExtensionSDK} />);
+    });
+
+    const input = screen.getByRole('textbox', { name: /wistia data api access bearer token/i });
+    expect(input).toHaveValue('saved-token-xyz');
+  });
+
+  it('does not show validation error before user interaction', async () => {
+    const freshInstallSdk = {
+      ...mockSdk,
+      app: {
+        ...mockSdk.app,
+        getParameters: vi.fn().mockResolvedValueOnce(null),
+      },
+    };
+
+    await act(async () => {
+      render(<ConfigScreen sdk={freshInstallSdk as unknown as AppExtensionSDK} />);
+    });
+
+    expect(screen.queryByText('Please, provide a bearer token value')).not.toBeInTheDocument();
+  });
+
+  it('shows validation error when submitting empty token', async () => {
+    const freshInstallSdk = {
+      ...mockSdk,
+      app: {
+        ...mockSdk.app,
+        getParameters: vi.fn().mockResolvedValueOnce(null),
+      },
+    };
+
+    await act(async () => {
+      render(<ConfigScreen sdk={freshInstallSdk as unknown as AppExtensionSDK} />);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /display wistia projects/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Please, provide a bearer token value')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/wistia-videos/src/components/ConfigScreen.tsx
+++ b/apps/wistia-videos/src/components/ConfigScreen.tsx
@@ -36,6 +36,9 @@ const Config = (props: ConfigProps) => {
     apiBearerToken: '',
     excludedProjects: [],
   });
+  // Decoupled input state — keeps the TextInput editable without triggering the
+  // parameters.apiBearerToken useEffect (which fires a Wistia API call on every change).
+  const [tokenInput, setTokenInput] = useState('');
   const [loading, setLoadingStatus] = useState(false);
 
   const getProjects = useCallback(async () => {
@@ -90,6 +93,7 @@ const Config = (props: ConfigProps) => {
       // Set local parameter state based on the installation params
       if (currentParameters) {
         setParameters(currentParameters);
+        setTokenInput(currentParameters.apiBearerToken || '');
       } else {
         setParameters({
           apiBearerToken: '',
@@ -102,24 +106,15 @@ const Config = (props: ConfigProps) => {
   }, [props.sdk]);
 
   const getInputValue: () => void = async () => {
-    const tokenField = document.getElementById('apiBearerTokenInput') as HTMLInputElement | null;
-    if (tokenField !== null) {
-      const value = tokenField?.value;
-      if (!value) {
-        setRequiredMessage('Please, provide a bearer token value');
+    if (!tokenInput) {
+      setRequiredMessage('Please, provide a bearer token value');
+    } else {
+      // in case the value provided is the same as the one stored, tries to fetch the projects anyway
+      // and the buttons will disappear in both the scenarios (succesful or error response)
+      if (tokenInput === parameters.apiBearerToken) {
+        getProjects();
       } else {
-        const newParameters: { [key: string]: any } = {
-          ...parameters,
-        };
-        newParameters['apiBearerToken'] = value;
-
-        // in case the value provided is the same as the one stored, tries to fetch the projects anyway
-        // and the buttons will disappear in both the scenarios (succesful or error response)
-        if (newParameters['apiBearerToken'] === parameters.apiBearerToken) {
-          getProjects();
-        } else {
-          setParameters(newParameters);
-        }
+        setParameters({ ...parameters, apiBearerToken: tokenInput });
       }
     }
   };
@@ -166,17 +161,20 @@ const Config = (props: ConfigProps) => {
             <Paragraph>Please provide your access bearer token for the Wistia Data API.</Paragraph>
             <Flex flexDirection="column" marginTop="spacingM">
               <div style={{ marginBottom: '20px' }}>
-                <FormControl id="apiBearerTokenInput">
+                <FormControl id="apiBearerTokenInput" isInvalid={!!requiredMessage}>
                   <FormControl.Label>Wistia Data API access bearer token</FormControl.Label>
                   <TextInput
                     isRequired
                     name="apiBearerTokenInput"
-                    onChange={() => setShowButton(true)}
-                    value={parameters.apiBearerToken}
+                    value={tokenInput}
+                    onChange={(e) => {
+                      setTokenInput(e.target.value);
+                      setShowButton(true);
+                    }}
                   />
-                  <FormControl.ValidationMessage>
-                    {requiredMessage || ''}
-                  </FormControl.ValidationMessage>
+                  {requiredMessage && (
+                    <FormControl.ValidationMessage>{requiredMessage}</FormControl.ValidationMessage>
+                  )}
                 </FormControl>
               </div>
               <div style={{ marginBottom: '5px' }}>

--- a/apps/wistia-videos/src/components/ConfigScreen.tsx
+++ b/apps/wistia-videos/src/components/ConfigScreen.tsx
@@ -60,6 +60,7 @@ const Config = (props: ConfigProps) => {
           setRequiredMessage(error.message);
         }
       }
+      setLoadingStatus(false);
     }
   }, [parameters.apiBearerToken]);
 


### PR DESCRIPTION
[AIS-199](https://contentful.atlassian.net/browse/AIS-199)

## Summary

- **Root cause:** `TextInput` at `ConfigScreen.tsx:174` was a fully controlled React component whose `onChange` only called `setShowButton(true)` — it never updated state. Since f36's `TextInput` enforces `value=` on every render (unlike the old `forma-36-react-components/TextField` which buffered internally), the field was permanently frozen at `''` for new installs with no previously-saved token. Regression introduced in PR #8942 (EXT-5808, Sep 2024).
- **Fix:** Introduce a dedicated `tokenInput` state variable decoupled from `parameters`. `tokenInput` drives the `TextInput` value and is synced from `getParameters()` on load — preserving existing-install pre-population. `parameters.apiBearerToken` is only updated when the user clicks "Display Wistia projects", keeping the `useEffect`→`getProjects()` trigger off the keystroke path.
- **Bonus:** Fix the premature f36 validation error icon that appeared on mount (isRequired + empty value). `FormControl.ValidationMessage` is now conditionally rendered only when there's a message, and `isInvalid` is driven from `!!requiredMessage`.

## Test plan

- [x] New install (no saved token): bearer token field accepts typed and pasted text
- [x] Existing install (saved token): field pre-populates correctly on load, no regression
- [x] Typing in the field does NOT fire Wistia API calls — only the "Display Wistia projects" button triggers them
- [x] Validation error icon does NOT appear on initial load before user interaction
- [x] Validation error DOES appear when clicking "Display Wistia projects" with an empty field
- [x] All 6 tests pass: `vitest --run` in `apps/wistia-videos`

Generated with [Claude Code](https://claude.com/claude-code)

[AIS-199]: https://contentful.atlassian.net/browse/AIS-199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ