### PR TITLE
fix(aem-assets): removes '/as/{{filename}}' from thumbURL to accommodate non-img assets []

### DIFF
--- a/apps/aem-assets/src/utils.js
+++ b/apps/aem-assets/src/utils.js
@@ -39,7 +39,7 @@ export function getThumbUrl(asset, config) {
   let thumbUrl = '';
   if (assetRootUrl) {
     const slash = assetRootUrl.endsWith('/') ? '' : '/';
-    thumbUrl = `${assetRootUrl}${slash}${assetId}/as/${assetName}`;
+    thumbUrl = `${assetRootUrl}${slash}${assetId}`;
   } else {
     const renditions = getRenditions(asset);
     if (Array.isArray(renditions) && renditions.length > 0) {


### PR DESCRIPTION
## Purpose

This update removes `/as/${assetName}` from the `thumbUrl` generated in the `getThumbUrl()` function. This was only useful for image assets and led to 404s for non-image assets.

## Approach

This was done based on conversations with RL and Adobe.

## Testing steps

- Navigate to an entry with an AEM Assets field.
- Click the **Select assets from AEM** button to open the Adobe Content Advisor modal.
- Select a non-image asset from the grid and click the **Select** button.
- Verify the thumbnail displayed in AEM Content Advisor appears in the Contentful UI.

## Breaking Changes

None

## Dependencies and/or References

None

## Deployment

None
