### PR TITLE
fix(remote-mcp): match font size on ExO accordion section title [AIS-187]

### DIFF
--- a/apps/remote-mcp/src/components/access-config/accessConfigAccordionStack.tsx
+++ b/apps/remote-mcp/src/components/access-config/accessConfigAccordionStack.tsx
@@ -74,7 +74,7 @@ export const PermissionsSection: FC<PermissionsSectionProps> = ({
       </Accordion.Item>
 
       <Accordion.Item
-        title="Experience orchestration actions"
+        title={<span style={{ fontSize: '14px' }}>Experience orchestration actions</span>}
         isExpanded={expandedAccordions.experienceOrchestration}
         onExpand={() => onAccordionToggle('experienceOrchestration', true)}
         onCollapse={() => onAccordionToggle('experienceOrchestration', false)}>


### PR DESCRIPTION
## Summary
- The "Experience orchestration actions" accordion title was rendering at the default (larger) font size because it was passed as a plain string, while the other two sections (`Content lifecycle actions` and `Actions on other features`) wrapped their titles in `<span style={{ fontSize: '14px' }}>`.
- One-line fix to wrap the ExO title in the same span so all three sections are visually consistent.

## Test plan
- [ ] Open the remote MCP config screen and verify all three accordion section titles render at the same font size

Generated with [Claude Code](https://claude.com/claude-code)