### PR TITLE
test: add WIZARD_STEPS routing and needsReferenceFieldStep skip coverage [INTEG-4450]

### DIFF
--- a/apps/drive-integration/test/locations/Page/components/modals/AddEntryWizard.spec.tsx
+++ b/apps/drive-integration/test/locations/Page/components/modals/AddEntryWizard.spec.tsx
@@ -211,102 +211,162 @@ describe('AddEntryWizard', () => {
 
     describe('next() transitions', () => {
       it('ContentType → IsReference', () => {
-        expect(WIZARD_STEPS[WizardStep.ContentType].next(baseState, { needsReferenceFieldStep: true })).toBe(WizardStep.IsReference);
+        expect(
+          WIZARD_STEPS[WizardStep.ContentType].next(baseState, { needsReferenceFieldStep: true })
+        ).toBe(WizardStep.IsReference);
       });
 
       it('IsReference → SelectReference when isReference is true', () => {
         const state = makeState({ isReference: true });
-        expect(WIZARD_STEPS[WizardStep.IsReference].next(state, { needsReferenceFieldStep: true })).toBe(WizardStep.SelectReference);
+        expect(
+          WIZARD_STEPS[WizardStep.IsReference].next(state, { needsReferenceFieldStep: true })
+        ).toBe(WizardStep.SelectReference);
       });
 
       it('IsReference → SelectFields when isReference is false', () => {
         const state = makeState({ isReference: false });
-        expect(WIZARD_STEPS[WizardStep.IsReference].next(state, { needsReferenceFieldStep: true })).toBe(WizardStep.SelectFields);
+        expect(
+          WIZARD_STEPS[WizardStep.IsReference].next(state, { needsReferenceFieldStep: true })
+        ).toBe(WizardStep.SelectFields);
       });
 
       it('SelectReference → SelectReferenceField when needsReferenceFieldStep is true', () => {
-        expect(WIZARD_STEPS[WizardStep.SelectReference].next(baseState, { needsReferenceFieldStep: true })).toBe(WizardStep.SelectReferenceField);
+        expect(
+          WIZARD_STEPS[WizardStep.SelectReference].next(baseState, {
+            needsReferenceFieldStep: true,
+          })
+        ).toBe(WizardStep.SelectReferenceField);
       });
 
       it('SelectReference → SelectFields when needsReferenceFieldStep is false', () => {
-        expect(WIZARD_STEPS[WizardStep.SelectReference].next(baseState, { needsReferenceFieldStep: false })).toBe(WizardStep.SelectFields);
+        expect(
+          WIZARD_STEPS[WizardStep.SelectReference].next(baseState, {
+            needsReferenceFieldStep: false,
+          })
+        ).toBe(WizardStep.SelectFields);
       });
 
       it('SelectReferenceField → SelectFields', () => {
-        expect(WIZARD_STEPS[WizardStep.SelectReferenceField].next(baseState, { needsReferenceFieldStep: true })).toBe(WizardStep.SelectFields);
+        expect(
+          WIZARD_STEPS[WizardStep.SelectReferenceField].next(baseState, {
+            needsReferenceFieldStep: true,
+          })
+        ).toBe(WizardStep.SelectFields);
       });
 
       it('SelectFields next() stays on SelectFields (terminal step)', () => {
         const state = makeState({ step: WizardStep.SelectFields });
-        expect(WIZARD_STEPS[WizardStep.SelectFields].next(state, { needsReferenceFieldStep: true })).toBe(WizardStep.SelectFields);
+        expect(
+          WIZARD_STEPS[WizardStep.SelectFields].next(state, { needsReferenceFieldStep: true })
+        ).toBe(WizardStep.SelectFields);
       });
     });
 
     describe('back() transitions', () => {
       it('ContentType back() stays on ContentType (no previous step)', () => {
         const state = makeState({ step: WizardStep.ContentType });
-        expect(WIZARD_STEPS[WizardStep.ContentType].back(state, { needsReferenceFieldStep: true })).toBe(WizardStep.ContentType);
+        expect(
+          WIZARD_STEPS[WizardStep.ContentType].back(state, { needsReferenceFieldStep: true })
+        ).toBe(WizardStep.ContentType);
       });
 
       it('IsReference → ContentType', () => {
-        expect(WIZARD_STEPS[WizardStep.IsReference].back(baseState, { needsReferenceFieldStep: true })).toBe(WizardStep.ContentType);
+        expect(
+          WIZARD_STEPS[WizardStep.IsReference].back(baseState, { needsReferenceFieldStep: true })
+        ).toBe(WizardStep.ContentType);
       });
 
       it('SelectReference → IsReference', () => {
-        expect(WIZARD_STEPS[WizardStep.SelectReference].back(baseState, { needsReferenceFieldStep: true })).toBe(WizardStep.IsReference);
+        expect(
+          WIZARD_STEPS[WizardStep.SelectReference].back(baseState, {
+            needsReferenceFieldStep: true,
+          })
+        ).toBe(WizardStep.IsReference);
       });
 
       it('SelectReferenceField → SelectReference', () => {
-        expect(WIZARD_STEPS[WizardStep.SelectReferenceField].back(baseState, { needsReferenceFieldStep: true })).toBe(WizardStep.SelectReference);
+        expect(
+          WIZARD_STEPS[WizardStep.SelectReferenceField].back(baseState, {
+            needsReferenceFieldStep: true,
+          })
+        ).toBe(WizardStep.SelectReference);
       });
 
       it('SelectFields → SelectReferenceField when isReference and needsReferenceFieldStep', () => {
         const state = makeState({ isReference: true });
-        expect(WIZARD_STEPS[WizardStep.SelectFields].back(state, { needsReferenceFieldStep: true })).toBe(WizardStep.SelectReferenceField);
+        expect(
+          WIZARD_STEPS[WizardStep.SelectFields].back(state, { needsReferenceFieldStep: true })
+        ).toBe(WizardStep.SelectReferenceField);
       });
 
       it('SelectFields → SelectReference when isReference but not needsReferenceFieldStep', () => {
         const state = makeState({ isReference: true });
-        expect(WIZARD_STEPS[WizardStep.SelectFields].back(state, { needsReferenceFieldStep: false })).toBe(WizardStep.SelectReference);
+        expect(
+          WIZARD_STEPS[WizardStep.SelectFields].back(state, { needsReferenceFieldStep: false })
+        ).toBe(WizardStep.SelectReference);
       });
 
       it('SelectFields → IsReference when not isReference', () => {
         const state = makeState({ isReference: false });
-        expect(WIZARD_STEPS[WizardStep.SelectFields].back(state, { needsReferenceFieldStep: false })).toBe(WizardStep.IsReference);
+        expect(
+          WIZARD_STEPS[WizardStep.SelectFields].back(state, { needsReferenceFieldStep: false })
+        ).toBe(WizardStep.IsReference);
       });
     });
 
     describe('isDisabled()', () => {
       it('ContentType is disabled when contentTypeId is empty', () => {
-        expect(WIZARD_STEPS[WizardStep.ContentType].isDisabled(makeState({ contentTypeId: '' }))).toBe(true);
+        expect(
+          WIZARD_STEPS[WizardStep.ContentType].isDisabled(makeState({ contentTypeId: '' }))
+        ).toBe(true);
       });
 
       it('ContentType is enabled when contentTypeId is set', () => {
-        expect(WIZARD_STEPS[WizardStep.ContentType].isDisabled(makeState({ contentTypeId: 'article' }))).toBe(false);
+        expect(
+          WIZARD_STEPS[WizardStep.ContentType].isDisabled(makeState({ contentTypeId: 'article' }))
+        ).toBe(false);
       });
 
       it('IsReference is disabled when isReference is null', () => {
-        expect(WIZARD_STEPS[WizardStep.IsReference].isDisabled(makeState({ isReference: null }))).toBe(true);
+        expect(
+          WIZARD_STEPS[WizardStep.IsReference].isDisabled(makeState({ isReference: null }))
+        ).toBe(true);
       });
 
       it('IsReference is enabled when isReference is set', () => {
-        expect(WIZARD_STEPS[WizardStep.IsReference].isDisabled(makeState({ isReference: false }))).toBe(false);
+        expect(
+          WIZARD_STEPS[WizardStep.IsReference].isDisabled(makeState({ isReference: false }))
+        ).toBe(false);
       });
 
       it('SelectReference is disabled when referenceEntryId is empty', () => {
-        expect(WIZARD_STEPS[WizardStep.SelectReference].isDisabled(makeState({ referenceEntryId: '' }))).toBe(true);
+        expect(
+          WIZARD_STEPS[WizardStep.SelectReference].isDisabled(makeState({ referenceEntryId: '' }))
+        ).toBe(true);
       });
 
       it('SelectReference is enabled when referenceEntryId is set', () => {
-        expect(WIZARD_STEPS[WizardStep.SelectReference].isDisabled(makeState({ referenceEntryId: 'entry-1' }))).toBe(false);
+        expect(
+          WIZARD_STEPS[WizardStep.SelectReference].isDisabled(
+            makeState({ referenceEntryId: 'entry-1' })
+          )
+        ).toBe(false);
       });
 
       it('SelectReferenceField is disabled when referenceFieldId is empty', () => {
-        expect(WIZARD_STEPS[WizardStep.SelectReferenceField].isDisabled(makeState({ referenceFieldId: '' }))).toBe(true);
+        expect(
+          WIZARD_STEPS[WizardStep.SelectReferenceField].isDisabled(
+            makeState({ referenceFieldId: '' })
+          )
+        ).toBe(true);
       });
 
       it('SelectReferenceField is enabled when referenceFieldId is set', () => {
-        expect(WIZARD_STEPS[WizardStep.SelectReferenceField].isDisabled(makeState({ referenceFieldId: 'author' }))).toBe(false);
+        expect(
+          WIZARD_STEPS[WizardStep.SelectReferenceField].isDisabled(
+            makeState({ referenceFieldId: 'author' })
+          )
+        ).toBe(false);
       });
 
       it('SelectFields is never disabled', () => {
@@ -318,7 +378,9 @@ describe('AddEntryWizard', () => {
   describe('needsReferenceFieldStep = false path', () => {
     it('skips SelectReferenceField when navigating forward from SelectReference', () => {
       expect(
-        WIZARD_STEPS[WizardStep.SelectReference].next(makeState(), { needsReferenceFieldStep: false })
+        WIZARD_STEPS[WizardStep.SelectReference].next(makeState(), {
+          needsReferenceFieldStep: false,
+        })
       ).toBe(WizardStep.SelectFields);
     });
 

--- a/apps/drive-integration/test/locations/Page/components/modals/AddEntryWizard.spec.tsx
+++ b/apps/drive-integration/test/locations/Page/components/modals/AddEntryWizard.spec.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import {
   AddEntryWizard,
   WizardStep,
+  WIZARD_STEPS,
   INITIAL_WIZARD_STATE,
   type Wizard,
 } from '../../../../../src/locations/Page/components/review/mapping/edit-modals/AddEntryWizard';
@@ -202,6 +203,130 @@ describe('AddEntryWizard', () => {
       await waitFor(() => {
         expect(screen.getByText('Field selection')).toBeTruthy();
       });
+    });
+  });
+
+  describe('WIZARD_STEPS routing', () => {
+    const baseState = makeState();
+
+    describe('next() transitions', () => {
+      it('ContentType → IsReference', () => {
+        expect(WIZARD_STEPS[WizardStep.ContentType].next(baseState, { needsReferenceFieldStep: true })).toBe(WizardStep.IsReference);
+      });
+
+      it('IsReference → SelectReference when isReference is true', () => {
+        const state = makeState({ isReference: true });
+        expect(WIZARD_STEPS[WizardStep.IsReference].next(state, { needsReferenceFieldStep: true })).toBe(WizardStep.SelectReference);
+      });
+
+      it('IsReference → SelectFields when isReference is false', () => {
+        const state = makeState({ isReference: false });
+        expect(WIZARD_STEPS[WizardStep.IsReference].next(state, { needsReferenceFieldStep: true })).toBe(WizardStep.SelectFields);
+      });
+
+      it('SelectReference → SelectReferenceField when needsReferenceFieldStep is true', () => {
+        expect(WIZARD_STEPS[WizardStep.SelectReference].next(baseState, { needsReferenceFieldStep: true })).toBe(WizardStep.SelectReferenceField);
+      });
+
+      it('SelectReference → SelectFields when needsReferenceFieldStep is false', () => {
+        expect(WIZARD_STEPS[WizardStep.SelectReference].next(baseState, { needsReferenceFieldStep: false })).toBe(WizardStep.SelectFields);
+      });
+
+      it('SelectReferenceField → SelectFields', () => {
+        expect(WIZARD_STEPS[WizardStep.SelectReferenceField].next(baseState, { needsReferenceFieldStep: true })).toBe(WizardStep.SelectFields);
+      });
+
+      it('SelectFields next() stays on SelectFields (terminal step)', () => {
+        const state = makeState({ step: WizardStep.SelectFields });
+        expect(WIZARD_STEPS[WizardStep.SelectFields].next(state, { needsReferenceFieldStep: true })).toBe(WizardStep.SelectFields);
+      });
+    });
+
+    describe('back() transitions', () => {
+      it('ContentType back() stays on ContentType (no previous step)', () => {
+        const state = makeState({ step: WizardStep.ContentType });
+        expect(WIZARD_STEPS[WizardStep.ContentType].back(state, { needsReferenceFieldStep: true })).toBe(WizardStep.ContentType);
+      });
+
+      it('IsReference → ContentType', () => {
+        expect(WIZARD_STEPS[WizardStep.IsReference].back(baseState, { needsReferenceFieldStep: true })).toBe(WizardStep.ContentType);
+      });
+
+      it('SelectReference → IsReference', () => {
+        expect(WIZARD_STEPS[WizardStep.SelectReference].back(baseState, { needsReferenceFieldStep: true })).toBe(WizardStep.IsReference);
+      });
+
+      it('SelectReferenceField → SelectReference', () => {
+        expect(WIZARD_STEPS[WizardStep.SelectReferenceField].back(baseState, { needsReferenceFieldStep: true })).toBe(WizardStep.SelectReference);
+      });
+
+      it('SelectFields → SelectReferenceField when isReference and needsReferenceFieldStep', () => {
+        const state = makeState({ isReference: true });
+        expect(WIZARD_STEPS[WizardStep.SelectFields].back(state, { needsReferenceFieldStep: true })).toBe(WizardStep.SelectReferenceField);
+      });
+
+      it('SelectFields → SelectReference when isReference but not needsReferenceFieldStep', () => {
+        const state = makeState({ isReference: true });
+        expect(WIZARD_STEPS[WizardStep.SelectFields].back(state, { needsReferenceFieldStep: false })).toBe(WizardStep.SelectReference);
+      });
+
+      it('SelectFields → IsReference when not isReference', () => {
+        const state = makeState({ isReference: false });
+        expect(WIZARD_STEPS[WizardStep.SelectFields].back(state, { needsReferenceFieldStep: false })).toBe(WizardStep.IsReference);
+      });
+    });
+
+    describe('isDisabled()', () => {
+      it('ContentType is disabled when contentTypeId is empty', () => {
+        expect(WIZARD_STEPS[WizardStep.ContentType].isDisabled(makeState({ contentTypeId: '' }))).toBe(true);
+      });
+
+      it('ContentType is enabled when contentTypeId is set', () => {
+        expect(WIZARD_STEPS[WizardStep.ContentType].isDisabled(makeState({ contentTypeId: 'article' }))).toBe(false);
+      });
+
+      it('IsReference is disabled when isReference is null', () => {
+        expect(WIZARD_STEPS[WizardStep.IsReference].isDisabled(makeState({ isReference: null }))).toBe(true);
+      });
+
+      it('IsReference is enabled when isReference is set', () => {
+        expect(WIZARD_STEPS[WizardStep.IsReference].isDisabled(makeState({ isReference: false }))).toBe(false);
+      });
+
+      it('SelectReference is disabled when referenceEntryId is empty', () => {
+        expect(WIZARD_STEPS[WizardStep.SelectReference].isDisabled(makeState({ referenceEntryId: '' }))).toBe(true);
+      });
+
+      it('SelectReference is enabled when referenceEntryId is set', () => {
+        expect(WIZARD_STEPS[WizardStep.SelectReference].isDisabled(makeState({ referenceEntryId: 'entry-1' }))).toBe(false);
+      });
+
+      it('SelectReferenceField is disabled when referenceFieldId is empty', () => {
+        expect(WIZARD_STEPS[WizardStep.SelectReferenceField].isDisabled(makeState({ referenceFieldId: '' }))).toBe(true);
+      });
+
+      it('SelectReferenceField is enabled when referenceFieldId is set', () => {
+        expect(WIZARD_STEPS[WizardStep.SelectReferenceField].isDisabled(makeState({ referenceFieldId: 'author' }))).toBe(false);
+      });
+
+      it('SelectFields is never disabled', () => {
+        expect(WIZARD_STEPS[WizardStep.SelectFields].isDisabled(makeState())).toBe(false);
+      });
+    });
+  });
+
+  describe('needsReferenceFieldStep = false path', () => {
+    it('skips SelectReferenceField when navigating forward from SelectReference', () => {
+      expect(
+        WIZARD_STEPS[WizardStep.SelectReference].next(makeState(), { needsReferenceFieldStep: false })
+      ).toBe(WizardStep.SelectFields);
+    });
+
+    it('skips SelectReferenceField when navigating back from SelectFields with isReference', () => {
+      const state = makeState({ isReference: true });
+      expect(
+        WIZARD_STEPS[WizardStep.SelectFields].back(state, { needsReferenceFieldStep: false })
+      ).toBe(WizardStep.SelectReference);
     });
   });
 });


### PR DESCRIPTION
[INTEG-4450](https://contentful.atlassian.net/browse/INTEG-4450)

## Purpose
Closes the two remaining gaps in `AddEntryWizard` test coverage called out in INTEG-4450: the `WIZARD_STEPS` routing logic and the `needsReferenceFieldStep = false` skip path were both untested.

## Summary
- Added pure unit tests against the exported `WIZARD_STEPS` object covering all `next()`, `back()`, and `isDisabled()` transitions for every wizard step
- Added focused tests for the `needsReferenceFieldStep = false` path confirming `SelectReference` jumps directly to `SelectFields` (both forward and back) when only one reference field option exists
- No rendering required — tests exercise the routing functions directly, keeping them fast and dependency-free

## Test plan
- [x] `npx vitest run test/locations/Page/components/modals/AddEntryWizard.spec.tsx` — 36/36 passing

Generated with [Claude Code](https://claude.com/claude-code)

[INTEG-4450]: https://contentful.atlassian.net/browse/INTEG-4450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ