### PR TITLE
fix(bulk-exporter): retry with smaller page size on CMA response-size errors [ES-630]

### DIFF
--- a/apps/bulk-exporter/src/lib/__tests__/exporter.test.ts
+++ b/apps/bulk-exporter/src/lib/__tests__/exporter.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Exporter, type ExportProgress } from '../exporter';
+
+describe('Exporter', () => {
+  it('surfaces the real CMA error message even when the error is not an Error instance', async () => {
+    // Matches ES-630: the app-sdk's postMessage bridge relays the raw CMA
+    // error object (not an `Error`), so `error instanceof Error` misses it.
+    const cmaError = {
+      sys: { type: 'Error', id: 'BadRequest' },
+      message: 'Response size too big. Maximum allowed response size: 7340032B.',
+      requestId: '9a90d083-9da4-46c0-adcf-cad04aea653a',
+    };
+
+    const mockCma = {
+      entry: {
+        getMany: vi.fn().mockRejectedValue(cmaError),
+      },
+    };
+
+    const exporter = new Exporter(mockCma as any);
+    const progressUpdates: ExportProgress[] = [];
+
+    await expect(
+      exporter.start({ contentType: null, contentTypeId: 'statement', locales: ['en-US'] }, (p) =>
+        progressUpdates.push(p)
+      )
+    ).rejects.toBe(cmaError);
+
+    const errorUpdate = progressUpdates.find((p) => p.status === 'error');
+    expect(errorUpdate?.message).toBe(
+      'Export failed: Response size too big. Maximum allowed response size: 7340032B.'
+    );
+  });
+
+  it('falls back to "Unknown error" when the thrown value has no message', async () => {
+    const mockCma = {
+      entry: {
+        getMany: vi.fn().mockRejectedValue('not an object'),
+      },
+    };
+
+    const exporter = new Exporter(mockCma as any);
+    const progressUpdates: ExportProgress[] = [];
+
+    await expect(
+      exporter.start({ contentType: null, contentTypeId: 'statement', locales: ['en-US'] }, (p) =>
+        progressUpdates.push(p)
+      )
+    ).rejects.toBe('not an object');
+
+    const errorUpdate = progressUpdates.find((p) => p.status === 'error');
+    expect(errorUpdate?.message).toBe('Export failed: Unknown error');
+  });
+});

--- a/apps/bulk-exporter/src/lib/__tests__/paginate.test.ts
+++ b/apps/bulk-exporter/src/lib/__tests__/paginate.test.ts
@@ -113,6 +113,122 @@ describe('paginate', () => {
     });
   });
 
+  describe('paginateEntries response-size handling', () => {
+    // Captured verbatim from the CMA response in ES-630: the app-sdk's
+    // postMessage bridge relays the raw API error object, not an Error
+    // instance, so this is the exact shape the retry logic must recognize.
+    const responseTooBigError = {
+      sys: { type: 'Error', id: 'BadRequest' },
+      message: 'Response size too big. Maximum allowed response size: 7340032B.',
+      requestId: '9a90d083-9da4-46c0-adcf-cad04aea653a',
+    };
+
+    it('halves the page size and retries when the CMA rejects a page as too big', async () => {
+      const getMany = vi
+        .fn()
+        .mockRejectedValueOnce(responseTooBigError)
+        .mockRejectedValueOnce(responseTooBigError)
+        .mockResolvedValueOnce({
+          items: Array(250).fill({ sys: { id: 'small' } }),
+          total: 250,
+        });
+
+      const mockCma = { entry: { getMany } };
+      const throttledFetch = vi.fn((fn) => fn());
+
+      const batches = [];
+      for await (const batch of paginateEntries(
+        mockCma as any,
+        { contentType: 'statement' },
+        throttledFetch
+      )) {
+        batches.push(batch);
+      }
+
+      expect(batches).toHaveLength(1);
+      expect(batches[0]).toHaveLength(250);
+      expect(getMany).toHaveBeenCalledTimes(3);
+      expect(getMany.mock.calls[0][0].query.limit).toBe(1000);
+      expect(getMany.mock.calls[1][0].query.limit).toBe(500);
+      expect(getMany.mock.calls[2][0].query.limit).toBe(250);
+    });
+
+    it('carries the reduced page size forward into subsequent pages', async () => {
+      const getMany = vi
+        .fn()
+        .mockRejectedValueOnce(responseTooBigError)
+        .mockResolvedValueOnce({
+          items: Array(500).fill({ sys: { id: 'page1' } }),
+          total: 700,
+        })
+        .mockResolvedValueOnce({
+          items: Array(200).fill({ sys: { id: 'page2' } }),
+          total: 700,
+        });
+
+      const mockCma = { entry: { getMany } };
+      const throttledFetch = vi.fn((fn) => fn());
+
+      const batches = [];
+      for await (const batch of paginateEntries(
+        mockCma as any,
+        { contentType: 'statement' },
+        throttledFetch
+      )) {
+        batches.push(batch);
+      }
+
+      expect(batches).toHaveLength(2);
+      expect(getMany.mock.calls[1][0].query.limit).toBe(500);
+      // Second page starts at the previously-successful 500 rather than
+      // re-discovering it by failing at 1000 again.
+      expect(getMany.mock.calls[2][0].query.limit).toBe(500);
+      expect(getMany.mock.calls[2][0].query.skip).toBe(500);
+    });
+
+    it('stops retrying and rethrows once the page size hits the floor', async () => {
+      const getMany = vi.fn().mockRejectedValue(responseTooBigError);
+      const mockCma = { entry: { getMany } };
+      const throttledFetch = vi.fn((fn) => fn());
+
+      const run = async () => {
+        for await (const _batch of paginateEntries(
+          mockCma as any,
+          { contentType: 'statement' },
+          throttledFetch
+        )) {
+          // drain
+        }
+      };
+
+      await expect(run()).rejects.toBe(responseTooBigError);
+
+      const limitsTried = getMany.mock.calls.map((call) => call[0].query.limit);
+      expect(limitsTried[limitsTried.length - 1]).toBe(25);
+      expect(Math.min(...limitsTried)).toBe(25);
+    });
+
+    it('rethrows unrelated errors without retrying', async () => {
+      const otherError = { sys: { type: 'Error', id: 'AccessDenied' }, message: 'Nope' };
+      const getMany = vi.fn().mockRejectedValue(otherError);
+      const mockCma = { entry: { getMany } };
+      const throttledFetch = vi.fn((fn) => fn());
+
+      const run = async () => {
+        for await (const _batch of paginateEntries(
+          mockCma as any,
+          { contentType: 'statement' },
+          throttledFetch
+        )) {
+          // drain
+        }
+      };
+
+      await expect(run()).rejects.toBe(otherError);
+      expect(getMany).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('getEntryCount', () => {
     it('should return total count', async () => {
       const mockCma = {

--- a/apps/bulk-exporter/src/lib/exporter.ts
+++ b/apps/bulk-exporter/src/lib/exporter.ts
@@ -4,6 +4,26 @@ import { paginateEntries, getEntryCount } from './paginate';
 import { flattenEntries, flattenEntry, type ContentType, type Entry } from './flatten';
 import { exportData, getFileExtension, type ExportFormat } from './exportFormats';
 
+/**
+ * CMA errors relayed through the app-sdk's postMessage bridge often come
+ * through as the raw API error object rather than an `Error` instance, so
+ * `error instanceof Error` misses them and the user sees a generic message.
+ */
+function extractErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (typeof error === 'object' && error !== null && 'message' in error) {
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === 'string' && message.length > 0) {
+      return message;
+    }
+  }
+
+  return 'Unknown error';
+}
+
 export interface ExportOptions {
   contentType: ContentType | null;
   contentTypeId: string;
@@ -241,7 +261,7 @@ export class Exporter {
         message: `Successfully exported ${fetched} entries as ${formatName}`,
       });
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'Unknown error';
+      const message = extractErrorMessage(error);
       onProgress({
         fetched: 0,
         total: 0,

--- a/apps/bulk-exporter/src/lib/paginate.ts
+++ b/apps/bulk-exporter/src/lib/paginate.ts
@@ -13,7 +13,59 @@ export interface PaginateResult {
 }
 
 const PAGE_SIZE = 1000;
+const MIN_PAGE_SIZE = 25;
 const MAX_SKIP = 9000;
+
+/**
+ * The CMA caps individual responses at ~7MB. Content types with large field
+ * values can blow past that at our default page size, so this matches the
+ * error the API returns (`sys.id: 'BadRequest'`, message mentions response
+ * size) regardless of whether the SDK/transport wraps it in an Error or
+ * passes the raw API error object through.
+ */
+function isResponseTooBigError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) {
+    return false;
+  }
+
+  const err = error as { message?: unknown; sys?: { id?: unknown }; status?: unknown };
+  const message = typeof err.message === 'string' ? err.message : '';
+
+  if (!/response size too big/i.test(message)) {
+    return false;
+  }
+
+  return err.sys?.id === 'BadRequest' || err.status === 400;
+}
+
+/**
+ * Fetches a page, halving `limit` and retrying if the CMA rejects it as too
+ * large. Returns the limit that actually worked so the caller can carry it
+ * forward as the starting point for the next page instead of re-discovering
+ * it on every request.
+ */
+async function fetchPageWithAdaptiveLimit(
+  cma: CMAClient,
+  queryParams: Record<string, unknown>,
+  startingLimit: number,
+  throttledFetch: <T>(fn: () => Promise<T>) => Promise<T>
+): Promise<{ result: PaginateResult; limitUsed: number }> {
+  let limit = startingLimit;
+
+  while (true) {
+    try {
+      const result = (await throttledFetch(() =>
+        cma.entry.getMany({ query: { ...queryParams, limit } })
+      )) as PaginateResult;
+      return { result, limitUsed: limit };
+    } catch (error) {
+      if (!isResponseTooBigError(error) || limit <= MIN_PAGE_SIZE) {
+        throw error;
+      }
+      limit = Math.max(MIN_PAGE_SIZE, Math.floor(limit / 2));
+    }
+  }
+}
 
 export async function* paginateEntries(
   cma: CMAClient,
@@ -24,10 +76,9 @@ export async function* paginateEntries(
 
   let skip = 0;
   let total = Infinity;
+  let limit = PAGE_SIZE;
 
   const queryParams: Record<string, unknown> = {
-    limit: PAGE_SIZE,
-    skip,
     order,
     ...filters,
   };
@@ -39,9 +90,13 @@ export async function* paginateEntries(
   while (skip < total && skip < MAX_SKIP) {
     queryParams.skip = skip;
 
-    const result = (await throttledFetch(() =>
-      cma.entry.getMany({ query: queryParams })
-    )) as PaginateResult;
+    const { result, limitUsed } = await fetchPageWithAdaptiveLimit(
+      cma,
+      queryParams,
+      limit,
+      throttledFetch
+    );
+    limit = limitUsed;
 
     if (result.items.length === 0) {
       break;
@@ -50,7 +105,7 @@ export async function* paginateEntries(
     total = result.total;
     yield result.items;
 
-    skip += PAGE_SIZE;
+    skip += result.items.length;
 
     if (skip >= total) {
       return;
@@ -58,7 +113,7 @@ export async function* paginateEntries(
   }
 
   if (skip >= MAX_SKIP && skip < total) {
-    yield* paginateByCursor(cma, options, throttledFetch, skip);
+    yield* paginateByCursor(cma, options, throttledFetch, skip, limit);
   }
 }
 
@@ -66,12 +121,13 @@ async function* paginateByCursor(
   cma: CMAClient,
   options: PaginateOptions,
   throttledFetch: <T>(fn: () => Promise<T>) => Promise<T>,
-  fetchedSoFar: number
+  fetchedSoFar: number,
+  startingLimit: number
 ): AsyncGenerator<unknown[], void, unknown> {
   const { contentType, filters = {}, order = 'sys.createdAt' } = options;
+  let limit = startingLimit;
 
   const queryParams: Record<string, unknown> = {
-    limit: PAGE_SIZE,
     skip: MAX_SKIP,
     order,
     ...filters,
@@ -81,9 +137,13 @@ async function* paginateByCursor(
     queryParams.content_type = contentType;
   }
 
-  const firstCursorResult = (await throttledFetch(() =>
-    cma.entry.getMany({ query: queryParams })
-  )) as PaginateResult;
+  const { result: firstCursorResult, limitUsed } = await fetchPageWithAdaptiveLimit(
+    cma,
+    queryParams,
+    limit,
+    throttledFetch
+  );
+  limit = limitUsed;
 
   if (firstCursorResult.items.length === 0) {
     return;
@@ -99,7 +159,6 @@ async function* paginateByCursor(
 
   while (fetched < total) {
     const cursorQueryParams: Record<string, unknown> = {
-      limit: PAGE_SIZE,
       order,
       'sys.createdAt[gt]': lastItem.sys.createdAt,
       ...filters,
@@ -109,9 +168,13 @@ async function* paginateByCursor(
       cursorQueryParams.content_type = contentType;
     }
 
-    const result = (await throttledFetch(() =>
-      cma.entry.getMany({ query: cursorQueryParams })
-    )) as PaginateResult;
+    const { result, limitUsed: nextLimitUsed } = await fetchPageWithAdaptiveLimit(
+      cma,
+      cursorQueryParams,
+      limit,
+      throttledFetch
+    );
+    limit = nextLimitUsed;
 
     if (result.items.length === 0) {
       break;


### PR DESCRIPTION
## Summary
- `paginateEntries` always requested pages of 1000 entries. For content types with large field values (e.g. the customer's "Statement" type in ES-630), a page of that size can exceed the CMA's ~7MB response cap, and the API rejects it with `400 BadRequest: Response size too big`. There was no fallback — the whole export just failed.
- Fixed by having `paginate.ts` detect that specific error and retry with a halved `limit` (down to a floor of 25), carrying the working size forward into subsequent pages instead of re-discovering it every time. Applied to both the skip-based and cursor-based pagination paths.
- Also fixed `exporter.ts` reporting `Export failed: Unknown error` for these (and any similar) failures: errors relayed through the app-sdk's postMessage bridge come through as the raw CMA error object, not an `Error` instance, so `error instanceof Error` was missing them and swallowing the real message.

## Root cause (ES-630)
Customer searched a "Statement" content type, got 447 results, and export failed with "Unknown error" in the UI. Support captured the actual response via network tab:
```json
{
  "sys": { "type": "Error", "id": "BadRequest" },
  "message": "Response size too big. Maximum allowed response size: 7340032B.",
  "requestId": "9a90d083-9da4-46c0-adcf-cad04aea653a"
}
```
A different search returning 2k+ smaller entries worked fine, confirming it's a response-size issue tied to entry size, not entry count.

## Test plan
- [x] Added unit tests in `paginate.test.ts` using the exact error object from the ticket, covering: halve-and-retry, carrying the reduced size forward, giving up at the floor, and not retrying unrelated errors
- [x] Added `exporter.test.ts` covering the "Unknown error" message-extraction bug directly
- [x] `npx vitest run` — all 95 tests pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint src` — clean
- [ ] Manual verification against a real space with large "Statement"-like entries (not done — no test space access from this session)

Jira: https://contentful.atlassian.net/browse/ES-630