### PR TITLE
Revert "fix(slack): log CMA lookup failures in getUserName/getSpaceName" [ES-557]

### DIFF
--- a/apps/slack/lambda/lib/routes/events/service.ts
+++ b/apps/slack/lambda/lib/routes/events/service.ts
@@ -54,14 +54,6 @@ export class EventsService {
         ? `${user.firstName} ${user.lastName}`
         : user.email || userId;
     } catch (e) {
-      const error = e as { name?: string; message?: string; response?: { status?: number } };
-      console.error('getUserName: cmaClient.user.getForSpace failed, falling back to raw ID', {
-        spaceId,
-        userId,
-        errorName: error?.name,
-        errorMessage: error?.message,
-        errorStatus: error?.response?.status,
-      });
       return userId; // fallback to user ID if we can't get user details
     }
   };
@@ -74,13 +66,6 @@ export class EventsService {
       const space = await cmaClient.space.get({ spaceId });
       return space.name || spaceId;
     } catch (e) {
-      const error = e as { name?: string; message?: string; response?: { status?: number } };
-      console.error('getSpaceName: cmaClient.space.get failed, falling back to raw ID', {
-        spaceId,
-        errorName: error?.name,
-        errorMessage: error?.message,
-        errorStatus: error?.response?.status,
-      });
       return spaceId; // fallback to space ID if we can't get space details
     }
   };


### PR DESCRIPTION
[ES-557](https://contentful.atlassian.net/browse/ES-557)

## Summary
- Reverts #11267 (`098cc2d`), which added `console.error` logging to the catch blocks in `getUserName`/`getSpaceName` in `apps/slack/lambda/lib/routes/events/service.ts`.
- That logging served its purpose for the ES-557 investigation — confirmed via production testing that the CMA lookups fail as expected — so it's no longer needed and is being pulled back out.
- Clean revert: removes exactly the 15 lines added in #11267, no other changes.

## Test plan
- [ ] `npm test` in `apps/slack/lambda` passes (should be identical to pre-#11267 state)
- [ ] Diff matches a straight revert with no unrelated changes

Generated with [Claude Code](https://claude.com/claude-code)

[ES-557]: https://contentful.atlassian.net/browse/ES-557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ