### PR TITLE
fix: rename deploy:test to upload-staging [TRANS-287]

### DIFF
--- a/apps/translation-companion/package.json
+++ b/apps/translation-companion/package.json
@@ -22,7 +22,7 @@
     "upload": "contentful-app-scripts upload --bundle-dir ./build",
     "upload-ci": "contentful-app-scripts upload --ci --bundle-dir ./build  --organization-id $CONTENTFUL_ORG_ID --definition-id $CONTENTFUL_APP_DEF_ID --token $CONTENTFUL_ACCESS_TOKEN",
     "deploy": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id ${DEFINITIONS_ORG_ID} --definition-id 1RQoKuwhLeFN3BMPOwUfV1 --token ${CONTENTFUL_CMA_TOKEN}",
-    "deploy:test": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id 7oPjKXwmGdQ9vnnjVe6MCy --definition-id 6JHs8kZdhdkARLNetwO3Jk --token $FLINKLY_CONTENTFUL_ACCESS_TOKEN --host api.flinkly.com",
+    "upload-staging": "contentful-app-scripts upload --ci --bundle-dir ./build --organization-id 7oPjKXwmGdQ9vnnjVe6MCy --definition-id 6JHs8kZdhdkARLNetwO3Jk --token $FLINKLY_CONTENTFUL_ACCESS_TOKEN --host api.flinkly.com",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "lint:write": "eslint . --ext .js,.jsx,.ts,.tsx --fix"
   },


### PR DESCRIPTION
## Purpose

The `deploy:test` script name auto-deploys a bundle, but it was failing because the env vars aren't set up for non-prod.

I changed the script name to `upload-staging` instead so it won't trigger an auto-deployment for non-prod.

Ticket: [TRANS-287](https://contentful.atlassian.net/browse/TRANS-287)

## Approach

- Renamed `deploy:test` to `upload-staging` in [apps/translation-companion/package.json](apps/translation-companion/package.json) so the script name accurately reflects its target (flinkly staging), preventing it from being mistaken for a no-op test run during releases.


[TRANS-287]: https://contentful.atlassian.net/browse/TRANS-287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ