### PR TITLE
feat(drive-integration): display validationFindings in mapping-review UI [INTEG-4383]

### DIFF
--- a/apps/drive-integration/src/locations/Page/components/overview/OverviewEntryList.tsx
+++ b/apps/drive-integration/src/locations/Page/components/overview/OverviewEntryList.tsx
@@ -2,6 +2,7 @@ import { Badge, Box, Card, Checkbox, Flex, Paragraph, Text } from '@contentful/f
 import tokens from '@contentful/f36-tokens';
 import { cx } from '@emotion/css';
 import type { EntryListRow as OverviewEntryListRow } from '../../../../utils/overviewEntryList';
+import { ValidationFindingSeverity } from '@types';
 import type { ValidationFinding } from '@types';
 import {
   noMappedContentBadge,
@@ -49,8 +50,8 @@ function OverviewEntryRowCard({
   const isSelected = row.entryIndex === selectedEntryIndex;
   const isEntrySelectedForCreation = selectedEntryKeys.has(row.id);
   const entryFindings = findingsByEntryIndex?.get(row.entryIndex) ?? [];
-  const hasBlockFindings = entryFindings.some((f) => f.severity === 'block');
-  const hasWarnFindings = entryFindings.some((f) => f.severity === 'warn');
+  const hasBlockFindings = entryFindings.some((f) => f.severity === ValidationFindingSeverity.Block);
+  const hasWarnFindings = entryFindings.some((f) => f.severity === ValidationFindingSeverity.Warn);
 
   const treeLineClass =
     showTreeLines && cx(treeChildRowBase, isLastRow ? treeChildRowLast : treeChildRowNotLast);

--- a/apps/drive-integration/src/locations/Page/components/overview/OverviewEntryList.tsx
+++ b/apps/drive-integration/src/locations/Page/components/overview/OverviewEntryList.tsx
@@ -2,6 +2,7 @@ import { Badge, Box, Card, Checkbox, Flex, Paragraph, Text } from '@contentful/f
 import tokens from '@contentful/f36-tokens';
 import { cx } from '@emotion/css';
 import type { EntryListRow as OverviewEntryListRow } from '../../../../utils/overviewEntryList';
+import type { ValidationFinding } from '@types';
 import {
   noMappedContentBadge,
   treeChildRowBase,
@@ -18,6 +19,8 @@ export interface OverviewEntryListProps {
   onSelect: (entryIndex: number) => void;
   onToggleEntrySelection: (entryKey: string, isSelected: boolean) => void;
   areEntrySelectionsDisabled?: boolean;
+  /** Validation findings keyed by entry index, for badge rendering. */
+  findingsByEntryIndex?: ReadonlyMap<number, ValidationFinding[]>;
 }
 
 interface OverviewEntryRowCardProps {
@@ -29,6 +32,7 @@ interface OverviewEntryRowCardProps {
   areEntrySelectionsDisabled: boolean;
   showTreeLines: boolean;
   isLastRow?: boolean;
+  findingsByEntryIndex?: ReadonlyMap<number, ValidationFinding[]>;
 }
 
 function OverviewEntryRowCard({
@@ -40,9 +44,13 @@ function OverviewEntryRowCard({
   areEntrySelectionsDisabled,
   showTreeLines,
   isLastRow = true,
+  findingsByEntryIndex,
 }: OverviewEntryRowCardProps) {
   const isSelected = row.entryIndex === selectedEntryIndex;
   const isEntrySelectedForCreation = selectedEntryKeys.has(row.id);
+  const entryFindings = findingsByEntryIndex?.get(row.entryIndex) ?? [];
+  const hasBlockFindings = entryFindings.some((f) => f.severity === 'block');
+  const hasWarnFindings = entryFindings.some((f) => f.severity === 'warn');
 
   const treeLineClass =
     showTreeLines && cx(treeChildRowBase, isLastRow ? treeChildRowLast : treeChildRowNotLast);
@@ -95,6 +103,16 @@ function OverviewEntryRowCard({
                   No mapped content
                 </Badge>
               )}
+              {hasBlockFindings && (
+                <Badge variant="negative" size="small" className={noMappedContentBadge}>
+                  Needs attention
+                </Badge>
+              )}
+              {!hasBlockFindings && hasWarnFindings && (
+                <Badge variant="warning" size="small" className={noMappedContentBadge}>
+                  Warning
+                </Badge>
+              )}
             </Paragraph>
           </button>
         </Flex>
@@ -112,6 +130,7 @@ function OverviewEntryRowCard({
               areEntrySelectionsDisabled={areEntrySelectionsDisabled}
               showTreeLines
               isLastRow={index === row.children.length - 1}
+              findingsByEntryIndex={findingsByEntryIndex}
             />
           ))}
         </Box>
@@ -137,6 +156,7 @@ export function OverviewEntryList({
   onSelect,
   onToggleEntrySelection,
   areEntrySelectionsDisabled = false,
+  findingsByEntryIndex,
 }: OverviewEntryListProps) {
   return (
     <Flex flexDirection="column" gap="spacingS">
@@ -150,6 +170,7 @@ export function OverviewEntryList({
           onToggleEntrySelection={onToggleEntrySelection}
           areEntrySelectionsDisabled={areEntrySelectionsDisabled}
           showTreeLines={false}
+          findingsByEntryIndex={findingsByEntryIndex}
         />
       ))}
     </Flex>

--- a/apps/drive-integration/src/locations/Page/components/overview/OverviewEntryList.tsx
+++ b/apps/drive-integration/src/locations/Page/components/overview/OverviewEntryList.tsx
@@ -50,7 +50,9 @@ function OverviewEntryRowCard({
   const isSelected = row.entryIndex === selectedEntryIndex;
   const isEntrySelectedForCreation = selectedEntryKeys.has(row.id);
   const entryFindings = findingsByEntryIndex?.get(row.entryIndex) ?? [];
-  const hasBlockFindings = entryFindings.some((f) => f.severity === ValidationFindingSeverity.Block);
+  const hasBlockFindings = entryFindings.some(
+    (f) => f.severity === ValidationFindingSeverity.Block
+  );
   const hasWarnFindings = entryFindings.some((f) => f.severity === ValidationFindingSeverity.Warn);
 
   const treeLineClass =

--- a/apps/drive-integration/src/locations/Page/components/overview/OverviewSection.tsx
+++ b/apps/drive-integration/src/locations/Page/components/overview/OverviewSection.tsx
@@ -82,8 +82,8 @@ const OverviewSection = ({
             <Note variant="negative">
               <Flex flexDirection="column" gap="spacingXs">
                 <Text>
-                  Some entries have issues that may prevent the content from being created correctly.
-                  Review the highlighted entries before proceeding.
+                  Some entries have issues that may prevent the content from being created
+                  correctly. Review the highlighted entries before proceeding.
                 </Text>
                 <Checkbox
                   isChecked={blockFindingsAcknowledged}

--- a/apps/drive-integration/src/locations/Page/components/overview/OverviewSection.tsx
+++ b/apps/drive-integration/src/locations/Page/components/overview/OverviewSection.tsx
@@ -18,6 +18,8 @@ interface OverviewProps {
   isCtaLoading?: boolean;
   isCtaDisabled?: boolean;
   areEntrySelectionsDisabled?: boolean;
+  /** Whether any block-severity findings exist; drives the acknowledgement Note visibility. */
+  hasBlockFindings?: boolean;
   /** Called with `true` when the user checks the block-findings acknowledgement. */
   onBlockFindingsAcknowledged?: (acknowledged: boolean) => void;
   /** Whether the user has acknowledged block findings. */
@@ -35,6 +37,7 @@ const OverviewSection = ({
   isCtaLoading = false,
   isCtaDisabled = false,
   areEntrySelectionsDisabled = false,
+  hasBlockFindings = false,
   onBlockFindingsAcknowledged,
   blockFindingsAcknowledged = false,
 }: OverviewProps) => {
@@ -59,8 +62,6 @@ const OverviewSection = ({
     return map;
   }, [payload.validationFindings]);
 
-  const hasBlockFindings = (payload.validationFindings ?? []).some((f) => f.severity === 'block');
-
   return (
     <>
       <Box padding="spacingL" className={overviewSectionBox}>
@@ -72,7 +73,7 @@ const OverviewSection = ({
             </Flex>
             <Paragraph marginBottom="none">
               Review your content and associated entries below. Highlight text to make adjustments.
-              Select which entries you’d like to create.
+              Select which entries you'd like to create.
             </Paragraph>
           </Flex>
 

--- a/apps/drive-integration/src/locations/Page/components/overview/OverviewSection.tsx
+++ b/apps/drive-integration/src/locations/Page/components/overview/OverviewSection.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
-import { Box, Button, Flex, Note, Paragraph, Text } from '@contentful/f36-components';
+import { Box, Button, Checkbox, Flex, Note, Paragraph, Text } from '@contentful/f36-components';
 import { LightbulbIcon } from '@contentful/f36-icons';
-import type { MappingReviewSuspendPayload } from '@types';
+import type { MappingReviewSuspendPayload, ValidationFinding } from '@types';
 import { buildEntryListFromEntryBlockGraph } from '../../../../utils/overviewEntryList';
 import { OverviewEntryList } from './OverviewEntryList';
 import { overviewSectionBox, overviewSectionBoxScrollable } from './OverviewSection.styles';
@@ -18,6 +18,10 @@ interface OverviewProps {
   isCtaLoading?: boolean;
   isCtaDisabled?: boolean;
   areEntrySelectionsDisabled?: boolean;
+  /** Called with `true` when the user checks the block-findings acknowledgement. */
+  onBlockFindingsAcknowledged?: (acknowledged: boolean) => void;
+  /** Whether the user has acknowledged block findings. */
+  blockFindingsAcknowledged?: boolean;
 }
 
 const OverviewSection = ({
@@ -31,6 +35,8 @@ const OverviewSection = ({
   isCtaLoading = false,
   isCtaDisabled = false,
   areEntrySelectionsDisabled = false,
+  onBlockFindingsAcknowledged,
+  blockFindingsAcknowledged = false,
 }: OverviewProps) => {
   const entryRows = useMemo(
     () =>
@@ -41,6 +47,19 @@ const OverviewSection = ({
       ),
     [payload.entryBlockGraph.entries, payload.contentTypes, payload.referenceGraph.edges]
   );
+
+  const findingsByEntryIndex = useMemo((): ReadonlyMap<number, ValidationFinding[]> => {
+    const map = new Map<number, ValidationFinding[]>();
+    for (const finding of payload.validationFindings ?? []) {
+      if (finding.entryIndex === undefined) continue;
+      const list = map.get(finding.entryIndex) ?? [];
+      list.push(finding);
+      map.set(finding.entryIndex, list);
+    }
+    return map;
+  }, [payload.validationFindings]);
+
+  const hasBlockFindings = (payload.validationFindings ?? []).some((f) => f.severity === 'block');
 
   return (
     <>
@@ -58,6 +77,22 @@ const OverviewSection = ({
           </Flex>
 
           <Splitter />
+
+          {hasBlockFindings && (
+            <Note variant="negative">
+              <Flex flexDirection="column" gap="spacingXs">
+                <Text>
+                  Some entries have issues that may prevent the content from being created correctly.
+                  Review the highlighted entries before proceeding.
+                </Text>
+                <Checkbox
+                  isChecked={blockFindingsAcknowledged}
+                  onChange={(event) => onBlockFindingsAcknowledged?.(event.target.checked)}>
+                  I have reviewed the issues and want to proceed
+                </Checkbox>
+              </Flex>
+            </Note>
+          )}
 
           <Flex justifyContent="space-between" alignItems="center" paddingBottom="none">
             <Flex flexDirection="column" gap="spacingXs">
@@ -91,6 +126,7 @@ const OverviewSection = ({
                 onSelect={onSelectEntryIndex}
                 onToggleEntrySelection={onToggleEntrySelection}
                 areEntrySelectionsDisabled={areEntrySelectionsDisabled}
+                findingsByEntryIndex={findingsByEntryIndex}
               />
             </Box>
           )}

--- a/apps/drive-integration/src/locations/Page/components/review/ReviewPage.tsx
+++ b/apps/drive-integration/src/locations/Page/components/review/ReviewPage.tsx
@@ -271,6 +271,7 @@ export const ReviewPage = ({
               (!hasSelectedEntries || (hasBlockFindings && !blockFindingsAcknowledged))
             }
             areEntrySelectionsDisabled={isMappingDisabled}
+            hasBlockFindings={hasBlockFindings}
             blockFindingsAcknowledged={blockFindingsAcknowledged}
             onBlockFindingsAcknowledged={setBlockFindingsAcknowledged}
           />

--- a/apps/drive-integration/src/locations/Page/components/review/ReviewPage.tsx
+++ b/apps/drive-integration/src/locations/Page/components/review/ReviewPage.tsx
@@ -52,6 +52,7 @@ export const ReviewPage = ({
   const [createdEntries, setCreatedEntries] = useState<EntryProps[] | null>(null);
   const [isSummaryModalOpen, setIsSummaryModalOpen] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
+  const [blockFindingsAcknowledged, setBlockFindingsAcknowledged] = useState(false);
   const [entryBlockGraph, setEntryBlockGraph] = useState<EntryBlockGraph>(() =>
     structuredClone(payload.entryBlockGraph)
   );
@@ -65,6 +66,7 @@ export const ReviewPage = ({
     const nextEntryBlockGraph = structuredClone(payload.entryBlockGraph);
     setEntryBlockGraph(nextEntryBlockGraph);
     setSelectedEntryKeys(getAllEntrySelectionKeys(nextEntryBlockGraph.entries));
+    setBlockFindingsAcknowledged(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- only re-init on run identity
   }, [runId, payload.documentId]);
 
@@ -84,6 +86,7 @@ export const ReviewPage = ({
   }, [payload.contentTypes]);
   const hasCreatedEntries = createdEntries !== null;
   const isMappingDisabled = isCreatePending || hasCreatedEntries;
+  const hasBlockFindings = (payload.validationFindings ?? []).some((f) => f.severity === 'block');
   const selectedEntryCount = useMemo(
     () => countSelectedEntries(entryBlockGraph.entries, selectedEntryKeys),
     [entryBlockGraph.entries, selectedEntryKeys]
@@ -263,8 +266,12 @@ export const ReviewPage = ({
             ctaLabel={hasCreatedEntries ? 'View entries' : 'Create selected entries'}
             onCtaClick={handleCreateOrViewEntries}
             isCtaLoading={isCreatePending}
-            isCtaDisabled={!hasCreatedEntries && !hasSelectedEntries}
+            isCtaDisabled={
+              !hasCreatedEntries && (!hasSelectedEntries || (hasBlockFindings && !blockFindingsAcknowledged))
+            }
             areEntrySelectionsDisabled={isMappingDisabled}
+            blockFindingsAcknowledged={blockFindingsAcknowledged}
+            onBlockFindingsAcknowledged={setBlockFindingsAcknowledged}
           />
           <MappingView
             payload={reviewPayload}

--- a/apps/drive-integration/src/locations/Page/components/review/ReviewPage.tsx
+++ b/apps/drive-integration/src/locations/Page/components/review/ReviewPage.tsx
@@ -267,7 +267,8 @@ export const ReviewPage = ({
             onCtaClick={handleCreateOrViewEntries}
             isCtaLoading={isCreatePending}
             isCtaDisabled={
-              !hasCreatedEntries && (!hasSelectedEntries || (hasBlockFindings && !blockFindingsAcknowledged))
+              !hasCreatedEntries &&
+              (!hasSelectedEntries || (hasBlockFindings && !blockFindingsAcknowledged))
             }
             areEntrySelectionsDisabled={isMappingDisabled}
             blockFindingsAcknowledged={blockFindingsAcknowledged}

--- a/apps/drive-integration/src/types/workflow.ts
+++ b/apps/drive-integration/src/types/workflow.ts
@@ -125,6 +125,23 @@ export interface TabsImagesSuspendPayload {
   tabs?: DocTabOption[];
 }
 
+/** Severity levels for validation findings produced by the validate-payload step. */
+export type ValidationFindingSeverity = 'block' | 'warn';
+
+/** A single validation finding from the validate-payload step. */
+export interface ValidationFinding {
+  /** Machine-readable finding code. */
+  code: string;
+  /** Human-readable explanation. */
+  message: string;
+  /** `block` findings prevent advancing; `warn` findings are advisory. */
+  severity: ValidationFindingSeverity;
+  /** Zero-based entry index, when entry-scoped. */
+  entryIndex?: number;
+  /** Field ID, when field-scoped. */
+  fieldId?: string;
+}
+
 export interface MappingReviewSuspendPayload {
   reason?: string;
   suspendStepId: 'mapping-review';
@@ -134,6 +151,8 @@ export interface MappingReviewSuspendPayload {
   entryBlockGraph: EntryBlockGraph;
   referenceGraph: ReviewedReferenceGraph;
   contentTypes: WorkflowContentType[];
+  /** Present when the google-docs-agent-improvements flag is on; absent otherwise. */
+  validationFindings?: ValidationFinding[];
 }
 
 export type WorkflowRunResult =

--- a/apps/drive-integration/src/types/workflow.ts
+++ b/apps/drive-integration/src/types/workflow.ts
@@ -125,8 +125,10 @@ export interface TabsImagesSuspendPayload {
   tabs?: DocTabOption[];
 }
 
-/** Severity levels for validation findings produced by the validate-payload step. */
-export type ValidationFindingSeverity = 'block' | 'warn';
+export enum ValidationFindingSeverity {
+  Block = 'block',
+  Warn = 'warn',
+}
 
 /** A single validation finding from the validate-payload step. */
 export interface ValidationFinding {
@@ -151,7 +153,6 @@ export interface MappingReviewSuspendPayload {
   entryBlockGraph: EntryBlockGraph;
   referenceGraph: ReviewedReferenceGraph;
   contentTypes: WorkflowContentType[];
-  /** Present when the google-docs-agent-improvements flag is on; absent otherwise. */
   validationFindings?: ValidationFinding[];
 }
 

--- a/apps/drive-integration/test/locations/Page/components/overview/OverviewEntryList.spec.tsx
+++ b/apps/drive-integration/test/locations/Page/components/overview/OverviewEntryList.spec.tsx
@@ -1,0 +1,85 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ValidationFinding } from '@types';
+import type { EntryListRow } from '../../../../../src/utils/overviewEntryList';
+import { OverviewEntryList } from '../../../../../src/locations/Page/components/overview/OverviewEntryList';
+
+const makeRow = (entryIndex: number, label: string): EntryListRow => ({
+  id: `row-${entryIndex}`,
+  entryIndex,
+  contentTypeName: 'Article',
+  entryTitle: label,
+  children: [],
+});
+
+const renderList = (
+  rows: EntryListRow[],
+  findingsByEntryIndex?: ReadonlyMap<number, ValidationFinding[]>
+) =>
+  render(
+    <OverviewEntryList
+      rows={rows}
+      selectedEntryIndex={null}
+      selectedEntryKeys={new Set()}
+      onSelect={vi.fn()}
+      onToggleEntrySelection={vi.fn()}
+      findingsByEntryIndex={findingsByEntryIndex}
+    />
+  );
+
+afterEach(() => cleanup());
+
+describe('OverviewEntryList — validation finding badges (INTEG-4383)', () => {
+  it('renders a "Needs attention" badge for entries with block findings', () => {
+    const rows = [makeRow(0, 'Entry A')];
+    const findings: ValidationFinding[] = [
+      { code: 'required-field-missing', message: 'title missing', severity: 'block', entryIndex: 0 },
+    ];
+    renderList(rows, new Map([[0, findings]]));
+
+    expect(screen.getByText('Needs attention')).toBeTruthy();
+    expect(screen.queryByText('Warning')).toBeNull();
+  });
+
+  it('renders a "Warning" badge for entries with only warn findings', () => {
+    const rows = [makeRow(0, 'Entry A')];
+    const findings: ValidationFinding[] = [
+      { code: 'displayField-blank', message: 'title blank', severity: 'warn', entryIndex: 0 },
+    ];
+    renderList(rows, new Map([[0, findings]]));
+
+    expect(screen.getByText('Warning')).toBeTruthy();
+    expect(screen.queryByText('Needs attention')).toBeNull();
+  });
+
+  it('renders "Needs attention" (not Warning) when entry has both block and warn findings', () => {
+    const rows = [makeRow(0, 'Entry A')];
+    const findings: ValidationFinding[] = [
+      { code: 'required-field-missing', message: 'title missing', severity: 'block', entryIndex: 0 },
+      { code: 'displayField-blank', message: 'title blank', severity: 'warn', entryIndex: 0 },
+    ];
+    renderList(rows, new Map([[0, findings]]));
+
+    expect(screen.getByText('Needs attention')).toBeTruthy();
+    expect(screen.queryByText('Warning')).toBeNull();
+  });
+
+  it('renders no finding badges when findingsByEntryIndex is undefined', () => {
+    const rows = [makeRow(0, 'Entry A')];
+    renderList(rows, undefined);
+
+    expect(screen.queryByText('Needs attention')).toBeNull();
+    expect(screen.queryByText('Warning')).toBeNull();
+  });
+
+  it('renders no finding badges for entries with no findings', () => {
+    const rows = [makeRow(0, 'Entry A'), makeRow(1, 'Entry B')];
+    const findings: ValidationFinding[] = [
+      { code: 'required-field-missing', message: 'title missing', severity: 'block', entryIndex: 1 },
+    ];
+    renderList(rows, new Map([[1, findings]]));
+
+    // Only entry 1 should have the badge
+    expect(screen.getAllByText('Needs attention')).toHaveLength(1);
+  });
+});

--- a/apps/drive-integration/test/locations/Page/components/overview/OverviewEntryList.spec.tsx
+++ b/apps/drive-integration/test/locations/Page/components/overview/OverviewEntryList.spec.tsx
@@ -1,5 +1,6 @@
 import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ValidationFindingSeverity } from '@types';
 import type { ValidationFinding } from '@types';
 import type { EntryListRow } from '../../../../../src/utils/overviewEntryList';
 import { OverviewEntryList } from '../../../../../src/locations/Page/components/overview/OverviewEntryList';
@@ -36,7 +37,7 @@ describe('OverviewEntryList — validation finding badges (INTEG-4383)', () => {
       {
         code: 'required-field-missing',
         message: 'title missing',
-        severity: 'block',
+        severity: ValidationFindingSeverity.Block,
         entryIndex: 0,
       },
     ];
@@ -49,7 +50,7 @@ describe('OverviewEntryList — validation finding badges (INTEG-4383)', () => {
   it('renders a "Warning" badge for entries with only warn findings', () => {
     const rows = [makeRow(0, 'Entry A')];
     const findings: ValidationFinding[] = [
-      { code: 'displayField-blank', message: 'title blank', severity: 'warn', entryIndex: 0 },
+      { code: 'displayField-blank', message: 'title blank', severity: ValidationFindingSeverity.Warn, entryIndex: 0 },
     ];
     renderList(rows, new Map([[0, findings]]));
 
@@ -63,10 +64,10 @@ describe('OverviewEntryList — validation finding badges (INTEG-4383)', () => {
       {
         code: 'required-field-missing',
         message: 'title missing',
-        severity: 'block',
+        severity: ValidationFindingSeverity.Block,
         entryIndex: 0,
       },
-      { code: 'displayField-blank', message: 'title blank', severity: 'warn', entryIndex: 0 },
+      { code: 'displayField-blank', message: 'title blank', severity: ValidationFindingSeverity.Warn, entryIndex: 0 },
     ];
     renderList(rows, new Map([[0, findings]]));
 
@@ -88,7 +89,7 @@ describe('OverviewEntryList — validation finding badges (INTEG-4383)', () => {
       {
         code: 'required-field-missing',
         message: 'title missing',
-        severity: 'block',
+        severity: ValidationFindingSeverity.Block,
         entryIndex: 1,
       },
     ];

--- a/apps/drive-integration/test/locations/Page/components/overview/OverviewEntryList.spec.tsx
+++ b/apps/drive-integration/test/locations/Page/components/overview/OverviewEntryList.spec.tsx
@@ -33,7 +33,12 @@ describe('OverviewEntryList — validation finding badges (INTEG-4383)', () => {
   it('renders a "Needs attention" badge for entries with block findings', () => {
     const rows = [makeRow(0, 'Entry A')];
     const findings: ValidationFinding[] = [
-      { code: 'required-field-missing', message: 'title missing', severity: 'block', entryIndex: 0 },
+      {
+        code: 'required-field-missing',
+        message: 'title missing',
+        severity: 'block',
+        entryIndex: 0,
+      },
     ];
     renderList(rows, new Map([[0, findings]]));
 
@@ -55,7 +60,12 @@ describe('OverviewEntryList — validation finding badges (INTEG-4383)', () => {
   it('renders "Needs attention" (not Warning) when entry has both block and warn findings', () => {
     const rows = [makeRow(0, 'Entry A')];
     const findings: ValidationFinding[] = [
-      { code: 'required-field-missing', message: 'title missing', severity: 'block', entryIndex: 0 },
+      {
+        code: 'required-field-missing',
+        message: 'title missing',
+        severity: 'block',
+        entryIndex: 0,
+      },
       { code: 'displayField-blank', message: 'title blank', severity: 'warn', entryIndex: 0 },
     ];
     renderList(rows, new Map([[0, findings]]));
@@ -75,7 +85,12 @@ describe('OverviewEntryList — validation finding badges (INTEG-4383)', () => {
   it('renders no finding badges for entries with no findings', () => {
     const rows = [makeRow(0, 'Entry A'), makeRow(1, 'Entry B')];
     const findings: ValidationFinding[] = [
-      { code: 'required-field-missing', message: 'title missing', severity: 'block', entryIndex: 1 },
+      {
+        code: 'required-field-missing',
+        message: 'title missing',
+        severity: 'block',
+        entryIndex: 1,
+      },
     ];
     renderList(rows, new Map([[1, findings]]));
 

--- a/apps/drive-integration/test/locations/Page/components/overview/OverviewEntryList.spec.tsx
+++ b/apps/drive-integration/test/locations/Page/components/overview/OverviewEntryList.spec.tsx
@@ -50,7 +50,12 @@ describe('OverviewEntryList — validation finding badges (INTEG-4383)', () => {
   it('renders a "Warning" badge for entries with only warn findings', () => {
     const rows = [makeRow(0, 'Entry A')];
     const findings: ValidationFinding[] = [
-      { code: 'displayField-blank', message: 'title blank', severity: ValidationFindingSeverity.Warn, entryIndex: 0 },
+      {
+        code: 'displayField-blank',
+        message: 'title blank',
+        severity: ValidationFindingSeverity.Warn,
+        entryIndex: 0,
+      },
     ];
     renderList(rows, new Map([[0, findings]]));
 
@@ -67,7 +72,12 @@ describe('OverviewEntryList — validation finding badges (INTEG-4383)', () => {
         severity: ValidationFindingSeverity.Block,
         entryIndex: 0,
       },
-      { code: 'displayField-blank', message: 'title blank', severity: ValidationFindingSeverity.Warn, entryIndex: 0 },
+      {
+        code: 'displayField-blank',
+        message: 'title blank',
+        severity: ValidationFindingSeverity.Warn,
+        entryIndex: 0,
+      },
     ];
     renderList(rows, new Map([[0, findings]]));
 

--- a/apps/drive-integration/test/locations/Page/components/review/ReviewPage.spec.tsx
+++ b/apps/drive-integration/test/locations/Page/components/review/ReviewPage.spec.tsx
@@ -2,8 +2,8 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { Layout } from '@contentful/f36-components';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { PageAppSDK } from '@contentful/app-sdk';
+import { RunStatus, ValidationFindingSeverity } from '@types';
 import type { MappingReviewSuspendPayload } from '@types';
-import { RunStatus } from '@types';
 import { createMockSDK } from '../../../../mocks';
 import { ReviewPage } from '../../../../../src/locations/Page/components/review/ReviewPage';
 
@@ -138,7 +138,7 @@ describe('ReviewPage — block findings acknowledgement (INTEG-4383)', () => {
         {
           code: 'required-field-missing',
           message: 'title missing',
-          severity: 'block',
+          severity: ValidationFindingSeverity.Block,
           entryIndex: 0,
         },
       ],
@@ -155,7 +155,7 @@ describe('ReviewPage — block findings acknowledgement (INTEG-4383)', () => {
         {
           code: 'required-field-missing',
           message: 'title missing',
-          severity: 'block',
+          severity: ValidationFindingSeverity.Block,
           entryIndex: 0,
         },
       ],
@@ -174,7 +174,7 @@ describe('ReviewPage — block findings acknowledgement (INTEG-4383)', () => {
     const payload: MappingReviewSuspendPayload = {
       ...createPayload(),
       validationFindings: [
-        { code: 'displayField-blank', message: 'title blank', severity: 'warn', entryIndex: 0 },
+        { code: 'displayField-blank', message: 'title blank', severity: ValidationFindingSeverity.Warn, entryIndex: 0 },
       ],
     };
     renderReviewPage(payload);

--- a/apps/drive-integration/test/locations/Page/components/review/ReviewPage.spec.tsx
+++ b/apps/drive-integration/test/locations/Page/components/review/ReviewPage.spec.tsx
@@ -174,7 +174,12 @@ describe('ReviewPage — block findings acknowledgement (INTEG-4383)', () => {
     const payload: MappingReviewSuspendPayload = {
       ...createPayload(),
       validationFindings: [
-        { code: 'displayField-blank', message: 'title blank', severity: ValidationFindingSeverity.Warn, entryIndex: 0 },
+        {
+          code: 'displayField-blank',
+          message: 'title blank',
+          severity: ValidationFindingSeverity.Warn,
+          entryIndex: 0,
+        },
       ],
     };
     renderReviewPage(payload);

--- a/apps/drive-integration/test/locations/Page/components/review/ReviewPage.spec.tsx
+++ b/apps/drive-integration/test/locations/Page/components/review/ReviewPage.spec.tsx
@@ -125,6 +125,62 @@ const renderReviewPage = (payload: MappingReviewSuspendPayload = createPayload()
     </Layout>
   );
 
+describe('ReviewPage — block findings acknowledgement (INTEG-4383)', () => {
+  beforeEach(() => {
+    sdk = createMockSDK() as PageAppSDK;
+    vi.clearAllMocks();
+  });
+
+  it('disables Create button when block findings are present and not acknowledged', () => {
+    const payload: MappingReviewSuspendPayload = {
+      ...createPayload(),
+      validationFindings: [
+        { code: 'required-field-missing', message: 'title missing', severity: 'block', entryIndex: 0 },
+      ],
+    };
+    renderReviewPage(payload);
+
+    expect(screen.getByRole('button', { name: 'Create selected entries' })).toBeDisabled();
+  });
+
+  it('enables Create button after user acknowledges block findings', () => {
+    const payload: MappingReviewSuspendPayload = {
+      ...createPayload(),
+      validationFindings: [
+        { code: 'required-field-missing', message: 'title missing', severity: 'block', entryIndex: 0 },
+      ],
+    };
+    renderReviewPage(payload);
+
+    const checkbox = screen.getByRole('checkbox', {
+      name: 'I have reviewed the issues and want to proceed',
+    });
+    fireEvent.click(checkbox);
+
+    expect(screen.getByRole('button', { name: 'Create selected entries' })).toBeEnabled();
+  });
+
+  it('does not disable Create button when only warn findings are present', () => {
+    const payload: MappingReviewSuspendPayload = {
+      ...createPayload(),
+      validationFindings: [
+        { code: 'displayField-blank', message: 'title blank', severity: 'warn', entryIndex: 0 },
+      ],
+    };
+    renderReviewPage(payload);
+
+    expect(screen.getByRole('button', { name: 'Create selected entries' })).toBeEnabled();
+  });
+
+  it('does not show acknowledgement note when there are no block findings', () => {
+    renderReviewPage();
+
+    expect(
+      screen.queryByText('I have reviewed the issues and want to proceed')
+    ).toBeNull();
+  });
+});
+
 describe('ReviewPage entry selection', () => {
   beforeEach(() => {
     sdk = createMockSDK() as PageAppSDK;

--- a/apps/drive-integration/test/locations/Page/components/review/ReviewPage.spec.tsx
+++ b/apps/drive-integration/test/locations/Page/components/review/ReviewPage.spec.tsx
@@ -135,7 +135,12 @@ describe('ReviewPage — block findings acknowledgement (INTEG-4383)', () => {
     const payload: MappingReviewSuspendPayload = {
       ...createPayload(),
       validationFindings: [
-        { code: 'required-field-missing', message: 'title missing', severity: 'block', entryIndex: 0 },
+        {
+          code: 'required-field-missing',
+          message: 'title missing',
+          severity: 'block',
+          entryIndex: 0,
+        },
       ],
     };
     renderReviewPage(payload);
@@ -147,7 +152,12 @@ describe('ReviewPage — block findings acknowledgement (INTEG-4383)', () => {
     const payload: MappingReviewSuspendPayload = {
       ...createPayload(),
       validationFindings: [
-        { code: 'required-field-missing', message: 'title missing', severity: 'block', entryIndex: 0 },
+        {
+          code: 'required-field-missing',
+          message: 'title missing',
+          severity: 'block',
+          entryIndex: 0,
+        },
       ],
     };
     renderReviewPage(payload);
@@ -175,9 +185,7 @@ describe('ReviewPage — block findings acknowledgement (INTEG-4383)', () => {
   it('does not show acknowledgement note when there are no block findings', () => {
     renderReviewPage();
 
-    expect(
-      screen.queryByText('I have reviewed the issues and want to proceed')
-    ).toBeNull();
+    expect(screen.queryByText('I have reviewed the issues and want to proceed')).toBeNull();
   });
 });
 


### PR DESCRIPTION
[INTEG-4383](https://contentful.atlassian.net/browse/INTEG-4383)

## Summary
- Adds `ValidationFinding` interface and `validationFindings?: ValidationFinding[]` to `MappingReviewSuspendPayload` so the UI can consume findings from the validate-payload step
- Renders per-entry badges in the overview list: `negative` ("Needs attention") for `block` findings, `warning` ("Warning") for `warn`-only entries
- Gates the "Create selected entries" button behind an explicit acknowledgement checkbox when block findings are present; warn findings annotate without blocking

<img width="1728" height="912" alt="Screenshot 2026-07-15 at 12 13 29 PM" src="https://github.com/user-attachments/assets/c2cbd984-cb56-48a2-bab3-5290c89434c1" />

## Test plan
- [ ] With `google-docs-agent-improvements` flag on: import a document, verify entries with block findings show "Needs attention" badge, warn-only entries show "Warning" badge, and Create button is disabled until the acknowledgement checkbox is checked
- [ ] With flag off (no `validationFindings` in payload): no badges rendered, Create button enabled as before
- [ ] Deselect all entries → Create button still disabled (existing behaviour preserved)
- [ ] `npm run test:ci` passes (166 tests, 9 new)

Generated with [Claude Code](https://claude.com/claude-code)

[INTEG-4383]: https://contentful.atlassian.net/browse/INTEG-4383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ