### PR TITLE
feat: adopt ExperienceCanvasToolbarAppSDK in ExO examples [AIS-307]

### DIFF
--- a/examples/experience-auditor/package.json
+++ b/examples/experience-auditor/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@contentful/app-sdk": "^4.67.0",
+    "@contentful/app-sdk": "^4.68.0",
     "@contentful/f36-components": "4.81.1",
     "@contentful/f36-icons": "^4.28.0",
     "@contentful/f36-tokens": "4.2.0",

--- a/examples/experience-auditor/src/demo/mockExperiences.ts
+++ b/examples/experience-auditor/src/demo/mockExperiences.ts
@@ -1,9 +1,9 @@
-import type { ExperienceEditorToolbarAppSDK } from '@contentful/app-sdk';
+import type { ExperienceCanvasToolbarAppSDK } from '@contentful/app-sdk';
 
 /**
  * DEMO ONLY — scaffolding for the standalone `?demo` mode. Typed loosely on
  * purpose: the mock only implements the surfaces the toolbar and collector
- * actually touch, and a single `as unknown as ExperienceEditorToolbarAppSDK`
+ * actually touch, and a single `as unknown as ExperienceCanvasToolbarAppSDK`
  * cast at the export bridges it to the real SDK type. Not used on any real path.
  */
 
@@ -68,4 +68,4 @@ export const demoSdk = {
       // selection intentionally omitted (see above)
     },
   },
-} as unknown as ExperienceEditorToolbarAppSDK;
+} as unknown as ExperienceCanvasToolbarAppSDK;

--- a/examples/experience-auditor/src/locations/ExperienceToolbar.tsx
+++ b/examples/experience-auditor/src/locations/ExperienceToolbar.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import type { ExperienceContext, ExperienceEditorToolbarAppSDK } from '@contentful/app-sdk';
+import type { ExperienceContext, ExperienceCanvasToolbarAppSDK } from '@contentful/app-sdk';
 import {
   Badge,
   Box,
@@ -32,7 +32,7 @@ import FindingList from '../components/FindingList';
  * outstanding errors.
  */
 const ExperienceToolbar = () => {
-  const sdk = useSDK<ExperienceEditorToolbarAppSDK>();
+  const sdk = useSDK<ExperienceCanvasToolbarAppSDK>();
 
   const [context, setContext] = useState<ExperienceContext>(() => sdk.experiences.context);
   const [report, setReport] = useState<AuditReport | null>(null);

--- a/examples/experience-toolbar/README.md
+++ b/examples/experience-toolbar/README.md
@@ -16,7 +16,7 @@ a toolbar app:
 - **Node inspection** — resolving the selected node with
   `sdk.experiences.experience.getNode(nodeId)` and reading its properties
 
-It is fully typed with `ExperienceEditorToolbarAppSDK`.
+It is fully typed with `ExperienceCanvasToolbarAppSDK`.
 
 > **Out of scope (by design).** This starter does not mutate the experience.
 > Data Assembly, `save()`/`publish()`, and property writes are deliberately left

--- a/examples/experience-toolbar/package.json
+++ b/examples/experience-toolbar/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@contentful/app-sdk": "^4.67.0",
+    "@contentful/app-sdk": "^4.68.0",
     "@contentful/f36-components": "4.81.1",
     "@contentful/f36-tokens": "4.2.0",
     "@contentful/react-apps-toolkit": "1.2.16",

--- a/examples/experience-toolbar/src/locations/ExperienceToolbar.tsx
+++ b/examples/experience-toolbar/src/locations/ExperienceToolbar.tsx
@@ -3,7 +3,7 @@ import type {
   ComponentPropertyDescriptor,
   ExperienceContext,
   ExperienceNodeType,
-  ExperienceEditorToolbarAppSDK,
+  ExperienceCanvasToolbarAppSDK,
 } from '@contentful/app-sdk';
 import {
   Badge,
@@ -42,7 +42,7 @@ interface Selection {
  * call on cleanup.
  */
 const ExperienceToolbar = () => {
-  const sdk = useSDK<ExperienceEditorToolbarAppSDK>();
+  const sdk = useSDK<ExperienceCanvasToolbarAppSDK>();
 
   const [context, setContext] = useState<ExperienceContext>(() => sdk.experiences.context);
   const [selection, setSelection] = useState<Selection>(() =>

--- a/examples/experience-toolbar/test/mocks/mockSdk.ts
+++ b/examples/experience-toolbar/test/mocks/mockSdk.ts
@@ -1,7 +1,7 @@
 import { vi } from 'vitest';
 
 /**
- * A minimal mock of the `ExperienceEditorToolbarAppSDK` surface used by the
+ * A minimal mock of the `ExperienceCanvasToolbarAppSDK` surface used by the
  * example. Subscription methods record their callback so tests can drive
  * changes (selection, context) and assert the UI reacts. Each
  * subscription returns an unsubscribe spy.


### PR DESCRIPTION
[AIS-307](https://contentful.atlassian.net/browse/AIS-307)

## Summary
- Updates the Experience Canvas Toolbar example apps to use the canonical `ExperienceCanvasToolbarAppSDK` type from `@contentful/app-sdk` 4.68.
- Bumps the examples' `@contentful/app-sdk` dependency floor to `^4.68.0`.

## Test plan
- [x] `npm run test` in `examples/experience-toolbar` (11 passing)
- [x] `npm run test` in `examples/experience-auditor` (38 passing)
- [x] Confirm examples still typecheck against `@contentful/app-sdk@4.68.0`


Made with [Cursor](https://cursor.com)

[AIS-307]: https://contentful.atlassian.net/browse/AIS-307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ