### PR TITLE
fix(drive-integration): link new Add Entry as child of selected parent [INTEG-4524]

### DIFF
--- a/apps/drive-integration/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/drive-integration/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -479,7 +479,7 @@ export const MappingView = ({
       entries: [...entryBlockGraph.entries, newEntry],
     };
 
-    if (isLinkedReference && parentEntry && refField?.id) {
+    if (isLinkedReference && parentEntry && refField?.id && refField.type) {
       const { parentEntry: updatedParent, edges: nextEdges } = linkChildToParentEntry({
         parentEntry,
         childTempId: tempId,

--- a/apps/drive-integration/src/locations/Page/components/review/mapping/MappingView.tsx
+++ b/apps/drive-integration/src/locations/Page/components/review/mapping/MappingView.tsx
@@ -49,6 +49,7 @@ import {
   hasFieldType,
   isEntryReferenceField,
 } from './fieldFormatting';
+import { linkChildToParentEntry, withUpdatedReferenceGraph } from './linkChildToParent';
 import { EditModal } from './edit-modals/EditModal';
 import { RichTextSelectionPreview } from './edit-modals/RichTextSelectionPreview';
 
@@ -433,6 +434,7 @@ export const MappingView = ({
         return {
           tempId: entry.tempId ?? `${entry.contentTypeId}-${idx}`,
           label: `${contentTypeName} (${entryTitle})`,
+          contentTypeId: entry.contentTypeId,
         };
       }),
     [entryBlockGraph.entries, payload.contentTypes]
@@ -445,29 +447,30 @@ export const MappingView = ({
     const newEntryIndex = entryBlockGraph.entries.length;
     const tempId = crypto.randomUUID();
 
+    const parentEntryIndex = isLinkedReference
+      ? entryBlockGraph.entries.findIndex(
+          (entry, idx) =>
+            (entry.tempId ?? `${entry.contentTypeId}-${idx}`) === params.referenceEntryId
+        )
+      : -1;
+    const parentEntry =
+      parentEntryIndex >= 0 ? entryBlockGraph.entries[parentEntryIndex] : undefined;
+    const parentContentType = parentEntry
+      ? payload.contentTypes.find((ct) => ct.sys.id === parentEntry.contentTypeId)
+      : undefined;
+
     const refField = isLinkedReference
-      ? contentType?.fields?.find(
+      ? parentContentType?.fields?.find(
           (f) =>
             f.id === params.referenceFieldId ||
             (!params.referenceFieldId && isEntryReferenceField(f))
         )
       : undefined;
 
-    const newEntryFields: Record<string, Record<string, unknown>> = refField?.id
-      ? {
-          [refField.id]: {
-            [defaultLocale]:
-              refField.type === 'Array'
-                ? [{ __ref: params.referenceEntryId }]
-                : { __ref: params.referenceEntryId },
-          },
-        }
-      : {};
-
     const newEntry = {
       contentTypeId,
       tempId,
-      fields: newEntryFields,
+      fields: {} as Record<string, Record<string, unknown>>,
       fieldMappings: [],
     };
 
@@ -475,6 +478,27 @@ export const MappingView = ({
       ...entryBlockGraph,
       entries: [...entryBlockGraph.entries, newEntry],
     };
+
+    if (isLinkedReference && parentEntry && refField?.id) {
+      const { parentEntry: updatedParent, edges: nextEdges } = linkChildToParentEntry({
+        parentEntry,
+        childTempId: tempId,
+        refField: { id: refField.id, type: refField.type },
+        defaultLocale,
+        previousEdges: referenceGraph.edges ?? [],
+      });
+
+      next = {
+        ...next,
+        entries: next.entries.map((entry, idx) =>
+          idx === parentEntryIndex ? updatedParent : entry
+        ),
+      };
+
+      if (onReferenceGraphChange) {
+        onReferenceGraphChange(withUpdatedReferenceGraph(referenceGraph, nextEdges));
+      }
+    }
 
     if (fieldIds.length > 0) {
       const resolvedTargets = fieldIds.flatMap((fieldId) => {
@@ -526,16 +550,6 @@ export const MappingView = ({
     }
 
     onEntryBlockGraphChange(next);
-
-    if (isLinkedReference && onReferenceGraphChange) {
-      onReferenceGraphChange({
-        ...referenceGraph,
-        edges: [
-          ...(referenceGraph.edges ?? []),
-          { from: tempId, to: params.referenceEntryId!, fieldId: refField?.id ?? '' },
-        ],
-      });
-    }
 
     closeEditModal();
   };

--- a/apps/drive-integration/src/locations/Page/components/review/mapping/edit-modals/AddEntryForm.tsx
+++ b/apps/drive-integration/src/locations/Page/components/review/mapping/edit-modals/AddEntryForm.tsx
@@ -47,14 +47,20 @@ const getParentContentTypeId = (
 ): string =>
   existingEntries.find((entry) => entry.tempId === state.referenceEntryId)?.contentTypeId ?? '';
 
+/** Existing entries whose content type has at least one Entry reference field. */
+export const getParentEntriesThatAcceptChildren = (
+  contentTypes: WorkflowContentType[],
+  existingEntries: ExistingEntryOption[]
+): ExistingEntryOption[] =>
+  existingEntries.filter(
+    (entry) => getReferenceFieldOptions(contentTypes, entry.contentTypeId).length > 0
+  );
+
 /** True when at least one existing entry's content type can accept a child reference. */
 export const canLinkAsChildReference = (
   contentTypes: WorkflowContentType[],
   existingEntries: ExistingEntryOption[]
-): boolean =>
-  existingEntries.some(
-    (entry) => getReferenceFieldOptions(contentTypes, entry.contentTypeId).length > 0
-  );
+): boolean => getParentEntriesThatAcceptChildren(contentTypes, existingEntries).length > 0;
 
 /** Returns true when the form lacks enough input to save. */
 export const isAddEntrySaveDisabled = (
@@ -63,7 +69,9 @@ export const isAddEntrySaveDisabled = (
   existingEntries: ExistingEntryOption[] = []
 ): boolean => {
   if (!state.contentTypeId) return true;
-  if (state.isReference === null) return true;
+  const canBeReference = canLinkAsChildReference(contentTypes, existingEntries);
+  // Reference Yes/No is hidden when no parent can accept a child — treat as No.
+  if (canBeReference && state.isReference === null) return true;
   if (state.isReference) {
     // Child link lives on the parent — require a parent, then its reference field when ambiguous.
     if (!state.referenceEntryId) return true;
@@ -130,10 +138,11 @@ export const AddEntryForm = ({
   );
   const showReferenceFieldSelect =
     Boolean(state.referenceEntryId) && referenceFieldOptions.length > 1;
-  const canBeReference = useMemo(
-    () => canLinkAsChildReference(contentTypes, existingEntries),
+  const parentEntryOptions = useMemo(
+    () => getParentEntriesThatAcceptChildren(contentTypes, existingEntries),
     [contentTypes, existingEntries]
   );
+  const canBeReference = parentEntryOptions.length > 0;
   const hasContentType = Boolean(state.contentTypeId);
 
   const handleContentTypeChange = (contentTypeId: string) => {
@@ -189,32 +198,33 @@ export const AddEntryForm = ({
 
       {hasContentType && (
         <>
-          <FormControl marginBottom="none">
-            <FormControl.Label>
-              Should this new entry be a reference of an existing entry?
-            </FormControl.Label>
-            <Flex flexDirection="column" gap="spacingXs">
-              <Radio
-                id="ref-yes"
-                name="is-reference"
-                value="yes"
-                isChecked={state.isReference === true}
-                isDisabled={!canBeReference}
-                onChange={() => handleReferenceChange(true)}>
-                Yes
-              </Radio>
-              <Radio
-                id="ref-no"
-                name="is-reference"
-                value="no"
-                isChecked={state.isReference === false}
-                onChange={() => handleReferenceChange(false)}>
-                No
-              </Radio>
-            </Flex>
-          </FormControl>
+          {canBeReference && (
+            <FormControl marginBottom="none">
+              <FormControl.Label>
+                Should this new entry be a reference of an existing entry?
+              </FormControl.Label>
+              <Flex flexDirection="column" gap="spacingXs">
+                <Radio
+                  id="ref-yes"
+                  name="is-reference"
+                  value="yes"
+                  isChecked={state.isReference === true}
+                  onChange={() => handleReferenceChange(true)}>
+                  Yes
+                </Radio>
+                <Radio
+                  id="ref-no"
+                  name="is-reference"
+                  value="no"
+                  isChecked={state.isReference === false}
+                  onChange={() => handleReferenceChange(false)}>
+                  No
+                </Radio>
+              </Flex>
+            </FormControl>
+          )}
 
-          {state.isReference === true && (
+          {canBeReference && state.isReference === true && (
             <FormControl marginBottom="none">
               <FormControl.Label>
                 Which existing entry should this new entry be a reference to?
@@ -225,7 +235,7 @@ export const AddEntryForm = ({
                 <Select.Option value="" isDisabled>
                   Select an entry
                 </Select.Option>
-                {existingEntries.map((entry) => (
+                {parentEntryOptions.map((entry) => (
                   <Select.Option key={entry.tempId} value={entry.tempId}>
                     {entry.label}
                   </Select.Option>
@@ -234,7 +244,7 @@ export const AddEntryForm = ({
             </FormControl>
           )}
 
-          {state.isReference === true && showReferenceFieldSelect && (
+          {canBeReference && state.isReference === true && showReferenceFieldSelect && (
             <FormControl marginBottom="none">
               <FormControl.Label>
                 Which field on the parent should link to this entry?

--- a/apps/drive-integration/src/locations/Page/components/review/mapping/edit-modals/AddEntryForm.tsx
+++ b/apps/drive-integration/src/locations/Page/components/review/mapping/edit-modals/AddEntryForm.tsx
@@ -7,7 +7,9 @@ import { FieldSelectionDropdown } from './FieldSelectionDropdown';
 export interface AddEntryFormState {
   contentTypeId: string;
   isReference: boolean | null;
+  /** Parent entry tempId when linking as a child reference. */
   referenceEntryId: string;
+  /** Reference field on the parent content type. */
   referenceFieldId: string;
   selectedFieldIds: string[];
 }
@@ -23,6 +25,7 @@ export const INITIAL_ADD_ENTRY_FORM_STATE: AddEntryFormState = {
 export interface ExistingEntryOption {
   tempId: string;
   label: string;
+  contentTypeId: string;
 }
 
 const getReferenceFieldOptions = (
@@ -38,17 +41,35 @@ const getReferenceFieldOptions = (
   });
 };
 
+const getParentContentTypeId = (
+  state: AddEntryFormState,
+  existingEntries: ExistingEntryOption[]
+): string =>
+  existingEntries.find((entry) => entry.tempId === state.referenceEntryId)?.contentTypeId ?? '';
+
+/** True when at least one existing entry's content type can accept a child reference. */
+export const canLinkAsChildReference = (
+  contentTypes: WorkflowContentType[],
+  existingEntries: ExistingEntryOption[]
+): boolean =>
+  existingEntries.some(
+    (entry) => getReferenceFieldOptions(contentTypes, entry.contentTypeId).length > 0
+  );
+
 /** Returns true when the form lacks enough input to save. */
 export const isAddEntrySaveDisabled = (
   state: AddEntryFormState,
-  contentTypes: WorkflowContentType[]
+  contentTypes: WorkflowContentType[],
+  existingEntries: ExistingEntryOption[] = []
 ): boolean => {
   if (!state.contentTypeId) return true;
   if (state.isReference === null) return true;
   if (state.isReference) {
-    const referenceFieldOptions = getReferenceFieldOptions(contentTypes, state.contentTypeId);
-    if (referenceFieldOptions.length === 0) return true;
+    // Child link lives on the parent — require a parent, then its reference field when ambiguous.
     if (!state.referenceEntryId) return true;
+    const parentContentTypeId = getParentContentTypeId(state, existingEntries);
+    const referenceFieldOptions = getReferenceFieldOptions(contentTypes, parentContentTypeId);
+    if (referenceFieldOptions.length === 0) return true;
     if (referenceFieldOptions.length > 1 && !state.referenceFieldId) return true;
   }
   return state.selectedFieldIds.length === 0;
@@ -57,9 +78,11 @@ export const isAddEntrySaveDisabled = (
 /** Maps form state to the payload expected by onAddEntry. */
 export const toAddEntryFormParams = (
   state: AddEntryFormState,
-  contentTypes: WorkflowContentType[]
+  contentTypes: WorkflowContentType[],
+  existingEntries: ExistingEntryOption[] = []
 ): AddEntryFormParams => {
-  const referenceFieldOptions = getReferenceFieldOptions(contentTypes, state.contentTypeId);
+  const parentContentTypeId = getParentContentTypeId(state, existingEntries);
+  const referenceFieldOptions = getReferenceFieldOptions(contentTypes, parentContentTypeId);
   return {
     contentTypeId: state.contentTypeId,
     isReference: state.isReference ?? false,
@@ -96,12 +119,21 @@ export const AddEntryForm = ({
     () => buildFieldOptionsForContentType(selectedContentType),
     [selectedContentType]
   );
-  const referenceFieldOptions = useMemo(
-    () => getReferenceFieldOptions(contentTypes, state.contentTypeId),
-    [contentTypes, state.contentTypeId]
+  const parentContentTypeId = useMemo(
+    () =>
+      existingEntries.find((entry) => entry.tempId === state.referenceEntryId)?.contentTypeId ?? '',
+    [existingEntries, state.referenceEntryId]
   );
-  const showReferenceFieldSelect = referenceFieldOptions.length > 1;
-  const canBeReference = referenceFieldOptions.length > 0;
+  const referenceFieldOptions = useMemo(
+    () => getReferenceFieldOptions(contentTypes, parentContentTypeId),
+    [contentTypes, parentContentTypeId]
+  );
+  const showReferenceFieldSelect =
+    Boolean(state.referenceEntryId) && referenceFieldOptions.length > 1;
+  const canBeReference = useMemo(
+    () => canLinkAsChildReference(contentTypes, existingEntries),
+    [contentTypes, existingEntries]
+  );
   const hasContentType = Boolean(state.contentTypeId);
 
   const handleContentTypeChange = (contentTypeId: string) => {
@@ -122,6 +154,13 @@ export const AddEntryForm = ({
     onChange({
       isReference: false,
       referenceEntryId: '',
+      referenceFieldId: '',
+    });
+  };
+
+  const handleParentEntryChange = (referenceEntryId: string) => {
+    onChange({
+      referenceEntryId,
       referenceFieldId: '',
     });
   };
@@ -151,7 +190,9 @@ export const AddEntryForm = ({
       {hasContentType && (
         <>
           <FormControl marginBottom="none">
-            <FormControl.Label>Should this entry be a reference entry?</FormControl.Label>
+            <FormControl.Label>
+              Should this new entry be a reference of an existing entry?
+            </FormControl.Label>
             <Flex flexDirection="column" gap="spacingXs">
               <Radio
                 id="ref-yes"
@@ -175,10 +216,12 @@ export const AddEntryForm = ({
 
           {state.isReference === true && (
             <FormControl marginBottom="none">
-              <FormControl.Label>Select the entry this should reference</FormControl.Label>
+              <FormControl.Label>
+                Which existing entry should this new entry be a reference to?
+              </FormControl.Label>
               <Select
                 value={state.referenceEntryId}
-                onChange={(e) => onChange({ referenceEntryId: e.target.value })}>
+                onChange={(e) => handleParentEntryChange(e.target.value)}>
                 <Select.Option value="" isDisabled>
                   Select an entry
                 </Select.Option>
@@ -193,7 +236,9 @@ export const AddEntryForm = ({
 
           {state.isReference === true && showReferenceFieldSelect && (
             <FormControl marginBottom="none">
-              <FormControl.Label>Which field should connect to this reference?</FormControl.Label>
+              <FormControl.Label>
+                Which field on the parent should link to this entry?
+              </FormControl.Label>
               <Select
                 value={state.referenceFieldId}
                 onChange={(e) => onChange({ referenceFieldId: e.target.value })}>

--- a/apps/drive-integration/src/locations/Page/components/review/mapping/edit-modals/EditModal.tsx
+++ b/apps/drive-integration/src/locations/Page/components/review/mapping/edit-modals/EditModal.tsx
@@ -118,12 +118,12 @@ export const EditModal = ({
 
   const handleAddEntrySave = () => {
     if (!addEntryFormState) return;
-    onAddEntry?.(toAddEntryFormParams(addEntryFormState, contentTypes));
+    onAddEntry?.(toAddEntryFormParams(addEntryFormState, contentTypes, existingEntries));
     setAddEntryFormState(null);
   };
 
   const isAddEntryFormSaveDisabled =
-    !addEntryFormState || isAddEntrySaveDisabled(addEntryFormState, contentTypes);
+    !addEntryFormState || isAddEntrySaveDisabled(addEntryFormState, contentTypes, existingEntries);
 
   const previewSectionTitle = viewModel.previewSectionTitle ?? 'Selected content';
   const previewText = (viewModel.contentPreview ?? viewModel.selectedText).trim();

--- a/apps/drive-integration/src/locations/Page/components/review/mapping/linkChildToParent.ts
+++ b/apps/drive-integration/src/locations/Page/components/review/mapping/linkChildToParent.ts
@@ -1,0 +1,101 @@
+import type {
+  EntryBlockGraphEntry,
+  ReviewedReferenceGraph,
+  ReviewedReferenceGraphEdge,
+  WorkflowContentTypeField,
+} from '@types';
+
+type ParentRefField = Pick<WorkflowContentTypeField, 'id' | 'type'>;
+
+/**
+ * Links a new child entry onto a parent for a given reference field.
+ * - Single Link: replaces existing field value, sourceEntryIds, and graph edges for that field
+ * - Array: appends the new child
+ */
+export function linkChildToParentEntry(args: {
+  parentEntry: EntryBlockGraphEntry;
+  childTempId: string;
+  refField: ParentRefField & { id: string };
+  defaultLocale: string;
+  previousEdges: ReviewedReferenceGraphEdge[];
+}): {
+  parentEntry: EntryBlockGraphEntry;
+  edges: ReviewedReferenceGraphEdge[];
+} {
+  const { parentEntry, childTempId, refField, defaultLocale, previousEdges } = args;
+  const isArrayRef = refField.type === 'Array';
+  const childRef = { __ref: childTempId };
+
+  const existingLocalized = parentEntry.fields?.[refField.id] ?? {};
+  const localesToWrite =
+    Object.keys(existingLocalized).length > 0 ? Object.keys(existingLocalized) : [defaultLocale];
+  const nextLocalized: Record<string, unknown> = { ...existingLocalized };
+  for (const locale of localesToWrite) {
+    if (isArrayRef) {
+      const existingRefs = Array.isArray(nextLocalized[locale])
+        ? (nextLocalized[locale] as unknown[])
+        : [];
+      nextLocalized[locale] = [...existingRefs, childRef];
+    } else {
+      nextLocalized[locale] = childRef;
+    }
+  }
+
+  const fmIdx = parentEntry.fieldMappings.findIndex((fm) => fm.fieldId === refField.id);
+  const nextFieldMappings = [...parentEntry.fieldMappings];
+  if (fmIdx >= 0) {
+    const fm = nextFieldMappings[fmIdx];
+    const previousIds = fm.sourceEntryIds ?? [];
+    nextFieldMappings[fmIdx] = {
+      ...fm,
+      sourceEntryIds: isArrayRef ? [...previousIds, childTempId] : [childTempId],
+    };
+  } else {
+    nextFieldMappings.push({
+      fieldId: refField.id,
+      fieldType: refField.type ?? 'Link',
+      sourceRefs: [],
+      sourceEntryIds: [childTempId],
+      confidence: 1,
+    });
+  }
+
+  const parentId = parentEntry.tempId;
+  const keptEdges =
+    !parentId || isArrayRef
+      ? previousEdges
+      : previousEdges.filter((edge) => !(edge.from === parentId && edge.fieldId === refField.id));
+
+  const nextEdges: ReviewedReferenceGraphEdge[] = parentId
+    ? [
+        ...keptEdges,
+        {
+          from: parentId,
+          to: childTempId,
+          fieldId: refField.id,
+        },
+      ]
+    : keptEdges;
+
+  return {
+    parentEntry: {
+      ...parentEntry,
+      fields: {
+        ...(parentEntry.fields ?? {}),
+        [refField.id]: nextLocalized,
+      },
+      fieldMappings: nextFieldMappings,
+    },
+    edges: nextEdges,
+  };
+}
+
+export function withUpdatedReferenceGraph(
+  referenceGraph: ReviewedReferenceGraph,
+  edges: ReviewedReferenceGraphEdge[]
+): ReviewedReferenceGraph {
+  return {
+    ...referenceGraph,
+    edges,
+  };
+}

--- a/apps/drive-integration/src/locations/Page/components/review/mapping/linkChildToParent.ts
+++ b/apps/drive-integration/src/locations/Page/components/review/mapping/linkChildToParent.ts
@@ -23,6 +23,12 @@ export function linkChildToParentEntry(args: {
   edges: ReviewedReferenceGraphEdge[];
 } {
   const { parentEntry, childTempId, refField, defaultLocale, previousEdges } = args;
+  const parentId = parentEntry.tempId;
+
+  if (!parentId) {
+    return { parentEntry, edges: previousEdges };
+  }
+
   const isArrayRef = refField.type === 'Array';
   const childRef = { __ref: childTempId };
 
@@ -60,22 +66,14 @@ export function linkChildToParentEntry(args: {
     });
   }
 
-  const parentId = parentEntry.tempId;
-  const keptEdges =
-    !parentId || isArrayRef
-      ? previousEdges
-      : previousEdges.filter((edge) => !(edge.from === parentId && edge.fieldId === refField.id));
+  const keptEdges = isArrayRef
+    ? previousEdges
+    : previousEdges.filter((edge) => !(edge.from === parentId && edge.fieldId === refField.id));
 
-  const nextEdges: ReviewedReferenceGraphEdge[] = parentId
-    ? [
-        ...keptEdges,
-        {
-          from: parentId,
-          to: childTempId,
-          fieldId: refField.id,
-        },
-      ]
-    : keptEdges;
+  const nextEdges: ReviewedReferenceGraphEdge[] = [
+    ...keptEdges,
+    { from: parentId, to: childTempId, fieldId: refField.id },
+  ];
 
   return {
     parentEntry: {

--- a/apps/drive-integration/src/locations/Page/components/review/mapping/linkChildToParent.ts
+++ b/apps/drive-integration/src/locations/Page/components/review/mapping/linkChildToParent.ts
@@ -41,12 +41,12 @@ export function linkChildToParentEntry(args: {
     }
   }
 
-  const fmIdx = parentEntry.fieldMappings.findIndex((fm) => fm.fieldId === refField.id);
+  const fieldMappingIndex = parentEntry.fieldMappings.findIndex((fm) => fm.fieldId === refField.id);
   const nextFieldMappings = [...parentEntry.fieldMappings];
-  if (fmIdx >= 0) {
-    const fm = nextFieldMappings[fmIdx];
+  if (fieldMappingIndex >= 0) {
+    const fm = nextFieldMappings[fieldMappingIndex];
     const previousIds = fm.sourceEntryIds ?? [];
-    nextFieldMappings[fmIdx] = {
+    nextFieldMappings[fieldMappingIndex] = {
       ...fm,
       sourceEntryIds: isArrayRef ? [...previousIds, childTempId] : [childTempId],
     };

--- a/apps/drive-integration/src/locations/Page/components/review/mapping/linkChildToParent.ts
+++ b/apps/drive-integration/src/locations/Page/components/review/mapping/linkChildToParent.ts
@@ -33,8 +33,8 @@ export function linkChildToParentEntry(args: {
   const childRef = { __ref: childTempId };
 
   const existingLocalized = parentEntry.fields?.[refField.id] ?? {};
-  const localesToWrite =
-    Object.keys(existingLocalized).length > 0 ? Object.keys(existingLocalized) : [defaultLocale];
+  const existingLocales = Object.keys(existingLocalized);
+  const localesToWrite = existingLocales.length > 0 ? existingLocales : [defaultLocale];
   const nextLocalized: Record<string, unknown> = { ...existingLocalized };
   for (const locale of localesToWrite) {
     if (isArrayRef) {
@@ -59,7 +59,7 @@ export function linkChildToParentEntry(args: {
   } else {
     nextFieldMappings.push({
       fieldId: refField.id,
-      fieldType: refField.type ?? 'Link',
+      fieldType: refField.type,
       sourceRefs: [],
       sourceEntryIds: [childTempId],
       confidence: 1,

--- a/apps/drive-integration/src/locations/Page/components/review/mapping/linkChildToParent.ts
+++ b/apps/drive-integration/src/locations/Page/components/review/mapping/linkChildToParent.ts
@@ -1,11 +1,11 @@
 import type {
   EntryBlockGraphEntry,
+  LocalizedField,
   ReviewedReferenceGraph,
   ReviewedReferenceGraphEdge,
-  WorkflowContentTypeField,
 } from '@types';
 
-type ParentRefField = Pick<WorkflowContentTypeField, 'id' | 'type'>;
+type ParentRefField = { id: string; type: string };
 
 /**
  * Links a new child entry onto a parent for a given reference field.
@@ -35,12 +35,10 @@ export function linkChildToParentEntry(args: {
   const existingLocalized = parentEntry.fields?.[refField.id] ?? {};
   const existingLocales = Object.keys(existingLocalized);
   const localesToWrite = existingLocales.length > 0 ? existingLocales : [defaultLocale];
-  const nextLocalized: Record<string, unknown> = { ...existingLocalized };
+  const nextLocalized: LocalizedField = { ...existingLocalized };
   for (const locale of localesToWrite) {
     if (isArrayRef) {
-      const existingRefs = Array.isArray(nextLocalized[locale])
-        ? (nextLocalized[locale] as unknown[])
-        : [];
+      const existingRefs = Array.isArray(nextLocalized[locale]) ? nextLocalized[locale] : [];
       nextLocalized[locale] = [...existingRefs, childRef];
     } else {
       nextLocalized[locale] = childRef;

--- a/apps/drive-integration/test/locations/Page/components/modals/AddEntryForm.spec.tsx
+++ b/apps/drive-integration/test/locations/Page/components/modals/AddEntryForm.spec.tsx
@@ -243,21 +243,47 @@ describe('AddEntryForm', () => {
       expect(screen.queryByText('Which field on the parent should link to this entry?')).toBeNull();
     });
 
-    it('disables Yes only when no existing parent can accept a reference', async () => {
+    it('hides the reference question when no existing parent can accept a child', async () => {
       renderForm(makeState({ contentTypeId: 'component' }), vi.fn(), entriesWithoutRefFields);
 
       await waitFor(() => {
-        expect(screen.getByLabelText('Yes')).toBeDisabled();
-        expect(screen.getByLabelText('No')).not.toBeDisabled();
+        expect(screen.getByText('Select the field(s) the content should map to')).toBeTruthy();
       });
+
+      expect(
+        screen.queryByText('Should this new entry be a reference of an existing entry?')
+      ).toBeNull();
+      expect(screen.queryByLabelText('Yes')).toBeNull();
+      expect(screen.queryByLabelText('No')).toBeNull();
     });
 
-    it('keeps Yes enabled when the new entry type has no reference fields but a parent can', async () => {
+    it('only lists parent entries whose content type can accept a child', async () => {
+      renderForm(
+        makeState({
+          contentTypeId: 'component',
+          isReference: true,
+        }),
+        vi.fn(),
+        [...existingEntries, ...entriesWithoutRefFields]
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Blog post')).toBeTruthy();
+        expect(screen.getByText('Landing page')).toBeTruthy();
+      });
+
+      expect(screen.queryByText('A tag')).toBeNull();
+    });
+
+    it('keeps the reference question when the new entry type has no reference fields but a parent can', async () => {
       renderForm(makeState({ contentTypeId: 'tag' }));
 
       await waitFor(() => {
-        expect(screen.getByLabelText('Yes')).not.toBeDisabled();
-        expect(screen.getByLabelText('No')).not.toBeDisabled();
+        expect(
+          screen.getByText('Should this new entry be a reference of an existing entry?')
+        ).toBeTruthy();
+        expect(screen.getByLabelText('Yes')).toBeTruthy();
+        expect(screen.getByLabelText('No')).toBeTruthy();
       });
     });
 
@@ -347,7 +373,7 @@ describe('AddEntryForm', () => {
       ).toBe(true);
     });
 
-    it('is disabled when isReference is null', () => {
+    it('is disabled when isReference is null and parents can accept a child', () => {
       expect(
         isAddEntrySaveDisabled(
           makeState({ contentTypeId: 'component', isReference: null, selectedFieldIds: ['title'] }),
@@ -355,6 +381,16 @@ describe('AddEntryForm', () => {
           existingEntries
         )
       ).toBe(true);
+    });
+
+    it('is enabled when isReference is null but no parent can accept a child', () => {
+      expect(
+        isAddEntrySaveDisabled(
+          makeState({ contentTypeId: 'component', isReference: null, selectedFieldIds: ['title'] }),
+          contentTypes as any,
+          entriesWithoutRefFields
+        )
+      ).toBe(false);
     });
 
     it('is disabled when No but no fields selected', () => {

--- a/apps/drive-integration/test/locations/Page/components/modals/AddEntryForm.spec.tsx
+++ b/apps/drive-integration/test/locations/Page/components/modals/AddEntryForm.spec.tsx
@@ -7,6 +7,7 @@ import {
   isAddEntrySaveDisabled,
   toAddEntryFormParams,
   type AddEntryFormState,
+  type ExistingEntryOption,
 } from '../../../../../src/locations/Page/components/review/mapping/edit-modals/AddEntryForm';
 
 vi.mock(
@@ -40,15 +41,24 @@ const contentTypes = [
     ],
   },
   {
+    sys: { id: 'component' },
+    name: 'Component',
+    fields: [{ id: 'title', name: 'Title', type: 'Symbol' }],
+  },
+  {
     sys: { id: 'tag' },
     name: 'Tag',
     fields: [{ id: 'label', name: 'Label', type: 'Symbol' }],
   },
 ];
 
-const existingEntries = [
-  { tempId: 'entry-1', label: 'Blog post' },
-  { tempId: 'entry-2', label: 'Landing page' },
+const existingEntries: ExistingEntryOption[] = [
+  { tempId: 'entry-1', label: 'Blog post', contentTypeId: 'article' },
+  { tempId: 'entry-2', label: 'Landing page', contentTypeId: 'page' },
+];
+
+const entriesWithoutRefFields: ExistingEntryOption[] = [
+  { tempId: 'tag-1', label: 'A tag', contentTypeId: 'tag' },
 ];
 
 const makeState = (overrides: Partial<AddEntryFormState> = {}): AddEntryFormState => ({
@@ -56,13 +66,17 @@ const makeState = (overrides: Partial<AddEntryFormState> = {}): AddEntryFormStat
   ...overrides,
 });
 
-const renderForm = (state: AddEntryFormState, onChange = vi.fn()) =>
+const renderForm = (
+  state: AddEntryFormState,
+  onChange = vi.fn(),
+  entries: ExistingEntryOption[] = existingEntries
+) =>
   render(
     <AddEntryForm
       state={state}
       onChange={onChange}
       contentTypes={contentTypes as any}
-      existingEntries={existingEntries}
+      existingEntries={entries}
       selectedText="Some text"
       isImageContent={false}
     />
@@ -83,15 +97,19 @@ describe('AddEntryForm', () => {
       });
     });
 
-    it('hides radios, entry select, and field multiselect until content type is selected', async () => {
+    it('hides radios, parent select, and field multiselect until content type is selected', async () => {
       renderForm(makeState());
 
       await waitFor(() => {
         expect(screen.getByText('Select content type')).toBeTruthy();
       });
 
-      expect(screen.queryByText('Should this entry be a reference entry?')).toBeNull();
-      expect(screen.queryByText('Select the entry this should reference')).toBeNull();
+      expect(
+        screen.queryByText('Should this new entry be a reference of an existing entry?')
+      ).toBeNull();
+      expect(
+        screen.queryByText('Which existing entry should this new entry be a reference to?')
+      ).toBeNull();
       expect(screen.queryByText('Field selection')).toBeNull();
     });
 
@@ -122,23 +140,27 @@ describe('AddEntryForm', () => {
 
   describe('controls after content type is selected', () => {
     it('shows radios and field multiselect together', async () => {
-      renderForm(makeState({ contentTypeId: 'article' }));
+      renderForm(makeState({ contentTypeId: 'component' }));
 
       await waitFor(() => {
-        expect(screen.getByText('Should this entry be a reference entry?')).toBeTruthy();
+        expect(
+          screen.getByText('Should this new entry be a reference of an existing entry?')
+        ).toBeTruthy();
         expect(screen.getByLabelText('Yes')).toBeTruthy();
         expect(screen.getByLabelText('No')).toBeTruthy();
         expect(screen.getByText('Select the field(s) the content should map to')).toBeTruthy();
         expect(screen.getByText('Field selection')).toBeTruthy();
       });
 
-      expect(screen.queryByText('Select the entry this should reference')).toBeNull();
-      expect(screen.queryByText('Which field should connect to this reference?')).toBeNull();
+      expect(
+        screen.queryByText('Which existing entry should this new entry be a reference to?')
+      ).toBeNull();
+      expect(screen.queryByText('Which field on the parent should link to this entry?')).toBeNull();
     });
 
     it('calls onChange with isReference: true when Yes is clicked', async () => {
       const onChange = vi.fn();
-      renderForm(makeState({ contentTypeId: 'article' }), onChange);
+      renderForm(makeState({ contentTypeId: 'component' }), onChange);
 
       fireEvent.click(screen.getByLabelText('Yes'));
 
@@ -149,7 +171,7 @@ describe('AddEntryForm', () => {
       const onChange = vi.fn();
       renderForm(
         makeState({
-          contentTypeId: 'article',
+          contentTypeId: 'component',
           isReference: true,
           referenceEntryId: 'entry-1',
           referenceFieldId: 'author',
@@ -166,54 +188,63 @@ describe('AddEntryForm', () => {
       });
     });
 
-    it('shows entry select when Yes is selected, keeping field multiselect visible', async () => {
+    it('shows parent entry select when Yes is selected', async () => {
       renderForm(
         makeState({
-          contentTypeId: 'article',
+          contentTypeId: 'component',
           isReference: true,
         })
       );
 
       await waitFor(() => {
-        expect(screen.getByText('Select the entry this should reference')).toBeTruthy();
+        expect(
+          screen.getByText('Which existing entry should this new entry be a reference to?')
+        ).toBeTruthy();
         expect(screen.getByText('Blog post')).toBeTruthy();
         expect(screen.getByText('Landing page')).toBeTruthy();
         expect(screen.getByText('Field selection')).toBeTruthy();
       });
     });
 
-    it('shows reference field select when Yes and multiple reference fields exist', async () => {
+    it('shows parent reference fields from the parent content type, not the new entry type', async () => {
+      // New entry is a Component (no ref fields); parent is Article (two ref fields)
       renderForm(
         makeState({
-          contentTypeId: 'article',
+          contentTypeId: 'component',
           isReference: true,
+          referenceEntryId: 'entry-1',
         })
       );
 
       await waitFor(() => {
-        expect(screen.getByText('Which field should connect to this reference?')).toBeTruthy();
+        expect(
+          screen.getByText('Which field on the parent should link to this entry?')
+        ).toBeTruthy();
         expect(screen.getByText('Related articles (Reference list)')).toBeTruthy();
         expect(screen.getByText('Author (Reference)')).toBeTruthy();
       });
     });
 
-    it('hides reference field select when only one reference field exists', async () => {
+    it('hides parent field select when parent has only one reference field', async () => {
       renderForm(
         makeState({
-          contentTypeId: 'page',
+          contentTypeId: 'component',
           isReference: true,
+          referenceEntryId: 'entry-2',
         })
       );
 
       await waitFor(() => {
-        expect(screen.getByText('Select the entry this should reference')).toBeTruthy();
+        expect(
+          screen.getByText('Which existing entry should this new entry be a reference to?')
+        ).toBeTruthy();
       });
 
-      expect(screen.queryByText('Which field should connect to this reference?')).toBeNull();
+      expect(screen.queryByText('Which field on the parent should link to this entry?')).toBeNull();
     });
 
-    it('disables Yes radio when content type has no reference fields', async () => {
-      renderForm(makeState({ contentTypeId: 'tag' }));
+    it('disables Yes only when no existing parent can accept a reference', async () => {
+      renderForm(makeState({ contentTypeId: 'component' }), vi.fn(), entriesWithoutRefFields);
 
       await waitFor(() => {
         expect(screen.getByLabelText('Yes')).toBeDisabled();
@@ -221,10 +252,37 @@ describe('AddEntryForm', () => {
       });
     });
 
-    it('hides entry and reference field selects when No is selected', async () => {
+    it('keeps Yes enabled when the new entry type has no reference fields but a parent can', async () => {
+      renderForm(makeState({ contentTypeId: 'tag' }));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Yes')).not.toBeDisabled();
+        expect(screen.getByLabelText('No')).not.toBeDisabled();
+      });
+    });
+
+    it('hides parent field select until a parent entry is chosen', async () => {
       renderForm(
         makeState({
-          contentTypeId: 'article',
+          contentTypeId: 'component',
+          isReference: true,
+          referenceEntryId: '',
+        })
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Which existing entry should this new entry be a reference to?')
+        ).toBeTruthy();
+      });
+
+      expect(screen.queryByText('Which field on the parent should link to this entry?')).toBeNull();
+    });
+
+    it('hides parent selects when No is selected', async () => {
+      renderForm(
+        makeState({
+          contentTypeId: 'component',
           isReference: false,
         })
       );
@@ -233,31 +291,38 @@ describe('AddEntryForm', () => {
         expect(screen.getByText('Field selection')).toBeTruthy();
       });
 
-      expect(screen.queryByText('Select the entry this should reference')).toBeNull();
-      expect(screen.queryByText('Which field should connect to this reference?')).toBeNull();
+      expect(
+        screen.queryByText('Which existing entry should this new entry be a reference to?')
+      ).toBeNull();
+      expect(screen.queryByText('Which field on the parent should link to this entry?')).toBeNull();
     });
 
-    it('calls onChange with referenceEntryId when an entry is selected', async () => {
+    it('resets referenceFieldId when parent entry changes', async () => {
       const onChange = vi.fn();
       renderForm(
         makeState({
-          contentTypeId: 'article',
+          contentTypeId: 'component',
           isReference: true,
+          referenceEntryId: 'entry-1',
+          referenceFieldId: 'author',
         }),
         onChange
       );
 
       const selects = screen.getAllByRole('combobox');
-      fireEvent.change(selects[1], { target: { value: 'entry-1' } });
+      fireEvent.change(selects[1], { target: { value: 'entry-2' } });
 
-      expect(onChange).toHaveBeenCalledWith({ referenceEntryId: 'entry-1' });
+      expect(onChange).toHaveBeenCalledWith({
+        referenceEntryId: 'entry-2',
+        referenceFieldId: '',
+      });
     });
 
-    it('calls onChange with referenceFieldId when a field is selected', async () => {
+    it('calls onChange with referenceFieldId when a parent field is selected', async () => {
       const onChange = vi.fn();
       renderForm(
         makeState({
-          contentTypeId: 'article',
+          contentTypeId: 'component',
           isReference: true,
           referenceEntryId: 'entry-1',
         }),
@@ -276,7 +341,8 @@ describe('AddEntryForm', () => {
       expect(
         isAddEntrySaveDisabled(
           makeState({ contentTypeId: '', isReference: false, selectedFieldIds: ['title'] }),
-          contentTypes as any
+          contentTypes as any,
+          existingEntries
         )
       ).toBe(true);
     });
@@ -284,8 +350,9 @@ describe('AddEntryForm', () => {
     it('is disabled when isReference is null', () => {
       expect(
         isAddEntrySaveDisabled(
-          makeState({ contentTypeId: 'article', isReference: null, selectedFieldIds: ['title'] }),
-          contentTypes as any
+          makeState({ contentTypeId: 'component', isReference: null, selectedFieldIds: ['title'] }),
+          contentTypes as any,
+          existingEntries
         )
       ).toBe(true);
     });
@@ -293,8 +360,9 @@ describe('AddEntryForm', () => {
     it('is disabled when No but no fields selected', () => {
       expect(
         isAddEntrySaveDisabled(
-          makeState({ contentTypeId: 'article', isReference: false, selectedFieldIds: [] }),
-          contentTypes as any
+          makeState({ contentTypeId: 'component', isReference: false, selectedFieldIds: [] }),
+          contentTypes as any,
+          existingEntries
         )
       ).toBe(true);
     });
@@ -303,106 +371,113 @@ describe('AddEntryForm', () => {
       expect(
         isAddEntrySaveDisabled(
           makeState({
-            contentTypeId: 'article',
+            contentTypeId: 'component',
             isReference: false,
             selectedFieldIds: ['title'],
           }),
-          contentTypes as any
+          contentTypes as any,
+          existingEntries
         )
       ).toBe(false);
     });
 
-    it('is disabled when Yes but no reference entry', () => {
+    it('is disabled when Yes but no parent entry', () => {
       expect(
         isAddEntrySaveDisabled(
           makeState({
-            contentTypeId: 'article',
+            contentTypeId: 'component',
             isReference: true,
             referenceEntryId: '',
             selectedFieldIds: ['title'],
           }),
-          contentTypes as any
+          contentTypes as any,
+          existingEntries
         )
       ).toBe(true);
     });
 
-    it('is disabled when Yes needs reference field but none selected', () => {
+    it('is disabled when Yes and parent needs a field but none selected', () => {
       expect(
         isAddEntrySaveDisabled(
           makeState({
-            contentTypeId: 'article',
+            contentTypeId: 'component',
             isReference: true,
             referenceEntryId: 'entry-1',
             referenceFieldId: '',
             selectedFieldIds: ['title'],
           }),
-          contentTypes as any
+          contentTypes as any,
+          existingEntries
         )
       ).toBe(true);
     });
 
-    it('is enabled when Yes with entry, field, and selected fields', () => {
+    it('is enabled when Yes with parent, field, and selected fields', () => {
       expect(
         isAddEntrySaveDisabled(
           makeState({
-            contentTypeId: 'article',
+            contentTypeId: 'component',
             isReference: true,
             referenceEntryId: 'entry-1',
             referenceFieldId: 'author',
             selectedFieldIds: ['title'],
           }),
-          contentTypes as any
+          contentTypes as any,
+          existingEntries
         )
       ).toBe(false);
     });
 
-    it('is enabled when Yes with entry and fields when reference field select not needed', () => {
+    it('is enabled when Yes with parent that has a single reference field', () => {
       expect(
         isAddEntrySaveDisabled(
           makeState({
-            contentTypeId: 'page',
+            contentTypeId: 'component',
             isReference: true,
-            referenceEntryId: 'entry-1',
+            referenceEntryId: 'entry-2',
             referenceFieldId: '',
             selectedFieldIds: ['title'],
           }),
-          contentTypes as any
+          contentTypes as any,
+          existingEntries
         )
       ).toBe(false);
     });
 
-    it('is disabled when Yes but content type has no reference fields', () => {
+    it('is disabled when Yes but selected parent has no reference fields', () => {
       expect(
         isAddEntrySaveDisabled(
           makeState({
-            contentTypeId: 'tag',
+            contentTypeId: 'component',
             isReference: true,
-            referenceEntryId: 'entry-1',
-            selectedFieldIds: ['label'],
+            referenceEntryId: 'tag-1',
+            selectedFieldIds: ['title'],
           }),
-          contentTypes as any
+          contentTypes as any,
+          [...existingEntries, ...entriesWithoutRefFields]
         )
       ).toBe(true);
     });
   });
 
   describe('toAddEntryFormParams', () => {
-    it('auto-picks the sole reference field when none is selected', () => {
+    it('auto-picks the sole parent reference field when none is selected', () => {
       expect(
         toAddEntryFormParams(
           makeState({
-            contentTypeId: 'page',
+            contentTypeId: 'component',
             isReference: true,
-            referenceEntryId: 'entry-1',
+            referenceEntryId: 'entry-2',
             referenceFieldId: '',
             selectedFieldIds: ['title'],
           }),
-          contentTypes as any
+          contentTypes as any,
+          existingEntries
         )
       ).toEqual({
-        contentTypeId: 'page',
+        contentTypeId: 'component',
         isReference: true,
-        referenceEntryId: 'entry-1',
+        referenceEntryId: 'entry-2',
         referenceFieldId: 'author',
         fieldIds: ['title'],
       });
@@ -412,16 +487,17 @@ describe('AddEntryForm', () => {
       expect(
         toAddEntryFormParams(
           makeState({
-            contentTypeId: 'article',
+            contentTypeId: 'component',
             isReference: false,
             referenceEntryId: 'entry-1',
             referenceFieldId: 'author',
             selectedFieldIds: ['title'],
           }),
-          contentTypes as any
+          contentTypes as any,
+          existingEntries
         )
       ).toEqual({
-        contentTypeId: 'article',
+        contentTypeId: 'component',
         isReference: false,
         referenceEntryId: null,
         referenceFieldId: null,

--- a/apps/drive-integration/test/locations/Page/components/modals/EditModal.spec.tsx
+++ b/apps/drive-integration/test/locations/Page/components/modals/EditModal.spec.tsx
@@ -33,8 +33,8 @@ const contentTypes = [
 ];
 
 const existingEntries = [
-  { tempId: 'entry-1', label: 'Blog post' },
-  { tempId: 'entry-2', label: 'Landing page' },
+  { tempId: 'entry-1', label: 'Blog post', contentTypeId: 'article' },
+  { tempId: 'entry-2', label: 'Landing page', contentTypeId: 'page' },
 ];
 
 const baseNewLocation = {
@@ -188,7 +188,9 @@ describe('EditModal', () => {
       expect(screen.getByRole('button', { name: 'Back' })).toBeTruthy();
       expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
       expect(screen.queryByRole('button', { name: 'Next' })).toBeNull();
-      expect(screen.queryByText('Should this entry be a reference entry?')).toBeNull();
+      expect(
+        screen.queryByText('Should this new entry be a reference of an existing entry?')
+      ).toBeNull();
     });
 
     it('shows radios and field multiselect together after content type is selected', async () => {
@@ -197,16 +199,20 @@ describe('EditModal', () => {
       fireEvent.change(screen.getByRole('combobox'), { target: { value: 'page' } });
 
       await waitFor(() => {
-        expect(screen.getByText('Should this entry be a reference entry?')).toBeTruthy();
+        expect(
+          screen.getByText('Should this new entry be a reference of an existing entry?')
+        ).toBeTruthy();
         expect(screen.getByLabelText('Yes')).toBeTruthy();
         expect(screen.getByLabelText('No')).toBeTruthy();
         expect(screen.getByText('Select the field(s) the content should map to')).toBeTruthy();
       });
 
-      expect(screen.queryByText('Select the entry this should reference')).toBeNull();
+      expect(
+        screen.queryByText('Which existing entry should this new entry be a reference to?')
+      ).toBeNull();
     });
 
-    it('shows reference entry select when Yes is chosen', async () => {
+    it('shows parent entry select when Yes is chosen', async () => {
       await openAddEntryForm();
 
       fireEvent.change(screen.getByRole('combobox'), { target: { value: 'article' } });
@@ -218,7 +224,9 @@ describe('EditModal', () => {
       fireEvent.click(screen.getByLabelText('Yes'));
 
       await waitFor(() => {
-        expect(screen.getByText('Select the entry this should reference')).toBeTruthy();
+        expect(
+          screen.getByText('Which existing entry should this new entry be a reference to?')
+        ).toBeTruthy();
         expect(screen.getByText('Blog post')).toBeTruthy();
       });
     });

--- a/apps/drive-integration/test/locations/Page/components/review/mapping/linkChildToParent.spec.ts
+++ b/apps/drive-integration/test/locations/Page/components/review/mapping/linkChildToParent.spec.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import type { EntryBlockGraphEntry } from '@types';
+import { linkChildToParentEntry } from '../../../../../../src/locations/Page/components/review/mapping/linkChildToParent';
+
+const parentEntry = (overrides: Partial<EntryBlockGraphEntry> = {}): EntryBlockGraphEntry => ({
+  tempId: 'parent-1',
+  contentTypeId: 'page',
+  fields: {
+    author: { 'en-US': { __ref: 'old-child' } },
+  },
+  fieldMappings: [
+    {
+      fieldId: 'author',
+      fieldType: 'Link',
+      sourceRefs: [],
+      sourceEntryIds: ['old-child'],
+      confidence: 1,
+    },
+  ],
+  ...overrides,
+});
+
+describe('linkChildToParentEntry', () => {
+  it('replaces a filled single Link field, sourceEntryIds, and edges with the new child', () => {
+    const result = linkChildToParentEntry({
+      parentEntry: parentEntry(),
+      childTempId: 'new-child',
+      refField: { id: 'author', type: 'Link' },
+      defaultLocale: 'en-US',
+      previousEdges: [
+        { from: 'parent-1', to: 'old-child', fieldId: 'author' },
+        { from: 'parent-1', to: 'other', fieldId: 'related' },
+      ],
+    });
+
+    expect(result.parentEntry.fields?.author).toEqual({
+      'en-US': { __ref: 'new-child' },
+    });
+    expect(result.parentEntry.fieldMappings[0].sourceEntryIds).toEqual(['new-child']);
+    expect(result.edges).toEqual([
+      { from: 'parent-1', to: 'other', fieldId: 'related' },
+      { from: 'parent-1', to: 'new-child', fieldId: 'author' },
+    ]);
+  });
+
+  it('writes the new child to every existing locale on a single Link field', () => {
+    const result = linkChildToParentEntry({
+      parentEntry: parentEntry({
+        fields: {
+          author: {
+            'en-US': { __ref: 'old-child' },
+            'de-DE': { __ref: 'old-child' },
+          },
+        },
+      }),
+      childTempId: 'new-child',
+      refField: { id: 'author', type: 'Link' },
+      defaultLocale: 'en-US',
+      previousEdges: [],
+    });
+
+    expect(result.parentEntry.fields?.author).toEqual({
+      'en-US': { __ref: 'new-child' },
+      'de-DE': { __ref: 'new-child' },
+    });
+  });
+
+  it('appends to Array reference fields and edges without removing prior children', () => {
+    const result = linkChildToParentEntry({
+      parentEntry: parentEntry({
+        fields: {
+          related: { 'en-US': [{ __ref: 'old-child' }] },
+        },
+        fieldMappings: [
+          {
+            fieldId: 'related',
+            fieldType: 'Array',
+            sourceRefs: [],
+            sourceEntryIds: ['old-child'],
+            confidence: 1,
+          },
+        ],
+      }),
+      childTempId: 'new-child',
+      refField: { id: 'related', type: 'Array' },
+      defaultLocale: 'en-US',
+      previousEdges: [{ from: 'parent-1', to: 'old-child', fieldId: 'related' }],
+    });
+
+    expect(result.parentEntry.fields?.related).toEqual({
+      'en-US': [{ __ref: 'old-child' }, { __ref: 'new-child' }],
+    });
+    expect(result.parentEntry.fieldMappings[0].sourceEntryIds).toEqual(['old-child', 'new-child']);
+    expect(result.edges).toEqual([
+      { from: 'parent-1', to: 'old-child', fieldId: 'related' },
+      { from: 'parent-1', to: 'new-child', fieldId: 'related' },
+    ]);
+  });
+});

--- a/apps/drive-integration/test/locations/Page/components/review/mapping/linkChildToParent.spec.ts
+++ b/apps/drive-integration/test/locations/Page/components/review/mapping/linkChildToParent.spec.ts
@@ -85,6 +85,22 @@ describe('linkChildToParentEntry', () => {
     ]);
   });
 
+  it('returns the entry and edges unchanged when parentEntry has no tempId', () => {
+    const entry = parentEntry({ tempId: undefined });
+    const edges = [{ from: 'other', to: 'old-child', fieldId: 'author' }];
+
+    const result = linkChildToParentEntry({
+      parentEntry: entry,
+      childTempId: 'new-child',
+      refField: { id: 'author', type: 'Link' },
+      defaultLocale: 'en-US',
+      previousEdges: edges,
+    });
+
+    expect(result.parentEntry).toBe(entry);
+    expect(result.edges).toBe(edges);
+  });
+
   it('appends to Array reference fields and edges without removing prior children', () => {
     const result = linkChildToParentEntry({
       parentEntry: parentEntry({

--- a/apps/drive-integration/test/locations/Page/components/review/mapping/linkChildToParent.spec.ts
+++ b/apps/drive-integration/test/locations/Page/components/review/mapping/linkChildToParent.spec.ts
@@ -65,6 +65,26 @@ describe('linkChildToParentEntry', () => {
     });
   });
 
+  it('adds a new fieldMapping when a new child entry is added to a parent with no existing mapping for that field', () => {
+    const result = linkChildToParentEntry({
+      parentEntry: parentEntry({ fieldMappings: [] }),
+      childTempId: 'new-child',
+      refField: { id: 'author', type: 'Link' },
+      defaultLocale: 'en-US',
+      previousEdges: [],
+    });
+
+    expect(result.parentEntry.fieldMappings).toEqual([
+      {
+        fieldId: 'author',
+        fieldType: 'Link',
+        sourceRefs: [],
+        sourceEntryIds: ['new-child'],
+        confidence: 1,
+      },
+    ]);
+  });
+
   it('appends to Array reference fields and edges without removing prior children', () => {
     const result = linkChildToParentEntry({
       parentEntry: parentEntry({


### PR DESCRIPTION
## Summary
- Flip Add Entry reference semantics: the **new entry is a child** of an existing parent (not a parent pointing at an existing entry).
- Reference fields come from the **parent** content type; `__ref` / `sourceEntryIds` are written on the **parent**; edge is `from=parent → to=child`.
- Single **Link** fields **replace** any prior child; **Array** fields **append**.
- Disable **Yes** only when no existing parent content type has an Entry reference field.
- Stacked on #11110 (UI form refactor).

## New reference logic

```mermaid
flowchart TD
  A[Select content type for new entry] --> B{Any existing parent<br/>has Entry reference fields?}
  B -->|No| C[Yes disabled — only No allowed]
  B -->|Yes| D{Should this new entry be a<br/>reference of an existing entry?}
  D -->|No| E[Map fields on new entry only]
  D -->|Yes| F[Select parent entry]
  F --> G{Parent has how many<br/>Entry reference fields?}
  G -->|0| H[Save disabled]
  G -->|1| I[Auto-pick that field]
  G -->|2+| J[Select parent field]
  I --> K[Save]
  J --> K
  K --> L[Create new child entry]
  L --> M{Parent field type}
  M -->|Link| N[Replace parent field value,<br/>sourceEntryIds, and edges]
  M -->|Array| O[Append child to parent field,<br/>sourceEntryIds, and edges]
  N --> P["Edge: from=parent → to=child"]
  O --> P
```

### Before vs after

| | Before (wrong) | After |
|---|---|---|
| Who holds `__ref` | New entry | Parent entry |
| Reference fields shown | New content type | Parent content type |
| Graph edge | `from=new → to=existing` | `from=parent → to=child` |
| Yes disabled when | New CT has no ref fields | No parent can accept a ref |

## Test plan
- [ ] Add entry **No** → saves standalone entry with mapped fields
- [ ] Add entry **Yes** with parent that has one Link field → links as child without showing field select
- [ ] Add entry **Yes** with parent that has multiple ref fields → field select appears; Save requires a choice
- [ ] Parent already has a filled single Link → creating a new child **replaces** the old reference on create
- [ ] Parent Array reference → new child is **appended**
- [ ] When every existing entry’s CT has no Entry refs → **Yes** is disabled, **No** still works
- [ ] New entry CT with no ref fields (e.g. Component/Tag) but parents can accept refs → **Yes** stays enabled


Made with [Cursor](https://cursor.com)