### PR TITLE
fix(drive-integration): disable Next button and reduce loading delay after tab/image selection []

### DIFF
--- a/apps/drive-integration/src/locations/Page/components/mainpage/ModalOrchestrator.tsx
+++ b/apps/drive-integration/src/locations/Page/components/mainpage/ModalOrchestrator.tsx
@@ -76,6 +76,7 @@ export const ModalOrchestrator = forwardRef<ModalOrchestratorHandle, ModalOrches
     const [useAllTabs, setUseAllTabs] = useState<boolean | null>(null);
     const [includeImages, setIncludeImages] = useState<boolean | null>(null);
     const [requiresImageSelection, setRequiresImageSelection] = useState(false);
+    const [isWorkflowStarting, setIsWorkflowStarting] = useState(false);
 
     const { startWorkflow } = useWorkflowAgent({
       sdk,
@@ -311,6 +312,7 @@ export const ModalOrchestrator = forwardRef<ModalOrchestratorHandle, ModalOrches
         return;
       }
 
+      setIsWorkflowStarting(true);
       try {
         const runId = await startWorkflow(contentTypeIds, documentSelection);
 
@@ -327,6 +329,8 @@ export const ModalOrchestrator = forwardRef<ModalOrchestratorHandle, ModalOrches
         onRunStarted(runId);
       } catch (err) {
         handleWorkflowError(err);
+      } finally {
+        setIsWorkflowStarting(false);
       }
     };
 
@@ -447,6 +451,7 @@ export const ModalOrchestrator = forwardRef<ModalOrchestratorHandle, ModalOrches
               setSelectedTabs={setSelectedTabs}
               useAllTabs={useAllTabs}
               setUseAllTabs={setUseAllTabs}
+              isLoading={isWorkflowStarting}
             />
           );
         case FlowStep.INCLUDE_IMAGES:
@@ -456,6 +461,7 @@ export const ModalOrchestrator = forwardRef<ModalOrchestratorHandle, ModalOrches
               setIncludeImages={setIncludeImages}
               onContinue={handleIncludeImagesContinue}
               onClose={showDiscardConfirmation}
+              isLoading={isWorkflowStarting}
             />
           );
         default:

--- a/apps/drive-integration/src/locations/Page/components/mainpage/ModalOrchestratorLegacy.tsx
+++ b/apps/drive-integration/src/locations/Page/components/mainpage/ModalOrchestratorLegacy.tsx
@@ -7,7 +7,6 @@ import { ErrorModal, type ErrorModalConfig } from '../modals/ErrorModal';
 import SelectDocumentModal from '../modals/step_1/SelectDocumentModal';
 import { LoadingModal } from '../modals/LoadingModal';
 import { ERROR_MESSAGES } from '@constants/messages';
-import { CONTENT_TYPE_SUBMIT_LOADING_DELAY_MS } from '@constants/agent';
 import { SelectTabsModal } from '../modals/step_3/SelectTabsModal';
 import {
   DocumentTabProps,
@@ -341,19 +340,11 @@ export const ModalOrchestratorLegacy = forwardRef<
       documentSelection: DocumentSelection
     ) => {
       setIsWorkflowStarting(true);
-      let isStartPending = true;
-      const loadingModalTimeout = window.setTimeout(() => {
-        if (isStartPending) {
-          setFlowStep(FlowStep.LOADING);
-        }
-      }, CONTENT_TYPE_SUBMIT_LOADING_DELAY_MS);
-
+      setFlowStep(FlowStep.LOADING);
       try {
         return await startWorkflow(contentTypeIds, documentSelection);
       } finally {
-        isStartPending = false;
         setIsWorkflowStarting(false);
-        window.clearTimeout(loadingModalTimeout);
       }
     };
 

--- a/apps/drive-integration/src/locations/Page/components/mainpage/ModalOrchestratorLegacy.tsx
+++ b/apps/drive-integration/src/locations/Page/components/mainpage/ModalOrchestratorLegacy.tsx
@@ -86,6 +86,7 @@ export const ModalOrchestratorLegacy = forwardRef<
     const [includeImages, setIncludeImages] = useState<boolean | null>(null);
     const [requiresImageSelection, setRequiresImageSelection] = useState(false);
     const [activeRunId, setActiveRunId] = useState<string | null>(null);
+    const [isWorkflowStarting, setIsWorkflowStarting] = useState(false);
     const { startWorkflow, resumeWorkflow } = useWorkflowAgentLegacy({
       sdk,
       documentId,
@@ -339,6 +340,7 @@ export const ModalOrchestratorLegacy = forwardRef<
       contentTypeIds: string[],
       documentSelection: DocumentSelection
     ) => {
+      setIsWorkflowStarting(true);
       let isStartPending = true;
       const loadingModalTimeout = window.setTimeout(() => {
         if (isStartPending) {
@@ -350,6 +352,7 @@ export const ModalOrchestratorLegacy = forwardRef<
         return await startWorkflow(contentTypeIds, documentSelection);
       } finally {
         isStartPending = false;
+        setIsWorkflowStarting(false);
         window.clearTimeout(loadingModalTimeout);
       }
     };
@@ -475,6 +478,7 @@ export const ModalOrchestratorLegacy = forwardRef<
               setSelectedTabs={setSelectedTabs}
               useAllTabs={useAllTabs}
               setUseAllTabs={setUseAllTabs}
+              isLoading={isWorkflowStarting}
             />
           );
         case FlowStep.INCLUDE_IMAGES:
@@ -484,6 +488,7 @@ export const ModalOrchestratorLegacy = forwardRef<
               setIncludeImages={setIncludeImages}
               onContinue={handleIncludeImagesContinue}
               onClose={showDiscardConfirmation}
+              isLoading={isWorkflowStarting}
             />
           );
         case FlowStep.LOADING:

--- a/apps/drive-integration/src/locations/Page/components/modals/step_3/SelectTabsModal.tsx
+++ b/apps/drive-integration/src/locations/Page/components/modals/step_3/SelectTabsModal.tsx
@@ -30,6 +30,7 @@ interface SelectTabsModalProps {
   setSelectedTabs: (tabs: DocumentTabProps[]) => void;
   useAllTabs: boolean | null;
   setUseAllTabs: (value: boolean | null) => void;
+  isLoading?: boolean;
 }
 
 export const SelectTabsModal = ({
@@ -40,6 +41,7 @@ export const SelectTabsModal = ({
   setSelectedTabs,
   useAllTabs,
   setUseAllTabs,
+  isLoading = false,
 }: SelectTabsModalProps) => {
   const [hasAttemptedSubmit, setHasAttemptedSubmit] = useState<boolean>(false);
   const multiselectListRef = useMultiselectScrollReflow(selectedTabs);
@@ -166,7 +168,11 @@ export const SelectTabsModal = ({
         <Button onClick={onClose} variant="secondary">
           Cancel
         </Button>
-        <Button onClick={handleContinue} variant="primary">
+        <Button
+          onClick={handleContinue}
+          variant="primary"
+          isLoading={isLoading}
+          isDisabled={isLoading}>
           Next
         </Button>
       </Modal.Controls>

--- a/apps/drive-integration/src/locations/Page/components/modals/step_4/IncludeImagesModal.tsx
+++ b/apps/drive-integration/src/locations/Page/components/modals/step_4/IncludeImagesModal.tsx
@@ -6,6 +6,7 @@ interface IncludeImagesModalProps {
   setIncludeImages: (includeImages: boolean) => void;
   onContinue: (includeImages: boolean) => void;
   onClose: () => void;
+  isLoading?: boolean;
 }
 
 export const IncludeImagesModal = ({
@@ -13,6 +14,7 @@ export const IncludeImagesModal = ({
   setIncludeImages,
   onContinue,
   onClose,
+  isLoading = false,
 }: IncludeImagesModalProps) => {
   const [hasAttemptedSubmit, setHasAttemptedSubmit] = useState(false);
 
@@ -53,7 +55,11 @@ export const IncludeImagesModal = ({
         <Button onClick={onClose} variant="secondary">
           Cancel
         </Button>
-        <Button onClick={handleContinue} variant="primary">
+        <Button
+          onClick={handleContinue}
+          variant="primary"
+          isLoading={isLoading}
+          isDisabled={isLoading}>
           Next
         </Button>
       </Modal.Controls>

--- a/apps/drive-integration/src/utils/constants/agent.ts
+++ b/apps/drive-integration/src/utils/constants/agent.ts
@@ -8,8 +8,6 @@ const EXTENDED_POLL_TIME_MS = 60 * 60 * 1000; // 60 minutes (google-docs-agent-i
 export const MAX_POLL_ATTEMPTS = Math.floor(MAX_POLL_TIME_MS / POLL_INTERVAL_MS);
 export const EXTENDED_MAX_POLL_ATTEMPTS = Math.floor(EXTENDED_POLL_TIME_MS / POLL_INTERVAL_MS);
 
-export const CONTENT_TYPE_SUBMIT_LOADING_DELAY_MS = 500; // brief delay before showing loading modal to avoid flash on fast responses
-
 // Agents-api writes PENDING_REVIEW status before the suspendPayload metadata flushes.
 // Allow this many consecutive PENDING_REVIEW polls with no suspendPayload before giving up.
 export const MAX_PENDING_REVIEW_MISSING_PAYLOAD_RETRIES = 5; // 5 × 10s = 50s max wait

--- a/apps/drive-integration/src/utils/constants/agent.ts
+++ b/apps/drive-integration/src/utils/constants/agent.ts
@@ -8,7 +8,7 @@ const EXTENDED_POLL_TIME_MS = 60 * 60 * 1000; // 60 minutes (google-docs-agent-i
 export const MAX_POLL_ATTEMPTS = Math.floor(MAX_POLL_TIME_MS / POLL_INTERVAL_MS);
 export const EXTENDED_MAX_POLL_ATTEMPTS = Math.floor(EXTENDED_POLL_TIME_MS / POLL_INTERVAL_MS);
 
-export const CONTENT_TYPE_SUBMIT_LOADING_DELAY_MS = 30000; // 30 seconds to wait for suspend payload
+export const CONTENT_TYPE_SUBMIT_LOADING_DELAY_MS = 500; // brief delay before showing loading modal to avoid flash on fast responses
 
 // Agents-api writes PENDING_REVIEW status before the suspendPayload metadata flushes.
 // Allow this many consecutive PENDING_REVIEW polls with no suspendPayload before giving up.


### PR DESCRIPTION
## Summary
- Reduce `CONTENT_TYPE_SUBMIT_LOADING_DELAY_MS` from 30s to 500ms — the 30s value was a holdover from the old suspend-routing flow and caused the UI to appear frozen after clicking Next on the tabs/images modals
- Add `isLoading` prop to `SelectTabsModal` and `IncludeImagesModal` — disables and shows spinner on the Next button while the workflow is starting, preventing repeated submits
- Track `isWorkflowStarting` state in both `ModalOrchestrator` (async) and `ModalOrchestratorLegacy` (flag-off), passed down as `isLoading`

## Test plan
- [ ] Select a multi-tab document with images, click through tabs → images → Next: button should immediately show spinner and be disabled
- [ ] Verify the loading modal appears after ~500ms (instead of 30s) if the backend is slow
- [ ] Verify fast responses skip the loading modal entirely (no flash)
- [ ] Confirm same behaviour on the async flow (flag ON)

Generated with [Claude Code](https://claude.com/claude-code)