### PR TITLE
feat(drive-integration): pass entryBlockGraph on mapping-review cancel [INTEG-4360]

### DIFF
--- a/apps/drive-integration/src/locations/Page/Page.tsx
+++ b/apps/drive-integration/src/locations/Page/Page.tsx
@@ -8,7 +8,7 @@ import {
 } from './components/mainpage/ModalOrchestrator';
 import { MainPageView } from './components/mainpage/MainPageView';
 import { ReviewPage } from './components/review/ReviewPage';
-import type { MappingReviewSuspendPayload } from '@types';
+import type { EntryBlockGraph, MappingReviewSuspendPayload } from '@types';
 import { useWorkflowAgent } from '@hooks/useWorkflowAgent';
 import { useGoogleDriveOAuth } from '@hooks/useGoogleDriveOAuth';
 import { isAiAccessDeniedError } from '../../utils/aiAccess';
@@ -57,14 +57,14 @@ const Page = () => {
     handleReturnToMainPage();
   };
 
-  const handleCancelMappingReview = async () => {
+  const handleCancelMappingReview = async (graph: EntryBlockGraph) => {
     if (!mappingReviewState?.runId) {
       resetFlowAndReturnToMainPage();
       return;
     }
 
     try {
-      await resumeWorkflow(mappingReviewState.runId, { cancelled: true });
+      await resumeWorkflow(mappingReviewState.runId, { cancelled: true, entryBlockGraph: graph });
     } catch (error) {
       console.error(error);
     } finally {

--- a/apps/drive-integration/src/locations/Page/components/review/ReviewPage.tsx
+++ b/apps/drive-integration/src/locations/Page/components/review/ReviewPage.tsx
@@ -33,7 +33,7 @@ interface ReviewPageProps {
   sdk: PageAppSDK;
   payload: MappingReviewSuspendPayload;
   runId?: string;
-  onCancelReview: () => Promise<void>;
+  onCancelReview: (graph: EntryBlockGraph) => Promise<void>;
   onExitReview: () => void;
 }
 
@@ -175,12 +175,12 @@ export const ReviewPage = ({
     setIsCancelling(true);
 
     try {
-      await onCancelReview();
+      await onCancelReview(entryBlockGraph);
     } finally {
       setIsCancelling(false);
       setIsConfirmCancelModalOpen(false);
     }
-  }, [onCancelReview]);
+  }, [onCancelReview, entryBlockGraph]);
 
   const handleCreateOrViewEntries = useCallback(() => {
     if (hasCreatedEntries) {


### PR DESCRIPTION
## Purpose

When a user cancels from the mapping-review step, the current (potentially edited) `entryBlockGraph` is now included in the resume payload. This allows the backend to compute and emit `hil_edited` and `rejected` analytics events on the cancel path, completing observability for INTEG-4360.

## Approach

- Changed `onCancelReview` prop signature in `ReviewPage` from `() => Promise<void>` to `(graph: EntryBlockGraph) => Promise<void>`.
- `handleConfirmCancel` now passes the local `entryBlockGraph` state (which tracks user edits) to `onCancelReview`.
- `handleCancelMappingReview` in `Page.tsx` accepts the graph and includes it in the resume payload: `{ cancelled: true, entryBlockGraph: graph }`.
- No type changes needed — `ResumePayload` already had `entryBlockGraph?: EntryBlockGraph` as an optional field.

## Testing steps

1. Start a Google Docs import and reach the mapping-review screen.
2. Edit a field mapping, then click Cancel and confirm.
3. Verify in Datadog that `hil_edited` and `rejected` events fire with the correct diff metrics.
4. Cancel without editing → only `rejected` fires, no `hil_edited`.

## Breaking Changes

No.

## Dependencies and/or References

- [INTEG-4360](https://contentful.atlassian.net/browse/INTEG-4360)
- [Backend companion PR](https://github.com/contentful/agents-api/actions/runs/29455849965/job/87488732959) **(this one needs to be merged first)**: `contentful/agents-api` — `wire-ggdocs-resume-events`

[INTEG-4360]: https://contentful.atlassian.net/browse/INTEG-4360

🤖 Co-authored with [Claude Code](https://claude.ai/code)