### PR TITLE
Fix/add asset url root []

### DIFF
--- a/apps/aem-assets/README.md
+++ b/apps/aem-assets/README.md
@@ -14,9 +14,10 @@ This app lets editors browse, select, sort, and remove AEM DAM assets from a Con
 | --- | --- | --- |
 | IMS Client ID | Yes | Client ID from Adobe IMS. Must be requested from Adobe support — not the standard Adobe Developer Console. |
 | IMS Organization | Yes | The Adobe Identity Management System (IMS) ID provided by Adobe when provisioning Adobe AEM CS for your organization. |
-| Repository ID | No | Restricts the asset selector to a single repository. |
-| AEM Tier | No | Restricts the asset selector to repositories in the selected tier(s). |
-| Environment | No | Restricts the asset selector to repositories in the selected environment. |
+| Repository ID | No | Restricts the asset selector to a single repository. [The AEM Tier and Environment values are ignored if a Repository value is provided.] |
+| AEM Tier | No | Restricts the asset selector to repositories in the selected tier(s). [Only used if a Repository value is not provided.] |
+| Environment | No | Restricts the asset selector to repositories in the selected environment. [Only used if a Repository value is not provided.] |
+| Assets URL Root | No | Specifies the root domain and path for constructing assets' URLs. [Used for generating tier or environment specific URLs] |
 | Prefill Selected Assets | No | Specifies if selected assets are pre-selected in the asset picker. |
 | Hide Asset Upload Button | No | Specifies if the upload button is displayed in the asset picker. |
 

--- a/apps/aem-assets/src/index.jsx
+++ b/apps/aem-assets/src/index.jsx
@@ -196,6 +196,7 @@ async function renderDialog(sdk) {
     aemTierType,
     env,
     hideUploadButton,
+    assetsUrlRoot,
     prefillSelectedAssets,
     selectedAssets,
     hideTreeNav,
@@ -268,9 +269,6 @@ async function renderDialog(sdk) {
 
   const contentAdvisorProps = {
     imsOrg,
-    repositoryId,
-    aemTierType: aemTierType && aemTierType !== 'both' ? [aemTierType] : ['delivery', 'author'],
-    env: env === 'stage' ? 'stage' : undefined,
     hideTreeNav,
     selectedAssets:
       prefillSelectedAssets === 'Yes' && selectedAssets && Array.isArray(selectedAssets)
@@ -280,7 +278,6 @@ async function renderDialog(sdk) {
     uploadConfig: {
       hideUploadButton: hideUploadButton === 'Yes' ? true : false,
     },
-    alwaysUseDMDelivery: aemTierType !== 'author',
     // handleAssetSelection, // only enabled for testing
     handleSelection,
     onClose,
@@ -288,13 +285,18 @@ async function renderDialog(sdk) {
     showToast: () => {},
   };
 
+  if (repositoryId) contentAdvisorProps.repositoryId = repositoryId;
+  if (!repositoryId && aemTierType && aemTierType !== 'both')
+    contentAdvisorProps.aemTierType = [aemTierType];
+  if (!repositoryId && env === 'stage') contentAdvisorProps.env = 'stage';
+
   // this function is only used for testing
   // function handleAssetSelection(assets) {
   //   const transformedAssets = transformAssets(assets);
   // }
 
   function handleSelection(assets) {
-    const transformedAssets = transformAssets(assets);
+    const transformedAssets = transformAssets(assets, config);
     sdk.close(transformedAssets);
   }
 
@@ -379,8 +381,8 @@ setup({
       id: 'repositoryId',
       name: 'Repository',
       type: 'Symbol',
-      description: 'Restricts the asset selector to a single repository.',
-      required: false,
+      description: `Restricts the asset selector to a single repository.
+        [The AEM Tier and Environment values are ignored if a Repository value is provided.]`,
     },
     {
       id: 'aemTierType',
@@ -388,8 +390,8 @@ setup({
       type: 'List',
       value: 'delivery,author,both',
       default: 'both',
-      description: 'Restricts the asset selector to repositories in the selected tier(s).',
-      required: false,
+      description: `Restricts the asset selector to repositories in the selected tier(s).
+        [Only used if a Repository value is not provided.]`,
     },
     {
       id: 'env',
@@ -397,7 +399,15 @@ setup({
       type: 'List',
       value: 'prod,stage',
       default: 'prod',
-      description: 'Restricts the asset selector to repositories in the selected environment.',
+      description: `Restricts the asset selector to repositories in the selected environment.
+        [Only used if a Repository value is not provided.]`,
+    },
+    {
+      id: 'assetsUrlRoot',
+      name: 'Assets URL Root',
+      type: 'Symbol',
+      description: `Specifies the root domain and path for constructing assets' URLs.
+        [Used for generating tier or environment specific URLs]`,
     },
     {
       id: 'prefillSelectedAssets',

--- a/apps/aem-assets/src/index.jsx
+++ b/apps/aem-assets/src/index.jsx
@@ -4,7 +4,7 @@ import { Button } from '@contentful/f36-components';
 import { setup } from '@contentful/dam-app-base';
 import './index.css';
 import logo from './logo.svg';
-import { getRenditions, pick, transformAssets } from './utils';
+import { getRenditions, getSafeRenditionUrl, pick, transformAssets } from './utils';
 
 const ADOBE_EXPERIENCE_CLOUD_DOMAIN = `https://experience.adobe.com`;
 const SCRIPT_URL = `${ADOBE_EXPERIENCE_CLOUD_DOMAIN}/solutions/CQ-assets-selectors/static-assets/resources/assets-selectors.js`;
@@ -30,9 +30,8 @@ const FIELDS_TO_PERSIST = [
 ];
 
 export function makeThumbnail(asset) {
-  const thumbRendition = asset?.computedMetadata?._links[ASSET_RENDITIONS_KEY][1];
-  const thumbnail = thumbRendition?.href || '';
-  const url = typeof thumbnail === 'string' ? thumbnail : undefined;
+  const renditions = getRenditions(asset);
+  const url = getSafeRenditionUrl(asset, renditions);
   const alt = asset.name || asset.id || '';
 
   return [url, alt];
@@ -40,8 +39,10 @@ export function makeThumbnail(asset) {
 
 async function openDialog(sdk, _currentValue, _config) {
   const parameters = { ..._config, ...sdk.parameters.instance };
-  const assetIds = _currentValue.map((asset) => ({ id: asset.id }));
-  parameters.selectedAssets = assetIds;
+  const currentAssets = Array.isArray(_currentValue) ? _currentValue : [];
+  parameters.selectedAssets = currentAssets
+    .filter((asset) => asset?.id)
+    .map((asset) => ({ id: asset.id }));
 
   const result = await sdk.dialogs.openCurrentApp({
     position: 'center',
@@ -53,10 +54,7 @@ async function openDialog(sdk, _currentValue, _config) {
     allowHeightOverflow: true,
   });
 
-  if (!Array.isArray(result)) {
-    return [];
-  }
-
+  if (!Array.isArray(result)) return undefined;
   return result.map((asset) => pick(asset, FIELDS_TO_PERSIST));
 }
 
@@ -94,14 +92,14 @@ function LogoutButton({ onLogout }) {
   );
 }
 
-function showAuthError(message) {
+function showAlert(message) {
   const banner = document.getElementById('content-advisor-error');
   if (!banner) return;
   banner.textContent = message;
   banner.hidden = false;
 }
 
-function hideAuthError() {
+function hideAlert() {
   const banner = document.getElementById('content-advisor-error');
   if (!banner) return;
   banner.hidden = true;
@@ -196,10 +194,9 @@ async function renderDialog(sdk) {
     aemTierType,
     env,
     hideUploadButton,
-    assetsUrlRoot,
     prefillSelectedAssets,
-    selectedAssets,
-    hideTreeNav,
+    selectedAssets, //value set with field instance parameter
+    hideTreeNav, //value set with field instance parameter
     selectionType,
   } = config;
 
@@ -228,12 +225,12 @@ async function renderDialog(sdk) {
           if (!imsInstance) return;
           try {
             await imsInstance.signOut().then(() => {
-              showAuthError(
+              showAlert(
                 'You have been logged out of Adobe. Close this dialog and reopen the asset selector to sign in again.'
               );
             });
           } catch (error) {
-            showAuthError(`Failed to log out of Adobe: ${error?.message || error}`);
+            showAlert(`Failed to log out of Adobe: ${error?.message || error}`);
           }
         }}
       />
@@ -247,18 +244,18 @@ async function renderDialog(sdk) {
     redirectUrl: window.location.href,
     modalMode: true,
     onErrorReceived: (errorType, errorMessage) => {
-      showAuthError(
+      showAlert(
         `Adobe authentication failed (${errorType}). Check that the IMS Client ID and IMS Organization ID in the app configuration are still valid. If this persists after re-checking configuration, the Adobe Assets Selector's required auth scope may have changed and the app needs to be updated. Details: ${errorMessage}`
       );
     },
     onAccessTokenExpired: () => {
-      showAuthError(
+      showAlert(
         'Your Adobe session has expired. Close this dialog and try selecting assets again.'
       );
     },
     onAccessTokenReceived: (imsToken) => {
       if (imsToken) {
-        hideAuthError();
+        hideAlert();
       } else {
         // Close the modal if we don't have a valid IMS token. The IMS login modal should open.
         // After signing in, the user can re-open the asset selector by clicking the select assets button.
@@ -281,8 +278,8 @@ async function renderDialog(sdk) {
     // handleAssetSelection, // only enabled for testing
     handleSelection,
     onClose,
-    expiryOptions: () => {},
-    showToast: () => {},
+    // expiryOptions: () => {},
+    // showToast: () => {},
   };
 
   if (repositoryId) contentAdvisorProps.repositoryId = repositoryId;
@@ -292,16 +289,21 @@ async function renderDialog(sdk) {
 
   // this function is only used for testing
   // function handleAssetSelection(assets) {
-  //   const transformedAssets = transformAssets(assets);
+  // console.log(`assets:`, assets);
+  // const transformedAssets = transformAssets(assets);
   // }
 
   function handleSelection(assets) {
-    const transformedAssets = transformAssets(assets, config);
-    sdk.close(transformedAssets);
+    try {
+      const transformedAssets = transformAssets(assets, config);
+      sdk.close(transformedAssets);
+    } catch (error) {
+      showAlert(`Unable to prepare the selected assets: ${error?.message || error}`);
+    }
   }
 
   function onClose() {
-    hideAuthError();
+    hideAlert();
     document.getElementById('content-advisor-dialog').close();
     sdk.close();
   }
@@ -328,15 +330,19 @@ async function renderDialog(sdk) {
 }
 
 async function customUpdateStateValue({ currentValue, result, config }, updateStateValue) {
-  if (config.prefillSelectedAssets === 'Yes') {
-    if (result) await updateStateValue(result);
-  } else {
-    if (Array.isArray(result) && result.length > 0) {
-      const newValue = [...(currentValue || []), ...result];
+  if (!Array.isArray(result)) return;
 
-      await updateStateValue(newValue);
-    }
+  if (config.prefillSelectedAssets === 'Yes') {
+    await updateStateValue(result);
+    return;
   }
+
+  const current = Array.isArray(currentValue) ? currentValue : [];
+  const byId = new Map(current.filter((a) => a?.id).map((a) => [a.id, a]));
+  for (const asset of result) {
+    if (asset?.id) byId.set(asset.id, asset);
+  }
+  await updateStateValue([...byId.values()]);
 }
 
 function isDisabled() {
@@ -383,15 +389,17 @@ setup({
       type: 'Symbol',
       description: `Restricts the asset selector to a single repository.
         [The AEM Tier and Environment values are ignored if a Repository value is provided.]`,
+      required: false,
     },
     {
       id: 'aemTierType',
       name: 'AEM Tier',
       type: 'List',
-      value: 'delivery,author,both',
+      value: 'both,delivery,author',
       default: 'both',
       description: `Restricts the asset selector to repositories in the selected tier(s).
         [Only used if a Repository value is not provided.]`,
+      required: false,
     },
     {
       id: 'env',
@@ -401,6 +409,7 @@ setup({
       default: 'prod',
       description: `Restricts the asset selector to repositories in the selected environment.
         [Only used if a Repository value is not provided.]`,
+      required: false,
     },
     {
       id: 'assetsUrlRoot',
@@ -408,22 +417,25 @@ setup({
       type: 'Symbol',
       description: `Specifies the root domain and path for constructing assets' URLs.
         [Used for generating tier or environment specific URLs]`,
+      required: false,
     },
     {
       id: 'prefillSelectedAssets',
       name: 'Prefill Selected Assets',
       type: 'List',
-      value: 'No,Yes',
+      value: 'Yes,No',
       default: 'Yes',
       description: 'Specifies if selected assets are pre-selected in the asset picker.',
+      required: false,
     },
     {
       id: 'hideUploadButton',
       name: 'Hide Asset Upload Button',
       type: 'List',
-      value: 'Yes, No',
+      value: 'Yes,No',
       default: 'Yes',
       description: 'Specifies if the upload button is displayed in the asset picker.',
+      required: false,
     },
   ],
   customUpdateStateValue,

--- a/apps/aem-assets/src/utils.js
+++ b/apps/aem-assets/src/utils.js
@@ -30,13 +30,18 @@ export function getRenditions(asset) {
   return renditions.sort((a, b) => a.width - b.width);
 }
 
-export function transformAssets(assets) {
+export function transformAssets(assets, config) {
   const transformedAssets = assets.map((asset) => {
+    const assetId = asset['repo:assetId'] || asset['repo:id'] || asset.id;
     const renditions = getRenditions(asset);
-    const thumbUrl = renditions.find((r) => r.width >= 150 && r.width <= 400).href;
+    const urlRoot = config.assetsUrlRoot;
+
+    const thumbUrl = urlRoot
+      ? `${urlRoot}${!urlRoot.endsWith('/') ? '/' : ''}${assetId}`
+      : renditions.find((r) => r.width >= 150 && r.width <= 400).href;
 
     const transformedAsset = {
-      id: asset['repo:assetId'] || asset['repo:id'] || asset.id,
+      id: assetId,
       name: asset['repo:name'] || asset.name || '',
       url: thumbUrl,
       metadata: getMetadata(asset, renditions),

--- a/apps/aem-assets/src/utils.js
+++ b/apps/aem-assets/src/utils.js
@@ -1,62 +1,74 @@
 const ASSET_RENDITIONS_KEY = 'http://ns.adobe.com/adobecloud/rel/rendition';
+const ADOBE_EXPERIENCE_URL = 'https://experience.adobe.com/';
 
 /**
  * Source: https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore#_pick
  */
 export function pick(object, keys) {
-  return keys.reduce((obj, key) => {
-    if (object && object.hasOwnProperty(key)) {
-      obj[key] = object[key];
+  return keys.reduce((result, key) => {
+    if (object && object.hasOwnProperty.call(object, key)) {
+      result[key] = object[key];
     }
-    return obj;
+    return result;
   }, {});
 }
 
+function getAssetId(asset) {
+  return asset['repo:assetId'] || asset['repo:id'] || asset.id;
+}
+
 export function getMetadata(asset, renditions) {
-  const { _embedded, _links, ...copy } = asset.computedMetadata;
-  const metadata = { ...copy, renditions };
-  return metadata;
+  const computed = asset?.computedMetadata || {};
+  const { embedded, links, ...copy } = computed;
+  return { ...copy, renditions };
 }
 
 export function getRenditions(asset) {
-  const renditions = asset?.computedMetadata?._links[ASSET_RENDITIONS_KEY]?.map((r) => {
-    return {
-      href: r.href,
-      height: r.height,
-      width: r.width,
-      type: r.type,
-    };
-  });
-  return renditions.sort((a, b) => a.width - b.width);
+  const links = asset?.computedMetadata?._links?.[ASSET_RENDITIONS_KEY] ?? [];
+  return links
+    .filter((r) => typeof r?.href === 'string' && r.href.length > 0)
+    .map((r) => ({ href: r.href, height: r.height, width: r.width, type: r.type }))
+    .sort((a, b) => Number(a.width) - Number(b.width));
+}
+
+export function getThumbUrl(asset, config) {
+  const assetRootUrl = config.assetsUrlRoot || null;
+  const assetId = getAssetId(asset);
+  const assetName = asset['repo:name'] || asset.name || '';
+
+  let thumbUrl = '';
+  if (assetRootUrl) {
+    const slash = assetRootUrl.endsWith('/') ? '' : '/';
+    thumbUrl = `${assetRootUrl}${slash}${assetId}/as/${assetName}`;
+  } else {
+    const renditions = getRenditions(asset);
+    if (Array.isArray(renditions) && renditions.length > 0) {
+      thumbUrl = getSafeRenditionUrl(asset, renditions);
+    } else {
+      thumbUrl = `${ADOBE_EXPERIENCE_URL}${assetId}`;
+    }
+  }
+  return thumbUrl;
+}
+
+export function getSafeRenditionUrl(asset, renditions) {
+  const usable = renditions.filter((r) => Number.isFinite(Number(r.width)));
+  const preferred = usable.find((r) => r.width >= 150 && r.width <= 400);
+  const nearest = usable[0];
+  return preferred?.href ?? nearest?.href ?? asset?.url ?? '';
 }
 
 export function transformAssets(assets, config) {
-  const transformedAssets = assets.map((asset) => {
-    const assetId = asset['repo:assetId'] || asset['repo:id'] || asset.id;
-    const renditions = getRenditions(asset);
-    const urlRoot = config.assetsUrlRoot;
-
-    const thumbUrl = urlRoot
-      ? `${urlRoot}${!urlRoot.endsWith('/') ? '/' : ''}${assetId}`
-      : renditions.find((r) => r.width >= 150 && r.width <= 400).href;
-
-    const transformedAsset = {
-      id: assetId,
-      name: asset['repo:name'] || asset.name || '',
-      url: thumbUrl,
-      metadata: getMetadata(asset, renditions),
-      // path: asset['repo:path'] || asset.path || '',
-      // size: asset['repo:size'] || 0,
-      // mimetype: asset['dc:format'] || asset.mimetype || '',
-      // width: asset['tiff:imageWidth'] || asset.width || 0,
-      // height: asset['tiff:imageLeength'] || asset.height || 0,
-      // state: asset['repo:state'] || '',
-      // isExpired: asset.isExpired || false,
-      // renditions: renditions,
-    };
-
-    return transformedAsset;
-  });
-
-  return transformedAssets;
+  const source = Array.isArray(assets) ? assets : [];
+  return source
+    .filter((asset) => asset?.id)
+    .map((asset) => {
+      const renditions = getRenditions(asset);
+      return {
+        id: asset['repo:assetId'] || asset['repo:id'] || asset.id,
+        name: asset['repo:name'] || asset.name || '',
+        url: getThumbUrl(asset, config),
+        metadata: getMetadata(asset, renditions),
+      };
+    });
 }

--- a/apps/aem-assets/src/utils.js
+++ b/apps/aem-assets/src/utils.js
@@ -19,7 +19,7 @@ function getAssetId(asset) {
 
 export function getMetadata(asset, renditions) {
   const computed = asset?.computedMetadata || {};
-  const { embedded, links, ...copy } = computed;
+  const { _embedded, _links, ...copy } = computed;
   return { ...copy, renditions };
 }
 


### PR DESCRIPTION
## Purpose

This PR includes the following fixes:
`index.jsx`
 - adds comments to `selectedAssets` and `hideTreeNav` variables from exploded `config` in `renderDialog()` to denote their origination from instance parameters.
 - changes `hideAuthError()` to `hideAlert()` and updates all uses as non-error messages use this method.
 - changes `showAuthError()` to `showAlert()` and updates all uses as non-error messages use this method.
 - updates `customUpdateStateValue()` to prevent duplicates in result per Adobe recommendations.
 - updates `handleSelection()` to support error handling per Adobe recommendations.
 - updates `makeThumbnail()` to use `getRenditions()` and `getSafeRenditionUrl()` from `utils.js` for consistency.
 - updates `openDialog()` for improved stability per Adobe recommendations.
 - updates multiple installation parameters in `setup()` to include `required: false` and reordered List options so the default value is the first option.
 - removes `alwaysUseDMDelivery` parameter from `contentAdvisorProps` as it is not listed in the Content Advisor properties table in the online documentation and was originally added as a workaround based on feedback from RL. The `assetsUrlRoot` installation parameter solves for the issue this was originally added for. 
 - removes `expiryOptions` and `showToast` from `contentAdvisorProps` per Adobe recommendations.

`utils.js`
 - adds `getAssetId()` helper method to reduce logic duplication.
 - adds `getSafeRendition()` to retrieve the closest available rendition when no rendition matches the preferred size per Adobe PS recommendations.
 - adds `/as/<asset-name>` onto the `thumbUrl` in `getThumbUrl()` when the `assetsUrlRoot` installation parameter is provided.
 - updates `getMetadata()` for improved performance and stability per Adobe recommendations.
 - updates `getRenditions()` for improved performance and stability per Adobe recommendations.
 - updates `getThumbUrl()` to use `getSafeRendition()` when no `assetsUrlRoot` is provided.
 - updates `getThumbUrl()` to use `https://experience.adobe.com` as the thumbnail URL root when `assetsUrlRoot` is not provided and `asset.renditions` is not an array.
 - updates `pick()` for improved stability per Adobe recommendations.
 - updates `transformAssets()` for improved stability per Adobe recommendations.

## Approach

The fixes were applied based on customer requirements and recommendations from Adobe based on code review.

## Testing steps

Test 1
 - Navigate to the Adobe AEM Assets connector configuration, enter a value for the **Assets URL Root** parameter and save the configuration. 
 - Navigate to a content entry containing an Adobe Assets field and click the `Select assets from AEM` button.
 - In the Adobe Content Advisor modal, select an image and then click the `Select` button in the top right corner.
 - Inspect the thumbnail image displayed in the Contentful UI and confirm that the source matches the pattern `{{assetsUrlRoot}}/{{assetId}}/as/{{assetName}}`.

Test 2
 - Navigate to the Adobe AEM Assets connector configuration, remove the value for the **Assets URL Root** parameter and save the configuration.
- Navigate to a content entry containing an Adobe Assets field and click the `Select assets from AEM` button.
 - In the Adobe Content Advisor modal, select an image and then click the `Select` button in the top right corner.
 - Inspect the thumbnail image displayed in the Contentful UI and confirm that the source doe not match the pattern `{{assetsUrlRoot}}/{{assetId}}/as/{{assetName}}`.

## Breaking Changes

none

## Dependencies and/or References

none

## Deployment

none
