### PR TITLE
fix(slack): resolve actor name via direct user lookup instead of paginated list[ES-557]

### DIFF
--- a/apps/slack/lambda/lib/routes/events/service.test.ts
+++ b/apps/slack/lambda/lib/routes/events/service.test.ts
@@ -54,11 +54,19 @@ describe('EventsService', () => {
         getMany: stub().resolves({ items: [{ default: true, code: 'de-DE' }] }),
       },
       user: {
-        getManyForSpace: stub().resolves({
-          items: [
-            { sys: { id: 'publisher' }, firstName: 'Pub', lastName: 'Lisher' },
-            { sys: { id: 'creator' }, firstName: 'Cre', lastName: 'Ator' },
-          ],
+        getForSpace: stub().callsFake(({ userId }) => {
+          const users: Record<
+            string,
+            { sys: { id: string }; firstName: string; lastName: string }
+          > = {
+            publisher: { sys: { id: 'publisher' }, firstName: 'Pub', lastName: 'Lisher' },
+            creator: { sys: { id: 'creator' }, firstName: 'Cre', lastName: 'Ator' },
+          };
+          const user = users[userId];
+          if (!user) {
+            return Promise.reject(new Error('not found'));
+          }
+          return Promise.resolve(user);
         }),
       },
       space: {
@@ -259,6 +267,22 @@ describe('EventsService', () => {
         eventBody
       );
       assert.deepEqual(resolvedEntity, expectedValue);
+    });
+    it('falls back to the raw actor ID when the user lookup fails', async () => {
+      const unknownActorEventBody = {
+        ...eventBody,
+        sys: { ...eventBody.sys, createdBy: { sys: { id: 'unknown-user' } } },
+      } as unknown as EventEntity;
+
+      const resolvedEntity = await instance.getResolvedEntity(
+        'space-id',
+        'env-id',
+        'contentful',
+        SlackAppEventKey.CREATED,
+        unknownActorEventBody
+      );
+      assert.equal(resolvedEntity?.actorId, 'unknown-user');
+      assert.equal(resolvedEntity?.actorName, 'unknown-user');
     });
     it('returns the expected resolved values for DELETE', async () => {
       const expectedValue = {

--- a/apps/slack/lambda/lib/routes/events/service.ts
+++ b/apps/slack/lambda/lib/routes/events/service.ts
@@ -41,24 +41,18 @@ export class EventsService {
 
   private getUserName = async (
     cmaClient: PlainClientAPI,
+    spaceId: string,
     userId?: string
   ): Promise<string | undefined> => {
     if (!userId) {
       return undefined;
     }
     try {
-      // Try to get user from space users first
-      const spaceUsers = await cmaClient.user.getManyForSpace({});
-      const user = spaceUsers.items.find((u) => u.sys.id === userId);
+      const user = await cmaClient.user.getForSpace({ spaceId, userId });
 
-      if (user) {
-        return user.firstName && user.lastName
-          ? `${user.firstName} ${user.lastName}`
-          : user.email || userId;
-      }
-
-      // If not found in space users, return the user ID as fallback
-      return userId;
+      return user.firstName && user.lastName
+        ? `${user.firstName} ${user.lastName}`
+        : user.email || userId;
     } catch (e) {
       return userId; // fallback to user ID if we can't get user details
     }
@@ -216,7 +210,7 @@ export class EventsService {
 
     // Fetch additional information
     const [actorName, spaceName] = await Promise.all([
-      this.getUserName(cmaClient, actorId),
+      this.getUserName(cmaClient, spaceId, actorId),
       this.getSpaceName(cmaClient, spaceId),
     ]);
 


### PR DESCRIPTION
## Purpose

Customer reported (ES-557) that Slack entry notifications show a raw, illegible user ID instead of the author's name — despite #11167 already adding actor name resolution.

## Approach

`getUserName` was resolving the actor's name by fetching `cmaClient.user.getManyForSpace({})` — a *paginated* collection — and searching for the actor in the first page of results. For spaces with more members than the default page size (e.g. large orgs synced via SSO), an actor outside that first page was never found, silently falling back to the raw ID. This matches the customer's report.

Replaced the paginated list + `.find()` with a direct single-user lookup: `cmaClient.user.getForSpace({ spaceId, userId })`. This resolves the exact actor in one call, independent of space size, and still falls back to the raw ID if the lookup fails (e.g. deleted user).

`getSpaceName` was checked as part of this investigation — it already uses `cmaClient.space.get({ spaceId })`, a direct single-space lookup, so it was not affected by this bug.

## Testing steps

- Updated `service.test.ts` to stub `user.getForSpace` instead of `user.getManyForSpace`.
- Added a test asserting the ID fallback still works when the user lookup fails/rejects.
- `npm test`, `tsc --noEmit`, and `eslint` all pass on the changed files.
