### PR TITLE
fix(security): scope Optimizely OAuth token postMessage to app origin []

### DIFF
--- a/apps/optimizely/src/index.jsx
+++ b/apps/optimizely/src/index.jsx
@@ -32,7 +32,7 @@ if (window.location.hash) {
   const { access_token = null, expires_in = null } = parseHash(window.location.hash);
   const expireTime = getTokenExpirationTime(expires_in);
 
-  window.opener.postMessage({ token: access_token, expires: expireTime }, '*');
+  window.opener.postMessage({ token: access_token, expires: expireTime }, window.location.origin);
   window.close();
 }
 


### PR DESCRIPTION
## Summary
- Optimizely's OAuth callback (`apps/optimizely/src/index.jsx:35`) forwarded the freshly-minted access token to `window.opener` via `postMessage` with target origin `'*'`, so the browser delivers it regardless of the opener tab's current origin (CWE-346).
- Scopes the target origin to `window.location.origin` instead, matching the fix already applied to Typeform, Slack, and Smartling under [AIS-298](https://contentful.atlassian.net/browse/AIS-298) — Optimizely was missed from that pass.
- The receiving `message` listener in this file already validates `event.origin` correctly, so this closes the one remaining gap on the send side.

## Test plan
- [ ] `yarn workspace optimizely test` (or repo-equivalent) passes
- [ ] Manually connect the Optimizely app in a Contentful environment and confirm the OAuth popup flow still authenticates successfully

[AIS-298]: https://contentful.atlassian.net/browse/AIS-298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ