### PR TITLE
Revert "add author, space, and environment context to notifications" [ES-557]

### DIFF
--- a/apps/slack/lambda/lib/routes/events/service.test.ts
+++ b/apps/slack/lambda/lib/routes/events/service.test.ts
@@ -53,17 +53,6 @@ describe('EventsService', () => {
       locale: {
         getMany: stub().resolves({ items: [{ default: true, code: 'de-DE' }] }),
       },
-      user: {
-        getManyForSpace: stub().resolves({
-          items: [
-            { sys: { id: 'publisher' }, firstName: 'Pub', lastName: 'Lisher' },
-            { sys: { id: 'creator' }, firstName: 'Cre', lastName: 'Ator' },
-          ],
-        }),
-      },
-      space: {
-        get: stub().resolves({ name: 'Test Space' }),
-      },
     } as unknown as PlainClientAPI);
     authTokenRepository.get.resolves({ token: 'whatever' } as AuthToken);
     instance = new EventsService(
@@ -206,12 +195,9 @@ describe('EventsService', () => {
     it('returns the expected resolved values for PUBLISH', async () => {
       const expectedValue = {
         actorId: 'publisher',
-        actorName: 'Pub Lisher',
         entryName: 'test',
         date: 'Mon Feb 01 2021',
         entity: entryMock,
-        spaceName: 'Test Space',
-        environmentId: 'env-id',
       };
       const resolvedEntity = await instance.getResolvedEntity(
         'space-id',
@@ -225,12 +211,9 @@ describe('EventsService', () => {
     it('returns the expected resolved values for UNPUBLISHED', async () => {
       const expectedValue = {
         actorId: undefined,
-        actorName: undefined,
         entryName: 'test',
         date: 'Mon Mar 01 2021',
         entity: entryMock,
-        spaceName: 'Test Space',
-        environmentId: 'env-id',
       };
       const resolvedEntity = await instance.getResolvedEntity(
         'space-id',
@@ -244,12 +227,9 @@ describe('EventsService', () => {
     it('returns the expected resolved values for CREATED', async () => {
       const expectedValue = {
         actorId: 'creator',
-        actorName: 'Cre Ator',
         entryName: undefined,
         date: 'Mon Mar 01 2021',
         entity: entryMock,
-        spaceName: 'Test Space',
-        environmentId: 'env-id',
       };
       const resolvedEntity = await instance.getResolvedEntity(
         'space-id',
@@ -263,12 +243,9 @@ describe('EventsService', () => {
     it('returns the expected resolved values for DELETE', async () => {
       const expectedValue = {
         actorId: undefined,
-        actorName: undefined,
         entryName: undefined,
         date: 'Fri Feb 01 2002',
         entity: undefined,
-        spaceName: 'Test Space',
-        environmentId: 'env-id',
       };
       const resolvedEntity = await instance.getResolvedEntity(
         'space-id',

--- a/apps/slack/lambda/lib/routes/events/service.test.ts
+++ b/apps/slack/lambda/lib/routes/events/service.test.ts
@@ -54,19 +54,11 @@ describe('EventsService', () => {
         getMany: stub().resolves({ items: [{ default: true, code: 'de-DE' }] }),
       },
       user: {
-        getForSpace: stub().callsFake(({ userId }) => {
-          const users: Record<
-            string,
-            { sys: { id: string }; firstName: string; lastName: string }
-          > = {
-            publisher: { sys: { id: 'publisher' }, firstName: 'Pub', lastName: 'Lisher' },
-            creator: { sys: { id: 'creator' }, firstName: 'Cre', lastName: 'Ator' },
-          };
-          const user = users[userId];
-          if (!user) {
-            return Promise.reject(new Error('not found'));
-          }
-          return Promise.resolve(user);
+        getManyForSpace: stub().resolves({
+          items: [
+            { sys: { id: 'publisher' }, firstName: 'Pub', lastName: 'Lisher' },
+            { sys: { id: 'creator' }, firstName: 'Cre', lastName: 'Ator' },
+          ],
         }),
       },
       space: {
@@ -267,22 +259,6 @@ describe('EventsService', () => {
         eventBody
       );
       assert.deepEqual(resolvedEntity, expectedValue);
-    });
-    it('falls back to the raw actor ID when the user lookup fails', async () => {
-      const unknownActorEventBody = {
-        ...eventBody,
-        sys: { ...eventBody.sys, createdBy: { sys: { id: 'unknown-user' } } },
-      } as unknown as EventEntity;
-
-      const resolvedEntity = await instance.getResolvedEntity(
-        'space-id',
-        'env-id',
-        'contentful',
-        SlackAppEventKey.CREATED,
-        unknownActorEventBody
-      );
-      assert.equal(resolvedEntity?.actorId, 'unknown-user');
-      assert.equal(resolvedEntity?.actorName, 'unknown-user');
     });
     it('returns the expected resolved values for DELETE', async () => {
       const expectedValue = {

--- a/apps/slack/lambda/lib/routes/events/service.ts
+++ b/apps/slack/lambda/lib/routes/events/service.ts
@@ -39,43 +39,6 @@ export class EventsService {
     }
   };
 
-  private getUserName = async (
-    cmaClient: PlainClientAPI,
-    userId?: string
-  ): Promise<string | undefined> => {
-    if (!userId) {
-      return undefined;
-    }
-    try {
-      // Try to get user from space users first
-      const spaceUsers = await cmaClient.user.getManyForSpace({});
-      const user = spaceUsers.items.find((u) => u.sys.id === userId);
-
-      if (user) {
-        return user.firstName && user.lastName
-          ? `${user.firstName} ${user.lastName}`
-          : user.email || userId;
-      }
-
-      // If not found in space users, return the user ID as fallback
-      return userId;
-    } catch (e) {
-      return userId; // fallback to user ID if we can't get user details
-    }
-  };
-
-  private getSpaceName = async (
-    cmaClient: PlainClientAPI,
-    spaceId: string
-  ): Promise<string | undefined> => {
-    try {
-      const space = await cmaClient.space.get({ spaceId });
-      return space.name || spaceId;
-    } catch (e) {
-      return spaceId; // fallback to space ID if we can't get space details
-    }
-  };
-
   convertToEventKey(topic?: string): SlackAppEventKey | undefined {
     if (!topic) {
       throw new NotFoundException({ errMessage: 'Event topic not found' });
@@ -214,37 +177,21 @@ export class EventsService {
       }
     }
 
-    // Fetch additional information
-    const [actorName, spaceName] = await Promise.all([
-      this.getUserName(cmaClient, actorId),
-      this.getSpaceName(cmaClient, spaceId),
-    ]);
-
     return {
       actorId,
-      actorName,
       entryName: entryName,
       date,
       entity: entry,
-      spaceName,
-      environmentId,
     };
   }
 
   createMessageBlocks(event: SlackAppEventKey, entry: EntryProps, resolvedEntity?: ResolvedEntity) {
-    // Create enhanced message with author, space, and environment information
-    const authorInfo = resolvedEntity?.actorName ? ` by ${resolvedEntity.actorName}` : '';
-    const spaceInfo = resolvedEntity?.spaceName ? ` in space "${resolvedEntity.spaceName}"` : '';
-    const environmentInfo = resolvedEntity?.environmentId
-      ? ` (${resolvedEntity.environmentId} environment)`
-      : '';
-
     const blocks: (Block | KnownBlock)[] = [
       {
         type: 'section',
         text: {
           type: 'mrkdwn',
-          text: `*${MESSAGE_EMOJI_MAP[event]} An entry was ${EVENT_TEXT_MAP[event]}${authorInfo}${spaceInfo}${environmentInfo}!*`,
+          text: `*${MESSAGE_EMOJI_MAP[event]} An entry was ${EVENT_TEXT_MAP[event]}!*`,
         },
       },
     ];
@@ -262,42 +209,17 @@ export class EventsService {
       });
     }
 
-    // Enhanced context information
-    const contextElements = [];
-
-    // Add content type and date
     if (resolvedEntity?.date) {
-      contextElements.push(`${entry.sys.contentType.sys.id} | ${resolvedEntity.date}`);
-    } else {
-      contextElements.push(entry.sys.contentType.sys.id);
-    }
-
-    // Add author information if available
-    if (resolvedEntity?.actorName) {
-      contextElements.push(`Author: ${resolvedEntity.actorName}`);
-    }
-
-    // Add space and environment information
-    if (resolvedEntity?.spaceName) {
-      contextElements.push(`Space: ${resolvedEntity.spaceName}`);
-    }
-
-    if (resolvedEntity?.environmentId) {
-      contextElements.push(`Environment: ${resolvedEntity.environmentId}`);
-    }
-
-    if (contextElements.length > 0) {
       blocks.push({
         type: 'context',
         elements: [
           {
             type: 'mrkdwn',
-            text: contextElements.join(' • '),
+            text: `${entry.sys.contentType.sys.id} | ${resolvedEntity.date || 'A while ago'}`,
           },
         ],
       });
     }
-
     blocks.push({
       type: 'divider',
     });

--- a/apps/slack/lambda/lib/routes/events/service.ts
+++ b/apps/slack/lambda/lib/routes/events/service.ts
@@ -41,18 +41,24 @@ export class EventsService {
 
   private getUserName = async (
     cmaClient: PlainClientAPI,
-    spaceId: string,
     userId?: string
   ): Promise<string | undefined> => {
     if (!userId) {
       return undefined;
     }
     try {
-      const user = await cmaClient.user.getForSpace({ spaceId, userId });
+      // Try to get user from space users first
+      const spaceUsers = await cmaClient.user.getManyForSpace({});
+      const user = spaceUsers.items.find((u) => u.sys.id === userId);
 
-      return user.firstName && user.lastName
-        ? `${user.firstName} ${user.lastName}`
-        : user.email || userId;
+      if (user) {
+        return user.firstName && user.lastName
+          ? `${user.firstName} ${user.lastName}`
+          : user.email || userId;
+      }
+
+      // If not found in space users, return the user ID as fallback
+      return userId;
     } catch (e) {
       return userId; // fallback to user ID if we can't get user details
     }
@@ -210,7 +216,7 @@ export class EventsService {
 
     // Fetch additional information
     const [actorName, spaceName] = await Promise.all([
-      this.getUserName(cmaClient, spaceId, actorId),
+      this.getUserName(cmaClient, actorId),
       this.getSpaceName(cmaClient, spaceId),
     ]);
 

--- a/apps/slack/lambda/lib/routes/events/types.ts
+++ b/apps/slack/lambda/lib/routes/events/types.ts
@@ -22,12 +22,9 @@ export interface SlackAppInstallationParameters {
 
 export interface ResolvedEntity {
   actorId?: string;
-  actorName?: string;
   entryName?: string;
   date?: string;
   entity?: EventEntity;
-  spaceName?: string;
-  environmentId?: string;
 }
 
 // For now we only listen on events for entries


### PR DESCRIPTION
[ES-557](https://contentful.atlassian.net/browse/ES-557)

## Summary
- Reverts #11167 and #11263, returning Slack entry-event notifications to their pre-Aug-3 format (no author/space/environment attribution — just the entry, content type, and date).
- **Why:** #11167 added author name + space name + environment to notifications, but this can never actually resolve to a name. The Slack app authenticates via App Identity, and [App Access Tokens don't have permission to read `User` or `Space` entities at all](https://www.contentful.com/developers/docs/extensibility/app-framework/app-identity/).
- Decision made: revert rather than keep showing raw IDs, so a clean two-commit revert (`570c159`, `ae3cf48`) of exactly the three files #11167/#11263 touched — no unrelated changes, no conflicts with the unrelated frontend fix in #11264.

## Test plan
- [ ] `npm test` in `apps/slack/lambda` passes — assertions should match the pre-#11167 test suite
- [ ] Trigger a publish/unpublish/create/delete event against a test space and confirm the Slack message matches the pre-Aug-3 format (no author/space/environment line)

Generated with [Claude Code](https://claude.com/claude-code)

[ES-557]: https://contentful.atlassian.net/browse/ES-557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ