### PR TITLE
chore(drive-integration): add missing Vite env var type declarations []

### DIFF
--- a/apps/drive-integration/src/vite-env.d.ts
+++ b/apps/drive-integration/src/vite-env.d.ts
@@ -3,6 +3,8 @@
 interface ImportMetaEnv {
   readonly VITE_LOCAL_AGENTS_API_BASE_URL?: string;
   readonly VITE_LD_CLIENT_ID?: string;
+  readonly VITE_GOOGLE_PICKER_API_KEY?: string;
+  readonly VITE_GOOGLE_APP_ID?: string;
 }
 
 declare module '*.png' {


### PR DESCRIPTION
## Summary
- `VITE_GOOGLE_PICKER_API_KEY` and `VITE_GOOGLE_APP_ID` are used in the CI build but were missing from `vite-env.d.ts` — adds them so `import.meta.env` is fully typed
- This also forces `build-deploy-prod` to redeploy drive-integration, which is needed because the LD client ID and user identification changes landed in commits that CI skipped (apps-test was failing at the time, so build-deploy-prod never ran for those commits)

## Test plan
- [ ] CI `apps-test` passes
- [ ] `build-deploy-prod` deploys drive-integration and the "No environment/client-side ID" LaunchDarkly error is gone

Generated with [Claude Code](https://claude.com/claude-code)