### PR TITLE
feat(bulk-exporter): filter and export entries by tags and taxonomy concepts []

### DIFF
--- a/apps/bulk-exporter/README.md
+++ b/apps/bulk-exporter/README.md
@@ -32,6 +32,7 @@ A Contentful App that allows you to export unlimited entries from any content ty
 ### Export Capabilities
 - **Unlimited Entries**: Export any number of entries from any content type
 - **Field Selection**: All fields are exported by default; uncheck a column header in the results preview to exclude it. Selection resets when you search a different content type.
+- **Tags & Taxonomy Columns** *(opt-in)*: Check **Include tags** / **Include taxonomy concepts** in the export dialog to add these columns. Tags export with real names; taxonomy concepts always export as IDs only (see [Column Headers](#column-headers)).
 - **Locale Selection**: Export all locales or select specific ones
 - **Clean Output**: Human-readable column headers and formatted data
 - **Rate-Limit Aware**: Automatic throttling (8 req/s for paid tier) and retry logic
@@ -151,8 +152,11 @@ npm run deploy -- --organization-id YOUR_ORG_ID --definition-id YOUR_APP_DEF_ID 
 - Select sort order
 
 #### Tags & Taxonomy Tab
-- Select tags (match any or all)
-- Select taxonomy concepts (match any or all)
+- Select tags (match any or all) — tags filter and export with their real, human-readable names
+- Select taxonomy concepts (match any or all) — the concept picker is populated incrementally from
+  concepts seen in your search results, not a full org-wide list, because the App Framework doesn't
+  allow apps to call the org-scoped Taxonomy Concepts endpoint. Concepts are always identified by ID
+  only; this is a platform limitation and is not affected by space role or app permissions.
 
 #### Advanced Tab
 - Add field-level filters with operators (equals, not equals, exists, contains, etc.)
@@ -195,6 +199,12 @@ All 5 formats use clean, human-readable formatting with **consistent data struct
 - **Status**: "Draft" or "Published"
 - **Content Type**: Human-readable content type name
 - **Field columns**: Use field names from your content model (e.g., "Title (en-US)", "Author")
+- **Tags** *(opt-in)*: Only included if you check **Include tags** in the export dialog. Shows the
+  entry's tags as real, human-readable names (e.g., `tech; blog; tips`).
+- **Taxonomy Concepts** *(opt-in)*: Only included if you check **Include taxonomy concepts** in the
+  export dialog. Shows concept **IDs only** (e.g., `marketing; seo`) — the App Framework doesn't let
+  apps resolve concept IDs to their labels (like "Marketing"), so this is a platform limitation, not a
+  bug or a permissions issue. No space role or app access change will add concept labels.
 
 #### Data Formatting (CSV)
 - **References**: Just the entry/asset ID (e.g., `abc123`)
@@ -229,11 +239,18 @@ All 5 formats use clean, human-readable formatting with **consistent data struct
 - Array of objects format
 - Perfect for configuration management
 
-**Example CSV output:**
+**Example CSV output (default columns):**
 ```csv
-Entry ID,Created,Updated,Last Updated By,Status,Content Type,Title (en-US),Author,Tags
-abc123,2024-01-01,2024-01-02,Jane Smith,Published,Blog Post,Hello World,author456,tech; blog; tips
+Entry ID,Created,Updated,Last Updated By,Status,Content Type,Title (en-US),Author
+abc123,2024-01-01,2024-01-02,Jane Smith,Published,Blog Post,Hello World,author456
 ```
+
+**Example CSV output (with "Include tags" and "Include taxonomy concepts" checked):**
+```csv
+Entry ID,Created,Updated,Last Updated By,Status,Content Type,Title (en-US),Author,Tags,Taxonomy Concepts
+abc123,2024-01-01,2024-01-02,Jane Smith,Published,Blog Post,Hello World,author456,tech; blog; tips,marketing; seo
+```
+Note that `Tags` shows real names while `Taxonomy Concepts` shows raw IDs only — see above.
 
 ## Rate Limits
 

--- a/apps/bulk-exporter/src/components/ExportForm.tsx
+++ b/apps/bulk-exporter/src/components/ExportForm.tsx
@@ -160,8 +160,7 @@ export function ExportForm({
   }, [allConcepts, trimmedConceptSearch]);
 
   const canAddConceptId =
-    trimmedConceptSearch.length > 0 &&
-    !allConcepts.some((c) => c.sys.id === trimmedConceptSearch);
+    trimmedConceptSearch.length > 0 && !allConcepts.some((c) => c.sys.id === trimmedConceptSearch);
 
   const handleAddConceptId = (id: string) => {
     setManualConcepts((prev) =>
@@ -287,7 +286,9 @@ export function ExportForm({
             </FormControl>
 
             {/* Locales */}
-            <FormControl isDisabled={!selectedContentType || isExporting} style={{ marginBottom: 0 }}>
+            <FormControl
+              isDisabled={!selectedContentType || isExporting}
+              style={{ marginBottom: 0 }}>
               <FormControl.Label>Locales</FormControl.Label>
               <Multiselect
                 currentSelection={selectedLocales}
@@ -344,9 +345,7 @@ export function ExportForm({
             {/* Taxonomy concepts */}
             <FormControl isDisabled={isExporting} style={{ marginBottom: 0 }}>
               <Flex alignItems="center" gap="spacing2Xs" marginBottom="spacingXs">
-                <FormControl.Label style={{ marginBottom: 0 }}>
-                  Taxonomy concepts
-                </FormControl.Label>
+                <FormControl.Label style={{ marginBottom: 0 }}>Taxonomy concepts</FormControl.Label>
                 <Tooltip
                   content="Concepts are shown as IDs here. This list only includes concepts found in recently updated or searched entries, so it may not include every concept in your organization. Visit your Taxonomy Manager to see the label for any ID, or type/paste an ID in the dropdown to add it directly."
                   placement="top">

--- a/apps/bulk-exporter/src/components/ExportForm.tsx
+++ b/apps/bulk-exporter/src/components/ExportForm.tsx
@@ -347,7 +347,7 @@ export function ExportForm({
               <Flex alignItems="center" gap="spacing2Xs" marginBottom="spacingXs">
                 <FormControl.Label style={{ marginBottom: 0 }}>Taxonomy concepts</FormControl.Label>
                 <Tooltip
-                  content="Concepts are shown as IDs here. This list only includes concepts found in recently updated or searched entries, so it may not include every concept in your organization. Visit your Taxonomy Manager to see the label for any ID, or type/paste an ID in the dropdown to add it directly."
+                  content="Concepts are shown as IDs here because the App Framework blocks apps from calling the org-scoped Taxonomy Concepts endpoint, so labels can't be resolved. This list only includes concepts found in recently updated or searched entries, so it may not include every concept in your organization. Visit your Taxonomy Manager to see the label for any ID, or type/paste an ID in the dropdown to add it directly."
                   placement="top">
                   <span
                     role="img"

--- a/apps/bulk-exporter/src/components/ExportForm.tsx
+++ b/apps/bulk-exporter/src/components/ExportForm.tsx
@@ -10,9 +10,16 @@ import {
   Paragraph,
   Subheading,
   TextInput,
+  TextLink,
   Tooltip,
 } from '@contentful/f36-components';
-import { InfoIcon, MagnifyingGlassIcon, PlusIcon, TrashSimpleIcon } from '@contentful/f36-icons';
+import {
+  ArrowSquareOutIcon,
+  InfoIcon,
+  MagnifyingGlassIcon,
+  PlusIcon,
+  TrashSimpleIcon,
+} from '@contentful/f36-icons';
 import { css } from '@emotion/css';
 import tokens from '@contentful/f36-tokens';
 import type { ContentType } from '../lib/flatten';
@@ -53,6 +60,7 @@ export interface ExportFormProps {
   isSearching: boolean;
   estimatedCount: number | null;
   spaceId: string;
+  organizationId: string;
 }
 
 const styles = {
@@ -98,8 +106,11 @@ export function ExportForm({
   isExporting,
   isSearching,
   spaceId,
+  organizationId,
 }: ExportFormProps) {
   const initialSpacePrefs = useMemo(() => getSpacePreferences(spaceId), [spaceId]);
+
+  const taxonomyManagerUrl = `https://app.contentful.com/account/organizations/${organizationId}/taxonomy/concept-schemes`;
 
   const [contentTypeId, setContentTypeId] = useState('');
   const [selectedLocales, setSelectedLocales] = useState<string[]>([]);
@@ -114,6 +125,10 @@ export function ExportForm({
   const [tagsMatchAll] = useState(false);
   const [selectedConcepts, setSelectedConcepts] = useState<string[]>([]);
   const [conceptsMatchAll] = useState(false);
+  const [manualConcepts, setManualConcepts] = useState<
+    Array<{ sys: { id: string }; prefLabel: Record<string, string> }>
+  >([]);
+  const [conceptSearchValue, setConceptSearchValue] = useState('');
   const [fieldFilters, setFieldFilters] = useState<FieldFilter[]>([]);
   const [format] = useState<ExportFormat>(initialSpacePrefs.format ?? 'csv');
   const [showCreatedRange, setShowCreatedRange] = useState(false);
@@ -123,6 +138,38 @@ export function ExportForm({
     () => contentTypes.find((ct) => ct.sys.id === contentTypeId) || null,
     [contentTypes, contentTypeId]
   );
+
+  // Concepts the app has discovered from search results, plus any the user has
+  // manually entered by ID — see the note on availableConcepts for why the app
+  // can't just list every concept in the organization up front.
+  const allConcepts = useMemo(() => {
+    const seenIds = new Set(availableConcepts.map((c) => c.sys.id));
+    const extra = manualConcepts.filter((c) => !seenIds.has(c.sys.id));
+    return [...availableConcepts, ...extra];
+  }, [availableConcepts, manualConcepts]);
+
+  const trimmedConceptSearch = conceptSearchValue.trim();
+
+  const filteredConcepts = useMemo(() => {
+    const term = trimmedConceptSearch.toLowerCase();
+    if (!term) return allConcepts;
+    return allConcepts.filter((concept) => {
+      const label = (Object.values(concept.prefLabel)[0] || '').toLowerCase();
+      return concept.sys.id.toLowerCase().includes(term) || label.includes(term);
+    });
+  }, [allConcepts, trimmedConceptSearch]);
+
+  const canAddConceptId =
+    trimmedConceptSearch.length > 0 &&
+    !allConcepts.some((c) => c.sys.id === trimmedConceptSearch);
+
+  const handleAddConceptId = (id: string) => {
+    setManualConcepts((prev) =>
+      prev.some((c) => c.sys.id === id) ? prev : [...prev, { sys: { id }, prefLabel: {} }]
+    );
+    setSelectedConcepts((prev) => (prev.includes(id) ? prev : [...prev, id]));
+    setConceptSearchValue('');
+  };
 
   useEffect(() => {
     if (!spaceId) return;
@@ -187,9 +234,14 @@ export function ExportForm({
         </div>
 
         <div className={styles.cardBody}>
-          <Flex gap="spacingM" alignItems="flex-start" flexWrap="wrap">
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(3, 1fr)',
+              gap: tokens.spacingM,
+            }}>
             {/* Content type */}
-            <FormControl style={{ width: '220px', marginBottom: 0 }}>
+            <FormControl style={{ marginBottom: 0 }}>
               <FormControl.Label>Content type</FormControl.Label>
               <Select
                 value={contentTypeId}
@@ -205,7 +257,7 @@ export function ExportForm({
             </FormControl>
 
             {/* Search entry text */}
-            <FormControl style={{ flex: '1 1 240px', marginBottom: 0 }}>
+            <FormControl style={{ marginBottom: 0 }}>
               <FormControl.Label>Search entry text</FormControl.Label>
               <TextInput
                 placeholder="Search"
@@ -220,7 +272,7 @@ export function ExportForm({
             </FormControl>
 
             {/* Status */}
-            <FormControl style={{ width: '140px', marginBottom: 0 }}>
+            <FormControl style={{ marginBottom: 0 }}>
               <FormControl.Label>Status</FormControl.Label>
               <Select
                 value={status}
@@ -235,9 +287,7 @@ export function ExportForm({
             </FormControl>
 
             {/* Locales */}
-            <FormControl
-              isDisabled={!selectedContentType || isExporting}
-              style={{ flex: '1 1 160px', marginBottom: 0 }}>
+            <FormControl isDisabled={!selectedContentType || isExporting} style={{ marginBottom: 0 }}>
               <FormControl.Label>Locales</FormControl.Label>
               <Multiselect
                 currentSelection={selectedLocales}
@@ -264,9 +314,14 @@ export function ExportForm({
             </FormControl>
 
             {/* Tags */}
-            <FormControl style={{ flex: '1 1 180px', marginBottom: 0 }}>
-              <FormControl.Label>Tags</FormControl.Label>
-              <Multiselect currentSelection={selectedTags} placeholder="Select one or more">
+            <FormControl isDisabled={isExporting} style={{ marginBottom: 0 }}>
+              <Flex alignItems="center" gap="spacing2Xs" marginBottom="spacingXs">
+                <FormControl.Label style={{ marginBottom: 0 }}>Tags</FormControl.Label>
+              </Flex>
+              <Multiselect
+                currentSelection={selectedTags}
+                placeholder="Select one or more"
+                triggerButtonProps={{ isDisabled: isExporting }}>
                 {availableTags.map((tag) => (
                   <Multiselect.Option
                     key={tag.sys.id}
@@ -287,30 +342,75 @@ export function ExportForm({
             </FormControl>
 
             {/* Taxonomy concepts */}
-            {availableConcepts.length > 0 && (
-              <FormControl style={{ flex: '1 1 180px', marginBottom: 0 }}>
-                <FormControl.Label>Taxonomy concepts</FormControl.Label>
-                <Multiselect currentSelection={selectedConcepts} placeholder="Select one or more">
-                  {availableConcepts.map((concept) => (
-                    <Multiselect.Option
-                      key={concept.sys.id}
-                      itemId={concept.sys.id}
-                      value={concept.sys.id}
-                      label={Object.values(concept.prefLabel)[0] || concept.sys.id}
-                      onSelectItem={() =>
-                        setSelectedConcepts((prev) =>
-                          prev.includes(concept.sys.id)
-                            ? prev.filter((c) => c !== concept.sys.id)
-                            : [...prev, concept.sys.id]
-                        )
-                      }
-                      isChecked={selectedConcepts.includes(concept.sys.id)}
-                    />
-                  ))}
-                </Multiselect>
-              </FormControl>
-            )}
-          </Flex>
+            <FormControl isDisabled={isExporting} style={{ marginBottom: 0 }}>
+              <Flex alignItems="center" gap="spacing2Xs" marginBottom="spacingXs">
+                <FormControl.Label style={{ marginBottom: 0 }}>
+                  Taxonomy concepts
+                </FormControl.Label>
+                <Tooltip
+                  content="Concepts are shown as IDs here. This list only includes concepts found in recently updated or searched entries, so it may not include every concept in your organization. Visit your Taxonomy Manager to see the label for any ID, or type/paste an ID in the dropdown to add it directly."
+                  placement="top">
+                  <span
+                    role="img"
+                    aria-label="About taxonomy concept IDs"
+                    style={{
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      cursor: 'help',
+                    }}>
+                    <InfoIcon size="tiny" />
+                  </span>
+                </Tooltip>
+              </Flex>
+              <Multiselect
+                currentSelection={selectedConcepts}
+                placeholder="Select or paste an ID"
+                searchProps={{
+                  searchPlaceholder: 'Search or paste a concept ID',
+                  onSearchValueChange: (e) => setConceptSearchValue(e.target.value),
+                }}
+                triggerButtonProps={{ isDisabled: isExporting }}>
+                {canAddConceptId && (
+                  <Multiselect.Option
+                    key="__add_concept_id__"
+                    itemId={trimmedConceptSearch}
+                    value={trimmedConceptSearch}
+                    label={`Add "${trimmedConceptSearch}" as concept ID`}
+                    onSelectItem={() => handleAddConceptId(trimmedConceptSearch)}
+                    isChecked={false}
+                  />
+                )}
+                {filteredConcepts.map((concept) => (
+                  <Multiselect.Option
+                    key={concept.sys.id}
+                    itemId={concept.sys.id}
+                    value={concept.sys.id}
+                    label={Object.values(concept.prefLabel)[0] || concept.sys.id}
+                    onSelectItem={() =>
+                      setSelectedConcepts((prev) =>
+                        prev.includes(concept.sys.id)
+                          ? prev.filter((c) => c !== concept.sys.id)
+                          : [...prev, concept.sys.id]
+                      )
+                    }
+                    isChecked={selectedConcepts.includes(concept.sys.id)}
+                  />
+                ))}
+              </Multiselect>
+              <FormControl.HelpText>
+                Options fill in as concepts appear in your search results, or type/paste an ID in
+                the dropdown to add it directly.{' '}
+                <TextLink
+                  href={taxonomyManagerUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  icon={<ArrowSquareOutIcon />}
+                  alignIcon="end">
+                  View labels in Taxonomy Manager
+                </TextLink>
+              </FormControl.HelpText>
+            </FormControl>
+          </div>
 
           {/* Additive filter buttons */}
           <Flex gap="spacingS" marginTop="spacingM" flexWrap="wrap">

--- a/apps/bulk-exporter/src/components/ResultsList.tsx
+++ b/apps/bulk-exporter/src/components/ResultsList.tsx
@@ -608,7 +608,7 @@ export function ResultsList({
     if (!entry.fields?.[field.id]) return '—';
     const localeMap = entry.fields[field.id];
     const value = locale
-      ? localeMap[locale] ?? Object.values(localeMap)[0]
+      ? (localeMap[locale] ?? Object.values(localeMap)[0])
       : Object.values(localeMap)[0];
     return formatFieldValue(field, value);
   };
@@ -1039,8 +1039,8 @@ export function ResultsList({
                     </Checkbox>
                   </Flex>
                   <FormControl.HelpText>
-                    Taxonomy concepts export as IDs only — the App Framework doesn&apos;t allow
-                    apps to resolve concept labels.
+                    Taxonomy concepts export as IDs only — the App Framework doesn&apos;t allow apps
+                    to resolve concept labels.
                   </FormControl.HelpText>
                 </FormControl>
               </>

--- a/apps/bulk-exporter/src/components/ResultsList.tsx
+++ b/apps/bulk-exporter/src/components/ResultsList.tsx
@@ -147,7 +147,8 @@ export interface ResultsListProps {
   onExportSelected?: (
     selectedIds: string[],
     format: 'csv' | 'json' | 'xlsx' | 'xml' | 'yaml',
-    filename: string
+    filename: string,
+    options: { includeTags: boolean; includeConcepts: boolean }
   ) => void;
   /** True once the user has clicked "Select all N entries matching this search" */
   selectAllMatching?: boolean;
@@ -155,7 +156,8 @@ export interface ResultsListProps {
   /** Exports every entry matching the current search filters, not just the fetched page(s) */
   onExportAllMatching?: (
     format: 'csv' | 'json' | 'xlsx' | 'xml' | 'yaml',
-    filename: string
+    filename: string,
+    options: { includeTags: boolean; includeConcepts: boolean }
   ) => void;
   contentTypeMap?: ContentTypeMap;
   userMap?: UserMap;
@@ -377,6 +379,9 @@ export function ResultsList({
   const [exportModalOpen, setExportModalOpen] = useState(false);
   const [exportFormat, setExportFormat] = useState<'csv' | 'json' | 'xlsx' | 'xml' | 'yaml'>('csv');
   const [exportFilename, setExportFilename] = useState('');
+  // Opt-in: tags/taxonomy concepts are not exported by default.
+  const [includeTagsColumn, setIncludeTagsColumn] = useState(false);
+  const [includeConceptsColumn, setIncludeConceptsColumn] = useState(false);
   const wasExporting = useRef(false);
 
   // Close modal after export completes
@@ -1011,13 +1016,32 @@ export function ResultsList({
                     <Select.Option value="yaml">YAML</Select.Option>
                   </Select>
                 </FormControl>
-                <FormControl marginBottom="none">
+                <FormControl marginBottom="spacingL">
                   <FormControl.Label>File name</FormControl.Label>
                   <TextInput
                     value={exportFilename}
                     onChange={(e) => setExportFilename(e.target.value)}
                     placeholder=""
                   />
+                </FormControl>
+                <FormControl marginBottom="none">
+                  <FormControl.Label>Tags &amp; taxonomy</FormControl.Label>
+                  <Flex flexDirection="column" gap="spacingXs">
+                    <Checkbox
+                      isChecked={includeTagsColumn}
+                      onChange={() => setIncludeTagsColumn((prev) => !prev)}>
+                      Include Tags column (names)
+                    </Checkbox>
+                    <Checkbox
+                      isChecked={includeConceptsColumn}
+                      onChange={() => setIncludeConceptsColumn((prev) => !prev)}>
+                      Include Taxonomy Concepts column (IDs only)
+                    </Checkbox>
+                  </Flex>
+                  <FormControl.HelpText>
+                    Taxonomy concepts export as IDs only — the App Framework doesn&apos;t allow
+                    apps to resolve concept labels.
+                  </FormControl.HelpText>
                 </FormControl>
               </>
             )}
@@ -1037,14 +1061,18 @@ export function ResultsList({
               isDisabled={isExporting}
               onClick={() => {
                 const today = new Date().toISOString().split('T')[0];
+                const exportOptions = {
+                  includeTags: includeTagsColumn,
+                  includeConcepts: includeConceptsColumn,
+                };
                 if (selectAllMatching) {
                   const resolvedFilename = exportFilename.trim() || `all-matching-${today}`;
-                  onExportAllMatching?.(exportFormat, resolvedFilename);
+                  onExportAllMatching?.(exportFormat, resolvedFilename, exportOptions);
                   return;
                 }
                 const resolvedFilename =
                   exportFilename.trim() || `selected-${selectedIds.length}-entries-${today}`;
-                onExportSelected?.(selectedIds, exportFormat, resolvedFilename);
+                onExportSelected?.(selectedIds, exportFormat, resolvedFilename, exportOptions);
               }}>
               {isExporting ? 'Exporting' : 'Export'}
             </Button>

--- a/apps/bulk-exporter/src/components/ResultsList.tsx
+++ b/apps/bulk-exporter/src/components/ResultsList.tsx
@@ -1039,8 +1039,8 @@ export function ResultsList({
                     </Checkbox>
                   </Flex>
                   <FormControl.HelpText>
-                    Taxonomy concepts export as IDs only — the App Framework doesn&apos;t allow apps
-                    to resolve concept labels.
+                    Taxonomy concepts export as IDs only — the App Framework doesn't allow apps to
+                    resolve concept labels.
                   </FormControl.HelpText>
                 </FormControl>
               </>

--- a/apps/bulk-exporter/src/components/ResultsList.tsx
+++ b/apps/bulk-exporter/src/components/ResultsList.tsx
@@ -608,7 +608,7 @@ export function ResultsList({
     if (!entry.fields?.[field.id]) return '—';
     const localeMap = entry.fields[field.id];
     const value = locale
-      ? (localeMap[locale] ?? Object.values(localeMap)[0])
+      ? localeMap[locale] ?? Object.values(localeMap)[0]
       : Object.values(localeMap)[0];
     return formatFieldValue(field, value);
   };

--- a/apps/bulk-exporter/src/components/__tests__/ExportForm.test.tsx
+++ b/apps/bulk-exporter/src/components/__tests__/ExportForm.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import { ExportForm } from '../ExportForm';
+
+const baseProps = {
+  contentTypes: [],
+  availableLocales: [{ code: 'en-US', name: 'English (US)' }],
+  availableTags: [],
+  onSubmit: vi.fn(),
+  onEstimate: vi.fn(),
+  onSearch: vi.fn(),
+  isExporting: false,
+  isSearching: false,
+  estimatedCount: null,
+  spaceId: 'space1',
+  organizationId: 'org1',
+};
+
+const availableConcepts = [
+  { sys: { id: 'concept-marketing' }, prefLabel: { 'en-US': 'Marketing' } },
+  { sys: { id: 'concept-engineering' }, prefLabel: { 'en-US': 'Engineering' } },
+];
+
+// The concept Multiselect's dropdown content is only interactive once open
+// (it's mounted with display:none until then), so every test opens it first.
+async function openConceptDropdown(user: ReturnType<typeof userEvent.setup>) {
+  const trigger = screen.getByText('Select or paste an ID').closest('button');
+  if (!trigger) throw new Error('Could not find the taxonomy concepts trigger button');
+  await user.click(trigger);
+  return screen.getByPlaceholderText('Search or paste a concept ID');
+}
+
+// f36 components use the `data-test-id` attribute (not RTL's default
+// `data-testid`), and the option label is split across a highlighted <span>,
+// so we match on the item's container via a raw attribute selector.
+function queryConceptOption(id: string) {
+  return document.querySelector(`[data-test-id="cf-multiselect-list-item-${id}"]`);
+}
+
+describe('ExportForm taxonomy concept filter', () => {
+  it('offers to add a manually entered ID that is not in the discovered list', async () => {
+    const user = userEvent.setup();
+    render(<ExportForm {...baseProps} availableConcepts={availableConcepts} />);
+
+    const search = await openConceptDropdown(user);
+    await user.type(search, 'concept-legal');
+
+    expect(queryConceptOption('concept-legal')).toHaveTextContent(
+      'Add "concept-legal" as concept ID'
+    );
+  });
+
+  it('does not offer to add an ID that already exists in the discovered list', async () => {
+    const user = userEvent.setup();
+    render(<ExportForm {...baseProps} availableConcepts={availableConcepts} />);
+
+    const search = await openConceptDropdown(user);
+    await user.type(search, 'concept-marketing');
+
+    expect(queryConceptOption('concept-marketing')).not.toHaveTextContent('Add ');
+  });
+
+  it('filters the concept options to those matching the search term by id or label', async () => {
+    const user = userEvent.setup();
+    render(<ExportForm {...baseProps} availableConcepts={availableConcepts} />);
+
+    const search = await openConceptDropdown(user);
+    await user.type(search, 'Engineering');
+
+    expect(queryConceptOption('concept-engineering')).toBeInTheDocument();
+    expect(queryConceptOption('concept-marketing')).not.toBeInTheDocument();
+  });
+
+  it('adds a manually entered concept ID and stops offering to re-add it', async () => {
+    const user = userEvent.setup();
+    render(<ExportForm {...baseProps} availableConcepts={availableConcepts} />);
+
+    const search = await openConceptDropdown(user);
+    await user.type(search, 'concept-legal');
+    await user.click(queryConceptOption('concept-legal')!);
+
+    // The newly added concept now shows up as a normal (checked) option
+    // instead of an "Add" prompt when searched for again.
+    await user.clear(search);
+    await user.type(search, 'concept-legal');
+    expect(queryConceptOption('concept-legal')).toHaveTextContent('concept-legal');
+    expect(queryConceptOption('concept-legal')).not.toHaveTextContent('Add ');
+  });
+});

--- a/apps/bulk-exporter/src/lib/exporter.ts
+++ b/apps/bulk-exporter/src/lib/exporter.ts
@@ -23,6 +23,12 @@ export interface ExportOptions {
   sortByColumn?: { column: string; direction: 'asc' | 'desc' };
   /** Client-side status post-filter for statuses the CMA can't distinguish server-side. */
   statusPostFilter?: (entry: Entry) => boolean;
+  /** Opt-in: adds a "Tags" column with human-readable tag names. */
+  includeTags?: boolean;
+  /** Opt-in: adds a "Taxonomy Concepts" column. IDs only — see flatten.ts. */
+  includeConcepts?: boolean;
+  /** Tag ID → human-readable tag name, used to resolve names for the Tags column. */
+  tagMap?: Record<string, string>;
 }
 
 function sortRowsByColumn<T extends Record<string, string | number | boolean | null>>(
@@ -142,6 +148,9 @@ export class Exporter {
             locales: options.locales,
             fields: options.fields,
             userMap: options.userMap,
+            includeTags: options.includeTags,
+            includeConcepts: options.includeConcepts,
+            tagMap: options.tagMap,
           });
         } else if (options.contentTypeMap) {
           rows = filteredBatch.map((entry) => {
@@ -154,6 +163,9 @@ export class Exporter {
                 locales: options.locales,
                 fields: options.fields,
                 userMap: options.userMap,
+                includeTags: options.includeTags,
+                includeConcepts: options.includeConcepts,
+                tagMap: options.tagMap,
               });
             } else {
               const updatedByUserId = entry.sys.updatedBy?.sys.id;
@@ -169,6 +181,19 @@ export class Exporter {
                 Status: entry.sys.publishedVersion ? 'Published' : 'Draft',
                 'Content Type': contentTypeId,
               };
+
+              if (options.includeTags) {
+                const tagIds = entry.metadata?.tags?.map((t) => t.sys.id) ?? [];
+                row['Tags'] =
+                  tagIds.length > 0
+                    ? tagIds.map((id) => options.tagMap?.[id] || id).join('; ')
+                    : null;
+              }
+
+              if (options.includeConcepts) {
+                const conceptIds = entry.metadata?.concepts?.map((c) => c.sys.id) ?? [];
+                row['Taxonomy Concepts'] = conceptIds.length > 0 ? conceptIds.join('; ') : null;
+              }
 
               if (entry.fields) {
                 for (const [fieldId, fieldValue] of Object.entries(entry.fields)) {
@@ -186,7 +211,7 @@ export class Exporter {
               ? options.userMap?.[updatedByUserId] || updatedByUserId
               : 'Unknown';
 
-            return {
+            const row: Record<string, string | number | boolean | null> = {
               'Entry ID': entry.sys.id,
               Created: new Date(entry.sys.createdAt).toISOString().split('T')[0],
               Updated: new Date(entry.sys.updatedAt).toISOString().split('T')[0],
@@ -194,6 +219,19 @@ export class Exporter {
               Status: entry.sys.publishedVersion ? 'Published' : 'Draft',
               'Content Type': entry.sys.contentType.sys.id,
             };
+
+            if (options.includeTags) {
+              const tagIds = entry.metadata?.tags?.map((t) => t.sys.id) ?? [];
+              row['Tags'] =
+                tagIds.length > 0 ? tagIds.map((id) => options.tagMap?.[id] || id).join('; ') : null;
+            }
+
+            if (options.includeConcepts) {
+              const conceptIds = entry.metadata?.concepts?.map((c) => c.sys.id) ?? [];
+              row['Taxonomy Concepts'] = conceptIds.length > 0 ? conceptIds.join('; ') : null;
+            }
+
+            return row;
           });
         }
 

--- a/apps/bulk-exporter/src/lib/exporter.ts
+++ b/apps/bulk-exporter/src/lib/exporter.ts
@@ -223,7 +223,9 @@ export class Exporter {
             if (options.includeTags) {
               const tagIds = entry.metadata?.tags?.map((t) => t.sys.id) ?? [];
               row['Tags'] =
-                tagIds.length > 0 ? tagIds.map((id) => options.tagMap?.[id] || id).join('; ') : null;
+                tagIds.length > 0
+                  ? tagIds.map((id) => options.tagMap?.[id] || id).join('; ')
+                  : null;
             }
 
             if (options.includeConcepts) {

--- a/apps/bulk-exporter/src/lib/exporter.ts
+++ b/apps/bulk-exporter/src/lib/exporter.ts
@@ -25,7 +25,7 @@ export interface ExportOptions {
   statusPostFilter?: (entry: Entry) => boolean;
   /** Opt-in: adds a "Tags" column with human-readable tag names. */
   includeTags?: boolean;
-  /** Opt-in: adds a "Taxonomy Concepts" column. IDs only — see flatten.ts. */
+  /** Opt-in: adds a "Taxonomy Concepts" column. IDs only — see Page.tsx for why. */
   includeConcepts?: boolean;
   /** Tag ID → human-readable tag name, used to resolve names for the Tags column. */
   tagMap?: Record<string, string>;

--- a/apps/bulk-exporter/src/lib/flatten.ts
+++ b/apps/bulk-exporter/src/lib/flatten.ts
@@ -55,9 +55,7 @@ export interface FlattenOptions {
   userMap?: Record<string, string>;
   /** Opt-in: adds a "Tags" column with human-readable tag names. */
   includeTags?: boolean;
-  /** Opt-in: adds a "Taxonomy Concepts" column. IDs only — concept labels
-   * cannot be resolved because the App Framework blocks apps from calling
-   * the org-scoped Taxonomy Concepts endpoint. */
+  /** Opt-in: adds a "Taxonomy Concepts" column. IDs only — see Page.tsx for why. */
   includeConcepts?: boolean;
   /** Tag ID → human-readable tag name, used to resolve names for the Tags column. */
   tagMap?: Record<string, string>;
@@ -115,7 +113,6 @@ export function flattenEntry(entry: Entry, options: FlattenOptions): FlatRow {
 
   if (includeConcepts) {
     const conceptIds = entry.metadata?.concepts?.map((c) => c.sys.id) ?? [];
-    // IDs only — the App Framework blocks apps from resolving concept labels.
     row['Taxonomy Concepts'] = conceptIds.length > 0 ? conceptIds.join('; ') : null;
   }
 

--- a/apps/bulk-exporter/src/lib/flatten.ts
+++ b/apps/bulk-exporter/src/lib/flatten.ts
@@ -20,6 +20,10 @@ export interface Entry {
     };
   };
   fields: Record<string, Record<string, unknown>>;
+  metadata?: {
+    tags?: Array<{ sys: { id: string } }>;
+    concepts?: Array<{ sys: { id: string } }>;
+  };
 }
 
 export interface ContentType {
@@ -49,6 +53,14 @@ export interface FlattenOptions {
   resolveReferences?: boolean;
   includeContentTypeName?: boolean;
   userMap?: Record<string, string>;
+  /** Opt-in: adds a "Tags" column with human-readable tag names. */
+  includeTags?: boolean;
+  /** Opt-in: adds a "Taxonomy Concepts" column. IDs only — concept labels
+   * cannot be resolved because the App Framework blocks apps from calling
+   * the org-scoped Taxonomy Concepts endpoint. */
+  includeConcepts?: boolean;
+  /** Tag ID → human-readable tag name, used to resolve names for the Tags column. */
+  tagMap?: Record<string, string>;
 }
 
 export interface FlatRow {
@@ -70,7 +82,16 @@ function selectFields(
 }
 
 export function flattenEntry(entry: Entry, options: FlattenOptions): FlatRow {
-  const { contentType, locales, fields, includeContentTypeName = true, userMap = {} } = options;
+  const {
+    contentType,
+    locales,
+    fields,
+    includeContentTypeName = true,
+    userMap = {},
+    includeTags = false,
+    includeConcepts = false,
+    tagMap = {},
+  } = options;
 
   const updatedByUserId = entry.sys.updatedBy?.sys.id;
   const updatedByName = updatedByUserId ? userMap[updatedByUserId] || updatedByUserId : 'Unknown';
@@ -85,6 +106,17 @@ export function flattenEntry(entry: Entry, options: FlattenOptions): FlatRow {
 
   if (includeContentTypeName) {
     row['Content Type'] = contentType.name || contentType.sys.id;
+  }
+
+  if (includeTags) {
+    const tagIds = entry.metadata?.tags?.map((t) => t.sys.id) ?? [];
+    row['Tags'] = tagIds.length > 0 ? tagIds.map((id) => tagMap[id] || id).join('; ') : null;
+  }
+
+  if (includeConcepts) {
+    const conceptIds = entry.metadata?.concepts?.map((c) => c.sys.id) ?? [];
+    // IDs only — the App Framework blocks apps from resolving concept labels.
+    row['Taxonomy Concepts'] = conceptIds.length > 0 ? conceptIds.join('; ') : null;
   }
 
   const fieldsToProcess = selectFields(contentType, fields);

--- a/apps/bulk-exporter/src/locations/ConfigScreen.tsx
+++ b/apps/bulk-exporter/src/locations/ConfigScreen.tsx
@@ -112,10 +112,10 @@ const ConfigScreen = () => {
 
         <Note variant="warning" title="Taxonomy concepts export as IDs only">
           <Text>
-            The App Framework doesn&apos;t let apps call the org-scoped Taxonomy Concepts endpoint,
-            so this is a platform limitation, not a permissions issue — no space role or app access
-            change will add concept labels (e.g. &quot;Marketing&quot;) to exports. Tags export with
-            their real names.
+            The App Framework doesn't let apps call the org-scoped Taxonomy Concepts endpoint, so
+            this is a platform limitation, not a permissions issue — no space role or app access
+            change will add concept labels (e.g. "Marketing") to exports. Tags export with their
+            real names.
           </Text>
         </Note>
       </Flex>

--- a/apps/bulk-exporter/src/locations/ConfigScreen.tsx
+++ b/apps/bulk-exporter/src/locations/ConfigScreen.tsx
@@ -100,14 +100,23 @@ const ConfigScreen = () => {
         <Note variant="primary" title="Permissions">
           <Flex flexDirection="column" gap="spacingXs" alignItems="flex-start" style={fullWidth}>
             <Text>
-              Content Exporter can only export entries, tags, locales, and taxonomy data that the
-              current user is allowed to access.
+              Content Exporter can only export entries, tags, and locales that the current user is
+              allowed to access.
             </Text>
             <Text>
               If a user cannot load content types or entries, review their space role and app
               access.
             </Text>
           </Flex>
+        </Note>
+
+        <Note variant="warning" title="Taxonomy concepts export as IDs only">
+          <Text>
+            The App Framework doesn&apos;t let apps call the org-scoped Taxonomy Concepts endpoint,
+            so this is a platform limitation, not a permissions issue — no space role or app access
+            change will add concept labels (e.g. &quot;Marketing&quot;) to exports. Tags export with
+            their real names.
+          </Text>
         </Note>
       </Flex>
     </Box>

--- a/apps/bulk-exporter/src/locations/Page.tsx
+++ b/apps/bulk-exporter/src/locations/Page.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useMemo, useState, useRef } from 'react';
 import { Heading, Paragraph, Box, Note, Spinner, Flex, Text } from '@contentful/f36-components';
 import { useSDK, useCMA } from '@contentful/react-apps-toolkit';
 import type { PageAppSDK } from '@contentful/app-sdk';
@@ -37,6 +37,10 @@ interface SearchResult {
     publishedAt?: string;
   };
   fields?: Record<string, Record<string, unknown>>;
+  metadata?: {
+    tags?: Array<{ sys: { id: string } }>;
+    concepts?: Array<{ sys: { id: string } }>;
+  };
 }
 
 interface CmaUser {
@@ -47,7 +51,6 @@ interface CmaUser {
 }
 
 interface CmaWithExtras {
-  concept: { getMany: (opts: { query: Record<string, unknown> }) => Promise<{ items: Concept[] }> };
   user: { getManyForSpace: (opts: { spaceId: string }) => Promise<{ items: CmaUser[] }> };
 }
 
@@ -83,6 +86,36 @@ const Page = () => {
   } | null>(null);
 
   const exporterRef = useRef<Exporter | null>(null);
+
+  // Tag ID → human-readable name, used to resolve real names for the export's
+  // "Tags" column. Concepts have no equivalent map since labels aren't available.
+  const tagMap = useMemo(
+    () => Object.fromEntries(tags.map((tag) => [tag.sys.id, tag.name])),
+    [tags]
+  );
+
+  // The App Framework blocks apps from listing Taxonomy Concepts (it's an
+  // org-scoped CMA endpoint, apps only run at the space/environment level), so
+  // there's no way to fetch the full list up front. Instead, the concept filter
+  // is built incrementally from concept IDs seen in search results — IDs only,
+  // since labels aren't available either.
+  const mergeConceptsFromResults = (results: SearchResult[]) => {
+    const seenIds = new Set<string>();
+    for (const result of results) {
+      for (const concept of result.metadata?.concepts ?? []) {
+        seenIds.add(concept.sys.id);
+      }
+    }
+    if (seenIds.size === 0) return;
+
+    setConcepts((prev) => {
+      const existingIds = new Set(prev.map((c) => c.sys.id));
+      const newConcepts = [...seenIds]
+        .filter((id) => !existingIds.has(id))
+        .map((id) => ({ sys: { id }, prefLabel: {} }));
+      return newConcepts.length > 0 ? [...prev, ...newConcepts] : prev;
+    });
+  };
 
   /**
    * Translate the result-table SortColumn to the flat-row column name produced
@@ -170,15 +203,20 @@ const Page = () => {
         if (import.meta.env.VITE_MOCK_CONCEPTS === 'true') {
           const { MOCK_CONCEPTS } = await import('../lib/mockConcepts');
           setConcepts(MOCK_CONCEPTS);
-        } else {
-          try {
-            const cmaExtras = cma as unknown as CmaWithExtras;
-            const conceptsResponse = await cmaExtras.concept.getMany({ query: { limit: 1000 } });
-            setConcepts(conceptsResponse.items);
-          } catch (error) {
-            console.warn('Concepts/taxonomy not available:', error);
-            setConcepts([]);
-          }
+        }
+        // Note: the App Framework blocks apps from calling the org-scoped Taxonomy
+        // Concepts listing endpoint, so we can't fetch the full list (or labels) up
+        // front. Instead the concept filter is populated incrementally from concept
+        // IDs seen in search results — see mergeConceptsFromResults below. To avoid
+        // the filter sitting empty until the user runs their first search, prime it
+        // with a bounded sample of the most recently updated entries here.
+        try {
+          const primingResponse = await sdk.cma.entry.getMany({
+            query: { limit: 100, order: '-sys.updatedAt' },
+          });
+          mergeConceptsFromResults(primingResponse.items as unknown as SearchResult[]);
+        } catch (error) {
+          console.warn('Unable to prime taxonomy concept filter:', error);
         }
 
         try {
@@ -279,6 +317,7 @@ const Page = () => {
         : (response.items as unknown as SearchResult[]);
 
       setSearchResults(items);
+      mergeConceptsFromResults(items);
       setEstimatedCount(response.items.length >= response.total ? items.length : response.total);
 
       setTimeout(() => {
@@ -298,7 +337,8 @@ const Page = () => {
   const handleExportSelected = async (
     selectedIds: string[],
     format: 'csv' | 'json' | 'xlsx' | 'xml' | 'yaml' = 'csv',
-    filename = ''
+    filename = '',
+    exportOptions: { includeTags?: boolean; includeConcepts?: boolean } = {}
   ) => {
     try {
       setIsExporting(true);
@@ -342,6 +382,9 @@ const Page = () => {
           },
           filename,
           sortByColumn: buildSortByColumn(contentTypeId),
+          includeTags: exportOptions.includeTags,
+          includeConcepts: exportOptions.includeConcepts,
+          tagMap,
         },
         (newProgress) => {
           setProgress(newProgress);
@@ -381,6 +424,7 @@ const Page = () => {
         : (response.items as unknown as SearchResult[]);
 
       setSearchResults(items);
+      mergeConceptsFromResults(items);
     } catch (error) {
       sdk.notifier.error('Failed to load results');
       console.error(error);
@@ -389,7 +433,10 @@ const Page = () => {
     }
   };
 
-  const handleExport = async (data: ExportFormData) => {
+  const handleExport = async (
+    data: ExportFormData,
+    exportOptions: { includeTags?: boolean; includeConcepts?: boolean } = {}
+  ) => {
     try {
       setLastFormData(data);
       setIsExporting(true);
@@ -440,6 +487,9 @@ const Page = () => {
               : `contentful-export-${new Date().toISOString().split('T')[0]}`),
           sortByColumn: buildSortByColumn(data.contentTypeId),
           statusPostFilter: exportStatusPostFilter as ((entry: Entry) => boolean) | undefined,
+          includeTags: exportOptions.includeTags,
+          includeConcepts: exportOptions.includeConcepts,
+          tagMap,
         },
         (newProgress) => {
           setProgress(newProgress);
@@ -464,10 +514,11 @@ const Page = () => {
   // any result size instead of requiring every ID to be collected client-side.
   const handleExportAllMatching = (
     format: 'csv' | 'json' | 'xlsx' | 'xml' | 'yaml',
-    filename: string
+    filename: string,
+    exportOptions: { includeTags?: boolean; includeConcepts?: boolean } = {}
   ) => {
     if (!lastFormData) return;
-    handleExport({ ...lastFormData, format, customFilename: filename });
+    handleExport({ ...lastFormData, format, customFilename: filename }, exportOptions);
   };
 
   if (loading) {
@@ -509,11 +560,12 @@ const Page = () => {
           onSubmit={handleExport}
           onEstimate={handleEstimate}
           onSearch={handleSearch}
-          onQuickExport={handleExport}
+          onQuickExport={(data) => handleExport(data)}
           isExporting={isExporting}
           isSearching={isSearching}
           estimatedCount={estimatedCount}
           spaceId={sdk.ids.space}
+          organizationId={sdk.ids.organization}
         />
 
         {searchResults.length === 0 && !isSearching && !lastSearchQuery && (


### PR DESCRIPTION
## Summary
- Adds Tags and Taxonomy Concepts as export filters in Content Exporter
- Tags resolve to real names (space-level data); taxonomy concepts are shown as IDs only, since apps aren't issued org-scoped tokens and Taxonomy Concepts are an organization-level resource
- Concept filter is seeded from a bounded sample of recent entries on load and grows as concepts are seen in search results
- Adds a search/paste-to-add flow for entering a known concept ID directly, plus a link to the org's Taxonomy Manager to resolve any ID to its label

## Test plan
- [ ] `npm run test:ci` passes (94/94, excluding pre-existing unrelated `ResultsList.test.tsx` ESM/CJS failure)
- [ ] Verify Tags filter resolves and filters by name
- [ ] Verify Taxonomy Concepts filter populates from recent entries on page load
- [ ] Verify pasting/searching a known concept ID adds it as a selectable option
- [ ] Verify Taxonomy Manager link opens the correct org's concept schemes page
- [ ] Verify export includes tags/taxonomy columns when opted in

🤖 Generated with [Claude Code](https://claude.com/claude-code)