### PR TITLE
fix: trim sfccApi App Action responses to fit size cap [ES-553]

### DIFF
--- a/apps/salesforce-commerce-cloud/functions/index.spec.ts
+++ b/apps/salesforce-commerce-cloud/functions/index.spec.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { handler } from './index';
+
+const installationParameters = {
+  clientId: 'client-id',
+  clientSecret: 'client-secret',
+  organizationId: 'f_ecom_zzte_053',
+  shortCode: 'abcd1234',
+  siteId: 'RefArchGlobal',
+};
+
+function mockContext() {
+  return { appInstallationParameters: installationParameters } as any;
+}
+
+function mockTokenResponse() {
+  return { ok: true, json: async () => ({ access_token: 'test-token' }) } as Response;
+}
+
+// Simulates the kind of full SFCC representation that triggers max-response-size-exceeded:
+// a couple of fields the UI actually renders, plus some nested data it never reads.
+function bulkyProduct(id: string) {
+  return {
+    id,
+    name: { default: `Product ${id}` },
+    image: { absUrl: `https://example.com/${id}.jpg`, alt: { default: 'alt text' } },
+    shortDescription: { default: { markup: 'x'.repeat(50_000) } },
+    variations: new Array(50).fill({ some: 'nested variation data the UI never reads' }),
+  };
+}
+
+function bulkyCategory(id: string) {
+  return {
+    id,
+    catalogId: 'catalog-1',
+    name: { default: `Category ${id}` },
+    pageDescription: { default: 'y'.repeat(50_000) },
+    paths: new Array(50).fill({ id: 'catalog-1', name: { default: 'Catalog One' } }),
+  };
+}
+
+describe('sfccApi function handler', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('trims searchProducts hits to id/name/image', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('dwsso/oauth2/access_token')) return mockTokenResponse();
+      if (url.includes('/product-search')) {
+        expect(url).not.toContain('limit=');
+        return { ok: true, json: async () => ({ hits: [bulkyProduct('prod-1')] }) } as Response;
+      }
+      throw new Error(`Unexpected fetch URL: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result: any = await handler(
+      { body: { type: 'searchProducts', query: 'test' } } as any,
+      mockContext()
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.data).toEqual([
+      {
+        id: 'prod-1',
+        name: { default: 'Product prod-1' },
+        image: { absUrl: 'https://example.com/prod-1.jpg', alt: { default: 'alt text' } },
+      },
+    ]);
+    expect(Buffer.byteLength(JSON.stringify(result.data))).toBeLessThan(1000);
+  });
+
+  it('trims searchCategories hits to id/catalogId/name', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('dwsso/oauth2/access_token')) return mockTokenResponse();
+      if (url.includes('/category-search')) {
+        expect(url).not.toContain('limit=');
+        return { ok: true, json: async () => ({ hits: [bulkyCategory('cat-1')] }) } as Response;
+      }
+      throw new Error(`Unexpected fetch URL: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result: any = await handler(
+      { body: { type: 'searchCategories', query: 'test' } } as any,
+      mockContext()
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.data).toEqual([
+      { id: 'cat-1', catalogId: 'catalog-1', name: { default: 'Category cat-1' } },
+    ]);
+    expect(Buffer.byteLength(JSON.stringify(result.data))).toBeLessThan(1000);
+  });
+
+  it('trims fetchProduct response to id/name/image', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('dwsso/oauth2/access_token')) return mockTokenResponse();
+      if (url.includes('/products/prod-1')) {
+        return { ok: true, json: async () => bulkyProduct('prod-1') } as Response;
+      }
+      throw new Error(`Unexpected fetch URL: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result: any = await handler(
+      { body: { type: 'fetchProduct', productId: 'prod-1' } } as any,
+      mockContext()
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.data).toEqual({
+      id: 'prod-1',
+      name: { default: 'Product prod-1' },
+      image: { absUrl: 'https://example.com/prod-1.jpg', alt: { default: 'alt text' } },
+    });
+  });
+
+  it('trims fetchCategory response to id/catalogId/name', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('dwsso/oauth2/access_token')) return mockTokenResponse();
+      if (url.includes('/categories/cat-1')) {
+        return { ok: true, json: async () => bulkyCategory('cat-1') } as Response;
+      }
+      throw new Error(`Unexpected fetch URL: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result: any = await handler(
+      { body: { type: 'fetchCategory', catalogId: 'catalog-1', categoryId: 'cat-1' } } as any,
+      mockContext()
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.data).toEqual({
+      id: 'cat-1',
+      catalogId: 'catalog-1',
+      name: { default: 'Category cat-1' },
+    });
+  });
+});

--- a/apps/salesforce-commerce-cloud/functions/index.ts
+++ b/apps/salesforce-commerce-cloud/functions/index.ts
@@ -19,6 +19,39 @@ interface InstallationParameters {
   siteId: string;
 }
 
+interface SfccLocalizedText {
+  default?: string;
+}
+
+interface SfccImage {
+  absUrl?: string;
+  alt?: SfccLocalizedText;
+}
+
+interface ProductSummary {
+  id: string;
+  name?: SfccLocalizedText;
+  image?: SfccImage;
+}
+
+interface CategorySummary {
+  id: string;
+  catalogId?: string;
+  name?: SfccLocalizedText;
+}
+
+// The UI only ever reads id/name/image (products) or id/catalogId/name (categories) —
+// see SearchBar, ProductSearchResults, CategorySearchResults, ItemCard. Projecting down
+// to those fields here keeps every sfccApi response far under the App Action platform's
+// response size cap, regardless of how much SFCC includes in the full representation.
+function toProductSummary(product: any): ProductSummary {
+  return { id: product?.id, name: product?.name, image: product?.image };
+}
+
+function toCategorySummary(category: any): CategorySummary {
+  return { id: category?.id, catalogId: category?.catalogId, name: category?.name };
+}
+
 async function fetchSfccToken(params: InstallationParameters): Promise<string> {
   const authToken = Buffer.from(`${params.clientId}:${params.clientSecret}`).toString('base64');
   const tenantId = params.organizationId.split('_').slice(2).join('_');
@@ -110,7 +143,7 @@ export const handler: FunctionEventHandler<FunctionTypeEnum.AppActionCall> = asy
           method: 'POST',
           body: JSON.stringify(buildSearchBody(action.query)),
         })) as { hits?: unknown[] };
-        return { ok: true, data: data.hits ?? [] };
+        return { ok: true, data: (data.hits ?? []).map(toProductSummary) };
       }
 
       case 'searchCategories': {
@@ -119,19 +152,19 @@ export const handler: FunctionEventHandler<FunctionTypeEnum.AppActionCall> = asy
           method: 'POST',
           body: JSON.stringify(buildSearchBody(action.query, true)),
         })) as { hits?: unknown[] };
-        return { ok: true, data: data.hits ?? [] };
+        return { ok: true, data: (data.hits ?? []).map(toCategorySummary) };
       }
 
       case 'fetchProduct': {
         const url = `${base}/product/products/v1/organizations/${organizationId}/products/${action.productId}?siteId=${siteId}`;
         const data = await sfccFetch(url, token, { method: 'GET' });
-        return { ok: true, data };
+        return { ok: true, data: toProductSummary(data) };
       }
 
       case 'fetchCategory': {
         const url = `${base}/product/catalogs/v1/organizations/${organizationId}/catalogs/${action.catalogId}/categories/${action.categoryId}`;
         const data = await sfccFetch(url, token, { method: 'GET' });
-        return { ok: true, data };
+        return { ok: true, data: toCategorySummary(data) };
       }
 
       default:


### PR DESCRIPTION
## Summary
- sfccApi's Function responses were relaying full SFCC product/category representations verbatim, exceeding the response cap.
- Quick fix for now: trim responses down to the fields the UI actually reads (`id`/`name`/`image` for products, `id`/`catalogId`/`name` for categories). This alone keeps every response far under the cap regardless of catalog size.
- Considered also pagination solution, but deferring that for now; will revisit and implement real pagination later only if the size issue turns out to persist after this trim.

## Test plan
- [x] `npm test` in `apps/salesforce-commerce-cloud` — new `functions/index.spec.ts` covers all 4 action branches (searchProducts, searchCategories, fetchProduct, fetchCategory) trimming down oversized mock SFCC payloads
- [x] `npx tsc --noEmit -p functions/tsconfig.json` — function type-checks clean
- [x] Deploy to test org and open the product/category picker dialog against a real sandbox catalog to confirm no regressions

Generated with [Claude Code](https://claude.com/claude-code)