### PR TITLE
feat: add Adobe Experience Manager Asset Selector app []

### DIFF
--- a/apps/aem-assets/AGENTS.md
+++ b/apps/aem-assets/AGENTS.md
@@ -1,0 +1,40 @@
+# Agent Guide — aem-assets
+
+## What This App Does
+"Adobe Experience Manager Asset Selector" — integrates Adobe Experience Manager (AEM) as a Cloud Service Assets with Contentful via Adobe's Content Advisor Micro-Frontend. Lets editors browse, select, sort, and remove AEM DAM assets directly from a Contentful entry field.
+
+## Archetype
+**DAM base app** — thin wrapper around `@contentful/dam-app-base`, plus a custom Adobe IMS OAuth handshake (popup-based login) that the base package does not handle out of the box.
+
+## Structure
+
+```
+apps/aem-assets/
+└── src/
+    ├── index.jsx   # Mounts the DAM base app; Adobe IMS auth wiring; logout button; popup auth-redirect fix
+    ├── utils.js     # Asset shape transforms (renditions, metadata) between AEM's API and dam-app-base's expected format
+    ├── index.css
+    └── logo.svg
+```
+
+## Key Dependencies
+
+| Package | Role |
+|---------|------|
+| `@contentful/dam-app-base` | Provides the picker dialog shell, entry-field UI, and CMA wiring |
+| `@contentful/f36-components` | Used for the custom `Log out` button (Forma 36 compliant) |
+| Adobe's `assets-selectors.js` (loaded at runtime from `experience.adobe.com`) | Renders the actual AEM Content Advisor picker UI inside the dialog |
+
+## Sharp Edges & Invariants
+
+- **Adobe IMS auth uses a popup, not a redirect within the iframe.** `modalMode: true` opens a real popup window for login. Per Adobe's own examples, `registerContentAdvisorAuthService` must be called unconditionally on every page load — including on the popup's own redirect page. This app's `renderDialog(sdk)` only runs after `@contentful/app-sdk`'s `init()` iframe handshake resolves, which never happens inside the plain popup window. See the clearly-delimited `EXPERIMENTAL: popup auth-redirect fix` block in `index.jsx` — it re-registers the auth service when the page is *not* embedded in an iframe, using IMS config persisted to `localStorage`. Flip `ENABLE_POPUP_AUTH_REDIRECT_FIX` to `false` (or delete the block) to fully revert if this ever needs rolling back.
+- **Adobe enforces CORS/origin allowlisting server-side** on the IMS token endpoint. The hosted app's origin (e.g. its Contentful-hosted bundle URL) must be allowlisted on the customer's IMS Client ID by Adobe support before auth will work at all — this is not fixable in app code. This must be called out in customer-facing help docs.
+- **IMS Client ID must come from an Adobe support ticket**, not the normal Adobe Developer Console — a common setup gotcha.
+- `makeThumbnail` in `index.jsx` references `ASSET_RENDITIONS_KEY`, which is not defined in that file (it's only defined in `utils.js`). This does not currently throw or cause visible bugs: optional chaining (`asset?.computedMetadata?._links[...]`) short-circuits before evaluating the bracket expression for the persisted asset shape (`{id, name, url, metadata}`), and `dam-app-base`'s `SortableComponent` overrides the computed thumbnail URL with the persisted `resource.url` anyway. Worth cleaning up, but is not the cause of any known rendering bug.
+- Unlike `bynder`/`cloudinary` (which use static credentials + session cookies, no OAuth), this app's auth model is fundamentally OAuth/popup-based because that's how Adobe's Content Advisor SDK works — there is no way to avoid the origin-allowlisting requirement within this architecture.
+
+## Never / Always
+
+- **Never** bypass `dam-app-base` to implement custom picker/entry-field UI — use the provided extension points (`makeThumbnail`, `openDialog`, `renderDialog`).
+- **Always** keep the popup auth-redirect fix block clearly delimited and flag-gated so it can be disabled without a full revert if it ever misbehaves.
+- **Always** return assets in the format expected by `dam-app-base` (array of `{id, name, url, metadata}`).

--- a/apps/aem-assets/LICENSE.md
+++ b/apps/aem-assets/LICENSE.md
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/apps/aem-assets/README.md
+++ b/apps/aem-assets/README.md
@@ -1,0 +1,26 @@
+# Adobe Experience Manager Asset Selector
+
+After you've installed the Adobe Experience Manager Asset Selector app, you can select media from your Adobe Experience Manager (AEM) as a Cloud Service Assets repository directly inside the Contentful web app, using Adobe's Content Advisor asset picker.
+
+## Overview
+
+This app lets editors browse, select, sort, and remove AEM DAM assets from a Contentful entry field, without leaving Contentful. Authentication uses Adobe's IMS (Identity Management System) OAuth flow via a popup window.
+
+## Configuration
+
+| Field | Required | Description |
+| --- | --- | --- |
+| IMS Client ID | Yes | Client ID from Adobe IMS. Must be requested from Adobe support — not the standard Adobe Developer Console. |
+| IMS Organization | Yes | The Adobe IMS org ID assigned when AEM as a Cloud Service was provisioned for your organization. |
+| Repository ID | No | Restricts asset selection to a single AEM repository. |
+| AEM Tier | No | Restricts the tier(s) searched (`delivery`, `author`). Defaults to both. |
+| Environment | No | Specifies the AEM repository environment (`prod`, `stage`). |
+| Hide Asset Upload Button | No | Hides the upload-to-AEM button inside the picker. Defaults to hidden. |
+
+## Important setup requirement: origin allowlisting
+
+Adobe enforces CORS/origin allowlisting on their IMS auth endpoint. **The exact origin this app is hosted from must be allowlisted by Adobe support on your IMS Client ID before authentication will work.** This is required in addition to the IMS Client ID and Organization fields above, and must be requested directly from Adobe support.
+
+## Learn more
+
+Built on [`@contentful/dam-app-base`](https://www.npmjs.com/package/@contentful/dam-app-base). Learn more about the App Framework in our [documentation](https://www.contentful.com/developers/docs/extensibility/app-framework/).

--- a/apps/aem-assets/index.html
+++ b/apps/aem-assets/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>DAM App</title>
+  </head>
+
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+    <script type="module" src="/src/index.jsx"></script>
+  </body>
+</html>

--- a/apps/aem-assets/package-lock.json
+++ b/apps/aem-assets/package-lock.json
@@ -1,0 +1,6604 @@
+{
+  "name": "@contentful/aem-assets",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@contentful/aem-assets",
+      "version": "0.1.0",
+      "dependencies": {
+        "@contentful/app-sdk": "^4.56.0",
+        "@contentful/dam-app-base": "4.0.5",
+        "@contentful/f36-components": "6.7.4",
+        "react": "19.2.5",
+        "react-dom": "19.2.5"
+      },
+      "devDependencies": {
+        "@contentful/app-scripts": "^2.5.11",
+        "@vitejs/plugin-react": "^6.0.1",
+        "vite": "^8.0.10"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@contentful/app-scripts": {
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@contentful/app-scripts/-/app-scripts-2.5.12.tgz",
+      "integrity": "sha512-e6jim+S824WI9cpV0aUKmdI4rX5YHtVX6+MQZdbnGl+zD+K1mzqkP+Xk791PnyC2kQloy9XiMSKJ2OgoYgGobg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
+        "@esbuild-plugins/node-modules-polyfill": "^0.2.2",
+        "@segment/analytics-node": "^3.0.0",
+        "adm-zip": "0.5.17",
+        "axios": "^1.15.2",
+        "bottleneck": "2.19.5",
+        "chalk": "4.1.2",
+        "commander": "12.1.0",
+        "contentful-management": "^11.75.0",
+        "dotenv": "17.4.2",
+        "esbuild": "^0.28.0",
+        "ignore": "7.0.5",
+        "inquirer": "8.2.7",
+        "lodash": "4.18.1",
+        "merge-options": "^3.0.4",
+        "open": "8.4.2",
+        "ora": "5.4.1",
+        "zod": "^3.24.1"
+      },
+      "bin": {
+        "contentful-app-scripts": "lib/bin.js"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=9"
+      }
+    },
+    "node_modules/@contentful/app-sdk": {
+      "version": "4.65.0",
+      "resolved": "https://registry.npmjs.org/@contentful/app-sdk/-/app-sdk-4.65.0.tgz",
+      "integrity": "sha512-8apIN25Yk8Hjyd9k8exod/krv7q/xL34zab+U2gv5W0V2q4Jj6/XFAwz2IzzC/8HlzSWQ6uZ36YRkV4iXFISFg==",
+      "license": "MIT",
+      "dependencies": {
+        "contentful-management": "^12.3.1"
+      }
+    },
+    "node_modules/@contentful/app-sdk/node_modules/contentful-management": {
+      "version": "12.8.0",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-12.8.0.tgz",
+      "integrity": "sha512-lARtEZYn2MYf80hz9nCYiLbJWvg95TTnOWmCZouMZtgNS1273dN27Vaz7weHQ3oSQuk7LeYXaXdGFhFPKlpilw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/rich-text-types": "^16.6.1",
+        "axios": "^1.15.0",
+        "contentful-sdk-core": "^9.4.4",
+        "fast-copy": "^3.0.0",
+        "globals": "^15.15.0",
+        "process": "^0.11.10"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@contentful/dam-app-base": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@contentful/dam-app-base/-/dam-app-base-4.0.5.tgz",
+      "integrity": "sha512-CA6m8X5V5wbt2ko0KVnOZ7M1sECr655rMU3mw1lJRJtFnxlDBd+VI2ACZ+SmZFbWMc/Dc6LZsHBdVilQDHwpoA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/app-sdk": "^4.51.3",
+        "@contentful/f36-components": "5.9.0",
+        "@contentful/f36-tokens": "5.1.0",
+        "@dnd-kit/core": "^6.1.0",
+        "@dnd-kit/sortable": "^8.0.0",
+        "@emotion/css": "^11.13.5",
+        "contentful-management": "^11.39.1"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-accordion": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-5.9.1.tgz",
+      "integrity": "sha512-3TTcYXBs4axgP6YQj0hFIh3CIrWdPMUx2DgBxUDBUmgttLTx0P8kMXA4Smc2wpGw0SySrjNNnrDMFajZaeKAJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-collapse": "^5.9.1",
+        "@contentful/f36-core": "^5.9.1",
+        "@contentful/f36-icons": "^5.9.1",
+        "@contentful/f36-tokens": "^5.1.0",
+        "@contentful/f36-typography": "^5.9.1",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-asset": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-5.9.1.tgz",
+      "integrity": "sha512-Y2AnZhxjVmLpesjPyURFkvzbFt4Jnr6PD+NQDTyoDYUsW74U7TXym3KVvAJNATeI+5S4RUF3hdxp0H8Ugym7+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^5.9.1",
+        "@contentful/f36-icon": "^5.9.1",
+        "@contentful/f36-icons": "^5.9.1",
+        "@contentful/f36-tokens": "^5.1.0",
+        "@contentful/f36-typography": "^5.9.1",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-autocomplete": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-5.9.1.tgz",
+      "integrity": "sha512-icPKC7KVGmg7Yfvrr8hLdXvO1tePSIbFPNrSMcLSJXu/XI0lYjtjAKwDyb3duCaHMyDeXaASl0LiajAcw37tlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^5.9.1",
+        "@contentful/f36-core": "^5.9.1",
+        "@contentful/f36-forms": "^5.9.1",
+        "@contentful/f36-icons": "^5.9.1",
+        "@contentful/f36-popover": "^5.9.1",
+        "@contentful/f36-skeleton": "^5.9.1",
+        "@contentful/f36-tokens": "^5.1.0",
+        "@contentful/f36-typography": "^5.9.1",
+        "@contentful/f36-utils": "^5.2.0",
+        "downshift": "^6.1.12",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-avatar": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-avatar/-/f36-avatar-5.9.1.tgz",
+      "integrity": "sha512-Aem9srqBF7ueyyAEPY4uOxa8j3yQ0ui7Xatw0z6uO2h0yhX8irmT7S833TdPvUblvAZOMFTgKC7OWOF2bx8CWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^5.9.1",
+        "@contentful/f36-image": "^5.9.1",
+        "@contentful/f36-menu": "^5.9.1",
+        "@contentful/f36-tokens": "^5.1.0",
+        "@contentful/f36-tooltip": "^5.9.1",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-badge": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-5.9.1.tgz",
+      "integrity": "sha512-4JaMmJZbD8BcSX4do14nijDORbClkzYOAxovTLBfzoGae69FxnXnNcVYsibwM7kYhyrBBgXevAcE/Y3GgG6jNw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^5.9.1",
+        "@contentful/f36-icons": "^5.9.1",
+        "@contentful/f36-tokens": "^5.1.0",
+        "@contentful/f36-utils": "^5.2.0",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-button": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-5.9.1.tgz",
+      "integrity": "sha512-2UVwQY3yekL3V4TO2uP5adN/ArRKRMvq8iB8OptnqnFEZClI7jT5YFuu/99AS4nLTdRVISNi/Bf2g7m0PIotvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^5.9.1",
+        "@contentful/f36-spinner": "^5.9.1",
+        "@contentful/f36-tokens": "^5.1.0",
+        "@contentful/f36-tooltip": "^5.9.1",
+        "@contentful/f36-utils": "^5.2.0",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-card": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-5.9.1.tgz",
+      "integrity": "sha512-1r1k96l6rnHwJQc8yV6Ys67d1FrsE2785R2TTQCqdNGItrrF5aJylkNCVI+CLXgKI7EVCiNAQvbMd1iy4bUZQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-asset": "^5.9.1",
+        "@contentful/f36-badge": "^5.9.1",
+        "@contentful/f36-button": "^5.9.1",
+        "@contentful/f36-core": "^5.9.1",
+        "@contentful/f36-drag-handle": "^5.9.1",
+        "@contentful/f36-icon": "^5.9.1",
+        "@contentful/f36-icons": "^5.9.1",
+        "@contentful/f36-menu": "^5.9.1",
+        "@contentful/f36-skeleton": "^5.9.1",
+        "@contentful/f36-tokens": "^5.1.0",
+        "@contentful/f36-tooltip": "^5.9.1",
+        "@contentful/f36-typography": "^5.9.1",
+        "emotion": "^10.0.17",
+        "truncate": "^3.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-collapse": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-5.9.1.tgz",
+      "integrity": "sha512-9n66T8PZJnRVlJeItnznFtwlfnndGizqYgF8e+Ad6d+xTNP009f70nLALg1qncpxtxd488Xwbkune7j9WVlaEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^5.9.1",
+        "@contentful/f36-tokens": "^5.1.0",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-components": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-5.9.0.tgz",
+      "integrity": "sha512-PiRQla7eJjTKJiF81evoMYxZtd2K8nnjmpdBJF2H2woOBzZBr7XJ8QcZYbOHWDOuOPccImeItw2zeD4VQXqUkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-accordion": "^5.9.0",
+        "@contentful/f36-asset": "^5.9.0",
+        "@contentful/f36-autocomplete": "^5.9.0",
+        "@contentful/f36-avatar": "^5.9.0",
+        "@contentful/f36-badge": "^5.9.0",
+        "@contentful/f36-button": "^5.9.0",
+        "@contentful/f36-card": "^5.9.0",
+        "@contentful/f36-collapse": "^5.9.0",
+        "@contentful/f36-copybutton": "^5.9.0",
+        "@contentful/f36-core": "^5.9.0",
+        "@contentful/f36-datepicker": "^5.9.0",
+        "@contentful/f36-datetime": "^5.9.0",
+        "@contentful/f36-drag-handle": "^5.9.0",
+        "@contentful/f36-empty-state": "^5.9.0",
+        "@contentful/f36-entity-list": "^5.9.0",
+        "@contentful/f36-forms": "^5.9.0",
+        "@contentful/f36-header": "^5.9.0",
+        "@contentful/f36-icon": "^5.9.0",
+        "@contentful/f36-icons": "^5.9.0",
+        "@contentful/f36-image": "^5.9.0",
+        "@contentful/f36-layout": "^5.9.0",
+        "@contentful/f36-list": "^5.9.0",
+        "@contentful/f36-menu": "^5.9.0",
+        "@contentful/f36-modal": "^5.9.0",
+        "@contentful/f36-multiselect": "^5.9.0",
+        "@contentful/f36-navlist": "^5.9.0",
+        "@contentful/f36-note": "^5.9.0",
+        "@contentful/f36-notification": "^5.9.0",
+        "@contentful/f36-pagination": "^5.9.0",
+        "@contentful/f36-pill": "^5.9.0",
+        "@contentful/f36-popover": "^5.9.0",
+        "@contentful/f36-progress-stepper": "^5.9.0",
+        "@contentful/f36-skeleton": "^5.9.0",
+        "@contentful/f36-spinner": "^5.9.0",
+        "@contentful/f36-table": "^5.9.0",
+        "@contentful/f36-tabs": "^5.9.0",
+        "@contentful/f36-text-link": "^5.9.0",
+        "@contentful/f36-tokens": "^5.1.0",
+        "@contentful/f36-tooltip": "^5.9.0",
+        "@contentful/f36-typography": "^5.9.0",
+        "@contentful/f36-usage-card": "^5.9.0",
+        "@contentful/f36-usage-count": "^5.9.0",
+        "@contentful/f36-utils": "^5.2.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "@types/react-dom": ">=16.8",
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-copybutton": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-5.9.1.tgz",
+      "integrity": "sha512-pCeahvjcNuDXjUZx6qiKDfUqDmYnRUTZPKFUTlKSSAMsU2smjnxG5fZhVhEbYgBpwxn/Uj2VvkozkIedhEOjuw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^5.9.1",
+        "@contentful/f36-core": "^5.9.1",
+        "@contentful/f36-icons": "^5.9.1",
+        "@contentful/f36-tokens": "^5.1.0",
+        "@contentful/f36-tooltip": "^5.9.1",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-core": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-5.9.1.tgz",
+      "integrity": "sha512-egPXjZLcUwF+LJ7q8w/9zpMVNTWVIIEV5DEmn5nAgPd4+FLQjyWFbL8ubyOMk41F0ceCbB1cp5AILuA0xRIsvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-tokens": "^5.1.0",
+        "@emotion/core": "^10.1.1",
+        "@emotion/is-prop-valid": "^1.2.0",
+        "csstype": "^3.1.1",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-datepicker": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-5.9.1.tgz",
+      "integrity": "sha512-T4xmo3o6TBhmRV5oW7RXKOn/FpiZOgBEptpMsgcU+ICJ4taTZ87vFdNIkfQf2LibwQzhJhBNxPbEhZ1pZNoVIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^5.9.1",
+        "@contentful/f36-core": "^5.9.1",
+        "@contentful/f36-forms": "^5.9.1",
+        "@contentful/f36-icons": "^5.9.1",
+        "@contentful/f36-popover": "^5.9.1",
+        "@contentful/f36-tokens": "^5.1.0",
+        "@contentful/f36-typography": "^5.9.1",
+        "date-fns": "^2.28.0",
+        "emotion": "^10.0.17",
+        "react-day-picker": "^8.7.1",
+        "react-focus-lock": "^2.9.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-datetime": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-5.9.1.tgz",
+      "integrity": "sha512-WHwlTQLM21J2SskvVxJisJMql+WcqDSu939KUegRgHjhriEkEfgUA/KyjHyjfKxZFrC7MamBYnaSV2IKBuDPDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^5.9.1",
+        "@contentful/f36-tokens": "^5.1.0",
+        "dayjs": "^1.11.5",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-drag-handle": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-5.9.1.tgz",
+      "integrity": "sha512-h8jCcob5pPp5FK88wgrqN/91N2uSxEBSAMoaxePwsNS15k6G0TpNV4U9vtlRVBx1htEzj2R2BSBR7ANlQEKMRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^5.9.1",
+        "@contentful/f36-icons": "^5.9.1",
+        "@contentful/f36-tokens": "^5.1.0",
+        "@contentful/f36-utils": "^5.2.0",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-empty-state": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-5.9.1.tgz",
+      "integrity": "sha512-6T07mp9aWWxFFJHICNbqPpBFrf04t2rVAX/kFST1ibsab934ZvutpwOAlQvjl/L9emY3c2LSt6dSnjsyaqHttA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-tokens": "^5.1.0",
+        "@contentful/f36-typography": "^5.9.1",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-entity-list": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-5.9.1.tgz",
+      "integrity": "sha512-agdjTStNZVJNbNfD8MX/HkJ1K9Nh5qtccpO76eubfWUa8ZOTzSwdV2I3pBMgQ1/Zpxt09+1yqG28Mdn0b5QhWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-badge": "^5.9.1",
+        "@contentful/f36-button": "^5.9.1",
+        "@contentful/f36-core": "^5.9.1",
+        "@contentful/f36-drag-handle": "^5.9.1",
+        "@contentful/f36-icon": "^5.9.1",
+        "@contentful/f36-icons": "^5.9.1",
+        "@contentful/f36-menu": "^5.9.1",
+        "@contentful/f36-skeleton": "^5.9.1",
+        "@contentful/f36-tokens": "^5.1.0",
+        "@contentful/f36-typography": "^5.9.1",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-forms": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-5.9.1.tgz",
+      "integrity": "sha512-hQMNJobHj5CrMtdVbNuxuM/jgUuYDTYNADRVGCpxKesl0KLC3c9efKKNCm8djE4wnCK8zZhXtLBAD4LJRCiUaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^5.9.1",
+        "@contentful/f36-icons": "^5.9.1",
+        "@contentful/f36-tokens": "^5.1.0",
+        "@contentful/f36-typography": "^5.9.1",
+        "@contentful/f36-utils": "^5.2.0",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-header": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-header/-/f36-header-5.9.1.tgz",
+      "integrity": "sha512-A5v7UkRRtAny6NBqAx+QgD2jdvy7KD5GFe3UItjhhbX8D1LDo5TfECYZjiNHgn5guCZyKsejN99b2Tqc3n++hw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^5.9.1",
+        "@contentful/f36-core": "^5.9.1",
+        "@contentful/f36-icons": "^5.9.1",
+        "@contentful/f36-tokens": "^5.1.0",
+        "@contentful/f36-typography": "^5.9.1",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-icon": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-5.9.1.tgz",
+      "integrity": "sha512-58Pa0r5vpSX6jr6Lsvoc0ah82Hid6kvNFvu8+/vGDO//KgX7On0LjLUYiygLmyNG9FeKaJingxB8RUe2FEIR6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^5.9.1",
+        "@contentful/f36-tokens": "^5.1.0",
+        "@phosphor-icons/react": "2.1.8",
+        "emotion": "^10.0.17"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-icons": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-5.9.1.tgz",
+      "integrity": "sha512-bq2i5W8rA+jYPsdPQdBegrWqbZquYfYcNHF6VOuxZuUl9xn78FvaiWHxiaVDyjFk/3kQFSDjMLUdQI3sePJSUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^5.9.1",
+        "@contentful/f36-icon": "^5.9.1",
+        "@contentful/f36-tokens": "^5.1.0",
+        "@phosphor-icons/react": "2.1.8",
+        "emotion": "^10.0.17"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-image": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-image/-/f36-image-5.9.1.tgz",
+      "integrity": "sha512-azVK98nlMWF1ElwZ0tvmN82opXwHMN0BVFG5g6zlZzqCeH7zYzm6lC5Lck5J/+ZVNStJoJjRdA9l4Pj7U1fnvg==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^5.9.1",
+        "@contentful/f36-skeleton": "^5.9.1",
+        "@contentful/f36-tokens": "^5.1.0",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-layout": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-layout/-/f36-layout-5.9.1.tgz",
+      "integrity": "sha512-JSrogs8BcCHpf6RTS27aFOSId9K2aSLH47eq+qE6v0OJTeep7iwDEruJarw4C4xBPxIJoKY2LC3JytdATzY6eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^5.9.1",
+        "@contentful/f36-header": "^5.9.1",
+        "@contentful/f36-tokens": "^5.1.0",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-list": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-5.9.1.tgz",
+      "integrity": "sha512-AVXiUb83CmMuAI0lLR3hAg4cqTbNx1jaUPLVmJ8xiFX1wJjgu7KdQnOazrwH4wfU0lOztiMnGgH8NRqWX8D5OQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^5.9.1",
+        "@contentful/f36-tokens": "^5.1.0",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-menu": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-5.9.1.tgz",
+      "integrity": "sha512-Za7rFmaJ3wYVt5IH4ONDZloPm+F/vPat5qnarDSrT/Unp8hvvJbv7oLGF/yueQY5jimZ1OrfeldghIqeq1+bxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^5.9.1",
+        "@contentful/f36-icons": "^5.9.1",
+        "@contentful/f36-popover": "^5.9.1",
+        "@contentful/f36-tokens": "^5.1.0",
+        "@contentful/f36-typography": "^5.9.1",
+        "@contentful/f36-utils": "^5.2.0",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-modal": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-5.9.1.tgz",
+      "integrity": "sha512-nau1EWXo7fXOQb+vbFqLvOZJYVdzA73QYUzZhl4YjSMDBbBmSZ7eNQJY32GxiQ+8bV7n2ozLcylghUnoKZhWSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^5.9.1",
+        "@contentful/f36-core": "^5.9.1",
+        "@contentful/f36-icons": "^5.9.1",
+        "@contentful/f36-tokens": "^5.1.0",
+        "@contentful/f36-typography": "^5.9.1",
+        "@types/react-modal": "^3.13.1",
+        "emotion": "^10.0.17",
+        "react-modal": "^3.16.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-multiselect": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-multiselect/-/f36-multiselect-5.9.1.tgz",
+      "integrity": "sha512-JWDwZ81Qdwh1550iTNDkMDcaXFLxG9fPpMDq13Lf+a7SHp1Tp3yFLOUdviWURgjeMJSFo3LXeU5iX60sxmomYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.1",
+        "@contentful/f36-button": "^5.9.1",
+        "@contentful/f36-core": "^5.9.1",
+        "@contentful/f36-forms": "^5.9.1",
+        "@contentful/f36-icons": "^5.9.1",
+        "@contentful/f36-popover": "^5.9.1",
+        "@contentful/f36-skeleton": "^5.9.1",
+        "@contentful/f36-tokens": "^5.1.0",
+        "@contentful/f36-tooltip": "^5.9.1",
+        "@contentful/f36-typography": "^5.9.1",
+        "@contentful/f36-utils": "^5.2.0",
+        "emotion": "^10.0.17",
+        "react-focus-lock": "^2.9.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-navlist": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-navlist/-/f36-navlist-5.9.1.tgz",
+      "integrity": "sha512-nPcKopkpt3HaaXJ0NFf0tyrQEyob1+q+5XiIYIBoc2TasEJvjIZX9veLCp6f0Ab8kUlegIRnTsCW2WaQmCB8kA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^5.9.1",
+        "@contentful/f36-tokens": "^5.1.0",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-note": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-5.9.1.tgz",
+      "integrity": "sha512-T6xYZDOCj9rEeV2bpVYTyKA/IQJWhTk738JdtGrOoUCfVaTYRHQZ7Lwr7FDbhZeBX+hXoe3G5JXUsAOe9/WNng==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^5.9.1",
+        "@contentful/f36-core": "^5.9.1",
+        "@contentful/f36-icon": "^5.9.1",
+        "@contentful/f36-icons": "^5.9.1",
+        "@contentful/f36-tokens": "^5.1.0",
+        "@contentful/f36-typography": "^5.9.1",
+        "@contentful/f36-utils": "^5.2.0",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-notification": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-5.9.1.tgz",
+      "integrity": "sha512-iV7QV/8cTiOJZNjeSeqCSgigxymfU/ksq60/PeS3NZq4HcKq+T9zQguJJnJnCbQ/Cx5qSrugQ5SuUrIi6CqEBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^5.9.1",
+        "@contentful/f36-core": "^5.9.1",
+        "@contentful/f36-icons": "^5.9.1",
+        "@contentful/f36-text-link": "^5.9.1",
+        "@contentful/f36-tokens": "^5.1.0",
+        "@contentful/f36-typography": "^5.9.1",
+        "emotion": "^10.0.17",
+        "react-animate-height": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-pagination": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-5.9.1.tgz",
+      "integrity": "sha512-YoK8+jEGvfX+lKGxGGQjBucQ/5fRg6SbvY6ZGLELcxhYm1ZZAwI0mLkNXQ/++N8uDejAIdqx3sYHW5uhEoRaEw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^5.9.1",
+        "@contentful/f36-core": "^5.9.1",
+        "@contentful/f36-forms": "^5.9.1",
+        "@contentful/f36-icons": "^5.9.1",
+        "@contentful/f36-tokens": "^5.1.0",
+        "@contentful/f36-typography": "^5.9.1",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-pill": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-5.9.1.tgz",
+      "integrity": "sha512-+lkq35mWHTWSUdjRi9+psrdMaIYM0f80vtJzqCRVS5IE9C7oXTlX6NxsrHMQUMX1jfNGylJv6vATTUgo6XA93Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^5.9.1",
+        "@contentful/f36-core": "^5.9.1",
+        "@contentful/f36-drag-handle": "^5.9.1",
+        "@contentful/f36-icons": "^5.9.1",
+        "@contentful/f36-tokens": "^5.1.0",
+        "@contentful/f36-tooltip": "^5.9.1",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-popover": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-5.9.1.tgz",
+      "integrity": "sha512-gLJyS4u0Umst7QYtFZq/gLjZP0pkZ756KzvGlxfGsRgfHq75AxWdMMnyMuWvqq1J2JcJuYrw28JJRs0tFMfl/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^5.9.1",
+        "@contentful/f36-tokens": "^5.1.0",
+        "@contentful/f36-utils": "^5.2.0",
+        "@popperjs/core": "^2.11.5",
+        "emotion": "^10.0.17",
+        "react-popper": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-popover/node_modules/react-popper": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
+      "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-fast-compare": "^3.0.1",
+        "warning": "^4.0.2"
+      },
+      "peerDependencies": {
+        "@popperjs/core": "^2.0.0",
+        "react": "^16.8.0 || ^17 || ^18",
+        "react-dom": "^16.8.0 || ^17 || ^18"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-progress-stepper": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-progress-stepper/-/f36-progress-stepper-5.9.1.tgz",
+      "integrity": "sha512-UQkGFDfl17WY1UIkaWnKVTCKZjVk7Mx9rkkE3c5OJ4llihbHDRI9mxD+6i5OXA+U3iEMW2UsUgxy3ACeOnSsmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^5.9.1",
+        "@contentful/f36-core": "^5.9.1",
+        "@contentful/f36-icons": "^5.9.1",
+        "@contentful/f36-tokens": "^5.1.0",
+        "@contentful/f36-typography": "^5.9.1",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-skeleton": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-5.9.1.tgz",
+      "integrity": "sha512-/xucQq3ON7oymJbJaMLFPL/vwc4VjW29/JumRls6nAHM0jSK/1g0KjShqVVdy+YPxi4VocYujdBKd8IMqS4eXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^5.9.1",
+        "@contentful/f36-table": "^5.9.1",
+        "@contentful/f36-tokens": "^5.1.0",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-spinner": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-5.9.1.tgz",
+      "integrity": "sha512-or3wkkdSZA6ljXIFURiDl2I1YhFgp7ouWiCxJYYOl8brujYnVGhZlxz5G0MUHzFx7N6tz+4wqY3Ru52lneHt+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^5.9.1",
+        "@contentful/f36-tokens": "^5.1.0",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-table": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-5.9.1.tgz",
+      "integrity": "sha512-QE8BIsIZpq1ZK55wp2Qokkcjsu21hW4LECKzBrx+Es/7dxeXGZaqFuQ6jzP+MyGAs5Cu2pYegs/qys17cr/QUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^5.9.1",
+        "@contentful/f36-icons": "^5.9.1",
+        "@contentful/f36-tokens": "^5.1.0",
+        "@contentful/f36-typography": "^5.9.1",
+        "@contentful/f36-utils": "^5.2.0",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-tabs": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-5.9.1.tgz",
+      "integrity": "sha512-Smvn0s/IWKQBhqsIxU51mjouaWWx/jDY65LGusK2qhtHMA3n9yg7TMsBXgZpJnX1Y9UOJD6nalAC7be3smWQug==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^5.9.1",
+        "@contentful/f36-tokens": "^5.1.0",
+        "@radix-ui/react-tabs": "^1.0.1",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-text-link": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-5.9.1.tgz",
+      "integrity": "sha512-I9HYYHTiyFkhvFQlGc+bNvRXwzKKLsQW4RJJZ3SiXxIA44/NNMIVxD0xg3CEYt89+DWpjiiLwp5q5ZJpq1hZIw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^5.9.1",
+        "@contentful/f36-tokens": "^5.1.0",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-tooltip": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-5.9.1.tgz",
+      "integrity": "sha512-q8XbO/sOr3CCGQJt/xJfNBXtiDccYyNFleZJwGirxj9Z5GnvMTOdM5Rc+hjxi4mCYczcutQTybu8aFvVJFR+FA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^5.9.1",
+        "@contentful/f36-tokens": "^5.1.0",
+        "@contentful/f36-utils": "^5.2.0",
+        "@popperjs/core": "^2.11.5",
+        "csstype": "^3.1.1",
+        "emotion": "^10.0.17",
+        "react-popper": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-tooltip/node_modules/react-popper": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
+      "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-fast-compare": "^3.0.1",
+        "warning": "^4.0.2"
+      },
+      "peerDependencies": {
+        "@popperjs/core": "^2.0.0",
+        "react": "^16.8.0 || ^17 || ^18",
+        "react-dom": "^16.8.0 || ^17 || ^18"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-typography": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-5.9.1.tgz",
+      "integrity": "sha512-EB05+XuBuocSJtBpE/BvXL8wq91GKwL+Hu5OFcVmpggWS1OUU/CeuQGUMggj96LwMSRGlKNKrZ7iLLT8FZVvAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^5.9.1",
+        "@contentful/f36-tokens": "^5.1.0",
+        "@contentful/f36-utils": "^5.2.0",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-usage-card": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-usage-card/-/f36-usage-card-5.9.1.tgz",
+      "integrity": "sha512-tdHjX3J86dUaFs859P9xrab7XZJ2NFhp6DxSN7TD2ZJ5Fy0qY8X8jk4GT/7sCyeg+7ZzL8PB+FeRHDMXq3gAXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-card": "^5.9.1",
+        "@contentful/f36-core": "^5.9.1",
+        "@contentful/f36-icons": "^5.9.1",
+        "@contentful/f36-text-link": "^5.9.1",
+        "@contentful/f36-tokens": "^5.1.0",
+        "@contentful/f36-tooltip": "^5.9.1",
+        "@contentful/f36-typography": "^5.9.1",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-usage-count": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-usage-count/-/f36-usage-count-5.9.1.tgz",
+      "integrity": "sha512-vlhGgoyiUtxLE48tAh+m/8Wv4YpBDUHh8nCAR2FgPkU/dR+BCYO6e/i2BFXXTax4dZDhIo+A9N/1FBJ+mmsngw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^5.9.1",
+        "@contentful/f36-tokens": "^5.1.0",
+        "@contentful/f36-typography": "^5.9.1",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/@contentful/f36-utils": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-utils/-/f36-utils-5.2.0.tgz",
+      "integrity": "sha512-0YWsKAdU2HeNz5DwuOCR0lnlHVhlXiDkqtYaH8hHqT9HlQKHDSBPQUI9Vk5OrPDRJ3uLVoyGOJcvUDf27tTopA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-tokens": "^5.1.0",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/compute-scroll-into-view": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.20.tgz",
+      "integrity": "sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/downshift": {
+      "version": "6.1.12",
+      "resolved": "https://registry.npmjs.org/downshift/-/downshift-6.1.12.tgz",
+      "integrity": "sha512-7XB/iaSJVS4T8wGFT3WRXmSF1UlBHAA40DshZtkrIscIN+VC+Lh363skLxFTvJwtNgHxAMDGEHT4xsyQFWL+UA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.14.8",
+        "compute-scroll-into-view": "^1.0.17",
+        "prop-types": "^15.7.2",
+        "react-is": "^17.0.2",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.12.0"
+      }
+    },
+    "node_modules/@contentful/dam-app-base/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-accordion": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-6.15.0.tgz",
+      "integrity": "sha512-QsnuyFT9wxJBVdlo1VZ6/C/c11yrgbF1NdU4zomI0D/NBXD8nQ2cw3jYNDHHQlt3RjZW6/KFAPcA1pUYAOktLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-collapse": "^6.15.0",
+        "@contentful/f36-core": "^6.15.0",
+        "@contentful/f36-icons": "^6.15.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.15.0",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-accordion/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-asset": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-6.15.0.tgz",
+      "integrity": "sha512-dQo2Q46B0o/EoXN42pqUuuqQGvkppotBAiBTycGdRqaTDHukQm42Hs5oIIQ9teIfivrc005udKN0D9AjDkOk0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.15.0",
+        "@contentful/f36-icon": "^6.15.0",
+        "@contentful/f36-icons": "^6.15.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.15.0",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-asset/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-autocomplete": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-6.15.0.tgz",
+      "integrity": "sha512-LV4hAIG6w43n5+aiOA1JMfPd/eEyXdp2u+yW3H7KFYR8TWKpwbxGFPiUPh+DDpVuhGwjPh5WH6wbhXYyNodfQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^6.15.0",
+        "@contentful/f36-core": "^6.15.0",
+        "@contentful/f36-forms": "^6.15.0",
+        "@contentful/f36-icons": "^6.15.0",
+        "@contentful/f36-popover": "^6.15.0",
+        "@contentful/f36-skeleton": "^6.15.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.15.0",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5",
+        "downshift": "^9.0.10"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-autocomplete/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-avatar": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-avatar/-/f36-avatar-6.15.0.tgz",
+      "integrity": "sha512-d9VPNbzVzwKrkhWi2Dyk1q1OU/4TXPMGR8s/iSgZVadmKdCLFoUr855SJX1Qxk0GfMYM2/EluKcY95z+uURp5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.15.0",
+        "@contentful/f36-image": "^6.15.0",
+        "@contentful/f36-menu": "^6.15.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-tooltip": "^6.15.0",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-avatar/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-badge": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-6.15.0.tgz",
+      "integrity": "sha512-inhffiXLFSfOMD/DC0iAUTju7BX8N+62duI9b/ei83dRyD9LIMMOp22N6Vu4b6I8E33W4BzbUqZkecb7WHXfzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.15.0",
+        "@contentful/f36-icons": "^6.15.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-badge/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-button": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-6.15.0.tgz",
+      "integrity": "sha512-ic1hnypr36FAYpFkFE5EXZ2GRJ1mS7QzSKWqmVzr+GckVqtuEJ5tx/TyWtUVLYMYWsOlCtL0KL5CzE9bH7V7aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.15.0",
+        "@contentful/f36-spinner": "^6.15.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-tooltip": "^6.15.0",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-button/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-card": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-6.15.0.tgz",
+      "integrity": "sha512-8FpViNEhkwdmQ2+QK7dVXvvxyu6dgGHRUpU6nhqK2UxMoLSnzbZNGHsCclRtMDX/b+cz42AL/AxiVrJaFV+DCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-asset": "^6.15.0",
+        "@contentful/f36-badge": "^6.15.0",
+        "@contentful/f36-button": "^6.15.0",
+        "@contentful/f36-core": "^6.15.0",
+        "@contentful/f36-drag-handle": "^6.15.0",
+        "@contentful/f36-icon": "^6.15.0",
+        "@contentful/f36-icons": "^6.15.0",
+        "@contentful/f36-menu": "^6.15.0",
+        "@contentful/f36-skeleton": "^6.15.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-tooltip": "^6.15.0",
+        "@contentful/f36-typography": "^6.15.0",
+        "@emotion/css": "^11.13.5",
+        "truncate": "^3.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-card/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-collapse": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-6.15.0.tgz",
+      "integrity": "sha512-xypTu+DPStBUDZVb4GHxsHBbCJ9WeJI1V94GJIixvl0aMzOxlG9JP5ESrZmQBaHbTWgNy5C0M59ncjg0/KLrhA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.15.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-collapse/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-components": {
+      "version": "6.7.4",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-6.7.4.tgz",
+      "integrity": "sha512-QGR3Fq6T9xD7sSRoHTEg6W4Hlzv+nhMRfAjsKYoA0WTZYSwNUBzjmFbOuFb3yNaCjsntQVHeafxLAmMfp5lNcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-accordion": "^6.7.4",
+        "@contentful/f36-asset": "^6.7.4",
+        "@contentful/f36-autocomplete": "^6.7.4",
+        "@contentful/f36-avatar": "^6.7.4",
+        "@contentful/f36-badge": "^6.7.4",
+        "@contentful/f36-button": "^6.7.4",
+        "@contentful/f36-card": "^6.7.4",
+        "@contentful/f36-collapse": "^6.7.4",
+        "@contentful/f36-copybutton": "^6.7.4",
+        "@contentful/f36-core": "^6.7.4",
+        "@contentful/f36-datepicker": "^6.7.4",
+        "@contentful/f36-datetime": "^6.7.4",
+        "@contentful/f36-drag-handle": "^6.7.4",
+        "@contentful/f36-empty-state": "^6.7.4",
+        "@contentful/f36-entity-list": "^6.7.4",
+        "@contentful/f36-forms": "^6.7.4",
+        "@contentful/f36-header": "^6.7.4",
+        "@contentful/f36-icon": "^6.7.4",
+        "@contentful/f36-icons": "^6.7.4",
+        "@contentful/f36-image": "^6.7.4",
+        "@contentful/f36-layout": "^6.7.4",
+        "@contentful/f36-list": "^6.7.4",
+        "@contentful/f36-menu": "^6.7.4",
+        "@contentful/f36-modal": "^6.7.4",
+        "@contentful/f36-multiselect": "^6.7.4",
+        "@contentful/f36-navlist": "^6.7.4",
+        "@contentful/f36-note": "^6.7.4",
+        "@contentful/f36-notification": "^6.7.4",
+        "@contentful/f36-pagination": "^6.7.4",
+        "@contentful/f36-pill": "^6.7.4",
+        "@contentful/f36-popover": "^6.7.4",
+        "@contentful/f36-progress-stepper": "^6.7.4",
+        "@contentful/f36-skeleton": "^6.7.4",
+        "@contentful/f36-spinner": "^6.7.4",
+        "@contentful/f36-table": "^6.7.4",
+        "@contentful/f36-tabs": "^6.7.4",
+        "@contentful/f36-text-link": "^6.7.4",
+        "@contentful/f36-tokens": "^6.1.0",
+        "@contentful/f36-tooltip": "^6.7.4",
+        "@contentful/f36-typography": "^6.7.4",
+        "@contentful/f36-usage-card": "^6.7.4",
+        "@contentful/f36-usage-count": "^6.7.4",
+        "@contentful/f36-utils": "^6.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.3.0 || >=19.1.0",
+        "@types/react-dom": "^18.3.0 || >=19.1.0",
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-copybutton": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-6.15.0.tgz",
+      "integrity": "sha512-jl+6HZQseZuztssDM0wfUxy0NHeRv0Pra6i7vPCrS+jerMsGx5P1CJf9t1FWj5rEgi3R7kV16FdH1CxRFYFlMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^6.15.0",
+        "@contentful/f36-core": "^6.15.0",
+        "@contentful/f36-icons": "^6.15.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-tooltip": "^6.15.0",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-copybutton/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-core": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-6.15.0.tgz",
+      "integrity": "sha512-DM9ab+wD+iOD0GtSaCCsO53rziGwolnIWyTyDuFdeM4KnqtfX4w3W+kyCYePQkLPmz0UN9hn/cvdDDEiSUuLXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5",
+        "@emotion/react": "^11.14.0",
+        "csstype": "^3.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-core/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-datepicker": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-6.15.0.tgz",
+      "integrity": "sha512-EE1iGyeGY/k5kslyHB/jSizjRey+fKxDSK08xSVSE8w73mEIEePNYZzauI6S698jd5G0jYIfr9Q9HYWDg2pGbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^6.15.0",
+        "@contentful/f36-core": "^6.15.0",
+        "@contentful/f36-forms": "^6.15.0",
+        "@contentful/f36-icons": "^6.15.0",
+        "@contentful/f36-popover": "^6.15.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.15.0",
+        "@emotion/css": "^11.13.5",
+        "date-fns": "^2.28.0",
+        "react-day-picker": "^8.7.1",
+        "react-focus-lock": "^2.9.1"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-datepicker/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-datetime": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-6.15.0.tgz",
+      "integrity": "sha512-siD8rKVjY4svvQCUavh8Zf7zmlp/haShe8/aJ8m+J8FjiTwxqmd0TIU/nHj7bvZ0lJo/+am8NtlHlFKyEhznbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.15.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5",
+        "dayjs": "^1.11.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-datetime/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-drag-handle": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-6.15.0.tgz",
+      "integrity": "sha512-w2hqx1xtfNOyA+DEjGZIIV2w7VVXCJSBeXyEUGAeF7NSMMjEIJMtxP7zPAhxxVUv6jinzMHrNopDDjHRmgD2EA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.15.0",
+        "@contentful/f36-icons": "^6.15.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-drag-handle/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-empty-state": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-6.15.0.tgz",
+      "integrity": "sha512-s7n6Bj8sLjr2bqexE2jfylbQAnOALsdg9nxqihZe7bdOT1nWDXRChtH2sCeMZfzHfNGRhv7Nl8WQVdTN15+fWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.15.0",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-empty-state/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-entity-list": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-6.15.0.tgz",
+      "integrity": "sha512-tYtr6W44fV+6sCBotTpKTOp+f1EjMiyRky7mvXcb8tNOs82VxL5xn2ZyM/noxLh3aEmZE9agHm85WyyxmwKUVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-badge": "^6.15.0",
+        "@contentful/f36-button": "^6.15.0",
+        "@contentful/f36-core": "^6.15.0",
+        "@contentful/f36-drag-handle": "^6.15.0",
+        "@contentful/f36-icon": "^6.15.0",
+        "@contentful/f36-icons": "^6.15.0",
+        "@contentful/f36-menu": "^6.15.0",
+        "@contentful/f36-skeleton": "^6.15.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.15.0",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-entity-list/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-forms": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-6.15.0.tgz",
+      "integrity": "sha512-nGZoYPYYxMepE3qqKQjjxWuyQjuszhgTTE+iUi4yO6rMmMPI6BX3TeFCrSh9rKV+/Ow4EcDxmyvh9tXKBtdXpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.15.0",
+        "@contentful/f36-icon": "^6.15.0",
+        "@contentful/f36-icons": "^6.15.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.15.0",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-forms/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-header": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-header/-/f36-header-6.15.0.tgz",
+      "integrity": "sha512-GSwlmwUcK368RyK4Qa7CCNvtoTTJRtgPlO7epEtEE+n4WtBxgD/TnszeEvzRywNeMK7E2qniHo5PxCygdAt6Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^6.15.0",
+        "@contentful/f36-core": "^6.15.0",
+        "@contentful/f36-icons": "^6.15.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.15.0",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-header/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-icon": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-6.15.0.tgz",
+      "integrity": "sha512-Hb5c00KR5mKSWr8cMy2zE+SJItOWfnBMNTxWoXplrzlBXgBNTTZpcBsSQe4rTL7ox2nEAbsdgiBk9zRlTBE/NQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.15.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5",
+        "@phosphor-icons/react": "2.1.8"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-icon/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-icons": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-6.15.0.tgz",
+      "integrity": "sha512-zjmXjpJJ6FGQaAX8wI3dwISn6n2Uklo+cgByX/CWYBqQfe5pK3mleNgct9YIZWXTeWDcHxTov4UaFK5ynb3dHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.15.0",
+        "@contentful/f36-icon": "^6.15.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5",
+        "@phosphor-icons/react": "2.1.8"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-icons/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-image": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-image/-/f36-image-6.15.0.tgz",
+      "integrity": "sha512-K37oFGoenKke+SYM58+EkeQ32CVxu//BZLKeidONQl5BlmZ482Pnt7Nmp2U5n8KpDpbLZ3kDrlS1WosJXa+Bbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.15.0",
+        "@contentful/f36-skeleton": "^6.15.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-image/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-layout": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-layout/-/f36-layout-6.15.0.tgz",
+      "integrity": "sha512-LoiQaalRiDkIzyxwPZHG03rTxUhEd6M8YqP2/pfGvsAlleiC5RBzR3k8GEawd6X3fnjn18bW/QTkvI86PfYs8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^6.15.0",
+        "@contentful/f36-core": "^6.15.0",
+        "@contentful/f36-header": "^6.15.0",
+        "@contentful/f36-icons": "^6.15.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.15.0",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-layout/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-list": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-6.15.0.tgz",
+      "integrity": "sha512-4SMlV74pFueuKS7lTc0h+Jfj1gqszyboALvZNh3d3gdbo5GnBvHgOZEYI1zdxb9qWUznSdbSbg38NCMaFbmQeA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.15.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-list/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-menu": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-6.15.0.tgz",
+      "integrity": "sha512-9T41lOsKJtnKUVpBoMLJkXrquHHKd8g4H5i7Ul2J0QKNhV9L7kDzCFBAIoubF1AFrAjdZPAi2ZyGE/6EQ4lC0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.15.0",
+        "@contentful/f36-icons": "^6.15.0",
+        "@contentful/f36-popover": "^6.15.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.15.0",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5",
+        "@floating-ui/dom": "^1.7.4",
+        "@floating-ui/react": "^0.27.16"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-menu/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-modal": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-6.15.0.tgz",
+      "integrity": "sha512-tW2pjn4fztH3+gXBaYaz6JXUELZlP7VWtUk90idg/ookunSKS/V4tl0g4W137O6JQZvKhkDkEqtGG/cHHFd1HA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^6.15.0",
+        "@contentful/f36-core": "^6.15.0",
+        "@contentful/f36-icons": "^6.15.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.15.0",
+        "@emotion/css": "^11.13.5",
+        "@types/react-modal": "^3.16.3",
+        "react-modal": "^3.16.3"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-modal/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-multiselect": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-multiselect/-/f36-multiselect-6.15.0.tgz",
+      "integrity": "sha512-FCGXabkKgskVFEnqWde3VS1XxmPQQ3E9CzNgRCPa7fYsdIL4vu6GWduNF0R4742Pf+Qdzu6KkL8dAMoGg1xgvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.1",
+        "@contentful/f36-button": "^6.15.0",
+        "@contentful/f36-core": "^6.15.0",
+        "@contentful/f36-forms": "^6.15.0",
+        "@contentful/f36-icons": "^6.15.0",
+        "@contentful/f36-popover": "^6.15.0",
+        "@contentful/f36-skeleton": "^6.15.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-tooltip": "^6.15.0",
+        "@contentful/f36-typography": "^6.15.0",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-multiselect/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-navlist": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-navlist/-/f36-navlist-6.15.0.tgz",
+      "integrity": "sha512-lJI2RxFTIofJlJ85McZHd0tZ3TfkXoKQh+3NhKbLgCaQPIMpJ8uYFJp5icIxMTYBJqRdEodMyBsPcM70LmFceQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.15.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-navlist/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-note": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-6.15.0.tgz",
+      "integrity": "sha512-0JABmcHjp7JVfrG6pSCd8SVw4XmW3WqfOuT9To53iVE3m/SUv3T8XtWtI0h7mhc3kGxsxwN1TuPyHjmqA3SP5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^6.15.0",
+        "@contentful/f36-core": "^6.15.0",
+        "@contentful/f36-icon": "^6.15.0",
+        "@contentful/f36-icons": "^6.15.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.15.0",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-note/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-notification": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-6.15.0.tgz",
+      "integrity": "sha512-+J1aqyX2RCcXKmAUD6F/HHK5IM4tmvxtUBld+cj7RUYyiLF3C6NMmrQayagn38JqfOF8tY6w5HRL9zbOirj/FA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^6.15.0",
+        "@contentful/f36-core": "^6.15.0",
+        "@contentful/f36-icons": "^6.15.0",
+        "@contentful/f36-text-link": "^6.15.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.15.0",
+        "@emotion/css": "^11.13.5",
+        "react-animate-height": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-notification/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-pagination": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-6.15.0.tgz",
+      "integrity": "sha512-Mh0AXru9KdhNaEeC2tV+64QGDMcwCZ+F/GifoHD+nT6JqEMfHCkpuaYgPC3cOf0Bf9Mdxhk/v66eWXH4Q/668A==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^6.15.0",
+        "@contentful/f36-core": "^6.15.0",
+        "@contentful/f36-forms": "^6.15.0",
+        "@contentful/f36-icons": "^6.15.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.15.0",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-pagination/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-pill": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-6.15.0.tgz",
+      "integrity": "sha512-EiofA9jPco2yc7dJzqzN5O0H8pbG66kCxJDlc46W/udXdgdL3AVMo4UKAVrw1tA9azpQcuoQldigCmfz7mjqIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^6.15.0",
+        "@contentful/f36-core": "^6.15.0",
+        "@contentful/f36-drag-handle": "^6.15.0",
+        "@contentful/f36-icons": "^6.15.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-tooltip": "^6.15.0",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-pill/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-popover": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-6.15.0.tgz",
+      "integrity": "sha512-qE4CwII9+ueZwZWohBVB0KaWBZNQQd9xbYb263Dl9ZZfM6JMRmfOWQSxR11NjbLWgduo6rnyP+r8nVwP6XU4uw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.15.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5",
+        "@floating-ui/dom": "^1.7.4",
+        "@floating-ui/react": "^0.27.16"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-popover/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-progress-stepper": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-progress-stepper/-/f36-progress-stepper-6.15.0.tgz",
+      "integrity": "sha512-HG+dDLvxsgQftwjAcKgU2N2fQqKUAhC4Ql3VlYOdG5KCoHzLvhlzXBpWmaaGCTY4OfHss0SiK7Qtt3iaGCODPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-button": "^6.15.0",
+        "@contentful/f36-core": "^6.15.0",
+        "@contentful/f36-icons": "^6.15.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.15.0",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-progress-stepper/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-skeleton": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-6.15.0.tgz",
+      "integrity": "sha512-7ElzLiDH+fIlIMnFY/iH5dwJtFrU8z0u9doTuqh2+8l0ioja2/mytkg25juyN7gzEuWxdEYeahCBxMJ2urA28Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.15.0",
+        "@contentful/f36-table": "^6.15.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-skeleton/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-spinner": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-6.15.0.tgz",
+      "integrity": "sha512-QN2RUrrFS8lFfKkF+4DDT3MquNyftmWOOn/4DGoHrdn6egxiemr35OcjuZVFyEeCdVtA/zJqq24xHjodLZ0k4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.15.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-spinner/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-table": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-6.15.0.tgz",
+      "integrity": "sha512-VoqQHbCkKnQwXXrWWu3MKidi2tVLDhHjlbXn4khiAPr2s19vXUvZmh5V4Emz556E1BRubO1JmZb7XytBI1/SbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.15.0",
+        "@contentful/f36-icons": "^6.15.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.15.0",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-table/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-tabs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-6.15.0.tgz",
+      "integrity": "sha512-ahsxbAMN6AQAsfrNBv9pzWO2mWFTXTmhDKGYaNphI2TY+w8GUf/G4t1avACPm/ABgpOclYiK9kNda7ZA8BzFLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.15.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5",
+        "@radix-ui/react-tabs": "^1.1.12"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-tabs/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-text-link": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-6.15.0.tgz",
+      "integrity": "sha512-gG5o5MXpsoO8jh34kmcU2EYyK98AMFjrouSBYVwWaUNghSlYm8Lo8OsRXYHGQ0nOPwJxJLPEZ8xsxIsbrEKabg==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.15.0",
+        "@contentful/f36-icons": "^6.15.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-text-link/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-tokens": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-5.1.0.tgz",
+      "integrity": "sha512-7++MPQiizK6qLhPkilWIKqM5Mhdr199tK7dL4iZ689iTwA82uvXXOojJr+0wVOurG2Odb+6/3WLe1XdveDZHEA==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-tooltip": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-6.15.0.tgz",
+      "integrity": "sha512-LloPJ+95WatStqw4PeEt03IewzZ0/mNCJL4Z+JNzaqSZFTkDKT1SEEHOu0UsHArquR9t/KHjCMzoBpN0m8a5TA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.15.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5",
+        "@floating-ui/dom": "^1.7.4",
+        "@floating-ui/react": "^0.27.16"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-tooltip/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-typography": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-6.15.0.tgz",
+      "integrity": "sha512-TUMkac6IGPGGjvmrFPMH1QoaNPJwXC/7zuj21fVix+T7HQc/bCY/XgoCS7EuqjMRTTge6iqO40ig4xRJMLucig==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.15.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-utils": "^6.1.2",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-typography/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-usage-card": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-usage-card/-/f36-usage-card-6.15.0.tgz",
+      "integrity": "sha512-8f+Dk4iqmAt3mf4E+R9h3LczQdIWFsp+DFCM1tg7KYnfVV98kR9XRD7P9WhE9X+d+rjqWW2QjQel1+Atste7Tw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-card": "^6.15.0",
+        "@contentful/f36-core": "^6.15.0",
+        "@contentful/f36-icons": "^6.15.0",
+        "@contentful/f36-text-link": "^6.15.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-tooltip": "^6.15.0",
+        "@contentful/f36-typography": "^6.15.0",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-usage-card/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-usage-count": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-usage-count/-/f36-usage-count-6.15.0.tgz",
+      "integrity": "sha512-TgnABMp9WEH/y2+xcrQRiv7m+0CgCnNH3kL1REHTZSdpV2LW7COM9Y9w4KAFXDCI+kgU1ZrVkPUett8WEzVqsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-core": "^6.15.0",
+        "@contentful/f36-tokens": "^6.1.3",
+        "@contentful/f36-typography": "^6.15.0",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-usage-count/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/f36-utils": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-utils/-/f36-utils-6.1.2.tgz",
+      "integrity": "sha512-gaG+q5NHVEfDzCEGoK12/+8Y1VODPO8k/DyrZjCIOTxTK9rXZ5l1xESMbnMAbwHnz2zXoLkkzI0QGCChW6xrpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/f36-tokens": "^6.1.2",
+        "@emotion/css": "^11.13.5"
+      },
+      "peerDependencies": {
+        "react": "^18.3.0 || >=19.1.0",
+        "react-dom": "^18.3.0 || >=19.1.0"
+      }
+    },
+    "node_modules/@contentful/f36-utils/node_modules/@contentful/f36-tokens": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-6.2.1.tgz",
+      "integrity": "sha512-Tp/tCDcZNINPSY8gNQIOS9dSBRREQB+O7cbfVvARNMpHMUplgsxFBIAIOJixOAz+Yyv22dA6GYOHPco8ofV33g==",
+      "license": "MIT"
+    },
+    "node_modules/@contentful/rich-text-types": {
+      "version": "16.8.5",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.8.5.tgz",
+      "integrity": "sha512-q18RJuJCOuYveGiCIjE5xLCQc5lZ3L2Qgxrlg/H2YEobDFqdtmklazRi1XwEWaK3tMg6yVXBzKKkQfLB4qW14A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-8.0.0.tgz",
+      "integrity": "sha512-U3jk5ebVXe1Lr7c2wU7SBZjcWdQP+j7peHJfCspnA81enlu88Mgd7CC8Q+pub9ubP7eKVETzJW+IBAhsqbSu/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.1.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+      "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/serialize": "^1.3.3",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/cache": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/core": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.3.1.tgz",
+      "integrity": "sha512-447aUEjPIm0MnE6QYIaFz9VQOHSXf4Iu6EWOIqq11EAPqinkSZmfymPTmlOE3QjLv846lH4JVZBUOtwGbuQoww==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "@emotion/cache": "^10.0.27",
+        "@emotion/css": "^10.0.27",
+        "@emotion/serialize": "^0.11.15",
+        "@emotion/sheet": "0.9.4",
+        "@emotion/utils": "0.11.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0"
+      }
+    },
+    "node_modules/@emotion/core/node_modules/@emotion/cache": {
+      "version": "10.0.29",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
+      "integrity": "sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/sheet": "0.9.4",
+        "@emotion/stylis": "0.8.5",
+        "@emotion/utils": "0.11.3",
+        "@emotion/weak-memoize": "0.2.5"
+      }
+    },
+    "node_modules/@emotion/core/node_modules/@emotion/css": {
+      "version": "10.0.27",
+      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-10.0.27.tgz",
+      "integrity": "sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/serialize": "^0.11.15",
+        "@emotion/utils": "0.11.3",
+        "babel-plugin-emotion": "^10.0.27"
+      }
+    },
+    "node_modules/@emotion/core/node_modules/@emotion/hash": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/core/node_modules/@emotion/memoize": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/core/node_modules/@emotion/serialize": {
+      "version": "0.11.16",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.16.tgz",
+      "integrity": "sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "0.8.0",
+        "@emotion/memoize": "0.7.4",
+        "@emotion/unitless": "0.7.5",
+        "@emotion/utils": "0.11.3",
+        "csstype": "^2.5.7"
+      }
+    },
+    "node_modules/@emotion/core/node_modules/@emotion/sheet": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.4.tgz",
+      "integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/core/node_modules/@emotion/unitless": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/core/node_modules/@emotion/utils": {
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
+      "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/core/node_modules/@emotion/weak-memoize": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
+      "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/core/node_modules/csstype": {
+      "version": "2.6.21",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
+      "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/css": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.13.5.tgz",
+      "integrity": "sha512-wQdD0Xhkn3Qy2VNcIzbLP9MR8TafI0MJb7BEAXKp+w4+XqErksWR4OXomuDzPsN4InLdGhVe6EYcn2ZIUCpB8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.13.5",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2"
+      }
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
+      "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/react": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
+      "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "hoist-non-react-statics": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/serialize": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/sheet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/stylis": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
+      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
+      "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emotion/utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/weak-memoize": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
+      "license": "MIT"
+    },
+    "node_modules/@esbuild-plugins/node-globals-polyfill": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-globals-polyfill/-/node-globals-polyfill-0.2.3.tgz",
+      "integrity": "sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "esbuild": "*"
+      }
+    },
+    "node_modules/@esbuild-plugins/node-modules-polyfill": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-modules-polyfill/-/node-modules-polyfill-0.2.2.tgz",
+      "integrity": "sha512-LXV7QsWJxRuMYvKbiznh+U1ilIop3g2TeKRzUxOG5X3YITc8JyyTa90BmLwqqv0YnX4v32CSlG+vsziZp9dMvA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "rollup-plugin-node-polyfills": "^0.2.1"
+      },
+      "peerDependencies": {
+        "esbuild": "*"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.8.0",
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.20",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.20.tgz",
+      "integrity": "sha512-CMqMy7OaXl9W0eq1Uy7L7i2Y/anPvHmFmESd2CEw0t5YvZhcVCeo4MBevAmswRllX7Y2dEidA4ozGPunLSTQpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.9",
+        "@floating-ui/utils": "^0.2.12",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+      "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.8.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
+      "license": "MIT"
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+      "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@lukeed/csprng": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
+      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@lukeed/uuid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@lukeed/uuid/-/uuid-2.0.1.tgz",
+      "integrity": "sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/csprng": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@phosphor-icons/react": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@phosphor-icons/react/-/react-2.1.8.tgz",
+      "integrity": "sha512-RxJlAkErO+t50DsY82ga9RGOULK6Jux0MdmXqvDjtOzG3PYQFz6rjdUU2q06lPMMbJTT+d+qurKYmF7i2Uv74A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8",
+        "react-dom": ">= 16.8"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.6.tgz",
+      "integrity": "sha512-w9hl+724uYEgCGR3bhuRepjBtrNB/6gkhCnAf58Ke+SLbHPPQqVZZB59z60roB+5H+nh3nWTcdJhQdFMEydWmw==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.12.tgz",
+      "integrity": "sha512-nb67INpE0IahJKN7EYPp9m9YGwYeKlnzxT3MwXVkgCskaSJia97kG4T0ywpjNUSSnoJk/uvk12V8vbrEHEj+/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-slot": "1.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.0.tgz",
+      "integrity": "sha512-fOE+JtN9rygNZkCnHRBEP0TAvLldlhyOxMsbwFvTP4nAs+nBmfnna+o/Zski2wkmY1YMrFC0aSzsHoLY47iLrg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.2.tgz",
+      "integrity": "sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz",
+      "integrity": "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.8.tgz",
+      "integrity": "sha512-0hhyrQdXMaATgq4ammLG9+iPqsXxzZkgTSIxdrJHdfLnXO4Uo5L7BoO3/Xf0AEaettadGZWGGJMw6ujzQvIpGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.7.tgz",
+      "integrity": "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.16.tgz",
+      "integrity": "sha512-w7lLsTSd3940vFYEshKkHw+NGf7H0QDJPHYsy8NRjDCVbO6ZdKW1X/xoJSYHZtttnrdZiYqbN2O/2uHGB0zasw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.6",
+        "@radix-ui/react-collection": "1.1.12",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-controllable-state": "1.2.4",
+        "@radix-ui/react-use-is-hydrated": "0.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.0.tgz",
+      "integrity": "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.18.tgz",
+      "integrity": "sha512-1zq2XkQkK/KfbZn84edytYpOLquhNalra5LXc3NAMKhNRSGtyXqjMv6OyC9jlSuNKpqvQtsb57WKoICNk1v/sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.6",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-presence": "1.1.8",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-roving-focus": "1.1.16",
+        "@radix-ui/react-use-controllable-state": "1.2.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz",
+      "integrity": "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.4.tgz",
+      "integrity": "sha512-cx2DixxmSfjCcEoRvDvy1NLd6SWK94XFcEEOZUcharUlXbmahFQGKCfwdKZL2ub34iIwOPOEFVF80xb+yfLYiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.6",
+        "@radix-ui/react-use-effect-event": "0.0.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
+      "integrity": "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-is-hydrated": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.1.tgz",
+      "integrity": "sha512-qwOiz4Tjo8CNnrOLAYUMXeZwDzXgXpvK4TKQPmWLECM9XoWvA6+0Z2/7Ag3A4ivjS4ovbLJPbskkxioFyBhr8A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@segment/analytics-core": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-core/-/analytics-core-1.8.3.tgz",
+      "integrity": "sha512-63X8e2DWb2ZnJ9S3H8iSOFnbeDXMkTGhA8kZG4eFAO07QBwBVyWo5BCpv6vmuOMEkv2le6t2FMg1p6ZeJQA/4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/uuid": "^2.0.0",
+        "@segment/analytics-generic-utils": "1.2.0",
+        "dset": "^3.1.4",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@segment/analytics-generic-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-generic-utils/-/analytics-generic-utils-1.2.0.tgz",
+      "integrity": "sha512-DfnW6mW3YQOLlDQQdR89k4EqfHb0g/3XvBXkovH1FstUN93eL1kfW9CsDcVQyH3bAC5ZsFyjA/o/1Q2j0QeoWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@segment/analytics-node": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-node/-/analytics-node-3.1.0.tgz",
+      "integrity": "sha512-F3pJmzUxmWZFV2wxJfuGvjLViCrQBFpxLLp4++fkoDsohWwS89T7n0M5nW1zxeYc2X2rA/v7q5ou3JZIw9bl3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/uuid": "^2.0.0",
+        "@segment/analytics-core": "1.8.3",
+        "@segment/analytics-generic-utils": "1.2.0",
+        "buffer": "^6.0.3",
+        "jose": "^5.1.0",
+        "tslib": "^2.4.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-modal": {
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/@types/react-modal/-/react-modal-3.16.3.tgz",
+      "integrity": "sha512-xXuGavyEGaFQDgBv4UVm8/ZsG+qxeQ7f77yNrW3n+1J6XAstUy5rYHeIHPh1KzsGc6IkCIdu6lQ2xWzu1jBTLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.3.tgz",
+      "integrity": "sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/babel-plugin-emotion": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.2.2.tgz",
+      "integrity": "sha512-SMSkGoqTbTyUTDeuVuPIWifPdUGkTk1Kf9BWRiXIOIcuyMfsdp2EjeiiFvOzX8NOBvEh/ypKYvUh2rkgAJMCLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@emotion/hash": "0.8.0",
+        "@emotion/memoize": "0.7.4",
+        "@emotion/serialize": "^0.11.16",
+        "babel-plugin-macros": "^2.0.0",
+        "babel-plugin-syntax-jsx": "^6.18.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^1.0.5",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7"
+      }
+    },
+    "node_modules/babel-plugin-emotion/node_modules/@emotion/hash": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==",
+      "license": "MIT"
+    },
+    "node_modules/babel-plugin-emotion/node_modules/@emotion/memoize": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+      "license": "MIT"
+    },
+    "node_modules/babel-plugin-emotion/node_modules/@emotion/serialize": {
+      "version": "0.11.16",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.16.tgz",
+      "integrity": "sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "0.8.0",
+        "@emotion/memoize": "0.7.4",
+        "@emotion/unitless": "0.7.5",
+        "@emotion/utils": "0.11.3",
+        "csstype": "^2.5.7"
+      }
+    },
+    "node_modules/babel-plugin-emotion/node_modules/@emotion/unitless": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
+      "license": "MIT"
+    },
+    "node_modules/babel-plugin-emotion/node_modules/@emotion/utils": {
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
+      "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw==",
+      "license": "MIT"
+    },
+    "node_modules/babel-plugin-emotion/node_modules/babel-plugin-macros": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
+      "integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "cosmiconfig": "^6.0.0",
+        "resolve": "^1.12.0"
+      }
+    },
+    "node_modules/babel-plugin-emotion/node_modules/cosmiconfig": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+      "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.1.0",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.7.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-emotion/node_modules/csstype": {
+      "version": "2.6.21",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
+      "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==",
+      "license": "MIT"
+    },
+    "node_modules/babel-plugin-emotion/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/babel-plugin-emotion/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/babel-plugin-syntax-jsx": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "integrity": "sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw==",
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/bottleneck": {
+      "version": "2.19.5",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chardet": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/compute-scroll-into-view": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
+      "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==",
+      "license": "MIT"
+    },
+    "node_modules/contentful-management": {
+      "version": "11.76.0",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.76.0.tgz",
+      "integrity": "sha512-KsqIZ65q1A6IP55sxTfuAMhBTNJfgGxlVZBoV2ghBuR1LaZZyTqway5vj9KHRDl/Z1uOQQsYSiz+FayMxBXXEw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/rich-text-types": "^16.6.1",
+        "axios": "^1.15.0",
+        "contentful-sdk-core": "^9.4.4",
+        "fast-copy": "^3.0.0",
+        "globals": "^15.15.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/contentful-sdk-core": {
+      "version": "9.4.5",
+      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-9.4.5.tgz",
+      "integrity": "sha512-8eGTMO11LXFAiosaiV38bjvW6cjoQFtNE38pNtVilZTXpmGFinClljihH0eriv11Ispd4q82TqtsXMJPYD/C+A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-copy": "^3.0.2",
+        "lodash": "^4.17.23",
+        "process": "^0.11.10",
+        "qs": "^6.15.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-linux-x64-gnu": "^4.18.0"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "license": "MIT"
+    },
+    "node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/create-emotion": {
+      "version": "10.0.27",
+      "resolved": "https://registry.npmjs.org/create-emotion/-/create-emotion-10.0.27.tgz",
+      "integrity": "sha512-fIK73w82HPPn/RsAij7+Zt8eCE8SptcJ3WoRMfxMtjteYxud8GDTKKld7MYwAX2TVhrw29uR1N/bVGxeStHILg==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/cache": "^10.0.27",
+        "@emotion/serialize": "^0.11.15",
+        "@emotion/sheet": "0.9.4",
+        "@emotion/utils": "0.11.3"
+      }
+    },
+    "node_modules/create-emotion/node_modules/@emotion/cache": {
+      "version": "10.0.29",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
+      "integrity": "sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/sheet": "0.9.4",
+        "@emotion/stylis": "0.8.5",
+        "@emotion/utils": "0.11.3",
+        "@emotion/weak-memoize": "0.2.5"
+      }
+    },
+    "node_modules/create-emotion/node_modules/@emotion/hash": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==",
+      "license": "MIT"
+    },
+    "node_modules/create-emotion/node_modules/@emotion/memoize": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+      "license": "MIT"
+    },
+    "node_modules/create-emotion/node_modules/@emotion/serialize": {
+      "version": "0.11.16",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.16.tgz",
+      "integrity": "sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "0.8.0",
+        "@emotion/memoize": "0.7.4",
+        "@emotion/unitless": "0.7.5",
+        "@emotion/utils": "0.11.3",
+        "csstype": "^2.5.7"
+      }
+    },
+    "node_modules/create-emotion/node_modules/@emotion/sheet": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.4.tgz",
+      "integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA==",
+      "license": "MIT"
+    },
+    "node_modules/create-emotion/node_modules/@emotion/unitless": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
+      "license": "MIT"
+    },
+    "node_modules/create-emotion/node_modules/@emotion/utils": {
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
+      "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw==",
+      "license": "MIT"
+    },
+    "node_modules/create-emotion/node_modules/@emotion/weak-memoize": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
+      "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==",
+      "license": "MIT"
+    },
+    "node_modules/create-emotion/node_modules/csstype": {
+      "version": "2.6.21",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
+      "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==",
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/downshift": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/downshift/-/downshift-9.4.0.tgz",
+      "integrity": "sha512-yIwyzRYzycKwMZhvOahsn4BmRr4Ffi0JymdWOtTDhR+LGDEXCZHTcwgUbNBC/oZLT6YrR46iwJe/BrQUS5ClQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "compute-scroll-into-view": "^3.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^18.2.0",
+        "tslib": "^2.8.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.12.0"
+      }
+    },
+    "node_modules/dset": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
+      "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emotion": {
+      "version": "10.0.27",
+      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
+      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-emotion": "^10.0.27",
+        "create-emotion": "^10.0.27"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/exenv": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+      "integrity": "sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-copy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.2.tgz",
+      "integrity": "sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==",
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/figures/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "license": "MIT"
+    },
+    "node_modules/focus-lock": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-1.3.6.tgz",
+      "integrity": "sha512-Ik/6OCk9RQQ0T5Xw+hKNLWrjSMtv51dD4GRmJjbD5a58TIEpI5a5iXagKVl3Z5UuyslMCA8Xwnu76jQob62Yhg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/globals": {
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/inquirer": {
+      "version": "8.2.7",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.7.tgz",
+      "integrity": "sha512-UjOaSel/iddGZJ5xP/Eixh6dY1XghiBw4XK13rCCIJcJfyhhoul/7KhLLUGtebEj6GDYM6Vnx/mVsjx2L/mFIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/external-editor": "^1.0.0",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.1",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.21",
+        "mute-stream": "0.0.8",
+        "ora": "^5.4.1",
+        "run-async": "^2.4.0",
+        "rxjs": "^7.5.5",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6",
+        "wrap-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "license": "MIT"
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "license": "MIT"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT"
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.20",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
+      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-animate-height": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/react-animate-height/-/react-animate-height-3.2.4.tgz",
+      "integrity": "sha512-wcT37yHsFWDx8DmNFMy0AqSrYgNPGAtU9dyEqwIq3kSUXW03DWSi5WqbhlOALvMXcowal8JWUJRXij6TexilGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/react-clientside-effect": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.8.tgz",
+      "integrity": "sha512-ma2FePH0z3px2+WOu6h+YycZcEvFmmxIlAb62cF52bG86eMySciO/EQZeQMXd07kPCYB0a1dWDT5J+KE9mCDUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.13"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/react-day-picker": {
+      "version": "8.10.2",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.10.2.tgz",
+      "integrity": "sha512-LK68OTbHB3oJNhl9cA0qVizzp3o26w61YSjAFkYi67N86iro32wx86kSNeFU/hq+gI8m1yzWhnomMLfZ041RzQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/gpbl"
+      },
+      "peerDependencies": {
+        "date-fns": "^2.28.0 || ^3.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.5"
+      }
+    },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-focus-lock": {
+      "version": "2.13.7",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.13.7.tgz",
+      "integrity": "sha512-20lpZHEQrXPb+pp1tzd4ULL6DyO5D2KnR0G69tTDdydrmNhU7pdFmbQUYVyHUgp+xN29IuFR0PVuhOmvaZL9Og==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "focus-lock": "^1.3.6",
+        "prop-types": "^15.6.2",
+        "react-clientside-effect": "^1.2.7",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
+    },
+    "node_modules/react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
+      "license": "MIT"
+    },
+    "node_modules/react-modal": {
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.16.3.tgz",
+      "integrity": "sha512-yCYRJB5YkeQDQlTt17WGAgFJ7jr2QYcWa1SHqZ3PluDmnKJ/7+tVU+E6uKyZ0nODaeEj+xCpK4LcSnKXLMC0Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "exenv": "^1.2.0",
+        "prop-types": "^15.7.2",
+        "react-lifecycles-compat": "^3.0.0",
+        "warning": "^4.0.3"
+      },
+      "peerDependencies": {
+        "react": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18 || ^19",
+        "react-dom": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/rollup-plugin-inject": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-inject/-/rollup-plugin-inject-3.0.2.tgz",
+      "integrity": "sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==",
+      "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^0.6.1",
+        "magic-string": "^0.25.3",
+        "rollup-pluginutils": "^2.8.1"
+      }
+    },
+    "node_modules/rollup-plugin-node-polyfills": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-polyfills/-/rollup-plugin-node-polyfills-0.2.1.tgz",
+      "integrity": "sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rollup-plugin-inject": "^3.0.0"
+      }
+    },
+    "node_modules/rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^0.6.1"
+      }
+    },
+    "node_modules/run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tabbable": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
+      "license": "MIT"
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/truncate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/truncate/-/truncate-3.0.0.tgz",
+      "integrity": "sha512-C+0Xojw7wZPl6MDq5UjMTuxZvBPK04mtdFet7k+GSZPINcvLZFCXg+15kWIL4wAqDB7CksIsKiRLbQ1wa7rKdw==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/apps/aem-assets/package.json
+++ b/apps/aem-assets/package.json
@@ -7,9 +7,6 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "echo \"no tests yet\"",
-    "test:ci": "echo \"no tests yet\"",
-    "lint": "eslint src",
     "deploy": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEFINITIONS_ORG_ID} --definition-id ${AEM_ASSETS_APP_DEF_ID} --token ${CONTENTFUL_CMA_TOKEN}",
     "deploy:test": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEV_TESTING_ORG_ID} --definition-id ${AEM_ASSETS_APP_DEF_ID_TEST} --token ${TEST_CMA_TOKEN}"
   },

--- a/apps/aem-assets/package.json
+++ b/apps/aem-assets/package.json
@@ -7,8 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "deploy": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEFINITIONS_ORG_ID} --definition-id ${AEM_ASSETS_APP_DEF_ID} --token ${CONTENTFUL_CMA_TOKEN}",
-    "deploy:test": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEV_TESTING_ORG_ID} --definition-id ${AEM_ASSETS_APP_DEF_ID_TEST} --token ${TEST_CMA_TOKEN}"
+    "deploy": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEFINITIONS_ORG_ID} --definition-id 1vE7iT7E8Wid6U52gxBXY2 --token ${CONTENTFUL_CMA_TOKEN}",
+    "deploy:test": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEV_TESTING_ORG_ID} --definition-id 7wt4UW8rciutTE4lXQTpuc --token ${TEST_CMA_TOKEN}"
   },
   "dependencies": {
     "@contentful/app-sdk": "^4.56.0",

--- a/apps/aem-assets/package.json
+++ b/apps/aem-assets/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@contentful/aem-assets",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "vite",
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "echo \"no tests yet\"",
+    "test:ci": "echo \"no tests yet\"",
+    "lint": "eslint src",
+    "deploy": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEFINITIONS_ORG_ID} --definition-id ${AEM_ASSETS_APP_DEF_ID} --token ${CONTENTFUL_CMA_TOKEN}",
+    "deploy:test": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEV_TESTING_ORG_ID} --definition-id ${AEM_ASSETS_APP_DEF_ID_TEST} --token ${TEST_CMA_TOKEN}"
+  },
+  "dependencies": {
+    "@contentful/app-sdk": "^4.56.0",
+    "@contentful/dam-app-base": "4.0.5",
+    "@contentful/f36-components": "6.7.4",
+    "react": "19.2.5",
+    "react-dom": "19.2.5"
+  },
+  "devDependencies": {
+    "@contentful/app-scripts": "^2.5.11",
+    "@vitejs/plugin-react": "^6.0.1",
+    "vite": "^8.0.10"
+  },
+  "browserslist": {
+    "production": [">0.2%", "not dead", "not op_mini all"],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  },
+  "homepage": "."
+}

--- a/apps/aem-assets/src/index.css
+++ b/apps/aem-assets/src/index.css
@@ -1,0 +1,39 @@
+html,
+body,
+div {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
+  font-family: system, sans-serif;
+}
+
+.dialog-container {
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  position: relative;
+}
+
+/* Colors match Forma 36 tokens red100/red500/red700 (@contentful/f36-tokens) */
+.content-advisor-error {
+  background-color: #fff2f2;
+  border: 1px solid #da294a;
+  color: #990017;
+  padding: 12px 16px;
+  margin-bottom: 8px;
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.content-advisor-error[hidden] {
+  display: none;
+}
+
+.content-advisor-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  padding: 8px 16px 0;
+}

--- a/apps/aem-assets/src/index.jsx
+++ b/apps/aem-assets/src/index.jsx
@@ -1,0 +1,391 @@
+import { useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import { Button } from '@contentful/f36-components';
+import { setup } from '@contentful/dam-app-base';
+import './index.css';
+import logo from './logo.svg';
+import { getRenditions, pick, transformAssets } from './utils';
+
+const ADOBE_EXPERIENCE_CLOUD_DOMAIN = `https://experience.adobe.com`;
+const SCRIPT_URL = `${ADOBE_EXPERIENCE_CLOUD_DOMAIN}/solutions/CQ-assets-selectors/static-assets/resources/assets-selectors.js`;
+// Required scope for the Assets Selectors Content Advisor auth service. This is
+// dictated by Adobe (see adobe/aem-assets-selectors-mfe-examples), not by the
+// customer's Adobe org, so it is not exposed as an app config field. If Adobe
+// ever changes this requirement, auth will start failing with an errorType of
+// 'invalid_scope' surfaced via the banner in renderDialog's onErrorReceived.
+const IMS_SCOPE =
+  'AdobeID,openid,additional_info.projectedProductContext,read_organizations';
+const FIELDS_TO_PERSIST = [
+  'id',
+  'name',
+  'url',
+  'metadata',
+  // 'mimetype',
+  // 'width',
+  // 'height',
+  // 'state',
+  // 'isExpired',
+  // 'thumbnails',
+  // 'url',
+  // 'renditions',
+];
+
+export function makeThumbnail(asset) {
+  const thumbRendition =
+    asset?.computedMetadata?._links[ASSET_RENDITIONS_KEY][1];
+  const thumbnail = thumbRendition?.href || '';
+  const url = typeof thumbnail === 'string' ? thumbnail : undefined;
+  const alt = asset.name || asset.id || '';
+
+  return [url, alt];
+}
+
+async function openDialog(sdk, _currentValue, _config) {
+  const parameters = { ..._config, ...sdk.parameters.instance };
+  // const assetIds = _currentValue.map((asset) => ({ id: asset.id }));
+  // parameters.selectedAssets = assetIds;
+
+  const result = await sdk.dialogs.openCurrentApp({
+    position: 'center',
+    shouldCloseOnOverlayClick: true,
+    shouldCloseOnEscapePress: true,
+    parameters,
+    width: 'fullWidth',
+    minHeight: '80vh',
+    allowHeightOverflow: true,
+  });
+
+  if (!Array.isArray(result)) {
+    return [];
+  }
+
+  return result.map((asset) => pick(asset, FIELDS_TO_PERSIST));
+}
+
+function prepareAEMAssetsHTML() {
+  return `
+    <dialog id='content-advisor-dialog' style='width:100%;height:100%;'>
+      <div id='content-advisor-error' class='content-advisor-error' role='alert' hidden></div>
+      <div class='content-advisor-toolbar'>
+        <div id='content-advisor-logout-container'></div>
+      </div>
+      <div id='content-advisor' style='overflow-x:auto;width:100%;height:100%;'></div>
+    </dialog>
+  `;
+}
+
+function LogoutButton({ onLogout }) {
+  const [isLoggingOut, setIsLoggingOut] = useState(false);
+
+  return (
+    <Button
+      variant="secondary"
+      size="small"
+      isDisabled={isLoggingOut}
+      isLoading={isLoggingOut}
+      onClick={async () => {
+        setIsLoggingOut(true);
+        try {
+          await onLogout();
+        } finally {
+          setIsLoggingOut(false);
+        }
+      }}
+    >
+      Log out
+    </Button>
+  );
+}
+
+function showAuthError(message) {
+  const banner = document.getElementById('content-advisor-error');
+  if (!banner) return;
+  banner.textContent = message;
+  banner.hidden = false;
+}
+
+function hideAuthError() {
+  const banner = document.getElementById('content-advisor-error');
+  if (!banner) return;
+  banner.hidden = true;
+}
+
+// ============================================================================
+// EXPERIMENTAL: popup auth-redirect fix. Flip this to `false` (or delete the
+// block below, down to the matching END marker) to fully revert to the
+// original behavior if this doesn't fix the auth flow.
+//
+// Why this exists: with `modalMode: true`, Adobe's IMS login opens a popup
+// and, once sign-in completes, navigates that popup to `redirectUrl` (this
+// app's own URL). Per Adobe's own docs/examples, `registerContentAdvisorAuthService`
+// must also be called on that redirect page. In this app, registration only
+// ever happens inside renderDialog(sdk), which itself only runs after
+// @contentful/app-sdk's init() completes a handshake with a Contentful parent
+// iframe. The popup is a plain top-level window with no such parent, so
+// init() never resolves there and the auth service never re-registers -
+// which is the likely cause of the popup dying a couple seconds after login.
+//
+// This block re-registers the auth service unconditionally, but only when
+// the page is NOT embedded in an iframe (i.e. this is that popup), using
+// IMS config persisted to localStorage by the real, Contentful-embedded
+// dialog session (see persistImsConfig() call in renderDialog below).
+const ENABLE_POPUP_AUTH_REDIRECT_FIX = true;
+const IMS_CONFIG_STORAGE_KEY = 'aem-assets-app:ims-auth-config';
+
+function persistImsConfig({ imsClientId, imsOrg }) {
+  try {
+    window.localStorage.setItem(
+      IMS_CONFIG_STORAGE_KEY,
+      JSON.stringify({ imsClientId, imsOrg }),
+    );
+  } catch (e) {
+    // localStorage unavailable (private mode, disabled storage, etc). The
+    // popup redirect fix just won't have config to work with in that case -
+    // same as if this whole block were disabled.
+  }
+}
+
+function readPersistedImsConfig() {
+  try {
+    const raw = window.localStorage.getItem(IMS_CONFIG_STORAGE_KEY);
+    return raw ? JSON.parse(raw) : null;
+  } catch (e) {
+    return null;
+  }
+}
+
+function isEmbeddedInIframe() {
+  try {
+    return window.top !== window.self;
+  } catch (e) {
+    // Cross-origin access to window.top throws when embedded cross-origin,
+    // which still means "embedded" - so treat the throw as embedded=true.
+    return true;
+  }
+}
+
+function registerImsAuthServiceForPopupRedirect() {
+  const persisted = readPersistedImsConfig();
+  if (!persisted?.imsClientId) return;
+
+  const script = document.createElement('script');
+  script.src = SCRIPT_URL;
+  script.async = true;
+  script.addEventListener('load', () => {
+    PureJSSelectors.registerContentAdvisorAuthService(
+      {
+        imsClientId: persisted.imsClientId,
+        imsOrg: persisted.imsOrg,
+        imsScope: IMS_SCOPE,
+        redirectUrl: window.location.href,
+        modalMode: true,
+      },
+      false,
+    );
+  });
+  document.body.appendChild(script);
+}
+
+if (ENABLE_POPUP_AUTH_REDIRECT_FIX && !isEmbeddedInIframe()) {
+  registerImsAuthServiceForPopupRedirect();
+}
+// ============================================================================
+// END EXPERIMENTAL popup auth-redirect fix
+// ============================================================================
+
+async function renderDialog(sdk) {
+  const config = sdk.parameters.invocation;
+  const {
+    imsClientId,
+    imsOrg,
+    repositoryId,
+    aemTierType,
+    env,
+    hideUploadButton,
+    hideTreeNav,
+  } = config;
+
+  if (ENABLE_POPUP_AUTH_REDIRECT_FIX) {
+    persistImsConfig({ imsClientId, imsOrg });
+  }
+
+  const script = document.createElement('script');
+  script.src = SCRIPT_URL;
+  script.async = true;
+  document.body.appendChild(script);
+
+  const container = document.createElement('div');
+  container.innerHTML = prepareAEMAssetsHTML();
+  document.body.appendChild(container);
+
+  sdk.window.startAutoResizer();
+
+  let imsInstance = null;
+
+  const logoutContainer = document.getElementById(
+    'content-advisor-logout-container',
+  );
+  if (logoutContainer) {
+    createRoot(logoutContainer).render(
+      <LogoutButton
+        onLogout={async () => {
+          if (!imsInstance) return;
+          try {
+            await imsInstance.signOut();
+            showAuthError(
+              'You have been logged out of Adobe. Close this dialog and reopen the asset selector to sign in again.',
+            );
+          } catch (error) {
+            showAuthError(`Failed to log out of Adobe: ${error?.message || error}`);
+          }
+        }}
+      />,
+    );
+  }
+
+  const imsAuthProps = {
+    imsClientId: imsClientId,
+    imsScope: IMS_SCOPE,
+    redirectUrl: window.location.href,
+    modalMode: true,
+    onErrorReceived: (errorType, errorMessage) => {
+      showAuthError(
+        `Adobe authentication failed (${errorType}). Check that the IMS Client ID and IMS Organization ID in the app configuration are still valid. If this persists after re-checking configuration, the Adobe Assets Selector's required auth scope may have changed and the app needs to be updated. Details: ${errorMessage}`,
+      );
+    },
+    onAccessTokenExpired: () => {
+      showAuthError(
+        'Your Adobe session has expired. Close this dialog and try selecting assets again.',
+      );
+    },
+    onAccessTokenReceived: () => {
+      hideAuthError();
+    },
+  };
+
+  const contentAdvisorProps = {
+    imsOrg,
+    aemTierType: aemTierType ? aemTierType.split(',') : ['delivery', 'author'],
+    env,
+    hideTreeNav,
+    selectionType: 'multiple',
+    uploadConfig: {
+      hideUploadButton: hideUploadButton === 'Yes' ? true : false,
+    },
+    alwaysUseDMDelivery: true,
+    // handleAssetSelection, // only enabled for testing
+    handleSelection,
+    onClose,
+    expiryOptions: () => {},
+    showToast: () => {},
+  };
+
+  // this function is only used for testing
+  // function handleAssetSelection(assets) {
+  //   const transformedAssets = transformAssets(assets);
+  // }
+
+  function handleSelection(assets) {
+    const transformedAssets = transformAssets(assets);
+    sdk.close(transformedAssets);
+  }
+
+  function onClose() {
+    hideAuthError();
+    document.getElementById('content-advisor-dialog').close();
+    sdk.close();
+  }
+
+  function registerImsAuthService() {
+    const registeredTokenService =
+      PureJSSelectors.registerContentAdvisorAuthService(imsAuthProps, false);
+    imsInstance = registeredTokenService;
+  }
+
+  async function renderContentAdvisor() {
+    const container = document.getElementById('content-advisor');
+    PureJSSelectors.renderContentAdvisorWithAuthFlow(
+      container,
+      contentAdvisorProps,
+      () => {
+        document.getElementById('content-advisor-dialog').showModal();
+      },
+    );
+  }
+
+  script.addEventListener('load', () => {
+    registerImsAuthService();
+    renderContentAdvisor();
+  });
+}
+
+function validateParameters({ imsClientId }) {
+  if (!imsClientId) {
+    return 'Please add your IMS Client ID';
+  }
+  return null;
+}
+
+setup({
+  cta: 'Select assets from AEM',
+  name: 'Adobe Experience Manager Asset Selector',
+  logo: logo,
+  color: '#ED2224',
+  description:
+    'The AEM Assets Selector uses the AEM Content Advisor Micro-Frontend allowing editors to select media from their AEM Assets account.',
+  parameterDefinitions: [
+    {
+      id: 'imsClientId',
+      type: 'Symbol',
+      name: 'IMS Client ID',
+      description: 'Your Client ID from Adobe IMS.',
+      required: true,
+    },
+    {
+      id: 'imsOrg',
+      name: 'IMS Organization',
+      type: 'Symbol',
+      description:
+        'Adobe Identity Management System (IMS) ID that is assigned while provisioning Adobe Experience Manager as a Cloud Service for your organization',
+      required: true,
+    },
+    {
+      id: 'repositoryId',
+      name: 'Repository ID',
+      type: 'Symbol',
+      description: 'Restricts access to a single repository',
+      required: false,
+    },
+    {
+      id: 'aemTierType',
+      name: 'AEM Tier',
+      type: 'Symbol',
+      description:
+        'Specifies the tier type [delivery, author] for the app (defaults to both)',
+      required: false,
+      default: 'delivery,author',
+    },
+    {
+      id: 'env',
+      name: 'Environment',
+      type: 'Symbol',
+      description:
+        'Specifies the AEM repository environment [prod,stage] for the app',
+      required: false,
+    },
+    {
+      id: 'hideUploadButton',
+      name: 'Hide Asset Upload Button',
+      type: 'List',
+      value: 'Yes, No',
+      default: 'Yes',
+      description: 'Specifies whether to show or hide the upload button',
+      required: false,
+    },
+  ],
+  validateParameters,
+  makeThumbnail,
+  renderDialog,
+  openDialog,
+  isDisabled: () => false,
+});

--- a/apps/aem-assets/src/index.jsx
+++ b/apps/aem-assets/src/index.jsx
@@ -13,8 +13,7 @@ const SCRIPT_URL = `${ADOBE_EXPERIENCE_CLOUD_DOMAIN}/solutions/CQ-assets-selecto
 // customer's Adobe org, so it is not exposed as an app config field. If Adobe
 // ever changes this requirement, auth will start failing with an errorType of
 // 'invalid_scope' surfaced via the banner in renderDialog's onErrorReceived.
-const IMS_SCOPE =
-  'AdobeID,openid,additional_info.projectedProductContext,read_organizations';
+const IMS_SCOPE = 'AdobeID,openid,additional_info.projectedProductContext,read_organizations';
 const FIELDS_TO_PERSIST = [
   'id',
   'name',
@@ -31,8 +30,7 @@ const FIELDS_TO_PERSIST = [
 ];
 
 export function makeThumbnail(asset) {
-  const thumbRendition =
-    asset?.computedMetadata?._links[ASSET_RENDITIONS_KEY][1];
+  const thumbRendition = asset?.computedMetadata?._links[ASSET_RENDITIONS_KEY][1];
   const thumbnail = thumbRendition?.href || '';
   const url = typeof thumbnail === 'string' ? thumbnail : undefined;
   const alt = asset.name || asset.id || '';
@@ -90,8 +88,7 @@ function LogoutButton({ onLogout }) {
         } finally {
           setIsLoggingOut(false);
         }
-      }}
-    >
+      }}>
       Log out
     </Button>
   );
@@ -134,10 +131,7 @@ const IMS_CONFIG_STORAGE_KEY = 'aem-assets-app:ims-auth-config';
 
 function persistImsConfig({ imsClientId, imsOrg }) {
   try {
-    window.localStorage.setItem(
-      IMS_CONFIG_STORAGE_KEY,
-      JSON.stringify({ imsClientId, imsOrg }),
-    );
+    window.localStorage.setItem(IMS_CONFIG_STORAGE_KEY, JSON.stringify({ imsClientId, imsOrg }));
   } catch (e) {
     // localStorage unavailable (private mode, disabled storage, etc). The
     // popup redirect fix just won't have config to work with in that case -
@@ -180,7 +174,7 @@ function registerImsAuthServiceForPopupRedirect() {
         redirectUrl: window.location.href,
         modalMode: true,
       },
-      false,
+      false
     );
   });
   document.body.appendChild(script);
@@ -195,15 +189,8 @@ if (ENABLE_POPUP_AUTH_REDIRECT_FIX && !isEmbeddedInIframe()) {
 
 async function renderDialog(sdk) {
   const config = sdk.parameters.invocation;
-  const {
-    imsClientId,
-    imsOrg,
-    repositoryId,
-    aemTierType,
-    env,
-    hideUploadButton,
-    hideTreeNav,
-  } = config;
+  const { imsClientId, imsOrg, repositoryId, aemTierType, env, hideUploadButton, hideTreeNav } =
+    config;
 
   if (ENABLE_POPUP_AUTH_REDIRECT_FIX) {
     persistImsConfig({ imsClientId, imsOrg });
@@ -222,9 +209,7 @@ async function renderDialog(sdk) {
 
   let imsInstance = null;
 
-  const logoutContainer = document.getElementById(
-    'content-advisor-logout-container',
-  );
+  const logoutContainer = document.getElementById('content-advisor-logout-container');
   if (logoutContainer) {
     createRoot(logoutContainer).render(
       <LogoutButton
@@ -233,13 +218,13 @@ async function renderDialog(sdk) {
           try {
             await imsInstance.signOut();
             showAuthError(
-              'You have been logged out of Adobe. Close this dialog and reopen the asset selector to sign in again.',
+              'You have been logged out of Adobe. Close this dialog and reopen the asset selector to sign in again.'
             );
           } catch (error) {
             showAuthError(`Failed to log out of Adobe: ${error?.message || error}`);
           }
         }}
-      />,
+      />
     );
   }
 
@@ -250,12 +235,12 @@ async function renderDialog(sdk) {
     modalMode: true,
     onErrorReceived: (errorType, errorMessage) => {
       showAuthError(
-        `Adobe authentication failed (${errorType}). Check that the IMS Client ID and IMS Organization ID in the app configuration are still valid. If this persists after re-checking configuration, the Adobe Assets Selector's required auth scope may have changed and the app needs to be updated. Details: ${errorMessage}`,
+        `Adobe authentication failed (${errorType}). Check that the IMS Client ID and IMS Organization ID in the app configuration are still valid. If this persists after re-checking configuration, the Adobe Assets Selector's required auth scope may have changed and the app needs to be updated. Details: ${errorMessage}`
       );
     },
     onAccessTokenExpired: () => {
       showAuthError(
-        'Your Adobe session has expired. Close this dialog and try selecting assets again.',
+        'Your Adobe session has expired. Close this dialog and try selecting assets again.'
       );
     },
     onAccessTokenReceived: () => {
@@ -297,20 +282,18 @@ async function renderDialog(sdk) {
   }
 
   function registerImsAuthService() {
-    const registeredTokenService =
-      PureJSSelectors.registerContentAdvisorAuthService(imsAuthProps, false);
+    const registeredTokenService = PureJSSelectors.registerContentAdvisorAuthService(
+      imsAuthProps,
+      false
+    );
     imsInstance = registeredTokenService;
   }
 
   async function renderContentAdvisor() {
     const container = document.getElementById('content-advisor');
-    PureJSSelectors.renderContentAdvisorWithAuthFlow(
-      container,
-      contentAdvisorProps,
-      () => {
-        document.getElementById('content-advisor-dialog').showModal();
-      },
-    );
+    PureJSSelectors.renderContentAdvisorWithAuthFlow(container, contentAdvisorProps, () => {
+      document.getElementById('content-advisor-dialog').showModal();
+    });
   }
 
   script.addEventListener('load', () => {
@@ -360,8 +343,7 @@ setup({
       id: 'aemTierType',
       name: 'AEM Tier',
       type: 'Symbol',
-      description:
-        'Specifies the tier type [delivery, author] for the app (defaults to both)',
+      description: 'Specifies the tier type [delivery, author] for the app (defaults to both)',
       required: false,
       default: 'delivery,author',
     },
@@ -369,8 +351,7 @@ setup({
       id: 'env',
       name: 'Environment',
       type: 'Symbol',
-      description:
-        'Specifies the AEM repository environment [prod,stage] for the app',
+      description: 'Specifies the AEM repository environment [prod,stage] for the app',
       required: false,
     },
     {

--- a/apps/aem-assets/src/logo.svg
+++ b/apps/aem-assets/src/logo.svg
@@ -1,0 +1,17 @@
+<svg width="512" height="512" viewBox="0 0 60 60" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
+ <!-- Generator: Sketch 3.1.1 (8761) - http://www.bohemiancoding.com/sketch -->
+ <title>
+  adobe
+ </title>
+ <desc>
+  Created with Sketch.
+ </desc>
+ <defs>
+ </defs>
+ <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
+  <g id="adobe" sketch:type="MSArtboardGroup" fill="#fa0c00">
+   <path d="M37.8297763,3 L60,3 L60,56 L37.8297763,3 Z M22.1972229,3 L0,3 L0,56 L22.1972229,3 Z M30.0077141,22.5281464 L44.1437388,56 L34.8791463,56 L30.6479815,45.3373924 L20.3034199,45.3373924 L30.0077141,22.5281464 Z" id="Fill-1" sketch:type="MSShapeGroup">
+   </path>
+  </g>
+ </g>
+</svg>

--- a/apps/aem-assets/src/utils.js
+++ b/apps/aem-assets/src/utils.js
@@ -19,25 +19,21 @@ export function getMetadata(asset, renditions) {
 }
 
 export function getRenditions(asset) {
-  const renditions = asset?.computedMetadata?._links[ASSET_RENDITIONS_KEY]?.map(
-    (r) => {
-      return {
-        href: r.href,
-        height: r.height,
-        width: r.width,
-        type: r.type,
-      };
-    },
-  );
+  const renditions = asset?.computedMetadata?._links[ASSET_RENDITIONS_KEY]?.map((r) => {
+    return {
+      href: r.href,
+      height: r.height,
+      width: r.width,
+      type: r.type,
+    };
+  });
   return renditions.sort((a, b) => a.width - b.width);
 }
 
 export function transformAssets(assets) {
   const transformedAssets = assets.map((asset) => {
     const renditions = getRenditions(asset);
-    const thumbUrl = renditions.find(
-      (r) => r.width >= 150 && r.width <= 400,
-    ).href;
+    const thumbUrl = renditions.find((r) => r.width >= 150 && r.width <= 400).href;
 
     const transformedAsset = {
       id: asset['repo:assetId'] || asset['repo:id'] || asset.id,

--- a/apps/aem-assets/src/utils.js
+++ b/apps/aem-assets/src/utils.js
@@ -1,0 +1,61 @@
+const ASSET_RENDITIONS_KEY = 'http://ns.adobe.com/adobecloud/rel/rendition';
+
+/**
+ * Source: https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore#_pick
+ */
+export function pick(object, keys) {
+  return keys.reduce((obj, key) => {
+    if (object && object.hasOwnProperty(key)) {
+      obj[key] = object[key];
+    }
+    return obj;
+  }, {});
+}
+
+export function getMetadata(asset, renditions) {
+  const { _embedded, _links, ...copy } = asset.computedMetadata;
+  const metadata = { ...copy, renditions };
+  return metadata;
+}
+
+export function getRenditions(asset) {
+  const renditions = asset?.computedMetadata?._links[ASSET_RENDITIONS_KEY]?.map(
+    (r) => {
+      return {
+        href: r.href,
+        height: r.height,
+        width: r.width,
+        type: r.type,
+      };
+    },
+  );
+  return renditions.sort((a, b) => a.width - b.width);
+}
+
+export function transformAssets(assets) {
+  const transformedAssets = assets.map((asset) => {
+    const renditions = getRenditions(asset);
+    const thumbUrl = renditions.find(
+      (r) => r.width >= 150 && r.width <= 400,
+    ).href;
+
+    const transformedAsset = {
+      id: asset['repo:assetId'] || asset['repo:id'] || asset.id,
+      name: asset['repo:name'] || asset.name || '',
+      url: thumbUrl,
+      metadata: getMetadata(asset, renditions),
+      // path: asset['repo:path'] || asset.path || '',
+      // size: asset['repo:size'] || 0,
+      // mimetype: asset['dc:format'] || asset.mimetype || '',
+      // width: asset['tiff:imageWidth'] || asset.width || 0,
+      // height: asset['tiff:imageLeength'] || asset.height || 0,
+      // state: asset['repo:state'] || '',
+      // isExpired: asset.isExpired || false,
+      // renditions: renditions,
+    };
+
+    return transformedAsset;
+  });
+
+  return transformedAssets;
+}

--- a/apps/aem-assets/vite.config.mjs
+++ b/apps/aem-assets/vite.config.mjs
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: 'localhost',
+    port: 3000,
+  },
+  build: {
+    outDir: 'build',
+  },
+  base: '', // relative paths
+});

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -58,6 +58,25 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
+  name: aem-assets
+  annotations:
+    github.com/project-slug: contentful/apps/aem-assets
+    contentful.com/service-tier: '2'
+    contentful.com/ci-alert-slack: prd-marketplace-bots
+  tags:
+    - node
+    - service
+    - sast-enabled
+    - tier-2
+spec:
+  type: service
+  lifecycle: production
+  owner: group:team-marketplace
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
   name: aws-amplify
   annotations:
     github.com/project-slug: contentful/apps/aws-amplify


### PR DESCRIPTION
## Summary
- Adds the "Adobe Experience Manager Asset Selector" app (`apps/aem-assets`), letting editors select Adobe AEM as a Cloud Service assets from a Contentful entry field via Adobe's Content Advisor Micro-Frontend picker.
- Built on `@contentful/dam-app-base`, with a custom Adobe IMS OAuth handshake (popup-based login, including a flag-gated fix for a popup-redirect auth re-registration gap) and a Forma 36 `Log out` control, since neither is provided by the base package.
- Registers the app in `catalog-info.yaml` following the existing `brandfolder`/`dropbox`/`frontify` DAM-app pattern.

## Notes for reviewers
- Deploy scripts (`deploy`/`deploy:test`) use env-var placeholders (`AEM_ASSETS_APP_DEF_ID`, `AEM_ASSETS_APP_DEF_ID_TEST`) — real app-definition IDs still need to be wired in once definitions exist for the target org(s).
- Adobe enforces CORS/origin allowlisting on their IMS token endpoint; the app's hosted origin must be allowlisted by Adobe support on the customer's IMS Client ID before auth will work. This is called out in the app's README and will also need to go into customer-facing help docs.
- See `apps/aem-assets/AGENTS.md` for known sharp edges (popup auth-redirect fix, dead `ASSET_RENDITIONS_KEY` reference in `makeThumbnail`, etc.)

## Test plan
- [ ] `npm install && npm run build` succeeds in `apps/aem-assets`
- [ ] Install the app in a test space, configure IMS Client ID/Org, and confirm the Content Advisor picker opens and asset selection works
- [ ] Confirm `Log out` button re-triggers Adobe login on next picker open
- [ ] Confirm allowlisted-origin requirement is documented before customer rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)