### PR TITLE
fix: apply signature-verification middleware to POST /api/tokens [AIS-297]

### DIFF
--- a/apps/slack/lambda/lib/app.ts
+++ b/apps/slack/lambda/lib/app.ts
@@ -52,7 +52,7 @@ export function bootstrap(): serverless.Application {
 
   app.use(createServerlessMiddleware(config.serverless));
   app.use(
-    ['/api/messages', '/api/spaces/*', '/api/events', 'api/tokens'],
+    ['/api/messages', '/api/spaces/*', '/api/events', '/api/tokens'],
     createContentfulRequestVerificationMiddleware(config.signingSecret)
   );
   app.use('/api/slack-events', createSlackEventsMiddleware(config.slack, authTokenRepository));


### PR DESCRIPTION
[AIS-297](https://contentful.atlassian.net/browse/AIS-297) / [AIS-299](https://contentful.atlassian.net/browse/AIS-299)

## What's happening here

The Contentful request-signature-verification middleware is meant to be mounted on `/api/messages`, `/api/spaces/*`, `/api/events`, and `/api/tokens`:

```ts
app.use(
  ['/api/messages', '/api/spaces/*', '/api/events', 'api/tokens'],  // <- missing leading slash
  createContentfulRequestVerificationMiddleware(config.signingSecret)
);
```

The last entry is `'api/tokens'` — missing the leading `/`. Express path-matching requires an exact match against the route path (`'/api/tokens'`), so this entry silently never matched anything. `POST /api/tokens` (wired up a few lines below via `app.post('/api/tokens', authToken.post)`) has been running with **no signature verification at all** — any caller could hit it without a valid Contentful app signature.

This closes AIS-297/AIS-299 (duplicate tickets for the same finding, from the Cypress SAST sweep).

## Fix

One-character fix: `'api/tokens'` → `'/api/tokens'`. No other route in the array had this typo (checked `/api/messages`, `/api/spaces/*`, `/api/events` — all correctly prefixed already).

## Test plan

- [ ] No existing test covers `app.ts`'s route-to-middleware wiring (the app's tests are unit tests against individual controllers/middleware in isolation — there's no `supertest`-style HTTP integration test harness here), so I'm not introducing one for a one-line fix; flagging that as a gap rather than pretending coverage exists
- [ ] Manually verify: `POST /api/tokens` without a valid Contentful signature now returns the same rejection the other protected routes already return
- [ ] Manually verify: `POST /api/tokens` with a valid signature still succeeds (no regression to the legitimate OAuth token flow)

Generated with [Claude Code](https://claude.com/claude-code)

[AIS-297]: https://contentful.atlassian.net/browse/AIS-297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AIS-299]: https://contentful.atlassian.net/browse/AIS-299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ