### PR TITLE
fix(bulk-exporter): selection banner follow-ups []

### DIFF
--- a/apps/bulk-exporter/README.md
+++ b/apps/bulk-exporter/README.md
@@ -1,4 +1,4 @@
-# Entry Exporter for Contentful
+# Content Exporter for Contentful
 
 A Contentful App that allows you to export unlimited entries from any content type to **5 different formats** (CSV, JSON, XLSX, XML, YAML), bypassing the 40-entry limitation of the Contentful web interface.
 
@@ -144,7 +144,7 @@ npm run deploy -- --organization-id YOUR_ORG_ID --definition-id YOUR_APP_DEF_ID 
 ### Search & Preview
 
 1. Navigate to **Apps** in the Contentful web UI main menu
-2. Select **Entry Exporter**
+2. Select **Content Exporter**
 3. Use the tabbed interface to build your query:
 
 #### Filter Tab

--- a/apps/bulk-exporter/contentful-app.json
+++ b/apps/bulk-exporter/contentful-app.json
@@ -1,6 +1,6 @@
 {
   "id": "1Oz4Ttx1lCCwdkiS4cEe11",
-  "name": "Entry Exporter",
+  "name": "Content Exporter",
   "locations": [
     {
       "location": "app-config"

--- a/apps/bulk-exporter/index.html
+++ b/apps/bulk-exporter/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Bulk Entry Exporter</title>
+    <title>Content Exporter</title>
     <link rel="preconnect" href="https://cdn.f36.contentful.com" />
     <link rel="stylesheet" href="https://cdn.f36.contentful.com/font/geist/geist.css" />
     <style>

--- a/apps/bulk-exporter/src/components/ResultsList.tsx
+++ b/apps/bulk-exporter/src/components/ResultsList.tsx
@@ -590,7 +590,7 @@ export function ResultsList({
     if (!entry.fields?.[field.id]) return '—';
     const localeMap = entry.fields[field.id];
     const value = locale
-      ? (localeMap[locale] ?? Object.values(localeMap)[0])
+      ? localeMap[locale] ?? Object.values(localeMap)[0]
       : Object.values(localeMap)[0];
     return formatFieldValue(field, value);
   };
@@ -671,7 +671,9 @@ export function ResultsList({
                     </TextLink>
                   </>
                 ) : (
-                  `${selectedIds.length} ${selectedIds.length === 1 ? 'entry' : 'entries'} selected:`
+                  `${selectedIds.length} ${
+                    selectedIds.length === 1 ? 'entry' : 'entries'
+                  } selected:`
                 )}
               </Text>
               {onExportSelected && (

--- a/apps/bulk-exporter/src/components/ResultsList.tsx
+++ b/apps/bulk-exporter/src/components/ResultsList.tsx
@@ -843,7 +843,7 @@ export function ResultsList({
                           }}>
                           {onSelectionChange && (
                             <Checkbox
-                              isChecked={selectedIds.includes(entry.sys.id)}
+                              isChecked={selectedIds.includes(entry.sys.id) || selectAllMatching}
                               onChange={() => handleSelectOne(entry.sys.id)}
                               aria-label={`Select ${getTitle(entry)}`}
                             />

--- a/apps/bulk-exporter/src/components/ResultsList.tsx
+++ b/apps/bulk-exporter/src/components/ResultsList.tsx
@@ -149,6 +149,14 @@ export interface ResultsListProps {
     format: 'csv' | 'json' | 'xlsx' | 'xml' | 'yaml',
     filename: string
   ) => void;
+  /** True once the user has clicked "Select all N entries matching this search" */
+  selectAllMatching?: boolean;
+  onSelectAllMatchingChange?: (value: boolean) => void;
+  /** Exports every entry matching the current search filters, not just the fetched page(s) */
+  onExportAllMatching?: (
+    format: 'csv' | 'json' | 'xlsx' | 'xml' | 'yaml',
+    filename: string
+  ) => void;
   contentTypeMap?: ContentTypeMap;
   userMap?: UserMap;
   spaceId?: string;
@@ -338,6 +346,9 @@ export function ResultsList({
   selectedIds = [],
   onSelectionChange,
   onExportSelected,
+  selectAllMatching = false,
+  onSelectAllMatchingChange,
+  onExportAllMatching,
   contentTypeMap = {},
   userMap = {},
   spaceId = '',
@@ -503,6 +514,12 @@ export function ResultsList({
 
   const handleSelectAll = () => {
     if (!onSelectionChange) return;
+    if (selectAllMatching) {
+      // Unchecking while every matching entry is selected drops back to no selection.
+      onSelectAllMatchingChange?.(false);
+      onSelectionChange([]);
+      return;
+    }
     if (allSelected) {
       onSelectionChange(selectedIds.filter((id) => !allCurrentIds.includes(id)));
     } else {
@@ -513,12 +530,30 @@ export function ResultsList({
 
   const handleSelectOne = (id: string) => {
     if (!onSelectionChange) return;
+    if (selectAllMatching) {
+      // Deselecting a single row while every matching entry is selected falls back
+      // to page-level selection (minus that row) rather than tracking exclusions.
+      onSelectAllMatchingChange?.(false);
+      onSelectionChange(allCurrentIds.filter((currentId) => currentId !== id));
+      return;
+    }
     if (selectedIds.includes(id)) {
       onSelectionChange(selectedIds.filter((selectedId) => selectedId !== id));
     } else {
       onSelectionChange([...selectedIds, id]);
     }
   };
+
+  const handleClearSelection = () => {
+    onSelectAllMatchingChange?.(false);
+    onSelectionChange?.([]);
+  };
+
+  const showSelectAllBanner =
+    !selectAllMatching &&
+    allSelected &&
+    totalCount !== undefined &&
+    totalCount > allCurrentIds.length;
 
   const getTitle = (entry: SearchResult): string => {
     if (!entry.fields) return entry.sys.id;
@@ -606,18 +641,38 @@ export function ResultsList({
         </Flex>
 
         {/* Selection bar */}
-        {selectedIds.length > 0 && (
+        {(selectedIds.length > 0 || selectAllMatching) && (
           <div style={{ padding: '0 24px' }}>
             <Flex
               alignItems="center"
               gap="spacingS"
+              flexWrap="wrap"
               style={{
                 padding: '12px 0',
                 borderTop: `1px solid ${tokens.gray200}`,
                 borderBottom: `1px solid ${tokens.gray200}`,
               }}>
               <Text fontSize="fontSizeS" fontColor="gray700">
-                {selectedIds.length} {selectedIds.length === 1 ? 'entry' : 'entries'} selected:
+                {selectAllMatching ? (
+                  <>
+                    All {(totalCount ?? selectedIds.length).toLocaleString()}{' '}
+                    {(totalCount ?? selectedIds.length) === 1 ? 'entry' : 'entries'} matching this
+                    search are selected.{' '}
+                    <TextLink as="button" onClick={handleClearSelection}>
+                      Clear selection
+                    </TextLink>
+                  </>
+                ) : showSelectAllBanner ? (
+                  <>
+                    All {allCurrentIds.length} {allCurrentIds.length === 1 ? 'entry' : 'entries'} on
+                    this page are selected.{' '}
+                    <TextLink as="button" onClick={() => onSelectAllMatchingChange?.(true)}>
+                      Select all {totalCount?.toLocaleString()} entries matching this search
+                    </TextLink>
+                  </>
+                ) : (
+                  `${selectedIds.length} ${selectedIds.length === 1 ? 'entry' : 'entries'} selected:`
+                )}
               </Text>
               {onExportSelected && (
                 <Button
@@ -635,7 +690,8 @@ export function ResultsList({
         {/* Table — horizontal scroll when field columns overflow.
             tableLayout: fixed lets us set exact column widths so sticky
             left offsets are reliable pixel values. */}
-        <div style={{ padding: `${selectedIds.length > 0 ? '24px' : '0'} 24px 24px` }}>
+        <div
+          style={{ padding: `${selectedIds.length > 0 || selectAllMatching ? '24px' : '0'} 24px 24px` }}>
           <div style={{ border: '1px solid #E7EBEE', borderRadius: '6px', overflow: 'hidden' }}>
             <div style={{ overflowX: 'auto', width: '100%' }}>
               <Table
@@ -672,8 +728,8 @@ export function ResultsList({
                       }}>
                       {onSelectionChange && (
                         <Checkbox
-                          isChecked={allSelected}
-                          isIndeterminate={someSelected}
+                          isChecked={allSelected || selectAllMatching}
+                          isIndeterminate={someSelected && !selectAllMatching}
                           onChange={handleSelectAll}
                           aria-label="Select all entries on this page"
                         />
@@ -900,7 +956,10 @@ export function ResultsList({
           <div style={{ padding: '16px 24px 0' }}>
             {isExporting ? (
               <Text>
-                {exportProgress?.message || `Exporting ${selectedIds.length} selected entries`}
+                {exportProgress?.message ||
+                  (selectAllMatching
+                    ? `Exporting ${(totalCount ?? 0).toLocaleString()} matching entries`
+                    : `Exporting ${selectedIds.length} selected entries`)}
               </Text>
             ) : (
               <>
@@ -944,6 +1003,11 @@ export function ResultsList({
               isDisabled={isExporting}
               onClick={() => {
                 const today = new Date().toISOString().split('T')[0];
+                if (selectAllMatching) {
+                  const resolvedFilename = exportFilename.trim() || `all-matching-${today}`;
+                  onExportAllMatching?.(exportFormat, resolvedFilename);
+                  return;
+                }
                 const resolvedFilename =
                   exportFilename.trim() || `selected-${selectedIds.length}-entries-${today}`;
                 onExportSelected?.(selectedIds, exportFormat, resolvedFilename);

--- a/apps/bulk-exporter/src/components/ResultsList.tsx
+++ b/apps/bulk-exporter/src/components/ResultsList.tsx
@@ -652,7 +652,7 @@ export function ResultsList({
                 borderTop: `1px solid ${tokens.gray200}`,
                 borderBottom: `1px solid ${tokens.gray200}`,
               }}>
-              <Text fontSize="fontSizeS" fontColor="gray700">
+              <Text fontSize="fontSizeM" fontColor="gray700">
                 {selectAllMatching ? (
                   <>
                     All {(totalCount ?? selectedIds.length).toLocaleString()}{' '}

--- a/apps/bulk-exporter/src/components/ResultsList.tsx
+++ b/apps/bulk-exporter/src/components/ResultsList.tsx
@@ -590,7 +590,7 @@ export function ResultsList({
     if (!entry.fields?.[field.id]) return '—';
     const localeMap = entry.fields[field.id];
     const value = locale
-      ? localeMap[locale] ?? Object.values(localeMap)[0]
+      ? (localeMap[locale] ?? Object.values(localeMap)[0])
       : Object.values(localeMap)[0];
     return formatFieldValue(field, value);
   };
@@ -691,7 +691,9 @@ export function ResultsList({
             tableLayout: fixed lets us set exact column widths so sticky
             left offsets are reliable pixel values. */}
         <div
-          style={{ padding: `${selectedIds.length > 0 || selectAllMatching ? '24px' : '0'} 24px 24px` }}>
+          style={{
+            padding: `${selectedIds.length > 0 || selectAllMatching ? '24px' : '0'} 24px 24px`,
+          }}>
           <div style={{ border: '1px solid #E7EBEE', borderRadius: '6px', overflow: 'hidden' }}>
             <div style={{ overflowX: 'auto', width: '100%' }}>
               <Table

--- a/apps/bulk-exporter/src/locations/ConfigScreen.tsx
+++ b/apps/bulk-exporter/src/locations/ConfigScreen.tsx
@@ -48,8 +48,8 @@ const ConfigScreen = () => {
         </Flex>
 
         <Note variant="positive" title="Ready to install">
-          Content Exporter adds a page to the Apps menu. After installation, users with access to this
-          space can open the page and export entries from the content types they are allowed to
+          Content Exporter adds a page to the Apps menu. After installation, users with access to
+          this space can open the page and export entries from the content types they are allowed to
           read.
         </Note>
 

--- a/apps/bulk-exporter/src/locations/ConfigScreen.tsx
+++ b/apps/bulk-exporter/src/locations/ConfigScreen.tsx
@@ -40,7 +40,7 @@ const ConfigScreen = () => {
     <Box padding="spacingXl" style={{ maxWidth: '900px', margin: '0 auto' }}>
       <Flex flexDirection="column" gap="spacingXl" alignItems="stretch">
         <Flex flexDirection="column" gap="spacingS" alignItems="flex-start" style={fullWidth}>
-          <Heading>Bulk Exporter</Heading>
+          <Heading>Content Exporter</Heading>
           <Paragraph>
             Export entries from Contentful with filters, saved field selections, and multiple file
             formats. No additional configuration is required before installation.
@@ -48,7 +48,7 @@ const ConfigScreen = () => {
         </Flex>
 
         <Note variant="positive" title="Ready to install">
-          Bulk Exporter adds a page to the Apps menu. After installation, users with access to this
+          Content Exporter adds a page to the Apps menu. After installation, users with access to this
           space can open the page and export entries from the content types they are allowed to
           read.
         </Note>
@@ -100,7 +100,7 @@ const ConfigScreen = () => {
         <Note variant="primary" title="Permissions">
           <Flex flexDirection="column" gap="spacingXs" alignItems="flex-start" style={fullWidth}>
             <Text>
-              Bulk Exporter can only export entries, tags, locales, and taxonomy data that the
+              Content Exporter can only export entries, tags, locales, and taxonomy data that the
               current user is allowed to access.
             </Text>
             <Text>

--- a/apps/bulk-exporter/src/locations/Page.tsx
+++ b/apps/bulk-exporter/src/locations/Page.tsx
@@ -535,7 +535,7 @@ const Page = () => {
           onSortChange={setColumnSort}
           contentTypeSchema={
             lastFormData?.contentTypeId
-              ? contentTypeSchemaMap[lastFormData.contentTypeId] ?? null
+              ? (contentTypeSchemaMap[lastFormData.contentTypeId] ?? null)
               : null
           }
           locales={lastFormData?.locales ?? []}

--- a/apps/bulk-exporter/src/locations/Page.tsx
+++ b/apps/bulk-exporter/src/locations/Page.tsx
@@ -535,7 +535,7 @@ const Page = () => {
           onSortChange={setColumnSort}
           contentTypeSchema={
             lastFormData?.contentTypeId
-              ? (contentTypeSchemaMap[lastFormData.contentTypeId] ?? null)
+              ? contentTypeSchemaMap[lastFormData.contentTypeId] ?? null
               : null
           }
           locales={lastFormData?.locales ?? []}

--- a/apps/bulk-exporter/src/locations/Page.tsx
+++ b/apps/bulk-exporter/src/locations/Page.tsx
@@ -70,6 +70,7 @@ const Page = () => {
   const ITEMS_PER_PAGE = 50;
   const [lastFormData, setLastFormData] = useState<ExportFormData | null>(null);
   const [selectedEntryIds, setSelectedEntryIds] = useState<string[]>([]);
+  const [selectAllMatching, setSelectAllMatching] = useState(false);
   const [contentTypeMap, setContentTypeMap] = useState<
     Record<string, { name: string; displayField?: string }>
   >({});
@@ -231,6 +232,7 @@ const Page = () => {
       setIsSearching(true);
       setSearchResults([]);
       setSelectedEntryIds([]);
+      setSelectAllMatching(false);
       setActivePage(0);
       setLastFormData(data);
 
@@ -340,6 +342,7 @@ const Page = () => {
       setIsSearching(true);
       setActivePage(page);
       setSelectedEntryIds([]);
+      setSelectAllMatching(false);
 
       const response = await sdk.cma.entry.getMany({
         query: { ...lastSearchQuery, limit: ITEMS_PER_PAGE, skip: page * ITEMS_PER_PAGE },
@@ -431,6 +434,17 @@ const Page = () => {
     }
   };
 
+  // Exports every entry matching the current filters (not just the fetched page),
+  // reusing the same filtered query the main "Export" flow uses so it scales to
+  // any result size instead of requiring every ID to be collected client-side.
+  const handleExportAllMatching = (
+    format: 'csv' | 'json' | 'xlsx' | 'xml' | 'yaml',
+    filename: string
+  ) => {
+    if (!lastFormData) return;
+    handleExport({ ...lastFormData, format, customFilename: filename });
+  };
+
   if (loading) {
     return (
       <Flex
@@ -449,7 +463,7 @@ const Page = () => {
     <Box style={{ maxWidth: '1400px', margin: '0 auto', width: '100%' }}>
       <Flex flexDirection="column" alignItems="stretch" gap="spacingL" padding="spacingL">
         <Box style={{ width: '100%', maxWidth: '1040px' }}>
-          <Heading marginBottom="spacingS">Entry Exporter</Heading>
+          <Heading marginBottom="spacingS">Content Exporter</Heading>
           <Paragraph marginBottom="none" style={{ maxWidth: '700px' }}>
             Search, preview, and export Contentful entries across one content type or the whole
             space. Use filters to narrow the result set, then export matching or selected entries.
@@ -509,6 +523,9 @@ const Page = () => {
           selectedIds={selectedEntryIds}
           onSelectionChange={setSelectedEntryIds}
           onExportSelected={handleExportSelected}
+          selectAllMatching={selectAllMatching}
+          onSelectAllMatchingChange={setSelectAllMatching}
+          onExportAllMatching={handleExportAllMatching}
           contentTypeMap={contentTypeMap}
           userMap={userMap}
           spaceId={sdk.ids.space}


### PR DESCRIPTION
## Summary
Follow-up to #11277 (already merged as 3464ffba5). This branch had extra commits pushed after that PR was merged, so they need a new PR to land:
- Match selection banner sentence font size to the larger `TextLink` size
- Fix Prettier formatting (repo's pinned 2.8.8 + root `.prettierrc`)
- Fix row checkboxes not appearing checked while in select-all-matching mode, per review feedback on #11277

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] Selection banner sentence and "Select all.../Clear selection" link render at the same font size
- [ ] While "select all matching" is active, every row checkbox appears checked
- [ ] Clicking a single row checkbox while in select-all-matching mode deselects just that row and exits select-all-matching mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)