### PR TITLE
fix: fixes repositoryId issue and adds selection type of single or multiple []

### DIFF
--- a/apps/aem-assets/src/index.jsx
+++ b/apps/aem-assets/src/index.jsx
@@ -40,8 +40,8 @@ export function makeThumbnail(asset) {
 
 async function openDialog(sdk, _currentValue, _config) {
   const parameters = { ..._config, ...sdk.parameters.instance };
-  // const assetIds = _currentValue.map((asset) => ({ id: asset.id }));
-  // parameters.selectedAssets = assetIds;
+  const assetIds = _currentValue.map((asset) => ({ id: asset.id }));
+  parameters.selectedAssets = assetIds;
 
   const result = await sdk.dialogs.openCurrentApp({
     position: 'center',
@@ -189,8 +189,18 @@ if (ENABLE_POPUP_AUTH_REDIRECT_FIX && !isEmbeddedInIframe()) {
 
 async function renderDialog(sdk) {
   const config = sdk.parameters.invocation;
-  const { imsClientId, imsOrg, repositoryId, aemTierType, env, hideUploadButton, hideTreeNav } =
-    config;
+  const {
+    imsClientId,
+    imsOrg,
+    repositoryId,
+    aemTierType,
+    env,
+    hideUploadButton,
+    prefillSelectedAssets,
+    selectedAssets,
+    hideTreeNav,
+    selectionType,
+  } = config;
 
   if (ENABLE_POPUP_AUTH_REDIRECT_FIX) {
     persistImsConfig({ imsClientId, imsOrg });
@@ -250,10 +260,12 @@ async function renderDialog(sdk) {
 
   const contentAdvisorProps = {
     imsOrg,
+    repositoryId,
     aemTierType: aemTierType ? aemTierType.split(',') : ['delivery', 'author'],
-    env,
+    env: env === 'stage' ? 'stage' : undefined,
     hideTreeNav,
-    selectionType: 'multiple',
+    selectedAssets: selectedAssets && Array.isArray(selectedAssets) ? selectedAssets : [],
+    selectionType,
     uploadConfig: {
       hideUploadButton: hideUploadButton === 'Yes' ? true : false,
     },
@@ -302,6 +314,22 @@ async function renderDialog(sdk) {
   });
 }
 
+async function customUpdateStateValue({ currentValue, result, config }, updateStateValue) {
+  if (config.prefillSelectedAssets === 'Yes') {
+    if (result) await updateStateValue(result);
+  } else {
+    if (Array.isArray(result) && result.length > 0) {
+      const newValue = [...(currentValue || []), ...result];
+
+      await updateStateValue(newValue);
+    }
+  }
+}
+
+function isDisabled() {
+  return false;
+}
+
 function validateParameters({ imsClientId }) {
   if (!imsClientId) {
     return 'Please add your IMS Client ID';
@@ -342,17 +370,30 @@ setup({
     {
       id: 'aemTierType',
       name: 'AEM Tier',
-      type: 'Symbol',
-      description: 'Specifies the tier type [delivery, author] for the app (defaults to both)',
+      type: 'List',
+      value: 'delivery,author',
+      default: '',
+      description:
+        'Specifies the tier type for the app (defaults to delivery and author if no selection made)',
       required: false,
-      default: 'delivery,author',
     },
     {
       id: 'env',
       name: 'Environment',
-      type: 'Symbol',
-      description: 'Specifies the AEM repository environment [prod,stage] for the app',
-      required: false,
+      type: 'List',
+      value: 'prod,stage',
+      default: 'prod',
+      description:
+        'Specifies the AEM repository environment for the app (defaults to prod if no selection made)',
+    },
+    {
+      id: 'prefillSelectedAssets',
+      name: 'Prefill Selected Assets',
+      type: 'List',
+      value: 'No,Yes',
+      default: 'Yes',
+      description:
+        'Determines whether the selected assets will be prefilled when opening the asset picker.',
     },
     {
       id: 'hideUploadButton',
@@ -361,12 +402,12 @@ setup({
       value: 'Yes, No',
       default: 'Yes',
       description: 'Specifies whether to show or hide the upload button',
-      required: false,
     },
   ],
-  validateParameters,
+  customUpdateStateValue,
+  isDisabled,
   makeThumbnail,
-  renderDialog,
   openDialog,
-  isDisabled: () => false,
+  renderDialog,
+  validateParameters,
 });

--- a/apps/aem-assets/src/index.jsx
+++ b/apps/aem-assets/src/index.jsx
@@ -264,7 +264,10 @@ async function renderDialog(sdk) {
     aemTierType: aemTierType ? aemTierType.split(',') : ['delivery', 'author'],
     env: env === 'stage' ? 'stage' : undefined,
     hideTreeNav,
-    selectedAssets: selectedAssets && Array.isArray(selectedAssets) ? selectedAssets : [],
+    selectedAssets:
+      prefillSelectedAssets === 'Yes' && selectedAssets && Array.isArray(selectedAssets)
+        ? selectedAssets
+        : [],
     selectionType,
     uploadConfig: {
       hideUploadButton: hideUploadButton === 'Yes' ? true : false,


### PR DESCRIPTION
## Purpose

This update adds following capabilities:

- The `repositoryId` property was missing from the Adobe Content Advisor config properties and has been added so it can be used for restricting user access to a single repository
- The `selectedAssets` property has been added to the Content Advisor config properties to persist previously selected assets and uses the asset ids from the current field value if the `prefillSelectedAssets` config value is 'Yes'
- The `CustomUpdateStateValueFn` has been added to modify the save functionality so the app replaces the existing field values with the new selections if the `prefillSelectedAssets` config value is 'Yes' and adds the new selections to the previously selected assets if the value is 'No'
- The `prefillSelectedAssets` config has been added to support the `selectedAssets` property in the Content Advisor props and the `CustomUpdateStateValueFn`
- The `selectionType` property has been added to the Content Advisor props to support the creation of asset fields that contain a 'single' asset or 'multiple' assets (the selectionType property is populated from the value of a new instance config property of the same name with the following options: single, multiple
- The `aemTierType` config property has been changed from text to a dropdown to prevent invalid values and contains the following options: delivery, author
- The `env` config property has been changed from text to a dropdown to prevent invalid values and contains the following options: prod, stage

## Approach

The changes were made in accordance with the capabilities provided by the `contentful/dam-app-base` package, the Adobe Content Advisor front-end-as-a-service app, and best practices for installation and instance config properties. 

## Testing steps

The following tests should be passed:
- Providing the `repositoryId` in the application's installation config restricts users to the identified repository and no others
- Omitting the `repositoryId` in the application's installation config allows users to see all repositories available to them based on their AEM Assets permissions
- Setting `prefillSelectedAssets` to 'Yes' selects all previously selected assets when opening the Adobe Content Advisor modal
- Setting `prefillSelectedAssets` to 'Yes' causes the previously selected assets to be replaced with the assets selected in the Adobe Content Advisor modal
- Setting `prefillSelectedAssets` to 'No' leaves the previously selected assets unselected when opening the Adobe Content Advisor modal
- Setting `prefillSelectedAssets` to 'No' cause the assets selected in the Adobe Content Advisor modal to be added to the previously selected assets
- Setting `selectionType` to 'single' restricts the user to the selection of a single asset in the Adobe Content Advisor modal
- Setting `selectionType` to 'multiple' allows the user to select multiple assets in the Adobe Content Advisor modal
- Setting `aemTierType` to 'delivery' or 'stage' restricts the user to repositories of the selected type
- Setting `env` to 'prod' or 'stage' restricts the user to repositories in the selected environment

## Breaking Changes

None

## Dependencies and/or References

All changes are based on information collected in zoom calls, email or slack

## Deployment

None that I am aware of
