### PR TITLE
fix: scope Klaviyo OAuth popup message to the app's own origin []

### DIFF
--- a/apps/klaviyo/src/index.tsx
+++ b/apps/klaviyo/src/index.tsx
@@ -28,7 +28,7 @@ const handleOAuthCallback = () => {
         code: params.get('code'),
         state: params.get('state'),
       },
-      '*'
+      window.location.origin
     );
     // Close the popup window
     window.close();


### PR DESCRIPTION
## Summary
The Klaviyo app's OAuth callback popup posts its completion message to the parent window using a wildcard target origin. This means the authorization code and state are broadcast to whatever window ends up as `window.opener`, rather than only to the app's own window.

## Solution
- Scope the `postMessage` call in the OAuth callback handler to `window.location.origin` instead of `'*'`.

## Context
This is the first of a small stack of hardening fixes to the Klaviyo app's OAuth flow and a couple of adjacent function-level issues found during a routine security review. Each fix is scoped narrowly and stacked so they can be reviewed and landed independently.

## Test plan
- [x] `tsc --noEmit` passes
- [x] Frontend build (`vite build`) succeeds
- [ ] Manual OAuth connect flow verified in a staging environment