### PR TITLE
fix(slack): delete correct notification row instead of the last one []

### DIFF
--- a/apps/slack/frontend/src/components/NotificationsPanel.tsx
+++ b/apps/slack/frontend/src/components/NotificationsPanel.tsx
@@ -111,7 +111,7 @@ export const NotificationsPanel = (props: Props) => {
         <ChannelNote />
         {notifications.map((notification, index) => (
           <NotificationItem
-            key={index}
+            key={notification.id}
             index={index}
             contentTypes={contentTypes}
             notification={notification}

--- a/apps/slack/frontend/src/notification.store.ts
+++ b/apps/slack/frontend/src/notification.store.ts
@@ -1,4 +1,5 @@
 import create from 'zustand';
+import { v4 as uuidv4 } from 'uuid';
 
 export enum SlackAppEventKey {
   PUBLISH = 'publish',
@@ -8,6 +9,7 @@ export enum SlackAppEventKey {
 }
 
 export interface SlackNotification {
+  id: string;
   selectedChannel: string | null;
   selectedContentType: string | null;
   selectedEvent: Record<SlackAppEventKey, boolean>;
@@ -20,13 +22,13 @@ interface NotificationStore {
   setSelectedChannel: (channelId: string, index: number) => void;
   setSelectedContentType: (contentTypeId: string, index: number) => void;
   toggleEvent: (event: SlackAppEventKey, index: number) => void;
-  createNotification: (notification?: SlackNotification) => void;
+  createNotification: (notification?: Omit<SlackNotification, 'id'>) => void;
   setNotifications: (notifications: SlackNotification[]) => void;
   removeNotificationAtIndex: (index: number) => void;
   setActive: (active: boolean) => void;
 }
 
-const NOTIFICATION_TEMPLATE: SlackNotification = {
+const NOTIFICATION_TEMPLATE: Omit<SlackNotification, 'id'> = {
   selectedChannel: null,
   selectedContentType: null,
   selectedEvent: {
@@ -73,8 +75,18 @@ export const useNotificationStore = create<NotificationStore>((set, get) => ({
     }),
   createNotification: (notification) =>
     set((state) => ({
-      notifications: [...state.notifications, notification || NOTIFICATION_TEMPLATE],
+      notifications: [
+        ...state.notifications,
+        { ...(notification || NOTIFICATION_TEMPLATE), id: uuidv4() },
+      ],
     })),
-  setNotifications: (notifications: SlackNotification[]) => set({ notifications }),
+  setNotifications: (notifications: SlackNotification[]) =>
+    set({
+      // backfill ids for notifications persisted before ids were introduced
+      notifications: notifications.map((notification) => ({
+        ...notification,
+        id: notification.id || uuidv4(),
+      })),
+    }),
   setActive: (active: boolean) => set({ active }),
 }));


### PR DESCRIPTION
## Summary
- Notification rows in the Slack app's config screen were keyed by array index (`key={index}`), so deleting a row in the middle of the list caused React to reconcile the last DOM row rather than the one the user clicked delete on. The store logic (`removeNotificationAtIndex`) already removed the correct item — this was purely a rendering/reconciliation bug.
- Added a stable `id` to `SlackNotification` (generated with `uuid`), assigned on creation and backfilled on load for notifications persisted before this change, and keyed the list by `notification.id` instead of index.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx eslint` passes on changed files
- [x] `npx vitest run` — all existing tests pass (8/8)
- [ ] Manually verify in a real installation: add several notifications, delete one from the middle of the list, confirm the correct row disappears and remaining rows keep their own channel/content type selections

🤖 Generated with [Claude Code](https://claude.com/claude-code)