### PR TITLE
chore(drive-integration): add VITE_ENV to vite-env.d.ts type declarations []

### DIFF
--- a/apps/drive-integration/src/vite-env.d.ts
+++ b/apps/drive-integration/src/vite-env.d.ts
@@ -5,6 +5,7 @@ interface ImportMetaEnv {
   readonly VITE_LD_CLIENT_ID?: string;
   readonly VITE_GOOGLE_PICKER_API_KEY?: string;
   readonly VITE_GOOGLE_APP_ID?: string;
+  readonly VITE_ENV?: string;
 }
 
 declare module '*.png' {


### PR DESCRIPTION
## Summary
- Adds `VITE_ENV` to `vite-env.d.ts` so `import.meta.env.VITE_ENV` is typed (it's already passed in the CI build commands)
- This also serves as the first drive-integration source change since the explicit deploy step was wired up in CI, triggering the first proper bundle upload via `upload:app-prod`

## Test plan
- [ ] CI `build-deploy-prod` runs the new "Build and deploy drive-integration to prod" step (not skipped)
- [ ] Drive-integration bundle at `app.contentful.com` is updated (newer Last-Modified timestamp)
- [ ] No LaunchDarkly "No environment/client-side ID" console error

Generated with [Claude Code](https://claude.com/claude-code)