### PR TITLE
fix(typeform): scope OAuth token postMessage to the app origin [AIS-298]

### DIFF
--- a/apps/typeform/frontend/src/Auth/TypeformOAuth.tsx
+++ b/apps/typeform/frontend/src/Auth/TypeformOAuth.tsx
@@ -33,8 +33,9 @@ export function TypeformOAuth({
       return;
     }
 
-    const handleTokenEvent = ({ data, source }: any) => {
-      if (source !== oauthWindow) {
+    const handleTokenEvent = ({ data, source, origin }: MessageEvent) => {
+      // Only trust a token that came from our own OAuth popup on our own origin.
+      if (source !== oauthWindow || origin !== window.location.origin) {
         return;
       }
 

--- a/apps/typeform/frontend/src/Auth/TypeformOAuth.tsx
+++ b/apps/typeform/frontend/src/Auth/TypeformOAuth.tsx
@@ -34,7 +34,6 @@ export function TypeformOAuth({
     }
 
     const handleTokenEvent = ({ data, source, origin }: MessageEvent) => {
-      // Only trust a token that came from our own OAuth popup on our own origin.
       if (source !== oauthWindow || origin !== window.location.origin) {
         return;
       }

--- a/apps/typeform/frontend/src/processTokenCallback.spec.ts
+++ b/apps/typeform/frontend/src/processTokenCallback.spec.ts
@@ -1,0 +1,75 @@
+import { vi } from 'vitest';
+import processTokenCallback from './processTokenCallback';
+
+// The app's deployed origin, per `apps/typeform/lambda/config/serverless-env.prd.yml`.
+const APP_ORIGIN = 'https://typeform.ctfapps.net';
+
+function mockWindow(href: string) {
+  return {
+    location: { href },
+    opener: { postMessage: vi.fn() },
+    history: { replaceState: vi.fn() },
+  };
+}
+
+describe('processTokenCallback', () => {
+  beforeEach(() => {
+    Date.now = vi.fn(() => 0);
+  });
+
+  it('posts the token scoped to the app origin, never to a wildcard', () => {
+    const window = mockWindow(`${APP_ORIGIN}/frontend/?token=abc123&expiresIn=10`);
+
+    processTokenCallback(window as any);
+
+    expect(window.opener.postMessage).toHaveBeenCalledWith(
+      { token: 'abc123', expireTime: 10000 },
+      APP_ORIGIN
+    );
+    expect(window.history.replaceState).toHaveBeenCalledWith({}, 'oauth', '/');
+  });
+
+  it('falls back to the default expiration when expiresIn is missing', () => {
+    const window = mockWindow(`${APP_ORIGIN}/frontend/?token=abc123`);
+
+    processTokenCallback(window as any);
+
+    expect(window.opener.postMessage).toHaveBeenCalledWith(
+      { token: 'abc123', expireTime: 604800000 },
+      APP_ORIGIN
+    );
+  });
+
+  it('posts an error from the query string scoped to the app origin', () => {
+    const window = mockWindow(`${APP_ORIGIN}/frontend/?error=nope`);
+
+    processTokenCallback(window as any);
+
+    expect(window.opener.postMessage).toHaveBeenCalledWith({ error: 'nope' }, APP_ORIGIN);
+    expect(window.history.replaceState).not.toHaveBeenCalled();
+  });
+
+  it('posts an error scoped to the app origin when there is no query string', () => {
+    const window = mockWindow(`${APP_ORIGIN}/frontend/`);
+
+    processTokenCallback(window as any);
+
+    expect(window.opener.postMessage).toHaveBeenCalledWith(
+      { error: 'No query string provided!' },
+      APP_ORIGIN
+    );
+  });
+
+  // Guards against someone hardcoding the prod origin, which every other test
+  // here would still accept.
+  it('derives the target origin from the callback URL rather than hardcoding one', () => {
+    const window = mockWindow('http://localhost:3000/frontend/?token=abc123&expiresIn=10');
+
+    processTokenCallback(window as any);
+
+    expect(window.opener.postMessage).toHaveBeenCalledWith(
+      { token: 'abc123', expireTime: 10000 },
+      'http://localhost:3000'
+    );
+  });
+});

--- a/apps/typeform/frontend/src/processTokenCallback.spec.ts
+++ b/apps/typeform/frontend/src/processTokenCallback.spec.ts
@@ -60,8 +60,6 @@ describe('processTokenCallback', () => {
     );
   });
 
-  // Guards against someone hardcoding the prod origin, which every other test
-  // here would still accept.
   it('derives the target origin from the callback URL rather than hardcoding one', () => {
     const window = mockWindow('http://localhost:3000/frontend/?token=abc123&expiresIn=10');
 

--- a/apps/typeform/frontend/src/processTokenCallback.ts
+++ b/apps/typeform/frontend/src/processTokenCallback.ts
@@ -1,13 +1,16 @@
 const DEFAULT_TOKEN_EXPIRATION_TIME = 604800;
 
 const processTokenCallback = (window: Window) => {
-  const { searchParams, search } = new URL(window.location.href);
+  const { searchParams, search, origin } = new URL(window.location.href);
 
+  // The OAuth callback is served from the same origin as the config screen that
+  // opened it, so scope the message to that origin instead of broadcasting the
+  // token to whatever origin the opener happens to be on.
   if (search.length) {
     const error = searchParams.get('error');
 
     if (error) {
-      window.opener.postMessage({ error }, '*');
+      window.opener.postMessage({ error }, origin);
       return;
     }
 
@@ -17,11 +20,11 @@ const processTokenCallback = (window: Window) => {
 
     const expireTime = Date.now() + expiresIn * 1000;
 
-    window.opener.postMessage({ token, expireTime }, '*');
+    window.opener.postMessage({ token, expireTime }, origin);
 
     window.history.replaceState({}, 'oauth', '/');
   } else {
-    window.opener.postMessage({ error: 'No query string provided!' }, '*');
+    window.opener.postMessage({ error: 'No query string provided!' }, origin);
   }
 };
 export default processTokenCallback;

--- a/apps/typeform/frontend/src/processTokenCallback.ts
+++ b/apps/typeform/frontend/src/processTokenCallback.ts
@@ -1,11 +1,10 @@
 const DEFAULT_TOKEN_EXPIRATION_TIME = 604800;
 
 const processTokenCallback = (window: Window) => {
+  // The callback and the config screen that opened it share an origin, so the
+  // callback URL's own origin is the one to scope the token message to.
   const { searchParams, search, origin } = new URL(window.location.href);
 
-  // The OAuth callback is served from the same origin as the config screen that
-  // opened it, so scope the message to that origin instead of broadcasting the
-  // token to whatever origin the opener happens to be on.
   if (search.length) {
     const error = searchParams.get('error');
 


### PR DESCRIPTION
## Purpose

The Typeform OAuth landing page forwarded the access token to `window.opener` with a `'*'` target origin, so the browser delivers it regardless of what origin the opener is on. The receiving config screen only checked `event.source`, not `event.origin`.

## Approach

The callback is served from the same origin as the config screen that opened it, so both sides are pinned to that origin:

- **Sender** (`processTokenCallback.ts`) — post to the origin parsed from the callback URL instead of `'*'`.
- **Receiver** (`Auth/TypeformOAuth.tsx`) — also require `origin === window.location.origin`.

Origin chain: the popup opens `` `${window.location.origin}/callback` `` → the lambda redirects to `` `${origin}/frontend/?token=...` `` on the same host.

Target origin comes from the already-parsed callback URL rather than `window.location`, keeping `processTokenCallback(window)` injectable for tests. Mirrors the AB Tasty fix in `marketplace-partner-apps` (AIS-301).


