### PR TITLE
chore(remote-mcp): rename ExO permission labels for AIS-348 [AIS-348]

### DIFF
--- a/apps/remote-mcp/src/components/access-config/ContentLifecyclePermissionsTable.tsx
+++ b/apps/remote-mcp/src/components/access-config/ContentLifecyclePermissionsTable.tsx
@@ -90,11 +90,14 @@ export const ContentLifecyclePermissionsTable: FC<ContentLifecyclePermissionsTab
                 tags: 'Tags',
                 concepts: 'Concepts',
                 conceptSchemes: 'Concept schemes',
-                componentTypes: 'Component types',
+                // ExO labels follow the entity renaming. The keys stay as
+                // they are — they're app-installation-parameter keys already
+                // persisted on every existing install. See ../types/config.ts.
+                componentTypes: 'Components',
                 experiences: 'Experiences',
-                templates: 'Templates',
+                templates: 'Experience templates',
                 dataAssemblies: 'Data assemblies',
-                fragments: 'Fragments',
+                fragments: 'Experience fragments',
               };
 
               // Get available actions for this entity

--- a/apps/remote-mcp/src/components/types/config.ts
+++ b/apps/remote-mcp/src/components/types/config.ts
@@ -26,6 +26,11 @@ export interface ContentLifecyclePermissions {
   conceptSchemes: EntityPermissions;
   // ExO (Experience Orchestration) entities. Shown on the config screen only
   // in ExO-enabled or empty spaces. See AIS-187.
+  //
+  // These keys predate the entity renaming (Component Type →
+  // Component, Template → Experience Template, Fragment → Experience
+  // Fragment) and are deliberately left alone: Only the user-facing labels in
+  // ../access-config/ContentLifecyclePermissionsTable.tsx were renamed.
   componentTypes: EntityPermissions;
   experiences: EntityPermissions;
   templates: EntityPermissions;

--- a/apps/remote-mcp/src/locations/ConfigScreen.spec.tsx
+++ b/apps/remote-mcp/src/locations/ConfigScreen.spec.tsx
@@ -52,11 +52,11 @@ describe('Config Screen component', () => {
     const { findByText } = render(<ConfigScreen />);
     await waitFor(() => expect(mockSdk.app.setReady).toHaveBeenCalled());
 
-    expect(await findByText('Component types')).toBeInTheDocument();
+    expect(await findByText('Components')).toBeInTheDocument();
     expect(await findByText('Experiences')).toBeInTheDocument();
     expect(await findByText('Data assemblies')).toBeInTheDocument();
-    expect(await findByText('Fragments')).toBeInTheDocument();
-    expect(await findByText('Templates')).toBeInTheDocument();
+    expect(await findByText('Experience fragments')).toBeInTheDocument();
+    expect(await findByText('Experience templates')).toBeInTheDocument();
   });
 
   it('does not render the migration section', async () => {


### PR DESCRIPTION
[AIS-348](https://contentful.atlassian.net/browse/AIS-348)

## Summary

- Renames the user-facing labels in the remote MCP app's **Experience orchestration actions** section to the AIS-348 entity naming: `Component types` → **Components**, `Templates` → **Experience templates**, `Fragments` → **Experience fragments**. `Experiences` and `Data assemblies` are unchanged by AIS-348. Sentence case follows the table's existing convention (`Content types`, `AI actions`, `Concept schemes`).
- **App installation parameter keys are deliberately left alone.** `componentTypes` / `templates` / `fragments` are persisted `AppInstallationParameters` already written to every existing install — not API identifiers. Renaming them would orphan each install's ExO permission config. The asymmetry is now documented in `config.ts` so it doesn't read as a missed rename. This is the app-side half of the same decision made in the remote mcp server, which maps tool-derived entity names onto these keys.

## Test plan

- [x] `npx vitest run` — 10/10 pass. `ConfigScreen.spec.tsx` asserts the renamed labels directly; its three ExO assertions were updated in this commit.
- [x] `npx tsc --noEmit` — one error, byte-identical before and after these changes (verified by stashing and re-running). See note below.
- [x] `npx prettier --check` clean on all three files.
- [ ] Visual check on the config screen: the Experience orchestration section shows Components / Experiences / Experience templates / Data assemblies / Experience fragments.
- [ ] Confirm an **existing** install's ExO permissions survive: open the config screen on a space that had ExO permissions saved before this change and verify the checkboxes are still populated (this is what the un-renamed keys protect).

Generated with [Claude Code](https://claude.com/claude-code)

[AIS-348]: https://contentful.atlassian.net/browse/AIS-348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ