### PR TITLE
adds field for specifying assets URLs for thumbnails

### DIFF
--- a/apps/aem-assets/README.md
+++ b/apps/aem-assets/README.md
@@ -14,9 +14,10 @@ This app lets editors browse, select, sort, and remove AEM DAM assets from a Con
 | --- | --- | --- |
 | IMS Client ID | Yes | Client ID from Adobe IMS. Must be requested from Adobe support — not the standard Adobe Developer Console. |
 | IMS Organization | Yes | The Adobe Identity Management System (IMS) ID provided by Adobe when provisioning Adobe AEM CS for your organization. |
-| Repository ID | No | Restricts the asset selector to a single repository. |
-| AEM Tier | No | Restricts the asset selector to repositories in the selected tier(s). |
-| Environment | No | Restricts the asset selector to repositories in the selected environment. |
+| Repository ID | No | Restricts the asset selector to a single repository. [The AEM Tier and Environment values are ignored if a Repository value is provided.] |
+| AEM Tier | No | Restricts the asset selector to repositories in the selected tier(s). [Only used if a Repository value is not provided.] |
+| Environment | No | Restricts the asset selector to repositories in the selected environment. [Only used if a Repository value is not provided.] |
+| Assets URL Root | No | Specifies the root domain and path for constructing assets' URLs. [Used for generating tier or environment specific URLs] |
 | Prefill Selected Assets | No | Specifies if selected assets are pre-selected in the asset picker. |
 | Hide Asset Upload Button | No | Specifies if the upload button is displayed in the asset picker. |
 

--- a/apps/aem-assets/src/index.jsx
+++ b/apps/aem-assets/src/index.jsx
@@ -196,6 +196,7 @@ async function renderDialog(sdk) {
     aemTierType,
     env,
     hideUploadButton,
+    assetsUrlRoot,
     prefillSelectedAssets,
     selectedAssets,
     hideTreeNav,
@@ -268,9 +269,6 @@ async function renderDialog(sdk) {
 
   const contentAdvisorProps = {
     imsOrg,
-    repositoryId,
-    aemTierType: aemTierType && aemTierType !== 'both' ? [aemTierType] : ['delivery', 'author'],
-    env: env === 'stage' ? 'stage' : undefined,
     hideTreeNav,
     selectedAssets:
       prefillSelectedAssets === 'Yes' && selectedAssets && Array.isArray(selectedAssets)
@@ -280,7 +278,6 @@ async function renderDialog(sdk) {
     uploadConfig: {
       hideUploadButton: hideUploadButton === 'Yes' ? true : false,
     },
-    alwaysUseDMDelivery: aemTierType !== 'author',
     // handleAssetSelection, // only enabled for testing
     handleSelection,
     onClose,
@@ -288,13 +285,18 @@ async function renderDialog(sdk) {
     showToast: () => {},
   };
 
+  if (repositoryId) contentAdvisorProps.repositoryId = repositoryId;
+  if (!repositoryId && aemTierType && aemTierType !== 'both')
+    contentAdvisorProps.aemTierType = [aemTierType];
+  if (!repositoryId && env === 'stage') contentAdvisorProps.env = 'stage';
+
   // this function is only used for testing
   // function handleAssetSelection(assets) {
   //   const transformedAssets = transformAssets(assets);
   // }
 
   function handleSelection(assets) {
-    const transformedAssets = transformAssets(assets);
+    const transformedAssets = transformAssets(assets, config);
     sdk.close(transformedAssets);
   }
 
@@ -379,8 +381,8 @@ setup({
       id: 'repositoryId',
       name: 'Repository',
       type: 'Symbol',
-      description: 'Restricts the asset selector to a single repository.',
-      required: false,
+      description: `Restricts the asset selector to a single repository.
+        [The AEM Tier and Environment values are ignored if a Repository value is provided.]`,
     },
     {
       id: 'aemTierType',
@@ -388,8 +390,8 @@ setup({
       type: 'List',
       value: 'delivery,author,both',
       default: 'both',
-      description: 'Restricts the asset selector to repositories in the selected tier(s).',
-      required: false,
+      description: `Restricts the asset selector to repositories in the selected tier(s).
+        [Only used if a Repository value is not provided.]`,
     },
     {
       id: 'env',
@@ -397,7 +399,15 @@ setup({
       type: 'List',
       value: 'prod,stage',
       default: 'prod',
-      description: 'Restricts the asset selector to repositories in the selected environment.',
+      description: `Restricts the asset selector to repositories in the selected environment.
+        [Only used if a Repository value is not provided.]`,
+    },
+    {
+      id: 'assetsUrlRoot',
+      name: 'Assets URL Root',
+      type: 'Symbol',
+      description: `Specifies the root domain and path for constructing assets' URLs.
+        [Used for generating tier or environment specific URLs]`,
     },
     {
       id: 'prefillSelectedAssets',

--- a/apps/aem-assets/src/utils.js
+++ b/apps/aem-assets/src/utils.js
@@ -30,13 +30,18 @@ export function getRenditions(asset) {
   return renditions.sort((a, b) => a.width - b.width);
 }
 
-export function transformAssets(assets) {
+export function transformAssets(assets, config) {
   const transformedAssets = assets.map((asset) => {
+    const assetId = asset['repo:assetId'] || asset['repo:id'] || asset.id;
     const renditions = getRenditions(asset);
-    const thumbUrl = renditions.find((r) => r.width >= 150 && r.width <= 400).href;
+    const urlRoot = config.assetsUrlRoot;
+
+    const thumbUrl = urlRoot
+      ? `${urlRoot}${!urlRoot.endsWith('/') ? '/' : ''}${assetId}`
+      : renditions.find((r) => r.width >= 150 && r.width <= 400).href;
 
     const transformedAsset = {
-      id: asset['repo:assetId'] || asset['repo:id'] || asset.id,
+      id: assetId,
       name: asset['repo:name'] || asset.name || '',
       url: thumbUrl,
       metadata: getMetadata(asset, renditions),


### PR DESCRIPTION
## Purpose

This branch includes the following changes:
 - adds the installation parameter `assetsUrlRoot` which allows customers to set the root to be used when generating asset thumbnail URLs
 - updates the `transformAssets` function to accept a `config` parameter and use its `assetsUrlRoot` property to modify each asset's `thumbUrl` if not null
 - removes `repositoryId`, `aemTierType`, and `env` from the `contentAdvisorProps` object instantiation and makes them conditional
 - updates the descriptions for `repositoryId`, `aemTierType`, and `env` in the `setup` function to clarify their conditional usage
 - updates the descriptions for `repositoryId`, `aemTierType`, and `env` and adds `assetsUrlRoot` in the **Installation Parameters** table of the `README.md` file

## Approach

The addition of the `assetsRootUrl` field was necessary to allow Ralph Lauren to generate a valid thumbnail URL for assets selected from their author environment which does not provide publicly accessible asset URLs.
The change to `repositoryId`, `aemTierType` and `env` was made to prevent the app from passing conflicting configuration parameters to the AEM Content Advisor micro front-end.

## Testing steps

Test 1: Enter a valid AEM Assets base URL in the `assetsUrlRoot` and save the configuration. Open a content entry that uses the AEM Assets connector and click the button labeled 'Select assets from AEM'. Click on an asset in the Content Advisor modal window and then click the button labeled 'Select' in the top right corner. Inspect the thumbnail image generated by the AEM Assets connector and verify the asset URL base matches the value of the `assetsUrlRoot` configuration parameter.

## Breaking Changes

None

## Dependencies and/or References

None

## Deployment

None
