### PR TITLE
fix: stop writing the Klaviyo bearer token to function logs []

### DIFF
--- a/apps/klaviyo/functions/__tests__/klaviyoService.test.ts
+++ b/apps/klaviyo/functions/__tests__/klaviyoService.test.ts
@@ -23,7 +23,9 @@ describe('KlaviyoService.makeRequest token handling', () => {
       text: vi.fn().mockResolvedValue('{"errors":[{"detail":"boom"}]}'),
     });
 
-    await expect((service as any).makeRequest('GET', 'template-universal-content')).rejects.toThrow();
+    await expect(
+      (service as any).makeRequest('GET', 'template-universal-content')
+    ).rejects.toThrow();
 
     const allLoggedArgs = consoleErrorSpy.mock.calls.flat();
     for (const arg of allLoggedArgs) {
@@ -63,7 +65,9 @@ describe('KlaviyoService.makeRequest token handling', () => {
       text: vi.fn().mockResolvedValue('service unavailable'),
     });
 
-    await expect((service as any).makeRequest('GET', 'template-universal-content')).rejects.toThrow();
+    await expect(
+      (service as any).makeRequest('GET', 'template-universal-content')
+    ).rejects.toThrow();
 
     const allLoggedArgs = consoleErrorSpy.mock.calls.flat().map((arg) => JSON.stringify(arg));
     expect(allLoggedArgs.some((arg) => arg.includes('503'))).toBe(true);

--- a/apps/klaviyo/functions/__tests__/klaviyoService.test.ts
+++ b/apps/klaviyo/functions/__tests__/klaviyoService.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { KlaviyoService } from '../klaviyoService';
+
+function buildOauthSdk(token: any) {
+  return { token: vi.fn().mockResolvedValue(token) } as any;
+}
+
+describe('KlaviyoService.makeRequest token handling', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('does not log the Authorization header when the Klaviyo API returns a non-OK response', async () => {
+    const secretToken = 'super-secret-access-token';
+    const oauthSdk = buildOauthSdk({ accessToken: secretToken });
+    const service = new KlaviyoService(oauthSdk);
+
+    (global.fetch as any) = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: vi.fn().mockResolvedValue('{"errors":[{"detail":"boom"}]}'),
+    });
+
+    await expect((service as any).makeRequest('GET', 'template-universal-content')).rejects.toThrow();
+
+    const allLoggedArgs = consoleErrorSpy.mock.calls.flat();
+    for (const arg of allLoggedArgs) {
+      const serialized = JSON.stringify(arg);
+      expect(serialized).not.toContain(secretToken);
+      expect(serialized).not.toContain('Authorization');
+    }
+  });
+
+  it('does not log the raw token value when the OAuth SDK returns an unrecognized token shape', async () => {
+    const secretToken = 'unexpected-shape-secret-value';
+    const oauthSdk = buildOauthSdk({ notAToken: secretToken });
+    const service = new KlaviyoService(oauthSdk);
+
+    (global.fetch as any) = vi.fn();
+
+    await expect((service as any).makeRequest('GET', 'template-universal-content')).rejects.toThrow(
+      'Invalid token format received from OAuth SDK'
+    );
+
+    expect(global.fetch).not.toHaveBeenCalled();
+
+    const allLoggedArgs = consoleErrorSpy.mock.calls.flat();
+    for (const arg of allLoggedArgs) {
+      const serialized = JSON.stringify(arg);
+      expect(serialized).not.toContain(secretToken);
+    }
+  });
+
+  it('still logs response status, body, and URL on a non-OK response (fix should not swallow debugging info)', async () => {
+    const oauthSdk = buildOauthSdk({ accessToken: 'token' });
+    const service = new KlaviyoService(oauthSdk);
+
+    (global.fetch as any) = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      text: vi.fn().mockResolvedValue('service unavailable'),
+    });
+
+    await expect((service as any).makeRequest('GET', 'template-universal-content')).rejects.toThrow();
+
+    const allLoggedArgs = consoleErrorSpy.mock.calls.flat().map((arg) => JSON.stringify(arg));
+    expect(allLoggedArgs.some((arg) => arg.includes('503'))).toBe(true);
+    expect(allLoggedArgs.some((arg) => arg.includes('service unavailable'))).toBe(true);
+  });
+});

--- a/apps/klaviyo/functions/__tests__/proxyRequest.test.ts
+++ b/apps/klaviyo/functions/__tests__/proxyRequest.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handler } from '../proxyRequest';
+
+function buildEvent(body: Record<string, any>) {
+  return { body } as any;
+}
+
+function buildContext(token: { tokenType: string; accessToken: string } = {
+  tokenType: 'Bearer',
+  accessToken: 'test-access-token',
+}) {
+  return {
+    oauthSdk: {
+      token: vi.fn().mockResolvedValue(token),
+    },
+  } as any;
+}
+
+describe('proxyRequest endpoint allowlist', () => {
+  beforeEach(() => {
+    (global.fetch as any) = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ data: [] }),
+    });
+  });
+
+  it('allows an exact allowlisted endpoint', async () => {
+    const result = await handler(
+      buildEvent({
+        endpoint: 'template-universal-content',
+        method: 'GET',
+        data: { foo: 'bar' },
+        params: { page: 1 },
+      }),
+      buildContext()
+    );
+
+    expect(result).not.toEqual({ response: { error: 'Endpoint not allowed' } });
+    expect(global.fetch).toHaveBeenCalledOnce();
+  });
+
+  it('allows an allowlisted endpoint followed by a single id segment', async () => {
+    const result = await handler(
+      buildEvent({
+        endpoint: 'template-universal-content/abc123',
+        method: 'GET',
+        data: { foo: 'bar' },
+        params: { page: 1 },
+      }),
+      buildContext()
+    );
+
+    expect(result).not.toEqual({ response: { error: 'Endpoint not allowed' } });
+    expect(global.fetch).toHaveBeenCalledOnce();
+  });
+
+  it('rejects a path-traversal endpoint that resolves outside the allowlist', async () => {
+    const result = await handler(
+      buildEvent({
+        endpoint: 'template-universal-content/../lists',
+        method: 'GET',
+        data: { foo: 'bar' },
+        params: { page: 1 },
+      }),
+      buildContext()
+    );
+
+    expect(result).toEqual({ response: { error: 'Endpoint not allowed' } });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects an endpoint not on the allowlist at all', async () => {
+    const result = await handler(
+      buildEvent({
+        endpoint: 'lists',
+        method: 'GET',
+        data: { foo: 'bar' },
+        params: { page: 1 },
+      }),
+      buildContext()
+    );
+
+    expect(result).toEqual({ response: { error: 'Endpoint not allowed' } });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects an endpoint with a trailing traversal segment appended to a real id', async () => {
+    const result = await handler(
+      buildEvent({
+        endpoint: 'template-universal-content/abc123/../../lists',
+        method: 'GET',
+        data: { foo: 'bar' },
+        params: { page: 1 },
+      }),
+      buildContext()
+    );
+
+    expect(result).toEqual({ response: { error: 'Endpoint not allowed' } });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/klaviyo/functions/__tests__/proxyRequest.test.ts
+++ b/apps/klaviyo/functions/__tests__/proxyRequest.test.ts
@@ -5,10 +5,12 @@ function buildEvent(body: Record<string, any>) {
   return { body } as any;
 }
 
-function buildContext(token: { tokenType: string; accessToken: string } = {
-  tokenType: 'Bearer',
-  accessToken: 'test-access-token',
-}) {
+function buildContext(
+  token: { tokenType: string; accessToken: string } = {
+    tokenType: 'Bearer',
+    accessToken: 'test-access-token',
+  }
+) {
   return {
     oauthSdk: {
       token: vi.fn().mockResolvedValue(token),

--- a/apps/klaviyo/functions/klaviyoService.ts
+++ b/apps/klaviyo/functions/klaviyoService.ts
@@ -826,7 +826,7 @@ export class KlaviyoService {
       } else if (token && typeof token === 'object' && 'token' in token) {
         tokenString = (token as any).token;
       } else {
-        console.error('Invalid token format:', token);
+        console.error('Invalid token format received from OAuth SDK:', typeof token);
         throw new Error('Invalid token format received from OAuth SDK');
       }
 
@@ -838,8 +838,9 @@ export class KlaviyoService {
       const responseText = await response.text();
 
       if (!response.ok) {
+        const { Authorization, ...safeHeaders } = headers as Record<string, string>;
         console.error(`API error (${response.status}): ${responseText}`);
-        console.error(`Request headers:`, headers);
+        console.error(`Request headers:`, safeHeaders);
         console.error(`Request URL: ${fullUrl}`);
 
         throw new Error(`Klaviyo API error (${response.status}): ${responseText}`);

--- a/apps/klaviyo/functions/proxyRequest.ts
+++ b/apps/klaviyo/functions/proxyRequest.ts
@@ -7,8 +7,7 @@ import type {
 
 const KLAVIYO_API_URL = 'https://a.klaviyo.com/api';
 const KLAVIYO_API_REVISION = '2025-04-15';
-const ALLOWED_ENDPOINTS = ['template-universal-content', 'images'];
-const ALLOWED_ENDPOINT_PATTERN = new RegExp(`^(${ALLOWED_ENDPOINTS.join('|')})(/[A-Za-z0-9_-]+)?$`);
+const ALLOWED_ENDPOINT_PATTERN = /^(template-universal-content|images)(\/[A-Za-z0-9_-]+)?$/;
 
 type AppActionParameters = {
   endpoint: string;

--- a/apps/klaviyo/functions/proxyRequest.ts
+++ b/apps/klaviyo/functions/proxyRequest.ts
@@ -8,6 +8,7 @@ import type {
 const KLAVIYO_API_URL = 'https://a.klaviyo.com/api';
 const KLAVIYO_API_REVISION = '2025-04-15';
 const ALLOWED_ENDPOINTS = ['template-universal-content', 'images'];
+const ALLOWED_ENDPOINT_PATTERN = new RegExp(`^(${ALLOWED_ENDPOINTS.join('|')})(/[A-Za-z0-9_-]+)?$`);
 
 type AppActionParameters = {
   endpoint: string;
@@ -58,8 +59,7 @@ export const handler: FunctionEventHandler<FunctionTypeEnum.AppActionCall> = asy
       console.error('Missing params');
       return { response: { error: 'Missing required params' } };
     }
-    const baseEndpoint = endpoint.split('/')[0];
-    if (!ALLOWED_ENDPOINTS.includes(baseEndpoint))
+    if (!ALLOWED_ENDPOINT_PATTERN.test(endpoint))
       return { response: { error: 'Endpoint not allowed' } };
     const formattedEndpoint = endpoint.endsWith('/') ? endpoint : `${endpoint}/`;
     let url = `${KLAVIYO_API_URL}/${formattedEndpoint}`;

--- a/apps/klaviyo/src/index.tsx
+++ b/apps/klaviyo/src/index.tsx
@@ -28,7 +28,7 @@ const handleOAuthCallback = () => {
         code: params.get('code'),
         state: params.get('state'),
       },
-      '*'
+      window.location.origin
     );
     // Close the popup window
     window.close();

--- a/apps/klaviyo/src/locations/ConfigScreen.tsx
+++ b/apps/klaviyo/src/locations/ConfigScreen.tsx
@@ -224,6 +224,9 @@ const ConfigScreen = () => {
   };
 
   const messageHandler = async (event: MessageEvent) => {
+    if (event.origin !== window.location.origin || event.source !== popupWindowRef.current) {
+      return;
+    }
     if (event.data.type === 'oauth:complete') {
       console.log('oauth:complete');
       const appDefinitionId = sdk.ids.app;

--- a/apps/klaviyo/vitest.config.ts
+++ b/apps/klaviyo/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: ['./test/setup.ts'],
-    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    include: ['src/**/*.{test,spec}.{ts,tsx}', 'functions/**/*.{test,spec}.{ts,tsx}'],
     coverage: {
       reporter: ['text', 'json', 'html'],
       exclude: ['**/node_modules/**', '**/dist/**', '**/coverage/**'],


### PR DESCRIPTION
## Summary
The Klaviyo request helper logged the full outgoing request headers — including the `Authorization` bearer token it had just set — whenever the Klaviyo API returned a non-OK response. It also logged the raw token object on the invalid-token-format error path.

## Solution
- Strip the `Authorization` header before logging request headers on API errors.
- Log only the token's type (not its value) on the invalid-token-format path.

## Context
Last in a small stack of hardening fixes to the Klaviyo app found during a routine security review.

## Test plan
- [x] `tsc --noEmit` passes
- [x] Functions build (`build-functions`) succeeds