### PR TITLE
feat(drive-integration): gate 60-min poll timeout behind LD flag []

### DIFF
--- a/apps/drive-integration/package.json
+++ b/apps/drive-integration/package.json
@@ -17,6 +17,7 @@
     "contentful-management": "^11.76.0",
     "googleapis": "^166.0.0",
     "mammoth": "^1.11.0",
+    "launchdarkly-react-client-sdk": "^3.0.8",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/apps/drive-integration/src/hooks/useGoogleDocsAgentFlags.ts
+++ b/apps/drive-integration/src/hooks/useGoogleDocsAgentFlags.ts
@@ -1,0 +1,12 @@
+import { useFlags } from 'launchdarkly-react-client-sdk';
+
+interface GoogleDocsAgentFlags {
+  'google-docs-agent-improvements': boolean;
+}
+
+export const useGoogleDocsAgentFlags = (): GoogleDocsAgentFlags => {
+  const flags = useFlags<GoogleDocsAgentFlags>();
+  return {
+    'google-docs-agent-improvements': flags['google-docs-agent-improvements'] ?? false,
+  };
+};

--- a/apps/drive-integration/src/hooks/useWorkflowAgent.ts
+++ b/apps/drive-integration/src/hooks/useWorkflowAgent.ts
@@ -3,9 +3,11 @@ import { PageAppSDK } from '@contentful/app-sdk';
 import {
   POLL_INTERVAL_MS,
   MAX_POLL_ATTEMPTS,
+  EXTENDED_MAX_POLL_ATTEMPTS,
   WORKFLOW_AGENT_ID,
   MAX_PENDING_REVIEW_MISSING_PAYLOAD_RETRIES,
 } from '../utils/constants/agent';
+import { useGoogleDocsAgentFlags } from './useGoogleDocsAgentFlags';
 import {
   MappingReviewSuspendPayload,
   ResumePayload,
@@ -198,13 +200,14 @@ const pollAgentRun = async (
   sdk: PageAppSDK,
   spaceId: string,
   environmentId: string,
-  runId: string
+  runId: string,
+  maxAttempts: number
 ): Promise<WorkflowRunResult> => {
   const startMs = Date.now();
   let pendingReviewMissingPayloadCount = 0;
   console.log(`⏳ Polling run [${runId}]`);
 
-  for (let attempt = 0; attempt < MAX_POLL_ATTEMPTS; attempt++) {
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
     const runData = await getWorkflowRun(sdk, spaceId, environmentId, runId);
 
     if (!runData) {
@@ -244,6 +247,8 @@ export const useWorkflowAgent = ({
   oauthToken,
 }: UseWorkflowParams): WorkflowHook => {
   const [isAnalyzing, setIsAnalyzing] = useState(false);
+  const { 'google-docs-agent-improvements': extendedTimeout } = useGoogleDocsAgentFlags();
+  const maxPollAttempts = extendedTimeout ? EXTENDED_MAX_POLL_ATTEMPTS : MAX_POLL_ATTEMPTS;
 
   const startWorkflow = useCallback(
     async (contentTypeIds: string[], documentSelection: DocumentSelection) => {
@@ -278,7 +283,7 @@ export const useWorkflowAgent = ({
 
       try {
         const runId = await startAgentRun(sdk, spaceId, environmentId, payload);
-        return await pollAgentRun(sdk, spaceId, environmentId, runId);
+        return await pollAgentRun(sdk, spaceId, environmentId, runId, maxPollAttempts);
       } catch (err) {
         const error = err instanceof Error ? err : new Error('Workflow failed');
         throw error;
@@ -298,7 +303,7 @@ export const useWorkflowAgent = ({
 
       try {
         await resumeWorkflowRun(sdk, spaceId, environmentId, runId, resumePayload);
-        return await pollAgentRun(sdk, spaceId, environmentId, runId);
+        return await pollAgentRun(sdk, spaceId, environmentId, runId, maxPollAttempts);
       } catch (err) {
         console.error(`✗ resumeWorkflow [${runId}] failed`, err);
         const error = err instanceof Error ? err : new Error('Workflow failed');

--- a/apps/drive-integration/src/index.tsx
+++ b/apps/drive-integration/src/index.tsx
@@ -1,9 +1,17 @@
 import { GlobalStyles } from '@contentful/f36-components';
 import { SDKProvider } from '@contentful/react-apps-toolkit';
-import { asyncWithLDProvider } from 'launchdarkly-react-client-sdk';
+import { withLDProvider } from 'launchdarkly-react-client-sdk';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 import LocalhostWarning from './locations/LocalhostWarning';
+
+const AppWithLD = withLDProvider({
+  clientSideID: import.meta.env.VITE_LD_CLIENT_ID ?? '',
+  options: { bootstrap: 'localStorage' },
+})(App);
+
+const container = document.getElementById('root')!;
+const root = createRoot(container);
 
 const handleOAuthCallback = () => {
   const params = new URLSearchParams(window.location.search);
@@ -26,26 +34,16 @@ const handleOAuthCallback = () => {
 // Check if this is an OAuth callback page
 if (window.location.search.includes('code=') && window.location.search.includes('state=')) {
   handleOAuthCallback();
+}
+
+if (process.env.NODE_ENV === 'development' && window.self === window.top) {
+  // You can remove this if block before deploying your app
+  root.render(<LocalhostWarning />);
 } else {
-  const container = document.getElementById('root')!;
-  const root = createRoot(container);
-
-  if (process.env.NODE_ENV === 'development' && window.self === window.top) {
-    // You can remove this if block before deploying your app
-    root.render(<LocalhostWarning />);
-  } else {
-    const LDProvider = await asyncWithLDProvider({
-      clientSideID: import.meta.env.VITE_LD_CLIENT_ID ?? '',
-      options: { bootstrap: 'localStorage' },
-    });
-
-    root.render(
-      <LDProvider>
-        <SDKProvider>
-          <GlobalStyles />
-          <App />
-        </SDKProvider>
-      </LDProvider>
-    );
-  }
+  root.render(
+    <SDKProvider>
+      <GlobalStyles />
+      <AppWithLD />
+    </SDKProvider>
+  );
 }

--- a/apps/drive-integration/src/index.tsx
+++ b/apps/drive-integration/src/index.tsx
@@ -1,11 +1,9 @@
 import { GlobalStyles } from '@contentful/f36-components';
 import { SDKProvider } from '@contentful/react-apps-toolkit';
+import { asyncWithLDProvider } from 'launchdarkly-react-client-sdk';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 import LocalhostWarning from './locations/LocalhostWarning';
-
-const container = document.getElementById('root')!;
-const root = createRoot(container);
 
 const handleOAuthCallback = () => {
   const params = new URLSearchParams(window.location.search);
@@ -28,16 +26,26 @@ const handleOAuthCallback = () => {
 // Check if this is an OAuth callback page
 if (window.location.search.includes('code=') && window.location.search.includes('state=')) {
   handleOAuthCallback();
-}
-
-if (process.env.NODE_ENV === 'development' && window.self === window.top) {
-  // You can remove this if block before deploying your app
-  root.render(<LocalhostWarning />);
 } else {
-  root.render(
-    <SDKProvider>
-      <GlobalStyles />
-      <App />
-    </SDKProvider>
-  );
+  const container = document.getElementById('root')!;
+  const root = createRoot(container);
+
+  if (process.env.NODE_ENV === 'development' && window.self === window.top) {
+    // You can remove this if block before deploying your app
+    root.render(<LocalhostWarning />);
+  } else {
+    const LDProvider = await asyncWithLDProvider({
+      clientSideID: import.meta.env.VITE_LD_CLIENT_ID ?? '',
+      options: { bootstrap: 'localStorage' },
+    });
+
+    root.render(
+      <LDProvider>
+        <SDKProvider>
+          <GlobalStyles />
+          <App />
+        </SDKProvider>
+      </LDProvider>
+    );
+  }
 }

--- a/apps/drive-integration/src/utils/constants/agent.ts
+++ b/apps/drive-integration/src/utils/constants/agent.ts
@@ -3,8 +3,10 @@ export const WORKFLOW_AGENT_ID = 'google-docs-workflow-agent';
 export const POLL_INTERVAL_MS = 10000; // 10 seconds
 
 const MAX_POLL_TIME_MS = 20 * 60 * 1000; // 20 minutes
+const EXTENDED_POLL_TIME_MS = 60 * 60 * 1000; // 60 minutes (google-docs-agent-improvements flag)
 
 export const MAX_POLL_ATTEMPTS = Math.floor(MAX_POLL_TIME_MS / POLL_INTERVAL_MS);
+export const EXTENDED_MAX_POLL_ATTEMPTS = Math.floor(EXTENDED_POLL_TIME_MS / POLL_INTERVAL_MS);
 
 export const CONTENT_TYPE_SUBMIT_LOADING_DELAY_MS = 30000; // 30 seconds to wait for suspend payload
 

--- a/apps/drive-integration/src/vite-env.d.ts
+++ b/apps/drive-integration/src/vite-env.d.ts
@@ -4,6 +4,7 @@ interface ImportMetaEnv {
   readonly VITE_ENABLE_MOCK_EDIT_MODAL?: string;
   readonly VITE_ENABLE_MOCK_REVIEW_PAYLOAD?: string;
   readonly VITE_LOCAL_AGENTS_API_BASE_URL?: string;
+  readonly VITE_LD_CLIENT_ID?: string;
 }
 
 declare module '*.png' {


### PR DESCRIPTION
## Summary
- Adds `launchdarkly-react-client-sdk` to drive-integration and wires `asyncWithLDProvider` into `index.tsx`
- Introduces `EXTENDED_MAX_POLL_ATTEMPTS` (60 min) alongside the existing 20-min cap in `agent.ts`
- New `useGoogleDocsAgentFlags` hook provides a typed interface to the `google-docs-agent-improvements` flag
- `useWorkflowAgent` reads the flag and selects the appropriate poll cap for both `startWorkflow` and `resumeWorkflow`

## Test plan
- [ ] Set `VITE_LD_CLIENT_ID` in `.env` and confirm app boots without errors
- [ ] With flag **off**: confirm import times out after ~20 min as before
- [ ] With flag **on**: confirm poller runs up to 60 min before timing out
- [ ] Confirm OAuth callback flow is unaffected (LD provider is not initialized on the callback path)
- [ ] Confirm `useFlags` returns `false` as default when LD is unavailable

Generated with [Claude Code](https://claude.com/claude-code)