### PR TITLE
refactor: bump experience example apps to app-sdk 4.68.1 (ExO rename) [PROD-3331]

### DIFF
--- a/examples/experience-auditor/package.json
+++ b/examples/experience-auditor/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@contentful/app-sdk": "^4.68.0",
+    "@contentful/app-sdk": "^4.68.1",
     "@contentful/f36-components": "4.81.1",
     "@contentful/f36-icons": "^4.28.0",
     "@contentful/f36-tokens": "4.2.0",

--- a/examples/experience-toolbar/package.json
+++ b/examples/experience-toolbar/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@contentful/app-sdk": "^4.68.0",
+    "@contentful/app-sdk": "^4.68.1",
     "@contentful/f36-components": "4.81.1",
     "@contentful/f36-tokens": "4.2.0",
     "@contentful/react-apps-toolkit": "1.2.16",


### PR DESCRIPTION
## What

Bumps `@contentful/app-sdk` to `^4.68.1` (latest published; `5.0.0` is alpha-only) in the two Experiences example apps:
- `examples/experience-toolbar`
- `examples/experience-auditor`

Resolves [PROD-3331](https://contentful.atlassian.net/browse/PROD-3331).

## Why

4.68.1 ships the [ExO M2 Terminology Update](https://contentful.atlassian.net/wiki/spaces/PROD/pages/6791430163/ExO+M2+Terminology+Update) rename. The relevant public types widened to accept **both** legacy and canonical vocabulary:

- `ExperienceNodeType` → `'Component' | 'Fragment' | 'ExperienceFragment' | 'InlineFragment' | 'InlineExperienceFragment' | 'Slot'`
- `ExperienceContext.type` → `'experience' | 'fragment' | 'experienceFragment'`
- `ExperienceSnapshot` gains an `ExperienceFragment` arm (`sys.component` / `Contentful:Component`)

Both apps consume the product exclusively through the typed `sdk.experiences.*` surface — no hardcoded CMA routes, no entity-type-string comparisons against removed values — so they're only affected transitively. **No source changes were required.**

## AC verification

- ✅ `@contentful/app-sdk` bumped to the rename version in both apps (resolves to 4.68.1).
- ✅ Both apps typecheck (`tsc --noEmit`, exit 0), build (`vite build`), and pass their existing suites — **toolbar 11/11**, **auditor 38/38**.
- ✅ `context.type === 'experience'` comparison in `ExperienceToolbar.tsx` verified against the widened public union: it still type-checks; the new `experienceFragment` value groups with `fragment` on the `secondary` badge, which is the correct behavior. Left unchanged per the "update only if the SDK changed that contract" guidance.
- ✅ `node.nodeType` / `ExperienceNodeType` usages resolve against the widened union unchanged.
- ✅ No behavioral regression.

## Out of scope

No changes to shipped first-party/partner apps or `marketplace-listing-api`; not owning the SDK rename itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PROD-3331]: https://contentful.atlassian.net/browse/PROD-3331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ