### PR TITLE
test: add agents-api and workflow orchestration integration tests [INTEG-4369]

### DIFF
--- a/apps/drive-integration/test/hooks/useWorkflowAgent.test.tsx
+++ b/apps/drive-integration/test/hooks/useWorkflowAgent.test.tsx
@@ -8,11 +8,6 @@ import { createMockSDK } from '../mocks';
 // Minimal valid googleDocPayload that passes validatePayloadShape
 const COMPLETED_PAYLOAD = { entries: [], assets: [], referenceGraph: {} };
 
-const TABS_SUSPEND_PAYLOAD = {
-  suspendStepId: 'select-tabs-images-step' as const,
-  documentId: 'doc-1',
-};
-
 const MAPPING_SUSPEND_PAYLOAD = {
   suspendStepId: 'mapping-review' as const,
   documentId: 'doc-1',
@@ -55,16 +50,10 @@ describe('useWorkflowAgent — workflow orchestration', () => {
 
   // Helper: renders the hook and kicks off startWorkflow, advancing timers
   // between each queued agentRun.get response.
-  async function drivePolling(
-    mockResponses: ReturnType<typeof makeRun>[],
-    opts: { runId?: string } = {}
-  ) {
+  async function drivePolling(mockResponses: ReturnType<typeof makeRun>[]) {
     const { result } = renderHook(() =>
       useWorkflowAgent({ sdk, documentId: 'doc-1', oauthToken: 'token-x' })
     );
-
-    const runId = opts.runId ?? 'run-123';
-    vi.mocked(sdk.cma.agent.generate).mockResolvedValue({ sys: { id: runId } } as any);
 
     let callIndex = 0;
     vi.mocked(sdk.cma.agentRun.get).mockImplementation(async () => {
@@ -91,6 +80,37 @@ describe('useWorkflowAgent — workflow orchestration', () => {
     return resultPromise!;
   }
 
+  async function driveResume(
+    runId: string,
+    resumePayload: Record<string, unknown>,
+    mockResponses: ReturnType<typeof makeRun>[]
+  ) {
+    const { result } = renderHook(() =>
+      useWorkflowAgent({ sdk, documentId: 'doc-1', oauthToken: 'token-x' })
+    );
+
+    let callIndex = 0;
+    vi.mocked(sdk.cma.agentRun.get).mockImplementation(async () => {
+      const response = mockResponses[Math.min(callIndex, mockResponses.length - 1)];
+      callIndex++;
+      return response as any;
+    });
+
+    let resultPromise: Promise<any>;
+    act(() => {
+      resultPromise = result.current.resumeWorkflow(runId, resumePayload);
+      void resultPromise.catch(() => {});
+    });
+
+    for (let i = 0; i < mockResponses.length; i++) {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_000);
+      });
+    }
+
+    return resultPromise!;
+  }
+
   describe('startWorkflow', () => {
     it('polls until COMPLETED and returns the googleDocPayload', async () => {
       const responses = [
@@ -107,6 +127,10 @@ describe('useWorkflowAgent — workflow orchestration', () => {
     });
 
     it('polls through IN_PROGRESS and resolves on PENDING_REVIEW with suspendPayload', async () => {
+      const TABS_SUSPEND_PAYLOAD = {
+        suspendStepId: 'select-tabs-images-step' as const,
+        documentId: 'doc-1',
+      };
       const responses = [
         makeRun(RunStatus.IN_PROGRESS),
         makeRun(RunStatus.PENDING_REVIEW, { suspendPayload: TABS_SUSPEND_PAYLOAD }),
@@ -265,31 +289,13 @@ describe('useWorkflowAgent — workflow orchestration', () => {
     });
 
     it('resumes a run and polls to COMPLETED', async () => {
-      let callIndex = 0;
       const responses = [
         makeRun(RunStatus.IN_PROGRESS),
         makeRun(RunStatus.COMPLETED, { googleDocPayload: COMPLETED_PAYLOAD }),
       ];
-      vi.mocked(sdk.cma.agentRun.get).mockImplementation(async () => {
-        return responses[Math.min(callIndex++, responses.length - 1)] as any;
-      });
 
-      const { result } = renderHook(() =>
-        useWorkflowAgent({ sdk, documentId: 'doc-1', oauthToken: 'token-x' })
-      );
+      const workflowResult = await driveResume('run-123', { includeImages: true }, responses);
 
-      let resultPromise: Promise<any>;
-      act(() => {
-        resultPromise = result.current.resumeWorkflow('run-123', { includeImages: true });
-      });
-
-      for (let i = 0; i < 2; i++) {
-        await act(async () => {
-          await vi.advanceTimersByTimeAsync(10_000);
-        });
-      }
-
-      const workflowResult = await resultPromise!;
       expect(sdk.cma.agentRun.resume).toHaveBeenCalledWith(
         expect.objectContaining({ runId: 'run-123' }),
         { resumePayload: { includeImages: true } }
@@ -298,58 +304,28 @@ describe('useWorkflowAgent — workflow orchestration', () => {
     });
 
     it('resumes a mapping-review step and polls to a second PENDING_REVIEW with new suspendPayload', async () => {
-      let callIndex = 0;
       const responses = [
         makeRun(RunStatus.IN_PROGRESS),
         makeRun(RunStatus.PENDING_REVIEW, { suspendPayload: MAPPING_SUSPEND_PAYLOAD }),
       ];
-      vi.mocked(sdk.cma.agentRun.get).mockImplementation(async () => {
-        return responses[Math.min(callIndex++, responses.length - 1)] as any;
-      });
 
-      const { result } = renderHook(() =>
-        useWorkflowAgent({ sdk, documentId: 'doc-1', oauthToken: 'token-x' })
+      const workflowResult = await driveResume(
+        'run-123',
+        { entryBlockGraph: { entries: [], excludedSourceRefs: [] } },
+        responses
       );
 
-      let resultPromise: Promise<any>;
-      act(() => {
-        resultPromise = result.current.resumeWorkflow('run-123', {
-          entryBlockGraph: { entries: [], excludedSourceRefs: [] },
-        });
-      });
-
-      for (let i = 0; i < 2; i++) {
-        await act(async () => {
-          await vi.advanceTimersByTimeAsync(10_000);
-        });
-      }
-
-      const workflowResult = await resultPromise!;
       expect(workflowResult.status).toBe(RunStatus.PENDING_REVIEW);
       expect(workflowResult.suspendPayload).toEqual(MAPPING_SUSPEND_PAYLOAD);
     });
 
     it('handles cancellation resume payload and returns COMPLETED', async () => {
-      vi.mocked(sdk.cma.agentRun.get).mockResolvedValue(
-        makeRun(RunStatus.COMPLETED, {
-          googleDocPayload: { cancelled: true, documentId: 'doc-1' },
-        }) as any
-      );
+      const responses = [
+        makeRun(RunStatus.COMPLETED, { googleDocPayload: { cancelled: true, documentId: 'doc-1' } }),
+      ];
 
-      const { result } = renderHook(() =>
-        useWorkflowAgent({ sdk, documentId: 'doc-1', oauthToken: 'token-x' })
-      );
+      const workflowResult = await driveResume('run-123', { cancelled: true }, responses);
 
-      let resultPromise: Promise<any>;
-      act(() => {
-        resultPromise = result.current.resumeWorkflow('run-123', { cancelled: true });
-      });
-
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(10_000);
-      });
-
-      const workflowResult = await resultPromise!;
       expect(workflowResult.status).toBe(RunStatus.COMPLETED);
       // Cancelled runs produce an empty payload — no entries or assets
       expect(workflowResult.googleDocPayload.entries).toEqual([]);
@@ -358,22 +334,9 @@ describe('useWorkflowAgent — workflow orchestration', () => {
     it('throws if resume API call fails', async () => {
       vi.mocked(sdk.cma.agentRun.resume).mockRejectedValue(new Error('Resume rejected'));
 
-      const { result } = renderHook(() =>
-        useWorkflowAgent({ sdk, documentId: 'doc-1', oauthToken: 'token-x' })
-      );
-
-      let resultPromise: Promise<any>;
-      act(() => {
-        resultPromise = result.current.resumeWorkflow('run-123', { includeImages: false });
-        void resultPromise.catch(() => {});
-      });
-
-      // No timer advance needed — resume throws synchronously before polling starts
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(0);
-      });
-
-      await expect(resultPromise!).rejects.toThrow('Resume rejected');
+      await expect(
+        driveResume('run-123', { includeImages: false }, [makeRun(RunStatus.IN_PROGRESS)])
+      ).rejects.toThrow('Resume rejected');
     });
   });
 });

--- a/apps/drive-integration/test/hooks/useWorkflowAgent.test.tsx
+++ b/apps/drive-integration/test/hooks/useWorkflowAgent.test.tsx
@@ -321,7 +321,9 @@ describe('useWorkflowAgent — workflow orchestration', () => {
 
     it('handles cancellation resume payload and returns COMPLETED', async () => {
       const responses = [
-        makeRun(RunStatus.COMPLETED, { googleDocPayload: { cancelled: true, documentId: 'doc-1' } }),
+        makeRun(RunStatus.COMPLETED, {
+          googleDocPayload: { cancelled: true, documentId: 'doc-1' },
+        }),
       ];
 
       const workflowResult = await driveResume('run-123', { cancelled: true }, responses);

--- a/apps/drive-integration/test/hooks/useWorkflowAgent.test.tsx
+++ b/apps/drive-integration/test/hooks/useWorkflowAgent.test.tsx
@@ -1,0 +1,379 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { PageAppSDK } from '@contentful/app-sdk';
+import { useWorkflowAgent } from '@hooks/useWorkflowAgent';
+import { RunStatus, WorkflowFailureReason } from '@types';
+import { createMockSDK } from '../mocks';
+
+// Minimal valid googleDocPayload that passes validatePayloadShape
+const COMPLETED_PAYLOAD = { entries: [], assets: [], referenceGraph: {} };
+
+const TABS_SUSPEND_PAYLOAD = {
+  suspendStepId: 'select-tabs-images-step' as const,
+  documentId: 'doc-1',
+};
+
+const MAPPING_SUSPEND_PAYLOAD = {
+  suspendStepId: 'mapping-review' as const,
+  documentId: 'doc-1',
+  normalizedDocument: {
+    documentId: 'doc-1',
+    title: 'Test doc',
+    designValues: [],
+    contentBlocks: [],
+    images: [],
+    tables: [],
+    assets: [],
+  },
+  entryBlockGraph: { entries: [], excludedSourceRefs: [] },
+  referenceGraph: {},
+  contentTypes: [],
+};
+
+function makeRun(status: RunStatus, extra: Record<string, unknown> = {}) {
+  return {
+    sys: { id: 'run-123', status },
+    metadata: { status, ...extra },
+  };
+}
+
+describe('useWorkflowAgent — workflow orchestration', () => {
+  let sdk: PageAppSDK;
+
+  beforeEach(() => {
+    sdk = createMockSDK() as PageAppSDK;
+    vi.useFakeTimers();
+
+    // Default: generate returns a run ID
+    vi.mocked(sdk.cma.agent.generate).mockResolvedValue({ sys: { id: 'run-123' } } as any);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  // Helper: renders the hook and kicks off startWorkflow, advancing timers
+  // between each queued agentRun.get response.
+  async function drivePolling(
+    mockResponses: ReturnType<typeof makeRun>[],
+    opts: { runId?: string } = {}
+  ) {
+    const { result } = renderHook(() =>
+      useWorkflowAgent({ sdk, documentId: 'doc-1', oauthToken: 'token-x' })
+    );
+
+    const runId = opts.runId ?? 'run-123';
+    vi.mocked(sdk.cma.agent.generate).mockResolvedValue({ sys: { id: runId } } as any);
+
+    let callIndex = 0;
+    vi.mocked(sdk.cma.agentRun.get).mockImplementation(async () => {
+      const response = mockResponses[Math.min(callIndex, mockResponses.length - 1)];
+      callIndex++;
+      return response as any;
+    });
+
+    let resultPromise: Promise<any>;
+    act(() => {
+      resultPromise = result.current.startWorkflow(['blogPost']);
+      // Attach a no-op catch immediately so Node doesn't flag the rejection as
+      // unhandled between the act() call and the rejects assertion below.
+      void resultPromise.catch(() => {});
+    });
+
+    // Advance timers for each poll interval needed
+    for (let i = 0; i < mockResponses.length; i++) {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_000);
+      });
+    }
+
+    return resultPromise!;
+  }
+
+  describe('startWorkflow', () => {
+    it('polls until COMPLETED and returns the googleDocPayload', async () => {
+      const responses = [
+        makeRun(RunStatus.IN_PROGRESS),
+        makeRun(RunStatus.IN_PROGRESS),
+        makeRun(RunStatus.COMPLETED, { googleDocPayload: COMPLETED_PAYLOAD }),
+      ];
+
+      const result = await drivePolling(responses);
+
+      expect(result.status).toBe(RunStatus.COMPLETED);
+      expect(result.googleDocPayload).toEqual(COMPLETED_PAYLOAD);
+      expect(result.runId).toBe('run-123');
+    });
+
+    it('polls through IN_PROGRESS and resolves on PENDING_REVIEW with suspendPayload', async () => {
+      const responses = [
+        makeRun(RunStatus.IN_PROGRESS),
+        makeRun(RunStatus.PENDING_REVIEW, { suspendPayload: TABS_SUSPEND_PAYLOAD }),
+      ];
+
+      const result = await drivePolling(responses);
+
+      expect(result.status).toBe(RunStatus.PENDING_REVIEW);
+      expect(result.suspendPayload).toEqual(TABS_SUSPEND_PAYLOAD);
+    });
+
+    it('retries when PENDING_REVIEW arrives without suspendPayload, then resolves when payload flushes', async () => {
+      // First 3 polls: PENDING_REVIEW with no suspendPayload (backend flush delay)
+      // 4th poll: suspendPayload arrives
+      const responses = [
+        makeRun(RunStatus.IN_PROGRESS),
+        makeRun(RunStatus.PENDING_REVIEW), // no suspendPayload
+        makeRun(RunStatus.PENDING_REVIEW), // no suspendPayload
+        makeRun(RunStatus.PENDING_REVIEW), // no suspendPayload
+        makeRun(RunStatus.PENDING_REVIEW, { suspendPayload: MAPPING_SUSPEND_PAYLOAD }),
+      ];
+
+      const result = await drivePolling(responses);
+
+      expect(result.status).toBe(RunStatus.PENDING_REVIEW);
+      expect(result.suspendPayload).toEqual(MAPPING_SUSPEND_PAYLOAD);
+      expect(sdk.cma.agentRun.get).toHaveBeenCalledTimes(5);
+    });
+
+    it('throws WorkflowRunError when PENDING_REVIEW missing payload exceeds retry limit', async () => {
+      // MAX_PENDING_REVIEW_MISSING_PAYLOAD_RETRIES = 5, so 6 consecutive missing = throw
+      const responses = Array(7).fill(makeRun(RunStatus.PENDING_REVIEW)); // never gets payload
+
+      await expect(drivePolling(responses)).rejects.toThrow(
+        'Workflow paused for review, but suspend payload was missing.'
+      );
+    });
+
+    it('throws WorkflowRunError with correct reason on FAILED status', async () => {
+      const responses = [
+        makeRun(RunStatus.IN_PROGRESS),
+        makeRun(RunStatus.FAILED, {
+          workflowFailure: {
+            code: WorkflowFailureReason.GOOGLE_DRIVE_AUTH_EXPIRED,
+            message: 'OAuth expired',
+          },
+        }),
+      ];
+
+      const promise = drivePolling(responses);
+      await expect(promise).rejects.toMatchObject({
+        name: 'WorkflowRunError',
+        reason: WorkflowFailureReason.GOOGLE_DRIVE_AUTH_EXPIRED,
+      });
+    });
+
+    it('throws WorkflowRunError with GENERIC reason for unknown failure codes', async () => {
+      const responses = [
+        makeRun(RunStatus.FAILED, {
+          workflowFailure: { code: 'some-unknown-code', message: 'Unknown' },
+        }),
+      ];
+
+      const promise = drivePolling(responses);
+      await expect(promise).rejects.toMatchObject({
+        name: 'WorkflowRunError',
+        reason: WorkflowFailureReason.GENERIC,
+      });
+    });
+
+    it('throws WorkflowRunError with PROCESSING_TIMEOUT after max poll attempts', async () => {
+      // Always returns IN_PROGRESS so polling exhausts MAX_POLL_ATTEMPTS (120)
+      vi.mocked(sdk.cma.agentRun.get).mockResolvedValue(makeRun(RunStatus.IN_PROGRESS) as any);
+
+      const { result } = renderHook(() =>
+        useWorkflowAgent({ sdk, documentId: 'doc-1', oauthToken: 'token-x' })
+      );
+
+      let resultPromise: Promise<any>;
+      act(() => {
+        resultPromise = result.current.startWorkflow(['blogPost']);
+        void resultPromise.catch(() => {});
+      });
+
+      // Advance past all 120 poll attempts (120 × 10s = 1200s)
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1_210_000);
+      });
+
+      await expect(resultPromise!).rejects.toMatchObject({
+        name: 'WorkflowRunError',
+        reason: WorkflowFailureReason.PROCESSING_TIMEOUT,
+      });
+    });
+
+    it('handles a run that is initially not found, then appears', async () => {
+      let callCount = 0;
+      vi.mocked(sdk.cma.agentRun.get).mockImplementation(async () => {
+        callCount++;
+        if (callCount < 3) {
+          const err = Object.assign(new Error('Not found'), { code: 'NotFound' });
+          throw err;
+        }
+        return makeRun(RunStatus.COMPLETED, { googleDocPayload: COMPLETED_PAYLOAD }) as any;
+      });
+
+      const { result } = renderHook(() =>
+        useWorkflowAgent({ sdk, documentId: 'doc-1', oauthToken: 'token-x' })
+      );
+
+      let resultPromise: Promise<any>;
+      act(() => {
+        resultPromise = result.current.startWorkflow(['blogPost']);
+      });
+
+      for (let i = 0; i < 3; i++) {
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(10_000);
+        });
+      }
+
+      const workflowResult = await resultPromise!;
+      expect(workflowResult.status).toBe(RunStatus.COMPLETED);
+    });
+
+    it('sets isAnalyzing to true while running and false when done', async () => {
+      vi.mocked(sdk.cma.agentRun.get).mockResolvedValue(
+        makeRun(RunStatus.COMPLETED, { googleDocPayload: COMPLETED_PAYLOAD }) as any
+      );
+
+      const { result } = renderHook(() =>
+        useWorkflowAgent({ sdk, documentId: 'doc-1', oauthToken: 'token-x' })
+      );
+
+      expect(result.current.isAnalyzing).toBe(false);
+
+      let resultPromise: Promise<any>;
+      act(() => {
+        resultPromise = result.current.startWorkflow(['blogPost']);
+      });
+
+      expect(result.current.isAnalyzing).toBe(true);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_000);
+      });
+
+      await resultPromise!;
+      expect(result.current.isAnalyzing).toBe(false);
+    });
+  });
+
+  describe('resumeWorkflow', () => {
+    beforeEach(() => {
+      vi.mocked(sdk.cma.agentRun.resume).mockResolvedValue(undefined as any);
+    });
+
+    it('resumes a run and polls to COMPLETED', async () => {
+      let callIndex = 0;
+      const responses = [
+        makeRun(RunStatus.IN_PROGRESS),
+        makeRun(RunStatus.COMPLETED, { googleDocPayload: COMPLETED_PAYLOAD }),
+      ];
+      vi.mocked(sdk.cma.agentRun.get).mockImplementation(async () => {
+        return responses[Math.min(callIndex++, responses.length - 1)] as any;
+      });
+
+      const { result } = renderHook(() =>
+        useWorkflowAgent({ sdk, documentId: 'doc-1', oauthToken: 'token-x' })
+      );
+
+      let resultPromise: Promise<any>;
+      act(() => {
+        resultPromise = result.current.resumeWorkflow('run-123', { includeImages: true });
+      });
+
+      for (let i = 0; i < 2; i++) {
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(10_000);
+        });
+      }
+
+      const workflowResult = await resultPromise!;
+      expect(sdk.cma.agentRun.resume).toHaveBeenCalledWith(
+        expect.objectContaining({ runId: 'run-123' }),
+        { resumePayload: { includeImages: true } }
+      );
+      expect(workflowResult.status).toBe(RunStatus.COMPLETED);
+    });
+
+    it('resumes a mapping-review step and polls to a second PENDING_REVIEW with new suspendPayload', async () => {
+      let callIndex = 0;
+      const responses = [
+        makeRun(RunStatus.IN_PROGRESS),
+        makeRun(RunStatus.PENDING_REVIEW, { suspendPayload: MAPPING_SUSPEND_PAYLOAD }),
+      ];
+      vi.mocked(sdk.cma.agentRun.get).mockImplementation(async () => {
+        return responses[Math.min(callIndex++, responses.length - 1)] as any;
+      });
+
+      const { result } = renderHook(() =>
+        useWorkflowAgent({ sdk, documentId: 'doc-1', oauthToken: 'token-x' })
+      );
+
+      let resultPromise: Promise<any>;
+      act(() => {
+        resultPromise = result.current.resumeWorkflow('run-123', {
+          entryBlockGraph: { entries: [], excludedSourceRefs: [] },
+        });
+      });
+
+      for (let i = 0; i < 2; i++) {
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(10_000);
+        });
+      }
+
+      const workflowResult = await resultPromise!;
+      expect(workflowResult.status).toBe(RunStatus.PENDING_REVIEW);
+      expect(workflowResult.suspendPayload).toEqual(MAPPING_SUSPEND_PAYLOAD);
+    });
+
+    it('handles cancellation resume payload and returns COMPLETED', async () => {
+      vi.mocked(sdk.cma.agentRun.get).mockResolvedValue(
+        makeRun(RunStatus.COMPLETED, {
+          googleDocPayload: { cancelled: true, documentId: 'doc-1' },
+        }) as any
+      );
+
+      const { result } = renderHook(() =>
+        useWorkflowAgent({ sdk, documentId: 'doc-1', oauthToken: 'token-x' })
+      );
+
+      let resultPromise: Promise<any>;
+      act(() => {
+        resultPromise = result.current.resumeWorkflow('run-123', { cancelled: true });
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_000);
+      });
+
+      const workflowResult = await resultPromise!;
+      expect(workflowResult.status).toBe(RunStatus.COMPLETED);
+      // Cancelled runs produce an empty payload — no entries or assets
+      expect(workflowResult.googleDocPayload.entries).toEqual([]);
+    });
+
+    it('throws if resume API call fails', async () => {
+      vi.mocked(sdk.cma.agentRun.resume).mockRejectedValue(new Error('Resume rejected'));
+
+      const { result } = renderHook(() =>
+        useWorkflowAgent({ sdk, documentId: 'doc-1', oauthToken: 'token-x' })
+      );
+
+      let resultPromise: Promise<any>;
+      act(() => {
+        resultPromise = result.current.resumeWorkflow('run-123', { includeImages: false });
+        void resultPromise.catch(() => {});
+      });
+
+      // No timer advance needed — resume throws synchronously before polling starts
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      await expect(resultPromise!).rejects.toThrow('Resume rejected');
+    });
+  });
+});

--- a/apps/drive-integration/test/mocks/mockCma.ts
+++ b/apps/drive-integration/test/mocks/mockCma.ts
@@ -23,6 +23,13 @@ export const createMockCMA = () => {
     appAction: {
       getManyForEnvironment: vi.fn().mockResolvedValue({ items: [] }),
     },
+    agent: {
+      generate: vi.fn(),
+    },
+    agentRun: {
+      get: vi.fn(),
+      resume: vi.fn(),
+    },
   };
 };
 

--- a/apps/drive-integration/test/services/agents-api.test.ts
+++ b/apps/drive-integration/test/services/agents-api.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { PageAppSDK } from '@contentful/app-sdk';
+import { getWorkflowRun, startAgentRun, resumeWorkflowRun } from '../../src/services/agents-api';
+import { RunStatus, WorkflowFailureReason } from '@types';
+import { createMockSDK } from '../mocks';
+
+describe('agents-api', () => {
+  let sdk: PageAppSDK;
+
+  beforeEach(() => {
+    sdk = createMockSDK() as PageAppSDK;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe('getWorkflowRun', () => {
+    it('returns run data with sys.id and status via sdk.cma.agentRun.get', async () => {
+      const runData = {
+        sys: { id: 'run-abc', status: RunStatus.IN_PROGRESS },
+        metadata: { status: RunStatus.IN_PROGRESS },
+      };
+      vi.mocked(sdk.cma.agentRun.get).mockResolvedValue(runData as any);
+
+      const result = await getWorkflowRun(sdk, 'space-1', 'master', 'run-abc');
+
+      expect(sdk.cma.agentRun.get).toHaveBeenCalledWith({
+        spaceId: 'space-1',
+        environmentId: 'master',
+        runId: 'run-abc',
+      });
+      expect(result?.sys?.id).toBe('run-abc');
+      expect(result?.sys?.status).toBe(RunStatus.IN_PROGRESS);
+    });
+
+    it('returns null when run is not found (NotFound code)', async () => {
+      const notFound = Object.assign(new Error('Not found'), { code: 'NotFound' });
+      vi.mocked(sdk.cma.agentRun.get).mockRejectedValue(notFound);
+
+      const result = await getWorkflowRun(sdk, 'space-1', 'master', 'missing-run');
+
+      expect(result).toBeNull();
+    });
+
+    it('rethrows non-NotFound errors as normalised errors', async () => {
+      vi.mocked(sdk.cma.agentRun.get).mockRejectedValue(new Error('Server exploded'));
+
+      await expect(getWorkflowRun(sdk, 'space-1', 'master', 'run-bad')).rejects.toThrow(
+        'Server exploded'
+      );
+    });
+
+    it('returns PENDING_REVIEW status with suspendPayload intact', async () => {
+      const suspendPayload = {
+        suspendStepId: 'select-tabs-images-step' as const,
+        documentId: 'doc-1',
+      };
+      const runData = {
+        sys: { id: 'run-pr', status: RunStatus.PENDING_REVIEW },
+        metadata: { status: RunStatus.PENDING_REVIEW, suspendPayload },
+      };
+      vi.mocked(sdk.cma.agentRun.get).mockResolvedValue(runData as any);
+
+      const result = await getWorkflowRun(sdk, 'space-1', 'master', 'run-pr');
+
+      expect(result?.sys?.status).toBe(RunStatus.PENDING_REVIEW);
+      expect(result?.metadata?.suspendPayload).toEqual(suspendPayload);
+    });
+
+    it('returns COMPLETED status with googleDocPayload', async () => {
+      const googleDocPayload = { entries: [], assets: [], referenceGraph: {} };
+      const runData = {
+        sys: { id: 'run-done', status: RunStatus.COMPLETED },
+        metadata: { status: RunStatus.COMPLETED, googleDocPayload },
+      };
+      vi.mocked(sdk.cma.agentRun.get).mockResolvedValue(runData as any);
+
+      const result = await getWorkflowRun(sdk, 'space-1', 'master', 'run-done');
+
+      expect(result?.sys?.status).toBe(RunStatus.COMPLETED);
+      expect(result?.metadata?.googleDocPayload).toEqual(googleDocPayload);
+    });
+
+    it('returns FAILED status with workflowFailure metadata', async () => {
+      const workflowFailure = {
+        code: WorkflowFailureReason.AI_SERVICE_UNAVAILABLE,
+        message: 'AI unavailable',
+      };
+      const runData = {
+        sys: { id: 'run-fail', status: RunStatus.FAILED },
+        metadata: { status: RunStatus.FAILED, workflowFailure },
+      };
+      vi.mocked(sdk.cma.agentRun.get).mockResolvedValue(runData as any);
+
+      const result = await getWorkflowRun(sdk, 'space-1', 'master', 'run-fail');
+
+      expect(result?.sys?.status).toBe(RunStatus.FAILED);
+      expect(result?.metadata?.workflowFailure?.code).toBe(
+        WorkflowFailureReason.AI_SERVICE_UNAVAILABLE
+      );
+    });
+  });
+
+  describe('startAgentRun', () => {
+    const payload = {
+      messages: [{ role: 'user' as const, parts: [{ type: 'text' as const, text: 'analyze' }] }],
+      metadata: { documentId: 'doc-1', contentTypeIds: ['blogPost'], oauthToken: 'token-x' },
+      threadId: 'thread-1',
+    };
+
+    it('returns sys.id from the agent generate response', async () => {
+      vi.mocked(sdk.cma.agent.generate).mockResolvedValue({
+        sys: { id: 'run-new-123' },
+      } as any);
+
+      const runId = await startAgentRun(sdk, 'space-1', 'master', payload);
+
+      expect(runId).toBe('run-new-123');
+    });
+
+    it('throws when generate response has no sys.id', async () => {
+      vi.mocked(sdk.cma.agent.generate).mockResolvedValue({ sys: {} } as any);
+
+      await expect(startAgentRun(sdk, 'space-1', 'master', payload)).rejects.toThrow(
+        'Agent run started but no run ID was returned'
+      );
+    });
+
+    it('rethrows generate errors as normalised errors', async () => {
+      vi.mocked(sdk.cma.agent.generate).mockRejectedValue(new Error('Rate limited'));
+
+      await expect(startAgentRun(sdk, 'space-1', 'master', payload)).rejects.toThrow(
+        'Rate limited'
+      );
+    });
+  });
+
+  describe('resumeWorkflowRun', () => {
+    const resumePayload = { includeImages: true };
+
+    it('calls agentRun.resume with the correct params', async () => {
+      vi.mocked(sdk.cma.agentRun.resume).mockResolvedValue(undefined as any);
+
+      await resumeWorkflowRun(sdk, 'space-1', 'master', 'run-abc', resumePayload);
+
+      expect(sdk.cma.agentRun.resume).toHaveBeenCalledWith(
+        { spaceId: 'space-1', environmentId: 'master', runId: 'run-abc' },
+        { resumePayload }
+      );
+    });
+
+    it('rethrows resume errors as normalised errors', async () => {
+      vi.mocked(sdk.cma.agentRun.resume).mockRejectedValue(new Error('Resume failed'));
+
+      await expect(
+        resumeWorkflowRun(sdk, 'space-1', 'master', 'run-abc', resumePayload)
+      ).rejects.toThrow('Resume failed');
+    });
+
+    it('calls legacy resumeRun when resume is absent', async () => {
+      const legacyResumeRun = vi.fn().mockResolvedValue(undefined);
+      const sdkWithLegacy = {
+        ...sdk,
+        cma: {
+          ...sdk.cma,
+          agentRun: { resumeRun: legacyResumeRun },
+        },
+      } as unknown as PageAppSDK;
+
+      await resumeWorkflowRun(sdkWithLegacy, 'space-1', 'master', 'run-abc', resumePayload);
+
+      expect(legacyResumeRun).toHaveBeenCalledWith(
+        { spaceId: 'space-1', environmentId: 'master', runId: 'run-abc' },
+        { resumePayload }
+      );
+    });
+
+    it('throws when neither resume nor resumeRun is available', async () => {
+      const sdkNoResume = {
+        ...sdk,
+        cma: { ...sdk.cma, agentRun: {} },
+      } as unknown as PageAppSDK;
+
+      await expect(
+        resumeWorkflowRun(sdkNoResume, 'space-1', 'master', 'run-abc', resumePayload)
+      ).rejects.toThrow('Agent run resume is not available in the current SDK.');
+    });
+  });
+});


### PR DESCRIPTION
[INTEG-4369](https://contentful.atlassian.net/browse/INTEG-4369)

## Purpose
The agents-api service and `useWorkflowAgent` hook had no test coverage for the polling state machine or SDK boundary calls. This PR adds integration tests to verify the full workflow lifecycle so regressions in polling logic are caught before they reach prod.

## Summary
- Adds `agents-api.test.ts`: covers `getWorkflowRun`, `startAgentRun`, and `resumeWorkflowRun` including all status transitions (`IN_PROGRESS`, `PENDING_REVIEW`, `COMPLETED`, `FAILED`), `NotFound` handling, and the legacy `resumeRun` fallback path
- Adds `useWorkflowAgent.test.tsx`: covers the full `pollAgentRun` state machine via fake timers — including delayed `suspendPayload` flush retries, retry-limit exhaustion, PROCESSING_TIMEOUT after MAX_POLL_ATTEMPTS, resume flows (tabs, mapping-review, cancellation), and `isAnalyzing` state lifecycle
- Extends `createMockCMA` with `agent.generate` and `agentRun.get/resume` stubs

## Test plan
- [ ] `pnpm test` passes in `apps/drive-integration`
- [ ] No source files changed — verify diff is test-only

Generated with [Claude Code](https://claude.com/claude-code)

[INTEG-4369]: https://contentful.atlassian.net/browse/INTEG-4369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ