### PR TITLE
fix(drive-integration): restore pre-flight tab/image selection in legacy flow []

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,20 +142,6 @@ jobs:
             GOOGLE_DOCS_TEST_CLOUDFRONT_DIST_ID=$GOOGLE_DOCS_TEST_CLOUDFRONT_DIST_ID \
             STAGE='test' npm run deploy:test
       - run:
-          name: Build and deploy drive-integration to staging
-          command: |
-            if git diff --name-only HEAD^ HEAD | grep -q "^apps/drive-integration/"; then
-              cd apps/drive-integration
-              VITE_GOOGLE_PICKER_API_KEY=$VITE_GOOGLE_PICKER_API_KEY \
-              VITE_GOOGLE_APP_ID=$VITE_GOOGLE_APP_ID \
-              VITE_LD_CLIENT_ID='588a047044b03e0b3211298d' \
-              NODE_ENV='staging' \
-              npm run build:frontend
-              npm run upload:app-staging
-            else
-              echo "No drive-integration changes, skipping deploy"
-            fi
-      - run:
           name: Invalidate Slack staging cloudfront distribution
           command: aws cloudfront create-invalidation --distribution-id $SLACK_TEST_CLOUDFRONT_DIST_ID --paths "/*"
 
@@ -204,23 +190,6 @@ jobs:
             VITE_LD_CLIENT_ID='588a047044b03e0b3211298e' \
             GOOGLE_DOCS_PROD_CLOUDFRONT_DIST_ID=$GOOGLE_DOCS_PROD_CLOUDFRONT_DIST_ID \
             STAGE='prd' npm run deploy
-      - run:
-          name: Build and deploy drive-integration to prod
-          command: |
-            if git diff --name-only HEAD^ HEAD | grep -q "^apps/drive-integration/"; then
-              cd apps/drive-integration
-              VITE_GOOGLE_PICKER_API_KEY=$VITE_GOOGLE_PICKER_API_KEY \
-              VITE_GOOGLE_APP_ID=$VITE_GOOGLE_APP_ID \
-              VITE_LD_CLIENT_ID='588a047044b03e0b3211298e' \
-              NODE_ENV='production' \
-              npm run build:frontend
-              STATIC_S3_BASE="s3://cf-apps-static/apps" \
-              GOOGLE_DOCS_PROD_CLOUDFRONT_DIST_ID=$GOOGLE_DOCS_PROD_CLOUDFRONT_DIST_ID \
-              npm run deploy:sync-prod
-              npm run upload:app-prod
-            else
-              echo "No drive-integration changes, skipping deploy"
-            fi
       - run:
           name: Post Deploy
           command: npm run post-deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,6 +142,20 @@ jobs:
             GOOGLE_DOCS_TEST_CLOUDFRONT_DIST_ID=$GOOGLE_DOCS_TEST_CLOUDFRONT_DIST_ID \
             STAGE='test' npm run deploy:test
       - run:
+          name: Build and deploy drive-integration to staging
+          command: |
+            if git diff --name-only HEAD^ HEAD | grep -q "^apps/drive-integration/"; then
+              cd apps/drive-integration
+              VITE_GOOGLE_PICKER_API_KEY=$VITE_GOOGLE_PICKER_API_KEY \
+              VITE_GOOGLE_APP_ID=$VITE_GOOGLE_APP_ID \
+              VITE_LD_CLIENT_ID='588a047044b03e0b3211298d' \
+              NODE_ENV='staging' \
+              npm run build:frontend
+              npm run upload:app-staging
+            else
+              echo "No drive-integration changes, skipping deploy"
+            fi
+      - run:
           name: Invalidate Slack staging cloudfront distribution
           command: aws cloudfront create-invalidation --distribution-id $SLACK_TEST_CLOUDFRONT_DIST_ID --paths "/*"
 

--- a/apps/drive-integration/package.json
+++ b/apps/drive-integration/package.json
@@ -35,6 +35,7 @@
     "upload:app-flinkly": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id 3m1Cqy5lzALpWNY9GjP2Zm --definition-id 7r10omUtVNoq8X3Yy4YfBL --token $FLINKLY_CONTENTFUL_ACCESS_TOKEN --host api.flinkly.com",
     "deploy:sync-flinkly": "aws s3 sync ./build ${STATIC_S3_BASE}/google-docs-dev/flinkly && aws cloudfront create-invalidation --distribution-id $GOOGLE_DOCS_TEST_CLOUDFRONT_DIST_ID --paths \"/*\" > /dev/null 2>&1",
     "deploy:flinkly": "npm run build && npm run upload:app-flinkly && npm run deploy:sync-flinkly",
+    "upload:app-staging": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id 6xdLsz6lCsk0yPOccSsDK7 --definition-id 4i0mp5lQtgNsHYVrD5jIkj --token $CONTENTFUL_CMA_TOKEN",
     "upload:app-prod": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id 5EJGHo8tYJcjnEhYWDxivp --definition-id 3EaGZUMKRKVZUyrcoNJ4o4 --token $CONTENTFUL_CMA_TOKEN",
     "deploy:sync-prod": "aws s3 sync ./build ${STATIC_S3_BASE}/google-docs && aws cloudfront create-invalidation --distribution-id $GOOGLE_DOCS_PROD_CLOUDFRONT_DIST_ID --paths \"/*\" > /dev/null 2>&1",
     "deploy:prod": "npm run build && npm run upload:app-prod && npm run deploy:sync-prod",

--- a/apps/drive-integration/src/locations/Page/components/mainpage/ModalOrchestratorLegacy.tsx
+++ b/apps/drive-integration/src/locations/Page/components/mainpage/ModalOrchestratorLegacy.tsx
@@ -12,8 +12,6 @@ import { SelectTabsModal } from '../modals/step_3/SelectTabsModal';
 import {
   DocumentTabProps,
   MappingReviewSuspendPayload,
-  ResumePayload,
-  TabsImagesSuspendPayload,
   RunStatus,
   WorkflowRunResult,
   WorkflowFailureReason,
@@ -23,6 +21,10 @@ import { ContentTypePickerModal } from '../modals/step_2/ContentTypePickerModal'
 import { IncludeImagesModal } from '../modals/step_4/IncludeImagesModal';
 import { useWorkflowAgentLegacy } from '@hooks/useWorkflowAgentLegacy';
 import { isAiAccessDeniedError } from '../../../../utils/aiAccess';
+import {
+  fetchDocumentSelection,
+  DocumentSelectionConfig,
+} from '../../../../utils/fetchDocumentSelection';
 
 export interface ModalOrchestratorLegacyHandle {
   startFlow: () => void;
@@ -275,68 +277,50 @@ export const ModalOrchestratorLegacy = forwardRef<
       showDiscardConfirmation();
     };
 
-    const showDocumentScopeReview = (suspendPayload?: TabsImagesSuspendPayload) => {
-      setAvailableTabs(
-        (suspendPayload?.tabs ?? []).map((tab) => ({
-          tabId: tab.id ?? '',
-          tabTitle: tab.title ?? '',
-        }))
-      );
+    const showDocumentScopeReview = (
+      selectionConfig: DocumentSelectionConfig,
+      contentTypeIds: string[]
+    ) => {
+      setAvailableTabs(selectionConfig.tabs.map((tab) => ({ tabId: tab.id, tabTitle: tab.title })));
       setSelectedTabs([]);
       setUseAllTabs(null);
       setIncludeImages(null);
-      setRequiresImageSelection(Boolean(suspendPayload?.requiresImageSelection));
+      const requiresTabSelection = selectionConfig.tabs.length > 1;
+      const requiresImages = selectionConfig.imageCount > 0;
+      setRequiresImageSelection(requiresImages);
 
-      if (suspendPayload?.requiresTabSelection) {
+      if (requiresTabSelection) {
         setFlowStep(FlowStep.SELECT_TABS);
         return;
       }
 
-      if (suspendPayload?.requiresImageSelection) {
+      if (requiresImages) {
         setFlowStep(FlowStep.INCLUDE_IMAGES);
         return;
       }
 
-      setFlowStep(null);
+      void startWorkflowWithDelayedLoading(contentTypeIds, {
+        selectedTabIds: [],
+        includeImages: false,
+      }).catch(handleWorkflowError);
     };
 
     const handleWorkflowResult = (workflowRun: WorkflowRunResult) => {
       setActiveRunId(workflowRun.runId);
 
       if (workflowRun.status === RunStatus.PENDING_REVIEW) {
-        if (workflowRun.suspendPayload.suspendStepId === 'mapping-review') {
-          setFlowStep(null);
-          onMappingReviewReady(workflowRun.suspendPayload, workflowRun.runId);
-          return;
-        }
-
-        showDocumentScopeReview(workflowRun.suspendPayload as unknown as TabsImagesSuspendPayload);
+        setFlowStep(null);
+        onMappingReviewReady(workflowRun.suspendPayload, workflowRun.runId);
         return;
       }
 
       setFlowStep(null);
     };
 
-    const continueWorkflow = async (resumePayloadOverrides?: Partial<ResumePayload>) => {
-      if (!activeRunId) {
-        throw new Error('Workflow run id is missing for resume.');
-      }
-
-      const resumePayload: ResumePayload = {
-        ...(selectedTabs.length > 0
-          ? { selectedTabIds: selectedTabs.map((tab) => tab.tabId) }
-          : {}),
-        ...(includeImages !== null ? { includeImages } : {}),
-        ...resumePayloadOverrides,
-      };
-
-      setFlowStep(FlowStep.LOADING);
-
-      const workflowRun = await resumeWorkflow(activeRunId, resumePayload);
-      handleWorkflowResult(workflowRun);
-    };
-
-    const startWorkflowWithDelayedLoading = async (contentTypeIds: string[]) => {
+    const startWorkflowWithDelayedLoading = async (
+      contentTypeIds: string[],
+      documentSelection: { selectedTabIds: string[]; includeImages: boolean }
+    ) => {
       let isStartPending = true;
       const loadingModalTimeout = window.setTimeout(() => {
         if (isStartPending) {
@@ -345,7 +329,7 @@ export const ModalOrchestratorLegacy = forwardRef<
       }, CONTENT_TYPE_SUBMIT_LOADING_DELAY_MS);
 
       try {
-        return await startWorkflow(contentTypeIds, { selectedTabIds: [], includeImages: false });
+        return await startWorkflow(contentTypeIds, documentSelection);
       } finally {
         isStartPending = false;
         window.clearTimeout(loadingModalTimeout);
@@ -363,11 +347,15 @@ export const ModalOrchestratorLegacy = forwardRef<
         return;
       }
 
+      let selectionConfig: DocumentSelectionConfig;
       try {
-        handleWorkflowResult(await startWorkflowWithDelayedLoading(contentTypeIds));
+        selectionConfig = await fetchDocumentSelection(documentId, oauthToken);
       } catch (error) {
         handleWorkflowError(error);
+        return;
       }
+
+      showDocumentScopeReview(selectionConfig, contentTypeIds);
     };
 
     const handleSelectTabsContinue = async (selectedTabs: DocumentTabProps[]) => {
@@ -379,7 +367,12 @@ export const ModalOrchestratorLegacy = forwardRef<
       }
 
       try {
-        await continueWorkflow({ selectedTabIds: selectedTabs.map((tab) => tab.tabId) });
+        handleWorkflowResult(
+          await startWorkflowWithDelayedLoading(
+            selectedContentTypes.map((ct) => ct.sys.id),
+            { selectedTabIds: selectedTabs.map((tab) => tab.tabId), includeImages: false }
+          )
+        );
       } catch (error) {
         handleWorkflowError(error);
       }
@@ -389,7 +382,15 @@ export const ModalOrchestratorLegacy = forwardRef<
       setIncludeImages(includeImages);
 
       try {
-        await continueWorkflow({ includeImages });
+        handleWorkflowResult(
+          await startWorkflowWithDelayedLoading(
+            selectedContentTypes.map((ct) => ct.sys.id),
+            {
+              selectedTabIds: selectedTabs.map((tab) => tab.tabId),
+              includeImages,
+            }
+          )
+        );
       } catch (error) {
         handleWorkflowError(error);
       }


### PR DESCRIPTION
**Staging test PR** — contains the fix from #11144 plus a CI step to deploy to app definition `4i0mp5lQtgNsHYVrD5jIkj` (org `6xdLsz6lCsk0yPOccSsDK7`) for testing. Once validated, the actual fix should be merged via #11144 without the staging deploy scaffolding.

## What's included
- Cherry-pick of #11144 fix: restores pre-flight `fetchDocumentSelection` in `ModalOrchestratorLegacy` so the legacy flow (flag off) correctly shows tab/image selection before starting the workflow
- New `upload:app-staging` script in `package.json` targeting definition `4i0mp5lQtgNsHYVrD5jIkj`
- New `build-deploy-staging` CI step that builds and uploads drive-integration when its files change

## Test plan
- [ ] Merge this PR, wait for `build-deploy-staging` CI to complete
- [ ] Open app `4i0mp5lQtgNsHYVrD5jIkj` with flag OFF — tab selection modal appears for multi-tab docs
- [ ] Single-tab doc with no images — skips directly to loading, processes correctly
- [ ] If confirmed working, merge #11144 to ship to prod

Generated with [Claude Code](https://claude.com/claude-code)