### PR TITLE
fix: anchor Klaviyo proxy endpoint allowlist to the full path shape []

### DIFF
--- a/apps/klaviyo/functions/__tests__/proxyRequest.test.ts
+++ b/apps/klaviyo/functions/__tests__/proxyRequest.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handler } from '../proxyRequest';
+
+function buildEvent(body: Record<string, any>) {
+  return { body } as any;
+}
+
+function buildContext(token: { tokenType: string; accessToken: string } = {
+  tokenType: 'Bearer',
+  accessToken: 'test-access-token',
+}) {
+  return {
+    oauthSdk: {
+      token: vi.fn().mockResolvedValue(token),
+    },
+  } as any;
+}
+
+describe('proxyRequest endpoint allowlist', () => {
+  beforeEach(() => {
+    (global.fetch as any) = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ data: [] }),
+    });
+  });
+
+  it('allows an exact allowlisted endpoint', async () => {
+    const result = await handler(
+      buildEvent({
+        endpoint: 'template-universal-content',
+        method: 'GET',
+        data: { foo: 'bar' },
+        params: { page: 1 },
+      }),
+      buildContext()
+    );
+
+    expect(result).not.toEqual({ response: { error: 'Endpoint not allowed' } });
+    expect(global.fetch).toHaveBeenCalledOnce();
+  });
+
+  it('allows an allowlisted endpoint followed by a single id segment', async () => {
+    const result = await handler(
+      buildEvent({
+        endpoint: 'template-universal-content/abc123',
+        method: 'GET',
+        data: { foo: 'bar' },
+        params: { page: 1 },
+      }),
+      buildContext()
+    );
+
+    expect(result).not.toEqual({ response: { error: 'Endpoint not allowed' } });
+    expect(global.fetch).toHaveBeenCalledOnce();
+  });
+
+  it('rejects a path-traversal endpoint that resolves outside the allowlist', async () => {
+    const result = await handler(
+      buildEvent({
+        endpoint: 'template-universal-content/../lists',
+        method: 'GET',
+        data: { foo: 'bar' },
+        params: { page: 1 },
+      }),
+      buildContext()
+    );
+
+    expect(result).toEqual({ response: { error: 'Endpoint not allowed' } });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects an endpoint not on the allowlist at all', async () => {
+    const result = await handler(
+      buildEvent({
+        endpoint: 'lists',
+        method: 'GET',
+        data: { foo: 'bar' },
+        params: { page: 1 },
+      }),
+      buildContext()
+    );
+
+    expect(result).toEqual({ response: { error: 'Endpoint not allowed' } });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects an endpoint with a trailing traversal segment appended to a real id', async () => {
+    const result = await handler(
+      buildEvent({
+        endpoint: 'template-universal-content/abc123/../../lists',
+        method: 'GET',
+        data: { foo: 'bar' },
+        params: { page: 1 },
+      }),
+      buildContext()
+    );
+
+    expect(result).toEqual({ response: { error: 'Endpoint not allowed' } });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/klaviyo/functions/__tests__/proxyRequest.test.ts
+++ b/apps/klaviyo/functions/__tests__/proxyRequest.test.ts
@@ -5,10 +5,12 @@ function buildEvent(body: Record<string, any>) {
   return { body } as any;
 }
 
-function buildContext(token: { tokenType: string; accessToken: string } = {
-  tokenType: 'Bearer',
-  accessToken: 'test-access-token',
-}) {
+function buildContext(
+  token: { tokenType: string; accessToken: string } = {
+    tokenType: 'Bearer',
+    accessToken: 'test-access-token',
+  }
+) {
   return {
     oauthSdk: {
       token: vi.fn().mockResolvedValue(token),

--- a/apps/klaviyo/functions/proxyRequest.ts
+++ b/apps/klaviyo/functions/proxyRequest.ts
@@ -7,8 +7,7 @@ import type {
 
 const KLAVIYO_API_URL = 'https://a.klaviyo.com/api';
 const KLAVIYO_API_REVISION = '2025-04-15';
-const ALLOWED_ENDPOINTS = ['template-universal-content', 'images'];
-const ALLOWED_ENDPOINT_PATTERN = new RegExp(`^(${ALLOWED_ENDPOINTS.join('|')})(/[A-Za-z0-9_-]+)?$`);
+const ALLOWED_ENDPOINT_PATTERN = /^(template-universal-content|images)(\/[A-Za-z0-9_-]+)?$/;
 
 type AppActionParameters = {
   endpoint: string;

--- a/apps/klaviyo/functions/proxyRequest.ts
+++ b/apps/klaviyo/functions/proxyRequest.ts
@@ -8,6 +8,7 @@ import type {
 const KLAVIYO_API_URL = 'https://a.klaviyo.com/api';
 const KLAVIYO_API_REVISION = '2025-04-15';
 const ALLOWED_ENDPOINTS = ['template-universal-content', 'images'];
+const ALLOWED_ENDPOINT_PATTERN = new RegExp(`^(${ALLOWED_ENDPOINTS.join('|')})(/[A-Za-z0-9_-]+)?$`);
 
 type AppActionParameters = {
   endpoint: string;
@@ -58,8 +59,7 @@ export const handler: FunctionEventHandler<FunctionTypeEnum.AppActionCall> = asy
       console.error('Missing params');
       return { response: { error: 'Missing required params' } };
     }
-    const baseEndpoint = endpoint.split('/')[0];
-    if (!ALLOWED_ENDPOINTS.includes(baseEndpoint))
+    if (!ALLOWED_ENDPOINT_PATTERN.test(endpoint))
       return { response: { error: 'Endpoint not allowed' } };
     const formattedEndpoint = endpoint.endsWith('/') ? endpoint : `${endpoint}/`;
     let url = `${KLAVIYO_API_URL}/${formattedEndpoint}`;

--- a/apps/klaviyo/src/index.tsx
+++ b/apps/klaviyo/src/index.tsx
@@ -28,7 +28,7 @@ const handleOAuthCallback = () => {
         code: params.get('code'),
         state: params.get('state'),
       },
-      '*'
+      window.location.origin
     );
     // Close the popup window
     window.close();

--- a/apps/klaviyo/src/locations/ConfigScreen.tsx
+++ b/apps/klaviyo/src/locations/ConfigScreen.tsx
@@ -224,6 +224,9 @@ const ConfigScreen = () => {
   };
 
   const messageHandler = async (event: MessageEvent) => {
+    if (event.origin !== window.location.origin || event.source !== popupWindowRef.current) {
+      return;
+    }
     if (event.data.type === 'oauth:complete') {
       console.log('oauth:complete');
       const appDefinitionId = sdk.ids.app;

--- a/apps/klaviyo/vitest.config.ts
+++ b/apps/klaviyo/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: ['./test/setup.ts'],
-    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    include: ['src/**/*.{test,spec}.{ts,tsx}', 'functions/**/*.{test,spec}.{ts,tsx}'],
     coverage: {
       reporter: ['text', 'json', 'html'],
       exclude: ['**/node_modules/**', '**/dist/**', '**/coverage/**'],


### PR DESCRIPTION
## Summary
The Klaviyo proxy function's endpoint allowlist only checked the path segment before the first slash. A value like `template-universal-content/../lists` passed that check, and the traversal segment let the request reach a Klaviyo API endpoint that was never allowlisted.

## Solution
- Replace the prefix-only check with a pattern anchored to the exact shape the app actually sends: an allowed endpoint name, optionally followed by a single id segment. Anything else is rejected outright.

## Context
Third in a small stack of hardening fixes to the Klaviyo app found during a routine security review. Verified the new pattern still matches every endpoint value the frontend currently sends (bare endpoint names and `endpoint/{id}`), while rejecting traversal and encoded-traversal variants.

## Test plan
- [x] `tsc --noEmit` passes
- [x] Functions build (`build-functions`) succeeds
- [x] Verified the allowlist pattern against real call sites plus traversal payloads