### PR TITLE
ci: add explicit build-deploy step for drive-integration []

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,6 +191,19 @@ jobs:
             GOOGLE_DOCS_PROD_CLOUDFRONT_DIST_ID=$GOOGLE_DOCS_PROD_CLOUDFRONT_DIST_ID \
             STAGE='prd' npm run deploy
       - run:
+          name: Build and deploy drive-integration to prod
+          command: |
+            cd apps/drive-integration
+            VITE_GOOGLE_PICKER_API_KEY=$VITE_GOOGLE_PICKER_API_KEY \
+            VITE_GOOGLE_APP_ID=$VITE_GOOGLE_APP_ID \
+            VITE_LD_CLIENT_ID='588a047044b03e0b3211298e' \
+            NODE_ENV='production' \
+            npm run build:frontend
+            STATIC_S3_BASE="s3://cf-apps-static/apps" \
+            GOOGLE_DOCS_PROD_CLOUDFRONT_DIST_ID=$GOOGLE_DOCS_PROD_CLOUDFRONT_DIST_ID \
+            npm run deploy:sync-prod
+            npm run upload:app-prod
+      - run:
           name: Post Deploy
           command: npm run post-deploy
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,16 +193,20 @@ jobs:
       - run:
           name: Build and deploy drive-integration to prod
           command: |
-            cd apps/drive-integration
-            VITE_GOOGLE_PICKER_API_KEY=$VITE_GOOGLE_PICKER_API_KEY \
-            VITE_GOOGLE_APP_ID=$VITE_GOOGLE_APP_ID \
-            VITE_LD_CLIENT_ID='588a047044b03e0b3211298e' \
-            NODE_ENV='production' \
-            npm run build:frontend
-            STATIC_S3_BASE="s3://cf-apps-static/apps" \
-            GOOGLE_DOCS_PROD_CLOUDFRONT_DIST_ID=$GOOGLE_DOCS_PROD_CLOUDFRONT_DIST_ID \
-            npm run deploy:sync-prod
-            npm run upload:app-prod
+            if git diff --name-only HEAD^ HEAD | grep -q "^apps/drive-integration/"; then
+              cd apps/drive-integration
+              VITE_GOOGLE_PICKER_API_KEY=$VITE_GOOGLE_PICKER_API_KEY \
+              VITE_GOOGLE_APP_ID=$VITE_GOOGLE_APP_ID \
+              VITE_LD_CLIENT_ID='588a047044b03e0b3211298e' \
+              NODE_ENV='production' \
+              npm run build:frontend
+              STATIC_S3_BASE="s3://cf-apps-static/apps" \
+              GOOGLE_DOCS_PROD_CLOUDFRONT_DIST_ID=$GOOGLE_DOCS_PROD_CLOUDFRONT_DIST_ID \
+              npm run deploy:sync-prod
+              npm run upload:app-prod
+            else
+              echo "No drive-integration changes, skipping deploy"
+            fi
       - run:
           name: Post Deploy
           command: npm run post-deploy


### PR DESCRIPTION
## Summary
- drive-integration is a **private** lerna package — `lerna run deploy --since` excludes private packages, so its `deploy:prod` script has never been called by CI
- This means every drive-integration change that landed on master was never actually deployed to `app.contentful.com`
- Fix: add a dedicated `Build and deploy drive-integration to prod` step in `build-deploy-prod` that runs `build:frontend` + `deploy:sync-prod` + `upload:app-prod` directly with the correct Vite env vars, bypassing lerna entirely

## Test plan
- [ ] CI `build-deploy-prod` completes and includes the new "Build and deploy drive-integration to prod" step
- [ ] The drive-integration bundle timestamp at `app.contentful.com` is newer than the last deploy
- [ ] No LaunchDarkly "No environment/client-side ID" error in the console

Generated with [Claude Code](https://claude.com/claude-code)