### PR TITLE
fix(slack): log CMA lookup failures in getUserName/getSpaceName [ES-557]

### DIFF
--- a/apps/slack/lambda/lib/routes/events/service.ts
+++ b/apps/slack/lambda/lib/routes/events/service.ts
@@ -54,6 +54,14 @@ export class EventsService {
         ? `${user.firstName} ${user.lastName}`
         : user.email || userId;
     } catch (e) {
+      const error = e as { name?: string; message?: string; response?: { status?: number } };
+      console.error('getUserName: cmaClient.user.getForSpace failed, falling back to raw ID', {
+        spaceId,
+        userId,
+        errorName: error?.name,
+        errorMessage: error?.message,
+        errorStatus: error?.response?.status,
+      });
       return userId; // fallback to user ID if we can't get user details
     }
   };
@@ -66,6 +74,13 @@ export class EventsService {
       const space = await cmaClient.space.get({ spaceId });
       return space.name || spaceId;
     } catch (e) {
+      const error = e as { name?: string; message?: string; response?: { status?: number } };
+      console.error('getSpaceName: cmaClient.space.get failed, falling back to raw ID', {
+        spaceId,
+        errorName: error?.name,
+        errorMessage: error?.message,
+        errorStatus: error?.response?.status,
+      });
       return spaceId; // fallback to space ID if we can't get space details
     }
   };


### PR DESCRIPTION
[ES-557](https://contentful.atlassian.net/browse/ES-557)

## Summary
- `getUserName` and `getSpaceName` in `apps/slack/lambda/lib/routes/events/service.ts` catch CMA lookup failures and silently fall back to the raw ID, with no logging at all — there was no way to tell why user/space names weren't resolving.
- Adds a `console.error` with the space/user ID and error name/message/status on each catch path, matching the existing `console.error` pattern used elsewhere in this lambda (`workspaces/controller.ts`, `helpers/getHost.ts`).
- This doesn't change any return values or control flow — same fallback-to-ID behavior, just observable now.

Related to the ES-557 investigation: `#11263` fixed the *pagination* path for `getUserName`, but the customer is still seeing raw IDs in production. This logging will make that failure visible in CloudWatch going forward to help with investigation.

## Test plan
- [ ] `npm test` in `apps/slack/lambda` — existing fallback-to-ID assertions should be unaffected
- [ ] `tsc --noEmit` / lint clean
- [ ] Manually trigger a publish/unpublish event against a space and confirm logging

Generated with [Claude Code](https://claude.com/claude-code)

[ES-557]: https://contentful.atlassian.net/browse/ES-557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ