### PR TITLE
fix(bulk-exporter): detect CMA response-size errors [ES-630]

### DIFF
--- a/apps/bulk-exporter/src/lib/__tests__/cmaError.test.ts
+++ b/apps/bulk-exporter/src/lib/__tests__/cmaError.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { isResponseTooBigError, extractErrorMessage } from '../cmaError';
+
+const API_MESSAGE = 'Response size too big. Maximum allowed response size: 7340032B.';
+
+/** The raw API error body, as returned by the CMA. */
+const rawApiError = {
+  sys: { type: 'Error', id: 'BadRequest' },
+  message: API_MESSAGE,
+  requestId: '9a90d083-9da4-46c0-adcf-cad04aea653a',
+};
+
+/** What contentful-sdk-core throws: the code in `name`, a JSON blob in `message`. */
+const sdkCoreError = Object.assign(
+  new Error(
+    JSON.stringify(
+      {
+        status: 400,
+        statusText: 'Bad Request',
+        message: API_MESSAGE,
+        request: { url: '/entries', headers: { Authorization: 'Bearer ...ecret' } },
+        requestId: '9a90d083-9da4-46c0-adcf-cad04aea653a',
+      },
+      null,
+      '  '
+    )
+  ),
+  { name: 'BadRequest' }
+);
+
+/**
+ * What an app actually catches: the web app relays the rejection into the
+ * iframe over postMessage, which strips the prototype and every
+ * non-enumerable field, leaving `{ code, message, data }`.
+ */
+const bridgedError = {
+  code: 'BadRequest',
+  message: sdkCoreError.message,
+  data: undefined,
+};
+
+describe('isResponseTooBigError', () => {
+  it('detects the response-size error in every shape it can arrive as', () => {
+    expect(isResponseTooBigError(rawApiError)).toBe(true);
+    expect(isResponseTooBigError(sdkCoreError)).toBe(true);
+    expect(isResponseTooBigError(bridgedError)).toBe(true);
+  });
+
+  it('ignores unrelated failures', () => {
+    expect(isResponseTooBigError({ sys: { id: 'AccessDenied' }, message: 'Nope' })).toBe(false);
+    expect(isResponseTooBigError(new Error('Rate limit exceeded'))).toBe(false);
+    expect(isResponseTooBigError({ code: 'BadRequest', message: 'Unknown field' })).toBe(false);
+    expect(isResponseTooBigError('not an object')).toBe(false);
+    expect(isResponseTooBigError(null)).toBe(false);
+    expect(isResponseTooBigError(undefined)).toBe(false);
+  });
+});
+
+describe('extractErrorMessage', () => {
+  it("returns the API's own message rather than the JSON blob wrapping it", () => {
+    expect(extractErrorMessage(rawApiError)).toBe(API_MESSAGE);
+    expect(extractErrorMessage(sdkCoreError)).toBe(API_MESSAGE);
+    expect(extractErrorMessage(bridgedError)).toBe(API_MESSAGE);
+  });
+
+  it('keeps the obscured auth header out of the message', () => {
+    expect(extractErrorMessage(bridgedError)).not.toContain('Authorization');
+  });
+
+  it('passes through a plain message unchanged', () => {
+    expect(extractErrorMessage(new Error('Boom'))).toBe('Boom');
+  });
+
+  it('falls back to "Unknown error" when there is no usable message', () => {
+    expect(extractErrorMessage('not an object')).toBe('Unknown error');
+    expect(extractErrorMessage(null)).toBe('Unknown error');
+    expect(extractErrorMessage({})).toBe('Unknown error');
+    expect(extractErrorMessage({ message: '{ truncated json' })).toBe('{ truncated json');
+  });
+});

--- a/apps/bulk-exporter/src/lib/__tests__/exporter.test.ts
+++ b/apps/bulk-exporter/src/lib/__tests__/exporter.test.ts
@@ -3,8 +3,6 @@ import { Exporter, type ExportProgress } from '../exporter';
 
 describe('Exporter', () => {
   it('surfaces the real CMA error message even when the error is not an Error instance', async () => {
-    // Matches ES-630: the app-sdk's postMessage bridge relays the raw CMA
-    // error object (not an `Error`), so `error instanceof Error` misses it.
     const cmaError = {
       sys: { type: 'Error', id: 'BadRequest' },
       message: 'Response size too big. Maximum allowed response size: 7340032B.',
@@ -30,6 +28,41 @@ describe('Exporter', () => {
     expect(errorUpdate?.message).toBe(
       'Export failed: Response size too big. Maximum allowed response size: 7340032B.'
     );
+  });
+
+  it('unwraps the message from the JSON blob the App Framework bridge delivers', async () => {
+    // The web app relays a rejection into the app's iframe over postMessage,
+    // leaving a plain object whose `message` is contentful-sdk-core's JSON
+    // blob. Reporting that blob verbatim would also put the (obscured) auth
+    // header in front of the user.
+    const bridgedError = {
+      code: 'BadRequest',
+      message: JSON.stringify({
+        status: 400,
+        statusText: 'Bad Request',
+        message: 'Response size too big. Maximum allowed response size: 7340032B.',
+        request: {
+          url: '/spaces/60i3uyhfow4o/environments/master/entries',
+          headers: { Authorization: 'Bearer ...ecret' },
+        },
+      }),
+    };
+
+    const mockCma = { entry: { getMany: vi.fn().mockRejectedValue(bridgedError) } };
+    const exporter = new Exporter(mockCma as any);
+    const progressUpdates: ExportProgress[] = [];
+
+    await expect(
+      exporter.start({ contentType: null, contentTypeId: 'statement', locales: ['en-US'] }, (p) =>
+        progressUpdates.push(p)
+      )
+    ).rejects.toBe(bridgedError);
+
+    const errorUpdate = progressUpdates.find((p) => p.status === 'error');
+    expect(errorUpdate?.message).toBe(
+      'Export failed: Response size too big. Maximum allowed response size: 7340032B.'
+    );
+    expect(errorUpdate?.message).not.toContain('Authorization');
   });
 
   it('falls back to "Unknown error" when the thrown value has no message', async () => {

--- a/apps/bulk-exporter/src/lib/__tests__/paginate.test.ts
+++ b/apps/bulk-exporter/src/lib/__tests__/paginate.test.ts
@@ -114,13 +114,25 @@ describe('paginate', () => {
   });
 
   describe('paginateEntries response-size handling', () => {
-    // Captured verbatim from the CMA response in ES-630: the app-sdk's
-    // postMessage bridge relays the raw API error object, not an Error
-    // instance, so this is the exact shape the retry logic must recognize.
+    // What the app actually catches in production. The web app relays the
+    // rejection into the app's iframe over postMessage, which reduces the
+    // error to `{ code, message, data }` -- no prototype, no `sys`, no
+    // `status` -- and puts contentful-sdk-core's JSON blob in `message`.
     const responseTooBigError = {
-      sys: { type: 'Error', id: 'BadRequest' },
-      message: 'Response size too big. Maximum allowed response size: 7340032B.',
-      requestId: '9a90d083-9da4-46c0-adcf-cad04aea653a',
+      code: 'BadRequest',
+      message: JSON.stringify(
+        {
+          status: 400,
+          statusText: 'Bad Request',
+          message: 'Response size too big. Maximum allowed response size: 7340032B.',
+          details: {},
+          request: { url: '/spaces/60i3uyhfow4o/environments/master/entries', method: 'get' },
+          requestId: '9a90d083-9da4-46c0-adcf-cad04aea653a',
+        },
+        null,
+        '  '
+      ),
+      data: undefined,
     };
 
     it('halves the page size and retries when the CMA rejects a page as too big', async () => {
@@ -186,7 +198,7 @@ describe('paginate', () => {
       expect(getMany.mock.calls[2][0].query.skip).toBe(500);
     });
 
-    it('stops retrying and rethrows once the page size hits the floor', async () => {
+    it('halves down to a single entry before giving up', async () => {
       const getMany = vi.fn().mockRejectedValue(responseTooBigError);
       const mockCma = { entry: { getMany } };
       const throttledFetch = vi.fn((fn) => fn());
@@ -204,8 +216,55 @@ describe('paginate', () => {
       await expect(run()).rejects.toBe(responseTooBigError);
 
       const limitsTried = getMany.mock.calls.map((call) => call[0].query.limit);
-      expect(limitsTried[limitsTried.length - 1]).toBe(25);
-      expect(Math.min(...limitsTried)).toBe(25);
+      expect(limitsTried).toEqual([1000, 500, 250, 125, 62, 31, 15, 7, 3, 1]);
+    });
+
+    it('recovers when only a very small page fits under the response cap', async () => {
+      const getMany = vi
+        .fn()
+        .mockImplementation(({ query }) =>
+          query.limit > 25
+            ? Promise.reject(responseTooBigError)
+            : Promise.resolve({ items: Array(query.limit).fill({ sys: { id: 'big' } }), total: 15 })
+        );
+      const mockCma = { entry: { getMany } };
+      const throttledFetch = vi.fn((fn) => fn());
+
+      const batches = [];
+      for await (const batch of paginateEntries(
+        mockCma as any,
+        { contentType: 'statement' },
+        throttledFetch
+      )) {
+        batches.push(batch);
+      }
+
+      expect(batches.flat()).toHaveLength(15);
+    });
+
+    it('retries the raw API error body shape', async () => {
+      const rawApiError = {
+        sys: { type: 'Error', id: 'BadRequest' },
+        message: 'Response size too big. Maximum allowed response size: 7340032B.',
+        requestId: '9a90d083-9da4-46c0-adcf-cad04aea653a',
+      };
+      const getMany = vi
+        .fn()
+        .mockRejectedValueOnce(rawApiError)
+        .mockResolvedValueOnce({ items: [{ sys: { id: 'ok' } }], total: 1 });
+      const mockCma = { entry: { getMany } };
+
+      const batches = [];
+      for await (const batch of paginateEntries(
+        mockCma as any,
+        { contentType: 'statement' },
+        vi.fn((fn) => fn())
+      )) {
+        batches.push(batch);
+      }
+
+      expect(batches.flat()).toHaveLength(1);
+      expect(getMany.mock.calls[1][0].query.limit).toBe(500);
     });
 
     it('rethrows unrelated errors without retrying', async () => {

--- a/apps/bulk-exporter/src/lib/cmaError.ts
+++ b/apps/bulk-exporter/src/lib/cmaError.ts
@@ -1,0 +1,64 @@
+/**
+ * `contentful-sdk-core`'s error handler puts a pretty-printed JSON blob in
+ * `Error.message` rather than the API's own message, so the useful text is one
+ * level down.
+ */
+function parseNestedErrorBody(message: string): { message?: unknown } | null {
+  if (!message.startsWith('{')) {
+    return null;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(message);
+    return typeof parsed === 'object' && parsed !== null ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * A CMA failure reaches an app in one of three shapes:
+ *
+ * 1. the raw API error body, carrying `sys.id` and a plain `message`;
+ * 2. an `Error` from `contentful-sdk-core`, with the code in `name` and a JSON
+ *    blob in `message`;
+ * 3. a plain `{ code, message, data }` object, which is what the App Framework
+ *    delivers -- the web app relays the rejection into the app's iframe over
+ *    `postMessage`, and that crossing drops the prototype along with any
+ *    non-enumerable field, so `instanceof Error`, `sys` and `status` are all
+ *    gone by the time an app sees it.
+ *
+ * Only the message survives all three, so it is the one field worth reading.
+ */
+function extractCmaErrorMessage(error: unknown): string {
+  if (typeof error !== 'object' || error === null) {
+    return '';
+  }
+
+  const rawMessage = (error as { message?: unknown }).message;
+  if (typeof rawMessage !== 'string') {
+    return '';
+  }
+
+  const nested = parseNestedErrorBody(rawMessage);
+  return typeof nested?.message === 'string' && nested.message.length > 0
+    ? nested.message
+    : rawMessage;
+}
+
+/**
+ * The CMA caps a single response at ~7MB. Content types with large field values
+ * can exceed that well below our default page size, and the only way back is to
+ * ask for fewer entries per request.
+ */
+export function isResponseTooBigError(error: unknown): boolean {
+  return /response size too big/i.test(extractCmaErrorMessage(error));
+}
+
+/**
+ * Prefers the API's own message over the JSON blob wrapping it, which also
+ * keeps the obscured auth header in that blob out of the UI.
+ */
+export function extractErrorMessage(error: unknown): string {
+  return extractCmaErrorMessage(error) || 'Unknown error';
+}

--- a/apps/bulk-exporter/src/lib/exporter.ts
+++ b/apps/bulk-exporter/src/lib/exporter.ts
@@ -3,26 +3,7 @@ import { createThrottler } from './throttle';
 import { paginateEntries, getEntryCount } from './paginate';
 import { flattenEntries, flattenEntry, type ContentType, type Entry } from './flatten';
 import { exportData, getFileExtension, type ExportFormat } from './exportFormats';
-
-/**
- * CMA errors relayed through the app-sdk's postMessage bridge often come
- * through as the raw API error object rather than an `Error` instance, so
- * `error instanceof Error` misses them and the user sees a generic message.
- */
-function extractErrorMessage(error: unknown): string {
-  if (error instanceof Error) {
-    return error.message;
-  }
-
-  if (typeof error === 'object' && error !== null && 'message' in error) {
-    const message = (error as { message?: unknown }).message;
-    if (typeof message === 'string' && message.length > 0) {
-      return message;
-    }
-  }
-
-  return 'Unknown error';
-}
+import { extractErrorMessage } from './cmaError';
 
 export interface ExportOptions {
   contentType: ContentType | null;

--- a/apps/bulk-exporter/src/lib/paginate.ts
+++ b/apps/bulk-exporter/src/lib/paginate.ts
@@ -1,4 +1,5 @@
 import type { CMAClient } from '@contentful/app-sdk';
+import { isResponseTooBigError } from './cmaError';
 
 export interface PaginateOptions {
   contentType?: string;
@@ -13,36 +14,18 @@ export interface PaginateResult {
 }
 
 const PAGE_SIZE = 1000;
-const MIN_PAGE_SIZE = 25;
+const MIN_PAGE_SIZE = 1;
 const MAX_SKIP = 9000;
-
-/**
- * The CMA caps individual responses at ~7MB. Content types with large field
- * values can blow past that at our default page size, so this matches the
- * error the API returns (`sys.id: 'BadRequest'`, message mentions response
- * size) regardless of whether the SDK/transport wraps it in an Error or
- * passes the raw API error object through.
- */
-function isResponseTooBigError(error: unknown): boolean {
-  if (typeof error !== 'object' || error === null) {
-    return false;
-  }
-
-  const err = error as { message?: unknown; sys?: { id?: unknown }; status?: unknown };
-  const message = typeof err.message === 'string' ? err.message : '';
-
-  if (!/response size too big/i.test(message)) {
-    return false;
-  }
-
-  return err.sys?.id === 'BadRequest' || err.status === 400;
-}
 
 /**
  * Fetches a page, halving `limit` and retrying if the CMA rejects it as too
  * large. Returns the limit that actually worked so the caller can carry it
- * forward as the starting point for the next page instead of re-discovering
- * it on every request.
+ * forward as the starting point for the next page instead of re-discovering it
+ * on every request.
+ *
+ * Halves all the way to a single entry: any floor above 1 turns an export of
+ * sufficiently large entries into an unrecoverable failure, and only a
+ * single-entry page that is still too big is genuinely beyond our reach.
  */
 async function fetchPageWithAdaptiveLimit(
   cma: CMAClient,


### PR DESCRIPTION
## Purpose

The retry-on-response-too-big logic added in #11283 checked `err.sys?.id` and `err.status`, but the App Framework's postMessage bridge into the app iframe strips both fields, so the check could never match in production and large exports failed outright instead of retrying with a smaller page size.

## Approach

- Moved detection into a new `cmaError.ts`, matching on the error message alone since that is the only field that survives every transport shape (raw API error, `contentful-sdk-core` wrapper, and the bridged `{ code, message, data }` object).
- Lowered the adaptive page-size floor from 25 to 1, since any floor above 1 can still exceed the response cap for sufficiently large entries and turn the export into an unrecoverable failure.
- Rewrote the paginate/exporter tests around the actual bridged error shape instead of the raw API shape, so a regression here fails a test again.

## Testing steps

Reproducing this requires entries large enough to trip the CMA's ~7 MB response-size cap, so use a test space, not a customer space.

1. On a test space, pad a batch of entries so a full page of them exceeds ~7 MB. I created a `huge-test-entries` environment in the `Content Exporter (development)` space to test this.
2. Run the app against `master` and export that content type. It should fail with a generic/unhandled error instead of retrying.
3. Run the app against this branch and export the same content type. It should succeed, transparently retrying with a smaller page size.
4. `npm test` in `apps/bulk-exporter` for the updated unit tests (`cmaError.test.ts`, `paginate.test.ts`, `exporter.test.ts`).

## Breaking Changes

None. This only changes internal error-detection logic and the adaptive page-size floor (25 -> 1); no public API, schema, or config changes.

## Dependencies and/or References

- Builds on the retry logic from PR #11283, whose detection check never matched in production

## Deployment

None. Ships as part of the normal app bundle deploy, no config or migration steps.

## Demo

Before these changes

https://github.com/user-attachments/assets/55d1b98d-5662-4da1-ac24-0b808d14061b

After these changes

https://github.com/user-attachments/assets/dc963045-9076-440a-8d44-cf72b6bdb28d


