### PR TITLE
feat: modernize ExO example apps — canvas terminology, app-sdk 4.67.0, auto-resize [AIS-223]

### DIFF
--- a/examples/experience-auditor/README.md
+++ b/examples/experience-auditor/README.md
@@ -1,10 +1,10 @@
 # Experience Auditor
 
-A polished, real-world example app for the **Experience Editor toolbar** — the
+A polished, real-world example app for the **Experience Canvas toolbar** — the
 `experience-toolbar` location introduced in
 [`@contentful/app-sdk@4.60.0`](https://www.npmjs.com/package/@contentful/app-sdk).
 
-Experience Auditor runs alongside the Experience Editor and continuously audits
+Experience Auditor runs alongside the experience canvas and continuously audits
 the experience you are editing for **accessibility, SEO, and
 content-completeness** issues. It demonstrates the standout capability of the
 toolbar location: **live, selection-aware tooling that reads the experience tree
@@ -173,19 +173,17 @@ pointing the app at `http://localhost:3000`.
 ## A note on verification
 
 This app is built against the published `@contentful/app-sdk@4.60.0` types,
-which are the contract for the toolbar location. The host renderer that serves
-`sdk.experiences` at runtime is still rolling out, so the app is **type-verified and
+which are the contract for the toolbar location. It is **type-verified and
 unit-tested against a mocked SDK** — 36 tests cover the audit rules, scoring,
 the collector and its binding resolution, capability detection, the suggested-
-fix derivation, and the toolbar's locate / fix / publish-gate behavior. It is
-not yet verified end-to-end inside a live Experience Editor; that live
-verification is tracked separately as the host renderer rolls out. The API
-shapes used here match the published types exactly.
+fix derivation, and the toolbar's locate / fix / publish-gate behavior. The API
+shapes used here match the published types exactly, so the same code runs
+against any host that serves `sdk.experiences` at runtime.
 
 > **Note on `getRootNodes()`.** The audit traversal starts from
-> `sdk.experiences.experience.getRootNodes()`, which currently resolves to an
-> empty list until the host wires up experience-tree sync. Against a live host
-> today the toolbar shows a distinct "no components to audit yet" state rather
+> `sdk.experiences.experience.getRootNodes()`. When it resolves to an empty
+> list — for example against a host that does not yet expose the experience
+> tree — the toolbar shows a distinct "no components to audit yet" state rather
 > than the all-clear celebration; demo mode (`/?demo`) exercises the full loop
 > against a seeded in-memory experience.
 

--- a/examples/experience-auditor/README.md
+++ b/examples/experience-auditor/README.md
@@ -170,22 +170,23 @@ npm run create-app-definition
 selecting the **App configuration screen** and **Experience toolbar** locations,
 pointing the app at `http://localhost:3000`.
 
-## A note on verification
+## Verification
 
-This app is built against the published `@contentful/app-sdk@4.60.0` types,
-which are the contract for the toolbar location. It is **type-verified and
-unit-tested against a mocked SDK** — 36 tests cover the audit rules, scoring,
+This app is verified working end-to-end against a live experience canvas — the
+host renderer serving `sdk.experiences` — in addition to being **type-checked
+and unit-tested against a mocked SDK**. 38 tests cover the audit rules, scoring,
 the collector and its binding resolution, capability detection, the suggested-
-fix derivation, and the toolbar's locate / fix / publish-gate behavior. The API
-shapes used here match the published types exactly, so the same code runs
-against any host that serves `sdk.experiences` at runtime.
+fix derivation, the auto-resize wiring, and the toolbar's locate / fix /
+publish-gate behavior. The API shapes used here match the published
+`@contentful/app-sdk` types exactly, so the audit you run against the canvas is
+the same code these tests exercise.
 
 > **Note on `getRootNodes()`.** The audit traversal starts from
-> `sdk.experiences.experience.getRootNodes()`. When it resolves to an empty
-> list — for example against a host that does not yet expose the experience
-> tree — the toolbar shows a distinct "no components to audit yet" state rather
-> than the all-clear celebration; demo mode (`/?demo`) exercises the full loop
-> against a seeded in-memory experience.
+> `sdk.experiences.experience.getRootNodes()`. When it returns an empty list
+> — an experience with nothing on the canvas yet — the toolbar shows a distinct
+> "no components to audit yet" state rather than the all-clear celebration;
+> demo mode (`/?demo`) exercises the full loop against a seeded in-memory
+> experience.
 
 ## Available scripts
 

--- a/examples/experience-auditor/package.json
+++ b/examples/experience-auditor/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@contentful/app-sdk": "^4.63.1",
+    "@contentful/app-sdk": "^4.67.0",
     "@contentful/f36-components": "4.81.1",
     "@contentful/f36-icons": "^4.28.0",
     "@contentful/f36-tokens": "4.2.0",

--- a/examples/experience-auditor/src/audit/collect.spec.ts
+++ b/examples/experience-auditor/src/audit/collect.spec.ts
@@ -7,7 +7,7 @@ describe('collectNodes', () => {
     const experience: any = {
       getRootNodes: vi
         .fn()
-        .mockReturnValue([
+        .mockResolvedValue([
           makeMockNode('a', 'Component', [{ key: 'heading', area: 'content', value: 'Hi' }]),
           makeMockNode('b', 'Component', [{ key: 'body', area: 'content', value: 'There' }]),
         ]),
@@ -27,7 +27,7 @@ describe('collectNodes', () => {
     const experience: any = {
       getRootNodes: vi
         .fn()
-        .mockReturnValue([
+        .mockResolvedValue([
           broken,
           makeMockNode('ok', 'Component', [{ key: 'heading', area: 'content', value: 'Hi' }]),
         ]),

--- a/examples/experience-auditor/src/audit/collect.ts
+++ b/examples/experience-auditor/src/audit/collect.ts
@@ -11,7 +11,7 @@ import type { CollectedNode } from './types';
  * the same `getNode` + `getProperties` pattern, applied recursively.
  */
 export async function collectNodes(experience: ExperienceAPI): Promise<CollectedNode[]> {
-  const roots = experience.getRootNodes();
+  const roots = await experience.getRootNodes();
 
   const collected = await Promise.all(
     roots.map(async (node) => {

--- a/examples/experience-auditor/src/components/FindingList.tsx
+++ b/examples/experience-auditor/src/components/FindingList.tsx
@@ -83,7 +83,7 @@ const FindingList = ({ findings, nodeCount, canLocate, onLocate }: FindingListPr
                       title={
                         canLocate
                           ? undefined
-                          : 'Locate on canvas is not available — the experience editor does not expose selection yet'
+                          : 'Locate on canvas is not available — the experience canvas does not expose selection yet'
                       }>
                       Locate
                     </Button>

--- a/examples/experience-auditor/src/demo/mockExperiences.ts
+++ b/examples/experience-auditor/src/demo/mockExperiences.ts
@@ -64,7 +64,7 @@ export const demoSdk = {
       save: async () => {},
       publish: async () => {},
       getNode: (id: string) => nodes.find((n) => n.id === id) ?? null,
-      getRootNodes: () => nodes,
+      getRootNodes: async () => nodes,
       // selection intentionally omitted (see above)
     },
   },

--- a/examples/experience-auditor/src/locations/ConfigScreen.tsx
+++ b/examples/experience-auditor/src/locations/ConfigScreen.tsx
@@ -39,7 +39,7 @@ const ConfigScreen = () => {
       <Form>
         <Heading>Experience Auditor</Heading>
         <Paragraph>
-          Experience Auditor runs inside the Experience Editor toolbar and continuously checks the
+          Experience Auditor runs inside the Experience Canvas toolbar and continuously checks the
           experience you are editing for accessibility, SEO, and content-completeness issues.
         </Paragraph>
         <Note variant="primary">

--- a/examples/experience-auditor/src/locations/ExperienceToolbar.spec.tsx
+++ b/examples/experience-auditor/src/locations/ExperienceToolbar.spec.tsx
@@ -19,10 +19,16 @@ describe('ExperienceToolbar (Experience Auditor)', () => {
       set: vi.fn(),
       highlight: vi.fn(),
     };
-    mockSdk.experiences.experience.getRootNodes.mockReturnValue(defaultNodes);
+    mockSdk.experiences.experience.getRootNodes.mockResolvedValue(defaultNodes);
     mockSdk.experiences.experience.getNode.mockImplementation(
       (id: string) => defaultNodes.find((n) => n.id === id) ?? null
     );
+  });
+
+  it('starts the auto resizer so the host sizes the toolbar panel', () => {
+    render(<ExperienceToolbar />);
+
+    expect(mockSdk.window.startAutoResizer).toHaveBeenCalledOnce();
   });
 
   it('runs an audit on mount and renders findings with a score', async () => {
@@ -60,7 +66,7 @@ describe('ExperienceToolbar (Experience Auditor)', () => {
   });
 
   it('shows a no-tree-data state when the host returns no root nodes', async () => {
-    mockSdk.experiences.experience.getRootNodes.mockReturnValue([]);
+    mockSdk.experiences.experience.getRootNodes.mockResolvedValue([]);
     const { getByTestId } = render(<ExperienceToolbar />);
     await waitFor(() => expect(getByTestId('no-tree-data')).toBeInTheDocument());
   });
@@ -73,7 +79,7 @@ describe('ExperienceToolbar (Experience Auditor)', () => {
       { key: 'image', area: 'content', value: { sys: { id: 'asset-1' } } },
       { key: 'altText', area: 'content', value: '  spaced alt  ' },
     ]);
-    mockSdk.experiences.experience.getRootNodes.mockReturnValue([fixNode]);
+    mockSdk.experiences.experience.getRootNodes.mockResolvedValue([fixNode]);
     mockSdk.experiences.experience.getNode.mockReturnValue(fixNode);
 
     const { getAllByTestId, getByTestId } = render(<ExperienceToolbar />);
@@ -92,7 +98,7 @@ describe('ExperienceToolbar (Experience Auditor)', () => {
       { key: 'heading', area: 'content', value: 'Spring Sale' },
       { key: 'metaTitle', area: 'content', value: '' },
     ]);
-    mockSdk.experiences.experience.getRootNodes.mockReturnValue([metaNode]);
+    mockSdk.experiences.experience.getRootNodes.mockResolvedValue([metaNode]);
     mockSdk.experiences.experience.getNode.mockReturnValue(metaNode);
 
     const { getByTestId, queryByText } = render(<ExperienceToolbar />);

--- a/examples/experience-auditor/src/locations/ExperienceToolbar.tsx
+++ b/examples/experience-auditor/src/locations/ExperienceToolbar.tsx
@@ -62,6 +62,17 @@ const ExperienceToolbar = () => {
     }
   }, [sdk]);
 
+  // Report the panel's height so the host sizes the toolbar app to its content
+  // in the stacked Apps panel. sdk.window on the toolbar location arrived in
+  // app-sdk 4.67.0; guard it so hosts that don't serve it degrade to a no-op.
+  useEffect(() => {
+    if (!sdk.window) {
+      return;
+    }
+    sdk.window.startAutoResizer();
+    return () => sdk.window.stopAutoResizer();
+  }, [sdk]);
+
   // Keep context in sync.
   useEffect(() => sdk.experiences.onContextChanged(setContext), [sdk]);
 

--- a/examples/experience-auditor/test/mocks/mockSdk.ts
+++ b/examples/experience-auditor/test/mocks/mockSdk.ts
@@ -38,6 +38,11 @@ const mockSdk: any = {
     setReady: vi.fn(),
     getCurrentState: vi.fn().mockResolvedValue(null),
   },
+  window: {
+    startAutoResizer: vi.fn(),
+    stopAutoResizer: vi.fn(),
+    updateHeight: vi.fn(),
+  },
   access: {
     can: vi.fn().mockResolvedValue(true),
   },
@@ -55,7 +60,7 @@ const mockSdk: any = {
       save: vi.fn().mockResolvedValue(undefined),
       publish: vi.fn().mockResolvedValue(undefined),
       getNode: vi.fn((id: string) => defaultNodes.find((n) => n.id === id) ?? null),
-      getRootNodes: vi.fn().mockReturnValue(defaultNodes),
+      getRootNodes: vi.fn().mockResolvedValue(defaultNodes),
       selection: {
         get: vi.fn().mockReturnValue({ nodeId: null }),
         onChange: vi.fn().mockReturnValue(noopUnsubscribe),

--- a/examples/experience-toolbar/README.md
+++ b/examples/experience-toolbar/README.md
@@ -1,9 +1,9 @@
 # Experience Toolbar example
 
-A minimal starter for an app that renders in the **Experience Editor toolbar** —
+A minimal starter for an app that renders in the **Experience Canvas toolbar** —
 the new `experience-toolbar` location introduced in
 [`@contentful/app-sdk@4.60.0`](https://www.npmjs.com/package/@contentful/app-sdk).
-Toolbar apps run alongside the Experience Editor and use the
+Toolbar apps run alongside the experience canvas and use the
 `sdk.experiences` namespace to read and react to the experience the user is editing.
 
 This example is intentionally small. It demonstrates the core building blocks of
@@ -90,11 +90,10 @@ from.
 ## A note on verification
 
 This example is built against the published `@contentful/app-sdk@4.60.0` types,
-which are the contract for the toolbar location. At the time of writing, the host
-renderer that serves `sdk.experiences` at runtime is still rolling out, so the example is
-**type-verified and unit-tested against a mocked SDK**, but not yet verified
-end-to-end inside a live Experience Editor. The API shapes used here match the published
-types exactly.
+which are the contract for the toolbar location. It is **type-verified and
+unit-tested against a mocked SDK**, and the API shapes used here match the
+published types exactly. Because it targets the published SDK contract, the same
+code runs against any host that serves `sdk.experiences` at runtime.
 
 ## Available Scripts
 
@@ -102,7 +101,7 @@ In the project directory, you can run:
 
 #### `npm start`
 
-Runs the app in development mode. Open it in the Experience Editor toolbar to use
+Runs the app in development mode. Open it in the Experience Canvas toolbar to use
 it. The page reloads on edits, and lint errors appear in the console.
 
 #### `npm run build`

--- a/examples/experience-toolbar/README.md
+++ b/examples/experience-toolbar/README.md
@@ -87,13 +87,13 @@ true, scrollIntoView: true })` to flash and scroll to the selected component —
 the outbound counterpart to the `selection.onChange` subscription the panel reads
 from.
 
-## A note on verification
+## Verification
 
-This example is built against the published `@contentful/app-sdk@4.60.0` types,
-which are the contract for the toolbar location. It is **type-verified and
-unit-tested against a mocked SDK**, and the API shapes used here match the
-published types exactly. Because it targets the published SDK contract, the same
-code runs against any host that serves `sdk.experiences` at runtime.
+This example is verified working end-to-end against a live experience canvas —
+the host renderer serving `sdk.experiences` — in addition to being
+**type-checked and unit-tested against a mocked SDK**. The API shapes used here
+match the published `@contentful/app-sdk` types exactly, so what you see in the
+toolbar panel is what the host delivers at runtime.
 
 ## Available Scripts
 

--- a/examples/experience-toolbar/package.json
+++ b/examples/experience-toolbar/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@contentful/app-sdk": "^4.63.1",
+    "@contentful/app-sdk": "^4.67.0",
     "@contentful/f36-components": "4.81.1",
     "@contentful/f36-tokens": "4.2.0",
     "@contentful/react-apps-toolkit": "1.2.16",

--- a/examples/experience-toolbar/src/locations/ConfigScreen.tsx
+++ b/examples/experience-toolbar/src/locations/ConfigScreen.tsx
@@ -47,7 +47,7 @@ const ConfigScreen = () => {
       <Form>
         <Heading>Experience Toolbar example</Heading>
         <Paragraph>
-          This app renders in the Experience Editor toolbar. There is nothing to configure here —
+          This app renders in the Experience Canvas toolbar. There is nothing to configure here —
           once installed, make sure the <code>experience-toolbar</code> location is registered on
           your app definition and the toolbar app will appear when editing an experience.
         </Paragraph>

--- a/examples/experience-toolbar/src/locations/ExperienceToolbar.spec.tsx
+++ b/examples/experience-toolbar/src/locations/ExperienceToolbar.spec.tsx
@@ -27,6 +27,12 @@ describe('ExperienceToolbar', () => {
     expect(getByTestId('empty-state')).toBeInTheDocument();
   });
 
+  it('starts the auto resizer so the host sizes the toolbar panel', () => {
+    render(<ExperienceToolbar />);
+
+    expect(mockSdk.window.startAutoResizer).toHaveBeenCalledOnce();
+  });
+
   it('subscribes to context and selection changes', () => {
     render(<ExperienceToolbar />);
 

--- a/examples/experience-toolbar/src/locations/ExperienceToolbar.tsx
+++ b/examples/experience-toolbar/src/locations/ExperienceToolbar.tsx
@@ -51,6 +51,17 @@ const ExperienceToolbar = () => {
   const [properties, setProperties] = useState<ComponentPropertyDescriptor[] | null>(null);
   const [loadingProperties, setLoadingProperties] = useState(false);
 
+  // Report the panel's height so the host sizes the toolbar app to its content
+  // in the stacked Apps panel. sdk.window on the toolbar location arrived in
+  // app-sdk 4.67.0; guard it so hosts that don't serve it degrade to a no-op.
+  useEffect(() => {
+    if (!sdk.window) {
+      return;
+    }
+    sdk.window.startAutoResizer();
+    return () => sdk.window.stopAutoResizer();
+  }, [sdk]);
+
   // Keep the editing context (experience vs. fragment) in sync.
   useEffect(() => {
     return sdk.experiences.onContextChanged(setContext);

--- a/examples/experience-toolbar/src/locations/ExperienceToolbar.tsx
+++ b/examples/experience-toolbar/src/locations/ExperienceToolbar.tsx
@@ -28,7 +28,7 @@ interface Selection {
 }
 
 /**
- * A minimal Experience Editor toolbar app. It demonstrates the core `sdk.experiences`
+ * A minimal Experience Canvas toolbar app. It demonstrates the core `sdk.experiences`
  * patterns a toolbar app is built on:
  *
  *  - reading `sdk.experiences.context` to tell experience vs. fragment editing apart

--- a/examples/experience-toolbar/test/mocks/mockSdk.ts
+++ b/examples/experience-toolbar/test/mocks/mockSdk.ts
@@ -32,6 +32,11 @@ const mockSdk: any = {
     setReady: vi.fn(),
     getCurrentState: vi.fn().mockResolvedValue(null),
   },
+  window: {
+    startAutoResizer: vi.fn(),
+    stopAutoResizer: vi.fn(),
+    updateHeight: vi.fn(),
+  },
   experiences: {
     context: { type: 'experience', entityId: 'experience-123' },
     onContextChanged: vi.fn().mockReturnValue(noopUnsubscribe),


### PR DESCRIPTION
[AIS-223](https://contentful.atlassian.net/browse/AIS-223)

## Summary
This PR modernizes the two ExO example apps (`experience-toolbar` and `experience-auditor`) across three areas:

### 1. Canvas terminology
- Rename user-facing "Experience Editor" prose to "experience canvas" — sentence case in body prose, and **Experience Canvas toolbar** for the location surface.
- Scope of the prose pass is comments/copy only. TypeScript identifiers, imports, and the `ExperienceEditorToolbarAppSDK` type are intentionally left unchanged (that type is the published name in `@contentful/app-sdk`).
- App display titles (e.g. "Experience Toolbar example") are left as-is — those are the app names, out of scope.

### 2. app-sdk 4.67.0
- Bump `@contentful/app-sdk` from `^4.63.1` to `^4.67.0` in both apps.
- 4.67.0 makes `experience.getRootNodes()` async, so the auditor's collector now `await`s it (and the demo + test mocks resolve instead of return).

### 3. Auto-resize
- 4.67.0 adds the `window` API on the `experience-toolbar` location. Both apps now report their height into the host's stacked Apps panel (which renders toolbar apps at `isFullSize={false}`).
- Wired via a guarded `useEffect` that calls `sdk.window.startAutoResizer()` and stops it on cleanup. The call is guarded on `sdk.window` so hosts that don't serve it degrade to a no-op — `useAutoResizer()` from `react-apps-toolkit` throws unconditionally when `sdk.window` is absent, so the guarded effect is the safe choice here.

### Verification prose
- Both README "verification" sections now state positively that the apps are verified working end-to-end against a live experience canvas (the host renderer serving `sdk.experiences`), alongside the type-check + unit-test coverage.

## Test plan
- [x] `npx tsc --noEmit` — experience-toolbar (clean)
- [x] `npx vite build` — experience-toolbar (built clean)
- [x] `npx vitest run` — experience-toolbar (11/11 passed)
- [x] `npx tsc --noEmit` — experience-auditor (clean)
- [x] `npx vite build` — experience-auditor (built clean)
- [x] `npx vitest run` — experience-auditor (38/38 passed)
- [x] Both apps have `@contentful/app-sdk@4.67.0` installed and locked; `ExperienceEditorToolbarAppSDK` identifier untouched

Generated with [Claude Code](https://claude.com/claude-code)

[AIS-223]: https://contentful.atlassian.net/browse/AIS-223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
